### PR TITLE
infer node roles when a testrig is initialized

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
@@ -128,6 +128,7 @@ public class BfConsts {
   public static final String RELPATH_FAILURE_QUERY_PREFIX = "failure-query";
   public static final String RELPATH_FLOWS_DUMP_DIR = "flowdump";
   public static final String RELPATH_HOST_CONFIGS_DIR = "hosts";
+  public static final String RELPATH_INFERRED_NODE_ROLES_PATH = "node_roles_inferred.json";
   public static final String RELPATH_INTERFACE_BLACKLIST_FILE = "interface_blacklist";
   public static final String RELPATH_MULTIPATH_QUERY_PREFIX = "multipath-query";
   public static final String RELPATH_NODE_BLACKLIST_FILE = "node_blacklist";

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/role/InferRoles.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/role/InferRoles.java
@@ -1,0 +1,246 @@
+package org.batfish.role;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.OptionalDouble;
+import java.util.Random;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.concurrent.Callable;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.batfish.common.BatfishException;
+import org.batfish.common.Pair;
+import org.batfish.common.plugin.IBatfish;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.Edge;
+import org.batfish.datamodel.NodeRoleSpecifier;
+import org.batfish.datamodel.RoleEdge;
+import org.batfish.datamodel.Topology;
+
+public class InferRoles implements Callable<NodeRoleSpecifier> {
+
+  private IBatfish _batfish;
+  private Map<String,Configuration> _configurations;
+  private List<String> _nodes;
+
+  // the node name that is used to infer a regex
+  private String _chosenNode;
+  // a tokenized version of _chosenNode
+  private List<Pair<String,InferRolesCharClass>> _tokens;
+  // the regex produced by generalizing from _tokens
+  private List<String> _regex;
+  // the list of nodes that match _regex
+  private List<String> _matchingNodes;
+
+  public InferRoles(List<String> nodes, Map<String, Configuration> configurations,
+      IBatfish batfish) {
+    _nodes = nodes;
+    _configurations = configurations;
+    _batfish = batfish;
+  }
+
+  // Node names are parsed into a sequence of alphanumeric strings and
+  // delimiters (strings of non-alphanumeric characters).
+  public enum InferRolesCharClass {
+    ALPHANUMERIC,
+    DELIMITER;
+
+    public static InferRolesCharClass charToCharClass(char c) {
+      if (Character.isAlphabetic(c) || Character.isDigit(c)) {
+        return InferRolesCharClass.ALPHANUMERIC;
+      } else {
+        return InferRolesCharClass.DELIMITER;
+      }
+    }
+
+    public String tokenToRegex(String s) {
+      switch (this) {
+      case ALPHANUMERIC:
+        return "\\p{Alnum}+";
+      case DELIMITER:
+        return Pattern.quote(s);
+      default:
+        throw new BatfishException("this case should be unreachable");
+      }
+    }
+  }
+
+  @Override
+  public NodeRoleSpecifier call() {
+
+    NodeRoleSpecifier result = new NodeRoleSpecifier();
+
+    int allNodesCount = _nodes.size();
+
+    if (allNodesCount == 0) {
+      return result;
+    }
+
+    boolean commonRegexFound = inferCommonRegex(_nodes);
+
+    if (!commonRegexFound) {
+      return result;
+    }
+
+
+    List<String> candidateRegexes = possibleRoleGroups();
+
+    int numCands = candidateRegexes.size();
+    if (numCands == 0) {
+      return result;
+    } else {
+      // choose the role group with the maximal "role score"
+      String roleRegex = candidateRegexes.get(0);
+      double maxRoleScore = computeRoleScore(roleRegex);
+      for (int i = 1; i < candidateRegexes.size(); i++) {
+        String cand = candidateRegexes.get(i);
+        double roleScore = computeRoleScore(cand);
+        if (roleScore > maxRoleScore) {
+          maxRoleScore = roleScore;
+          roleRegex = cand;
+        }
+      }
+      NodeRoleSpecifier roleSpecifier = regexToRoleSpecifier(roleRegex);
+      return roleSpecifier;
+    }
+  }
+
+  // try to identify a regex that most node names match
+  private boolean inferCommonRegex(List<String> nodes) {
+    for (int attempts = 0 ; attempts < 10; attempts++) {
+      // pick a random node name, in order to find one with a common pattern
+      _chosenNode = nodes.get(new Random().nextInt(nodes.size()));
+      _tokens = tokenizeName(_chosenNode);
+      _regex = _tokens
+          .stream()
+          .map((p) -> p.getSecond().tokenToRegex(p.getFirst()))
+          .collect(Collectors.toList());
+      Pattern p = Pattern.compile(String.join("", _regex));
+      _matchingNodes = nodes
+          .stream()
+          .filter((node) -> p.matcher(node).matches())
+          .collect(Collectors.toList());
+      // keep this regex if it matches more than half of the node names; otherwise try again
+      if ((double) _matchingNodes.size() / nodes.size() >= 0.5) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // a very simple lexer that tokenizes a name into a sequence of
+  // alphanumeric and non-alphanumeric strings
+  private List<Pair<String,InferRolesCharClass>> tokenizeName(String name) {
+    List<Pair<String,InferRolesCharClass>> pattern = new ArrayList<>();
+    char c = name.charAt(0);
+    InferRolesCharClass cc = InferRolesCharClass.charToCharClass(c);
+    StringBuffer curr = new StringBuffer();
+    curr.append(c);
+    for (int i = 1; i < name.length(); i++) {
+      c = name.charAt(i);
+      InferRolesCharClass currClass = InferRolesCharClass.charToCharClass(c);
+      if (currClass == cc) {
+        curr.append(c);
+      } else {
+        pattern.add(new Pair<>(new String(curr), cc));
+        curr = new StringBuffer();
+        cc = currClass;
+        curr.append(c);
+      }
+    }
+    pattern.add(new Pair<>(new String(curr), cc));
+    return pattern;
+  }
+
+
+  // If for every node name matching the identified regex,
+  // a particular alphanumeric token starts with one or more alphabetic characters,
+  // the string of initial alphabetic characters is considered a candidate for the role name.
+  // This method returns all such candidates, each represented as a regex
+  // with a single group indicating the role name.
+  private List<String> possibleRoleGroups() {
+    List<String> candidateRegexes = new ArrayList<>();
+    for (int i = 0; i < _tokens.size(); i++) {
+      if (_tokens.get(i).getSecond() == InferRolesCharClass.DELIMITER) {
+        continue;
+      }
+      List<String> regexCopy = new ArrayList<>(_regex);
+      regexCopy.set(i, "(\\p{Alpha}+)\\p{Alnum}*");
+      Pattern newp = Pattern.compile(String.join("", regexCopy));
+      boolean matchesAll = true;
+      for (String node : _matchingNodes) {
+        Matcher newm = newp.matcher(node);
+        if (!newm.matches()) {
+          matchesAll = false;
+          break;
+        }
+      }
+      if (matchesAll) {
+        candidateRegexes.add(String.join("", regexCopy));
+      }
+    }
+    return candidateRegexes;
+  }
+
+
+  // A regex's role score is computed by obtaining role-level edges under the assumption
+  // that the regex's group indeed represents each node's role, and then taking the negation
+  // of the average degree of each node in this role-level graph.  Intuitively, the "real"
+  // roles will have a smaller average degree, since the real roles will impose some
+  // topological structure on the graph.
+  private double computeRoleScore(String regex) {
+
+    Topology topology = _batfish.computeTopology(_configurations);
+
+    // produce a role-level topology
+    SortedSet<RoleEdge> roleEdges = new TreeSet<>();
+    Pattern p = Pattern.compile(regex);
+    for (Edge e : topology.getEdges()) {
+      String n1 = e.getNode1();
+      String n2 = e.getNode2();
+      Matcher m1 = p.matcher(n1);
+      Matcher m2 = p.matcher(n2);
+      if (m1.matches() && m2.matches()) {
+        try {
+          String role1 = m1.group(1);
+          String role2 = m2.group(1);
+          roleEdges.add(new RoleEdge(role1, role2));
+        } catch (IndexOutOfBoundsException exn) {
+          throw new BatfishException(
+              "Inferred role regex does not contain a group: \"" + p.pattern() + "\"", exn);
+        }
+      }
+    }
+
+    // compute the average degree of each role in the role-level topology,
+    // and use its negation as the role score of this candidate regex
+    Map<String, Integer> roleDegrees = new HashMap<>();
+    for (RoleEdge edge : roleEdges) {
+      String role = edge.getRole1();
+      roleDegrees.merge(role, 1, (currCount, one) -> currCount + one);
+    }
+    int numRoles = roleDegrees.size();
+    OptionalDouble averageDegree = roleDegrees.values()
+        .stream()
+        .mapToDouble((i) -> (double) i / numRoles)
+        .average();
+    if (averageDegree.isPresent()) {
+      return - averageDegree.getAsDouble();
+    } else {
+      return Double.NEGATIVE_INFINITY;
+    }
+  }
+
+  NodeRoleSpecifier regexToRoleSpecifier(String regex) {
+    List<String> regexes = new ArrayList<>();
+    regexes.add(regex);
+    NodeRoleSpecifier result = new NodeRoleSpecifier();
+    result.setRoleRegexes(regexes);
+    return result;
+  }
+
+}

--- a/projects/batfish/src/main/java/org/batfish/config/Settings.java
+++ b/projects/batfish/src/main/java/org/batfish/config/Settings.java
@@ -228,6 +228,8 @@ public final class Settings extends BaseSettings implements GrammarSettings {
 
     private EnvironmentSettings _environmentSettings;
 
+    private Path _inferredNodeRolesPath;
+
     private String _name;
 
     private Path _nodeRolesPath;
@@ -272,6 +274,10 @@ public final class Settings extends BaseSettings implements GrammarSettings {
 
     public EnvironmentSettings getEnvironmentSettings() {
       return _environmentSettings;
+    }
+
+    public Path getInferredNodeRolesPath() {
+      return _inferredNodeRolesPath;
     }
 
     public String getName() {
@@ -331,6 +337,10 @@ public final class Settings extends BaseSettings implements GrammarSettings {
 
     public void setEnvironmentSettings(EnvironmentSettings environmentSettings) {
       _environmentSettings = environmentSettings;
+    }
+
+    public void setInferredNodeRolesPath(Path inferredNodeRolesPath) {
+      _inferredNodeRolesPath = inferredNodeRolesPath;
     }
 
     public void setName(String name) {

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -163,6 +163,7 @@ import org.batfish.job.ParseVendorConfigurationResult;
 import org.batfish.representation.aws_vpcs.AwsVpcConfiguration;
 import org.batfish.representation.host.HostConfiguration;
 import org.batfish.representation.iptables.IptablesVendorConfiguration;
+import org.batfish.role.InferRoles;
 import org.batfish.vendor.VendorConfiguration;
 import org.batfish.z3.AclLine;
 import org.batfish.z3.AclReachabilityQuerySynthesizer;
@@ -214,6 +215,9 @@ public class Batfish extends PluginConsumer implements AutoCloseable, IBatfish {
     settings.setNodeRolesPath(
         testrigDir.resolve(
             Paths.get(BfConsts.RELPATH_TEST_RIG_DIR, BfConsts.RELPATH_NODE_ROLES_PATH)));
+    settings.setInferredNodeRolesPath(
+        testrigDir.resolve(
+            Paths.get(BfConsts.RELPATH_TEST_RIG_DIR, BfConsts.RELPATH_INFERRED_NODE_ROLES_PATH)));
     settings.setTopologyPath(testrigDir.resolve(BfConsts.RELPATH_TESTRIG_TOPOLOGY_PATH));
     if (envName != null) {
       envSettings.setName(envName);
@@ -1926,6 +1930,12 @@ public class Batfish extends PluginConsumer implements AutoCloseable, IBatfish {
     }
   }
 
+  private NodeRoleSpecifier inferNodeRoles(Map<String, Configuration> configurations) {
+    InferRoles ir =
+        new InferRoles(new ArrayList<>(configurations.keySet()), configurations, this);
+    return ir.call();
+  }
+
   private void initAnalysisQuestionPath(String analysisName, String questionName) {
     Path questionDir =
         _testrigSettings
@@ -3390,22 +3400,30 @@ public class Batfish extends PluginConsumer implements AutoCloseable, IBatfish {
     }
   }
 
+  /* Set the roles of each configuration.  Use an explicitly provided NodeRoleSpecifier
+     if one exists; otherwise use the results of our node-role inference.
+   */
   private void processNodeRoles(Map<String, Configuration> configurations) {
     TestrigSettings settings = _settings.getActiveTestrigSettings();
     Path nodeRolesPath = settings.getNodeRolesPath();
-    if (Files.exists(nodeRolesPath)) {
-      SortedMap<String, SortedSet<String>> nodeRoles =
-          parseNodeRoles(nodeRolesPath, configurations.keySet());
-      for (Entry<String, SortedSet<String>> nodeRolesEntry : nodeRoles.entrySet()) {
-        String hostname = nodeRolesEntry.getKey();
-        Configuration config = configurations.get(hostname);
-        if (config == null) {
-          throw new BatfishException(
-              "role set assigned to non-existent node: \"" + hostname + "\"");
-        }
-        SortedSet<String> roles = nodeRolesEntry.getValue();
-        config.setRoles(roles);
+    if (!Files.exists(nodeRolesPath)) {
+      nodeRolesPath = settings.getInferredNodeRolesPath();
+      if (!Files.exists(nodeRolesPath)) {
+        return;
       }
+    }
+
+    SortedMap<String, SortedSet<String>> nodeRoles =
+        parseNodeRoles(nodeRolesPath, configurations.keySet());
+    for (Entry<String, SortedSet<String>> nodeRolesEntry : nodeRoles.entrySet()) {
+      String hostname = nodeRolesEntry.getKey();
+      Configuration config = configurations.get(hostname);
+      if (config == null) {
+        throw new BatfishException(
+            "role set assigned to non-existent node: \"" + hostname + "\"");
+      }
+      SortedSet<String> roles = nodeRolesEntry.getValue();
+      config.setRoles(roles);
     }
   }
 
@@ -4023,6 +4041,9 @@ public class Batfish extends PluginConsumer implements AutoCloseable, IBatfish {
     Map<String, Configuration> configurations = getConfigurations(vendorConfigPath, answerElement);
     Topology topology = computeTopology(_testrigSettings.getTestRigPath(), configurations);
     serializeAsJson(_testrigSettings.getTopologyPath(), topology, "testrig topology");
+    NodeRoleSpecifier roleSpecifier = inferNodeRoles(configurations);
+    serializeAsJson(_testrigSettings.getInferredNodeRolesPath(), roleSpecifier,
+        "inferred node roles");
     serializeIndependentConfigs(configurations, outputPath);
     serializeObject(answerElement, _testrigSettings.getConvertAnswerPath());
     return answer;

--- a/projects/question/src/main/java/org/batfish/question/InferRolesQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/InferRolesQuestionPlugin.java
@@ -1,31 +1,21 @@
 package org.batfish.question;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.OptionalDouble;
-import java.util.Random;
 import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeSet;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import org.batfish.common.Answerer;
 import org.batfish.common.BatfishException;
-import org.batfish.common.Pair;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.common.util.CommonUtil;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.NodeRoleSpecifier;
-import org.batfish.datamodel.RoleEdge;
 import org.batfish.datamodel.answers.AnswerElement;
 import org.batfish.datamodel.questions.Question;
-import org.batfish.question.NeighborsQuestionPlugin.EdgeStyle;
-import org.batfish.question.NeighborsQuestionPlugin.NeighborsAnswerElement;
-import org.batfish.question.NeighborsQuestionPlugin.NeighborsQuestion;
+import org.batfish.role.InferRoles;
 
 public class InferRolesQuestionPlugin extends QuestionPlugin {
 
@@ -134,15 +124,6 @@ public class InferRolesQuestionPlugin extends QuestionPlugin {
 
   public static class InferRolesAnswerer extends Answerer {
 
-    // the node name that is used to infer a regex
-    String _chosenNode;
-    // a tokenized version of _chosenNode
-    List<Pair<String,InferRolesCharClass>> _tokens;
-    // the regex produced by generalizing from _tokens
-    List<String> _regex;
-    // the list of nodes that match _regex
-    List<String> _matchingNodes;
-
     public InferRolesAnswerer(Question question, IBatfish batfish) {
       super(question, batfish);
     }
@@ -164,160 +145,21 @@ public class InferRolesQuestionPlugin extends QuestionPlugin {
       answerElement.setAllNodes(nodes);
       answerElement.setAllNodesCount(allNodesCount);
 
-      if (allNodesCount == 0) {
-        return answerElement;
+      NodeRoleSpecifier roleSpecifier =
+          new InferRoles(nodes, configurations, _batfish).call();
+      answerElement.setRoleSpecifier(roleSpecifier);
+
+      SortedMap<String, SortedSet<String>> roleNodesMap =
+          roleSpecifier.createRoleNodesMap(new TreeSet<>(nodes));
+      SortedSet<String> matchingNodes = new TreeSet<>();
+      for (SortedSet<String> nodeSet : roleNodesMap.values()) {
+        matchingNodes.addAll(nodeSet);
       }
 
-      boolean commonRegexFound = inferCommonRegex(nodes);
-
-      if (!commonRegexFound) {
-        return answerElement;
-      }
-
-
-      List<String> candidateRegexes = possibleRoleGroups();
-
-      int numCands = candidateRegexes.size();
-      if (numCands == 0) {
-        return answerElement;
-      } else {
-        // choose the role group with the maximal "role score"
-        String roleRegex = null;
-        double maxRoleScore = Double.NEGATIVE_INFINITY;
-        for (String cand : candidateRegexes) {
-          double roleScore = computeRoleScore(cand);
-          if (roleScore > maxRoleScore) {
-            maxRoleScore = roleScore;
-            roleRegex = cand;
-          }
-        }
-        NodeRoleSpecifier roleSpecifier = regexToRoleSpecifier(roleRegex);
-        answerElement.setRoleSpecifier(roleSpecifier);
-        answerElement.setMatchingNodesCount(_matchingNodes.size());
-        return answerElement;
+      answerElement.setMatchingNodesCount(matchingNodes.size());
+      return answerElement;
       }
     }
-
-    // try to identify a regex that most node names match
-    private boolean inferCommonRegex(List<String> nodes) {
-      for (int attempts = 0 ; attempts < 10; attempts++) {
-        // pick a random node name, in order to find one with a common pattern
-        _chosenNode = nodes.get(new Random().nextInt(nodes.size()));
-        _tokens = tokenizeName(_chosenNode);
-        _regex = _tokens
-            .stream()
-            .map((p) -> p.getSecond().tokenToRegex(p.getFirst()))
-            .collect(Collectors.toList());
-        Pattern p = Pattern.compile(String.join("", _regex));
-        _matchingNodes = nodes
-            .stream()
-            .filter((node) -> p.matcher(node).matches())
-            .collect(Collectors.toList());
-        // keep this regex if it matches more than half of the node names; otherwise try again
-        if ((double) _matchingNodes.size() / nodes.size() >= 0.5) {
-          return true;
-        }
-      }
-      return false;
-    }
-
-    // a very simple lexer that tokenizes a name into a sequence of
-    // alphanumeric and non-alphanumeric strings
-    private List<Pair<String,InferRolesCharClass>> tokenizeName(String name) {
-      List<Pair<String,InferRolesCharClass>> pattern = new ArrayList<>();
-      char c = name.charAt(0);
-      InferRolesCharClass cc = InferRolesCharClass.charToCharClass(c);
-      StringBuffer curr = new StringBuffer();
-      curr.append(c);
-      for (int i = 1; i < name.length(); i++) {
-        c = name.charAt(i);
-        InferRolesCharClass currClass = InferRolesCharClass.charToCharClass(c);
-        if (currClass == cc) {
-          curr.append(c);
-        } else {
-          pattern.add(new Pair<>(new String(curr), cc));
-          curr = new StringBuffer();
-          cc = currClass;
-          curr.append(c);
-        }
-      }
-      pattern.add(new Pair<>(new String(curr), cc));
-      return pattern;
-    }
-
-
-    // If for every node name matching the identified regex,
-    // a particular alphanumeric token starts with one or more alphabetic characters,
-    // the string of initial alphabetic characters is considered a candidate for the role name.
-    // This method returns all such candidates, each represented as a regex
-    // with a single group indicating the role name.
-    private List<String> possibleRoleGroups() {
-      List<String> candidateRegexes = new ArrayList<>();
-      for (int i = 0; i < _tokens.size(); i++) {
-        if (_tokens.get(i).getSecond() == InferRolesCharClass.DELIMITER) {
-          continue;
-        }
-        List<String> regexCopy = new ArrayList<>(_regex);
-        regexCopy.set(i, "(\\p{Alpha}+)\\p{Alnum}*");
-        Pattern newp = Pattern.compile(String.join("", regexCopy));
-        boolean matchesAll = true;
-        for (String node : _matchingNodes) {
-          Matcher newm = newp.matcher(node);
-          if (!newm.matches()) {
-            matchesAll = false;
-            break;
-          }
-        }
-        if (matchesAll) {
-          candidateRegexes.add(String.join("", regexCopy));
-        }
-      }
-      return candidateRegexes;
-    }
-
-
-    // A regex's role score is computed by obtaining role-level edges under the assumption
-    // that the regex's group indeed represents each node's role, and then taking the negation
-    // of the average degree of each node in this role-level graph.  Intuitively, the "real"
-    // roles will have a smaller average degree, since the real roles will impose some
-    // topological structure on the graph.
-    double computeRoleScore(String regex) {
-      InferRolesQuestion irq = (InferRolesQuestion) _question;
-      NeighborsQuestion nq = new NeighborsQuestion();
-      nq.setNode1Regex(irq.getNodeRegex());
-      nq.setNode2Regex(irq.getNodeRegex());
-      nq.setStyle(EdgeStyle.ROLE);
-      nq.setRoleSpecifier(regexToRoleSpecifier(regex));
-
-      NeighborsAnswerElement ae =
-          new NeighborsQuestionPlugin.NeighborsAnswerer(nq, _batfish).answer();
-      SortedSet<RoleEdge> edges = ae.getRoleLanNeighbors();
-      Map<String, Integer> roleDegrees = new HashMap<>();
-      for (RoleEdge edge : edges) {
-        String role = edge.getRole1();
-        roleDegrees.merge(role, 1, (currCount, one) -> currCount + one);
-      }
-      int numRoles = roleDegrees.size();
-      OptionalDouble averageDegree = roleDegrees.values()
-          .stream()
-          .mapToDouble((i) -> (double) i / numRoles)
-          .average();
-      if (averageDegree.isPresent()) {
-          return - averageDegree.getAsDouble();
-      } else {
-        return Double.NEGATIVE_INFINITY;
-      }
-    }
-
-    NodeRoleSpecifier regexToRoleSpecifier(String regex) {
-      List<String> regexes = new ArrayList<>();
-      regexes.add(regex);
-      NodeRoleSpecifier result = new NodeRoleSpecifier();
-      result.setRoleRegexes(regexes);
-      return result;
-    }
-
-  }
 
   // <question_page_comment>
   /**

--- a/test_rigs/example2/node_roles.json
+++ b/test_rigs/example2/node_roles.json
@@ -1,3 +1,0 @@
-{"roleMap": { "host": ["dc1-host-01-01", "dc1-host-01-02"] },
- "roleRegexes": ["[a-z\\d]+\\-([a-z]+)\\-\\d+"]
-}

--- a/tests/basic/commands
+++ b/tests/basic/commands
@@ -40,6 +40,7 @@ test tests/basic/outliers.ref get outliers
 # example2 testrig
 test tests/basic/init-example2.ref init-testrig test_rigs/example2
 test tests/basic/inferRoles.ref get inferRoles
+test tests/basic/roleNeighbors2.ref get neighbors neighborTypes=["ebgp","ibgp","ospf","lan"], style="role"
 
 # disable-as-reuse
 test tests/basic/init-dc-as-reuse.ref init-testrig test_rigs/dc-as-reuse

--- a/tests/basic/nodes-unit-tests.ref
+++ b/tests/basic/nodes-unit-tests.ref
@@ -56,6 +56,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "aaa"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "aaa" : {
@@ -126,6 +129,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "access"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "access_list"
@@ -142,6 +148,9 @@
           "configurationFormat" : "CISCO_IOS",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "address"
+          ],
           "route6FilterLists" : {
             "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
               "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
@@ -622,6 +631,9 @@
           "configurationFormat" : "ARISTA",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "arista"
+          ],
           "route6FilterLists" : {
             "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
               "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
@@ -715,6 +727,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "arista"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "arista_logging",
@@ -734,6 +749,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "arista"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "defaultSwitchportMode" : "NONE",
@@ -751,6 +769,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "arista"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "enableSecret" : "a450caf35b93cba6024429006d971e68a18697468c1999449b1240b07fb26a04",
@@ -880,6 +901,9 @@
               ]
             }
           },
+          "roles" : [
+            "asa"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "asa_acl"
@@ -896,6 +920,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "asa"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "asa_ssh"
@@ -939,6 +966,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "banner"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "banners" : {
@@ -1315,6 +1345,9 @@
           "configurationFormat" : "CISCO_IOS",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "bgp"
+          ],
           "route6FilterLists" : {
             "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
               "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
@@ -1444,6 +1477,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "bgp"
+          ],
           "route6FilterLists" : {
             "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
               "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
@@ -1662,6 +1698,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "aaa" : {
@@ -1998,6 +2037,9 @@
               "name" : "standard"
             }
           },
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_acl"
@@ -2073,6 +2115,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_authentication"
@@ -2089,6 +2134,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "route6FilterLists" : {
             "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
               "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
@@ -2148,6 +2196,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_callhome",
@@ -2181,6 +2232,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_controller"
@@ -2197,6 +2251,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_crypto"
@@ -2213,6 +2270,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_dhcp"
@@ -2281,6 +2341,9 @@
           ],
           "dnsSourceInterface" : "Loopback666",
           "domainName" : "my.domain.name",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_domain"
@@ -2297,6 +2360,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_dot11"
@@ -2313,6 +2379,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_dot1x"
@@ -2329,6 +2398,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_dspfarm"
@@ -2475,6 +2547,9 @@
               ]
             }
           },
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_eigrp"
@@ -2491,6 +2566,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "enableSecret" : "41fb440a375eb13f1ca17ea2d14b0d4c73c37c32d764f9a34584a62fe8837ca8",
@@ -2508,6 +2586,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_flow"
@@ -2524,6 +2605,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_hardware"
@@ -2563,6 +2647,9 @@
               "vrf" : "default"
             }
           },
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_hsrp"
@@ -2973,6 +3060,9 @@
               "vrf" : "default"
             }
           },
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_interface"
@@ -3009,6 +3099,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_ip"
@@ -3139,6 +3232,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_ipsla"
@@ -3155,6 +3251,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_ipv6"
@@ -3514,6 +3613,9 @@
               "vrf" : "default"
             }
           },
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_isis"
@@ -3540,6 +3642,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_line",
@@ -4054,6 +4159,9 @@
             "dead:beef::1"
           ],
           "loggingSourceInterface" : "Management0",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_logging",
@@ -4116,6 +4224,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "aaa" : {
@@ -4149,6 +4260,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_mpls"
@@ -4165,6 +4279,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_multicast"
@@ -4186,6 +4303,9 @@
             "2.3.4.5"
           ],
           "ntpSourceInterface" : "Loopback0",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_ntp",
@@ -4271,6 +4391,9 @@
               "vrf" : "default"
             }
           },
+          "roles" : [
+            "cisco"
+          ],
           "routingPolicies" : {
             "~OSPF_EXPORT_POLICY:default~" : {
               "name" : "~OSPF_EXPORT_POLICY:default~",
@@ -4336,6 +4459,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_pim"
@@ -4352,6 +4478,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_platform"
@@ -4368,6 +4497,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_privilege"
@@ -4384,6 +4516,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_qos"
@@ -4416,6 +4551,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_redundancy"
@@ -4432,6 +4570,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_role"
@@ -4559,6 +4700,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_sccp"
@@ -4575,6 +4719,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "snmpSourceInterface" : "Loopback0",
           "snmpTrapServers" : [
             "10.1.2.3"
@@ -4715,6 +4862,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_ssh",
@@ -4734,6 +4884,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_stcapp"
@@ -4814,6 +4967,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "defaultSwitchportMode" : "NONE",
@@ -4831,6 +4987,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "tacacsServers" : [
             "1.2.3.4",
             "1.example.com",
@@ -4864,6 +5023,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_track"
@@ -4880,6 +5042,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_username",
@@ -4935,6 +5100,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_vdc"
@@ -4951,6 +5119,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_vlan"
@@ -4983,6 +5154,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_vpdn"
@@ -4999,6 +5173,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_vpn"
@@ -5015,6 +5192,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_vrf"
@@ -5044,6 +5224,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_vrrp"
@@ -5060,6 +5243,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_webvpn"
@@ -5076,6 +5262,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "cisco"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "cisco_wsma"
@@ -5452,6 +5641,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "community"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "community_set"
@@ -5617,6 +5809,9 @@
           "configurationFormat" : "FOUNDRY",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "foundry"
+          ],
           "route6FilterLists" : {
             "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
               "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
@@ -5699,6 +5894,9 @@
               "vrf" : "default"
             }
           },
+          "roles" : [
+            "foundry"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "foundry_interface"
@@ -5718,6 +5916,9 @@
           "configurationFormat" : "FOUNDRY",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "foundry"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "foundry_misc",
@@ -6308,6 +6509,9 @@
               "vrf" : "default"
             }
           },
+          "roles" : [
+            "interface"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "interface_exit"
@@ -6414,6 +6618,9 @@
               "vrf" : "default"
             }
           },
+          "roles" : [
+            "interface"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "interface_name"
@@ -6464,6 +6671,9 @@
               "vrf" : "default"
             }
           },
+          "roles" : [
+            "interface"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "interface_sdr"
@@ -6483,6 +6693,9 @@
           "configurationFormat" : "CISCO_IOS",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "ios"
+          ],
           "route6FilterLists" : {
             "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
               "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
@@ -7493,6 +7706,9 @@
           "configurationFormat" : "FLAT_JUNIPER",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "juniper"
+          ],
           "routingPolicies" : {
             "~DEFAULT_BGP_EXPORT_POLICY~" : {
               "name" : "~DEFAULT_BGP_EXPORT_POLICY~",
@@ -7775,6 +7991,9 @@
               ]
             }
           },
+          "roles" : [
+            "juniper"
+          ],
           "vendorFamily" : {
             "juniper" : { }
           },
@@ -7967,6 +8186,9 @@
               "vrf" : "default"
             }
           },
+          "roles" : [
+            "juniper"
+          ],
           "vendorFamily" : {
             "juniper" : { }
           },
@@ -7988,6 +8210,9 @@
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
           "domainName" : "my.domain.name",
+          "roles" : [
+            "juniper"
+          ],
           "vendorFamily" : {
             "juniper" : { }
           },
@@ -8006,6 +8231,9 @@
             "1.2.3.4",
             "2.3.4.5"
           ],
+          "roles" : [
+            "juniper"
+          ],
           "vendorFamily" : {
             "juniper" : { }
           },
@@ -8020,6 +8248,9 @@
           "configurationFormat" : "FLAT_JUNIPER",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "juniper"
+          ],
           "tacacsServers" : [
             "1.2.3.4",
             "1.2.3.5"
@@ -8100,6 +8331,9 @@
               "vrf" : "default"
             }
           },
+          "roles" : [
+            "juniper"
+          ],
           "vendorFamily" : {
             "juniper" : { }
           },
@@ -8132,6 +8366,9 @@
           "configurationFormat" : "FLAT_JUNIPER",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "juniper"
+          ],
           "vendorFamily" : {
             "juniper" : { }
           },
@@ -8169,6 +8406,9 @@
           "loggingServers" : [
             "1.2.3.4"
           ],
+          "roles" : [
+            "juniper"
+          ],
           "vendorFamily" : {
             "juniper" : { }
           },
@@ -8183,6 +8423,9 @@
           "configurationFormat" : "FLAT_JUNIPER",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "juniper"
+          ],
           "vendorFamily" : {
             "juniper" : { }
           },
@@ -8197,6 +8440,9 @@
           "configurationFormat" : "FLAT_JUNIPER",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "juniper"
+          ],
           "tacacsServers" : [
             "1.2.3.4",
             "5.6.7.8"
@@ -8562,6 +8808,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "neighbor"
+          ],
           "route6FilterLists" : {
             "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
               "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
@@ -8720,6 +8969,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "neighbor"
+          ],
           "route6FilterLists" : {
             "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
               "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
@@ -8995,6 +9247,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "neighbor"
+          ],
           "route6FilterLists" : {
             "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
               "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
@@ -9220,6 +9475,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "nexus"
+          ],
           "route6FilterLists" : {
             "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
               "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~",
@@ -9402,6 +9660,9 @@
             "1.2.3.4",
             "10.1.2.3"
           ],
+          "roles" : [
+            "nexus"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "nexus_ntp",
@@ -9432,6 +9693,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "nexus"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "nexus_ssh"
@@ -9666,6 +9930,9 @@
               "name" : "standard"
             }
           },
+          "roles" : [
+            "nxos"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "nxos_acl"
@@ -9698,6 +9965,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "peer"
+          ],
           "route6FilterLists" : {
             "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
               "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
@@ -10182,6 +10452,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "pim"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "pim_snooping"
@@ -13432,6 +13705,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "router"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "router_msdp"
@@ -13556,6 +13832,9 @@
               "vrf" : "default"
             }
           },
+          "roles" : [
+            "switchport"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "switchport_range"
@@ -13942,6 +14221,9 @@
           "configurationFormat" : "CISCO_NX",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "underscore"
+          ],
           "routingPolicies" : {
             "JKL_MNO_PQR" : {
               "name" : "JKL_MNO_PQR",
@@ -14034,6 +14316,9 @@
               "vrf" : "default"
             }
           },
+          "roles" : [
+            "variables"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "variables_dos"
@@ -14176,6 +14461,9 @@
           "configurationFormat" : "CISCO_IOS",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
+          "roles" : [
+            "vrf"
+          ],
           "vendorFamily" : {
             "cisco" : {
               "hostname" : "vrf_context"

--- a/tests/basic/roleNeighbors2.ref
+++ b/tests/basic/roleNeighbors2.ref
@@ -1,0 +1,105 @@
+{
+  "answerElements" : [
+    {
+      "class" : "org.batfish.question.NeighborsQuestionPlugin$NeighborsAnswerElement",
+      "roleEbgpNeighbors" : [
+        {
+          "role1" : "border",
+          "role2" : "border"
+        },
+        {
+          "role1" : "leaf",
+          "role2" : "spine"
+        },
+        {
+          "role1" : "spine",
+          "role2" : "leaf"
+        }
+      ],
+      "roleIbgpNeighbors" : [
+        {
+          "role1" : "border",
+          "role2" : "core"
+        },
+        {
+          "role1" : "core",
+          "role2" : "border"
+        },
+        {
+          "role1" : "core",
+          "role2" : "spine"
+        },
+        {
+          "role1" : "spine",
+          "role2" : "core"
+        }
+      ],
+      "roleLanNeighbors" : [
+        {
+          "role1" : "border",
+          "role2" : "border"
+        },
+        {
+          "role1" : "border",
+          "role2" : "core"
+        },
+        {
+          "role1" : "core",
+          "role2" : "border"
+        },
+        {
+          "role1" : "core",
+          "role2" : "core"
+        },
+        {
+          "role1" : "core",
+          "role2" : "spine"
+        },
+        {
+          "role1" : "leaf",
+          "role2" : "spine"
+        },
+        {
+          "role1" : "spine",
+          "role2" : "core"
+        },
+        {
+          "role1" : "spine",
+          "role2" : "leaf"
+        }
+      ],
+      "roleOspfNeighbors" : [
+        {
+          "role1" : "border",
+          "role2" : "core"
+        },
+        {
+          "role1" : "core",
+          "role2" : "border"
+        },
+        {
+          "role1" : "core",
+          "role2" : "spine"
+        },
+        {
+          "role1" : "spine",
+          "role2" : "core"
+        }
+      ]
+    }
+  ],
+  "question" : {
+    "class" : "org.batfish.question.NeighborsQuestionPlugin$NeighborsQuestion",
+    "differential" : false,
+    "neighborTypes" : [
+      "ebgp",
+      "ibgp",
+      "lan",
+      "ospf"
+    ],
+    "node1Regex" : ".*",
+    "node2Regex" : ".*",
+    "style" : "role"
+  },
+  "status" : "SUCCESS"
+}

--- a/tests/ui-focused/list-testrigs1.ref
+++ b/tests/ui-focused/list-testrigs1.ref
@@ -21,4 +21,5 @@ iptables/
   host1.iptables
   host2.iptables
 node_roles.json
+node_roles_inferred.json
 


### PR DESCRIPTION
Role inference is performed when a testrig is initialized.  The produced NodeRoleSpecifier is written to the file node_roles_inferred.json.  When roles are required to answer a question, explicitly provided node roles (in node_roles.json) are used if available, and otherwise the inferred roles are used.