### PR TITLE
Skipping the static routes with null nextHopIp in initStaticRib

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/bdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/bdp/VirtualRouter.java
@@ -644,10 +644,12 @@ public class VirtualRouter extends ComparableStructure<String> {
         continue;
       }
       // interface route
-      if (sr.getNextHopIp().equals(Route.UNSET_ROUTE_NEXT_HOP_IP)) {
-        _staticInterfaceRib.mergeRoute(sr);
-      } else {
-        _staticRib.mergeRoute(sr);
+      if (sr.getNextHopIp() != null) {
+        if (sr.getNextHopIp().equals(Route.UNSET_ROUTE_NEXT_HOP_IP)) {
+          _staticInterfaceRib.mergeRoute(sr);
+        } else {
+          _staticRib.mergeRoute(sr);
+        }
       }
     }
   }


### PR DESCRIPTION
Fix for issue #207, details are in the comment on this commit