### PR TITLE
BatfishObjectMapper: use ALWAYS content serialization

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/BatfishObjectMapper.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/BatfishObjectMapper.java
@@ -1,5 +1,6 @@
 package org.batfish.common.util;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -48,7 +49,10 @@ public class BatfishObjectMapper extends ObjectMapper {
       enable(SerializationFeature.INDENT_OUTPUT);
     }
     enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY);
-    setSerializationInclusion(Include.NON_EMPTY);
+    // See https://groups.google.com/forum/#!topic/jackson-user/WfZzlt5C2Ww
+    //  This fixes issues in which non-empty maps with keys with empty values would get omitted
+    //  entirely. See also https://github.com/batfish/batfish/issues/256
+    setDefaultPropertyInclusion(JsonInclude.Value.construct(Include.NON_EMPTY, Include.ALWAYS));
   }
 
   public BatfishObjectMapper(ClassLoader cl) {

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/BatfishObjectMapperTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/BatfishObjectMapperTest.java
@@ -1,0 +1,36 @@
+package org.batfish.common.util;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThat;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class BatfishObjectMapperTest {
+  private static class Foo {
+    @JsonProperty("map")
+    public Map<String, String[]> _map = new HashMap<>();
+  }
+
+  @Test
+  public void testMapFieldWithEmptyValue() throws JsonProcessingException {
+    Foo foo = new Foo();
+    foo._map.put("key", new String[0]);
+
+    ObjectMapper mapper =
+        new ObjectMapper()
+            .setDefaultPropertyInclusion(
+                JsonInclude.Value.construct(Include.NON_EMPTY, Include.ALWAYS));
+    assertThat(mapper.writeValueAsString(foo), allOf(containsString("map"), containsString("key")));
+  }
+}


### PR DESCRIPTION
ObjectMapper has two separate configurations for inclusion: value and
content. The default method for configuring the inclusion applies the
supplied inclusion strategy to both.  However, Batfish's default of
NON_NULL means that we could serialize {map: {key: []}} to {} (where the
class Foo has a single property Map<String, String[]>), because:

1. key's value is empty, so we drop key
2. the map is empty, so we drop the map.

By swapping from value=NON_NULL (which applies to properties like
Foo.map) and content=NON_NULL (which applies to the content of
collections that are inside of objects) to content=ALWAYS, we do not
drop key from the map and thus don't drop the map.

This fixes batfish/batfish#256.