### PR TITLE
refactor variables with name (xxx)_VAR that are used in JsonProperty

### DIFF
--- a/projects/batfish-client/src/main/java/org/batfish/client/Client.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/Client.java
@@ -522,7 +522,7 @@ public class Client extends AbstractClient implements IClient {
     }
     JSONObject instanceJson;
     try {
-      instanceJson = questionJson.getJSONObject(BfConsts.INSTANCE_VAR);
+      instanceJson = questionJson.getJSONObject(BfConsts.PROP_INSTANCE);
     } catch (JSONException e) {
       throw new BatfishException("Question is missing instance data", e);
     }
@@ -543,7 +543,7 @@ public class Client extends AbstractClient implements IClient {
     try {
       modifiedInstanceDataStr = mapper.writeValueAsString(instanceData);
       JSONObject modifiedInstanceData = new JSONObject(modifiedInstanceDataStr);
-      questionJson.put(BfConsts.INSTANCE_VAR, modifiedInstanceData);
+      questionJson.put(BfConsts.PROP_INSTANCE, modifiedInstanceData);
     } catch (JSONException | JsonProcessingException e) {
       throw new BatfishException("Could not process modified instance data", e);
     }
@@ -552,8 +552,8 @@ public class Client extends AbstractClient implements IClient {
     // check whether question is valid modulo instance data
     try {
       questionJsonDifferential =
-          questionJson.has(BfConsts.DIFFERENTIAL_VAR)
-              && questionJson.getBoolean(BfConsts.DIFFERENTIAL_VAR);
+          questionJson.has(BfConsts.PROP_DIFFERENTIAL)
+              && questionJson.getBoolean(BfConsts.PROP_DIFFERENTIAL);
     } catch (JSONException e) {
       throw new BatfishException("Could not find whether question is explicitly differential", e);
     }
@@ -1756,8 +1756,8 @@ public class Client extends AbstractClient implements IClient {
     String questionText = CommonUtil.readFile(file);
     try {
       JSONObject questionObj = new JSONObject(questionText);
-      if (questionObj.has(BfConsts.INSTANCE_VAR) && !questionObj.isNull(BfConsts.INSTANCE_VAR)) {
-        JSONObject instanceDataObj = questionObj.getJSONObject(BfConsts.INSTANCE_VAR);
+      if (questionObj.has(BfConsts.PROP_INSTANCE) && !questionObj.isNull(BfConsts.PROP_INSTANCE)) {
+        JSONObject instanceDataObj = questionObj.getJSONObject(BfConsts.PROP_INSTANCE);
         String instanceDataStr = instanceDataObj.toString();
         BatfishObjectMapper mapper = new BatfishObjectMapper(getCurrentClassLoader());
         InstanceData instanceData =

--- a/projects/batfish-client/src/main/java/org/batfish/client/answer/LoadQuestionAnswerElement.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/answer/LoadQuestionAnswerElement.java
@@ -8,11 +8,11 @@ import org.batfish.datamodel.answers.AnswerElement;
 
 public class LoadQuestionAnswerElement implements AnswerElement {
 
-  private static final String ADDED_VAR = "added";
+  private static final String PROP_ADDED = "added";
 
-  private static final String NUM_LOADED_VAR = "numLoaded";
+  private static final String PROP_NUM_LOADED = "numLoaded";
 
-  private static final String REPLACED_VAR = "replaced";
+  private static final String PROP_REPLACED = "replaced";
 
   private SortedSet<String> _added;
 
@@ -26,17 +26,17 @@ public class LoadQuestionAnswerElement implements AnswerElement {
     _replaced = new TreeSet<>();
   }
 
-  @JsonProperty(ADDED_VAR)
+  @JsonProperty(PROP_ADDED)
   public SortedSet<String> getAdded() {
     return _added;
   }
 
-  @JsonProperty(NUM_LOADED_VAR)
+  @JsonProperty(PROP_NUM_LOADED)
   public int getNumLoaded() {
     return _numLoaded;
   }
 
-  @JsonProperty(REPLACED_VAR)
+  @JsonProperty(PROP_REPLACED)
   public SortedSet<String> getReplaced() {
     return _replaced;
   }
@@ -55,17 +55,17 @@ public class LoadQuestionAnswerElement implements AnswerElement {
     }
   }
 
-  @JsonProperty(ADDED_VAR)
+  @JsonProperty(PROP_ADDED)
   public void setAdded(SortedSet<String> added) {
     _added = added;
   }
 
-  @JsonProperty(NUM_LOADED_VAR)
+  @JsonProperty(PROP_NUM_LOADED)
   public void setNumLoaded(int numLoaded) {
     _numLoaded = numLoaded;
   }
 
-  @JsonProperty(REPLACED_VAR)
+  @JsonProperty(PROP_REPLACED)
   public void setReplaced(SortedSet<String> replaced) {
     _replaced = replaced;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/BatfishException.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/BatfishException.java
@@ -19,7 +19,7 @@ public class BatfishException extends RuntimeException {
 
   public static class BatfishStackTrace implements Serializable, AnswerElement {
 
-    private static final String LINES_VAR = "answer";
+    private static final String PROP_LINES = "answer";
 
     /** */
     private static final long serialVersionUID = 1L;
@@ -35,7 +35,7 @@ public class BatfishException extends RuntimeException {
     }
 
     @JsonCreator
-    public BatfishStackTrace(@JsonProperty(LINES_VAR) List<String> lines) {
+    public BatfishStackTrace(@JsonProperty(PROP_LINES) List<String> lines) {
       _lines = lines;
       _exception = null;
     }
@@ -45,7 +45,7 @@ public class BatfishException extends RuntimeException {
       return _exception;
     }
 
-    @JsonProperty(LINES_VAR)
+    @JsonProperty(PROP_LINES)
     public List<String> getLineMap() {
       return _lines;
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
@@ -30,8 +30,8 @@ public class BfConsts {
   /*
    * JSON key names
    */
-  public static final String ALLOWED_VALUES_VAR = "allowedValues";
-  public static final String ANSWER_ELEMENTS_VAR = "answerElements";
+  public static final String PROP_ALLOWED_VALUES = "allowedValues";
+  public static final String PROP_ANSWER_ELEMENTS = "answerElements";
   public static final String ARG_ANALYSIS_NAME = "analysisname";
   public static final String ARG_ANSWER_JSON_PATH = "answerjsonpath";
   public static final String ARG_BLOCK_NAMES = "blocknames";
@@ -81,22 +81,22 @@ public class BfConsts {
   public static final String COMMAND_QUERY = "query";
   public static final String COMMAND_REPORT = "report";
 
-  public static final String DESCRIPTION_VAR = "description";
-  public static final String DIFFERENTIAL_VAR = "differential";
-  public static final String INNER_QUESTION_VAR = "innerQuestion";
-  public static final String INSTANCE_NAME_VAR = "instanceName";
-  public static final String INSTANCE_VAR = "instance";
+  public static final String PROP_DESCRIPTION = "description";
+  public static final String PROP_DIFFERENTIAL = "differential";
+  public static final String PROP_INNER_QUESTION = "innerQuestion";
+  public static final String PROP_INSTANCE_NAME = "instanceName";
+  public static final String PROP_INSTANCE = "instance";
   public static final String KEY_BGP_ANNOUNCEMENTS = "Announcements";
-  public static final String LONG_DESCRIPTION_VAR = "longDescription";
-  public static final String MIN_ELEMENTS_VAR = "minElements";
-  public static final String MIN_LENGTH_VAR = "minLength";
-  public static final String OPTIONAL_VAR = "optional";
+  public static final String PROP_LONG_DESCRIPTION = "longDescription";
+  public static final String PROP_MIN_ELEMENTS = "minElements";
+  public static final String PROP_MIN_LENGTH = "minLength";
+  public static final String PROP_OPTIONAL = "optional";
   public static final String PROP_ALLINONE_PROPERTIES_PATH = "batfishAllinonePropertiesPath";
   public static final String PROP_BATFISH_PROPERTIES_PATH = "batfishBatfishPropertiesPath";
   public static final String PROP_CLIENT_PROPERTIES_PATH = "batfishClientPropertiesPath";
   public static final String PROP_COORDINATOR_PROPERTIES_PATH = "batfishCoordinatorPropertiesPath";
   public static final String PROP_QUESTION_PLUGIN_DIR = "batfishQuestionPluginDir";
-  public static final String QUESTION_VAR = "question";
+  public static final String PROP_QUESTION = "question";
   public static final String RELPATH_ANALYSES_DIR = "analyses";
   public static final String RELPATH_ANALYSIS_FILE = "analysis";
   public static final String RELPATH_ANSWER_HTML = "answer.html";
@@ -149,7 +149,7 @@ public class BfConsts {
   public static final String RELPATH_VENDOR_SPECIFIC_CONFIG_DIR = "vendor";
 
   public static final String RELPATH_Z3_DATA_PLANE_FILE = "dataplane.smt2";
-  public static final String STATUS_VAR = "status";
+  public static final String PROP_STATUS = "status";
   public static final String SUFFIX_ANSWER_JSON_FILE = ".json";
   public static final String SUFFIX_LOG_FILE = ".log";
   public static final String SVC_BASE_RSC = "/batfishservice";
@@ -161,8 +161,8 @@ public class BfConsts {
   public static final String SVC_SUCCESS_KEY = "success";
   public static final String SVC_TASK_KEY = "task";
   public static final String SVC_TASKID_KEY = "taskid";
-  public static final String TAGS_VAR = "tags";
-  public static final String TYPE_VAR = "type";
-  public static final String VALUE_VAR = "value";
-  public static final String VARIABLES_VAR = "variables";
+  public static final String PROP_TAGS = "tags";
+  public static final String PROP_TYPE = "type";
+  public static final String PROP_VALUE = "value";
+  public static final String PROP_VARIABLES = "variables";
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/Container.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/Container.java
@@ -8,9 +8,9 @@ import java.util.Objects;
 import java.util.SortedSet;
 
 public final class Container {
-  private static final String NAME_VAR = "name";
-  private static final String TESTRIGS_VAR = "testrigs";
-  private static final String ANALYSIS_VAR = "analysis";
+  private static final String PROP_NAME = "name";
+  private static final String PROP_TESTRIGS = "testrigs";
+  private static final String PROP_ANALYSIS = "analysis";
 
   private String _name;
   private SortedSet<String> _testrigs;
@@ -18,7 +18,8 @@ public final class Container {
 
   @JsonCreator
   public static Container of(
-      @JsonProperty(NAME_VAR) String name, @JsonProperty(TESTRIGS_VAR) SortedSet<String> testrigs) {
+      @JsonProperty(PROP_NAME) String name,
+      @JsonProperty(PROP_TESTRIGS) SortedSet<String> testrigs) {
     return new Container(name, testrigs);
   }
 
@@ -27,32 +28,32 @@ public final class Container {
     this._testrigs = testrigs;
   }
 
-  @JsonProperty(NAME_VAR)
+  @JsonProperty(PROP_NAME)
   public String getName() {
     return _name;
   }
 
-  @JsonProperty(TESTRIGS_VAR)
+  @JsonProperty(PROP_TESTRIGS)
   public SortedSet<String> getTestrigs() {
     return _testrigs;
   }
 
-  @JsonProperty(ANALYSIS_VAR)
+  @JsonProperty(PROP_ANALYSIS)
   public Path getAnalysis() {
     return _analysis;
   }
 
-  @JsonProperty(NAME_VAR)
+  @JsonProperty(PROP_NAME)
   public void setName(String name) {
     _name = name;
   }
 
-  @JsonProperty(TESTRIGS_VAR)
+  @JsonProperty(PROP_TESTRIGS)
   public void setTestrigs(SortedSet<String> testrigs) {
     _testrigs = testrigs;
   }
 
-  @JsonProperty(ANALYSIS_VAR)
+  @JsonProperty(PROP_ANALYSIS)
   public void setAnalysis(Path analysis) {
     _analysis = analysis;
   }
@@ -60,8 +61,8 @@ public final class Container {
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(Container.class)
-        .add(NAME_VAR, _name)
-        .add(TESTRIGS_VAR, _testrigs)
+        .add(PROP_NAME, _name)
+        .add(PROP_TESTRIGS, _testrigs)
         .toString();
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/Directory.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/Directory.java
@@ -40,7 +40,7 @@ public class Directory extends ComparableStructure<String> {
   }
 
   @JsonCreator
-  public Directory(@JsonProperty(NAME_VAR) String name) {
+  public Directory(@JsonProperty(PROP_NAME) String name) {
     super(name);
     _directories = new TreeSet<>();
     _files = new TreeSet<>();

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/Task.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/Task.java
@@ -15,13 +15,13 @@ public class Task {
 
   public static class Batch {
 
-    private static final String COMPLETED_VAR = "completed";
+    private static final String PROP_COMPLETED = "completed";
 
-    private static final String DESCRIPTION_VAR = "description";
+    private static final String PROP_DESCRIPTION = "description";
 
-    private static final String SIZE_VAR = "size";
+    private static final String PROP_SIZE = "size";
 
-    private static final String START_DATE_VAR = "startDate";
+    private static final String PROP_START_DATE = "startDate";
 
     private AtomicInteger _completed;
 
@@ -36,42 +36,42 @@ public class Task {
       _completed = new AtomicInteger();
     }
 
-    @JsonProperty(COMPLETED_VAR)
+    @JsonProperty(PROP_COMPLETED)
     public AtomicInteger getCompleted() {
       return _completed;
     }
 
-    @JsonProperty(DESCRIPTION_VAR)
+    @JsonProperty(PROP_DESCRIPTION)
     public String getDescription() {
       return _description;
     }
 
-    @JsonProperty(SIZE_VAR)
+    @JsonProperty(PROP_SIZE)
     public int getSize() {
       return _size;
     }
 
-    @JsonProperty(START_DATE_VAR)
+    @JsonProperty(PROP_START_DATE)
     public Date getStartDate() {
       return _startDate;
     }
 
-    @JsonProperty(COMPLETED_VAR)
+    @JsonProperty(PROP_COMPLETED)
     private void setCompleted(AtomicInteger completed) {
       _completed = completed;
     }
 
-    @JsonProperty(DESCRIPTION_VAR)
+    @JsonProperty(PROP_DESCRIPTION)
     public void setDescription(String description) {
       _description = description;
     }
 
-    @JsonProperty(SIZE_VAR)
+    @JsonProperty(PROP_SIZE)
     public void setSize(int size) {
       _size = size;
     }
 
-    @JsonProperty(START_DATE_VAR)
+    @JsonProperty(PROP_START_DATE)
     public void setStartDate(Date startDate) {
       _startDate = startDate;
     }
@@ -87,13 +87,13 @@ public class Task {
     }
   }
 
-  private static final String ARGS_VAR = "args";
+  private static final String PROP_ARGS = "args";
 
-  private static final String OBTAINED_VAR = "obtained";
+  private static final String PROP_OBTAINED = "obtained";
 
-  private static final String STATUS_VAR = "status";
+  private static final String PROP_STATUS = "status";
 
-  private static final String TERMINATED_VAR = "terminated";
+  private static final String PROP_TERMINATED = "terminated";
 
   private String[] _args;
 
@@ -118,7 +118,7 @@ public class Task {
     _status = TaskStatus.Unscheduled;
   }
 
-  @JsonProperty(ARGS_VAR)
+  @JsonProperty(PROP_ARGS)
   public String[] getArgs() {
     return _args;
   }
@@ -127,17 +127,17 @@ public class Task {
     return _batches;
   }
 
-  @JsonProperty(OBTAINED_VAR)
+  @JsonProperty(PROP_OBTAINED)
   public Date getObtained() {
     return _obtained;
   }
 
-  @JsonProperty(STATUS_VAR)
+  @JsonProperty(PROP_STATUS)
   public TaskStatus getStatus() {
     return _status;
   }
 
-  @JsonProperty(TERMINATED_VAR)
+  @JsonProperty(PROP_TERMINATED)
   public Date getTerminated() {
     return _terminated;
   }
@@ -161,7 +161,7 @@ public class Task {
     _terminationRequested = true;
   }
 
-  @JsonProperty(ARGS_VAR)
+  @JsonProperty(PROP_ARGS)
   public void setArgs(String[] args) {
     _args = args;
   }
@@ -170,12 +170,12 @@ public class Task {
     _batches = batches;
   }
 
-  @JsonProperty(OBTAINED_VAR)
+  @JsonProperty(PROP_OBTAINED)
   private void setObtained(Date obtained) {
     _obtained = obtained;
   }
 
-  @JsonProperty(STATUS_VAR)
+  @JsonProperty(PROP_STATUS)
   public void setStatus(TaskStatus status) {
     _status = status;
   }
@@ -184,7 +184,7 @@ public class Task {
     _terminated = new Date();
   }
 
-  @JsonProperty(TERMINATED_VAR)
+  @JsonProperty(PROP_TERMINATED)
   public void setTerminated(Date terminated) {
     _terminated = terminated;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/ComparableStructure.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/ComparableStructure.java
@@ -10,12 +10,12 @@ public abstract class ComparableStructure<KeyT extends Comparable<KeyT>>
     extends ReferenceCountedStructure
     implements Comparable<ComparableStructure<KeyT>>, Serializable {
 
-  protected static final String NAME_VAR = "name";
+  protected static final String PROP_NAME = "name";
   private static final long serialVersionUID = 1L;
   protected KeyT _key;
 
   @JsonCreator
-  public ComparableStructure(@JsonProperty(NAME_VAR) KeyT name) {
+  public ComparableStructure(@JsonProperty(PROP_NAME) KeyT name) {
     _key = name;
   }
 
@@ -34,7 +34,7 @@ public abstract class ComparableStructure<KeyT extends Comparable<KeyT>>
     }
   }
 
-  @JsonProperty(NAME_VAR)
+  @JsonProperty(PROP_NAME)
   @JsonPropertyDescription("The name of this structure")
   public KeyT getName() {
     return _key;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractRoute.java
@@ -13,29 +13,29 @@ import org.batfish.common.BatfishException;
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "class")
 public abstract class AbstractRoute implements Serializable, Comparable<AbstractRoute> {
 
-  protected static final String ADMINISTRATIVE_COST_VAR = "administrativeCost";
+  protected static final String PROP_ADMINISTRATIVE_COST = "administrativeCost";
 
-  protected static final String METRIC_VAR = "metric";
+  protected static final String PROP_METRIC = "metric";
 
-  protected static final String NETWORK_VAR = "network";
+  protected static final String PROP_NETWORK = "network";
 
-  protected static final String NEXT_HOP_INTERFACE_VAR = "nextHopInterface";
+  protected static final String PROP_NEXT_HOP_INTERFACE = "nextHopInterface";
 
-  protected static final String NEXT_HOP_IP_VAR = "nextHopIp";
+  protected static final String PROP_NEXT_HOP_IP = "nextHopIp";
 
-  private static final String NEXT_HOP_VAR = "nextHop";
+  private static final String PROP_NEXT_HOP = "nextHop";
 
   public static final int NO_TAG = -1;
 
-  private static final String NODE_VAR = "node";
+  private static final String PROP_NODE = "node";
 
-  protected static final String PROTOCOL_VAR = "protocol";
+  protected static final String PROP_PROTOCOL = "protocol";
 
   private static final long serialVersionUID = 1L;
 
-  protected static final String TAG_VAR = "tag";
+  protected static final String PROP_TAG = "tag";
 
-  private static final String VRF_VAR = "vrf";
+  private static final String PROP_VRF = "vrf";
 
   protected final Prefix _network;
 
@@ -48,7 +48,7 @@ public abstract class AbstractRoute implements Serializable, Comparable<Abstract
   private String _vrf;
 
   @JsonCreator
-  public AbstractRoute(@JsonProperty(NETWORK_VAR) Prefix network) {
+  public AbstractRoute(@JsonProperty(PROP_NETWORK) Prefix network) {
     if (network == null) {
       throw new BatfishException("Cannot construct AbstractRoute with null network");
     }
@@ -159,13 +159,13 @@ public abstract class AbstractRoute implements Serializable, Comparable<Abstract
   @JsonIgnore
   public abstract Integer getMetric();
 
-  @JsonProperty(NETWORK_VAR)
+  @JsonProperty(PROP_NETWORK)
   @JsonPropertyDescription("IPV4 network of this route")
   public final Prefix getNetwork() {
     return _network;
   }
 
-  @JsonProperty(NEXT_HOP_VAR)
+  @JsonProperty(PROP_NEXT_HOP)
   public String getNextHop() {
     return _nextHop;
   }
@@ -178,7 +178,7 @@ public abstract class AbstractRoute implements Serializable, Comparable<Abstract
   @JsonIgnore
   public abstract Ip getNextHopIp();
 
-  @JsonProperty(NODE_VAR)
+  @JsonProperty(PROP_NODE)
   public String getNode() {
     return _node;
   }
@@ -194,7 +194,7 @@ public abstract class AbstractRoute implements Serializable, Comparable<Abstract
   @JsonIgnore
   public abstract int getTag();
 
-  @JsonProperty(VRF_VAR)
+  @JsonProperty(PROP_VRF)
   public String getVrf() {
     return _vrf;
   }
@@ -206,12 +206,12 @@ public abstract class AbstractRoute implements Serializable, Comparable<Abstract
 
   public abstract int routeCompare(AbstractRoute rhs);
 
-  @JsonProperty(NEXT_HOP_VAR)
+  @JsonProperty(PROP_NEXT_HOP)
   public void setNextHop(String nextHop) {
     _nextHop = nextHop;
   }
 
-  @JsonProperty(NODE_VAR)
+  @JsonProperty(PROP_NODE)
   public void setNode(String node) {
     _node = node;
   }
@@ -221,7 +221,7 @@ public abstract class AbstractRoute implements Serializable, Comparable<Abstract
     _nonRouting = nonRouting;
   }
 
-  @JsonProperty(VRF_VAR)
+  @JsonProperty(PROP_VRF)
   public void setVrf(String vrf) {
     _vrf = vrf;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractRoute6.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractRoute6.java
@@ -9,13 +9,13 @@ import org.batfish.common.BatfishException;
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "class")
 public abstract class AbstractRoute6 implements Serializable {
 
-  protected static final String ADMINISTRATIVE_COST_VAR = "administrativeCost";
+  protected static final String PROP_ADMINISTRATIVE_COST = "administrativeCost";
 
-  private static final String METRIC_VAR = "metric";
+  private static final String PROP_METRIC = "metric";
 
-  protected static final String NETWORK_VAR = "network";
+  protected static final String PROP_NETWORK = "network";
 
-  protected static final String NEXT_HOP_IP_VAR = "nextHopIp";
+  protected static final String PROP_NEXT_HOP_IP = "nextHopIp";
 
   public static final int NO_TAG = -1;
 
@@ -38,20 +38,20 @@ public abstract class AbstractRoute6 implements Serializable {
   @Override
   public abstract boolean equals(Object o);
 
-  @JsonProperty(ADMINISTRATIVE_COST_VAR)
+  @JsonProperty(PROP_ADMINISTRATIVE_COST)
   public abstract int getAdministrativeCost();
 
-  @JsonProperty(METRIC_VAR)
+  @JsonProperty(PROP_METRIC)
   public abstract Integer getMetric();
 
-  @JsonProperty(NETWORK_VAR)
+  @JsonProperty(PROP_NETWORK)
   public final Prefix6 getNetwork() {
     return _network;
   }
 
   public abstract String getNextHopInterface();
 
-  @JsonProperty(NEXT_HOP_IP_VAR)
+  @JsonProperty(PROP_NEXT_HOP_IP)
   public Ip6 getNextHopIp() {
     return _nextHopIp;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsPathAccessList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsPathAccessList.java
@@ -20,7 +20,7 @@ import org.batfish.common.util.ComparableStructure;
     "An AsPathAccessList is used to filter e/iBGP routes according to their AS-path attribute.")
 public final class AsPathAccessList extends ComparableStructure<String> implements Serializable {
 
-  private static final String LINES_VAR = "lines";
+  private static final String PROP_LINES = "lines";
 
   private static final long serialVersionUID = 1L;
 
@@ -37,8 +37,8 @@ public final class AsPathAccessList extends ComparableStructure<String> implemen
 
   @JsonCreator
   public AsPathAccessList(
-      @JsonProperty(NAME_VAR) String name,
-      @JsonProperty(LINES_VAR) List<AsPathAccessListLine> lines) {
+      @JsonProperty(PROP_NAME) String name,
+      @JsonProperty(PROP_LINES) List<AsPathAccessListLine> lines) {
     super(name);
     _lines = lines;
   }
@@ -52,7 +52,7 @@ public final class AsPathAccessList extends ComparableStructure<String> implemen
     return other._lines.equals(_lines);
   }
 
-  @JsonProperty(LINES_VAR)
+  @JsonProperty(PROP_LINES)
   @JsonPropertyDescription(
       "The list of lines against which a route's AS-path will be checked in order.")
   public List<AsPathAccessListLine> getLines() {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpAdvertisement.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpAdvertisement.java
@@ -57,42 +57,42 @@ public class BgpAdvertisement implements Comparable<BgpAdvertisement>, Serializa
     }
   }
 
-  private static final String AS_PATH_VAR = "asPath";
+  private static final String PROP_AS_PATH = "asPath";
 
-  private static final String CLUSTER_LIST_VAR = "clusterList";
+  private static final String PROP_CLUSTER_LIST = "clusterList";
 
-  private static final String COMMUNITIES_VAR = "communities";
+  private static final String PROP_COMMUNITIES = "communities";
 
-  private static final String DST_IP_VAR = "dstIp";
+  private static final String PROP_DST_IP = "dstIp";
 
-  private static final String DST_NODE_VAR = "dstNode";
+  private static final String PROP_DST_NODE = "dstNode";
 
-  private static final String DST_VRF_VAR = "dstVrf";
+  private static final String PROP_DST_VRF = "dstVrf";
 
-  private static final String LOCAL_PREFERENCE_VAR = "localPreference";
+  private static final String PROP_LOCAL_PREFERENCE = "localPreference";
 
-  private static final String MED_VAR = "med";
+  private static final String PROP_MED = "med";
 
-  private static final String NETWORK_VAR = "network";
+  private static final String PROP_NETWORK = "network";
 
-  private static final String NEXT_HOP_IP_VAR = "nextHopIp";
+  private static final String PROP_NEXT_HOP_IP = "nextHopIp";
 
-  private static final String ORIGIN_TYPE_VAR = "originType";
+  private static final String PROP_ORIGIN_TYPE = "originType";
 
-  private static final String ORIGINATOR_IP_VAR = "originatorIp";
+  private static final String PROP_ORIGINATOR_IP = "originatorIp";
 
   /** */
   private static final long serialVersionUID = 1L;
 
-  private static final String SRC_IP_VAR = "srcIp";
+  private static final String PROP_SRC_IP = "srcIp";
 
-  private static final String SRC_NODE_VAR = "srcNode";
+  private static final String PROP_SRC_NODE = "srcNode";
 
-  private static final String SRC_PROTOCOL_VAR = "srcProtocol";
+  private static final String PROP_SRC_PROTOCOL = "srcProtocol";
 
-  private static final String SRC_VRF_VAR = "srcVrf";
+  private static final String PROP_SRC_VRF = "srcVrf";
 
-  private static final String TYPE_VAR = "type";
+  private static final String PROP_TYPE = "type";
 
   public static final int UNSET_LOCAL_PREFERENCE = 0;
 
@@ -100,7 +100,7 @@ public class BgpAdvertisement implements Comparable<BgpAdvertisement>, Serializa
 
   public static final int UNSET_WEIGHT = 0;
 
-  private static final String WEIGHT_VAR = "weight";
+  private static final String PROP_WEIGHT = "weight";
 
   private final AsPath _asPath;
 
@@ -140,24 +140,24 @@ public class BgpAdvertisement implements Comparable<BgpAdvertisement>, Serializa
 
   @JsonCreator
   public BgpAdvertisement(
-      @JsonProperty(TYPE_VAR) BgpAdvertisementType type,
-      @JsonProperty(NETWORK_VAR) Prefix network,
-      @JsonProperty(NEXT_HOP_IP_VAR) Ip nextHopIp,
-      @JsonProperty(SRC_NODE_VAR) String srcNode,
-      @JsonProperty(SRC_VRF_VAR) String srcVrf,
-      @JsonProperty(SRC_IP_VAR) Ip srcIp,
-      @JsonProperty(DST_NODE_VAR) String dstNode,
-      @JsonProperty(DST_VRF_VAR) String dstVrf,
-      @JsonProperty(DST_IP_VAR) Ip dstIp,
-      @JsonProperty(SRC_PROTOCOL_VAR) RoutingProtocol srcProtocol,
-      @JsonProperty(ORIGIN_TYPE_VAR) OriginType originType,
-      @JsonProperty(LOCAL_PREFERENCE_VAR) int localPreference,
-      @JsonProperty(MED_VAR) int med,
-      @JsonProperty(ORIGINATOR_IP_VAR) Ip originatorIp,
-      @JsonProperty(AS_PATH_VAR) AsPath asPath,
-      @JsonProperty(COMMUNITIES_VAR) SortedSet<Long> communities,
-      @JsonProperty(CLUSTER_LIST_VAR) SortedSet<Long> clusterList,
-      @JsonProperty(WEIGHT_VAR) int weight) {
+      @JsonProperty(PROP_TYPE) BgpAdvertisementType type,
+      @JsonProperty(PROP_NETWORK) Prefix network,
+      @JsonProperty(PROP_NEXT_HOP_IP) Ip nextHopIp,
+      @JsonProperty(PROP_SRC_NODE) String srcNode,
+      @JsonProperty(PROP_SRC_VRF) String srcVrf,
+      @JsonProperty(PROP_SRC_IP) Ip srcIp,
+      @JsonProperty(PROP_DST_NODE) String dstNode,
+      @JsonProperty(PROP_DST_VRF) String dstVrf,
+      @JsonProperty(PROP_DST_IP) Ip dstIp,
+      @JsonProperty(PROP_SRC_PROTOCOL) RoutingProtocol srcProtocol,
+      @JsonProperty(PROP_ORIGIN_TYPE) OriginType originType,
+      @JsonProperty(PROP_LOCAL_PREFERENCE) int localPreference,
+      @JsonProperty(PROP_MED) int med,
+      @JsonProperty(PROP_ORIGINATOR_IP) Ip originatorIp,
+      @JsonProperty(PROP_AS_PATH) AsPath asPath,
+      @JsonProperty(PROP_COMMUNITIES) SortedSet<Long> communities,
+      @JsonProperty(PROP_CLUSTER_LIST) SortedSet<Long> clusterList,
+      @JsonProperty(PROP_WEIGHT) int weight) {
     _type = type;
     _network = network;
     _nextHopIp = nextHopIp;
@@ -329,92 +329,92 @@ public class BgpAdvertisement implements Comparable<BgpAdvertisement>, Serializa
     return true;
   }
 
-  @JsonProperty(AS_PATH_VAR)
+  @JsonProperty(PROP_AS_PATH)
   public AsPath getAsPath() {
     return _asPath;
   }
 
-  @JsonProperty(CLUSTER_LIST_VAR)
+  @JsonProperty(PROP_CLUSTER_LIST)
   public SortedSet<Long> getClusterList() {
     return Collections.unmodifiableSortedSet(_clusterList);
   }
 
-  @JsonProperty(COMMUNITIES_VAR)
+  @JsonProperty(PROP_COMMUNITIES)
   public SortedSet<Long> getCommunities() {
     return Collections.unmodifiableSortedSet(_communities);
   }
 
-  @JsonProperty(DST_IP_VAR)
+  @JsonProperty(PROP_DST_IP)
   public Ip getDstIp() {
     return _dstIp;
   }
 
-  @JsonProperty(DST_NODE_VAR)
+  @JsonProperty(PROP_DST_NODE)
   public String getDstNode() {
     return _dstNode;
   }
 
-  @JsonProperty(DST_VRF_VAR)
+  @JsonProperty(PROP_DST_VRF)
   public String getDstVrf() {
     return _dstVrf;
   }
 
-  @JsonProperty(LOCAL_PREFERENCE_VAR)
+  @JsonProperty(PROP_LOCAL_PREFERENCE)
   public int getLocalPreference() {
     return _localPreference;
   }
 
-  @JsonProperty(MED_VAR)
+  @JsonProperty(PROP_MED)
   public int getMed() {
     return _med;
   }
 
-  @JsonProperty(NETWORK_VAR)
+  @JsonProperty(PROP_NETWORK)
   public Prefix getNetwork() {
     return _network;
   }
 
-  @JsonProperty(NEXT_HOP_IP_VAR)
+  @JsonProperty(PROP_NEXT_HOP_IP)
   public Ip getNextHopIp() {
     return _nextHopIp;
   }
 
-  @JsonProperty(ORIGINATOR_IP_VAR)
+  @JsonProperty(PROP_ORIGINATOR_IP)
   public Ip getOriginatorIp() {
     return _originatorIp;
   }
 
-  @JsonProperty(ORIGIN_TYPE_VAR)
+  @JsonProperty(PROP_ORIGIN_TYPE)
   public OriginType getOriginType() {
     return _originType;
   }
 
-  @JsonProperty(SRC_IP_VAR)
+  @JsonProperty(PROP_SRC_IP)
   public Ip getSrcIp() {
     return _srcIp;
   }
 
-  @JsonProperty(SRC_NODE_VAR)
+  @JsonProperty(PROP_SRC_NODE)
   public String getSrcNode() {
     return _srcNode;
   }
 
-  @JsonProperty(SRC_PROTOCOL_VAR)
+  @JsonProperty(PROP_SRC_PROTOCOL)
   public RoutingProtocol getSrcProtocol() {
     return _srcProtocol;
   }
 
-  @JsonProperty(SRC_VRF_VAR)
+  @JsonProperty(PROP_SRC_VRF)
   public String getSrcVrf() {
     return _srcVrf;
   }
 
-  @JsonProperty(TYPE_VAR)
+  @JsonProperty(PROP_TYPE)
   public BgpAdvertisementType getType() {
     return _type;
   }
 
-  @JsonProperty(WEIGHT_VAR)
+  @JsonProperty(PROP_WEIGHT)
   public int getWeight() {
     return _weight;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpNeighbor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpNeighbor.java
@@ -20,24 +20,24 @@ public final class BgpNeighbor extends ComparableStructure<Prefix> {
 
   public static final class BgpNeighborSummary extends ComparableStructure<String> {
 
-    private static final String DESCRIPTION_VAR = "description";
+    private static final String PROP_DESCRIPTION = "description";
 
-    private static final String GROUP_VAR = "group";
+    private static final String PROP_GROUP = "group";
 
-    private static final String LOCAL_AS_VAR = "localAs";
+    private static final String PROP_LOCAL_AS = "localAs";
 
-    private static final String LOCAL_IP_VAR = "localIp";
+    private static final String PROP_LOCAL_IP = "localIp";
 
-    private static final String REMOTE_AS_VAR = "remoteAs";
+    private static final String PROP_REMOTE_AS = "remoteAs";
 
-    private static final String REMOTE_IP_VAR = "remoteIp";
+    private static final String PROP_REMOTE_IP = "remoteIp";
 
-    private static final String REMOTE_PREFIX_VAR = "dynamicRemotePrefix";
+    private static final String PROP_REMOTE_PREFIX = "dynamicRemotePrefix";
 
     /** */
     private static final long serialVersionUID = 1L;
 
-    private static final String VRF_VAR = "vrf";
+    private static final String PROP_VRF = "vrf";
 
     private final String _description;
 
@@ -74,15 +74,15 @@ public final class BgpNeighbor extends ComparableStructure<Prefix> {
 
     @JsonCreator
     public BgpNeighborSummary(
-        @JsonProperty(NAME_VAR) String name,
-        @JsonProperty(DESCRIPTION_VAR) String description,
-        @JsonProperty(GROUP_VAR) String group,
-        @JsonProperty(LOCAL_AS_VAR) int localAs,
-        @JsonProperty(LOCAL_IP_VAR) Ip localIp,
-        @JsonProperty(REMOTE_AS_VAR) int remoteAs,
-        @JsonProperty(REMOTE_IP_VAR) Ip remoteIp,
-        @JsonProperty(REMOTE_PREFIX_VAR) Prefix remotePrefix,
-        @JsonProperty(VRF_VAR) String vrf) {
+        @JsonProperty(PROP_NAME) String name,
+        @JsonProperty(PROP_DESCRIPTION) String description,
+        @JsonProperty(PROP_GROUP) String group,
+        @JsonProperty(PROP_LOCAL_AS) int localAs,
+        @JsonProperty(PROP_LOCAL_IP) Ip localIp,
+        @JsonProperty(PROP_REMOTE_AS) int remoteAs,
+        @JsonProperty(PROP_REMOTE_IP) Ip remoteIp,
+        @JsonProperty(PROP_REMOTE_PREFIX) Prefix remotePrefix,
+        @JsonProperty(PROP_VRF) String vrf) {
       super(name);
       _description = description;
       _group = group;
@@ -94,22 +94,22 @@ public final class BgpNeighbor extends ComparableStructure<Prefix> {
       _vrf = vrf;
     }
 
-    @JsonProperty(DESCRIPTION_VAR)
+    @JsonProperty(PROP_DESCRIPTION)
     public String getDescription() {
       return _description;
     }
 
-    @JsonProperty(GROUP_VAR)
+    @JsonProperty(PROP_GROUP)
     public String getGroup() {
       return _group;
     }
 
-    @JsonProperty(LOCAL_AS_VAR)
+    @JsonProperty(PROP_LOCAL_AS)
     public int getLocalAs() {
       return _localAs;
     }
 
-    @JsonProperty(LOCAL_IP_VAR)
+    @JsonProperty(PROP_LOCAL_IP)
     public Ip getLocalIp() {
       return _localIp;
     }
@@ -123,70 +123,70 @@ public final class BgpNeighbor extends ComparableStructure<Prefix> {
       }
     }
 
-    @JsonProperty(REMOTE_AS_VAR)
+    @JsonProperty(PROP_REMOTE_AS)
     public int getRemoteAs() {
       return _remoteAs;
     }
 
-    @JsonProperty(REMOTE_IP_VAR)
+    @JsonProperty(PROP_REMOTE_IP)
     public Ip getRemoteIp() {
       return _remoteIp;
     }
 
-    @JsonProperty(REMOTE_PREFIX_VAR)
+    @JsonProperty(PROP_REMOTE_PREFIX)
     public Prefix getRemotePrefix() {
       return _remotePrefix;
     }
 
-    @JsonProperty(VRF_VAR)
+    @JsonProperty(PROP_VRF)
     public String getVrf() {
       return _vrf;
     }
   }
 
-  private static final String ADDITIONAL_PATHS_RECEIVE_VAR = "additionalPathsReceive";
+  private static final String PROP_ADDITIONAL_PATHS_RECEIVE = "additionalPathsReceive";
 
-  private static final String ADDITIONAL_PATHS_SELECT_ALL_VAR = "additionalPathsSelectAll";
+  private static final String PROP_ADDITIONAL_PATHS_SELECT_ALL = "additionalPathsSelectAll";
 
-  private static final String ADDITIONAL_PATHS_SEND_VAR = "additionalPathsSend";
+  private static final String PROP_ADDITIONAL_PATHS_SEND = "additionalPathsSend";
 
-  private static final String ADDRESS_VAR = "address";
+  private static final String PROP_ADDRESS = "address";
 
-  private static final String ADVERTISE_EXTERNAL_VAR = "advertiseExternal";
+  private static final String PROP_ADVERTISE_EXTERNAL = "advertiseExternal";
 
-  private static final String ADVERTISE_INACTIVE_VAR = "advertiseInactive";
+  private static final String PROP_ADVERTISE_INACTIVE = "advertiseInactive";
 
-  private static final String ALLOW_LOCAL_AS_IN_VAR = "allowLocalAsIn";
+  private static final String PROP_ALLOW_LOCAL_AS_IN = "allowLocalAsIn";
 
-  private static final String ALLOW_REMOTE_AS_OUT_VAR = "allowRemoteAsOut";
+  private static final String PROP_ALLOW_REMOTE_AS_OUT = "allowRemoteAsOut";
 
-  private static final String CLUSTER_ID_VAR = "clusterId";
+  private static final String PROP_CLUSTER_ID = "clusterId";
 
-  private static final String DEFAULT_METRIC_VAR = "defaultMetric";
+  private static final String PROP_DEFAULT_METRIC = "defaultMetric";
 
-  private static final String DESCRIPTION_VAR = "description";
+  private static final String PROP_DESCRIPTION = "description";
 
-  private static final String DYNAMIC_VAR = "dynamic";
+  private static final String PROP_DYNAMIC = "dynamic";
 
-  private static final String EBGP_MULTIHOP_VAR = "ebgpMultihop";
+  private static final String PROP_EBGP_MULTIHOP = "ebgpMultihop";
 
-  private static final String GENERATED_ROUTES_VAR = "generatedRoutes";
+  private static final String PROP_GENERATED_ROUTES = "generatedRoutes";
 
-  private static final String GROUP_VAR = "group";
+  private static final String PROP_GROUP = "group";
 
-  private static final String LOCAL_AS_VAR = "localAs";
+  private static final String PROP_LOCAL_AS = "localAs";
 
-  private static final String LOCAL_IP_VAR = "localIp";
+  private static final String PROP_LOCAL_IP = "localIp";
 
-  private static final String NAME_VAR = "name";
+  private static final String PROP_NAME = "name";
 
-  private static final String OWNER_VAR = "owner";
+  private static final String PROP_OWNER = "owner";
 
-  private static final String REMOTE_AS_VAR = "remoteAs";
+  private static final String PROP_REMOTE_AS = "remoteAs";
 
-  private static final String REMOTE_PREFIX_VAR = "remotePrefix";
+  private static final String PROP_REMOTE_PREFIX = "remotePrefix";
 
-  private static final String SEND_COMMUNITY_VAR = "sendCommunity";
+  private static final String PROP_SEND_COMMUNITY = "sendCommunity";
 
   /** */
   private static final long serialVersionUID = 1L;
@@ -274,7 +274,7 @@ public final class BgpNeighbor extends ComparableStructure<Prefix> {
   }
 
   @JsonCreator
-  public BgpNeighbor(@JsonProperty(NAME_VAR) Prefix prefix) {
+  public BgpNeighbor(@JsonProperty(PROP_NAME) Prefix prefix) {
     super(prefix);
     _generatedRoutes = new LinkedHashSet<>();
   }
@@ -352,23 +352,23 @@ public final class BgpNeighbor extends ComparableStructure<Prefix> {
     return true;
   }
 
-  @JsonProperty(ADDITIONAL_PATHS_RECEIVE_VAR)
+  @JsonProperty(PROP_ADDITIONAL_PATHS_RECEIVE)
   public boolean getAdditionalPathsReceive() {
     return _additionalPathsReceive;
   }
 
-  @JsonProperty(ADDITIONAL_PATHS_SELECT_ALL_VAR)
+  @JsonProperty(PROP_ADDITIONAL_PATHS_SELECT_ALL)
   public boolean getAdditionalPathsSelectAll() {
     return _additionalPathsSelectAll;
   }
 
-  @JsonProperty(ADDITIONAL_PATHS_SEND_VAR)
+  @JsonProperty(PROP_ADDITIONAL_PATHS_SEND)
   public boolean getAdditionalPathsSend() {
     return _additionalPathsSend;
   }
 
   @Nullable
-  @JsonProperty(ADDRESS_VAR)
+  @JsonProperty(PROP_ADDRESS)
   @JsonPropertyDescription("The IPV4 address of the remote peer if not dynamic (passive)")
   public Ip getAddress() {
     if (_key != null && _key.getPrefixLength() == 32) {
@@ -378,7 +378,7 @@ public final class BgpNeighbor extends ComparableStructure<Prefix> {
     }
   }
 
-  @JsonProperty(ADVERTISE_EXTERNAL_VAR)
+  @JsonProperty(PROP_ADVERTISE_EXTERNAL)
   @JsonPropertyDescription(
       "Whether to advertise the best eBGP route for each network independently of whether it is "
           + "the best BGP route for that network")
@@ -386,7 +386,7 @@ public final class BgpNeighbor extends ComparableStructure<Prefix> {
     return _advertiseExternal;
   }
 
-  @JsonProperty(ADVERTISE_INACTIVE_VAR)
+  @JsonProperty(PROP_ADVERTISE_INACTIVE)
   @JsonPropertyDescription(
       "Whether to advertise the best BGP route for each network independently of whether it is "
           + "the best overall route for that network")
@@ -394,14 +394,14 @@ public final class BgpNeighbor extends ComparableStructure<Prefix> {
     return _advertiseInactive;
   }
 
-  @JsonProperty(ALLOW_LOCAL_AS_IN_VAR)
+  @JsonProperty(PROP_ALLOW_LOCAL_AS_IN)
   @JsonPropertyDescription(
       "Whether to allow reception of advertisements containing the local AS number in the AS-path")
   public boolean getAllowLocalAsIn() {
     return _allowLocalAsIn;
   }
 
-  @JsonProperty(ALLOW_REMOTE_AS_OUT_VAR)
+  @JsonProperty(PROP_ALLOW_REMOTE_AS_OUT)
   @JsonPropertyDescription(
       "Whether to allow sending of advertisements containing the remote AS number in the AS-path")
   public boolean getAllowRemoteAsOut() {
@@ -413,25 +413,25 @@ public final class BgpNeighbor extends ComparableStructure<Prefix> {
     return _candidateRemoteBgpNeighbors;
   }
 
-  @JsonProperty(CLUSTER_ID_VAR)
+  @JsonProperty(PROP_CLUSTER_ID)
   @JsonPropertyDescription("Route-reflection cluster-id for this peer")
   public Long getClusterId() {
     return _clusterId;
   }
 
-  @JsonProperty(DEFAULT_METRIC_VAR)
+  @JsonProperty(PROP_DEFAULT_METRIC)
   @JsonPropertyDescription("Default MED for routes sent to this neighbor")
   public int getDefaultMetric() {
     return _defaultMetric;
   }
 
-  @JsonProperty(DESCRIPTION_VAR)
+  @JsonProperty(PROP_DESCRIPTION)
   @JsonPropertyDescription("Description of this peer")
   public String getDescription() {
     return _description;
   }
 
-  @JsonProperty(DYNAMIC_VAR)
+  @JsonProperty(PROP_DYNAMIC)
   @JsonPropertyDescription(
       "Whether this represents a connection to a specific peer (false) or a passive connection to "
           + "a network of peers (true)")
@@ -439,7 +439,7 @@ public final class BgpNeighbor extends ComparableStructure<Prefix> {
     return _key != null && _key.getPrefixLength() < 32;
   }
 
-  @JsonProperty(EBGP_MULTIHOP_VAR)
+  @JsonProperty(PROP_EBGP_MULTIHOP)
   @JsonPropertyDescription(
       "Whether to allow establishment of a multihop eBGP connection with this peer")
   public boolean getEbgpMultihop() {
@@ -451,14 +451,14 @@ public final class BgpNeighbor extends ComparableStructure<Prefix> {
     return _exportPolicy;
   }
 
-  @JsonProperty(GENERATED_ROUTES_VAR)
+  @JsonProperty(PROP_GENERATED_ROUTES)
   @JsonPropertyDescription(
       "Generated routes specific to this peer not otherwise imported into any of this node's RIBs")
   public Set<GeneratedRoute> getGeneratedRoutes() {
     return _generatedRoutes;
   }
 
-  @JsonProperty(GROUP_VAR)
+  @JsonProperty(PROP_GROUP)
   @JsonPropertyDescription(
       "Name of a group in the original vendor-specific configuration to which this peer is "
           + "assigned")
@@ -471,13 +471,13 @@ public final class BgpNeighbor extends ComparableStructure<Prefix> {
     return _importPolicy;
   }
 
-  @JsonProperty(LOCAL_AS_VAR)
+  @JsonProperty(PROP_LOCAL_AS)
   @JsonPropertyDescription("The local autonomous sysem of this peering")
   public Integer getLocalAs() {
     return _localAs;
   }
 
-  @JsonProperty(LOCAL_IP_VAR)
+  @JsonProperty(PROP_LOCAL_IP)
   @JsonPropertyDescription("The local (source) IPV4 address of this peering")
   public Ip getLocalIp() {
     return _localIp;
@@ -488,7 +488,7 @@ public final class BgpNeighbor extends ComparableStructure<Prefix> {
     return _owner;
   }
 
-  @JsonProperty(REMOTE_PREFIX_VAR)
+  @JsonProperty(PROP_REMOTE_PREFIX)
   @JsonPropertyDescription(
       "The remote (destination) IPV4 address of this peering (when prefix-length is 32), or the "
           + "network of peers allowed to connect on this peering (otherwise)")
@@ -496,7 +496,7 @@ public final class BgpNeighbor extends ComparableStructure<Prefix> {
     return _key;
   }
 
-  @JsonProperty(REMOTE_AS_VAR)
+  @JsonProperty(PROP_REMOTE_AS)
   @JsonPropertyDescription("The remote autonomous sysem of this peering")
   public Integer getRemoteAs() {
     return _remoteAs;
@@ -512,7 +512,7 @@ public final class BgpNeighbor extends ComparableStructure<Prefix> {
     return _routeReflectorClient;
   }
 
-  @JsonProperty(SEND_COMMUNITY_VAR)
+  @JsonProperty(PROP_SEND_COMMUNITY)
   @JsonPropertyDescription(
       "Whether or not to propagate the community attribute(s) of advertisements to this peer")
   public boolean getSendCommunity() {
@@ -533,67 +533,67 @@ public final class BgpNeighbor extends ComparableStructure<Prefix> {
     _owner = owner;
   }
 
-  @JsonProperty(ADDITIONAL_PATHS_RECEIVE_VAR)
+  @JsonProperty(PROP_ADDITIONAL_PATHS_RECEIVE)
   public void setAdditionalPathsReceive(boolean additionalPathsReceive) {
     _additionalPathsReceive = additionalPathsReceive;
   }
 
-  @JsonProperty(ADDITIONAL_PATHS_SELECT_ALL_VAR)
+  @JsonProperty(PROP_ADDITIONAL_PATHS_SELECT_ALL)
   public void setAdditionalPathsSelectAll(boolean additionalPathsSelectAll) {
     _additionalPathsSelectAll = additionalPathsSelectAll;
   }
 
-  @JsonProperty(ADDITIONAL_PATHS_SEND_VAR)
+  @JsonProperty(PROP_ADDITIONAL_PATHS_SEND)
   public void setAdditionalPathsSend(boolean additionalPathsSend) {
     _additionalPathsSend = additionalPathsSend;
   }
 
-  @JsonProperty(ADDRESS_VAR)
+  @JsonProperty(PROP_ADDRESS)
   public void setAddress(Ip address) {
     // Intentionally empty
   }
 
-  @JsonProperty(ADVERTISE_EXTERNAL_VAR)
+  @JsonProperty(PROP_ADVERTISE_EXTERNAL)
   public void setAdvertiseExternal(boolean advertiseExternal) {
     _advertiseExternal = advertiseExternal;
   }
 
-  @JsonProperty(ADVERTISE_INACTIVE_VAR)
+  @JsonProperty(PROP_ADVERTISE_INACTIVE)
   public void setAdvertiseInactive(boolean advertiseInactive) {
     _advertiseInactive = advertiseInactive;
   }
 
-  @JsonProperty(ALLOW_LOCAL_AS_IN_VAR)
+  @JsonProperty(PROP_ALLOW_LOCAL_AS_IN)
   public void setAllowLocalAsIn(boolean allowLocalAsIn) {
     _allowLocalAsIn = allowLocalAsIn;
   }
 
-  @JsonProperty(ALLOW_REMOTE_AS_OUT_VAR)
+  @JsonProperty(PROP_ALLOW_REMOTE_AS_OUT)
   public void setAllowRemoteAsOut(boolean allowRemoteAsOut) {
     _allowRemoteAsOut = allowRemoteAsOut;
   }
 
-  @JsonProperty(CLUSTER_ID_VAR)
+  @JsonProperty(PROP_CLUSTER_ID)
   public void setClusterId(Long clusterId) {
     _clusterId = clusterId;
   }
 
-  @JsonProperty(DEFAULT_METRIC_VAR)
+  @JsonProperty(PROP_DEFAULT_METRIC)
   public void setDefaultMetric(int defaultMetric) {
     _defaultMetric = defaultMetric;
   }
 
-  @JsonProperty(DESCRIPTION_VAR)
+  @JsonProperty(PROP_DESCRIPTION)
   public void setDescription(String description) {
     _description = description;
   }
 
-  @JsonProperty(DYNAMIC_VAR)
+  @JsonProperty(PROP_DYNAMIC)
   public void setDynamic(boolean dynamic) {
     // Intentionally empty
   }
 
-  @JsonProperty(EBGP_MULTIHOP_VAR)
+  @JsonProperty(PROP_EBGP_MULTIHOP)
   public void setEbgpMultihop(boolean ebgpMultihop) {
     _ebgpMultihop = ebgpMultihop;
   }
@@ -602,12 +602,12 @@ public final class BgpNeighbor extends ComparableStructure<Prefix> {
     _exportPolicy = originationPolicyName;
   }
 
-  @JsonProperty(GENERATED_ROUTES_VAR)
+  @JsonProperty(PROP_GENERATED_ROUTES)
   public void setGeneratedRoutes(Set<GeneratedRoute> generatedRoutes) {
     _generatedRoutes = generatedRoutes;
   }
 
-  @JsonProperty(GROUP_VAR)
+  @JsonProperty(PROP_GROUP)
   public void setGroup(String name) {
     _group = name;
   }
@@ -616,22 +616,22 @@ public final class BgpNeighbor extends ComparableStructure<Prefix> {
     _importPolicy = importPolicy;
   }
 
-  @JsonProperty(LOCAL_AS_VAR)
+  @JsonProperty(PROP_LOCAL_AS)
   public void setLocalAs(Integer localAs) {
     _localAs = localAs;
   }
 
-  @JsonProperty(LOCAL_IP_VAR)
+  @JsonProperty(PROP_LOCAL_IP)
   public void setLocalIp(Ip localIp) {
     _localIp = localIp;
   }
 
-  @JsonProperty(OWNER_VAR)
+  @JsonProperty(PROP_OWNER)
   public void setOwner(Configuration owner) {
     _owner = owner;
   }
 
-  @JsonProperty(REMOTE_AS_VAR)
+  @JsonProperty(PROP_REMOTE_AS)
   public void setRemoteAs(Integer remoteAs) {
     _remoteAs = remoteAs;
   }
@@ -640,7 +640,7 @@ public final class BgpNeighbor extends ComparableStructure<Prefix> {
     _remoteBgpNeighbor = remoteBgpNeighbor;
   }
 
-  @JsonProperty(REMOTE_PREFIX_VAR)
+  @JsonProperty(PROP_REMOTE_PREFIX)
   public void setRemotePrefix(Prefix remotePrefix) {
     // Intentionally empty
   }
@@ -649,7 +649,7 @@ public final class BgpNeighbor extends ComparableStructure<Prefix> {
     _routeReflectorClient = routeReflectorClient;
   }
 
-  @JsonProperty(SEND_COMMUNITY_VAR)
+  @JsonProperty(PROP_SEND_COMMUNITY)
   public void setSendCommunity(boolean sendCommunity) {
     _sendCommunity = sendCommunity;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpProcess.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpProcess.java
@@ -14,15 +14,15 @@ import java.util.TreeSet;
 @JsonSchemaDescription("A BGP routing process")
 public class BgpProcess implements Serializable {
 
-  private static final String GENERATED_ROUTES_VAR = "generatedRoutes";
+  private static final String PROP_GENERATED_ROUTES = "generatedRoutes";
 
-  private static final String MULTIPATH_EBGP_VAR = "multipathEbgp";
+  private static final String PROP_MULTIPATH_EBGP = "multipathEbgp";
 
-  private static final String MULTIPATH_IBGP_VAR = "multipathIbgp";
+  private static final String PROP_MULTIPATH_IBGP = "multipathIbgp";
 
-  private static final String NEIGHBORS_VAR = "neighbors";
+  private static final String PROP_NEIGHBORS = "neighbors";
 
-  private static final String ROUTER_ID_VAR = "routerId";
+  private static final String PROP_ROUTER_ID = "routerId";
 
   /** */
   private static final long serialVersionUID = 1L;
@@ -54,25 +54,25 @@ public class BgpProcess implements Serializable {
   }
 
   /** @return {@link #_generatedRoutes} */
-  @JsonProperty(GENERATED_ROUTES_VAR)
+  @JsonProperty(PROP_GENERATED_ROUTES)
   @JsonPropertyDescription(
       "IPV4 routes generated in the BGP RIB that are not imported into the main RIB for this VRF")
   public SortedSet<GeneratedRoute> getGeneratedRoutes() {
     return _generatedRoutes;
   }
 
-  @JsonProperty(MULTIPATH_EBGP_VAR)
+  @JsonProperty(PROP_MULTIPATH_EBGP)
   public boolean getMultipathEbgp() {
     return _multipathEbgp;
   }
 
-  @JsonProperty(MULTIPATH_IBGP_VAR)
+  @JsonProperty(PROP_MULTIPATH_IBGP)
   public boolean getMultipathIbgp() {
     return _multipathIbgp;
   }
 
   /** @return {@link #_neighbors} */
-  @JsonProperty(NEIGHBORS_VAR)
+  @JsonProperty(PROP_NEIGHBORS)
   @JsonPropertyDescription("Neighbor relationships configured for this BGP process")
   public SortedMap<Prefix, BgpNeighbor> getNeighbors() {
     return _neighbors;
@@ -83,7 +83,7 @@ public class BgpProcess implements Serializable {
     return _originationSpace;
   }
 
-  @JsonProperty(ROUTER_ID_VAR)
+  @JsonProperty(PROP_ROUTER_ID)
   @JsonPropertyDescription(
       "The configured router ID for this BGP process. Note that it can be overridden for "
           + "individual neighbors.")
@@ -91,22 +91,22 @@ public class BgpProcess implements Serializable {
     return _routerId;
   }
 
-  @JsonProperty(GENERATED_ROUTES_VAR)
+  @JsonProperty(PROP_GENERATED_ROUTES)
   public void setGeneratedRoutes(SortedSet<GeneratedRoute> generatedRoutes) {
     _generatedRoutes = generatedRoutes;
   }
 
-  @JsonProperty(MULTIPATH_EBGP_VAR)
+  @JsonProperty(PROP_MULTIPATH_EBGP)
   public void setMultipathEbgp(boolean multipathEbgp) {
     _multipathEbgp = multipathEbgp;
   }
 
-  @JsonProperty(MULTIPATH_IBGP_VAR)
+  @JsonProperty(PROP_MULTIPATH_IBGP)
   public void setMultipathIbgp(boolean multipathIbgp) {
     _multipathIbgp = multipathIbgp;
   }
 
-  @JsonProperty(NEIGHBORS_VAR)
+  @JsonProperty(PROP_NEIGHBORS)
   public void setNeighbors(SortedMap<Prefix, BgpNeighbor> neighbors) {
     _neighbors = neighbors;
   }
@@ -115,7 +115,7 @@ public class BgpProcess implements Serializable {
     _originationSpace = originationSpace;
   }
 
-  @JsonProperty(ROUTER_ID_VAR)
+  @JsonProperty(PROP_ROUTER_ID)
   public void setRouterId(Ip routerId) {
     _routerId = routerId;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpProcessDiff.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpProcessDiff.java
@@ -6,9 +6,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class BgpProcessDiff {
 
-  private static final String IN_AFTER_ONLY_VAR = "inAfterOnly";
+  private static final String PROP_IN_AFTER_ONLY = "inAfterOnly";
 
-  private static final String IN_BEFORE_ONLY_VAR = "inBeforeOnly";
+  private static final String PROP_IN_BEFORE_ONLY = "inBeforeOnly";
 
   private Boolean _inAfterOnly;
 
@@ -32,12 +32,12 @@ public class BgpProcessDiff {
     }
   }
 
-  @JsonProperty(IN_AFTER_ONLY_VAR)
+  @JsonProperty(PROP_IN_AFTER_ONLY)
   public Boolean getInAfterOnly() {
     return _inAfterOnly;
   }
 
-  @JsonProperty(IN_BEFORE_ONLY_VAR)
+  @JsonProperty(PROP_IN_BEFORE_ONLY)
   public Boolean getInBeforeOnly() {
     return _inBeforeOnly;
   }
@@ -47,12 +47,12 @@ public class BgpProcessDiff {
     return _neighborsDiff == null && _inBeforeOnly == null && _inAfterOnly == null;
   }
 
-  @JsonProperty(IN_AFTER_ONLY_VAR)
+  @JsonProperty(PROP_IN_AFTER_ONLY)
   public void setInAfterOnly(Boolean inAfterOnly) {
     _inAfterOnly = inAfterOnly;
   }
 
-  @JsonProperty(IN_BEFORE_ONLY_VAR)
+  @JsonProperty(PROP_IN_BEFORE_ONLY)
   public void setInBeforeOnly(Boolean inBeforeOnly) {
     _inBeforeOnly = inBeforeOnly;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpRoute.java
@@ -147,29 +147,29 @@ public class BgpRoute extends AbstractRoute {
     }
   }
 
-  private static final String AS_PATH_VAR = "asPath";
+  private static final String PROP_AS_PATH = "asPath";
 
-  private static final String CLUSTER_LIST_VAR = "clusterList";
+  private static final String PROP_CLUSTER_LIST = "clusterList";
 
-  private static final String COMMUNITIES_VAR = "communities";
+  private static final String PROP_COMMUNITIES = "communities";
 
   public static final int DEFAULT_LOCAL_PREFERENCE = 100;
 
-  private static final String LOCAL_PREFERENCE_VAR = "localPreference";
+  private static final String PROP_LOCAL_PREFERENCE = "localPreference";
 
-  private static final String ORIGIN_TYPE_VAR = "originType";
+  private static final String PROP_ORIGIN_TYPE = "originType";
 
-  private static final String ORIGINATOR_IP_VAR = "originatorIp";
+  private static final String PROP_ORIGINATOR_IP = "originatorIp";
 
-  private static final String RECEIVED_FROM_ROUTE_REFLECTOR_CLIENT_VAR =
+  private static final String PROP_RECEIVED_FROM_ROUTE_REFLECTOR_CLIENT =
       "receivedFromRouteReflectorClient";
 
   /** */
   private static final long serialVersionUID = 1L;
 
-  private static final String SRC_PROTOCOL_VAR = "srcProtocol";
+  private static final String PROP_SRC_PROTOCOL = "srcProtocol";
 
-  private static final String WEIGHT_VAR = "weight";
+  private static final String PROP_WEIGHT = "weight";
 
   private final int _admin;
 
@@ -199,21 +199,21 @@ public class BgpRoute extends AbstractRoute {
 
   @JsonCreator
   public BgpRoute(
-      @JsonProperty(NETWORK_VAR) Prefix network,
-      @JsonProperty(NEXT_HOP_IP_VAR) Ip nextHopIp,
-      @JsonProperty(ADMINISTRATIVE_COST_VAR) int admin,
-      @JsonProperty(AS_PATH_VAR) AsPath asPath,
-      @JsonProperty(COMMUNITIES_VAR) SortedSet<Long> communities,
-      @JsonProperty(LOCAL_PREFERENCE_VAR) int localPreference,
-      @JsonProperty(METRIC_VAR) int med,
-      @JsonProperty(ORIGINATOR_IP_VAR) Ip originatorIp,
-      @JsonProperty(CLUSTER_LIST_VAR) SortedSet<Long> clusterList,
-      @JsonProperty(RECEIVED_FROM_ROUTE_REFLECTOR_CLIENT_VAR)
+      @JsonProperty(PROP_NETWORK) Prefix network,
+      @JsonProperty(PROP_NEXT_HOP_IP) Ip nextHopIp,
+      @JsonProperty(PROP_ADMINISTRATIVE_COST) int admin,
+      @JsonProperty(PROP_AS_PATH) AsPath asPath,
+      @JsonProperty(PROP_COMMUNITIES) SortedSet<Long> communities,
+      @JsonProperty(PROP_LOCAL_PREFERENCE) int localPreference,
+      @JsonProperty(PROP_METRIC) int med,
+      @JsonProperty(PROP_ORIGINATOR_IP) Ip originatorIp,
+      @JsonProperty(PROP_CLUSTER_LIST) SortedSet<Long> clusterList,
+      @JsonProperty(PROP_RECEIVED_FROM_ROUTE_REFLECTOR_CLIENT)
           boolean receivedFromRouteReflectorClient,
-      @JsonProperty(ORIGIN_TYPE_VAR) OriginType originType,
-      @JsonProperty(PROTOCOL_VAR) RoutingProtocol protocol,
-      @JsonProperty(SRC_PROTOCOL_VAR) RoutingProtocol srcProtocol,
-      @JsonProperty(WEIGHT_VAR) int weight) {
+      @JsonProperty(PROP_ORIGIN_TYPE) OriginType originType,
+      @JsonProperty(PROP_PROTOCOL) RoutingProtocol protocol,
+      @JsonProperty(PROP_SRC_PROTOCOL) RoutingProtocol srcProtocol,
+      @JsonProperty(PROP_WEIGHT) int weight) {
     super(network);
     _admin = admin;
     _asPath = asPath;
@@ -284,34 +284,34 @@ public class BgpRoute extends AbstractRoute {
   }
 
   @JsonIgnore(false)
-  @JsonProperty(ADMINISTRATIVE_COST_VAR)
+  @JsonProperty(PROP_ADMINISTRATIVE_COST)
   @Override
   public int getAdministrativeCost() {
     return _admin;
   }
 
-  @JsonProperty(AS_PATH_VAR)
+  @JsonProperty(PROP_AS_PATH)
   public AsPath getAsPath() {
     return _asPath;
   }
 
-  @JsonProperty(CLUSTER_LIST_VAR)
+  @JsonProperty(PROP_CLUSTER_LIST)
   public SortedSet<Long> getClusterList() {
     return Collections.unmodifiableSortedSet(_clusterList);
   }
 
-  @JsonProperty(COMMUNITIES_VAR)
+  @JsonProperty(PROP_COMMUNITIES)
   public SortedSet<Long> getCommunities() {
     return Collections.unmodifiableSortedSet(_communities);
   }
 
-  @JsonProperty(LOCAL_PREFERENCE_VAR)
+  @JsonProperty(PROP_LOCAL_PREFERENCE)
   public int getLocalPreference() {
     return _localPreference;
   }
 
   @JsonIgnore(false)
-  @JsonProperty(METRIC_VAR)
+  @JsonProperty(PROP_METRIC)
   @Override
   public Integer getMetric() {
     return _med;
@@ -326,35 +326,35 @@ public class BgpRoute extends AbstractRoute {
 
   @Nonnull
   @JsonIgnore(false)
-  @JsonProperty(NEXT_HOP_IP_VAR)
+  @JsonProperty(PROP_NEXT_HOP_IP)
   @Override
   public Ip getNextHopIp() {
     return _nextHopIp;
   }
 
-  @JsonProperty(ORIGINATOR_IP_VAR)
+  @JsonProperty(PROP_ORIGINATOR_IP)
   public Ip getOriginatorIp() {
     return _originatorIp;
   }
 
-  @JsonProperty(ORIGIN_TYPE_VAR)
+  @JsonProperty(PROP_ORIGIN_TYPE)
   public OriginType getOriginType() {
     return _originType;
   }
 
   @JsonIgnore(false)
-  @JsonProperty(PROTOCOL_VAR)
+  @JsonProperty(PROP_PROTOCOL)
   @Override
   public RoutingProtocol getProtocol() {
     return _protocol;
   }
 
-  @JsonProperty(RECEIVED_FROM_ROUTE_REFLECTOR_CLIENT_VAR)
+  @JsonProperty(PROP_RECEIVED_FROM_ROUTE_REFLECTOR_CLIENT)
   public boolean getReceivedFromRouteReflectorClient() {
     return _receivedFromRouteReflectorClient;
   }
 
-  @JsonProperty(SRC_PROTOCOL_VAR)
+  @JsonProperty(PROP_SRC_PROTOCOL)
   public RoutingProtocol getSrcProtocol() {
     return _srcProtocol;
   }
@@ -364,7 +364,7 @@ public class BgpRoute extends AbstractRoute {
     return NO_TAG;
   }
 
-  @JsonProperty(WEIGHT_VAR)
+  @JsonProperty(PROP_WEIGHT)
   public int getWeight() {
     return _weight;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/CommunityList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/CommunityList.java
@@ -20,7 +20,7 @@ import org.batfish.common.util.ComparableStructure;
         + "attributes sent with a bgp advertisement")
 public class CommunityList extends ComparableStructure<String> {
 
-  private static final String LINES_VAR = "lines";
+  private static final String PROP_LINES = "lines";
 
   /** */
   private static final long serialVersionUID = 1L;
@@ -46,7 +46,8 @@ public class CommunityList extends ComparableStructure<String> {
    */
   @JsonCreator
   public CommunityList(
-      @JsonProperty(NAME_VAR) String name, @JsonProperty(LINES_VAR) List<CommunityListLine> lines) {
+      @JsonProperty(PROP_NAME) String name,
+      @JsonProperty(PROP_LINES) List<CommunityListLine> lines) {
     super(name);
     _lines = lines;
   }
@@ -67,7 +68,7 @@ public class CommunityList extends ComparableStructure<String> {
     return _invertMatch;
   }
 
-  @JsonProperty(LINES_VAR)
+  @JsonProperty(PROP_LINES)
   @JsonPropertyDescription(
       "The list of lines that are checked in order against the community attribute(s) of a bgp "
           + "advertisement")

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/CommunityListLine.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/CommunityListLine.java
@@ -14,9 +14,9 @@ import org.batfish.common.util.CommonUtil;
 @JsonSchemaDescription("A line in a CommunityList")
 public class CommunityListLine implements Serializable {
 
-  private static final String ACTION_VAR = "action";
+  private static final String PROP_ACTION = "action";
 
-  private static final String REGEX_VAR = "regex";
+  private static final String PROP_REGEX = "regex";
 
   private static final long serialVersionUID = 1L;
 
@@ -26,7 +26,7 @@ public class CommunityListLine implements Serializable {
 
   @JsonCreator
   public CommunityListLine(
-      @JsonProperty(ACTION_VAR) LineAction action, @JsonProperty(REGEX_VAR) String regex) {
+      @JsonProperty(PROP_ACTION) LineAction action, @JsonProperty(PROP_REGEX) String regex) {
     _action = action;
     _regex = regex;
   }
@@ -46,7 +46,7 @@ public class CommunityListLine implements Serializable {
     return true;
   }
 
-  @JsonProperty(ACTION_VAR)
+  @JsonProperty(PROP_ACTION)
   @JsonPropertyDescription(
       "The action the underlying access-list will take when this line matches a route.")
   public LineAction getAction() {
@@ -79,7 +79,7 @@ public class CommunityListLine implements Serializable {
     return matchingCommunitites;
   }
 
-  @JsonProperty(REGEX_VAR)
+  @JsonProperty(PROP_REGEX)
   @JsonPropertyDescription("The regex against which a route's communities will be compared")
   public String getRegex() {
     return _regex;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ConfigDiffElement.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ConfigDiffElement.java
@@ -14,15 +14,15 @@ import org.batfish.datamodel.answers.AnswerElement;
 
 public class ConfigDiffElement implements AnswerElement {
 
-  private static final String DIFF_INFO_VAR = "diffInfo";
+  private static final String PROP_DIFF_INFO = "diffInfo";
 
-  private static final String DIFF_VAR = "diff";
+  private static final String PROP_DIFF = "diff";
 
-  // private static final String IDENTICAL_VAR = "identical";
+  // private static final String PROP_IDENTICAL = "identical";
 
-  private static final String IN_AFTER_ONLY_VAR = "inAfterOnly";
+  private static final String PROP_IN_AFTER_ONLY = "inAfterOnly";
 
-  private static final String IN_BEFORE_ONLY_VAR = "inBeforeOnly";
+  private static final String PROP_IN_BEFORE_ONLY = "inBeforeOnly";
 
   private static final int MAX_IDENTICAL = 5;
 
@@ -82,28 +82,28 @@ public class ConfigDiffElement implements AnswerElement {
     return CommonUtil.intersection(_before, _after, TreeSet::new);
   }
 
-  @JsonProperty(DIFF_VAR)
+  @JsonProperty(PROP_DIFF)
   public SortedSet<String> getDiff() {
     return _diff;
   }
 
-  @JsonProperty(DIFF_INFO_VAR)
+  @JsonProperty(PROP_DIFF_INFO)
   public SortedMap<String, AnswerElement> getDiffInfo() {
     return _diffInfo;
   }
 
-  // @JsonProperty(IDENTICAL_VAR)
+  // @JsonProperty(PROP_IDENTICAL)
   @JsonIgnore
   public SortedSet<String> getIdentical() {
     return _identical;
   }
 
-  @JsonProperty(IN_AFTER_ONLY_VAR)
+  @JsonProperty(PROP_IN_AFTER_ONLY)
   public SortedSet<String> getInAfterOnly() {
     return _inAfterOnly;
   }
 
-  @JsonProperty(IN_BEFORE_ONLY_VAR)
+  @JsonProperty(PROP_IN_BEFORE_ONLY)
   public SortedSet<String> getInBeforeOnly() {
     return _inBeforeOnly;
   }
@@ -116,28 +116,28 @@ public class ConfigDiffElement implements AnswerElement {
         && _inAfterOnly.isEmpty();
   }
 
-  @JsonProperty(DIFF_VAR)
+  @JsonProperty(PROP_DIFF)
   public void setDiff(SortedSet<String> diff) {
     _diff = diff;
   }
 
-  @JsonProperty(DIFF_INFO_VAR)
+  @JsonProperty(PROP_DIFF_INFO)
   public void setDiffInfo(SortedMap<String, AnswerElement> diffInfo) {
     _diffInfo = diffInfo;
   }
 
-  // @JsonProperty(IDENTICAL_VAR)
+  // @JsonProperty(PROP_IDENTICAL)
   @JsonIgnore
   public void setIdentical(SortedSet<String> identical) {
     _identical = identical;
   }
 
-  @JsonProperty(IN_AFTER_ONLY_VAR)
+  @JsonProperty(PROP_IN_AFTER_ONLY)
   public void setInAfterOnly(SortedSet<String> inAfterOnly) {
     _inAfterOnly = inAfterOnly;
   }
 
-  @JsonProperty(IN_BEFORE_ONLY_VAR)
+  @JsonProperty(PROP_IN_BEFORE_ONLY)
   public void setInBeforeOnly(SortedSet<String> inBeforeOnly) {
     _inBeforeOnly = inBeforeOnly;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Configuration.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Configuration.java
@@ -25,57 +25,57 @@ import org.codehaus.jettison.json.JSONObject;
         + "firewall.")
 public final class Configuration extends ComparableStructure<String> {
 
-  private static final String AS_PATH_ACCESS_LISTS_VAR = "asPathAccessLists";
+  private static final String PROP_AS_PATH_ACCESS_LISTS = "asPathAccessLists";
 
-  private static final String COMMUNITY_LISTS_VAR = "communityLists";
+  private static final String PROP_COMMUNITY_LISTS = "communityLists";
 
-  private static final String CONFIGURATION_FORMAT_VAR = "configurationFormat";
+  private static final String PROP_CONFIGURATION_FORMAT = "configurationFormat";
 
-  private static final String DEFAULT_CROSS_ZONE_ACTION_VAR = "defaultCrossZoneAction";
+  private static final String PROP_DEFAULT_CROSS_ZONE_ACTION = "defaultCrossZoneAction";
 
-  private static final String DEFAULT_INBOUND_ACTION_VAR = "defaultInboundAction";
+  private static final String PROP_DEFAULT_INBOUND_ACTION = "defaultInboundAction";
 
   public static final String DEFAULT_VRF_NAME = "default";
 
-  private static final String DNS_SOURCE_INTERFACE_VAR = "dnsSourceInterface";
+  private static final String PROP_DNS_SOURCE_INTERFACE = "dnsSourceInterface";
 
-  private static final String IKE_GATEWAYS_VAR = "ikeGateways";
+  private static final String PROP_IKE_GATEWAYS = "ikeGateways";
 
-  private static final String IKE_POLICIES_VAR = "ikePolicies";
+  private static final String PROP_IKE_POLICIES = "ikePolicies";
 
-  private static final String IKE_PROPOSALS_VAR = "ikeProposals";
+  private static final String PROP_IKE_PROPOSALS = "ikeProposals";
 
-  private static final String IP_ACCESS_LISTS_VAR = "ipAccessLists";
+  private static final String PROP_IP_ACCESS_LISTS = "ipAccessLists";
 
-  private static final String IPSEC_POLICIES_VAR = "ipsecPolicies";
+  private static final String PROP_IPSEC_POLICIES = "ipsecPolicies";
 
-  private static final String IPSEC_PROPOSALS_VAR = "ipsecProposals";
+  private static final String PROP_IPSEC_PROPOSALS = "ipsecProposals";
 
-  private static final String IPSEC_VPNS_VAR = "ipsecVpns";
+  private static final String PROP_IPSEC_VPNS = "ipsecVpns";
 
-  private static final String LOGGING_SOURCE_INTERFACE_VAR = "loggingSourceInterface";
+  private static final String PROP_LOGGING_SOURCE_INTERFACE = "loggingSourceInterface";
 
   public static final String NODE_NONE_NAME = "(none)";
 
-  private static final String NTP_SOURCE_INTERFACE_VAR = "ntpSourceInterface";
+  private static final String PROP_NTP_SOURCE_INTERFACE = "ntpSourceInterface";
 
-  private static final String ROLES_VAR = "roles";
+  private static final String PROP_ROLES = "roles";
 
-  private static final String ROUTE_FILTER_LISTS_VAR = "routeFilterLists";
+  private static final String PROP_ROUTE_FILTER_LISTS = "routeFilterLists";
 
-  private static final String ROUTING_POLICIES_VAR = "routingPolicies";
+  private static final String PROP_ROUTING_POLICIES = "routingPolicies";
 
   private static final long serialVersionUID = 1L;
 
-  private static final String SNMP_SOURCE_INTERFACE_VAR = "snmpSourceInterface";
+  private static final String PROP_SNMP_SOURCE_INTERFACE = "snmpSourceInterface";
 
-  private static final String TACACS_SOURCE_INTERFACE_VAR = "tacacsSourceInterface";
+  private static final String PROP_TACACS_SOURCE_INTERFACE = "tacacsSourceInterface";
 
   private static final int VLAN_NORMAL_MAX_DEFAULT = 4094;
 
   private static final int VLAN_NORMAL_MIN_DEFAULT = 1;
 
-  private static final String ZONES_VAR = "zones";
+  private static final String PROP_ZONES = "zones";
 
   private NavigableMap<String, AsPathAccessList> _asPathAccessLists;
 
@@ -169,7 +169,7 @@ public final class Configuration extends ComparableStructure<String> {
   private NavigableMap<String, Zone> _zones;
 
   @JsonCreator
-  public Configuration(@JsonProperty(NAME_VAR) String hostname) {
+  public Configuration(@JsonProperty(PROP_NAME) String hostname) {
     super(hostname);
     _asPathAccessLists = new TreeMap<>();
     _communityLists = new TreeMap<>();
@@ -197,7 +197,7 @@ public final class Configuration extends ComparableStructure<String> {
     _zones = new TreeMap<>();
   }
 
-  @JsonProperty(AS_PATH_ACCESS_LISTS_VAR)
+  @JsonProperty(PROP_AS_PATH_ACCESS_LISTS)
   @JsonPropertyDescription("Dictionary of all AS-path access-lists for this node.")
   public NavigableMap<String, AsPathAccessList> getAsPathAccessLists() {
     return _asPathAccessLists;
@@ -208,13 +208,13 @@ public final class Configuration extends ComparableStructure<String> {
     return _bgpAdvertisements;
   }
 
-  @JsonProperty(COMMUNITY_LISTS_VAR)
+  @JsonProperty(PROP_COMMUNITY_LISTS)
   @JsonPropertyDescription("Dictionary of all community-lists for this node.")
   public NavigableMap<String, CommunityList> getCommunityLists() {
     return _communityLists;
   }
 
-  @JsonProperty(CONFIGURATION_FORMAT_VAR)
+  @JsonProperty(PROP_CONFIGURATION_FORMAT)
   @JsonPropertyDescription(
       "Best guess at vendor configuration format. Used for setting default values, protocol "
           + "costs, etc.")
@@ -222,14 +222,14 @@ public final class Configuration extends ComparableStructure<String> {
     return _configurationFormat;
   }
 
-  @JsonProperty(DEFAULT_CROSS_ZONE_ACTION_VAR)
+  @JsonProperty(PROP_DEFAULT_CROSS_ZONE_ACTION)
   @JsonPropertyDescription(
       "Default forwarding action to take for traffic that crosses firewall zones.")
   public LineAction getDefaultCrossZoneAction() {
     return _defaultCrossZoneAction;
   }
 
-  @JsonProperty(DEFAULT_INBOUND_ACTION_VAR)
+  @JsonProperty(PROP_DEFAULT_INBOUND_ACTION)
   @JsonPropertyDescription(
       "Default forwarding action to take for traffic destined for this device.")
   public LineAction getDefaultInboundAction() {
@@ -245,7 +245,7 @@ public final class Configuration extends ComparableStructure<String> {
     return _dnsServers;
   }
 
-  @JsonProperty(DNS_SOURCE_INTERFACE_VAR)
+  @JsonProperty(PROP_DNS_SOURCE_INTERFACE)
   public String getDnsSourceInterface() {
     return _dnsSourceInterface;
   }
@@ -255,25 +255,25 @@ public final class Configuration extends ComparableStructure<String> {
     return _domainName;
   }
 
-  @JsonProperty(NAME_VAR)
+  @JsonProperty(PROP_NAME)
   @JsonPropertyDescription("Hostname of this node.")
   public String getHostname() {
     return _key;
   }
 
-  @JsonProperty(IKE_GATEWAYS_VAR)
+  @JsonProperty(PROP_IKE_GATEWAYS)
   @JsonPropertyDescription("Dictionary of all IKE gateways for this node.")
   public NavigableMap<String, IkeGateway> getIkeGateways() {
     return _ikeGateways;
   }
 
-  @JsonProperty(IKE_POLICIES_VAR)
+  @JsonProperty(PROP_IKE_POLICIES)
   @JsonPropertyDescription("Dictionary of all IKE policies for this node.")
   public NavigableMap<String, IkePolicy> getIkePolicies() {
     return _ikePolicies;
   }
 
-  @JsonProperty(IKE_PROPOSALS_VAR)
+  @JsonProperty(PROP_IKE_PROPOSALS)
   @JsonPropertyDescription("Dictionary of all IKE proposals for this node.")
   public NavigableMap<String, IkeProposal> getIkeProposals() {
     return _ikeProposals;
@@ -289,25 +289,25 @@ public final class Configuration extends ComparableStructure<String> {
     return _ip6AccessLists;
   }
 
-  @JsonProperty(IP_ACCESS_LISTS_VAR)
+  @JsonProperty(PROP_IP_ACCESS_LISTS)
   @JsonPropertyDescription("Dictionary of all IPV4 access-lists for this node.")
   public NavigableMap<String, IpAccessList> getIpAccessLists() {
     return _ipAccessLists;
   }
 
-  @JsonProperty(IPSEC_POLICIES_VAR)
+  @JsonProperty(PROP_IPSEC_POLICIES)
   @JsonPropertyDescription("Dictionary of all IPSEC policies for this node.")
   public NavigableMap<String, IpsecPolicy> getIpsecPolicies() {
     return _ipsecPolicies;
   }
 
-  @JsonProperty(IPSEC_PROPOSALS_VAR)
+  @JsonProperty(PROP_IPSEC_PROPOSALS)
   @JsonPropertyDescription("Dictionary of all IPSEC proposals for this node.")
   public NavigableMap<String, IpsecProposal> getIpsecProposals() {
     return _ipsecProposals;
   }
 
-  @JsonProperty(IPSEC_VPNS_VAR)
+  @JsonProperty(PROP_IPSEC_VPNS)
   @JsonPropertyDescription("Dictionary of all IPSEC VPNs for this node.")
   public NavigableMap<String, IpsecVpn> getIpsecVpns() {
     return _ipsecVpns;
@@ -317,7 +317,7 @@ public final class Configuration extends ComparableStructure<String> {
     return _loggingServers;
   }
 
-  @JsonProperty(LOGGING_SOURCE_INTERFACE_VAR)
+  @JsonProperty(PROP_LOGGING_SOURCE_INTERFACE)
   public String getLoggingSourceInterface() {
     return _loggingSourceInterface;
   }
@@ -331,7 +331,7 @@ public final class Configuration extends ComparableStructure<String> {
     return _ntpServers;
   }
 
-  @JsonProperty(NTP_SOURCE_INTERFACE_VAR)
+  @JsonProperty(PROP_NTP_SOURCE_INTERFACE)
   public String getNtpSourceInterface() {
     return _ntpSourceInterface;
   }
@@ -366,7 +366,7 @@ public final class Configuration extends ComparableStructure<String> {
     return _receivedIbgpAdvertisements;
   }
 
-  @JsonProperty(ROLES_VAR)
+  @JsonProperty(PROP_ROLES)
   @JsonPropertyDescription("Set of all roles in which this node serves.")
   public SortedSet<String> getRoles() {
     return _roles;
@@ -377,7 +377,7 @@ public final class Configuration extends ComparableStructure<String> {
     return _route6FilterLists;
   }
 
-  @JsonProperty(ROUTE_FILTER_LISTS_VAR)
+  @JsonProperty(PROP_ROUTE_FILTER_LISTS)
   @JsonPropertyDescription("Dictionary of all IPV4 route filter lists for this node.")
   public NavigableMap<String, RouteFilterList> getRouteFilterLists() {
     return _routeFilterLists;
@@ -388,7 +388,7 @@ public final class Configuration extends ComparableStructure<String> {
     return _routes;
   }
 
-  @JsonProperty(ROUTING_POLICIES_VAR)
+  @JsonProperty(PROP_ROUTING_POLICIES)
   @JsonPropertyDescription("Dictionary of all routing policies for this node.")
   public NavigableMap<String, RoutingPolicy> getRoutingPolicies() {
     return _routingPolicies;
@@ -409,7 +409,7 @@ public final class Configuration extends ComparableStructure<String> {
     return _sentIbgpAdvertisements;
   }
 
-  @JsonProperty(SNMP_SOURCE_INTERFACE_VAR)
+  @JsonProperty(PROP_SNMP_SOURCE_INTERFACE)
   public String getSnmpSourceInterface() {
     return _snmpSourceInterface;
   }
@@ -422,7 +422,7 @@ public final class Configuration extends ComparableStructure<String> {
     return _tacacsServers;
   }
 
-  @JsonProperty(TACACS_SOURCE_INTERFACE_VAR)
+  @JsonProperty(PROP_TACACS_SOURCE_INTERFACE)
   public String getTacacsSourceInterface() {
     return _tacacsSourceInterface;
   }
@@ -437,7 +437,7 @@ public final class Configuration extends ComparableStructure<String> {
     return _vrfs;
   }
 
-  @JsonProperty(ZONES_VAR)
+  @JsonProperty(PROP_ZONES)
   @JsonPropertyDescription("Dictionary of all firewall zones for this node.")
   public NavigableMap<String, Zone> getZones() {
     return _zones;
@@ -503,12 +503,12 @@ public final class Configuration extends ComparableStructure<String> {
     }
   }
 
-  @JsonProperty(AS_PATH_ACCESS_LISTS_VAR)
+  @JsonProperty(PROP_AS_PATH_ACCESS_LISTS)
   public void setAsPathAccessLists(NavigableMap<String, AsPathAccessList> asPathAccessLists) {
     _asPathAccessLists = asPathAccessLists;
   }
 
-  @JsonProperty(COMMUNITY_LISTS_VAR)
+  @JsonProperty(PROP_COMMUNITY_LISTS)
   public void setCommunityLists(NavigableMap<String, CommunityList> communityLists) {
     _communityLists = communityLists;
   }
@@ -529,7 +529,7 @@ public final class Configuration extends ComparableStructure<String> {
     _dnsServers = dnsServers;
   }
 
-  @JsonProperty(DNS_SOURCE_INTERFACE_VAR)
+  @JsonProperty(PROP_DNS_SOURCE_INTERFACE)
   public void setDnsSourceInterface(String dnsSourceInterface) {
     _dnsSourceInterface = dnsSourceInterface;
   }
@@ -538,17 +538,17 @@ public final class Configuration extends ComparableStructure<String> {
     _domainName = domainName;
   }
 
-  @JsonProperty(IKE_GATEWAYS_VAR)
+  @JsonProperty(PROP_IKE_GATEWAYS)
   public void setIkeGateways(NavigableMap<String, IkeGateway> ikeGateways) {
     _ikeGateways = ikeGateways;
   }
 
-  @JsonProperty(IKE_POLICIES_VAR)
+  @JsonProperty(PROP_IKE_POLICIES)
   public void setIkePolicies(NavigableMap<String, IkePolicy> ikePolicies) {
     _ikePolicies = ikePolicies;
   }
 
-  @JsonProperty(IKE_PROPOSALS_VAR)
+  @JsonProperty(PROP_IKE_PROPOSALS)
   public void setIkeProposals(NavigableMap<String, IkeProposal> ikeProposals) {
     _ikeProposals = ikeProposals;
   }
@@ -561,22 +561,22 @@ public final class Configuration extends ComparableStructure<String> {
     _ip6AccessLists = ip6AccessLists;
   }
 
-  @JsonProperty(IP_ACCESS_LISTS_VAR)
+  @JsonProperty(PROP_IP_ACCESS_LISTS)
   public void setIpAccessLists(NavigableMap<String, IpAccessList> ipAccessLists) {
     _ipAccessLists = ipAccessLists;
   }
 
-  @JsonProperty(IPSEC_POLICIES_VAR)
+  @JsonProperty(PROP_IPSEC_POLICIES)
   public void setIpsecPolicies(NavigableMap<String, IpsecPolicy> ipsecPolicies) {
     _ipsecPolicies = ipsecPolicies;
   }
 
-  @JsonProperty(IPSEC_PROPOSALS_VAR)
+  @JsonProperty(PROP_IPSEC_PROPOSALS)
   public void setIpsecProposals(NavigableMap<String, IpsecProposal> ipsecProposals) {
     _ipsecProposals = ipsecProposals;
   }
 
-  @JsonProperty(IPSEC_VPNS_VAR)
+  @JsonProperty(PROP_IPSEC_VPNS)
   public void setIpsecVpns(NavigableMap<String, IpsecVpn> ipsecVpns) {
     _ipsecVpns = ipsecVpns;
   }
@@ -585,7 +585,7 @@ public final class Configuration extends ComparableStructure<String> {
     _loggingServers = loggingServers;
   }
 
-  @JsonProperty(LOGGING_SOURCE_INTERFACE_VAR)
+  @JsonProperty(PROP_LOGGING_SOURCE_INTERFACE)
   public void setLoggingSourceInterface(String loggingSourceInterface) {
     _loggingSourceInterface = loggingSourceInterface;
   }
@@ -599,7 +599,7 @@ public final class Configuration extends ComparableStructure<String> {
     _ntpServers = ntpServers;
   }
 
-  @JsonProperty(NTP_SOURCE_INTERFACE_VAR)
+  @JsonProperty(PROP_NTP_SOURCE_INTERFACE)
   public void setNtpSourceInterface(String ntpSourceInterface) {
     _ntpSourceInterface = ntpSourceInterface;
   }
@@ -612,17 +612,17 @@ public final class Configuration extends ComparableStructure<String> {
     _route6FilterLists = route6FilterLists;
   }
 
-  @JsonProperty(ROUTE_FILTER_LISTS_VAR)
+  @JsonProperty(PROP_ROUTE_FILTER_LISTS)
   public void setRouteFilterLists(NavigableMap<String, RouteFilterList> routeFilterLists) {
     _routeFilterLists = routeFilterLists;
   }
 
-  @JsonProperty(ROUTING_POLICIES_VAR)
+  @JsonProperty(PROP_ROUTING_POLICIES)
   public void setRoutingPolicies(NavigableMap<String, RoutingPolicy> routingPolicies) {
     _routingPolicies = routingPolicies;
   }
 
-  @JsonProperty(SNMP_SOURCE_INTERFACE_VAR)
+  @JsonProperty(PROP_SNMP_SOURCE_INTERFACE)
   public void setSnmpSourceInterface(String snmpSourceInterface) {
     _snmpSourceInterface = snmpSourceInterface;
   }
@@ -635,7 +635,7 @@ public final class Configuration extends ComparableStructure<String> {
     _tacacsServers = tacacsServers;
   }
 
-  @JsonProperty(TACACS_SOURCE_INTERFACE_VAR)
+  @JsonProperty(PROP_TACACS_SOURCE_INTERFACE)
   public void setTacacsSourceInterface(String tacacsSourceInterface) {
     _tacacsSourceInterface = tacacsSourceInterface;
   }
@@ -648,7 +648,7 @@ public final class Configuration extends ComparableStructure<String> {
     _vrfs = vrfs;
   }
 
-  @JsonProperty(ZONES_VAR)
+  @JsonProperty(PROP_ZONES)
   public void setZones(NavigableMap<String, Zone> zones) {
     _zones = zones;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ConfigurationDiff.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ConfigurationDiff.java
@@ -7,19 +7,19 @@ import org.batfish.datamodel.answers.AnswerElement;
 
 public class ConfigurationDiff implements AnswerElement {
 
-  private static final String AS_PATH_ACCESS_LISTS_DIFF_VAR = "asPathAccessListsDiff";
+  private static final String PROP_AS_PATH_ACCESS_LISTS_DIFF = "asPathAccessListsDiff";
 
-  private static final String COMMUNITY_LISTS_DIFF_VAR = "comunityListsDiff";
+  private static final String PROP_COMMUNITY_LISTS_DIFF = "comunityListsDiff";
 
-  private static final String INTERFACES_DIFF_VAR = "interfacesDiff";
+  private static final String PROP_INTERFACES_DIFF = "interfacesDiff";
 
-  private static final String IP_ACCESS_LISTS_DIFF_VAR = "ipAccessListsDiff";
+  private static final String PROP_IP_ACCESS_LISTS_DIFF = "ipAccessListsDiff";
 
-  private static final String ROUTE_FILTER_LISTS_DIFF_VAR = "routeFilterListsDiff";
+  private static final String PROP_ROUTE_FILTER_LISTS_DIFF = "routeFilterListsDiff";
 
-  private static final String ROUTING_POLICIES_DIFF_VAR = "routingPoliciesDiff";
+  private static final String PROP_ROUTING_POLICIES_DIFF = "routingPoliciesDiff";
 
-  private static final String VRFS_DIFF_VAR = "vrfsDiff";
+  private static final String PROP_VRFS_DIFF = "vrfsDiff";
 
   private AsPathAccessListsDiff _asPathAccessListsDiff;
 
@@ -73,37 +73,37 @@ public class ConfigurationDiff implements AnswerElement {
     }
   }
 
-  @JsonProperty(AS_PATH_ACCESS_LISTS_DIFF_VAR)
+  @JsonProperty(PROP_AS_PATH_ACCESS_LISTS_DIFF)
   public AsPathAccessListsDiff getAsPathAccessListsDiff() {
     return _asPathAccessListsDiff;
   }
 
-  @JsonProperty(COMMUNITY_LISTS_DIFF_VAR)
+  @JsonProperty(PROP_COMMUNITY_LISTS_DIFF)
   public CommunityListsDiff getCommunityListsDiff() {
     return _communityListsDiff;
   }
 
-  @JsonProperty(INTERFACES_DIFF_VAR)
+  @JsonProperty(PROP_INTERFACES_DIFF)
   public InterfacesDiff getInterfacesDiff() {
     return _interfacesDiff;
   }
 
-  @JsonProperty(IP_ACCESS_LISTS_DIFF_VAR)
+  @JsonProperty(PROP_IP_ACCESS_LISTS_DIFF)
   public IpAccessListsDiff getIpAccessListsDiff() {
     return _ipAccessListsDiff;
   }
 
-  @JsonProperty(ROUTE_FILTER_LISTS_DIFF_VAR)
+  @JsonProperty(PROP_ROUTE_FILTER_LISTS_DIFF)
   public RouteFilterListsDiff getRouteFilterListsDiff() {
     return _routeFilterListsDiff;
   }
 
-  @JsonProperty(ROUTING_POLICIES_DIFF_VAR)
+  @JsonProperty(PROP_ROUTING_POLICIES_DIFF)
   public RoutingPoliciesDiff getRoutingPoliciesDiff() {
     return _routingPoliciesDiff;
   }
 
-  @JsonProperty(VRFS_DIFF_VAR)
+  @JsonProperty(PROP_VRFS_DIFF)
   public VrfsDiff getVrfsDiff() {
     return _vrfsDiff;
   }
@@ -119,37 +119,37 @@ public class ConfigurationDiff implements AnswerElement {
         && _routingPoliciesDiff == null;
   }
 
-  @JsonProperty(AS_PATH_ACCESS_LISTS_DIFF_VAR)
+  @JsonProperty(PROP_AS_PATH_ACCESS_LISTS_DIFF)
   public void setAsPathAccessListsDiff(AsPathAccessListsDiff asPathAccessListsDiff) {
     _asPathAccessListsDiff = asPathAccessListsDiff;
   }
 
-  @JsonProperty(COMMUNITY_LISTS_DIFF_VAR)
+  @JsonProperty(PROP_COMMUNITY_LISTS_DIFF)
   public void setCommunityListsDiff(CommunityListsDiff communityListsDiff) {
     _communityListsDiff = communityListsDiff;
   }
 
-  @JsonProperty(INTERFACES_DIFF_VAR)
+  @JsonProperty(PROP_INTERFACES_DIFF)
   public void setInterfacesDiff(InterfacesDiff interfacesDiff) {
     _interfacesDiff = interfacesDiff;
   }
 
-  @JsonProperty(IP_ACCESS_LISTS_DIFF_VAR)
+  @JsonProperty(PROP_IP_ACCESS_LISTS_DIFF)
   public void setIpAccessListsDiff(IpAccessListsDiff ipAccessListsDiff) {
     _ipAccessListsDiff = ipAccessListsDiff;
   }
 
-  @JsonProperty(ROUTE_FILTER_LISTS_DIFF_VAR)
+  @JsonProperty(PROP_ROUTE_FILTER_LISTS_DIFF)
   public void setRouteFilterListsDiff(RouteFilterListsDiff routeFilterListsDiff) {
     _routeFilterListsDiff = routeFilterListsDiff;
   }
 
-  @JsonProperty(ROUTING_POLICIES_DIFF_VAR)
+  @JsonProperty(PROP_ROUTING_POLICIES_DIFF)
   public void setRoutingPoliciesDiff(RoutingPoliciesDiff routingPoliciesDiff) {
     _routingPoliciesDiff = routingPoliciesDiff;
   }
 
-  @JsonProperty(VRFS_DIFF_VAR)
+  @JsonProperty(PROP_VRFS_DIFF)
   public void setVrfsDiff(VrfsDiff vrfsDiff) {
     _vrfsDiff = vrfsDiff;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ConnectedRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ConnectedRoute.java
@@ -15,8 +15,8 @@ public class ConnectedRoute extends AbstractRoute {
 
   @JsonCreator
   public ConnectedRoute(
-      @JsonProperty(NETWORK_VAR) Prefix network,
-      @JsonProperty(NEXT_HOP_INTERFACE_VAR) String nextHopInterface) {
+      @JsonProperty(PROP_NETWORK) Prefix network,
+      @JsonProperty(PROP_NEXT_HOP_INTERFACE) String nextHopInterface) {
     super(network);
     _nextHopInterface = firstNonNull(nextHopInterface, Route.UNSET_NEXT_HOP_INTERFACE);
   }
@@ -40,7 +40,7 @@ public class ConnectedRoute extends AbstractRoute {
 
   @Nonnull
   @JsonIgnore(false)
-  @JsonProperty(NEXT_HOP_INTERFACE_VAR)
+  @JsonProperty(PROP_NEXT_HOP_INTERFACE)
   @Override
   public String getNextHopInterface() {
     return _nextHopInterface;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Edge.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Edge.java
@@ -8,13 +8,13 @@ import org.batfish.datamodel.collections.NodeInterfacePair;
 
 public class Edge extends Pair<NodeInterfacePair, NodeInterfacePair> {
 
-  private static final String INT1_VAR = "node1interface";
+  private static final String PROP_INT1 = "node1interface";
 
-  private static final String INT2_VAR = "node2interface";
+  private static final String PROP_INT2 = "node2interface";
 
-  private static final String NODE1_VAR = "node1";
+  private static final String PROP_NODE1 = "node1";
 
-  private static final String NODE2_VAR = "node2";
+  private static final String PROP_NODE2 = "node2";
 
   private static final long serialVersionUID = 1L;
 
@@ -24,19 +24,19 @@ public class Edge extends Pair<NodeInterfacePair, NodeInterfacePair> {
 
   @JsonCreator
   public Edge(
-      @JsonProperty(NODE1_VAR) String node1,
-      @JsonProperty(INT1_VAR) String int1,
-      @JsonProperty(NODE2_VAR) String node2,
-      @JsonProperty(INT2_VAR) String int2) {
+      @JsonProperty(PROP_NODE1) String node1,
+      @JsonProperty(PROP_INT1) String int1,
+      @JsonProperty(PROP_NODE2) String node2,
+      @JsonProperty(PROP_INT2) String int2) {
     super(new NodeInterfacePair(node1, int1), new NodeInterfacePair(node2, int2));
   }
 
-  @JsonProperty(INT1_VAR)
+  @JsonProperty(PROP_INT1)
   public String getInt1() {
     return _first.getInterface();
   }
 
-  @JsonProperty(INT2_VAR)
+  @JsonProperty(PROP_INT2)
   public String getInt2() {
     return _second.getInterface();
   }
@@ -51,12 +51,12 @@ public class Edge extends Pair<NodeInterfacePair, NodeInterfacePair> {
     return _second;
   }
 
-  @JsonProperty(NODE1_VAR)
+  @JsonProperty(PROP_NODE1)
   public String getNode1() {
     return _first.getHostname();
   }
 
-  @JsonProperty(NODE2_VAR)
+  @JsonProperty(PROP_NODE2)
   public String getNode2() {
     return _second.getHostname();
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Flow.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Flow.java
@@ -341,53 +341,53 @@ public final class Flow implements Comparable<Flow> {
     }
   }
 
-  private static final String DSCP_VAR = "dscp";
+  private static final String PROP_DSCP = "dscp";
 
-  private static final String DST_IP_VAR = "dstIp";
+  private static final String PROP_DST_IP = "dstIp";
 
-  private static final String DST_PORT_VAR = "dstPort";
+  private static final String PROP_DST_PORT = "dstPort";
 
-  private static final String ECN_VAR = "ecn";
+  private static final String PROP_ECN = "ecn";
 
-  private static final String FRAGMENT_OFFSET_VAR = "fragmentOffset";
+  private static final String PROP_FRAGMENT_OFFSET = "fragmentOffset";
 
-  private static final String ICMP_CODE_VAR = "icmpCode";
+  private static final String PROP_ICMP_CODE = "icmpCode";
 
-  private static final String ICMP_TYPE_VAR = "icmpVar";
+  private static final String PROP_ICMP_TYPE = "icmpVar";
 
-  private static final String INGRESS_INTERFACE_VAR = "ingressInterface";
+  private static final String PROP_INGRESS_INTERFACE = "ingressInterface";
 
-  private static final String INGRESS_NODE_VAR = "ingressNode";
+  private static final String PROP_INGRESS_NODE = "ingressNode";
 
-  private static final String INGRESS_VRF_VAR = "ingressVrf";
+  private static final String PROP_INGRESS_VRF = "ingressVrf";
 
-  private static final String IP_PROTOCOL_VAR = "ipProtocol";
+  private static final String PROP_IP_PROTOCOL = "ipProtocol";
 
-  private static final String PACKET_LENGTH_VAR = "packetLength";
+  private static final String PROP_PACKET_LENGTH = "packetLength";
 
-  private static final String SRC_IP_VAR = "srcIp";
+  private static final String PROP_SRC_IP = "srcIp";
 
-  private static final String SRC_PORT_VAR = "srcPort";
+  private static final String PROP_SRC_PORT = "srcPort";
 
-  private static final String STATE_VAR = "state";
+  private static final String PROP_STATE = "state";
 
-  private static final String TAG_VAR = "tag";
+  private static final String PROP_TAG = "tag";
 
-  private static final String TCP_FLAGS_ACK_VAR = "tcpFlagsAck";
+  private static final String PROP_TCP_FLAGS_ACK = "tcpFlagsAck";
 
-  private static final String TCP_FLAGS_CWR_VAR = "tcpFlagsCwr";
+  private static final String PROP_TCP_FLAGS_CWR = "tcpFlagsCwr";
 
-  private static final String TCP_FLAGS_ECE_VAR = "tcpFlagsEce";
+  private static final String PROP_TCP_FLAGS_ECE = "tcpFlagsEce";
 
-  private static final String TCP_FLAGS_FIN_VAR = "tcpFlagsFin";
+  private static final String PROP_TCP_FLAGS_FIN = "tcpFlagsFin";
 
-  private static final String TCP_FLAGS_PSH_VAR = "tcpFlagsPsh";
+  private static final String PROP_TCP_FLAGS_PSH = "tcpFlagsPsh";
 
-  private static final String TCP_FLAGS_RST_VAR = "tcpFlagsRst";
+  private static final String PROP_TCP_FLAGS_RST = "tcpFlagsRst";
 
-  private static final String TCP_FLAGS_SYN_VAR = "tcpFlagsSyn";
+  private static final String PROP_TCP_FLAGS_SYN = "tcpFlagsSyn";
 
-  private static final String TCP_FLAGS_URG_VAR = "tcpFlagsUrg";
+  private static final String PROP_TCP_FLAGS_URG = "tcpFlagsUrg";
 
   private final int _dscp;
 
@@ -439,30 +439,30 @@ public final class Flow implements Comparable<Flow> {
 
   @JsonCreator
   public Flow(
-      @JsonProperty(INGRESS_NODE_VAR) String ingressNode,
-      @JsonProperty(INGRESS_INTERFACE_VAR) String ingressInterface,
-      @JsonProperty(INGRESS_VRF_VAR) String ingressVrf,
-      @JsonProperty(SRC_IP_VAR) Ip srcIp,
-      @JsonProperty(DST_IP_VAR) Ip dstIp,
-      @JsonProperty(SRC_PORT_VAR) int srcPort,
-      @JsonProperty(DST_PORT_VAR) int dstPort,
-      @JsonProperty(IP_PROTOCOL_VAR) IpProtocol ipProtocol,
-      @JsonProperty(DSCP_VAR) int dscp,
-      @JsonProperty(ECN_VAR) int ecn,
-      @JsonProperty(FRAGMENT_OFFSET_VAR) int fragmentOffset,
-      @JsonProperty(ICMP_TYPE_VAR) int icmpType,
-      @JsonProperty(ICMP_CODE_VAR) int icmpCode,
-      @JsonProperty(PACKET_LENGTH_VAR) int packetLength,
-      @JsonProperty(STATE_VAR) State state,
-      @JsonProperty(TCP_FLAGS_CWR_VAR) int tcpFlagsCwr,
-      @JsonProperty(TCP_FLAGS_ECE_VAR) int tcpFlagsEce,
-      @JsonProperty(TCP_FLAGS_URG_VAR) int tcpFlagsUrg,
-      @JsonProperty(TCP_FLAGS_ACK_VAR) int tcpFlagsAck,
-      @JsonProperty(TCP_FLAGS_PSH_VAR) int tcpFlagsPsh,
-      @JsonProperty(TCP_FLAGS_RST_VAR) int tcpFlagsRst,
-      @JsonProperty(TCP_FLAGS_SYN_VAR) int tcpFlagsSyn,
-      @JsonProperty(TCP_FLAGS_FIN_VAR) int tcpFlagsFin,
-      @JsonProperty(TAG_VAR) String tag) {
+      @JsonProperty(PROP_INGRESS_NODE) String ingressNode,
+      @JsonProperty(PROP_INGRESS_INTERFACE) String ingressInterface,
+      @JsonProperty(PROP_INGRESS_VRF) String ingressVrf,
+      @JsonProperty(PROP_SRC_IP) Ip srcIp,
+      @JsonProperty(PROP_DST_IP) Ip dstIp,
+      @JsonProperty(PROP_SRC_PORT) int srcPort,
+      @JsonProperty(PROP_DST_PORT) int dstPort,
+      @JsonProperty(PROP_IP_PROTOCOL) IpProtocol ipProtocol,
+      @JsonProperty(PROP_DSCP) int dscp,
+      @JsonProperty(PROP_ECN) int ecn,
+      @JsonProperty(PROP_FRAGMENT_OFFSET) int fragmentOffset,
+      @JsonProperty(PROP_ICMP_TYPE) int icmpType,
+      @JsonProperty(PROP_ICMP_CODE) int icmpCode,
+      @JsonProperty(PROP_PACKET_LENGTH) int packetLength,
+      @JsonProperty(PROP_STATE) State state,
+      @JsonProperty(PROP_TCP_FLAGS_CWR) int tcpFlagsCwr,
+      @JsonProperty(PROP_TCP_FLAGS_ECE) int tcpFlagsEce,
+      @JsonProperty(PROP_TCP_FLAGS_URG) int tcpFlagsUrg,
+      @JsonProperty(PROP_TCP_FLAGS_ACK) int tcpFlagsAck,
+      @JsonProperty(PROP_TCP_FLAGS_PSH) int tcpFlagsPsh,
+      @JsonProperty(PROP_TCP_FLAGS_RST) int tcpFlagsRst,
+      @JsonProperty(PROP_TCP_FLAGS_SYN) int tcpFlagsSyn,
+      @JsonProperty(PROP_TCP_FLAGS_FIN) int tcpFlagsFin,
+      @JsonProperty(PROP_TAG) String tag) {
     _ingressNode = ingressNode;
     _ingressInterface = ingressInterface;
     _ingressVrf = ingressVrf;
@@ -651,122 +651,122 @@ public final class Flow implements Comparable<Flow> {
     return _tag.equals(other._tag);
   }
 
-  @JsonProperty(DSCP_VAR)
+  @JsonProperty(PROP_DSCP)
   public int getDscp() {
     return _dscp;
   }
 
-  @JsonProperty(DST_IP_VAR)
+  @JsonProperty(PROP_DST_IP)
   public Ip getDstIp() {
     return _dstIp;
   }
 
-  @JsonProperty(DST_PORT_VAR)
+  @JsonProperty(PROP_DST_PORT)
   public Integer getDstPort() {
     return _dstPort;
   }
 
-  @JsonProperty(ECN_VAR)
+  @JsonProperty(PROP_ECN)
   public int getEcn() {
     return _ecn;
   }
 
-  @JsonProperty(FRAGMENT_OFFSET_VAR)
+  @JsonProperty(PROP_FRAGMENT_OFFSET)
   public int getFragmentOffset() {
     return _fragmentOffset;
   }
 
-  @JsonProperty(ICMP_CODE_VAR)
+  @JsonProperty(PROP_ICMP_CODE)
   public Integer getIcmpCode() {
     return _icmpCode;
   }
 
-  @JsonProperty(ICMP_TYPE_VAR)
+  @JsonProperty(PROP_ICMP_TYPE)
   public Integer getIcmpType() {
     return _icmpType;
   }
 
-  @JsonProperty(INGRESS_INTERFACE_VAR)
+  @JsonProperty(PROP_INGRESS_INTERFACE)
   public String getIngressInterface() {
     return _ingressInterface;
   }
 
-  @JsonProperty(INGRESS_NODE_VAR)
+  @JsonProperty(PROP_INGRESS_NODE)
   public String getIngressNode() {
     return _ingressNode;
   }
 
-  @JsonProperty(INGRESS_VRF_VAR)
+  @JsonProperty(PROP_INGRESS_VRF)
   public String getIngressVrf() {
     return _ingressVrf;
   }
 
-  @JsonProperty(IP_PROTOCOL_VAR)
+  @JsonProperty(PROP_IP_PROTOCOL)
   public IpProtocol getIpProtocol() {
     return _ipProtocol;
   }
 
-  @JsonProperty(PACKET_LENGTH_VAR)
+  @JsonProperty(PROP_PACKET_LENGTH)
   public int getPacketLength() {
     return _packetLength;
   }
 
-  @JsonProperty(SRC_IP_VAR)
+  @JsonProperty(PROP_SRC_IP)
   public Ip getSrcIp() {
     return _srcIp;
   }
 
-  @JsonProperty(SRC_PORT_VAR)
+  @JsonProperty(PROP_SRC_PORT)
   public Integer getSrcPort() {
     return _srcPort;
   }
 
-  @JsonProperty(STATE_VAR)
+  @JsonProperty(PROP_STATE)
   public State getState() {
     return _state;
   }
 
-  @JsonProperty(TAG_VAR)
+  @JsonProperty(PROP_TAG)
   public String getTag() {
     return _tag;
   }
 
-  @JsonProperty(TCP_FLAGS_ACK_VAR)
+  @JsonProperty(PROP_TCP_FLAGS_ACK)
   public int getTcpFlagsAck() {
     return _tcpFlagsAck;
   }
 
-  @JsonProperty(TCP_FLAGS_CWR_VAR)
+  @JsonProperty(PROP_TCP_FLAGS_CWR)
   public int getTcpFlagsCwr() {
     return _tcpFlagsCwr;
   }
 
-  @JsonProperty(TCP_FLAGS_ECE_VAR)
+  @JsonProperty(PROP_TCP_FLAGS_ECE)
   public int getTcpFlagsEce() {
     return _tcpFlagsEce;
   }
 
-  @JsonProperty(TCP_FLAGS_FIN_VAR)
+  @JsonProperty(PROP_TCP_FLAGS_FIN)
   public int getTcpFlagsFin() {
     return _tcpFlagsFin;
   }
 
-  @JsonProperty(TCP_FLAGS_PSH_VAR)
+  @JsonProperty(PROP_TCP_FLAGS_PSH)
   public int getTcpFlagsPsh() {
     return _tcpFlagsPsh;
   }
 
-  @JsonProperty(TCP_FLAGS_RST_VAR)
+  @JsonProperty(PROP_TCP_FLAGS_RST)
   public int getTcpFlagsRst() {
     return _tcpFlagsRst;
   }
 
-  @JsonProperty(TCP_FLAGS_SYN_VAR)
+  @JsonProperty(PROP_TCP_FLAGS_SYN)
   public int getTcpFlagsSyn() {
     return _tcpFlagsSyn;
   }
 
-  @JsonProperty(TCP_FLAGS_URG_VAR)
+  @JsonProperty(PROP_TCP_FLAGS_URG)
   public int getTcpFlagsUrg() {
     return _tcpFlagsUrg;
   }
@@ -858,7 +858,7 @@ public final class Flow implements Comparable<Flow> {
         + tcpFlagsStr;
   }
 
-  @JsonProperty(INGRESS_INTERFACE_VAR)
+  @JsonProperty(PROP_INGRESS_INTERFACE)
   public void setIngressInterface(String ingressInterface) {
     _ingressInterface = ingressInterface;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Flow6.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Flow6.java
@@ -8,47 +8,47 @@ import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 @JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@id")
 public final class Flow6 implements Comparable<Flow6> {
 
-  private static final String DSCP_VAR = "dscp";
+  private static final String PROP_DSCP = "dscp";
 
-  private static final String DST_IP_VAR = "dstIp";
+  private static final String PROP_DST_IP = "dstIp";
 
-  private static final String DST_PORT_VAR = "dstPort";
+  private static final String PROP_DST_PORT = "dstPort";
 
-  private static final String ECN_VAR = "ecn";
+  private static final String PROP_ECN = "ecn";
 
-  private static final String FRAGMENT_OFFSET_VAR = "fragmentOffset";
+  private static final String PROP_FRAGMENT_OFFSET = "fragmentOffset";
 
-  private static final String ICMP_CODE_VAR = "icmpCode";
+  private static final String PROP_ICMP_CODE = "icmpCode";
 
-  private static final String ICMP_TYPE_VAR = "icmpVar";
+  private static final String PROP_ICMP_TYPE = "icmpVar";
 
-  private static final String INGRESS_NODE_VAR = "ingressNode";
+  private static final String PROP_INGRESS_NODE = "ingressNode";
 
-  private static final String IP_PROTOCOL_VAR = "ipProtocol";
+  private static final String PROP_IP_PROTOCOL = "ipProtocol";
 
-  private static final String SRC_IP_VAR = "srcIp";
+  private static final String PROP_SRC_IP = "srcIp";
 
-  private static final String SRC_PORT_VAR = "srcPort";
+  private static final String PROP_SRC_PORT = "srcPort";
 
-  private static final String STATE_VAR = "state";
+  private static final String PROP_STATE = "state";
 
-  private static final String TAG_VAR = "tag";
+  private static final String PROP_TAG = "tag";
 
-  private static final String TCP_FLAGS_ACK_VAR = "tcpFlagsAck";
+  private static final String PROP_TCP_FLAGS_ACK = "tcpFlagsAck";
 
-  private static final String TCP_FLAGS_CWR_VAR = "tcpFlagsCwr";
+  private static final String PROP_TCP_FLAGS_CWR = "tcpFlagsCwr";
 
-  private static final String TCP_FLAGS_ECE_VAR = "tcpFlagsEce";
+  private static final String PROP_TCP_FLAGS_ECE = "tcpFlagsEce";
 
-  private static final String TCP_FLAGS_FIN_VAR = "tcpFlagsFin";
+  private static final String PROP_TCP_FLAGS_FIN = "tcpFlagsFin";
 
-  private static final String TCP_FLAGS_PSH_VAR = "tcpFlagsPsh";
+  private static final String PROP_TCP_FLAGS_PSH = "tcpFlagsPsh";
 
-  private static final String TCP_FLAGS_RST_VAR = "tcpFlagsRst";
+  private static final String PROP_TCP_FLAGS_RST = "tcpFlagsRst";
 
-  private static final String TCP_FLAGS_SYN_VAR = "tcpFlagsSyn";
+  private static final String PROP_TCP_FLAGS_SYN = "tcpFlagsSyn";
 
-  private static final String TCP_FLAGS_URG_VAR = "tcpFlagsUrg";
+  private static final String PROP_TCP_FLAGS_URG = "tcpFlagsUrg";
 
   private final int _dscp;
 
@@ -94,27 +94,27 @@ public final class Flow6 implements Comparable<Flow6> {
 
   @JsonCreator
   public Flow6(
-      @JsonProperty(INGRESS_NODE_VAR) String ingressNode,
-      @JsonProperty(SRC_IP_VAR) Ip6 srcIp,
-      @JsonProperty(DST_IP_VAR) Ip6 dstIp,
-      @JsonProperty(SRC_PORT_VAR) int srcPort,
-      @JsonProperty(DST_PORT_VAR) int dstPort,
-      @JsonProperty(IP_PROTOCOL_VAR) IpProtocol ipProtocol,
-      @JsonProperty(DSCP_VAR) int dscp,
-      @JsonProperty(ECN_VAR) int ecn,
-      @JsonProperty(FRAGMENT_OFFSET_VAR) int fragmentOffset,
-      @JsonProperty(ICMP_TYPE_VAR) int icmpType,
-      @JsonProperty(ICMP_CODE_VAR) int icmpCode,
-      @JsonProperty(STATE_VAR) State state,
-      @JsonProperty(TCP_FLAGS_CWR_VAR) int tcpFlagsCwr,
-      @JsonProperty(TCP_FLAGS_ECE_VAR) int tcpFlagsEce,
-      @JsonProperty(TCP_FLAGS_URG_VAR) int tcpFlagsUrg,
-      @JsonProperty(TCP_FLAGS_ACK_VAR) int tcpFlagsAck,
-      @JsonProperty(TCP_FLAGS_PSH_VAR) int tcpFlagsPsh,
-      @JsonProperty(TCP_FLAGS_RST_VAR) int tcpFlagsRst,
-      @JsonProperty(TCP_FLAGS_SYN_VAR) int tcpFlagsSyn,
-      @JsonProperty(TCP_FLAGS_FIN_VAR) int tcpFlagsFin,
-      @JsonProperty(TAG_VAR) String tag) {
+      @JsonProperty(PROP_INGRESS_NODE) String ingressNode,
+      @JsonProperty(PROP_SRC_IP) Ip6 srcIp,
+      @JsonProperty(PROP_DST_IP) Ip6 dstIp,
+      @JsonProperty(PROP_SRC_PORT) int srcPort,
+      @JsonProperty(PROP_DST_PORT) int dstPort,
+      @JsonProperty(PROP_IP_PROTOCOL) IpProtocol ipProtocol,
+      @JsonProperty(PROP_DSCP) int dscp,
+      @JsonProperty(PROP_ECN) int ecn,
+      @JsonProperty(PROP_FRAGMENT_OFFSET) int fragmentOffset,
+      @JsonProperty(PROP_ICMP_TYPE) int icmpType,
+      @JsonProperty(PROP_ICMP_CODE) int icmpCode,
+      @JsonProperty(PROP_STATE) State state,
+      @JsonProperty(PROP_TCP_FLAGS_CWR) int tcpFlagsCwr,
+      @JsonProperty(PROP_TCP_FLAGS_ECE) int tcpFlagsEce,
+      @JsonProperty(PROP_TCP_FLAGS_URG) int tcpFlagsUrg,
+      @JsonProperty(PROP_TCP_FLAGS_ACK) int tcpFlagsAck,
+      @JsonProperty(PROP_TCP_FLAGS_PSH) int tcpFlagsPsh,
+      @JsonProperty(PROP_TCP_FLAGS_RST) int tcpFlagsRst,
+      @JsonProperty(PROP_TCP_FLAGS_SYN) int tcpFlagsSyn,
+      @JsonProperty(PROP_TCP_FLAGS_FIN) int tcpFlagsFin,
+      @JsonProperty(PROP_TAG) String tag) {
     _ingressNode = ingressNode;
     _srcIp = srcIp;
     _dstIp = dstIp;
@@ -286,107 +286,107 @@ public final class Flow6 implements Comparable<Flow6> {
     return _tag.equals(other._tag);
   }
 
-  @JsonProperty(DSCP_VAR)
+  @JsonProperty(PROP_DSCP)
   public int getDscp() {
     return _dscp;
   }
 
-  @JsonProperty(DST_IP_VAR)
+  @JsonProperty(PROP_DST_IP)
   public Ip6 getDstIp() {
     return _dstIp;
   }
 
-  @JsonProperty(DST_PORT_VAR)
+  @JsonProperty(PROP_DST_PORT)
   public Integer getDstPort() {
     return _dstPort;
   }
 
-  @JsonProperty(ECN_VAR)
+  @JsonProperty(PROP_ECN)
   public int getEcn() {
     return _ecn;
   }
 
-  @JsonProperty(FRAGMENT_OFFSET_VAR)
+  @JsonProperty(PROP_FRAGMENT_OFFSET)
   public int getFragmentOffset() {
     return _fragmentOffset;
   }
 
-  @JsonProperty(ICMP_CODE_VAR)
+  @JsonProperty(PROP_ICMP_CODE)
   public Integer getIcmpCode() {
     return _icmpCode;
   }
 
-  @JsonProperty(ICMP_TYPE_VAR)
+  @JsonProperty(PROP_ICMP_TYPE)
   public Integer getIcmpType() {
     return _icmpType;
   }
 
-  @JsonProperty(INGRESS_NODE_VAR)
+  @JsonProperty(PROP_INGRESS_NODE)
   public String getIngressNode() {
     return _ingressNode;
   }
 
-  @JsonProperty(IP_PROTOCOL_VAR)
+  @JsonProperty(PROP_IP_PROTOCOL)
   public IpProtocol getIpProtocol() {
     return _ipProtocol;
   }
 
-  @JsonProperty(SRC_IP_VAR)
+  @JsonProperty(PROP_SRC_IP)
   public Ip6 getSrcIp() {
     return _srcIp;
   }
 
-  @JsonProperty(SRC_PORT_VAR)
+  @JsonProperty(PROP_SRC_PORT)
   public Integer getSrcPort() {
     return _srcPort;
   }
 
-  @JsonProperty(STATE_VAR)
+  @JsonProperty(PROP_STATE)
   public State getState() {
     return _state;
   }
 
-  @JsonProperty(TAG_VAR)
+  @JsonProperty(PROP_TAG)
   public String getTag() {
     return _tag;
   }
 
-  @JsonProperty(TCP_FLAGS_ACK_VAR)
+  @JsonProperty(PROP_TCP_FLAGS_ACK)
   public int getTcpFlagsAck() {
     return _tcpFlagsAck;
   }
 
-  @JsonProperty(TCP_FLAGS_CWR_VAR)
+  @JsonProperty(PROP_TCP_FLAGS_CWR)
   public int getTcpFlagsCwr() {
     return _tcpFlagsCwr;
   }
 
-  @JsonProperty(TCP_FLAGS_ECE_VAR)
+  @JsonProperty(PROP_TCP_FLAGS_ECE)
   public int getTcpFlagsEce() {
     return _tcpFlagsEce;
   }
 
-  @JsonProperty(TCP_FLAGS_FIN_VAR)
+  @JsonProperty(PROP_TCP_FLAGS_FIN)
   public int getTcpFlagsFin() {
     return _tcpFlagsFin;
   }
 
-  @JsonProperty(TCP_FLAGS_PSH_VAR)
+  @JsonProperty(PROP_TCP_FLAGS_PSH)
   public int getTcpFlagsPsh() {
     return _tcpFlagsPsh;
   }
 
-  @JsonProperty(TCP_FLAGS_RST_VAR)
+  @JsonProperty(PROP_TCP_FLAGS_RST)
   public int getTcpFlagsRst() {
     return _tcpFlagsRst;
   }
 
-  @JsonProperty(TCP_FLAGS_SYN_VAR)
+  @JsonProperty(PROP_TCP_FLAGS_SYN)
   public int getTcpFlagsSyn() {
     return _tcpFlagsSyn;
   }
 
-  @JsonProperty(TCP_FLAGS_URG_VAR)
+  @JsonProperty(PROP_TCP_FLAGS_URG)
   public int getTcpFlagsUrg() {
     return _tcpFlagsUrg;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FlowTrace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FlowTrace.java
@@ -7,9 +7,9 @@ import java.util.Set;
 
 public class FlowTrace implements Comparable<FlowTrace> {
 
-  private static final String DISPOSITION_VAR = "disposition";
-  private static final String HOPS_VAR = "hops";
-  private static final String NOTES_VAR = "notes";
+  private static final String PROP_DISPOSITION = "disposition";
+  private static final String PROP_HOPS = "hops";
+  private static final String PROP_NOTES = "notes";
 
   private final FlowDisposition _disposition;
 
@@ -18,9 +18,9 @@ public class FlowTrace implements Comparable<FlowTrace> {
   private final String _notes;
 
   public FlowTrace(
-      @JsonProperty(DISPOSITION_VAR) FlowDisposition disposition,
-      @JsonProperty(HOPS_VAR) List<FlowTraceHop> hops,
-      @JsonProperty(NOTES_VAR) String notes) {
+      @JsonProperty(PROP_DISPOSITION) FlowDisposition disposition,
+      @JsonProperty(PROP_HOPS) List<FlowTraceHop> hops,
+      @JsonProperty(PROP_NOTES) String notes) {
     _disposition = disposition;
     _hops = hops != null ? hops : Collections.emptyList();
     _notes = notes;
@@ -61,17 +61,17 @@ public class FlowTrace implements Comparable<FlowTrace> {
     return true;
   }
 
-  @JsonProperty(DISPOSITION_VAR)
+  @JsonProperty(PROP_DISPOSITION)
   public FlowDisposition getDisposition() {
     return _disposition;
   }
 
-  @JsonProperty(HOPS_VAR)
+  @JsonProperty(PROP_HOPS)
   public List<FlowTraceHop> getHops() {
     return _hops;
   }
 
-  @JsonProperty(NOTES_VAR)
+  @JsonProperty(PROP_NOTES)
   public String getNotes() {
     return _notes;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FlowTraceHop.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FlowTraceHop.java
@@ -7,14 +7,14 @@ import java.util.SortedSet;
 
 public final class FlowTraceHop implements Serializable {
 
-  private static final String EDGE_VAR = "edge";
+  private static final String PROP_EDGE = "edge";
 
-  private static final String ROUTES_VAR = "routes";
+  private static final String PROP_ROUTES = "routes";
 
   /** */
   private static final long serialVersionUID = 1L;
 
-  private static final String TRANSFORMED_FLOW_VAR = "transformedFlow";
+  private static final String PROP_TRANSFORMED_FLOW = "transformedFlow";
 
   private final Edge _edge;
 
@@ -24,9 +24,9 @@ public final class FlowTraceHop implements Serializable {
 
   @JsonCreator
   public FlowTraceHop(
-      @JsonProperty(EDGE_VAR) Edge edge,
-      @JsonProperty(ROUTES_VAR) SortedSet<String> routes,
-      @JsonProperty(TRANSFORMED_FLOW_VAR) Flow transformedFlow) {
+      @JsonProperty(PROP_EDGE) Edge edge,
+      @JsonProperty(PROP_ROUTES) SortedSet<String> routes,
+      @JsonProperty(PROP_TRANSFORMED_FLOW) Flow transformedFlow) {
     _edge = edge;
     _routes = routes;
     _transformedFlow = transformedFlow;
@@ -68,17 +68,17 @@ public final class FlowTraceHop implements Serializable {
     return true;
   }
 
-  @JsonProperty(EDGE_VAR)
+  @JsonProperty(PROP_EDGE)
   public Edge getEdge() {
     return _edge;
   }
 
-  @JsonProperty(ROUTES_VAR)
+  @JsonProperty(PROP_ROUTES)
   public SortedSet<String> getRoutes() {
     return _routes;
   }
 
-  @JsonProperty(TRANSFORMED_FLOW_VAR)
+  @JsonProperty(PROP_TRANSFORMED_FLOW)
   public Flow getTransformedFlow() {
     return _transformedFlow;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/GeneratedRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/GeneratedRoute.java
@@ -73,15 +73,15 @@ public final class GeneratedRoute extends AbstractRoute {
     }
   }
 
-  private static final String AS_PATH_VAR = "asPath";
+  private static final String PROP_AS_PATH = "asPath";
 
-  private static final String ATTRIBUTE_POLICY_VAR = "attributePolicy";
+  private static final String PROP_ATTRIBUTE_POLICY = "attributePolicy";
 
-  private static final String DISCARD_VAR = "discard";
+  private static final String PROP_DISCARD = "discard";
 
-  private static final String GENERATION_POLICY_VAR = "generationPolicy";
+  private static final String PROP_GENERATION_POLICY = "generationPolicy";
 
-  private static final String METRIC_VAR = "metric";
+  private static final String PROP_METRIC = "metric";
 
   private static final long serialVersionUID = 1L;
 
@@ -103,15 +103,15 @@ public final class GeneratedRoute extends AbstractRoute {
 
   @JsonCreator
   public GeneratedRoute(
-      @JsonProperty(NETWORK_VAR) Prefix network,
-      @JsonProperty(ADMINISTRATIVE_COST_VAR) int administrativeCost,
-      @JsonProperty(NEXT_HOP_IP_VAR) Ip nextHopIp,
-      @JsonProperty(AS_PATH_VAR) AsPath asPath,
-      @JsonProperty(ATTRIBUTE_POLICY_VAR) String attributePolicy,
-      @JsonProperty(DISCARD_VAR) boolean discard,
-      @JsonProperty(GENERATION_POLICY_VAR) String generationPolicy,
-      @JsonProperty(METRIC_VAR) Integer metric,
-      @JsonProperty(NEXT_HOP_INTERFACE_VAR) String nextHopInterface) {
+      @JsonProperty(PROP_NETWORK) Prefix network,
+      @JsonProperty(PROP_ADMINISTRATIVE_COST) int administrativeCost,
+      @JsonProperty(PROP_NEXT_HOP_IP) Ip nextHopIp,
+      @JsonProperty(PROP_AS_PATH) AsPath asPath,
+      @JsonProperty(PROP_ATTRIBUTE_POLICY) String attributePolicy,
+      @JsonProperty(PROP_DISCARD) boolean discard,
+      @JsonProperty(PROP_GENERATION_POLICY) String generationPolicy,
+      @JsonProperty(PROP_METRIC) Integer metric,
+      @JsonProperty(PROP_NEXT_HOP_INTERFACE) String nextHopInterface) {
     super(network);
     _administrativeCost = administrativeCost;
     _asPath = asPath;
@@ -130,31 +130,31 @@ public final class GeneratedRoute extends AbstractRoute {
   }
 
   @JsonIgnore(false)
-  @JsonProperty(ADMINISTRATIVE_COST_VAR)
+  @JsonProperty(PROP_ADMINISTRATIVE_COST)
   @Override
   public int getAdministrativeCost() {
     return _administrativeCost;
   }
 
-  @JsonProperty(AS_PATH_VAR)
+  @JsonProperty(PROP_AS_PATH)
   @JsonPropertyDescription("A BGP AS-path attribute to associate with this generated route")
   public AsPath getAsPath() {
     return _asPath;
   }
 
-  @JsonProperty(ATTRIBUTE_POLICY_VAR)
+  @JsonProperty(PROP_ATTRIBUTE_POLICY)
   @JsonPropertyDescription("The name of the policy that sets attributes of this route")
   public String getAttributePolicy() {
     return _attributePolicy;
   }
 
-  @JsonProperty(DISCARD_VAR)
+  @JsonProperty(PROP_DISCARD)
   @JsonPropertyDescription("Whether this route is route is meant to discard all matching packets")
   public boolean getDiscard() {
     return _discard;
   }
 
-  @JsonProperty(GENERATION_POLICY_VAR)
+  @JsonProperty(PROP_GENERATION_POLICY)
   @JsonPropertyDescription(
       "The name of the policy that will generate this route if another route matches it")
   public String getGenerationPolicy() {
@@ -162,7 +162,7 @@ public final class GeneratedRoute extends AbstractRoute {
   }
 
   @JsonIgnore(false)
-  @JsonProperty(METRIC_VAR)
+  @JsonProperty(PROP_METRIC)
   @Override
   public Integer getMetric() {
     return _metric;
@@ -176,7 +176,7 @@ public final class GeneratedRoute extends AbstractRoute {
 
   @Nonnull
   @JsonIgnore(false)
-  @JsonProperty(NEXT_HOP_IP_VAR)
+  @JsonProperty(PROP_NEXT_HOP_IP)
   @Override
   public Ip getNextHopIp() {
     return _nextHopIp;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/GeneratedRoute6.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/GeneratedRoute6.java
@@ -56,11 +56,11 @@ public final class GeneratedRoute6 extends AbstractRoute6 implements Comparable<
     }
   }
 
-  private static final String AS_PATH_VAR = "asPath";
+  private static final String PROP_AS_PATH = "asPath";
 
-  private static final String DISCARD_VAR = "discard";
+  private static final String PROP_DISCARD = "discard";
 
-  private static final String METRIC_VAR = "metric";
+  private static final String PROP_METRIC = "metric";
 
   private static final long serialVersionUID = 1L;
 
@@ -79,7 +79,7 @@ public final class GeneratedRoute6 extends AbstractRoute6 implements Comparable<
   private String _nextHopInterface;
 
   @JsonCreator
-  public GeneratedRoute6(@JsonProperty(NETWORK_VAR) Prefix6 prefix6) {
+  public GeneratedRoute6(@JsonProperty(PROP_NETWORK) Prefix6 prefix6) {
     super(prefix6, Route6.UNSET_ROUTE_NEXT_HOP_IP);
   }
 
@@ -108,7 +108,7 @@ public final class GeneratedRoute6 extends AbstractRoute6 implements Comparable<
     return _administrativeCost;
   }
 
-  @JsonProperty(AS_PATH_VAR)
+  @JsonProperty(PROP_AS_PATH)
   public AsPath getAsPath() {
     return _asPath;
   }
@@ -117,7 +117,7 @@ public final class GeneratedRoute6 extends AbstractRoute6 implements Comparable<
     return _attributePolicy;
   }
 
-  @JsonProperty(DISCARD_VAR)
+  @JsonProperty(PROP_DISCARD)
   public boolean getDiscard() {
     return _discard;
   }
@@ -126,7 +126,7 @@ public final class GeneratedRoute6 extends AbstractRoute6 implements Comparable<
     return _generationPolicy;
   }
 
-  @JsonProperty(METRIC_VAR)
+  @JsonProperty(PROP_METRIC)
   @Override
   public Integer getMetric() {
     return _metric;
@@ -159,12 +159,12 @@ public final class GeneratedRoute6 extends AbstractRoute6 implements Comparable<
     return _network.hashCode();
   }
 
-  @JsonProperty(ADMINISTRATIVE_COST_VAR)
+  @JsonProperty(PROP_ADMINISTRATIVE_COST)
   public void setAdministrativePreference(int preference) {
     _administrativeCost = preference;
   }
 
-  @JsonProperty(AS_PATH_VAR)
+  @JsonProperty(PROP_AS_PATH)
   public void setAsPath(AsPath asPath) {
     _asPath = asPath;
   }
@@ -173,7 +173,7 @@ public final class GeneratedRoute6 extends AbstractRoute6 implements Comparable<
     _attributePolicy = attributePolicy;
   }
 
-  @JsonProperty(DISCARD_VAR)
+  @JsonProperty(PROP_DISCARD)
   public void setDiscard(boolean discard) {
     _discard = discard;
   }
@@ -182,7 +182,7 @@ public final class GeneratedRoute6 extends AbstractRoute6 implements Comparable<
     _generationPolicy = generationPolicy;
   }
 
-  @JsonProperty(METRIC_VAR)
+  @JsonProperty(PROP_METRIC)
   public void setMetric(int metric) {
     _metric = metric;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IkeGateway.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IkeGateway.java
@@ -7,7 +7,7 @@ import org.batfish.common.util.ComparableStructure;
 
 public class IkeGateway extends ComparableStructure<String> {
 
-  private static final String IKE_POLICY_VAR = "ikePolicy";
+  private static final String PROP_IKE_POLICY = "ikePolicy";
 
   /** */
   private static final long serialVersionUID = 1L;
@@ -74,7 +74,7 @@ public class IkeGateway extends ComparableStructure<String> {
     return _ikePolicy;
   }
 
-  @JsonProperty(IKE_POLICY_VAR)
+  @JsonProperty(PROP_IKE_POLICY)
   @JsonPropertyDescription("IKE policy to be used with this IKE gateway.")
   public String getIkePolicyName() {
     if (_ikePolicy != null) {
@@ -119,7 +119,7 @@ public class IkeGateway extends ComparableStructure<String> {
     _ikePolicy = ikePolicy;
   }
 
-  @JsonProperty(IKE_POLICY_VAR)
+  @JsonProperty(PROP_IKE_POLICY)
   public void setIkePolicyName(String ikePolicyName) {
     _ikePolicyName = ikePolicyName;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IkePolicy.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IkePolicy.java
@@ -12,7 +12,7 @@ import org.batfish.common.util.ComparableStructure;
 
 public final class IkePolicy extends ComparableStructure<String> {
 
-  private static final String PROPOSALS_VAR = "proposals";
+  private static final String PROP_PROPOSALS = "proposals";
 
   /** */
   private static final long serialVersionUID = 1L;
@@ -24,7 +24,7 @@ public final class IkePolicy extends ComparableStructure<String> {
   private SortedMap<String, IkeProposal> _proposals;
 
   @JsonCreator
-  public IkePolicy(@JsonProperty(NAME_VAR) String name) {
+  public IkePolicy(@JsonProperty(PROP_NAME) String name) {
     super(name);
     _proposals = new TreeMap<>();
   }
@@ -35,7 +35,7 @@ public final class IkePolicy extends ComparableStructure<String> {
     return _preSharedKeyHash;
   }
 
-  @JsonProperty(PROPOSALS_VAR)
+  @JsonProperty(PROP_PROPOSALS)
   @JsonPropertyDescription(
       "Dictionary of IKE proposals attached to this policy. Each stored as @id")
   public SortedSet<String> getProposalNames() {
@@ -63,7 +63,7 @@ public final class IkePolicy extends ComparableStructure<String> {
     _preSharedKeyHash = preSharedKeyHash;
   }
 
-  @JsonProperty(PROPOSALS_VAR)
+  @JsonProperty(PROP_PROPOSALS)
   public void setProposalNames(SortedSet<String> proposalNames) {
     _proposalNames = proposalNames;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IkeProposal.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IkeProposal.java
@@ -101,7 +101,7 @@ public final class IkeProposal extends ComparableStructure<String> {
   private Integer _lifetimeSeconds;
 
   @JsonCreator
-  private IkeProposal(@JsonProperty(NAME_VAR) String name) {
+  private IkeProposal(@JsonProperty(PROP_NAME) String name) {
     super(name);
     _definitionLine = -1;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -20,79 +20,79 @@ import org.codehaus.jettison.json.JSONObject;
 
 public final class Interface extends ComparableStructure<String> {
 
-  private static final String ACCESS_VLAN_VAR = "accessVlan";
+  private static final String PROP_ACCESS_VLAN = "accessVlan";
 
-  private static final String ACTIVE_VAR = "active";
+  private static final String PROP_ACTIVE = "active";
 
-  private static final String ALL_PREFIXES_VAR = "allPrefixes";
+  private static final String PROP_ALL_PREFIXES = "allPrefixes";
 
-  private static final String ALLOWED_VLANS_VAR = "allowedVlans";
+  private static final String PROP_ALLOWED_VLANS = "allowedVlans";
 
-  private static final String AUTOSTATE_VAR = "autostate";
+  private static final String PROP_AUTOSTATE = "autostate";
 
-  private static final String BANDWIDTH_VAR = "bandwidth";
+  private static final String PROP_BANDWIDTH = "bandwidth";
 
   private static final int DEFAULT_MTU = 1500;
 
-  private static final String DESCRIPTION_VAR = "description";
+  private static final String PROP_DESCRIPTION = "description";
 
-  private static final String DHCP_RELAY_ADDRESSES_VAR = "dhcpRelayAddresses";
+  private static final String PROP_DHCP_RELAY_ADDRESSES = "dhcpRelayAddresses";
 
   public static final String FLOW_SINK_TERMINATION_NAME = "flow_sink_termination";
 
-  private static final String INBOUND_FILTER_VAR = "inboundFilter";
+  private static final String PROP_INBOUND_FILTER = "inboundFilter";
 
-  private static final String INCOMING_FILTER_VAR = "incomingFilter";
+  private static final String PROP_INCOMING_FILTER = "incomingFilter";
 
-  private static final String INTERFACE_TYPE_VAR = "type";
+  private static final String PROP_INTERFACE_TYPE = "type";
 
-  private static final String ISIS_COST_VAR = "isisCost";
+  private static final String PROP_ISIS_COST = "isisCost";
 
-  private static final String ISIS_L1_INTERFACE_MODE_VAR = "isisL1InterfaceMode";
+  private static final String PROP_ISIS_L1_INTERFACE_MODE = "isisL1InterfaceMode";
 
-  private static final String ISIS_L2_INTERFACE_MODE_VAR = "isisL2InterfaceMode";
+  private static final String PROP_ISIS_L2_INTERFACE_MODE = "isisL2InterfaceMode";
 
-  private static final String MTU_VAR = "mtu";
+  private static final String PROP_MTU = "mtu";
 
-  private static final String NATIVE_VLAN_VAR = "nativeVlan";
+  private static final String PROP_NATIVE_VLAN = "nativeVlan";
 
   public static final String NULL_INTERFACE_NAME = "null_interface";
 
-  private static final String OSPF_AREA_VAR = "ospfArea";
+  private static final String PROP_OSPF_AREA = "ospfArea";
 
-  private static final String OSPF_COST_VAR = "ospfCost";
+  private static final String PROP_OSPF_COST = "ospfCost";
 
-  private static final String OSPF_DEAD_INTERVAL_VAR = "ospfDeadInterval";
+  private static final String PROP_OSPF_DEAD_INTERVAL = "ospfDeadInterval";
 
-  private static final String OSPF_ENABLED_VAR = "ospfEnabled";
+  private static final String PROP_OSPF_ENABLED = "ospfEnabled";
 
-  private static final String OSPF_HELLO_MULTIPLIER_VAR = "ospfHelloMultiplier";
+  private static final String PROP_OSPF_HELLO_MULTIPLIER = "ospfHelloMultiplier";
 
-  private static final String OSPF_PASSIVE_VAR = "ospfPassive";
+  private static final String PROP_OSPF_PASSIVE = "ospfPassive";
 
-  private static final String OUTGOING_FILTER_VAR = "outgoingFilter";
+  private static final String PROP_OUTGOING_FILTER = "outgoingFilter";
 
-  private static final String PREFIX_VAR = "prefix";
+  private static final String PROP_PREFIX = "prefix";
 
-  private static final String ROUTING_POLICY_VAR = "routingPolicy";
+  private static final String PROP_ROUTING_POLICY = "routingPolicy";
 
   private static final long serialVersionUID = 1L;
 
-  private static final String SOURCE_NAT_VAR = "sourceNat";
+  private static final String PROP_SOURCE_NAT = "sourceNat";
 
-  private static final String SPANNING_TREE_PORTFAST_VAR = "spanningTreePortfast";
+  private static final String PROP_SPANNING_TREE_PORTFAST = "spanningTreePortfast";
 
-  private static final String SWITCHPORT_MODE_VAR = "switchportMode";
+  private static final String PROP_SWITCHPORT_MODE = "switchportMode";
 
-  private static final String SWITCHPORT_TRUNK_ENCAPSULATION_VAR = "switchportTrunkEncapsulation";
+  private static final String PROP_SWITCHPORT_TRUNK_ENCAPSULATION = "switchportTrunkEncapsulation";
 
-  private static final String SWITCHPORT_VAR = "switchport";
+  private static final String PROP_SWITCHPORT = "switchport";
 
-  private static final String VRF_VAR = "vrf";
+  private static final String PROP_VRF = "vrf";
 
-  private static final String VRRP_GROUPS_VAR = "vrrpGroups";
+  private static final String PROP_VRRP_GROUPS = "vrrpGroups";
 
-  private static final String ZONE_VAR = "zone";
+  private static final String PROP_ZONE = "zone";
 
   private static InterfaceType computeAosInteraceType(String name) {
     if (name.startsWith("vlan")) {
@@ -341,7 +341,7 @@ public final class Interface extends ComparableStructure<String> {
   }
 
   @JsonCreator
-  public Interface(@JsonProperty(NAME_VAR) String name) {
+  public Interface(@JsonProperty(PROP_NAME) String name) {
     this(name, null);
   }
 
@@ -445,32 +445,32 @@ public final class Interface extends ComparableStructure<String> {
     return true;
   }
 
-  @JsonProperty(ACCESS_VLAN_VAR)
+  @JsonProperty(PROP_ACCESS_VLAN)
   @JsonPropertyDescription("Number of access VLAN when switchport mode is ACCESS")
   public int getAccessVlan() {
     return _accessVlan;
   }
 
-  @JsonProperty(ACTIVE_VAR)
+  @JsonProperty(PROP_ACTIVE)
   @JsonPropertyDescription(
       "Whether this interface is administratively active (true) or disabled (false)")
   public boolean getActive() {
     return _active;
   }
 
-  @JsonProperty(ALLOWED_VLANS_VAR)
+  @JsonProperty(PROP_ALLOWED_VLANS)
   @JsonPropertyDescription("Ranges of allowed VLANs when switchport mode is TRUNK")
   public List<SubRange> getAllowedVlans() {
     return _allowedVlans;
   }
 
-  @JsonProperty(ALL_PREFIXES_VAR)
+  @JsonProperty(PROP_ALL_PREFIXES)
   @JsonPropertyDescription("All IPV4 address/network assignments on this interface")
   public Set<Prefix> getAllPrefixes() {
     return _allPrefixes;
   }
 
-  @JsonProperty(AUTOSTATE_VAR)
+  @JsonProperty(PROP_AUTOSTATE)
   @JsonPropertyDescription(
       "Whether this VLAN interface's operational status is dependent on corresponding member "
           + "switchports")
@@ -478,7 +478,7 @@ public final class Interface extends ComparableStructure<String> {
     return _autoState;
   }
 
-  @JsonProperty(BANDWIDTH_VAR)
+  @JsonProperty(PROP_BANDWIDTH)
   @JsonPropertyDescription(
       "The nominal bandwidth of this interface in bits/sec for use in protocol cost calculations")
   public Double getBandwidth() {
@@ -490,13 +490,13 @@ public final class Interface extends ComparableStructure<String> {
     return _blacklisted;
   }
 
-  @JsonProperty(DESCRIPTION_VAR)
+  @JsonProperty(PROP_DESCRIPTION)
   @JsonPropertyDescription("Description of this interface")
   public String getDescription() {
     return _description;
   }
 
-  @JsonProperty(DHCP_RELAY_ADDRESSES_VAR)
+  @JsonProperty(PROP_DHCP_RELAY_ADDRESSES)
   public SortedSet<Ip> getDhcpRelayAddresses() {
     return _dhcpRelayAddresses;
   }
@@ -506,7 +506,7 @@ public final class Interface extends ComparableStructure<String> {
     return _inboundFilter;
   }
 
-  @JsonProperty(INBOUND_FILTER_VAR)
+  @JsonProperty(PROP_INBOUND_FILTER)
   @JsonPropertyDescription(
       "The IPV4 access-list used to filter traffic destined for this device on this interface.")
   public String getInboundFilterName() {
@@ -522,7 +522,7 @@ public final class Interface extends ComparableStructure<String> {
     return _incomingFilter;
   }
 
-  @JsonProperty(INCOMING_FILTER_VAR)
+  @JsonProperty(PROP_INCOMING_FILTER)
   @JsonPropertyDescription(
       "The IPV4 access-list used to filter traffic that arrives on this interface.")
   public String getIncomingFilterName() {
@@ -533,19 +533,19 @@ public final class Interface extends ComparableStructure<String> {
     }
   }
 
-  @JsonProperty(INTERFACE_TYPE_VAR)
+  @JsonProperty(PROP_INTERFACE_TYPE)
   @JsonPropertyDescription("The type of this interface")
   public InterfaceType getInterfaceType() {
     return _interfaceType;
   }
 
-  @JsonProperty(ISIS_COST_VAR)
+  @JsonProperty(PROP_ISIS_COST)
   @JsonPropertyDescription("The IS-IS cost of this interface")
   public Integer getIsisCost() {
     return _isisCost;
   }
 
-  @JsonProperty(ISIS_L1_INTERFACE_MODE_VAR)
+  @JsonProperty(PROP_ISIS_L1_INTERFACE_MODE)
   @JsonPropertyDescription(
       "Specifies whether this interface is active, passive, or unconfigured with respect to IS-IS "
           + "level 1")
@@ -553,7 +553,7 @@ public final class Interface extends ComparableStructure<String> {
     return _isisL1InterfaceMode;
   }
 
-  @JsonProperty(ISIS_L2_INTERFACE_MODE_VAR)
+  @JsonProperty(PROP_ISIS_L2_INTERFACE_MODE)
   @JsonPropertyDescription(
       "Specifies whether this interface is active, passive, or unconfigured with respect to IS-IS "
           + "level 2")
@@ -561,13 +561,13 @@ public final class Interface extends ComparableStructure<String> {
     return _isisL2InterfaceMode;
   }
 
-  @JsonProperty(MTU_VAR)
+  @JsonProperty(PROP_MTU)
   @JsonPropertyDescription("The maximum transmission unit (MTU) of this interface in bytes")
   public int getMtu() {
     return _mtu;
   }
 
-  @JsonProperty(NATIVE_VLAN_VAR)
+  @JsonProperty(PROP_NATIVE_VLAN)
   @JsonPropertyDescription("The native VLAN of this interface when switchport mode is TRUNK")
   public int getNativeVlan() {
     return _nativeVlan;
@@ -578,7 +578,7 @@ public final class Interface extends ComparableStructure<String> {
     return _ospfArea;
   }
 
-  @JsonProperty(OSPF_AREA_VAR)
+  @JsonProperty(PROP_OSPF_AREA)
   @JsonPropertyDescription("The OSPF area to which this interface belongs.")
   public Long getOspfAreaName() {
     if (_ospfArea != null) {
@@ -588,34 +588,34 @@ public final class Interface extends ComparableStructure<String> {
     }
   }
 
-  @JsonProperty(OSPF_COST_VAR)
+  @JsonProperty(PROP_OSPF_COST)
   @JsonPropertyDescription(
       "The explicit OSPF cost of this interface. If unset, the cost is automatically calculated.")
   public Integer getOspfCost() {
     return _ospfCost;
   }
 
-  @JsonProperty(OSPF_DEAD_INTERVAL_VAR)
+  @JsonProperty(PROP_OSPF_DEAD_INTERVAL)
   @JsonPropertyDescription("Dead-interval in seconds for OSPF updates")
   public int getOspfDeadInterval() {
     return _ospfDeadInterval;
   }
 
-  @JsonProperty(OSPF_ENABLED_VAR)
+  @JsonProperty(PROP_OSPF_ENABLED)
   @JsonPropertyDescription(
       "Whether or not OSPF is enabled at all on this interface (either actively or passively)")
   public boolean getOspfEnabled() {
     return _ospfEnabled;
   }
 
-  @JsonProperty(OSPF_HELLO_MULTIPLIER_VAR)
+  @JsonProperty(PROP_OSPF_HELLO_MULTIPLIER)
   @JsonPropertyDescription(
       "Number of OSPF packets to send out during dead-interval period for fast OSPF updates")
   public int getOspfHelloMultiplier() {
     return _ospfHelloMultiplier;
   }
 
-  @JsonProperty(OSPF_PASSIVE_VAR)
+  @JsonProperty(PROP_OSPF_PASSIVE)
   @JsonPropertyDescription(
       "Whether or not OSPF is enabled passively on this interface. If passive, this interface is "
           + "included in the OSPF RIB, but no OSPF packets are sent from it.")
@@ -628,7 +628,7 @@ public final class Interface extends ComparableStructure<String> {
     return _outgoingFilter;
   }
 
-  @JsonProperty(OUTGOING_FILTER_VAR)
+  @JsonProperty(PROP_OUTGOING_FILTER)
   @JsonPropertyDescription(
       "The IPV4 access-list used to filter traffic that is sent out this interface. Stored as @id")
   public String getOutgoingFilterName() {
@@ -644,7 +644,7 @@ public final class Interface extends ComparableStructure<String> {
     return _owner;
   }
 
-  @JsonProperty(PREFIX_VAR)
+  @JsonProperty(PROP_PREFIX)
   @JsonPropertyDescription("The primary IPV4 address/network of this interface")
   public Prefix getPrefix() {
     return _prefix;
@@ -660,7 +660,7 @@ public final class Interface extends ComparableStructure<String> {
     return _routingPolicy;
   }
 
-  @JsonProperty(ROUTING_POLICY_VAR)
+  @JsonProperty(PROP_ROUTING_POLICY)
   @JsonPropertyDescription(
       "The routing policy used on this interface for policy-routing (as opposed to destination-"
           + "routing). Stored as @id")
@@ -672,18 +672,18 @@ public final class Interface extends ComparableStructure<String> {
     }
   }
 
-  @JsonProperty(SOURCE_NAT_VAR)
+  @JsonProperty(PROP_SOURCE_NAT)
   public SourceNat getSourceNat() {
     return _sourceNat;
   }
 
-  @JsonProperty(SPANNING_TREE_PORTFAST_VAR)
+  @JsonProperty(PROP_SPANNING_TREE_PORTFAST)
   @JsonPropertyDescription("Whether or not spanning-tree portfast feature is enabled")
   public boolean getSpanningTreePortfast() {
     return _spanningTreePortfast;
   }
 
-  @JsonProperty(SWITCHPORT_VAR)
+  @JsonProperty(PROP_SWITCHPORT)
   @JsonPropertyDescription(
       "Whether this interface is explicitly set as a switchport. Nothing may be inferred from "
           + "absence of this field.")
@@ -691,13 +691,13 @@ public final class Interface extends ComparableStructure<String> {
     return _switchport;
   }
 
-  @JsonProperty(SWITCHPORT_MODE_VAR)
+  @JsonProperty(PROP_SWITCHPORT_MODE)
   @JsonPropertyDescription("The switchport mode (if any) of this interface")
   public SwitchportMode getSwitchportMode() {
     return _switchportMode;
   }
 
-  @JsonProperty(SWITCHPORT_TRUNK_ENCAPSULATION_VAR)
+  @JsonProperty(PROP_SWITCHPORT_TRUNK_ENCAPSULATION)
   @JsonPropertyDescription(
       "The switchport trunk encapsulation type of this interface. Only relevant when switchport "
           + "mode is TRUNK")
@@ -710,7 +710,7 @@ public final class Interface extends ComparableStructure<String> {
     return _vrf;
   }
 
-  @JsonProperty(VRF_VAR)
+  @JsonProperty(PROP_VRF)
   @JsonPropertyDescription("The name of the VRF to which this interface belongs")
   public String getVrfName() {
     if (_vrf != null) {
@@ -720,7 +720,7 @@ public final class Interface extends ComparableStructure<String> {
     }
   }
 
-  @JsonProperty(VRRP_GROUPS_VAR)
+  @JsonProperty(PROP_VRRP_GROUPS)
   public SortedMap<Integer, VrrpGroup> getVrrpGroups() {
     return _vrrpGroups;
   }
@@ -730,7 +730,7 @@ public final class Interface extends ComparableStructure<String> {
     return _zone;
   }
 
-  @JsonProperty(ZONE_VAR)
+  @JsonProperty(PROP_ZONE)
   @JsonPropertyDescription("The firewall zone to which this interface belongs.")
   public String getZoneName() {
     if (_zone != null) {
@@ -772,32 +772,32 @@ public final class Interface extends ComparableStructure<String> {
     }
   }
 
-  @JsonProperty(ACCESS_VLAN_VAR)
+  @JsonProperty(PROP_ACCESS_VLAN)
   public void setAccessVlan(int vlan) {
     _accessVlan = vlan;
   }
 
-  @JsonProperty(ACTIVE_VAR)
+  @JsonProperty(PROP_ACTIVE)
   public void setActive(boolean active) {
     _active = active;
   }
 
-  @JsonProperty(ALLOWED_VLANS_VAR)
+  @JsonProperty(PROP_ALLOWED_VLANS)
   public void setAllowedVlans(List<SubRange> allowedVlans) {
     _allowedVlans = allowedVlans;
   }
 
-  @JsonProperty(ALL_PREFIXES_VAR)
+  @JsonProperty(PROP_ALL_PREFIXES)
   public void setAllPrefixes(Set<Prefix> allPrefixes) {
     _allPrefixes = allPrefixes;
   }
 
-  @JsonProperty(AUTOSTATE_VAR)
+  @JsonProperty(PROP_AUTOSTATE)
   public void setAutoState(boolean autoState) {
     _autoState = autoState;
   }
 
-  @JsonProperty(BANDWIDTH_VAR)
+  @JsonProperty(PROP_BANDWIDTH)
   public void setBandwidth(Double bandwidth) {
     _bandwidth = bandwidth;
   }
@@ -807,12 +807,12 @@ public final class Interface extends ComparableStructure<String> {
     _blacklisted = blacklisted;
   }
 
-  @JsonProperty(DESCRIPTION_VAR)
+  @JsonProperty(PROP_DESCRIPTION)
   public void setDescription(String description) {
     _description = description;
   }
 
-  @JsonProperty(DHCP_RELAY_ADDRESSES_VAR)
+  @JsonProperty(PROP_DHCP_RELAY_ADDRESSES)
   public void setDhcpRelayAddresses(SortedSet<Ip> dhcpRelayAddresses) {
     _dhcpRelayAddresses = dhcpRelayAddresses;
   }
@@ -822,7 +822,7 @@ public final class Interface extends ComparableStructure<String> {
     _inboundFilter = inboundFilter;
   }
 
-  @JsonProperty(INBOUND_FILTER_VAR)
+  @JsonProperty(PROP_INBOUND_FILTER)
   public void setInboundFilterName(String inboundFilterName) {
     _inboundFilterName = inboundFilterName;
   }
@@ -832,37 +832,37 @@ public final class Interface extends ComparableStructure<String> {
     _incomingFilter = incomingFilter;
   }
 
-  @JsonProperty(INCOMING_FILTER_VAR)
+  @JsonProperty(PROP_INCOMING_FILTER)
   public void setIncomingFilterName(String incomingFilterName) {
     _incomingFilterName = incomingFilterName;
   }
 
-  @JsonProperty(INTERFACE_TYPE_VAR)
+  @JsonProperty(PROP_INTERFACE_TYPE)
   public void setInterfaceType(InterfaceType it) {
     _interfaceType = it;
   }
 
-  @JsonProperty(ISIS_COST_VAR)
+  @JsonProperty(PROP_ISIS_COST)
   public void setIsisCost(Integer isisCost) {
     _isisCost = isisCost;
   }
 
-  @JsonProperty(ISIS_L1_INTERFACE_MODE_VAR)
+  @JsonProperty(PROP_ISIS_L1_INTERFACE_MODE)
   public void setIsisL1InterfaceMode(IsisInterfaceMode mode) {
     _isisL1InterfaceMode = mode;
   }
 
-  @JsonProperty(ISIS_L2_INTERFACE_MODE_VAR)
+  @JsonProperty(PROP_ISIS_L2_INTERFACE_MODE)
   public void setIsisL2InterfaceMode(IsisInterfaceMode mode) {
     _isisL2InterfaceMode = mode;
   }
 
-  @JsonProperty(MTU_VAR)
+  @JsonProperty(PROP_MTU)
   public void setMtu(int mtu) {
     _mtu = mtu;
   }
 
-  @JsonProperty(NATIVE_VLAN_VAR)
+  @JsonProperty(PROP_NATIVE_VLAN)
   public void setNativeVlan(int vlan) {
     _nativeVlan = vlan;
   }
@@ -872,32 +872,32 @@ public final class Interface extends ComparableStructure<String> {
     _ospfArea = ospfArea;
   }
 
-  @JsonProperty(OSPF_AREA_VAR)
+  @JsonProperty(PROP_OSPF_AREA)
   public void setOspfAreaName(Long ospfAreaName) {
     _ospfAreaName = ospfAreaName;
   }
 
-  @JsonProperty(OSPF_COST_VAR)
+  @JsonProperty(PROP_OSPF_COST)
   public void setOspfCost(Integer ospfCost) {
     _ospfCost = ospfCost;
   }
 
-  @JsonProperty(OSPF_DEAD_INTERVAL_VAR)
+  @JsonProperty(PROP_OSPF_DEAD_INTERVAL)
   public void setOspfDeadInterval(int seconds) {
     _ospfDeadInterval = seconds;
   }
 
-  @JsonProperty(OSPF_ENABLED_VAR)
+  @JsonProperty(PROP_OSPF_ENABLED)
   public void setOspfEnabled(boolean b) {
     _ospfEnabled = b;
   }
 
-  @JsonProperty(OSPF_HELLO_MULTIPLIER_VAR)
+  @JsonProperty(PROP_OSPF_HELLO_MULTIPLIER)
   public void setOspfHelloMultiplier(int multiplier) {
     _ospfHelloMultiplier = multiplier;
   }
 
-  @JsonProperty(OSPF_PASSIVE_VAR)
+  @JsonProperty(PROP_OSPF_PASSIVE)
   public void setOspfPassive(boolean passive) {
     _ospfPassive = passive;
   }
@@ -907,7 +907,7 @@ public final class Interface extends ComparableStructure<String> {
     _outgoingFilter = outgoingFilter;
   }
 
-  @JsonProperty(OUTGOING_FILTER_VAR)
+  @JsonProperty(PROP_OUTGOING_FILTER)
   public void setOutgoingFilter(String outgoingFilterName) {
     _outgoingFilterName = outgoingFilterName;
   }
@@ -917,7 +917,7 @@ public final class Interface extends ComparableStructure<String> {
     _owner = owner;
   }
 
-  @JsonProperty(PREFIX_VAR)
+  @JsonProperty(PROP_PREFIX)
   public void setPrefix(Prefix prefix) {
     _prefix = prefix;
   }
@@ -931,32 +931,32 @@ public final class Interface extends ComparableStructure<String> {
     _routingPolicy = routingPolicy;
   }
 
-  @JsonProperty(ROUTING_POLICY_VAR)
+  @JsonProperty(PROP_ROUTING_POLICY)
   public void setRoutingPolicy(String routingPolicyName) {
     _routingPolicyName = routingPolicyName;
   }
 
-  @JsonProperty(SOURCE_NAT_VAR)
+  @JsonProperty(PROP_SOURCE_NAT)
   public void setSourceNat(SourceNat sourceNat) {
     _sourceNat = sourceNat;
   }
 
-  @JsonProperty(SPANNING_TREE_PORTFAST_VAR)
+  @JsonProperty(PROP_SPANNING_TREE_PORTFAST)
   public void setSpanningTreePortfast(boolean spanningTreePortfast) {
     _spanningTreePortfast = spanningTreePortfast;
   }
 
-  @JsonProperty(SWITCHPORT_VAR)
+  @JsonProperty(PROP_SWITCHPORT)
   public void setSwitchport(Boolean switchport) {
     _switchport = switchport;
   }
 
-  @JsonProperty(SWITCHPORT_MODE_VAR)
+  @JsonProperty(PROP_SWITCHPORT_MODE)
   public void setSwitchportMode(SwitchportMode switchportMode) {
     _switchportMode = switchportMode;
   }
 
-  @JsonProperty(SWITCHPORT_TRUNK_ENCAPSULATION_VAR)
+  @JsonProperty(PROP_SWITCHPORT_TRUNK_ENCAPSULATION)
   public void setSwitchportTrunkEncapsulation(SwitchportEncapsulationType encapsulation) {
     _switchportTrunkEncapsulation = encapsulation;
   }
@@ -969,12 +969,12 @@ public final class Interface extends ComparableStructure<String> {
     }
   }
 
-  @JsonProperty(VRF_VAR)
+  @JsonProperty(PROP_VRF)
   public void setVrfName(String vrfName) {
     _vrfName = vrfName;
   }
 
-  @JsonProperty(VRRP_GROUPS_VAR)
+  @JsonProperty(PROP_VRRP_GROUPS)
   public void setVrrpGroups(SortedMap<Integer, VrrpGroup> vrrpGroups) {
     _vrrpGroups = vrrpGroups;
   }
@@ -984,7 +984,7 @@ public final class Interface extends ComparableStructure<String> {
     _zone = zone;
   }
 
-  @JsonProperty(ZONE_VAR)
+  @JsonProperty(PROP_ZONE)
   public void setZoneName(String zoneName) {
     _zoneName = zoneName;
   }
@@ -993,8 +993,8 @@ public final class Interface extends ComparableStructure<String> {
     JSONObject iface = new JSONObject();
     iface.put("node", _owner.getName());
     iface.put("name", _key);
-    iface.put(PREFIX_VAR, _prefix.toString());
-    iface.put(INTERFACE_TYPE_VAR, _interfaceType.toString());
+    iface.put(PROP_PREFIX, _prefix.toString());
+    iface.put(PROP_INTERFACE_TYPE, _interfaceType.toString());
     return iface;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Ip6AccessList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Ip6AccessList.java
@@ -10,7 +10,7 @@ import org.batfish.common.util.ComparableStructure;
 @JsonSchemaDescription("An access-list used to filter IPV6 packets")
 public class Ip6AccessList extends ComparableStructure<String> {
 
-  private static final String LINES_VAR = "lines";
+  private static final String PROP_LINES = "lines";
 
   private static final long serialVersionUID = 1L;
 
@@ -37,7 +37,7 @@ public class Ip6AccessList extends ComparableStructure<String> {
   private List<Ip6AccessListLine> _lines;
 
   @JsonCreator
-  public Ip6AccessList(@JsonProperty(NAME_VAR) String name) {
+  public Ip6AccessList(@JsonProperty(PROP_NAME) String name) {
     super(name);
   }
 
@@ -65,7 +65,7 @@ public class Ip6AccessList extends ComparableStructure<String> {
     return new FilterResult(null, LineAction.REJECT);
   }
 
-  @JsonProperty(LINES_VAR)
+  @JsonProperty(PROP_LINES)
   @JsonPropertyDescription("The lines against which to check an IPV6 packet")
   public List<Ip6AccessListLine> getLines() {
     return _lines;
@@ -82,7 +82,7 @@ public class Ip6AccessList extends ComparableStructure<String> {
     return true;
   }
 
-  @JsonProperty(LINES_VAR)
+  @JsonProperty(PROP_LINES)
   public void setLines(List<Ip6AccessListLine> lines) {
     _lines = lines;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpAccessList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpAccessList.java
@@ -10,7 +10,7 @@ import org.batfish.common.util.ComparableStructure;
 @JsonSchemaDescription("An access-list used to filter IPV4 packets")
 public class IpAccessList extends ComparableStructure<String> {
 
-  private static final String LINES_VAR = "lines";
+  private static final String PROP_LINES = "lines";
 
   private static final long serialVersionUID = 1L;
 
@@ -37,7 +37,7 @@ public class IpAccessList extends ComparableStructure<String> {
   private List<IpAccessListLine> _lines;
 
   @JsonCreator
-  public IpAccessList(@JsonProperty(NAME_VAR) String name) {
+  public IpAccessList(@JsonProperty(PROP_NAME) String name) {
     super(name);
   }
 
@@ -65,7 +65,7 @@ public class IpAccessList extends ComparableStructure<String> {
     return new FilterResult(null, LineAction.REJECT);
   }
 
-  @JsonProperty(LINES_VAR)
+  @JsonProperty(PROP_LINES)
   @JsonPropertyDescription("The lines against which to check an IPV4 packet")
   public List<IpAccessListLine> getLines() {
     return _lines;
@@ -82,7 +82,7 @@ public class IpAccessList extends ComparableStructure<String> {
     return true;
   }
 
-  @JsonProperty(LINES_VAR)
+  @JsonProperty(PROP_LINES)
   public void setLines(List<IpAccessListLine> lines) {
     _lines = lines;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpsecPolicy.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpsecPolicy.java
@@ -12,7 +12,7 @@ import org.batfish.common.util.ComparableStructure;
 
 public class IpsecPolicy extends ComparableStructure<String> {
 
-  private static final String PROPOSALS_VAR = "proposals";
+  private static final String PROP_PROPOSALS = "proposals";
 
   /** */
   private static final long serialVersionUID = 1L;
@@ -26,7 +26,7 @@ public class IpsecPolicy extends ComparableStructure<String> {
   private SortedMap<String, IpsecProposal> _proposals;
 
   @JsonCreator
-  public IpsecPolicy(@JsonProperty(NAME_VAR) String name) {
+  public IpsecPolicy(@JsonProperty(PROP_NAME) String name) {
     super(name);
     _proposals = new TreeMap<>();
   }
@@ -39,7 +39,7 @@ public class IpsecPolicy extends ComparableStructure<String> {
     return _pfsKeyGroupDynamicIke;
   }
 
-  @JsonProperty(PROPOSALS_VAR)
+  @JsonProperty(PROP_PROPOSALS)
   @JsonPropertyDescription("IPSEC proposals to try with this policy")
   public SortedSet<String> getProposalNames() {
     if (_proposals != null && !_proposals.isEmpty()) {
@@ -70,7 +70,7 @@ public class IpsecPolicy extends ComparableStructure<String> {
     _pfsKeyGroupDynamicIke = pfsKeyGroupDynamicIke;
   }
 
-  @JsonProperty(PROPOSALS_VAR)
+  @JsonProperty(PROP_PROPOSALS)
   public void setProposalNames(SortedSet<String> proposalNames) {
     _proposalNames = proposalNames;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpsecProposal.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpsecProposal.java
@@ -83,7 +83,7 @@ public class IpsecProposal extends ComparableStructure<String> {
   private IpsecProtocol _protocol;
 
   @JsonCreator
-  private IpsecProposal(@JsonProperty(NAME_VAR) String name) {
+  private IpsecProposal(@JsonProperty(PROP_NAME) String name) {
     super(name);
     _definitionLine = -1;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpsecVpn.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpsecVpn.java
@@ -12,11 +12,11 @@ import org.batfish.common.util.ComparableStructure;
 
 public final class IpsecVpn extends ComparableStructure<String> {
 
-  private static final String BIND_INTERFACE_VAR = "bindInterface";
+  private static final String PROP_BIND_INTERFACE = "bindInterface";
 
-  private static final String IKE_GATEWAY_VAR = "ikeGateway";
+  private static final String PROP_IKE_GATEWAY = "ikeGateway";
 
-  private static final String IPSEC_POLICY_VAR = "ipsecPolicy";
+  private static final String PROP_IPSEC_POLICY = "ipsecPolicy";
 
   /** */
   private static final long serialVersionUID = 1L;
@@ -40,7 +40,7 @@ public final class IpsecVpn extends ComparableStructure<String> {
   private transient IpsecVpn _remoteIpsecVpn;
 
   @JsonCreator
-  public IpsecVpn(@JsonProperty(NAME_VAR) String name) {
+  public IpsecVpn(@JsonProperty(PROP_NAME) String name) {
     super(name);
   }
 
@@ -104,7 +104,7 @@ public final class IpsecVpn extends ComparableStructure<String> {
     return _bindInterface;
   }
 
-  @JsonProperty(BIND_INTERFACE_VAR)
+  @JsonProperty(PROP_BIND_INTERFACE)
   @JsonPropertyDescription("Tunnel interface on which the VPN will be bound")
   public String getBindInterfaceName() {
     if (_bindInterface != null) {
@@ -124,7 +124,7 @@ public final class IpsecVpn extends ComparableStructure<String> {
     return _ikeGateway;
   }
 
-  @JsonProperty(IKE_GATEWAY_VAR)
+  @JsonProperty(PROP_IKE_GATEWAY)
   @JsonPropertyDescription("Remote VPN gateway configuration")
   public String getIkeGatewayName() {
     if (_ikeGateway != null) {
@@ -139,7 +139,7 @@ public final class IpsecVpn extends ComparableStructure<String> {
     return _ipsecPolicy;
   }
 
-  @JsonProperty(IPSEC_POLICY_VAR)
+  @JsonProperty(PROP_IPSEC_POLICY)
   @JsonPropertyDescription("IPSEC policy for this VPN")
   public String getIpsecPolicyName() {
     if (_ipsecPolicy != null) {
@@ -181,7 +181,7 @@ public final class IpsecVpn extends ComparableStructure<String> {
     _bindInterface = bindInterface;
   }
 
-  @JsonProperty(BIND_INTERFACE_VAR)
+  @JsonProperty(PROP_BIND_INTERFACE)
   public void setBindInterfaceName(String bindInterfaceName) {
     _bindInterfaceName = bindInterfaceName;
   }
@@ -191,7 +191,7 @@ public final class IpsecVpn extends ComparableStructure<String> {
     _ikeGateway = ikeGateway;
   }
 
-  @JsonProperty(IKE_GATEWAY_VAR)
+  @JsonProperty(PROP_IKE_GATEWAY)
   public void setIkeGatewayName(String ikeGatewayName) {
     _ikeGatewayName = ikeGatewayName;
   }
@@ -201,7 +201,7 @@ public final class IpsecVpn extends ComparableStructure<String> {
     _ipsecPolicy = ipsecPolicy;
   }
 
-  @JsonProperty(IPSEC_POLICY_VAR)
+  @JsonProperty(PROP_IPSEC_POLICY)
   public void setIpsecPolicyName(String ipsecPolicyName) {
     _ipsecPolicyName = ipsecPolicyName;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/NodeRoleSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/NodeRoleSpecifier.java
@@ -15,9 +15,9 @@ import org.batfish.common.BatfishException;
 
 public class NodeRoleSpecifier {
 
-  private static final String ROLE_MAP_VAR = "roleMap";
+  private static final String PROP_ROLE_MAP = "roleMap";
 
-  private static final String ROLE_REGEXES_VAR = "roleRegexes";
+  private static final String PROP_ROLE_REGEXES = "roleRegexes";
 
   // a map from roles to the set of nodes that have that role
   private SortedMap<String, SortedSet<String>> _roleMap;
@@ -90,22 +90,22 @@ public class NodeRoleSpecifier {
     return nodeRolesMap;
   }
 
-  @JsonProperty(ROLE_MAP_VAR)
+  @JsonProperty(PROP_ROLE_MAP)
   public SortedMap<String, SortedSet<String>> getRoleMap() {
     return _roleMap;
   }
 
-  @JsonProperty(ROLE_REGEXES_VAR)
+  @JsonProperty(PROP_ROLE_REGEXES)
   public List<String> getRoleRegexes() {
     return _roleRegexes;
   }
 
-  @JsonProperty(ROLE_MAP_VAR)
+  @JsonProperty(PROP_ROLE_MAP)
   public void setRoleMap(SortedMap<String, SortedSet<String>> roleMap) {
     _roleMap = roleMap;
   }
 
-  @JsonProperty(ROLE_REGEXES_VAR)
+  @JsonProperty(PROP_ROLE_REGEXES)
   public void setRoleRegexes(List<String> roleRegexes) {
     _roleRegexes = roleRegexes;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfArea.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfArea.java
@@ -14,13 +14,13 @@ import org.batfish.common.util.ComparableStructure;
 
 public class OspfArea extends ComparableStructure<Long> implements Serializable {
 
-  private static final String INTERFACES_VAR = "interfaces";
+  private static final String PROP_INTERFACES = "interfaces";
 
   private static final long serialVersionUID = 1L;
 
-  private static final String SUMMARIES_VAR = "summaries";
+  private static final String PROP_SUMMARIES = "summaries";
 
-  private static final String SUMMARY_FILTER_VAR = "summaryFilter";
+  private static final String PROP_SUMMARY_FILTER = "summaryFilter";
 
   private transient SortedSet<String> _interfaceNames;
 
@@ -31,13 +31,13 @@ public class OspfArea extends ComparableStructure<Long> implements Serializable 
   private String _summaryFilter;
 
   @JsonCreator
-  public OspfArea(@JsonProperty(NAME_VAR) Long number) {
+  public OspfArea(@JsonProperty(PROP_NAME) Long number) {
     super(number);
     _interfaces = new TreeSet<>();
     _summaries = new TreeMap<>();
   }
 
-  @JsonProperty(INTERFACES_VAR)
+  @JsonProperty(PROP_INTERFACES)
   @JsonPropertyDescription("The interfaces assigned to this OSPF area")
   public SortedSet<String> getInterfaceNames() {
     if (_interfaces != null && !_interfaces.isEmpty()) {
@@ -52,12 +52,12 @@ public class OspfArea extends ComparableStructure<Long> implements Serializable 
     return _interfaces;
   }
 
-  @JsonProperty(SUMMARIES_VAR)
+  @JsonProperty(PROP_SUMMARIES)
   public SortedMap<Prefix, Boolean> getSummaries() {
     return _summaries;
   }
 
-  @JsonProperty(SUMMARY_FILTER_VAR)
+  @JsonProperty(PROP_SUMMARY_FILTER)
   public String getSummaryFilter() {
     return _summaryFilter;
   }
@@ -73,7 +73,7 @@ public class OspfArea extends ComparableStructure<Long> implements Serializable 
     }
   }
 
-  @JsonProperty(INTERFACES_VAR)
+  @JsonProperty(PROP_INTERFACES)
   public void setInterfaceNames(SortedSet<String> interfaceNames) {
     _interfaceNames = interfaceNames;
   }
@@ -83,12 +83,12 @@ public class OspfArea extends ComparableStructure<Long> implements Serializable 
     _interfaces = interfaces;
   }
 
-  @JsonProperty(SUMMARIES_VAR)
+  @JsonProperty(PROP_SUMMARIES)
   public void setSummaries(SortedMap<Prefix, Boolean> summaries) {
     _summaries = summaries;
   }
 
-  @JsonProperty(SUMMARY_FILTER_VAR)
+  @JsonProperty(PROP_SUMMARY_FILTER)
   public void setSummaryFilter(String summaryFilterName) {
     this._summaryFilter = summaryFilterName;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfExternalRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfExternalRoute.java
@@ -71,11 +71,11 @@ public abstract class OspfExternalRoute extends OspfRoute {
     }
   }
 
-  protected static final String ADVERTISER_VAR = "advertiser";
+  protected static final String PROP_ADVERTISER = "advertiser";
 
-  protected static final String COST_TO_ADVERTISER_VAR = "costToAdvertiser";
+  protected static final String PROP_COST_TO_ADVERTISER = "costToAdvertiser";
 
-  protected static final String OSPF_METRIC_TYPE_VAR = "ospfMetricType";
+  protected static final String PROP_OSPF_METRIC_TYPE = "ospfMetricType";
 
   /** */
   private static final long serialVersionUID = 1L;
@@ -86,12 +86,12 @@ public abstract class OspfExternalRoute extends OspfRoute {
 
   @JsonCreator
   public OspfExternalRoute(
-      @JsonProperty(NETWORK_VAR) Prefix prefix,
-      @JsonProperty(NEXT_HOP_IP_VAR) Ip nextHopIp,
-      @JsonProperty(ADMINISTRATIVE_COST_VAR) int admin,
+      @JsonProperty(PROP_NETWORK) Prefix prefix,
+      @JsonProperty(PROP_NEXT_HOP_IP) Ip nextHopIp,
+      @JsonProperty(PROP_ADMINISTRATIVE_COST) int admin,
       int metric,
-      @JsonProperty(ADVERTISER_VAR) String advertiser,
-      @JsonProperty(COST_TO_ADVERTISER_VAR) int costToAdvertiser) {
+      @JsonProperty(PROP_ADVERTISER) String advertiser,
+      @JsonProperty(PROP_COST_TO_ADVERTISER) int costToAdvertiser) {
     super(prefix, nextHopIp, admin, metric);
     _advertiser = advertiser;
     _costToAdvertiser = costToAdvertiser;
@@ -125,12 +125,12 @@ public abstract class OspfExternalRoute extends OspfRoute {
     return true;
   }
 
-  @JsonProperty(ADVERTISER_VAR)
+  @JsonProperty(PROP_ADVERTISER)
   public final String getAdvertiser() {
     return _advertiser;
   }
 
-  @JsonProperty(COST_TO_ADVERTISER_VAR)
+  @JsonProperty(PROP_COST_TO_ADVERTISER)
   public int getCostToAdvertiser() {
     return _costToAdvertiser;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfExternalType1Route.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfExternalType1Route.java
@@ -10,12 +10,12 @@ public class OspfExternalType1Route extends OspfExternalRoute {
 
   @JsonCreator
   public OspfExternalType1Route(
-      @JsonProperty(NETWORK_VAR) Prefix prefix,
-      @JsonProperty(NEXT_HOP_IP_VAR) Ip nextHopIp,
-      @JsonProperty(ADMINISTRATIVE_COST_VAR) int admin,
-      @JsonProperty(METRIC_VAR) int metric,
-      @JsonProperty(COST_TO_ADVERTISER_VAR) int costToAdvertiser,
-      @JsonProperty(ADVERTISER_VAR) String advertiser) {
+      @JsonProperty(PROP_NETWORK) Prefix prefix,
+      @JsonProperty(PROP_NEXT_HOP_IP) Ip nextHopIp,
+      @JsonProperty(PROP_ADMINISTRATIVE_COST) int admin,
+      @JsonProperty(PROP_METRIC) int metric,
+      @JsonProperty(PROP_COST_TO_ADVERTISER) int costToAdvertiser,
+      @JsonProperty(PROP_ADVERTISER) String advertiser) {
     super(prefix, nextHopIp, admin, metric, advertiser, costToAdvertiser);
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfExternalType2Route.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfExternalType2Route.java
@@ -10,12 +10,12 @@ public class OspfExternalType2Route extends OspfExternalRoute {
 
   @JsonCreator
   public OspfExternalType2Route(
-      @JsonProperty(NETWORK_VAR) Prefix network,
-      @JsonProperty(NEXT_HOP_IP_VAR) Ip nextHopIp,
-      @JsonProperty(ADMINISTRATIVE_COST_VAR) int admin,
-      @JsonProperty(METRIC_VAR) int metric,
-      @JsonProperty(COST_TO_ADVERTISER_VAR) int costToAdvertiser,
-      @JsonProperty(ADVERTISER_VAR) String advertiser) {
+      @JsonProperty(PROP_NETWORK) Prefix network,
+      @JsonProperty(PROP_NEXT_HOP_IP) Ip nextHopIp,
+      @JsonProperty(PROP_ADMINISTRATIVE_COST) int admin,
+      @JsonProperty(PROP_METRIC) int metric,
+      @JsonProperty(PROP_COST_TO_ADVERTISER) int costToAdvertiser,
+      @JsonProperty(PROP_ADVERTISER) String advertiser) {
     super(network, nextHopIp, admin, metric, advertiser, costToAdvertiser);
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfInterAreaRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfInterAreaRoute.java
@@ -6,7 +6,7 @@ import javax.annotation.Nonnull;
 
 public class OspfInterAreaRoute extends OspfRoute {
 
-  private static final String AREA_VAR = "area";
+  private static final String PROP_AREA = "area";
 
   /** */
   private static final long serialVersionUID = 1L;
@@ -15,11 +15,11 @@ public class OspfInterAreaRoute extends OspfRoute {
 
   @JsonCreator
   public OspfInterAreaRoute(
-      @JsonProperty(NETWORK_VAR) Prefix network,
-      @JsonProperty(NEXT_HOP_IP_VAR) Ip nextHopIp,
-      @JsonProperty(ADMINISTRATIVE_COST_VAR) int admin,
-      @JsonProperty(METRIC_VAR) int metric,
-      @JsonProperty(AREA_VAR) long area) {
+      @JsonProperty(PROP_NETWORK) Prefix network,
+      @JsonProperty(PROP_NEXT_HOP_IP) Ip nextHopIp,
+      @JsonProperty(PROP_ADMINISTRATIVE_COST) int admin,
+      @JsonProperty(PROP_METRIC) int metric,
+      @JsonProperty(PROP_AREA) long area) {
     super(network, nextHopIp, admin, metric);
     _area = area;
   }
@@ -49,7 +49,7 @@ public class OspfInterAreaRoute extends OspfRoute {
     return _network.equals(other._network);
   }
 
-  @JsonProperty(AREA_VAR)
+  @JsonProperty(PROP_AREA)
   public long getArea() {
     return _area;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfIntraAreaRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfIntraAreaRoute.java
@@ -6,7 +6,7 @@ import javax.annotation.Nonnull;
 
 public class OspfIntraAreaRoute extends OspfRoute {
 
-  private static final String AREA_VAR = "area";
+  private static final String PROP_AREA = "area";
 
   /** */
   private static final long serialVersionUID = 1L;
@@ -15,11 +15,11 @@ public class OspfIntraAreaRoute extends OspfRoute {
 
   @JsonCreator
   public OspfIntraAreaRoute(
-      @JsonProperty(NETWORK_VAR) Prefix network,
-      @JsonProperty(NEXT_HOP_IP_VAR) Ip nextHopIp,
-      @JsonProperty(ADMINISTRATIVE_COST_VAR) int admin,
-      @JsonProperty(METRIC_VAR) int metric,
-      @JsonProperty(AREA_VAR) long area) {
+      @JsonProperty(PROP_NETWORK) Prefix network,
+      @JsonProperty(PROP_NEXT_HOP_IP) Ip nextHopIp,
+      @JsonProperty(PROP_ADMINISTRATIVE_COST) int admin,
+      @JsonProperty(PROP_METRIC) int metric,
+      @JsonProperty(PROP_AREA) long area) {
     super(network, nextHopIp, admin, metric);
     _area = area;
   }
@@ -49,7 +49,7 @@ public class OspfIntraAreaRoute extends OspfRoute {
     return _network.equals(other._network);
   }
 
-  @JsonProperty(AREA_VAR)
+  @JsonProperty(PROP_AREA)
   public long getArea() {
     return _area;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfNeighbor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfNeighbor.java
@@ -10,14 +10,14 @@ public class OspfNeighbor extends ComparableStructure<Pair<Ip, Ip>> {
 
   public static final class OspfNeighborSummary extends ComparableStructure<String> {
 
-    private static final String LOCAL_IP_VAR = "localIp";
+    private static final String PROP_LOCAL_IP = "localIp";
 
-    private static final String REMOTE_IP_VAR = "remoteIp";
+    private static final String PROP_REMOTE_IP = "remoteIp";
 
     /** */
     private static final long serialVersionUID = 1L;
 
-    private static final String VRF_VAR = "vrf";
+    private static final String PROP_VRF = "vrf";
 
     private final Ip _localIp;
 
@@ -34,27 +34,27 @@ public class OspfNeighbor extends ComparableStructure<Pair<Ip, Ip>> {
 
     @JsonCreator
     public OspfNeighborSummary(
-        @JsonProperty(NAME_VAR) String name,
-        @JsonProperty(LOCAL_IP_VAR) Ip localIp,
-        @JsonProperty(REMOTE_IP_VAR) Ip remoteIp,
-        @JsonProperty(VRF_VAR) String vrf) {
+        @JsonProperty(PROP_NAME) String name,
+        @JsonProperty(PROP_LOCAL_IP) Ip localIp,
+        @JsonProperty(PROP_REMOTE_IP) Ip remoteIp,
+        @JsonProperty(PROP_VRF) String vrf) {
       super(name);
       _localIp = localIp;
       _remoteIp = remoteIp;
       _vrf = vrf;
     }
 
-    @JsonProperty(LOCAL_IP_VAR)
+    @JsonProperty(PROP_LOCAL_IP)
     public Ip getLocalIp() {
       return _localIp;
     }
 
-    @JsonProperty(REMOTE_IP_VAR)
+    @JsonProperty(PROP_REMOTE_IP)
     public Ip getRemoteIp() {
       return _remoteIp;
     }
 
-    @JsonProperty(VRF_VAR)
+    @JsonProperty(PROP_VRF)
     public String getVrf() {
       return _vrf;
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfRoute.java
@@ -20,10 +20,10 @@ public abstract class OspfRoute extends AbstractRoute {
 
   @JsonCreator
   public OspfRoute(
-      @JsonProperty(NETWORK_VAR) Prefix network,
-      @JsonProperty(NEXT_HOP_IP_VAR) Ip nextHopIp,
-      @JsonProperty(ADMINISTRATIVE_COST_VAR) int admin,
-      @JsonProperty(METRIC_VAR) int metric) {
+      @JsonProperty(PROP_NETWORK) Prefix network,
+      @JsonProperty(PROP_NEXT_HOP_IP) Ip nextHopIp,
+      @JsonProperty(PROP_ADMINISTRATIVE_COST) int admin,
+      @JsonProperty(PROP_METRIC) int metric) {
     super(network);
     _admin = admin;
     _metric = metric;
@@ -31,14 +31,14 @@ public abstract class OspfRoute extends AbstractRoute {
   }
 
   @JsonIgnore(false)
-  @JsonProperty(ADMINISTRATIVE_COST_VAR)
+  @JsonProperty(PROP_ADMINISTRATIVE_COST)
   @Override
   public final int getAdministrativeCost() {
     return _admin;
   }
 
   @JsonIgnore(false)
-  @JsonProperty(METRIC_VAR)
+  @JsonProperty(PROP_METRIC)
   @Override
   public final Integer getMetric() {
     return _metric;
@@ -46,7 +46,7 @@ public abstract class OspfRoute extends AbstractRoute {
 
   @Nonnull
   @JsonIgnore(false)
-  @JsonProperty(NEXT_HOP_IP_VAR)
+  @JsonProperty(PROP_NEXT_HOP_IP)
   @Override
   public final Ip getNextHopIp() {
     return _nextHopIp;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RoleEdge.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RoleEdge.java
@@ -6,23 +6,23 @@ import org.batfish.common.Pair;
 
 public class RoleEdge extends Pair<String, String> {
 
-  private static final String ROLE1_VAR = "role1";
+  private static final String PROP_ROLE1 = "role1";
 
-  private static final String ROLE2_VAR = "role2";
+  private static final String PROP_ROLE2 = "role2";
 
   private static final long serialVersionUID = 1L;
 
   @JsonCreator
-  public RoleEdge(@JsonProperty(ROLE1_VAR) String role1, @JsonProperty(ROLE2_VAR) String role2) {
+  public RoleEdge(@JsonProperty(PROP_ROLE1) String role1, @JsonProperty(PROP_ROLE2) String role2) {
     super(role1, role2);
   }
 
-  @JsonProperty(ROLE1_VAR)
+  @JsonProperty(PROP_ROLE1)
   public String getRole1() {
     return _first;
   }
 
-  @JsonProperty(ROLE2_VAR)
+  @JsonProperty(PROP_ROLE2)
   public String getRole2() {
     return _second;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Route.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Route.java
@@ -5,33 +5,33 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.io.Serializable;
 
-@JsonPropertyOrder({Route.DIFF_SYMBOL_VAR})
+@JsonPropertyOrder({Route.PROP_DIFF_SYMBOL})
 public class Route implements Comparable<Route>, Serializable {
 
-  private static final String ADMINISTRATIVE_COST_VAR = "administrativeCost";
+  private static final String PROP_ADMINISTRATIVE_COST = "administrativeCost";
 
   public static final String AMBIGUOUS_NEXT_HOP = "(ambiguous)";
 
-  protected static final String DIFF_SYMBOL_VAR = "diffSymbol";
+  protected static final String PROP_DIFF_SYMBOL = "diffSymbol";
 
-  private static final String METRIC_VAR = "metric";
+  private static final String PROP_METRIC = "metric";
 
-  private static final String NETWORK_VAR = "network";
+  private static final String PROP_NETWORK = "network";
 
-  private static final String NEXT_HOP_INTERFACE_VAR = "nextHopInterface";
+  private static final String PROP_NEXT_HOP_INTERFACE = "nextHopInterface";
 
-  private static final String NEXT_HOP_IP_VAR = "nextHopIp";
+  private static final String PROP_NEXT_HOP_IP = "nextHopIp";
 
-  private static final String NEXT_HOP_VAR = "nextHop";
+  private static final String PROP_NEXT_HOP = "nextHop";
 
-  private static final String NODE_VAR = "node";
+  private static final String PROP_NODE = "node";
 
-  private static final String PROTOCOL_VAR = "protocol";
+  private static final String PROP_PROTOCOL = "protocol";
 
   /** */
   private static final long serialVersionUID = 1L;
 
-  private static final String TAG_VAR = "tag";
+  private static final String PROP_TAG = "tag";
 
   public static final String UNSET_NEXT_HOP = "(unknown)";
 
@@ -45,7 +45,7 @@ public class Route implements Comparable<Route>, Serializable {
 
   public static final int UNSET_ROUTE_TAG = -1;
 
-  private static final String VRF_VAR = "vrf";
+  private static final String PROP_VRF = "vrf";
 
   private final int _administrativeCost;
 
@@ -69,16 +69,16 @@ public class Route implements Comparable<Route>, Serializable {
 
   @JsonCreator
   public Route(
-      @JsonProperty(NODE_VAR) String node,
-      @JsonProperty(VRF_VAR) String vrf,
-      @JsonProperty(NETWORK_VAR) Prefix network,
-      @JsonProperty(NEXT_HOP_IP_VAR) Ip nextHopIp,
-      @JsonProperty(NEXT_HOP_VAR) String nextHop,
-      @JsonProperty(NEXT_HOP_INTERFACE_VAR) String nextHopInterface,
-      @JsonProperty(ADMINISTRATIVE_COST_VAR) int administrativeCost,
-      @JsonProperty(METRIC_VAR) int metric,
-      @JsonProperty(PROTOCOL_VAR) RoutingProtocol protocol,
-      @JsonProperty(TAG_VAR) int tag) {
+      @JsonProperty(PROP_NODE) String node,
+      @JsonProperty(PROP_VRF) String vrf,
+      @JsonProperty(PROP_NETWORK) Prefix network,
+      @JsonProperty(PROP_NEXT_HOP_IP) Ip nextHopIp,
+      @JsonProperty(PROP_NEXT_HOP) String nextHop,
+      @JsonProperty(PROP_NEXT_HOP_INTERFACE) String nextHopInterface,
+      @JsonProperty(PROP_ADMINISTRATIVE_COST) int administrativeCost,
+      @JsonProperty(PROP_METRIC) int metric,
+      @JsonProperty(PROP_PROTOCOL) RoutingProtocol protocol,
+      @JsonProperty(PROP_TAG) int tag) {
     _network = network;
     _nextHopIp = nextHopIp;
     _node = node;
@@ -158,47 +158,47 @@ public class Route implements Comparable<Route>, Serializable {
     return true;
   }
 
-  @JsonProperty(ADMINISTRATIVE_COST_VAR)
+  @JsonProperty(PROP_ADMINISTRATIVE_COST)
   public int getAdministrativeCost() {
     return _administrativeCost;
   }
 
-  @JsonProperty(METRIC_VAR)
+  @JsonProperty(PROP_METRIC)
   public int getMetric() {
     return _metric;
   }
 
-  @JsonProperty(NETWORK_VAR)
+  @JsonProperty(PROP_NETWORK)
   public Prefix getNetwork() {
     return _network;
   }
 
-  @JsonProperty(NEXT_HOP_VAR)
+  @JsonProperty(PROP_NEXT_HOP)
   public String getNextHop() {
     return _nextHop;
   }
 
-  @JsonProperty(NEXT_HOP_INTERFACE_VAR)
+  @JsonProperty(PROP_NEXT_HOP_INTERFACE)
   public String getNextHopInterface() {
     return _nextHopInterface;
   }
 
-  @JsonProperty(NEXT_HOP_IP_VAR)
+  @JsonProperty(PROP_NEXT_HOP_IP)
   public Ip getNextHopIp() {
     return _nextHopIp;
   }
 
-  @JsonProperty(NODE_VAR)
+  @JsonProperty(PROP_NODE)
   public String getNode() {
     return _node;
   }
 
-  @JsonProperty(PROTOCOL_VAR)
+  @JsonProperty(PROP_PROTOCOL)
   public RoutingProtocol getProtocol() {
     return _protocol;
   }
 
-  @JsonProperty(TAG_VAR)
+  @JsonProperty(PROP_TAG)
   public int getTag() {
     return _tag;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Route6.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Route6.java
@@ -5,33 +5,33 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.io.Serializable;
 
-@JsonPropertyOrder({Route6.DIFF_SYMBOL_VAR})
+@JsonPropertyOrder({Route6.PROP_DIFF_SYMBOL})
 public class Route6 implements Comparable<Route6>, Serializable {
 
-  private static final String ADMINISTRATIVE_COST_VAR = "administrativeCost";
+  private static final String PROP_ADMINISTRATIVE_COST = "administrativeCost";
 
   public static final String AMBIGUOUS_NEXT_HOP = "(ambiguous)";
 
-  protected static final String DIFF_SYMBOL_VAR = "diffSymbol";
+  protected static final String PROP_DIFF_SYMBOL = "diffSymbol";
 
-  private static final String METRIC_VAR = "metric";
+  private static final String PROP_METRIC = "metric";
 
-  private static final String NETWORK_VAR = "network";
+  private static final String PROP_NETWORK = "network";
 
-  private static final String NEXT_HOP_INTERFACE_VAR = "nextHopInterface";
+  private static final String PROP_NEXT_HOP_INTERFACE = "nextHopInterface";
 
-  private static final String NEXT_HOP_IP_VAR = "nextHopIp";
+  private static final String PROP_NEXT_HOP_IP = "nextHopIp";
 
-  private static final String NEXT_HOP_VAR = "nextHop";
+  private static final String PROP_NEXT_HOP = "nextHop";
 
-  private static final String NODE_VAR = "node";
+  private static final String PROP_NODE = "node";
 
-  private static final String PROTOCOL_VAR = "protocol";
+  private static final String PROP_PROTOCOL = "protocol";
 
   /** */
   private static final long serialVersionUID = 1L;
 
-  private static final String TAG_VAR = "tag";
+  private static final String PROP_TAG = "tag";
 
   public static final String UNSET_NEXT_HOP = "(unknown)";
 
@@ -45,7 +45,7 @@ public class Route6 implements Comparable<Route6>, Serializable {
 
   public static final int UNSET_ROUTE_TAG = -1;
 
-  private static final String VRF_VAR = "vrf";
+  private static final String PROP_VRF = "vrf";
 
   private final int _administrativeCost;
 
@@ -71,16 +71,16 @@ public class Route6 implements Comparable<Route6>, Serializable {
 
   @JsonCreator
   public Route6(
-      @JsonProperty(NODE_VAR) String node,
-      @JsonProperty(VRF_VAR) String vrf,
-      @JsonProperty(NETWORK_VAR) Prefix6 network,
-      @JsonProperty(NEXT_HOP_IP_VAR) Ip6 nextHopIp,
-      @JsonProperty(NEXT_HOP_VAR) String nextHop,
-      @JsonProperty(NEXT_HOP_INTERFACE_VAR) String nextHopInterface,
-      @JsonProperty(ADMINISTRATIVE_COST_VAR) int administrativeCost,
-      @JsonProperty(METRIC_VAR) int metric,
-      @JsonProperty(PROTOCOL_VAR) RoutingProtocol protocol,
-      @JsonProperty(TAG_VAR) int tag) {
+      @JsonProperty(PROP_NODE) String node,
+      @JsonProperty(PROP_VRF) String vrf,
+      @JsonProperty(PROP_NETWORK) Prefix6 network,
+      @JsonProperty(PROP_NEXT_HOP_IP) Ip6 nextHopIp,
+      @JsonProperty(PROP_NEXT_HOP) String nextHop,
+      @JsonProperty(PROP_NEXT_HOP_INTERFACE) String nextHopInterface,
+      @JsonProperty(PROP_ADMINISTRATIVE_COST) int administrativeCost,
+      @JsonProperty(PROP_METRIC) int metric,
+      @JsonProperty(PROP_PROTOCOL) RoutingProtocol protocol,
+      @JsonProperty(PROP_TAG) int tag) {
     _network = network;
     _nextHopIp = nextHopIp;
     _node = node;
@@ -160,52 +160,52 @@ public class Route6 implements Comparable<Route6>, Serializable {
     return true;
   }
 
-  @JsonProperty(ADMINISTRATIVE_COST_VAR)
+  @JsonProperty(PROP_ADMINISTRATIVE_COST)
   public int getAdministrativeCost() {
     return _administrativeCost;
   }
 
-  @JsonProperty(DIFF_SYMBOL_VAR)
+  @JsonProperty(PROP_DIFF_SYMBOL)
   public String getDiffSymbol() {
     return _diffSymbol;
   }
 
-  @JsonProperty(METRIC_VAR)
+  @JsonProperty(PROP_METRIC)
   public int getMetric() {
     return _metric;
   }
 
-  @JsonProperty(NETWORK_VAR)
+  @JsonProperty(PROP_NETWORK)
   public Prefix6 getNetwork() {
     return _network;
   }
 
-  @JsonProperty(NEXT_HOP_VAR)
+  @JsonProperty(PROP_NEXT_HOP)
   public String getNextHop() {
     return _nextHop;
   }
 
-  @JsonProperty(NEXT_HOP_INTERFACE_VAR)
+  @JsonProperty(PROP_NEXT_HOP_INTERFACE)
   public String getNextHopInterface() {
     return _nextHopInterface;
   }
 
-  @JsonProperty(NEXT_HOP_IP_VAR)
+  @JsonProperty(PROP_NEXT_HOP_IP)
   public Ip6 getNextHopIp() {
     return _nextHopIp;
   }
 
-  @JsonProperty(NODE_VAR)
+  @JsonProperty(PROP_NODE)
   public String getNode() {
     return _node;
   }
 
-  @JsonProperty(PROTOCOL_VAR)
+  @JsonProperty(PROP_PROTOCOL)
   public RoutingProtocol getProtocol() {
     return _protocol;
   }
 
-  @JsonProperty(TAG_VAR)
+  @JsonProperty(PROP_TAG)
   public int getTag() {
     return _tag;
   }
@@ -263,7 +263,7 @@ public class Route6 implements Comparable<Route6>, Serializable {
     return routeStr;
   }
 
-  @JsonProperty(DIFF_SYMBOL_VAR)
+  @JsonProperty(PROP_DIFF_SYMBOL)
   public void setDiffSymbol(String diffSymbol) {
     _diffSymbol = diffSymbol;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Route6FilterLine.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Route6FilterLine.java
@@ -9,11 +9,11 @@ import java.io.Serializable;
 @JsonSchemaDescription("A line in an Route6FilterList")
 public class Route6FilterLine implements Serializable {
 
-  private static final String ACTION_VAR = "action";
+  private static final String PROP_ACTION = "action";
 
-  private static final String LENGTH_RANGE_VAR = "lengthRange";
+  private static final String PROP_LENGTH_RANGE = "lengthRange";
 
-  private static final String PREFIX_VAR = "prefix";
+  private static final String PROP_PREFIX = "prefix";
 
   private static final long serialVersionUID = 1L;
 
@@ -25,9 +25,9 @@ public class Route6FilterLine implements Serializable {
 
   @JsonCreator
   public Route6FilterLine(
-      @JsonProperty(ACTION_VAR) LineAction action,
-      @JsonProperty(PREFIX_VAR) Prefix6 prefix,
-      @JsonProperty(LENGTH_RANGE_VAR) SubRange lengthRange) {
+      @JsonProperty(PROP_ACTION) LineAction action,
+      @JsonProperty(PROP_PREFIX) Prefix6 prefix,
+      @JsonProperty(PROP_LENGTH_RANGE) SubRange lengthRange) {
     _action = action;
     _prefix = prefix;
     _lengthRange = lengthRange;
@@ -51,20 +51,20 @@ public class Route6FilterLine implements Serializable {
     return true;
   }
 
-  @JsonProperty(ACTION_VAR)
+  @JsonProperty(PROP_ACTION)
   @JsonPropertyDescription(
       "The action the underlying access-list will take when this line matches an IPV6 route.")
   public LineAction getAction() {
     return _action;
   }
 
-  @JsonProperty(LENGTH_RANGE_VAR)
+  @JsonProperty(PROP_LENGTH_RANGE)
   @JsonPropertyDescription("The range of acceptable prefix-lengths for a route.")
   public SubRange getLengthRange() {
     return _lengthRange;
   }
 
-  @JsonProperty(PREFIX_VAR)
+  @JsonProperty(PROP_PREFIX)
   @JsonPropertyDescription(
       "The bits against which to compare a route's prefix. The length of this prefix is used to "
           + "determine how many leading bits must match.")

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Route6FilterList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Route6FilterList.java
@@ -16,7 +16,7 @@ import org.batfish.common.util.ComparableStructure;
 @JsonSchemaDescription("An access-list used to filter IPV6 routes")
 public class Route6FilterList extends ComparableStructure<String> {
 
-  private static final String LINES_VAR = "lines";
+  private static final String PROP_LINES = "lines";
 
   private static final long serialVersionUID = 1L;
 
@@ -27,7 +27,7 @@ public class Route6FilterList extends ComparableStructure<String> {
   private transient Set<Prefix6> _permittedCache;
 
   @JsonCreator
-  public Route6FilterList(@JsonProperty(NAME_VAR) String name) {
+  public Route6FilterList(@JsonProperty(PROP_NAME) String name) {
     super(name);
     _lines = new ArrayList<>();
   }
@@ -45,7 +45,7 @@ public class Route6FilterList extends ComparableStructure<String> {
     return other._lines.equals(_lines);
   }
 
-  @JsonProperty(LINES_VAR)
+  @JsonProperty(PROP_LINES)
   @JsonPropertyDescription("The lines against which to check an IPV6 route")
   public List<Route6FilterLine> getLines() {
     return _lines;
@@ -92,7 +92,7 @@ public class Route6FilterList extends ComparableStructure<String> {
     _permittedCache = Collections.newSetFromMap(new ConcurrentHashMap<>());
   }
 
-  @JsonProperty(LINES_VAR)
+  @JsonProperty(PROP_LINES)
   public void setLines(List<Route6FilterLine> lines) {
     _lines = lines;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RouteFilterLine.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RouteFilterLine.java
@@ -9,11 +9,11 @@ import java.io.Serializable;
 @JsonSchemaDescription("A line in an RouteFilterList")
 public class RouteFilterLine implements Serializable {
 
-  private static final String ACTION_VAR = "action";
+  private static final String PROP_ACTION = "action";
 
-  private static final String LENGTH_RANGE_VAR = "lengthRange";
+  private static final String PROP_LENGTH_RANGE = "lengthRange";
 
-  private static final String PREFIX_VAR = "prefix";
+  private static final String PROP_PREFIX = "prefix";
 
   private static final long serialVersionUID = 1L;
 
@@ -25,9 +25,9 @@ public class RouteFilterLine implements Serializable {
 
   @JsonCreator
   public RouteFilterLine(
-      @JsonProperty(ACTION_VAR) LineAction action,
-      @JsonProperty(PREFIX_VAR) Prefix prefix,
-      @JsonProperty(LENGTH_RANGE_VAR) SubRange lengthRange) {
+      @JsonProperty(PROP_ACTION) LineAction action,
+      @JsonProperty(PROP_PREFIX) Prefix prefix,
+      @JsonProperty(PROP_LENGTH_RANGE) SubRange lengthRange) {
     _action = action;
     _prefix = prefix;
     _lengthRange = lengthRange;
@@ -51,20 +51,20 @@ public class RouteFilterLine implements Serializable {
     return true;
   }
 
-  @JsonProperty(ACTION_VAR)
+  @JsonProperty(PROP_ACTION)
   @JsonPropertyDescription(
       "The action the underlying access-list will take when this line matches an IPV4 route.")
   public LineAction getAction() {
     return _action;
   }
 
-  @JsonProperty(LENGTH_RANGE_VAR)
+  @JsonProperty(PROP_LENGTH_RANGE)
   @JsonPropertyDescription("The range of acceptable prefix-lengths for a route.")
   public SubRange getLengthRange() {
     return _lengthRange;
   }
 
-  @JsonProperty(PREFIX_VAR)
+  @JsonProperty(PROP_PREFIX)
   @JsonPropertyDescription(
       "The bits against which to compare a route's prefix. The length of this prefix is used to "
           + "determine how many leading bits must match.")

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RouteFilterList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RouteFilterList.java
@@ -16,7 +16,7 @@ import org.batfish.common.util.ComparableStructure;
 @JsonSchemaDescription("An access-list used to filter IPV4 routes")
 public class RouteFilterList extends ComparableStructure<String> {
 
-  private static final String LINES_VAR = "lines";
+  private static final String PROP_LINES = "lines";
 
   private static final long serialVersionUID = 1L;
 
@@ -27,7 +27,7 @@ public class RouteFilterList extends ComparableStructure<String> {
   private transient Set<Prefix> _permittedCache;
 
   @JsonCreator
-  public RouteFilterList(@JsonProperty(NAME_VAR) String name) {
+  public RouteFilterList(@JsonProperty(PROP_NAME) String name) {
     super(name);
     _lines = new ArrayList<>();
   }
@@ -45,7 +45,7 @@ public class RouteFilterList extends ComparableStructure<String> {
     return other._lines.equals(_lines);
   }
 
-  @JsonProperty(LINES_VAR)
+  @JsonProperty(PROP_LINES)
   @JsonPropertyDescription("The lines against which to check an IPV4 route")
   public List<RouteFilterLine> getLines() {
     return _lines;
@@ -92,7 +92,7 @@ public class RouteFilterList extends ComparableStructure<String> {
     _permittedCache = Collections.newSetFromMap(new ConcurrentHashMap<>());
   }
 
-  @JsonProperty(LINES_VAR)
+  @JsonProperty(PROP_LINES)
   public void setLines(List<RouteFilterLine> lines) {
     _lines = lines;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/SnmpCommunity.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/SnmpCommunity.java
@@ -21,7 +21,7 @@ public class SnmpCommunity extends ComparableStructure<String> {
 
   private boolean _rw;
 
-  public SnmpCommunity(@JsonProperty(NAME_VAR) String name) {
+  public SnmpCommunity(@JsonProperty(PROP_NAME) String name) {
     super(name);
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/SnmpHost.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/SnmpHost.java
@@ -8,7 +8,7 @@ public class SnmpHost extends ComparableStructure<String> {
   /** */
   private static final long serialVersionUID = 1L;
 
-  public SnmpHost(@JsonProperty(NAME_VAR) String name) {
+  public SnmpHost(@JsonProperty(PROP_NAME) String name) {
     super(name);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/SourceNat.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/SourceNat.java
@@ -5,11 +5,11 @@ import java.io.Serializable;
 
 public class SourceNat implements Serializable {
 
-  private static final String ACL_VAR = "acl";
+  private static final String PROP_ACL = "acl";
 
-  private static final String POOL_IP_FIRST_VAR = "poolIpFirst";
+  private static final String PROP_POOL_IP_FIRST = "poolIpFirst";
 
-  private static final String POOL_IP_LAST_VAR = "poolIpLast";
+  private static final String PROP_POOL_IP_LAST = "poolIpLast";
 
   /** */
   private static final long serialVersionUID = 1L;
@@ -20,32 +20,32 @@ public class SourceNat implements Serializable {
 
   private Ip _poolIpLast;
 
-  @JsonProperty(ACL_VAR)
+  @JsonProperty(PROP_ACL)
   public IpAccessList getAcl() {
     return _acl;
   }
 
-  @JsonProperty(POOL_IP_FIRST_VAR)
+  @JsonProperty(PROP_POOL_IP_FIRST)
   public Ip getPoolIpFirst() {
     return _poolIpFirst;
   }
 
-  @JsonProperty(POOL_IP_LAST_VAR)
+  @JsonProperty(PROP_POOL_IP_LAST)
   public Ip getPoolIpLast() {
     return _poolIpLast;
   }
 
-  @JsonProperty(ACL_VAR)
+  @JsonProperty(PROP_ACL)
   public void setAcl(IpAccessList acl) {
     _acl = acl;
   }
 
-  @JsonProperty(POOL_IP_FIRST_VAR)
+  @JsonProperty(PROP_POOL_IP_FIRST)
   public void setPoolIpFirst(Ip poolIpFirst) {
     _poolIpFirst = poolIpFirst;
   }
 
-  @JsonProperty(POOL_IP_LAST_VAR)
+  @JsonProperty(PROP_POOL_IP_LAST)
   public void setPoolIpLast(Ip poolIpLast) {
     _poolIpLast = poolIpLast;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/StaticRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/StaticRoute.java
@@ -10,7 +10,7 @@ import javax.annotation.Nullable;
 
 public class StaticRoute extends AbstractRoute {
 
-  private static final String NEXT_HOP_INTERFACE_VAR = "nextHopInterface";
+  private static final String PROP_NEXT_HOP_INTERFACE = "nextHopInterface";
 
   private static final long serialVersionUID = 1L;
 
@@ -26,11 +26,11 @@ public class StaticRoute extends AbstractRoute {
 
   @JsonCreator
   public StaticRoute(
-      @JsonProperty(NETWORK_VAR) Prefix network,
-      @JsonProperty(NEXT_HOP_IP_VAR) Ip nextHopIp,
-      @Nullable @JsonProperty(NEXT_HOP_INTERFACE_VAR) String nextHopInterface,
-      @JsonProperty(ADMINISTRATIVE_COST_VAR) int administrativeCost,
-      @JsonProperty(TAG_VAR) int tag) {
+      @JsonProperty(PROP_NETWORK) Prefix network,
+      @JsonProperty(PROP_NEXT_HOP_IP) Ip nextHopIp,
+      @Nullable @JsonProperty(PROP_NEXT_HOP_INTERFACE) String nextHopInterface,
+      @JsonProperty(PROP_ADMINISTRATIVE_COST) int administrativeCost,
+      @JsonProperty(PROP_TAG) int tag) {
     super(network);
     _administrativeCost = administrativeCost;
     _nextHopInterface = firstNonNull(nextHopInterface, Route.UNSET_NEXT_HOP_INTERFACE);
@@ -50,7 +50,7 @@ public class StaticRoute extends AbstractRoute {
 
   @Override
   @JsonIgnore(false)
-  @JsonProperty(ADMINISTRATIVE_COST_VAR)
+  @JsonProperty(PROP_ADMINISTRATIVE_COST)
   public int getAdministrativeCost() {
     return _administrativeCost;
   }
@@ -64,14 +64,14 @@ public class StaticRoute extends AbstractRoute {
   @Nonnull
   @Override
   @JsonIgnore(false)
-  @JsonProperty(NEXT_HOP_INTERFACE_VAR)
+  @JsonProperty(PROP_NEXT_HOP_INTERFACE)
   public String getNextHopInterface() {
     return _nextHopInterface;
   }
 
   @Nonnull
   @JsonIgnore(false)
-  @JsonProperty(NEXT_HOP_IP_VAR)
+  @JsonProperty(PROP_NEXT_HOP_IP)
   @Override
   public Ip getNextHopIp() {
     return _nextHopIp;
@@ -84,7 +84,7 @@ public class StaticRoute extends AbstractRoute {
 
   @Override
   @JsonIgnore(false)
-  @JsonProperty(TAG_VAR)
+  @JsonProperty(PROP_TAG)
   public int getTag() {
     return _tag;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/VerboseEdge.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/VerboseEdge.java
@@ -8,15 +8,15 @@ import org.batfish.datamodel.collections.VerboseNodeInterfacePair;
 
 public final class VerboseEdge extends Pair<VerboseNodeInterfacePair, VerboseNodeInterfacePair> {
 
-  private static final String EDGE_SUMMARY_VAR = "edgeSummary";
+  private static final String PROP_EDGE_SUMMARY = "edgeSummary";
 
-  private static final String NODE1_INTERFACE_VAR = "node1Interface";
+  private static final String PROP_NODE1_INTERFACE = "node1Interface";
 
-  private static final String NODE1_VAR = "node1";
+  private static final String PROP_NODE1 = "node1";
 
-  private static final String NODE2_INTERFACE_VAR = "node2Interface";
+  private static final String PROP_NODE2_INTERFACE = "node2Interface";
 
-  private static final String NODE2_VAR = "node2";
+  private static final String PROP_NODE2 = "node2";
 
   private static final long serialVersionUID = 1L;
 
@@ -24,11 +24,11 @@ public final class VerboseEdge extends Pair<VerboseNodeInterfacePair, VerboseNod
 
   @JsonCreator
   public VerboseEdge(
-      @JsonProperty(NODE1_VAR) Configuration node1,
-      @JsonProperty(NODE1_INTERFACE_VAR) Interface int1,
-      @JsonProperty(NODE2_VAR) Configuration node2,
-      @JsonProperty(NODE2_INTERFACE_VAR) Interface int2,
-      @JsonProperty(EDGE_SUMMARY_VAR) Edge e) {
+      @JsonProperty(PROP_NODE1) Configuration node1,
+      @JsonProperty(PROP_NODE1_INTERFACE) Interface int1,
+      @JsonProperty(PROP_NODE2) Configuration node2,
+      @JsonProperty(PROP_NODE2_INTERFACE) Interface int2,
+      @JsonProperty(PROP_EDGE_SUMMARY) Edge e) {
     this(new VerboseNodeInterfacePair(node1, int1), new VerboseNodeInterfacePair(node2, int2), e);
   }
 
@@ -37,17 +37,17 @@ public final class VerboseEdge extends Pair<VerboseNodeInterfacePair, VerboseNod
     this._edgeSummary = e;
   }
 
-  @JsonProperty(EDGE_SUMMARY_VAR)
+  @JsonProperty(PROP_EDGE_SUMMARY)
   public Edge getEdgeSummary() {
     return _edgeSummary;
   }
 
-  @JsonProperty(NODE1_INTERFACE_VAR)
+  @JsonProperty(PROP_NODE1_INTERFACE)
   public Interface getInt1() {
     return _first.getInterface();
   }
 
-  @JsonProperty(NODE2_INTERFACE_VAR)
+  @JsonProperty(PROP_NODE2_INTERFACE)
   public Interface getInt2() {
     return _second.getInterface();
   }
@@ -62,12 +62,12 @@ public final class VerboseEdge extends Pair<VerboseNodeInterfacePair, VerboseNod
     return _second;
   }
 
-  @JsonProperty(NODE1_VAR)
+  @JsonProperty(PROP_NODE1)
   public Configuration getNode1() {
     return _first.getHost();
   }
 
-  @JsonProperty(NODE2_VAR)
+  @JsonProperty(PROP_NODE2)
   public Configuration getNode2() {
     return _second.getHost();
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Vrf.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Vrf.java
@@ -15,20 +15,20 @@ import org.batfish.common.util.ComparableStructure;
 @JsonSchemaDescription("A virtual routing and forwarding (VRF) instance on a node.")
 public class Vrf extends ComparableStructure<String> {
 
-  private static final String BGP_PROCESS_VAR = "bgpProcess";
+  private static final String PROP_BGP_PROCESS = "bgpProcess";
 
-  private static final String GENERATED_ROUTES_VAR = "aggregateRoutes";
+  private static final String PROP_GENERATED_ROUTES = "aggregateRoutes";
 
-  private static final String INTERFACES_VAR = "interfaces";
+  private static final String PROP_INTERFACES = "interfaces";
 
-  private static final String ISIS_PROCESS_VAR = "isisProcess";
+  private static final String PROP_ISIS_PROCESS = "isisProcess";
 
-  private static final String OSPF_PROCESS_VAR = "ospfProcess";
+  private static final String PROP_OSPF_PROCESS = "ospfProcess";
 
   /** */
   private static final long serialVersionUID = 1L;
 
-  private static final String STATIC_ROUTES_VAR = "staticRoutes";
+  private static final String PROP_STATIC_ROUTES = "staticRoutes";
 
   private transient NavigableSet<BgpAdvertisement> _bgpAdvertisements;
 
@@ -71,7 +71,7 @@ public class Vrf extends ComparableStructure<String> {
   private NavigableSet<StaticRoute> _staticRoutes;
 
   @JsonCreator
-  public Vrf(@JsonProperty(NAME_VAR) String name) {
+  public Vrf(@JsonProperty(PROP_NAME) String name) {
     super(name);
     _generatedRoutes = new TreeSet<>();
     _generatedIpv6Routes = new TreeSet<>();
@@ -84,7 +84,7 @@ public class Vrf extends ComparableStructure<String> {
     return _bgpAdvertisements;
   }
 
-  @JsonProperty(BGP_PROCESS_VAR)
+  @JsonProperty(PROP_BGP_PROCESS)
   @JsonPropertyDescription("BGP routing process for this VRF")
   public BgpProcess getBgpProcess() {
     return _bgpProcess;
@@ -95,13 +95,13 @@ public class Vrf extends ComparableStructure<String> {
     return _generatedIpv6Routes;
   }
 
-  @JsonProperty(GENERATED_ROUTES_VAR)
+  @JsonProperty(PROP_GENERATED_ROUTES)
   @JsonPropertyDescription("Generated IPV4 routes for this VRF")
   public NavigableSet<GeneratedRoute> getGeneratedRoutes() {
     return _generatedRoutes;
   }
 
-  @JsonProperty(INTERFACES_VAR)
+  @JsonProperty(PROP_INTERFACES)
   @JsonPropertyDescription("Interfaces assigned to this VRF")
   public SortedSet<String> getInterfaceNames() {
     if (_interfaces != null && !_interfaces.isEmpty()) {
@@ -116,7 +116,7 @@ public class Vrf extends ComparableStructure<String> {
     return _interfaces;
   }
 
-  @JsonProperty(ISIS_PROCESS_VAR)
+  @JsonProperty(PROP_ISIS_PROCESS)
   @JsonPropertyDescription("IS-IS routing process for this VRF")
   public IsisProcess getIsisProcess() {
     return _isisProcess;
@@ -138,7 +138,7 @@ public class Vrf extends ComparableStructure<String> {
   }
 
   @JsonPropertyDescription("OSPF routing process for this VRF")
-  @JsonProperty(OSPF_PROCESS_VAR)
+  @JsonProperty(PROP_OSPF_PROCESS)
   public OspfProcess getOspfProcess() {
     return _ospfProcess;
   }
@@ -183,7 +183,7 @@ public class Vrf extends ComparableStructure<String> {
   }
 
   @JsonPropertyDescription("Static routes for this VRF")
-  @JsonProperty(STATIC_ROUTES_VAR)
+  @JsonProperty(PROP_STATIC_ROUTES)
   public NavigableSet<StaticRoute> getStaticRoutes() {
     return _staticRoutes;
   }
@@ -213,7 +213,7 @@ public class Vrf extends ComparableStructure<String> {
     }
   }
 
-  @JsonProperty(BGP_PROCESS_VAR)
+  @JsonProperty(PROP_BGP_PROCESS)
   public void setBgpProcess(BgpProcess process) {
     _bgpProcess = process;
   }
@@ -222,12 +222,12 @@ public class Vrf extends ComparableStructure<String> {
     _generatedIpv6Routes = generatedIpv6Routes;
   }
 
-  @JsonProperty(GENERATED_ROUTES_VAR)
+  @JsonProperty(PROP_GENERATED_ROUTES)
   public void setGeneratedRoutes(NavigableSet<GeneratedRoute> generatedRoutes) {
     _generatedRoutes = generatedRoutes;
   }
 
-  @JsonProperty(INTERFACES_VAR)
+  @JsonProperty(PROP_INTERFACES)
   public void setInterfaceNames(SortedSet<String> interfaceNames) {
     _interfaceNames = interfaceNames;
   }
@@ -237,12 +237,12 @@ public class Vrf extends ComparableStructure<String> {
     _interfaces = interfaces;
   }
 
-  @JsonProperty(ISIS_PROCESS_VAR)
+  @JsonProperty(PROP_ISIS_PROCESS)
   public void setIsisProcess(IsisProcess process) {
     _isisProcess = process;
   }
 
-  @JsonProperty(OSPF_PROCESS_VAR)
+  @JsonProperty(PROP_OSPF_PROCESS)
   public void setOspfProcess(OspfProcess process) {
     _ospfProcess = process;
   }
@@ -251,7 +251,7 @@ public class Vrf extends ComparableStructure<String> {
     _snmpServer = snmpServer;
   }
 
-  @JsonProperty(STATIC_ROUTES_VAR)
+  @JsonProperty(PROP_STATIC_ROUTES)
   public void setStaticRoutes(NavigableSet<StaticRoute> staticRoutes) {
     _staticRoutes = staticRoutes;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/VrfDiff.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/VrfDiff.java
@@ -6,19 +6,19 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class VrfDiff extends ConfigDiffElement {
 
-  private static final String AS_PATH_ACCESS_LISTS_DIFF_VAR = "asPathAccessListsDiff";
+  private static final String PROP_AS_PATH_ACCESS_LISTS_DIFF = "asPathAccessListsDiff";
 
-  private static final String COMMUNITY_LISTS_DIFF_VAR = "comunityListsDiff";
+  private static final String PROP_COMMUNITY_LISTS_DIFF = "comunityListsDiff";
 
-  private static final String INTERFACES_DIFF_VAR = "interfacesDiff";
+  private static final String PROP_INTERFACES_DIFF = "interfacesDiff";
 
-  private static final String IP_ACCESS_LISTS_DIFF_VAR = "ipAccessListsDiff";
+  private static final String PROP_IP_ACCESS_LISTS_DIFF = "ipAccessListsDiff";
 
-  private static final String ROUTE_FILTER_LISTS_DIFF_VAR = "routeFilterListsDiff";
+  private static final String PROP_ROUTE_FILTER_LISTS_DIFF = "routeFilterListsDiff";
 
-  private static final String ROUTING_POLICIES_DIFF_VAR = "routingPoliciesDiff";
+  private static final String PROP_ROUTING_POLICIES_DIFF = "routingPoliciesDiff";
 
-  private static final String VRFS_DIFF_VAR = "vrfsDiff";
+  private static final String PROP_VRFS_DIFF = "vrfsDiff";
 
   private AsPathAccessListsDiff _asPathAccessListsDiff;
 
@@ -46,37 +46,37 @@ public class VrfDiff extends ConfigDiffElement {
     }
   }
 
-  @JsonProperty(AS_PATH_ACCESS_LISTS_DIFF_VAR)
+  @JsonProperty(PROP_AS_PATH_ACCESS_LISTS_DIFF)
   public AsPathAccessListsDiff getAsPathAccessListsDiff() {
     return _asPathAccessListsDiff;
   }
 
-  @JsonProperty(COMMUNITY_LISTS_DIFF_VAR)
+  @JsonProperty(PROP_COMMUNITY_LISTS_DIFF)
   public CommunityListsDiff getCommunityListsDiff() {
     return _communityListsDiff;
   }
 
-  @JsonProperty(INTERFACES_DIFF_VAR)
+  @JsonProperty(PROP_INTERFACES_DIFF)
   public InterfacesDiff getInterfacesDiff() {
     return _interfacesDiff;
   }
 
-  @JsonProperty(IP_ACCESS_LISTS_DIFF_VAR)
+  @JsonProperty(PROP_IP_ACCESS_LISTS_DIFF)
   public IpAccessListsDiff getIpAccessListsDiff() {
     return _ipAccessListsDiff;
   }
 
-  @JsonProperty(ROUTE_FILTER_LISTS_DIFF_VAR)
+  @JsonProperty(PROP_ROUTE_FILTER_LISTS_DIFF)
   public RouteFilterListsDiff getRouteFilterListsDiff() {
     return _routeFilterListsDiff;
   }
 
-  @JsonProperty(ROUTING_POLICIES_DIFF_VAR)
+  @JsonProperty(PROP_ROUTING_POLICIES_DIFF)
   public RoutingPoliciesDiff getRoutingPoliciesDiff() {
     return _routingPoliciesDiff;
   }
 
-  @JsonProperty(VRFS_DIFF_VAR)
+  @JsonProperty(PROP_VRFS_DIFF)
   public VrfsDiff getVrfsDiff() {
     return _vrfsDiff;
   }
@@ -93,37 +93,37 @@ public class VrfDiff extends ConfigDiffElement {
         && _routingPoliciesDiff == null;
   }
 
-  @JsonProperty(AS_PATH_ACCESS_LISTS_DIFF_VAR)
+  @JsonProperty(PROP_AS_PATH_ACCESS_LISTS_DIFF)
   public void setAsPathAccessListsDiff(AsPathAccessListsDiff asPathAccessListsDiff) {
     _asPathAccessListsDiff = asPathAccessListsDiff;
   }
 
-  @JsonProperty(COMMUNITY_LISTS_DIFF_VAR)
+  @JsonProperty(PROP_COMMUNITY_LISTS_DIFF)
   public void setCommunityListsDiff(CommunityListsDiff communityListsDiff) {
     _communityListsDiff = communityListsDiff;
   }
 
-  @JsonProperty(INTERFACES_DIFF_VAR)
+  @JsonProperty(PROP_INTERFACES_DIFF)
   public void setInterfacesDiff(InterfacesDiff interfacesDiff) {
     _interfacesDiff = interfacesDiff;
   }
 
-  @JsonProperty(IP_ACCESS_LISTS_DIFF_VAR)
+  @JsonProperty(PROP_IP_ACCESS_LISTS_DIFF)
   public void setIpAccessListsDiff(IpAccessListsDiff ipAccessListsDiff) {
     _ipAccessListsDiff = ipAccessListsDiff;
   }
 
-  @JsonProperty(ROUTE_FILTER_LISTS_DIFF_VAR)
+  @JsonProperty(PROP_ROUTE_FILTER_LISTS_DIFF)
   public void setRouteFilterListsDiff(RouteFilterListsDiff routeFilterListsDiff) {
     _routeFilterListsDiff = routeFilterListsDiff;
   }
 
-  @JsonProperty(ROUTING_POLICIES_DIFF_VAR)
+  @JsonProperty(PROP_ROUTING_POLICIES_DIFF)
   public void setRoutingPoliciesDiff(RoutingPoliciesDiff routingPoliciesDiff) {
     _routingPoliciesDiff = routingPoliciesDiff;
   }
 
-  @JsonProperty(VRFS_DIFF_VAR)
+  @JsonProperty(PROP_VRFS_DIFF)
   public void setVrfsDiff(VrfsDiff vrfsDiff) {
     _vrfsDiff = vrfsDiff;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/VrrpGroup.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/VrrpGroup.java
@@ -6,14 +6,14 @@ import org.batfish.common.util.ComparableStructure;
 
 public class VrrpGroup extends ComparableStructure<Integer> {
 
-  private static final String PREEMPT_VAR = "preempt";
+  private static final String PROP_PREEMPT = "preempt";
 
-  private static final String PRIORITY_VAR = "priority";
+  private static final String PROP_PRIORITY = "priority";
 
   /** */
   private static final long serialVersionUID = 1L;
 
-  private static final String VIRTUAL_ADDRESS_VAR = "virtualAddress";
+  private static final String PROP_VIRTUAL_ADDRESS = "virtualAddress";
 
   private boolean _preempt;
 
@@ -22,36 +22,36 @@ public class VrrpGroup extends ComparableStructure<Integer> {
   private Prefix _virtualAddress;
 
   @JsonCreator
-  public VrrpGroup(@JsonProperty(NAME_VAR) Integer name) {
+  public VrrpGroup(@JsonProperty(PROP_NAME) Integer name) {
     super(name);
   }
 
-  @JsonProperty(PREEMPT_VAR)
+  @JsonProperty(PROP_PREEMPT)
   public boolean getPreempt() {
     return _preempt;
   }
 
-  @JsonProperty(PRIORITY_VAR)
+  @JsonProperty(PROP_PRIORITY)
   public int getPriority() {
     return _priority;
   }
 
-  @JsonProperty(VIRTUAL_ADDRESS_VAR)
+  @JsonProperty(PROP_VIRTUAL_ADDRESS)
   public Prefix getVirtualAddress() {
     return _virtualAddress;
   }
 
-  @JsonProperty(PREEMPT_VAR)
+  @JsonProperty(PROP_PREEMPT)
   public void setPreempt(boolean preempt) {
     _preempt = preempt;
   }
 
-  @JsonProperty(PRIORITY_VAR)
+  @JsonProperty(PROP_PRIORITY)
   public void setPriority(int priority) {
     _priority = priority;
   }
 
-  @JsonProperty(VIRTUAL_ADDRESS_VAR)
+  @JsonProperty(PROP_VIRTUAL_ADDRESS)
   public void setVirtualAddress(Prefix virtualAddress) {
     _virtualAddress = virtualAddress;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Zone.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Zone.java
@@ -12,18 +12,18 @@ import org.batfish.common.util.ComparableStructure;
 @JsonSchemaDescription("An IPV4 firewall zone")
 public final class Zone extends ComparableStructure<String> {
 
-  private static final String FROM_HOST_FILTER_VAR = "fromHostFilter";
+  private static final String PROP_FROM_HOST_FILTER = "fromHostFilter";
 
-  private static final String INBOUND_FILTER_VAR = "inboundFilter";
+  private static final String PROP_INBOUND_FILTER = "inboundFilter";
 
-  private static final String INBOUND_INTERFACE_FILTERS_VAR = "inboundInterfaceFilters";
+  private static final String PROP_INBOUND_INTERFACE_FILTERS = "inboundInterfaceFilters";
 
   /** */
   private static final long serialVersionUID = 1L;
 
-  private static final String TO_HOST_FILTER_VAR = "toHostFilter";
+  private static final String PROP_TO_HOST_FILTER = "toHostFilter";
 
-  private static final String TO_ZONE_POLICIES_VAR = "toZonePolicies";
+  private static final String PROP_TO_ZONE_POLICIES = "toZonePolicies";
 
   private IpAccessList _fromHostFilter;
 
@@ -46,7 +46,7 @@ public final class Zone extends ComparableStructure<String> {
   private transient SortedMap<String, String> _toZonePoliciesNames;
 
   @JsonCreator
-  public Zone(@JsonProperty(NAME_VAR) String name) {
+  public Zone(@JsonProperty(PROP_NAME) String name) {
     super(name);
   }
 
@@ -92,7 +92,7 @@ public final class Zone extends ComparableStructure<String> {
     return _fromHostFilter;
   }
 
-  @JsonProperty(FROM_HOST_FILTER_VAR)
+  @JsonProperty(PROP_FROM_HOST_FILTER)
   @JsonPropertyDescription(
       "Filter applied against packets originating from an interface in this zone on this node")
   public String getFromHostFilterName() {
@@ -108,7 +108,7 @@ public final class Zone extends ComparableStructure<String> {
     return _inboundFilter;
   }
 
-  @JsonProperty(INBOUND_FILTER_VAR)
+  @JsonProperty(PROP_INBOUND_FILTER)
   @JsonPropertyDescription(
       "Filter applied against packets whose final destination is an interface in this zone that "
           + "does not have its own inbound filter")
@@ -125,7 +125,7 @@ public final class Zone extends ComparableStructure<String> {
     return _inboundInterfaceFilters;
   }
 
-  @JsonProperty(INBOUND_INTERFACE_FILTERS_VAR)
+  @JsonProperty(PROP_INBOUND_INTERFACE_FILTERS)
   @JsonPropertyDescription(
       "Mapping of interfaces in this zone to their corresponding inbound filters: the filter "
           + "applied against packets whose final destination is the interface whose name is the "
@@ -148,7 +148,7 @@ public final class Zone extends ComparableStructure<String> {
     return _toHostFilter;
   }
 
-  @JsonProperty(TO_HOST_FILTER_VAR)
+  @JsonProperty(PROP_TO_HOST_FILTER)
   @JsonPropertyDescription(
       "Filter applied against packets whose final destination is an interface in this zone. If "
           + "this filter exists, it is applied IN ADDITION to the interface-specific or default "
@@ -166,7 +166,7 @@ public final class Zone extends ComparableStructure<String> {
     return _toZonePolicies;
   }
 
-  @JsonProperty(TO_ZONE_POLICIES_VAR)
+  @JsonProperty(PROP_TO_ZONE_POLICIES)
   @JsonPropertyDescription(
       "Maps names of destination zones to the corresponding filter applied against packets which "
           + "are received on this zone and routed to the named zone")
@@ -188,7 +188,7 @@ public final class Zone extends ComparableStructure<String> {
     _fromHostFilter = fromHostFilter;
   }
 
-  @JsonProperty(FROM_HOST_FILTER_VAR)
+  @JsonProperty(PROP_FROM_HOST_FILTER)
   public void setFromHostFilterName(String fromHostFilterName) {
     _fromHostFilterName = fromHostFilterName;
   }
@@ -198,7 +198,7 @@ public final class Zone extends ComparableStructure<String> {
     _inboundFilter = inboundFilter;
   }
 
-  @JsonProperty(INBOUND_FILTER_VAR)
+  @JsonProperty(PROP_INBOUND_FILTER)
   public void setInboundFilterName(String inboundFilterName) {
     _inboundFilterName = inboundFilterName;
   }
@@ -208,7 +208,7 @@ public final class Zone extends ComparableStructure<String> {
     _inboundInterfaceFilters = inboundInterfaceFilters;
   }
 
-  @JsonProperty(INBOUND_INTERFACE_FILTERS_VAR)
+  @JsonProperty(PROP_INBOUND_INTERFACE_FILTERS)
   public void setInboundInterfaceFiltersNames(
       SortedMap<String, String> inboundInterfaceFiltersNames) {
     _inboundInterfaceFiltersNames = inboundInterfaceFiltersNames;
@@ -219,7 +219,7 @@ public final class Zone extends ComparableStructure<String> {
     _toHostFilter = toHostFilter;
   }
 
-  @JsonProperty(TO_HOST_FILTER_VAR)
+  @JsonProperty(PROP_TO_HOST_FILTER)
   public void setToHostFilterName(String toHostFilterName) {
     _toHostFilterName = toHostFilterName;
   }
@@ -229,7 +229,7 @@ public final class Zone extends ComparableStructure<String> {
     _toZonePolicies = toZonePolicies;
   }
 
-  @JsonProperty(TO_ZONE_POLICIES_VAR)
+  @JsonProperty(PROP_TO_ZONE_POLICIES)
   public void setToZonePoliciesNames(SortedMap<String, String> toZonePoliciesNames) {
     _toZonePoliciesNames = toZonePoliciesNames;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AclLinesAnswerElement.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AclLinesAnswerElement.java
@@ -12,9 +12,9 @@ public class AclLinesAnswerElement implements AnswerElement {
 
   public static class AclReachabilityEntry implements Comparable<AclReachabilityEntry> {
 
-    private static final String INDEX_VAR = "index";
+    private static final String PROP_INDEX = "index";
 
-    private static final String NAME_VAR = "name";
+    private static final String PROP_NAME = "name";
 
     private boolean _differentAction;
 
@@ -28,7 +28,7 @@ public class AclLinesAnswerElement implements AnswerElement {
 
     @JsonCreator
     public AclReachabilityEntry(
-        @JsonProperty(INDEX_VAR) int index, @JsonProperty(NAME_VAR) String name) {
+        @JsonProperty(PROP_INDEX) int index, @JsonProperty(PROP_NAME) String name) {
       _index = index;
       _name = name;
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/Answer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/Answer.java
@@ -44,17 +44,17 @@ public class Answer {
     }
   }
 
-  @JsonProperty(BfConsts.ANSWER_ELEMENTS_VAR)
+  @JsonProperty(BfConsts.PROP_ANSWER_ELEMENTS)
   public List<AnswerElement> getAnswerElements() {
     return _answerElements;
   }
 
-  @JsonProperty(BfConsts.QUESTION_VAR)
+  @JsonProperty(BfConsts.PROP_QUESTION)
   public Question getQuestion() {
     return _question;
   }
 
-  @JsonProperty(BfConsts.STATUS_VAR)
+  @JsonProperty(BfConsts.PROP_STATUS)
   public AnswerStatus getStatus() {
     return _status;
   }
@@ -87,17 +87,17 @@ public class Answer {
     return answer;
   }
 
-  @JsonProperty(BfConsts.ANSWER_ELEMENTS_VAR)
+  @JsonProperty(BfConsts.PROP_ANSWER_ELEMENTS)
   public void setAnswerElements(List<AnswerElement> answerElements) {
     _answerElements = answerElements;
   }
 
-  @JsonProperty(BfConsts.QUESTION_VAR)
+  @JsonProperty(BfConsts.PROP_QUESTION)
   public void setQuestion(Question question) {
     _question = question;
   }
 
-  @JsonProperty(BfConsts.STATUS_VAR)
+  @JsonProperty(BfConsts.PROP_STATUS)
   public void setStatus(AnswerStatus status) {
     _status = status;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AnswerElement.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AnswerElement.java
@@ -11,10 +11,10 @@ import org.batfish.common.util.BatfishObjectMapper;
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "class")
 public interface AnswerElement {
 
-  String SUMMARY_VAR = "summary";
+  String PROP_SUMMARY = "summary";
 
   @Nullable
-  @JsonProperty(SUMMARY_VAR)
+  @JsonProperty(PROP_SUMMARY)
   default String getSummary() {
     return null;
   }
@@ -28,6 +28,6 @@ public interface AnswerElement {
     }
   }
 
-  @JsonProperty(SUMMARY_VAR)
+  @JsonProperty(PROP_SUMMARY)
   default void setSummary(String summary) {}
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/BdpAnswerElement.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/BdpAnswerElement.java
@@ -6,17 +6,17 @@ import java.util.TreeMap;
 
 public class BdpAnswerElement implements DataPlaneAnswerElement {
 
-  private static final String BGP_BEST_PATH_RIB_ROUTES_BY_ITERATION_VAR =
+  private static final String PROP_BGP_BEST_PATH_RIB_ROUTES_BY_ITERATION =
       "bgpBestPathRibRoutesByIteration";
 
-  private static final String BGP_MULTIPATH_RIB_ROUTES_BY_ITERATION_VAR =
+  private static final String PROP_BGP_MULTIPATH_RIB_ROUTES_BY_ITERATION =
       "bgpMultipathRibRoutesByIteration";
 
-  private static final String DEPENDENT_ROUTES_ITERATIONS_VAR = "dependentRoutesIterations";
+  private static final String PROP_DEPENDENT_ROUTES_ITERATIONS = "dependentRoutesIterations";
 
   private static final String MAIN_RIB_ROUTES_BY_ITERATION = "mainRibRoutesByIteration";
 
-  private static final String OSPF_INTERNAL_ITERATIONS_VAR = "ospfInternalIterations";
+  private static final String PROP_OSPF_INTERNAL_ITERATIONS = "ospfInternalIterations";
 
   /** */
   private static final long serialVersionUID = 1L;
@@ -39,17 +39,17 @@ public class BdpAnswerElement implements DataPlaneAnswerElement {
     _mainRibRoutesByIteration = new TreeMap<>();
   }
 
-  @JsonProperty(BGP_BEST_PATH_RIB_ROUTES_BY_ITERATION_VAR)
+  @JsonProperty(PROP_BGP_BEST_PATH_RIB_ROUTES_BY_ITERATION)
   public SortedMap<Integer, Integer> getBgpBestPathRibRoutesByIteration() {
     return _bgpBestPathRibRoutesByIteration;
   }
 
-  @JsonProperty(BGP_MULTIPATH_RIB_ROUTES_BY_ITERATION_VAR)
+  @JsonProperty(PROP_BGP_MULTIPATH_RIB_ROUTES_BY_ITERATION)
   public SortedMap<Integer, Integer> getBgpMultipathRibRoutesByIteration() {
     return _bgpMultipathRibRoutesByIteration;
   }
 
-  @JsonProperty(DEPENDENT_ROUTES_ITERATIONS_VAR)
+  @JsonProperty(PROP_DEPENDENT_ROUTES_ITERATIONS)
   public int getDependentRoutesIterations() {
     return _dependentRoutesIterations;
   }
@@ -59,13 +59,13 @@ public class BdpAnswerElement implements DataPlaneAnswerElement {
     return _mainRibRoutesByIteration;
   }
 
-  @JsonProperty(OSPF_INTERNAL_ITERATIONS_VAR)
+  @JsonProperty(PROP_OSPF_INTERNAL_ITERATIONS)
   public int getOspfInternalIterations() {
     return _ospfInternalIterations;
   }
 
   @Override
-  @JsonProperty(VERSION_VAR)
+  @JsonProperty(PROP_VERSION)
   public String getVersion() {
     return _version;
   }
@@ -84,19 +84,19 @@ public class BdpAnswerElement implements DataPlaneAnswerElement {
     return sb.toString();
   }
 
-  @JsonProperty(BGP_BEST_PATH_RIB_ROUTES_BY_ITERATION_VAR)
+  @JsonProperty(PROP_BGP_BEST_PATH_RIB_ROUTES_BY_ITERATION)
   public void setBgpBestPathRibRoutesByIteration(
       SortedMap<Integer, Integer> bgpBestPathRibRoutesByIteration) {
     _bgpBestPathRibRoutesByIteration = bgpBestPathRibRoutesByIteration;
   }
 
-  @JsonProperty(BGP_MULTIPATH_RIB_ROUTES_BY_ITERATION_VAR)
+  @JsonProperty(PROP_BGP_MULTIPATH_RIB_ROUTES_BY_ITERATION)
   public void setBgpMultipathRibRoutesByIteration(
       SortedMap<Integer, Integer> bgpMultipathRibRoutesByIteration) {
     _bgpMultipathRibRoutesByIteration = bgpMultipathRibRoutesByIteration;
   }
 
-  @JsonProperty(DEPENDENT_ROUTES_ITERATIONS_VAR)
+  @JsonProperty(PROP_DEPENDENT_ROUTES_ITERATIONS)
   public void setDependentRoutesIterations(int dependentRoutesIterations) {
     _dependentRoutesIterations = dependentRoutesIterations;
   }
@@ -106,12 +106,12 @@ public class BdpAnswerElement implements DataPlaneAnswerElement {
     _mainRibRoutesByIteration = mainRibRoutesByIteration;
   }
 
-  @JsonProperty(OSPF_INTERNAL_ITERATIONS_VAR)
+  @JsonProperty(PROP_OSPF_INTERNAL_ITERATIONS)
   public void setOspfInternalIterations(int ospfInternalIterations) {
     _ospfInternalIterations = ospfInternalIterations;
   }
 
-  @JsonProperty(VERSION_VAR)
+  @JsonProperty(PROP_VERSION)
   public void setVersion(String version) {
     _version = version;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/DataPlaneAnswerElement.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/DataPlaneAnswerElement.java
@@ -5,8 +5,8 @@ import java.io.Serializable;
 
 public interface DataPlaneAnswerElement extends AnswerElement, Serializable {
 
-  String VERSION_VAR = "version";
+  String PROP_VERSION = "version";
 
-  @JsonProperty(VERSION_VAR)
+  @JsonProperty(PROP_VERSION)
   String getVersion();
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/JsonDiffAnswerElement.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/JsonDiffAnswerElement.java
@@ -6,16 +6,16 @@ import org.batfish.common.util.JsonDiff;
 
 public class JsonDiffAnswerElement implements AnswerElement {
 
-  private static final String JSON_DIFF_VAR = "jsonDiff";
+  private static final String PROP_JSON_DIFF = "jsonDiff";
 
   private final JsonDiff _jsonDiff;
 
   @JsonCreator
-  public JsonDiffAnswerElement(@JsonProperty(JSON_DIFF_VAR) JsonDiff jsonDiff) {
+  public JsonDiffAnswerElement(@JsonProperty(PROP_JSON_DIFF) JsonDiff jsonDiff) {
     _jsonDiff = jsonDiff;
   }
 
-  @JsonProperty(JSON_DIFF_VAR)
+  @JsonProperty(PROP_JSON_DIFF)
   public JsonDiff getJsonDiff() {
     return _jsonDiff;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/Problem.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/Problem.java
@@ -8,9 +8,9 @@ import java.util.TreeMap;
 
 public class Problem implements Serializable {
 
-  private static final String DESCRIPTION_VAR = "description";
+  private static final String PROP_DESCRIPTION = "description";
 
-  private static final String FILES_VAR = "files";
+  private static final String PROP_FILES = "files";
 
   /** */
   private static final long serialVersionUID = 1L;
@@ -23,22 +23,22 @@ public class Problem implements Serializable {
     _files = new TreeMap<>();
   }
 
-  @JsonProperty(DESCRIPTION_VAR)
+  @JsonProperty(PROP_DESCRIPTION)
   public String getDescription() {
     return _description;
   }
 
-  @JsonProperty(FILES_VAR)
+  @JsonProperty(PROP_FILES)
   public SortedMap<String, SortedSet<Integer>> getFiles() {
     return _files;
   }
 
-  @JsonProperty(DESCRIPTION_VAR)
+  @JsonProperty(PROP_DESCRIPTION)
   public void setDescription(String description) {
     _description = description;
   }
 
-  @JsonProperty(FILES_VAR)
+  @JsonProperty(PROP_FILES)
   public void setFiles(SortedMap<String, SortedSet<Integer>> files) {
     _files = files;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/ProblemsAnswerElement.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/ProblemsAnswerElement.java
@@ -6,7 +6,7 @@ import java.util.TreeMap;
 
 public abstract class ProblemsAnswerElement implements AnswerElement {
 
-  private static final String PROBLEMS_VAR = "problems";
+  private static final String PROP_PROBLEMS = "problems";
 
   private SortedMap<String, Problem> _problems;
 
@@ -14,12 +14,12 @@ public abstract class ProblemsAnswerElement implements AnswerElement {
     _problems = new TreeMap<>();
   }
 
-  @JsonProperty(PROBLEMS_VAR)
+  @JsonProperty(PROP_PROBLEMS)
   public SortedMap<String, Problem> getProblems() {
     return _problems;
   }
 
-  @JsonProperty(PROBLEMS_VAR)
+  @JsonProperty(PROP_PROBLEMS)
   public void setProblems(SortedMap<String, Problem> problems) {
     _problems = problems;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/RunAnalysisAnswerElement.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/RunAnalysisAnswerElement.java
@@ -7,7 +7,7 @@ import java.util.TreeMap;
 
 public class RunAnalysisAnswerElement implements AnswerElement {
 
-  private static final String ANSWERS_VAR = "answers";
+  private static final String PROP_ANSWERS = "answers";
 
   private SortedMap<String, Answer> _answers;
 
@@ -16,12 +16,12 @@ public class RunAnalysisAnswerElement implements AnswerElement {
     _answers = new TreeMap<>();
   }
 
-  @JsonProperty(ANSWERS_VAR)
+  @JsonProperty(PROP_ANSWERS)
   public SortedMap<String, Answer> getAnswers() {
     return _answers;
   }
 
-  @JsonProperty(ANSWERS_VAR)
+  @JsonProperty(PROP_ANSWERS)
   public void setAnswers(SortedMap<String, Answer> answers) {
     _answers = answers;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/IpEdge.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/IpEdge.java
@@ -7,13 +7,13 @@ import org.batfish.datamodel.Ip;
 
 public class IpEdge extends Pair<NodeIpPair, NodeIpPair> {
 
-  private static final String IP1_VAR = "ip1";
+  private static final String PROP_IP1 = "ip1";
 
-  private static final String IP2_VAR = "ip2";
+  private static final String PROP_IP2 = "ip2";
 
-  private static final String NODE1_VAR = "node1";
+  private static final String PROP_NODE1 = "node1";
 
-  private static final String NODE2_VAR = "node2";
+  private static final String PROP_NODE2 = "node2";
 
   /** */
   private static final long serialVersionUID = 1L;
@@ -24,29 +24,29 @@ public class IpEdge extends Pair<NodeIpPair, NodeIpPair> {
 
   @JsonCreator
   public IpEdge(
-      @JsonProperty(NODE1_VAR) String node1,
-      @JsonProperty(IP1_VAR) Ip ip1,
-      @JsonProperty(NODE2_VAR) String node2,
-      @JsonProperty(IP2_VAR) Ip ip2) {
+      @JsonProperty(PROP_NODE1) String node1,
+      @JsonProperty(PROP_IP1) Ip ip1,
+      @JsonProperty(PROP_NODE2) String node2,
+      @JsonProperty(PROP_IP2) Ip ip2) {
     super(new NodeIpPair(node1, ip1), new NodeIpPair(node2, ip2));
   }
 
-  @JsonProperty(IP1_VAR)
+  @JsonProperty(PROP_IP1)
   public Ip getIp1() {
     return _first.getIp();
   }
 
-  @JsonProperty(IP2_VAR)
+  @JsonProperty(PROP_IP2)
   public Ip getIp2() {
     return _second.getIp();
   }
 
-  @JsonProperty(NODE1_VAR)
+  @JsonProperty(PROP_NODE1)
   public String getNode1() {
     return _first.getNode();
   }
 
-  @JsonProperty(NODE2_VAR)
+  @JsonProperty(PROP_NODE2)
   public String getNode2() {
     return _second.getNode();
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/NamedStructureEquivalenceSet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/NamedStructureEquivalenceSet.java
@@ -10,7 +10,7 @@ import org.batfish.common.util.CommonUtil;
 public class NamedStructureEquivalenceSet<T>
     implements Comparable<NamedStructureEquivalenceSet<T>> {
 
-  private static final String REPRESENTATIVE_ELEMENT_VAR = "representativeElement";
+  private static final String PROP_REPRESENTATIVE_ELEMENT = "representativeElement";
 
   // a null _namedStructure represents an equivalence class for nodes that are missing
   // a structure of a given name
@@ -22,7 +22,7 @@ public class NamedStructureEquivalenceSet<T>
 
   @JsonCreator
   public NamedStructureEquivalenceSet(
-      @JsonProperty(REPRESENTATIVE_ELEMENT_VAR) String representativeElement) {
+      @JsonProperty(PROP_REPRESENTATIVE_ELEMENT) String representativeElement) {
     _representativeElement = representativeElement;
   }
 
@@ -62,7 +62,7 @@ public class NamedStructureEquivalenceSet<T>
     return _nodes;
   }
 
-  @JsonProperty(REPRESENTATIVE_ELEMENT_VAR)
+  @JsonProperty(PROP_REPRESENTATIVE_ELEMENT)
   public String getRepresentativeElement() {
     return _representativeElement;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/NamedStructureOutlierSet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/NamedStructureOutlierSet.java
@@ -9,15 +9,15 @@ import java.util.SortedSet;
 
 public class NamedStructureOutlierSet<T> implements Comparable<NamedStructureOutlierSet<T>> {
 
-  private static final String NAME_VAR = "name";
+  private static final String PROP_NAME = "name";
 
-  private static final String STRUCT_TYPE_VAR = "structType";
+  private static final String PROP_STRUCT_TYPE = "structType";
 
-  private static final String NAMED_STRUCT_TYPES_VAR = "namedStructTypes";
+  private static final String PROP_NAMED_STRUCT_TYPES = "namedStructTypes";
 
-  private static final String CONFORMERS_VAR = "conformers";
+  private static final String PROP_CONFORMERS = "conformers";
 
-  private static final String OUTLIERS_VAR = "outliers";
+  private static final String PROP_OUTLIERS = "outliers";
 
   /** A lower bound on the probability at which a hypothesis should be considered to be true */
   private static final double THRESHOLD_PROBABILITY = 0.9;
@@ -42,11 +42,11 @@ public class NamedStructureOutlierSet<T> implements Comparable<NamedStructureOut
 
   @JsonCreator
   public NamedStructureOutlierSet(
-      @JsonProperty(STRUCT_TYPE_VAR) String structType,
-      @JsonProperty(NAME_VAR) String name,
-      @JsonProperty(NAMED_STRUCT_TYPES_VAR) T namedStructure,
-      @JsonProperty(CONFORMERS_VAR) SortedSet<String> conformers,
-      @JsonProperty(OUTLIERS_VAR) SortedSet<String> outliers) {
+      @JsonProperty(PROP_STRUCT_TYPE) String structType,
+      @JsonProperty(PROP_NAME) String name,
+      @JsonProperty(PROP_NAMED_STRUCT_TYPES) T namedStructure,
+      @JsonProperty(PROP_CONFORMERS) SortedSet<String> conformers,
+      @JsonProperty(PROP_OUTLIERS) SortedSet<String> outliers) {
     _structType = structType;
     _name = name;
     _namedStructure = namedStructure;
@@ -79,7 +79,7 @@ public class NamedStructureOutlierSet<T> implements Comparable<NamedStructureOut
     return _conformers;
   }
 
-  @JsonProperty(NAME_VAR)
+  @JsonProperty(PROP_NAME)
   public String getName() {
     return _name;
   }
@@ -94,7 +94,7 @@ public class NamedStructureOutlierSet<T> implements Comparable<NamedStructureOut
     return _outliers;
   }
 
-  @JsonProperty(STRUCT_TYPE_VAR)
+  @JsonProperty(PROP_STRUCT_TYPE)
   public String getStructType() {
     return _structType;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/NodeBgpSessionPair.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/NodeBgpSessionPair.java
@@ -8,24 +8,24 @@ import org.batfish.datamodel.Configuration;
 
 public class NodeBgpSessionPair extends Pair<Configuration, BgpNeighbor> {
 
-  private static final String NODE_VAR = "node";
+  private static final String PROP_NODE = "node";
 
   private static final long serialVersionUID = 1L;
 
-  private static final String SESSION_VAR = "session";
+  private static final String PROP_SESSION = "session";
 
   @JsonCreator
   public NodeBgpSessionPair(
-      @JsonProperty(NODE_VAR) Configuration t1, @JsonProperty(SESSION_VAR) BgpNeighbor t2) {
+      @JsonProperty(PROP_NODE) Configuration t1, @JsonProperty(PROP_SESSION) BgpNeighbor t2) {
     super(t1, t2);
   }
 
-  @JsonProperty(NODE_VAR)
+  @JsonProperty(PROP_NODE)
   public Configuration getNode() {
     return _first;
   }
 
-  @JsonProperty(SESSION_VAR)
+  @JsonProperty(PROP_SESSION)
   public BgpNeighbor getSession() {
     return _second;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/NodeInterfacePair.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/NodeInterfacePair.java
@@ -6,24 +6,24 @@ import org.batfish.common.Pair;
 
 public class NodeInterfacePair extends Pair<String, String> {
 
-  private static final String HOSTNAME_VAR = "hostname";
+  private static final String PROP_HOSTNAME = "hostname";
 
-  private static final String INTERFACE_VAR = "interface";
+  private static final String PROP_INTERFACE = "interface";
   /** */
   private static final long serialVersionUID = 1L;
 
   @JsonCreator
   public NodeInterfacePair(
-      @JsonProperty(HOSTNAME_VAR) String node, @JsonProperty(INTERFACE_VAR) String iface) {
+      @JsonProperty(PROP_HOSTNAME) String node, @JsonProperty(PROP_INTERFACE) String iface) {
     super(node, iface);
   }
 
-  @JsonProperty(HOSTNAME_VAR)
+  @JsonProperty(PROP_HOSTNAME)
   public String getHostname() {
     return _first;
   }
 
-  @JsonProperty(INTERFACE_VAR)
+  @JsonProperty(PROP_INTERFACE)
   public String getInterface() {
     return _second;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/NodeOspfSessionPair.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/NodeOspfSessionPair.java
@@ -8,24 +8,24 @@ import org.batfish.datamodel.OspfNeighbor;
 
 public class NodeOspfSessionPair extends Pair<Configuration, OspfNeighbor> {
 
-  private static final String NODE_VAR = "node";
+  private static final String PROP_NODE = "node";
 
   private static final long serialVersionUID = 1L;
 
-  private static final String SESSION_VAR = "session";
+  private static final String PROP_SESSION = "session";
 
   @JsonCreator
   public NodeOspfSessionPair(
-      @JsonProperty(NODE_VAR) Configuration t1, @JsonProperty(SESSION_VAR) OspfNeighbor t2) {
+      @JsonProperty(PROP_NODE) Configuration t1, @JsonProperty(PROP_SESSION) OspfNeighbor t2) {
     super(t1, t2);
   }
 
-  @JsonProperty(NODE_VAR)
+  @JsonProperty(PROP_NODE)
   public Configuration getHost() {
     return _first;
   }
 
-  @JsonProperty(SESSION_VAR)
+  @JsonProperty(PROP_SESSION)
   public OspfNeighbor getSession() {
     return _second;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/VerboseBgpEdge.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/VerboseBgpEdge.java
@@ -8,15 +8,15 @@ import org.batfish.datamodel.Configuration;
 
 public final class VerboseBgpEdge extends Pair<NodeBgpSessionPair, NodeBgpSessionPair> {
 
-  private static final String EDGE_SUMMARY_VAR = "edgeSummary";
+  private static final String PROP_EDGE_SUMMARY = "edgeSummary";
 
-  private static final String NODE1_SESSION_VAR = "node1Session";
+  private static final String PROP_NODE1_SESSION = "node1Session";
 
-  private static final String NODE1_VAR = "node1";
+  private static final String PROP_NODE1 = "node1";
 
-  private static final String NODE2_SESSION_VAR = "node2Session";
+  private static final String PROP_NODE2_SESSION = "node2Session";
 
-  private static final String NODE2_VAR = "node2";
+  private static final String PROP_NODE2 = "node2";
 
   private static final long serialVersionUID = 1L;
 
@@ -24,36 +24,36 @@ public final class VerboseBgpEdge extends Pair<NodeBgpSessionPair, NodeBgpSessio
 
   @JsonCreator
   public VerboseBgpEdge(
-      @JsonProperty(NODE1_VAR) Configuration node1,
-      @JsonProperty(NODE1_SESSION_VAR) BgpNeighbor s1,
-      @JsonProperty(NODE2_VAR) Configuration node2,
-      @JsonProperty(NODE2_SESSION_VAR) BgpNeighbor s2,
-      @JsonProperty(EDGE_SUMMARY_VAR) IpEdge e) {
+      @JsonProperty(PROP_NODE1) Configuration node1,
+      @JsonProperty(PROP_NODE1_SESSION) BgpNeighbor s1,
+      @JsonProperty(PROP_NODE2) Configuration node2,
+      @JsonProperty(PROP_NODE2_SESSION) BgpNeighbor s2,
+      @JsonProperty(PROP_EDGE_SUMMARY) IpEdge e) {
     super(new NodeBgpSessionPair(node1, s1), new NodeBgpSessionPair(node2, s2));
     this._edgeSummary = e;
   }
 
-  @JsonProperty(EDGE_SUMMARY_VAR)
+  @JsonProperty(PROP_EDGE_SUMMARY)
   public IpEdge getEdgeSummary() {
     return _edgeSummary;
   }
 
-  @JsonProperty(NODE1_VAR)
+  @JsonProperty(PROP_NODE1)
   public Configuration getNode1() {
     return _first.getNode();
   }
 
-  @JsonProperty(NODE1_SESSION_VAR)
+  @JsonProperty(PROP_NODE1_SESSION)
   public BgpNeighbor getNode1Session() {
     return _first.getSession();
   }
 
-  @JsonProperty(NODE2_VAR)
+  @JsonProperty(PROP_NODE2)
   public Configuration getNode2() {
     return _second.getNode();
   }
 
-  @JsonProperty(NODE2_SESSION_VAR)
+  @JsonProperty(PROP_NODE2_SESSION)
   public BgpNeighbor getNode2Session() {
     return _second.getSession();
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/VerboseNodeInterfacePair.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/VerboseNodeInterfacePair.java
@@ -8,24 +8,24 @@ import org.batfish.datamodel.Interface;
 
 public final class VerboseNodeInterfacePair extends Pair<Configuration, Interface> {
 
-  private static final String HOST_VAR = "host";
+  private static final String PROP_HOST = "host";
 
-  private static final String INTERFACE_VAR = "interface";
+  private static final String PROP_INTERFACE = "interface";
   /** */
   private static final long serialVersionUID = 1L;
 
   @JsonCreator
   public VerboseNodeInterfacePair(
-      @JsonProperty(HOST_VAR) Configuration node, @JsonProperty(INTERFACE_VAR) Interface iface) {
+      @JsonProperty(PROP_HOST) Configuration node, @JsonProperty(PROP_INTERFACE) Interface iface) {
     super(node, iface);
   }
 
-  @JsonProperty(HOST_VAR)
+  @JsonProperty(PROP_HOST)
   public Configuration getHost() {
     return _first;
   }
 
-  @JsonProperty(INTERFACE_VAR)
+  @JsonProperty(PROP_INTERFACE)
   public Interface getInterface() {
     return _second;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/VerboseOspfEdge.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/VerboseOspfEdge.java
@@ -8,15 +8,15 @@ import org.batfish.datamodel.OspfNeighbor;
 
 public final class VerboseOspfEdge extends Pair<NodeOspfSessionPair, NodeOspfSessionPair> {
 
-  private static final String EDGE_SUMMARY_VAR = "edgeSummary";
+  private static final String PROP_EDGE_SUMMARY = "edgeSummary";
 
-  private static final String NODE1_SESSION_VAR = "node1Session";
+  private static final String PROP_NODE1_SESSION = "node1Session";
 
-  private static final String NODE1_VAR = "node1";
+  private static final String PROP_NODE1 = "node1";
 
-  private static final String NODE2_SESSION_VAR = "node2Session";
+  private static final String PROP_NODE2_SESSION = "node2Session";
 
-  private static final String NODE2_VAR = "node2";
+  private static final String PROP_NODE2 = "node2";
 
   private static final long serialVersionUID = 1L;
 
@@ -24,36 +24,36 @@ public final class VerboseOspfEdge extends Pair<NodeOspfSessionPair, NodeOspfSes
 
   @JsonCreator
   public VerboseOspfEdge(
-      @JsonProperty(NODE1_VAR) Configuration node1,
-      @JsonProperty(NODE1_SESSION_VAR) OspfNeighbor s1,
-      @JsonProperty(NODE2_VAR) Configuration node2,
-      @JsonProperty(NODE2_SESSION_VAR) OspfNeighbor s2,
-      @JsonProperty(EDGE_SUMMARY_VAR) IpEdge e) {
+      @JsonProperty(PROP_NODE1) Configuration node1,
+      @JsonProperty(PROP_NODE1_SESSION) OspfNeighbor s1,
+      @JsonProperty(PROP_NODE2) Configuration node2,
+      @JsonProperty(PROP_NODE2_SESSION) OspfNeighbor s2,
+      @JsonProperty(PROP_EDGE_SUMMARY) IpEdge e) {
     super(new NodeOspfSessionPair(node1, s1), new NodeOspfSessionPair(node2, s2));
     this._edgeSummary = e;
   }
 
-  @JsonProperty(EDGE_SUMMARY_VAR)
+  @JsonProperty(PROP_EDGE_SUMMARY)
   public IpEdge getEdgeSummary() {
     return _edgeSummary;
   }
 
-  @JsonProperty(NODE1_VAR)
+  @JsonProperty(PROP_NODE1)
   public Configuration getNode1() {
     return _first.getHost();
   }
 
-  @JsonProperty(NODE2_VAR)
+  @JsonProperty(PROP_NODE2)
   public Configuration getNode2() {
     return _second.getHost();
   }
 
-  @JsonProperty(NODE1_SESSION_VAR)
+  @JsonProperty(PROP_NODE1_SESSION)
   public OspfNeighbor getSession1() {
     return _first.getSession();
   }
 
-  @JsonProperty(NODE2_SESSION_VAR)
+  @JsonProperty(PROP_NODE2_SESSION)
   public OspfNeighbor getSession2() {
     return _second.getSession();
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/Question.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/Question.java
@@ -106,73 +106,73 @@ public abstract class Question implements IQuestion {
         _allowedValues = new TreeSet<>();
       }
 
-      @JsonProperty(BfConsts.ALLOWED_VALUES_VAR)
+      @JsonProperty(BfConsts.PROP_ALLOWED_VALUES)
       public SortedSet<String> getAllowedValues() {
         return _allowedValues;
       }
 
-      @JsonProperty(BfConsts.DESCRIPTION_VAR)
+      @JsonProperty(BfConsts.PROP_DESCRIPTION)
       public String getDescription() {
         return _description;
       }
 
-      @JsonProperty(BfConsts.MIN_ELEMENTS_VAR)
+      @JsonProperty(BfConsts.PROP_MIN_ELEMENTS)
       public Integer getMinElements() {
         return _minElements;
       }
 
-      @JsonProperty(BfConsts.MIN_LENGTH_VAR)
+      @JsonProperty(BfConsts.PROP_MIN_LENGTH)
       public Integer getMinLength() {
         return _minLength;
       }
 
-      @JsonProperty(BfConsts.OPTIONAL_VAR)
+      @JsonProperty(BfConsts.PROP_OPTIONAL)
       public boolean getOptional() {
         return _optional;
       }
 
-      @JsonProperty(BfConsts.TYPE_VAR)
+      @JsonProperty(BfConsts.PROP_TYPE)
       public Type getType() {
         return _type;
       }
 
-      @JsonProperty(BfConsts.VALUE_VAR)
+      @JsonProperty(BfConsts.PROP_VALUE)
       @JsonInclude(Include.NON_NULL)
       public JsonNode getValue() {
         return _value;
       }
 
-      @JsonProperty(BfConsts.ALLOWED_VALUES_VAR)
+      @JsonProperty(BfConsts.PROP_ALLOWED_VALUES)
       public void setAllowedValues(SortedSet<String> allowedValues) {
         _allowedValues = allowedValues;
       }
 
-      @JsonProperty(BfConsts.DESCRIPTION_VAR)
+      @JsonProperty(BfConsts.PROP_DESCRIPTION)
       public void setDescription(String description) {
         _description = description;
       }
 
-      @JsonProperty(BfConsts.MIN_ELEMENTS_VAR)
+      @JsonProperty(BfConsts.PROP_MIN_ELEMENTS)
       public void setMinElements(Integer minElements) {
         _minElements = minElements;
       }
 
-      @JsonProperty(BfConsts.MIN_LENGTH_VAR)
+      @JsonProperty(BfConsts.PROP_MIN_LENGTH)
       public void setMinLength(Integer minLength) {
         _minLength = minLength;
       }
 
-      @JsonProperty(BfConsts.OPTIONAL_VAR)
+      @JsonProperty(BfConsts.PROP_OPTIONAL)
       public void setOptional(boolean optional) {
         _optional = optional;
       }
 
-      @JsonProperty(BfConsts.TYPE_VAR)
+      @JsonProperty(BfConsts.PROP_TYPE)
       public void setType(Type type) {
         _type = type;
       }
 
-      @JsonProperty(BfConsts.VALUE_VAR)
+      @JsonProperty(BfConsts.PROP_VALUE)
       public void setValue(JsonNode value) {
         if (value != null && value.isNull()) {
           _value = null;
@@ -197,52 +197,52 @@ public abstract class Question implements IQuestion {
       _variables = new TreeMap<>();
     }
 
-    @JsonProperty(BfConsts.DESCRIPTION_VAR)
+    @JsonProperty(BfConsts.PROP_DESCRIPTION)
     public String getDescription() {
       return _description;
     }
 
-    @JsonProperty(BfConsts.INSTANCE_NAME_VAR)
+    @JsonProperty(BfConsts.PROP_INSTANCE_NAME)
     public String getInstanceName() {
       return _instanceName;
     }
 
-    @JsonProperty(BfConsts.LONG_DESCRIPTION_VAR)
+    @JsonProperty(BfConsts.PROP_LONG_DESCRIPTION)
     public String getLongDescription() {
       return _longDescription;
     }
 
-    @JsonProperty(BfConsts.TAGS_VAR)
+    @JsonProperty(BfConsts.PROP_TAGS)
     public SortedSet<String> getTags() {
       return _tags;
     }
 
-    @JsonProperty(BfConsts.VARIABLES_VAR)
+    @JsonProperty(BfConsts.PROP_VARIABLES)
     public SortedMap<String, Variable> getVariables() {
       return _variables;
     }
 
-    @JsonProperty(BfConsts.DESCRIPTION_VAR)
+    @JsonProperty(BfConsts.PROP_DESCRIPTION)
     public void setDescription(String description) {
       _description = description;
     }
 
-    @JsonProperty(BfConsts.INSTANCE_NAME_VAR)
+    @JsonProperty(BfConsts.PROP_INSTANCE_NAME)
     public void setInstanceName(String instanceName) {
       _instanceName = instanceName;
     }
 
-    @JsonProperty(BfConsts.LONG_DESCRIPTION_VAR)
+    @JsonProperty(BfConsts.PROP_LONG_DESCRIPTION)
     public void setLongDescription(String longDescription) {
       _longDescription = longDescription;
     }
 
-    @JsonProperty(BfConsts.TAGS_VAR)
+    @JsonProperty(BfConsts.PROP_TAGS)
     public void setTags(SortedSet<String> tags) {
       _tags = tags;
     }
 
-    @JsonProperty(BfConsts.VARIABLES_VAR)
+    @JsonProperty(BfConsts.PROP_VARIABLES)
     public void setVariables(SortedMap<String, Variable> variables) {
       _variables = variables;
     }
@@ -259,12 +259,12 @@ public abstract class Question implements IQuestion {
   @JsonIgnore
   public abstract boolean getDataPlane();
 
-  @JsonProperty(BfConsts.DIFFERENTIAL_VAR)
+  @JsonProperty(BfConsts.PROP_DIFFERENTIAL)
   public boolean getDifferential() {
     return _differential;
   }
 
-  @JsonProperty(BfConsts.INSTANCE_VAR)
+  @JsonProperty(BfConsts.PROP_INSTANCE)
   public InstanceData getInstance() {
     return _instance;
   }
@@ -277,7 +277,7 @@ public abstract class Question implements IQuestion {
 
   protected boolean isBaseParamKey(String paramKey) {
     switch (paramKey) {
-      case BfConsts.DIFFERENTIAL_VAR:
+      case BfConsts.PROP_DIFFERENTIAL:
         return true;
       default:
         return false;
@@ -308,12 +308,12 @@ public abstract class Question implements IQuestion {
     }
   }
 
-  @JsonProperty(BfConsts.DIFFERENTIAL_VAR)
+  @JsonProperty(BfConsts.PROP_DIFFERENTIAL)
   public void setDifferential(boolean differential) {
     _differential = differential;
   }
 
-  @JsonProperty(BfConsts.INSTANCE_VAR)
+  @JsonProperty(BfConsts.PROP_INSTANCE)
   public void setInstance(InstanceData instance) {
     _instance = instance;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/RoutingPolicy.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/RoutingPolicy.java
@@ -21,14 +21,14 @@ public class RoutingPolicy extends ComparableStructure<String> {
   /** */
   private static final long serialVersionUID = 1L;
 
-  private static final String STATEMENTS_VAR = "statements";
+  private static final String PROP_STATEMENTS = "statements";
 
   private Configuration _owner;
 
   private List<Statement> _statements;
 
   @JsonCreator
-  private RoutingPolicy(@JsonProperty(NAME_VAR) String name) {
+  private RoutingPolicy(@JsonProperty(PROP_NAME) String name) {
     super(name);
     _statements = new ArrayList<>();
   }
@@ -69,7 +69,7 @@ public class RoutingPolicy extends ComparableStructure<String> {
     return _owner;
   }
 
-  @JsonProperty(STATEMENTS_VAR)
+  @JsonProperty(PROP_STATEMENTS)
   @JsonPropertyDescription("The list of routing-policy statements to execute")
   public List<Statement> getStatements() {
     return _statements;
@@ -86,7 +86,7 @@ public class RoutingPolicy extends ComparableStructure<String> {
     return result.getBooleanValue();
   }
 
-  @JsonProperty(STATEMENTS_VAR)
+  @JsonProperty(PROP_STATEMENTS)
   public void setStatements(List<Statement> statements) {
     _statements = statements;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/BooleanExprs.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/BooleanExprs.java
@@ -17,12 +17,12 @@ public enum BooleanExprs {
     /** */
     private static final long serialVersionUID = 1L;
 
-    private static final String TYPE_VAR = "type";
+    private static final String PROP_TYPE = "type";
 
     private BooleanExprs _type;
 
     @JsonCreator
-    public StaticBooleanExpr(@JsonProperty(TYPE_VAR) BooleanExprs type) {
+    public StaticBooleanExpr(@JsonProperty(PROP_TYPE) BooleanExprs type) {
       _type = type;
     }
 
@@ -57,7 +57,7 @@ public enum BooleanExprs {
       return result;
     }
 
-    @JsonProperty(TYPE_VAR)
+    @JsonProperty(PROP_TYPE)
     public BooleanExprs getType() {
       return _type;
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/CallExpr.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/CallExpr.java
@@ -8,7 +8,7 @@ import org.batfish.datamodel.routing_policy.RoutingPolicy;
 
 public class CallExpr extends BooleanExpr {
 
-  private static final String CALLED_POLICY_NAME_VAR = "calledPolicyName";
+  private static final String PROP_CALLED_POLICY_NAME = "calledPolicyName";
 
   /** */
   private static final long serialVersionUID = 1L;
@@ -65,7 +65,7 @@ public class CallExpr extends BooleanExpr {
     return result;
   }
 
-  @JsonProperty(CALLED_POLICY_NAME_VAR)
+  @JsonProperty(PROP_CALLED_POLICY_NAME)
   public String getCalledPolicyName() {
     return _calledPolicyName;
   }
@@ -78,7 +78,7 @@ public class CallExpr extends BooleanExpr {
     return result;
   }
 
-  @JsonProperty(CALLED_POLICY_NAME_VAR)
+  @JsonProperty(PROP_CALLED_POLICY_NAME)
   public void setCalledPolicyName(String calledPolicyName) {
     _calledPolicyName = calledPolicyName;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/CallStatement.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/CallStatement.java
@@ -8,7 +8,7 @@ import org.batfish.datamodel.routing_policy.RoutingPolicy;
 
 public class CallStatement extends Statement {
 
-  private static final String CALLED_POLICY_NAME_VAR = "calledPolicyName";
+  private static final String PROP_CALLED_POLICY_NAME = "calledPolicyName";
 
   /** */
   private static final long serialVersionUID = 1L;
@@ -63,7 +63,7 @@ public class CallStatement extends Statement {
     return result;
   }
 
-  @JsonProperty(CALLED_POLICY_NAME_VAR)
+  @JsonProperty(PROP_CALLED_POLICY_NAME)
   public String getCalledPolicyName() {
     return _calledPolicyName;
   }
@@ -76,7 +76,7 @@ public class CallStatement extends Statement {
     return result;
   }
 
-  @JsonProperty(CALLED_POLICY_NAME_VAR)
+  @JsonProperty(PROP_CALLED_POLICY_NAME)
   public void setCalledPolicyName(String calledPolicyName) {
     _calledPolicyName = calledPolicyName;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/Statement.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/Statement.java
@@ -33,7 +33,7 @@ import org.batfish.datamodel.routing_policy.Result;
 })
 public abstract class Statement implements Serializable {
 
-  private static final String COMMENT_VAR = "comment";
+  private static final String PROP_COMMENT = "comment";
 
   /** */
   private static final long serialVersionUID = 1L;
@@ -45,7 +45,7 @@ public abstract class Statement implements Serializable {
 
   public abstract Result execute(Environment environment);
 
-  @JsonProperty(COMMENT_VAR)
+  @JsonProperty(PROP_COMMENT)
   public final String getComment() {
     return _comment;
   }
@@ -53,7 +53,7 @@ public abstract class Statement implements Serializable {
   @Override
   public abstract int hashCode();
 
-  @JsonProperty(COMMENT_VAR)
+  @JsonProperty(PROP_COMMENT)
   public final void setComment(String comment) {
     _comment = comment;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/Statements.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/Statements.java
@@ -29,12 +29,12 @@ public enum Statements {
     /** */
     private static final long serialVersionUID = 1L;
 
-    private static final String TYPE_VAR = "type";
+    private static final String PROP_TYPE = "type";
 
     private Statements _type;
 
     @JsonCreator
-    public StaticStatement(@JsonProperty(TYPE_VAR) Statements type) {
+    public StaticStatement(@JsonProperty(PROP_TYPE) Statements type) {
       _type = type;
     }
 
@@ -133,7 +133,7 @@ public enum Statements {
       return result;
     }
 
-    @JsonProperty(TYPE_VAR)
+    @JsonProperty(PROP_TYPE)
     public Statements getType() {
       return _type;
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco/Line.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco/Line.java
@@ -32,7 +32,7 @@ public class Line extends ComparableStructure<String> {
   private SortedSet<String> _transportPreferred;
 
   @JsonCreator
-  public Line(@JsonProperty(NAME_VAR) String name) {
+  public Line(@JsonProperty(PROP_NAME) String name) {
     super(name);
     _transportInput = new TreeSet<>();
     _transportOutput = new TreeSet<>();

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco/LoggingHost.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco/LoggingHost.java
@@ -10,7 +10,7 @@ public class LoggingHost extends ComparableStructure<String> {
   private static final long serialVersionUID = 1L;
 
   @JsonCreator
-  public LoggingHost(@JsonProperty(NAME_VAR) String name) {
+  public LoggingHost(@JsonProperty(PROP_NAME) String name) {
     super(name);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco/NtpServer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco/NtpServer.java
@@ -10,7 +10,7 @@ public class NtpServer extends ComparableStructure<String> {
 
   private String _vrf;
 
-  public NtpServer(@JsonProperty(NAME_VAR) String hostname) {
+  public NtpServer(@JsonProperty(PROP_NAME) String hostname) {
     super(hostname);
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco/SntpServer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco/SntpServer.java
@@ -10,7 +10,7 @@ public class SntpServer extends ComparableStructure<String> {
 
   public Integer _version;
 
-  public SntpServer(@JsonProperty(NAME_VAR) String hostname) {
+  public SntpServer(@JsonProperty(PROP_NAME) String hostname) {
     super(hostname);
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco/User.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco/User.java
@@ -13,7 +13,7 @@ public class User extends ComparableStructure<String> {
 
   private String _role;
 
-  public User(@JsonProperty(NAME_VAR) String name) {
+  public User(@JsonProperty(PROP_NAME) String name) {
     super(name);
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/juniper/TacplusServer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/juniper/TacplusServer.java
@@ -16,7 +16,7 @@ public class TacplusServer extends ComparableStructure<String> {
   private Ip _sourceAddress;
 
   @JsonCreator
-  public TacplusServer(@JsonProperty(NAME_VAR) String name) {
+  public TacplusServer(@JsonProperty(PROP_NAME) String name) {
     super(name);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -3181,8 +3181,8 @@ public class Batfish extends PluginConsumer implements AutoCloseable, IBatfish {
   private String preprocessQuestion(String rawQuestionText) {
     try {
       JSONObject jobj = new JSONObject(rawQuestionText);
-      if (jobj.has(BfConsts.INSTANCE_VAR) && !jobj.isNull(BfConsts.INSTANCE_VAR)) {
-        String instanceDataStr = jobj.getString(BfConsts.INSTANCE_VAR);
+      if (jobj.has(BfConsts.PROP_INSTANCE) && !jobj.isNull(BfConsts.PROP_INSTANCE)) {
+        String instanceDataStr = jobj.getString(BfConsts.PROP_INSTANCE);
         BatfishObjectMapper mapper = new BatfishObjectMapper();
         InstanceData instanceData =
             mapper.<InstanceData>readValue(instanceDataStr, new TypeReference<InstanceData>() {});

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/NatPool.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/NatPool.java
@@ -6,9 +6,9 @@ import org.batfish.datamodel.Ip;
 
 public class NatPool extends ComparableStructure<String> {
 
-  private static final String FIRST_VAR = "first";
+  private static final String PROP_FIRST = "first";
 
-  private static final String LAST_VAR = "last";
+  private static final String PROP_LAST = "last";
 
   /** */
   private static final long serialVersionUID = 1L;
@@ -28,22 +28,22 @@ public class NatPool extends ComparableStructure<String> {
     return _definitionLine;
   }
 
-  @JsonProperty(FIRST_VAR)
+  @JsonProperty(PROP_FIRST)
   public Ip getFirst() {
     return _first;
   }
 
-  @JsonProperty(LAST_VAR)
+  @JsonProperty(PROP_LAST)
   public Ip getLast() {
     return _last;
   }
 
-  @JsonProperty(FIRST_VAR)
+  @JsonProperty(PROP_FIRST)
   public void setFirst(Ip first) {
     _first = first;
   }
 
-  @JsonProperty(LAST_VAR)
+  @JsonProperty(PROP_LAST)
   public void setLast(Ip last) {
     _last = last;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/NatPool.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/NatPool.java
@@ -1,14 +1,9 @@
 package org.batfish.representation.cisco;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import org.batfish.common.util.ComparableStructure;
 import org.batfish.datamodel.Ip;
 
 public class NatPool extends ComparableStructure<String> {
-
-  private static final String PROP_FIRST = "first";
-
-  private static final String PROP_LAST = "last";
 
   /** */
   private static final long serialVersionUID = 1L;
@@ -28,22 +23,18 @@ public class NatPool extends ComparableStructure<String> {
     return _definitionLine;
   }
 
-  @JsonProperty(PROP_FIRST)
   public Ip getFirst() {
     return _first;
   }
 
-  @JsonProperty(PROP_LAST)
   public Ip getLast() {
     return _last;
   }
 
-  @JsonProperty(PROP_FIRST)
   public void setFirst(Ip first) {
     _first = first;
   }
 
-  @JsonProperty(PROP_LAST)
   public void setLast(Ip last) {
     _last = last;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/host/HostConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/host/HostConfiguration.java
@@ -37,11 +37,11 @@ public class HostConfiguration extends VendorConfiguration {
 
   private static final Object FILTER_OUTPUT = "filter::OUTPUT";
 
-  private static final String HOST_INTERFACES_VAR = "hostInterfaces";
+  private static final String PROP_HOST_INTERFACES = "hostInterfaces";
 
-  private static final String HOSTNAME_VAR = "hostname";
+  private static final String PROP_HOSTNAME = "hostname";
 
-  private static final String IPTABLES_FILE_VAR = "iptablesFile";
+  private static final String PROP_IPTABLES_FILE = "iptablesFile";
 
   private static final String MANGLE_FORWARD = "mangle::FORWARD";
 
@@ -87,7 +87,7 @@ public class HostConfiguration extends VendorConfiguration {
   private final Set<HostStaticRoute> _staticRoutes;
 
   // @JsonCreator
-  // public HostConfiguration(@JsonProperty(HOSTNAME_VAR) String name) {
+  // public HostConfiguration(@JsonProperty(PROP_HOSTNAME) String name) {
   // _hostname = name;
   // _interfaces = new HashMap<String, Interface>();
   // _roles = new RoleSet();
@@ -100,12 +100,12 @@ public class HostConfiguration extends VendorConfiguration {
     _staticRoutes = new TreeSet<>();
   }
 
-  @JsonProperty(HOST_INTERFACES_VAR)
+  @JsonProperty(PROP_HOST_INTERFACES)
   public Map<String, HostInterface> getHostInterfaces() {
     return _hostInterfaces;
   }
 
-  @JsonProperty(HOSTNAME_VAR)
+  @JsonProperty(PROP_HOSTNAME)
   @Override
   public String getHostname() {
     return _hostname;
@@ -115,7 +115,7 @@ public class HostConfiguration extends VendorConfiguration {
     throw new UnsupportedOperationException("no implementation for generated method");
   }
 
-  @JsonProperty(IPTABLES_FILE_VAR)
+  @JsonProperty(PROP_IPTABLES_FILE)
   public String getIptablesFile() {
     return _iptablesFile;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/host/HostInterface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/host/HostInterface.java
@@ -14,20 +14,20 @@ import org.batfish.datamodel.Vrf;
 
 public class HostInterface implements Serializable {
 
-  private static final String BANDWIDTH_VAR = "bandwidth";
+  private static final String PROP_BANDWIDTH = "bandwidth";
 
-  private static final String GATEWAY_VAR = "gateway";
+  private static final String PROP_GATEWAY = "gateway";
 
-  private static final String NAME_VAR = "name";
+  private static final String PROP_NAME = "name";
 
-  private static final String OTHER_PREFIXES_VAR = "otherPrefixes";
+  private static final String PROP_OTHER_PREFIXES = "otherPrefixes";
 
-  private static final String PREFIX_VAR = "prefix";
+  private static final String PROP_PREFIX = "prefix";
 
   /** */
   private static final long serialVersionUID = 1L;
 
-  private static final String VRF_VAR = "vrf";
+  private static final String PROP_VRF = "vrf";
 
   private Double _bandwidth = 1000 * 1000 * 1000.0; // default is 1 Gbps
 
@@ -42,62 +42,62 @@ public class HostInterface implements Serializable {
   private Vrf _vrf;
 
   @JsonCreator
-  public HostInterface(@JsonProperty(NAME_VAR) String name) {
+  public HostInterface(@JsonProperty(PROP_NAME) String name) {
     _name = name;
     _otherPrefixes = new TreeSet<>();
   }
 
-  @JsonProperty(BANDWIDTH_VAR)
+  @JsonProperty(PROP_BANDWIDTH)
   public Double getBandwidth() {
     return _bandwidth;
   }
 
-  @JsonProperty(GATEWAY_VAR)
+  @JsonProperty(PROP_GATEWAY)
   public Ip getGateway() {
     return _gateway;
   }
 
-  @JsonProperty(NAME_VAR)
+  @JsonProperty(PROP_NAME)
   public String getName() {
     return _name;
   }
 
-  @JsonProperty(OTHER_PREFIXES_VAR)
+  @JsonProperty(PROP_OTHER_PREFIXES)
   public Set<Prefix> getOtherPrefixes() {
     return _otherPrefixes;
   }
 
-  @JsonProperty(PREFIX_VAR)
+  @JsonProperty(PROP_PREFIX)
   public Prefix getPrefix() {
     return _prefix;
   }
 
-  @JsonProperty(VRF_VAR)
+  @JsonProperty(PROP_VRF)
   public Vrf getVrf() {
     return _vrf;
   }
 
-  @JsonProperty(BANDWIDTH_VAR)
+  @JsonProperty(PROP_BANDWIDTH)
   public void setBandwidth(Double bandwidth) {
     _bandwidth = bandwidth;
   }
 
-  @JsonProperty(GATEWAY_VAR)
+  @JsonProperty(PROP_GATEWAY)
   public void setGateway(Ip gateway) {
     _gateway = gateway;
   }
 
-  @JsonProperty(OTHER_PREFIXES_VAR)
+  @JsonProperty(PROP_OTHER_PREFIXES)
   public void setOtherPrefixes(Set<Prefix> otherPrefixes) {
     _otherPrefixes = otherPrefixes;
   }
 
-  @JsonProperty(PREFIX_VAR)
+  @JsonProperty(PROP_PREFIX)
   public void setPrefix(Prefix prefix) {
     _prefix = prefix;
   }
 
-  @JsonProperty(VRF_VAR)
+  @JsonProperty(PROP_VRF)
   public void setVrf(Vrf vrf) {
     _vrf = vrf;
   }

--- a/projects/question/src/main/java/org/batfish/question/AclReachabilityQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/AclReachabilityQuestionPlugin.java
@@ -57,9 +57,9 @@ public class AclReachabilityQuestionPlugin extends QuestionPlugin {
    */
   public static class AclReachabilityQuestion extends Question {
 
-    private static final String ACL_NAME_REGEX_VAR = "aclNameRegex";
+    private static final String PROP_ACL_NAME_REGEX = "aclNameRegex";
 
-    private static final String NODE_REGEX_VAR = "nodeRegex";
+    private static final String PROP_NODE_REGEX = "nodeRegex";
 
     private String _aclNameRegex;
 
@@ -70,7 +70,7 @@ public class AclReachabilityQuestionPlugin extends QuestionPlugin {
       _aclNameRegex = ".*";
     }
 
-    @JsonProperty(ACL_NAME_REGEX_VAR)
+    @JsonProperty(PROP_ACL_NAME_REGEX)
     public String getAclNameRegex() {
       return _aclNameRegex;
     }
@@ -85,7 +85,7 @@ public class AclReachabilityQuestionPlugin extends QuestionPlugin {
       return "aclreachability";
     }
 
-    @JsonProperty(NODE_REGEX_VAR)
+    @JsonProperty(PROP_NODE_REGEX)
     public String getNodeRegex() {
       return _nodeRegex;
     }
@@ -102,19 +102,19 @@ public class AclReachabilityQuestionPlugin extends QuestionPlugin {
               "%s %s%s=\"%s\" %s=\"%s\"",
               getName(),
               prettyPrintBase(),
-              ACL_NAME_REGEX_VAR,
+              PROP_ACL_NAME_REGEX,
               _aclNameRegex,
-              NODE_REGEX_VAR,
+              PROP_NODE_REGEX,
               _nodeRegex);
       return retString;
     }
 
-    @JsonProperty(ACL_NAME_REGEX_VAR)
+    @JsonProperty(PROP_ACL_NAME_REGEX)
     public void setAclNameRegex(String regex) {
       _aclNameRegex = regex;
     }
 
-    @JsonProperty(NODE_REGEX_VAR)
+    @JsonProperty(PROP_NODE_REGEX)
     public void setNodeRegex(String regex) {
       _nodeRegex = regex;
     }

--- a/projects/question/src/main/java/org/batfish/question/BgpAdvertisementsQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/BgpAdvertisementsQuestionPlugin.java
@@ -32,15 +32,15 @@ public class BgpAdvertisementsQuestionPlugin extends QuestionPlugin {
   @JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@id")
   public static class BgpAdvertisementsAnswerElement implements AnswerElement {
 
-    private static final String ALL_REQUESTED_ADVERTISEMENTS_VAR = "allRequestedAdvertisements";
+    private static final String PROP_ALL_REQUESTED_ADVERTISEMENTS = "allRequestedAdvertisements";
 
-    private static final String RECEIVED_EBGP_ADVERTISEMENTS_VAR = "receivedEbgpAdvertisements";
+    private static final String PROP_RECEIVED_EBGP_ADVERTISEMENTS = "receivedEbgpAdvertisements";
 
-    private static final String RECEIVED_IBGP_ADVERTISEMENTS_VAR = "receivedIbgpAdvertisements";
+    private static final String PROP_RECEIVED_IBGP_ADVERTISEMENTS = "receivedIbgpAdvertisements";
 
-    private static final String SENT_EBGP_ADVERTISEMENTS_VAR = "sentEbgpAdvertisements";
+    private static final String PROP_SENT_EBGP_ADVERTISEMENTS = "sentEbgpAdvertisements";
 
-    private static final String SENT_IBGP_ADVERTISEMENTS_VAR = "sentIbgpAdvertisements";
+    private static final String PROP_SENT_IBGP_ADVERTISEMENTS = "sentIbgpAdvertisements";
 
     private SortedSet<BgpAdvertisement> _added;
 
@@ -162,19 +162,19 @@ public class BgpAdvertisementsQuestionPlugin extends QuestionPlugin {
       return _added;
     }
 
-    @JsonProperty(ALL_REQUESTED_ADVERTISEMENTS_VAR)
+    @JsonProperty(PROP_ALL_REQUESTED_ADVERTISEMENTS)
     public SortedSet<BgpAdvertisement> getAllRequestedAdvertisements() {
       return _allRequestedAdvertisements;
     }
 
     @JsonIdentityReference(alwaysAsId = true)
-    @JsonProperty(RECEIVED_EBGP_ADVERTISEMENTS_VAR)
+    @JsonProperty(PROP_RECEIVED_EBGP_ADVERTISEMENTS)
     public SortedMap<String, SortedSet<BgpAdvertisement>> getReceivedEbgpAdvertisements() {
       return _receivedEbgpAdvertisements;
     }
 
     @JsonIdentityReference(alwaysAsId = true)
-    @JsonProperty(RECEIVED_IBGP_ADVERTISEMENTS_VAR)
+    @JsonProperty(PROP_RECEIVED_IBGP_ADVERTISEMENTS)
     public SortedMap<String, SortedSet<BgpAdvertisement>> getReceivedIbgpAdvertisements() {
       return _receivedIbgpAdvertisements;
     }
@@ -184,13 +184,13 @@ public class BgpAdvertisementsQuestionPlugin extends QuestionPlugin {
     }
 
     @JsonIdentityReference(alwaysAsId = true)
-    @JsonProperty(SENT_EBGP_ADVERTISEMENTS_VAR)
+    @JsonProperty(PROP_SENT_EBGP_ADVERTISEMENTS)
     public SortedMap<String, SortedSet<BgpAdvertisement>> getSentEbgpAdvertisements() {
       return _sentEbgpAdvertisements;
     }
 
     @JsonIdentityReference(alwaysAsId = true)
-    @JsonProperty(SENT_IBGP_ADVERTISEMENTS_VAR)
+    @JsonProperty(PROP_SENT_IBGP_ADVERTISEMENTS)
     public SortedMap<String, SortedSet<BgpAdvertisement>> getSentIbgpAdvertisements() {
       return _sentIbgpAdvertisements;
     }
@@ -215,19 +215,19 @@ public class BgpAdvertisementsQuestionPlugin extends QuestionPlugin {
       _added = added;
     }
 
-    @JsonProperty(ALL_REQUESTED_ADVERTISEMENTS_VAR)
+    @JsonProperty(PROP_ALL_REQUESTED_ADVERTISEMENTS)
     public void setAllRequestedAdvertisements(
         SortedSet<BgpAdvertisement> allRequestedAdvertisements) {
       _allRequestedAdvertisements = allRequestedAdvertisements;
     }
 
-    @JsonProperty(RECEIVED_EBGP_ADVERTISEMENTS_VAR)
+    @JsonProperty(PROP_RECEIVED_EBGP_ADVERTISEMENTS)
     public void setReceivedEbgpAdvertisements(
         SortedMap<String, SortedSet<BgpAdvertisement>> receivedEbgpAdvertisements) {
       _receivedEbgpAdvertisements = receivedEbgpAdvertisements;
     }
 
-    @JsonProperty(RECEIVED_IBGP_ADVERTISEMENTS_VAR)
+    @JsonProperty(PROP_RECEIVED_IBGP_ADVERTISEMENTS)
     public void setReceivedIbgpAdvertisements(
         SortedMap<String, SortedSet<BgpAdvertisement>> receivedIbgpAdvertisements) {
       _receivedIbgpAdvertisements = receivedIbgpAdvertisements;
@@ -237,13 +237,13 @@ public class BgpAdvertisementsQuestionPlugin extends QuestionPlugin {
       _removed = removed;
     }
 
-    @JsonProperty(SENT_EBGP_ADVERTISEMENTS_VAR)
+    @JsonProperty(PROP_SENT_EBGP_ADVERTISEMENTS)
     public void setSentEbgpAdvertisements(
         SortedMap<String, SortedSet<BgpAdvertisement>> sentEbgpAdvertisements) {
       _sentEbgpAdvertisements = sentEbgpAdvertisements;
     }
 
-    @JsonProperty(SENT_IBGP_ADVERTISEMENTS_VAR)
+    @JsonProperty(PROP_SENT_IBGP_ADVERTISEMENTS)
     public void setSentIbgpAdvertisements(
         SortedMap<String, SortedSet<BgpAdvertisement>> sentIbgpAdvertisements) {
       _sentIbgpAdvertisements = sentIbgpAdvertisements;
@@ -327,19 +327,19 @@ public class BgpAdvertisementsQuestionPlugin extends QuestionPlugin {
    */
   public static class BgpAdvertisementsQuestion extends Question {
 
-    private static final String EBGP_VAR = "ebgp";
+    private static final String PROP_EBGP = "ebgp";
 
-    private static final String FROM_ENVIRONMENT_VAR = "fromEnvironment";
+    private static final String PROP_FROM_ENVIRONMENT = "fromEnvironment";
 
-    private static final String IBGP_VAR = "ibgp";
+    private static final String PROP_IBGP = "ibgp";
 
-    private static final String NODE_REGEX_VAR = "nodeRegex";
+    private static final String PROP_NODE_REGEX = "nodeRegex";
 
-    private static final String PREFIX_SPACE_VAR = "prefixSpace";
+    private static final String PROP_PREFIX_SPACE = "prefixSpace";
 
-    private static final String RECEIVED_VAR = "received";
+    private static final String PROP_RECEIVED = "received";
 
-    private static final String SENT_VAR = "sent";
+    private static final String PROP_SENT = "sent";
 
     private boolean _ebgp;
 
@@ -370,17 +370,17 @@ public class BgpAdvertisementsQuestionPlugin extends QuestionPlugin {
       return true;
     }
 
-    @JsonProperty(EBGP_VAR)
+    @JsonProperty(PROP_EBGP)
     public boolean getEbgp() {
       return _ebgp;
     }
 
-    @JsonProperty(FROM_ENVIRONMENT_VAR)
+    @JsonProperty(PROP_FROM_ENVIRONMENT)
     public boolean getFromEnvironment() {
       return _fromEnvironment;
     }
 
-    @JsonProperty(IBGP_VAR)
+    @JsonProperty(PROP_IBGP)
     public boolean getIbgp() {
       return _ibgp;
     }
@@ -390,22 +390,22 @@ public class BgpAdvertisementsQuestionPlugin extends QuestionPlugin {
       return "bgpadvertisements";
     }
 
-    @JsonProperty(NODE_REGEX_VAR)
+    @JsonProperty(PROP_NODE_REGEX)
     public String getNodeRegex() {
       return _nodeRegex;
     }
 
-    @JsonProperty(PREFIX_SPACE_VAR)
+    @JsonProperty(PROP_PREFIX_SPACE)
     public PrefixSpace getPrefixSpace() {
       return _prefixSpace;
     }
 
-    @JsonProperty(RECEIVED_VAR)
+    @JsonProperty(PROP_RECEIVED)
     public boolean getReceived() {
       return _received;
     }
 
-    @JsonProperty(SENT_VAR)
+    @JsonProperty(PROP_SENT)
     public boolean getSent() {
       return _sent;
     }
@@ -422,52 +422,52 @@ public class BgpAdvertisementsQuestionPlugin extends QuestionPlugin {
               "%s %s%s=\"%s\" %s=\"%s\" %s=\"%s\" %s=\"%s\" %s=\"%s\" %s=\"%s\"",
               getName(),
               prettyPrintBase(),
-              EBGP_VAR,
+              PROP_EBGP,
               _ebgp,
-              IBGP_VAR,
+              PROP_IBGP,
               _ibgp,
-              NODE_REGEX_VAR,
+              PROP_NODE_REGEX,
               _nodeRegex,
-              PREFIX_SPACE_VAR,
+              PROP_PREFIX_SPACE,
               _prefixSpace.toString(),
-              RECEIVED_VAR,
+              PROP_RECEIVED,
               _received,
-              SENT_VAR,
+              PROP_SENT,
               _sent);
       return retString;
     }
 
-    @JsonProperty(EBGP_VAR)
+    @JsonProperty(PROP_EBGP)
     public void setEbgp(boolean ebgp) {
       _ebgp = ebgp;
     }
 
-    @JsonProperty(FROM_ENVIRONMENT_VAR)
+    @JsonProperty(PROP_FROM_ENVIRONMENT)
     public void setFromEnvironment(boolean fromEnvironment) {
       _fromEnvironment = fromEnvironment;
     }
 
-    @JsonProperty(IBGP_VAR)
+    @JsonProperty(PROP_IBGP)
     public void setIbgp(boolean ibgp) {
       _ibgp = ibgp;
     }
 
-    @JsonProperty(NODE_REGEX_VAR)
+    @JsonProperty(PROP_NODE_REGEX)
     public void setNodeRegex(String nodeRegex) {
       _nodeRegex = nodeRegex;
     }
 
-    @JsonProperty(PREFIX_SPACE_VAR)
+    @JsonProperty(PROP_PREFIX_SPACE)
     private void setPrefixSpace(PrefixSpace prefixSpace) {
       _prefixSpace = prefixSpace;
     }
 
-    @JsonProperty(RECEIVED_VAR)
+    @JsonProperty(PROP_RECEIVED)
     public void setReceived(boolean received) {
       _received = received;
     }
 
-    @JsonProperty(SENT_VAR)
+    @JsonProperty(PROP_SENT)
     public void setSent(boolean sent) {
       _sent = sent;
     }

--- a/projects/question/src/main/java/org/batfish/question/BgpLoopbacksQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/BgpLoopbacksQuestionPlugin.java
@@ -183,7 +183,7 @@ public class BgpLoopbacksQuestionPlugin extends QuestionPlugin {
    */
   public static class BgpLoopbacksQuestion extends Question {
 
-    private static final String NODE_REGEX_VAR = "nodeRegex";
+    private static final String PROP_NODE_REGEX = "nodeRegex";
 
     private String _nodeRegex;
 
@@ -201,7 +201,7 @@ public class BgpLoopbacksQuestionPlugin extends QuestionPlugin {
       return "bgploopbacks";
     }
 
-    @JsonProperty(NODE_REGEX_VAR)
+    @JsonProperty(PROP_NODE_REGEX)
     public String getNodeRegex() {
       return _nodeRegex;
     }
@@ -214,11 +214,12 @@ public class BgpLoopbacksQuestionPlugin extends QuestionPlugin {
     @Override
     public String prettyPrint() {
       String retString =
-          String.format("%s %s%s=\"%s\"", getName(), prettyPrintBase(), NODE_REGEX_VAR, _nodeRegex);
+          String.format(
+              "%s %s%s=\"%s\"", getName(), prettyPrintBase(), PROP_NODE_REGEX, _nodeRegex);
       return retString;
     }
 
-    @JsonProperty(NODE_REGEX_VAR)
+    @JsonProperty(PROP_NODE_REGEX)
     public void setNodeRegex(String nodeRegex) {
       _nodeRegex = nodeRegex;
     }

--- a/projects/question/src/main/java/org/batfish/question/BgpSessionCheckQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/BgpSessionCheckQuestionPlugin.java
@@ -30,53 +30,53 @@ public class BgpSessionCheckQuestionPlugin extends QuestionPlugin {
 
   public static class BgpSessionCheckAnswerElement implements AnswerElement {
 
-    private static final String ALL_BGP_NEIGHBORS_VAR = "allBgpNeighbors";
+    private static final String PROP_ALL_BGP_NEIGHBORS = "allBgpNeighbors";
 
-    private static final String BROKEN_VAR = "broken";
+    private static final String PROP_BROKEN = "broken";
 
-    private static final String EBGP_BROKEN_VAR = "ebgpBroken";
+    private static final String PROP_EBGP_BROKEN = "ebgpBroken";
 
-    private static final String EBGP_HALF_OPEN_VAR = "ebgpHalfOpen";
+    private static final String PROP_EBGP_HALF_OPEN = "ebgpHalfOpen";
 
-    private static final String EBGP_LOCAL_IP_ON_LOOPBACK_VAR = "ebgpLocalIpOnLoopback";
+    private static final String PROP_EBGP_LOCAL_IP_ON_LOOPBACK = "ebgpLocalIpOnLoopback";
 
-    private static final String EBGP_LOCAL_IP_UNKNOWN_VAR = "ebgpLocalIpUnknown";
+    private static final String PROP_EBGP_LOCAL_IP_UNKNOWN = "ebgpLocalIpUnknown";
 
-    private static final String EBGP_MISSING_LOCAL_IP_VAR = "ebgpMissingLocalIp";
+    private static final String PROP_EBGP_MISSING_LOCAL_IP = "ebgpMissingLocalIp";
 
-    private static final String EBGP_NON_UNIQUE_ENDPOINT_VAR = "ebgpNonUniqueEndpoint";
+    private static final String PROP_EBGP_NON_UNIQUE_ENDPOINT = "ebgpNonUniqueEndpoint";
 
-    private static final String EBGP_REMOTE_IP_ON_LOOPBACK_VAR = "ebgpRemoteIpOnLoopback";
+    private static final String PROP_EBGP_REMOTE_IP_ON_LOOPBACK = "ebgpRemoteIpOnLoopback";
 
-    private static final String EBGP_REMOTE_IP_UNKNOWN_VAR = "ebgpRemoteIpUnknown";
+    private static final String PROP_EBGP_REMOTE_IP_UNKNOWN = "ebgpRemoteIpUnknown";
 
-    private static final String HALF_OPEN_VAR = "halfOpen";
+    private static final String PROP_HALF_OPEN = "halfOpen";
 
-    private static final String IBGP_BROKEN_VAR = "ibgpBroken";
+    private static final String PROP_IBGP_BROKEN = "ibgpBroken";
 
-    private static final String IBGP_HALF_OPEN_VAR = "ibgpHalfOpen";
+    private static final String PROP_IBGP_HALF_OPEN = "ibgpHalfOpen";
 
-    private static final String IBGP_LOCAL_IP_ON_NON_LOOPBACK_VAR = "ibgpLocalIpOnNonLoopback";
+    private static final String PROP_IBGP_REMOTE_IP_ON_NON_LOOPBACK = "ibgpLocalIpOnNonLoopback";
 
-    private static final String IBGP_LOCAL_IP_UNKNOWN_VAR = "ibgpLocalIpUnknown";
+    private static final String PROP_IBGP_LOCAL_IP_UNKNOWN = "ibgpLocalIpUnknown";
 
-    private static final String IBGP_MISSING_LOCAL_IP_VAR = "ibgpMissingLocalIp";
+    private static final String PROP_IBGP_MISSING_LOCAL_IP = "ibgpMissingLocalIp";
 
-    private static final String IBGP_NON_UNIQUE_ENDPOINT_VAR = "ibgpNonUniqueEndpoint";
+    private static final String PROP_IBGP_NON_UNIQUE_ENDPOINT = "ibgpNonUniqueEndpoint";
 
-    private static final String IBGP_REMOTE_IP_ON_NON_LOOPBACK_VAR = "ibgpRemoteIpOnNonLoopback";
+    private static final String PROP_IBGP_LOCAL_IP_ON_NON_LOOPBACK = "ibgpRemoteIpOnNonLoopback";
 
-    private static final String IBGP_REMOTE_IP_UNKNOWN_VAR = "ibgpRemoteIpUnknown";
+    private static final String PROP_IBGP_REMOTE_IP_UNKNOWN = "ibgpRemoteIpUnknown";
 
-    private static final String IGNORED_FOREIGN_ENDPOINTS_VAR = "ignoredForeignEndpoints";
+    private static final String PROP_IGNORED_FOREIGN_ENDPOINTS = "ignoredForeignEndpoints";
 
-    private static final String LOCAL_IP_UNKNOWN_VAR = "localIpUnkown";
+    private static final String PROP_LOCAL_IP_UNKNOWN = "localIpUnkown";
 
-    private static final String MISSING_LOCAL_IP_VAR = "missingLocalIp";
+    private static final String PROP_MISSING_LOCAL_IP = "missingLocalIp";
 
-    private static final String NON_UNIQUE_ENDPOINT_VAR = "nonUniqueEndpoint";
+    private static final String PROP_NON_UNIQUE_ENDPOINT = "nonUniqueEndpoint";
 
-    private static final String REMOTE_IP_UNKNOWN_VAR = "remoteIpUnknown";
+    private static final String PROP_REMOTE_IP_UNKNOWN = "remoteIpUnknown";
 
     private SortedMap<String, SortedMap<String, SortedMap<Prefix, BgpNeighborSummary>>>
         _allBgpNeighbors;
@@ -180,123 +180,123 @@ public class BgpSessionCheckQuestionPlugin extends QuestionPlugin {
       neighborsByPrefix.put(prefix, bgpNeighbor);
     }
 
-    @JsonProperty(ALL_BGP_NEIGHBORS_VAR)
+    @JsonProperty(PROP_ALL_BGP_NEIGHBORS)
     public SortedMap<String, SortedMap<String, SortedMap<Prefix, BgpNeighborSummary>>>
         getAllBgpNeighbors() {
       return _allBgpNeighbors;
     }
 
-    @JsonProperty(BROKEN_VAR)
+    @JsonProperty(PROP_BROKEN)
     public SortedMap<String, SortedMap<String, SortedSet<Prefix>>> getBroken() {
       return _broken;
     }
 
-    @JsonProperty(EBGP_BROKEN_VAR)
+    @JsonProperty(PROP_EBGP_BROKEN)
     public SortedMap<String, SortedMap<String, SortedSet<Prefix>>> getEbgpBroken() {
       return _ebgpBroken;
     }
 
-    @JsonProperty(EBGP_HALF_OPEN_VAR)
+    @JsonProperty(PROP_EBGP_HALF_OPEN)
     public SortedMap<String, SortedMap<String, SortedSet<Prefix>>> getEbgpHalfOpen() {
       return _ebgpHalfOpen;
     }
 
-    @JsonProperty(EBGP_LOCAL_IP_ON_LOOPBACK_VAR)
+    @JsonProperty(PROP_EBGP_LOCAL_IP_ON_LOOPBACK)
     public SortedMap<String, SortedMap<String, SortedSet<Prefix>>> getEbgpLocalIpOnLoopback() {
       return _ebgpLocalIpOnLoopback;
     }
 
-    @JsonProperty(EBGP_LOCAL_IP_UNKNOWN_VAR)
+    @JsonProperty(PROP_EBGP_LOCAL_IP_UNKNOWN)
     public SortedMap<String, SortedMap<String, SortedSet<Prefix>>> getEbgpLocalIpUnknown() {
       return _ebgpLocalIpUnknown;
     }
 
-    @JsonProperty(EBGP_MISSING_LOCAL_IP_VAR)
+    @JsonProperty(PROP_EBGP_MISSING_LOCAL_IP)
     public SortedMap<String, SortedMap<String, SortedSet<Prefix>>> getEbgpMissingLocalIp() {
       return _ebgpMissingLocalIp;
     }
 
-    @JsonProperty(EBGP_NON_UNIQUE_ENDPOINT_VAR)
+    @JsonProperty(PROP_EBGP_NON_UNIQUE_ENDPOINT)
     public SortedMap<String, SortedMap<String, SortedSet<Prefix>>> getEbgpNonUniqueEndpoint() {
       return _ebgpNonUniqueEndpoint;
     }
 
-    @JsonProperty(EBGP_REMOTE_IP_ON_LOOPBACK_VAR)
+    @JsonProperty(PROP_EBGP_REMOTE_IP_ON_LOOPBACK)
     public SortedMap<String, SortedMap<String, SortedSet<Prefix>>> getEbgpRemoteIpOnLoopback() {
       return _ebgpRemoteIpOnLoopback;
     }
 
-    @JsonProperty(EBGP_REMOTE_IP_UNKNOWN_VAR)
+    @JsonProperty(PROP_EBGP_REMOTE_IP_UNKNOWN)
     public SortedMap<String, SortedMap<String, SortedSet<Prefix>>> getEbgpRemoteIpUnknown() {
       return _ebgpRemoteIpUnknown;
     }
 
-    @JsonProperty(HALF_OPEN_VAR)
+    @JsonProperty(PROP_HALF_OPEN)
     public SortedMap<String, SortedMap<String, SortedSet<Prefix>>> getHalfOpen() {
       return _halfOpen;
     }
 
-    @JsonProperty(IBGP_BROKEN_VAR)
+    @JsonProperty(PROP_IBGP_BROKEN)
     public SortedMap<String, SortedMap<String, SortedSet<Prefix>>> getIbgpBroken() {
       return _ibgpBroken;
     }
 
-    @JsonProperty(IBGP_HALF_OPEN_VAR)
+    @JsonProperty(PROP_IBGP_HALF_OPEN)
     public SortedMap<String, SortedMap<String, SortedSet<Prefix>>> getIbgpHalfOpen() {
       return _ibgpHalfOpen;
     }
 
-    @JsonProperty(IBGP_LOCAL_IP_ON_NON_LOOPBACK_VAR)
+    @JsonProperty(PROP_IBGP_LOCAL_IP_ON_NON_LOOPBACK)
     public SortedMap<String, SortedMap<String, SortedSet<Prefix>>> getIbgpLocalIpOnNonLoopback() {
       return _ibgpLocalIpOnNonLoopback;
     }
 
-    @JsonProperty(IBGP_LOCAL_IP_UNKNOWN_VAR)
+    @JsonProperty(PROP_IBGP_LOCAL_IP_UNKNOWN)
     public SortedMap<String, SortedMap<String, SortedSet<Prefix>>> getIbgpLocalIpUnknown() {
       return _ibgpLocalIpUnknown;
     }
 
-    @JsonProperty(IBGP_MISSING_LOCAL_IP_VAR)
+    @JsonProperty(PROP_IBGP_MISSING_LOCAL_IP)
     public SortedMap<String, SortedMap<String, SortedSet<Prefix>>> getIbgpMissingLocalIp() {
       return _ibgpMissingLocalIp;
     }
 
-    @JsonProperty(IBGP_NON_UNIQUE_ENDPOINT_VAR)
+    @JsonProperty(PROP_IBGP_NON_UNIQUE_ENDPOINT)
     public SortedMap<String, SortedMap<String, SortedSet<Prefix>>> getIbgpNonUniqueEndpoint() {
       return _ibgpNonUniqueEndpoint;
     }
 
-    @JsonProperty(IBGP_REMOTE_IP_ON_NON_LOOPBACK_VAR)
+    @JsonProperty(PROP_IBGP_REMOTE_IP_ON_NON_LOOPBACK)
     public SortedMap<String, SortedMap<String, SortedSet<Prefix>>> getIbgpRemoteIpOnNonLoopback() {
       return _ibgpRemoteIpOnNonLoopback;
     }
 
-    @JsonProperty(IBGP_REMOTE_IP_UNKNOWN_VAR)
+    @JsonProperty(PROP_IBGP_REMOTE_IP_UNKNOWN)
     public SortedMap<String, SortedMap<String, SortedSet<Prefix>>> getIbgpRemoteIpUnknown() {
       return _ibgpRemoteIpUnknown;
     }
 
-    @JsonProperty(IGNORED_FOREIGN_ENDPOINTS_VAR)
+    @JsonProperty(PROP_IGNORED_FOREIGN_ENDPOINTS)
     public SortedMap<String, SortedMap<String, SortedSet<Prefix>>> getIgnoredForeignEndpoints() {
       return _ignoredForeignEndpoints;
     }
 
-    @JsonProperty(LOCAL_IP_UNKNOWN_VAR)
+    @JsonProperty(PROP_LOCAL_IP_UNKNOWN)
     public SortedMap<String, SortedMap<String, SortedSet<Prefix>>> getLocalIpUnknown() {
       return _localIpUnknown;
     }
 
-    @JsonProperty(MISSING_LOCAL_IP_VAR)
+    @JsonProperty(PROP_MISSING_LOCAL_IP)
     public SortedMap<String, SortedMap<String, SortedSet<Prefix>>> getMissingLocalIp() {
       return _missingLocalIp;
     }
 
-    @JsonProperty(NON_UNIQUE_ENDPOINT_VAR)
+    @JsonProperty(PROP_NON_UNIQUE_ENDPOINT)
     public SortedMap<String, SortedMap<String, SortedSet<Prefix>>> getNonUniqueEndpoint() {
       return _nonUniqueEndpoint;
     }
 
-    @JsonProperty(REMOTE_IP_UNKNOWN_VAR)
+    @JsonProperty(PROP_REMOTE_IP_UNKNOWN)
     public SortedMap<String, SortedMap<String, SortedSet<Prefix>>> getRemoteIpUnknown() {
       return _remoteIpUnknown;
     }
@@ -304,16 +304,17 @@ public class BgpSessionCheckQuestionPlugin extends QuestionPlugin {
     @Override
     public String prettyPrint() {
       StringBuilder sb = new StringBuilder();
-      sb.append(prettyPrintCategory(_ebgpLocalIpOnLoopback, EBGP_LOCAL_IP_ON_LOOPBACK_VAR));
-      sb.append(prettyPrintCategory(_ebgpRemoteIpOnLoopback, EBGP_REMOTE_IP_ON_LOOPBACK_VAR));
-      sb.append(prettyPrintCategory(_halfOpen, HALF_OPEN_VAR));
-      sb.append(prettyPrintCategory(_ibgpLocalIpOnNonLoopback, IBGP_LOCAL_IP_ON_NON_LOOPBACK_VAR));
+      sb.append(prettyPrintCategory(_ebgpLocalIpOnLoopback, PROP_EBGP_LOCAL_IP_ON_LOOPBACK));
+      sb.append(prettyPrintCategory(_ebgpRemoteIpOnLoopback, PROP_EBGP_REMOTE_IP_ON_LOOPBACK));
+      sb.append(prettyPrintCategory(_halfOpen, PROP_HALF_OPEN));
       sb.append(
-          prettyPrintCategory(_ibgpRemoteIpOnNonLoopback, IBGP_REMOTE_IP_ON_NON_LOOPBACK_VAR));
-      sb.append(prettyPrintCategory(_localIpUnknown, LOCAL_IP_UNKNOWN_VAR));
-      sb.append(prettyPrintCategory(_missingLocalIp, MISSING_LOCAL_IP_VAR));
-      sb.append(prettyPrintCategory(_nonUniqueEndpoint, NON_UNIQUE_ENDPOINT_VAR));
-      sb.append(prettyPrintCategory(_remoteIpUnknown, REMOTE_IP_UNKNOWN_VAR));
+          prettyPrintCategory(_ibgpLocalIpOnNonLoopback, PROP_IBGP_REMOTE_IP_ON_NON_LOOPBACK));
+      sb.append(
+          prettyPrintCategory(_ibgpRemoteIpOnNonLoopback, PROP_IBGP_LOCAL_IP_ON_NON_LOOPBACK));
+      sb.append(prettyPrintCategory(_localIpUnknown, PROP_LOCAL_IP_UNKNOWN));
+      sb.append(prettyPrintCategory(_missingLocalIp, PROP_MISSING_LOCAL_IP));
+      sb.append(prettyPrintCategory(_nonUniqueEndpoint, PROP_NON_UNIQUE_ENDPOINT));
+      sb.append(prettyPrintCategory(_remoteIpUnknown, PROP_REMOTE_IP_UNKNOWN));
       return sb.toString();
     }
 
@@ -356,142 +357,142 @@ public class BgpSessionCheckQuestionPlugin extends QuestionPlugin {
       return sb;
     }
 
-    @JsonProperty(ALL_BGP_NEIGHBORS_VAR)
+    @JsonProperty(PROP_ALL_BGP_NEIGHBORS)
     public void setAllBgpNeighbors(
         SortedMap<String, SortedMap<String, SortedMap<Prefix, BgpNeighborSummary>>>
             allBgpNeighbors) {
       _allBgpNeighbors = allBgpNeighbors;
     }
 
-    @JsonProperty(BROKEN_VAR)
+    @JsonProperty(PROP_BROKEN)
     public void setBroken(SortedMap<String, SortedMap<String, SortedSet<Prefix>>> broken) {
       _broken = broken;
     }
 
-    @JsonProperty(EBGP_BROKEN_VAR)
+    @JsonProperty(PROP_EBGP_BROKEN)
     public void setEbgpBroken(SortedMap<String, SortedMap<String, SortedSet<Prefix>>> ebgpBroken) {
       _ebgpBroken = ebgpBroken;
     }
 
-    @JsonProperty(EBGP_HALF_OPEN_VAR)
+    @JsonProperty(PROP_EBGP_HALF_OPEN)
     public void setEbgpHalfOpen(
         SortedMap<String, SortedMap<String, SortedSet<Prefix>>> ebgpHalfOpen) {
       _ebgpHalfOpen = ebgpHalfOpen;
     }
 
-    @JsonProperty(EBGP_LOCAL_IP_ON_LOOPBACK_VAR)
+    @JsonProperty(PROP_EBGP_LOCAL_IP_ON_LOOPBACK)
     public void setEbgpLocalIpOnLoopback(
         SortedMap<String, SortedMap<String, SortedSet<Prefix>>> ebgpLocalIpOnLoopback) {
       _ebgpLocalIpOnLoopback = ebgpLocalIpOnLoopback;
     }
 
-    @JsonProperty(EBGP_LOCAL_IP_UNKNOWN_VAR)
+    @JsonProperty(PROP_EBGP_LOCAL_IP_UNKNOWN)
     public void setEbgpLocalIpUnknown(
         SortedMap<String, SortedMap<String, SortedSet<Prefix>>> ebgpLocalIpUnknown) {
       _ebgpLocalIpUnknown = ebgpLocalIpUnknown;
     }
 
-    @JsonProperty(EBGP_MISSING_LOCAL_IP_VAR)
+    @JsonProperty(PROP_EBGP_MISSING_LOCAL_IP)
     public void setEbgpMissingLocalIp(
         SortedMap<String, SortedMap<String, SortedSet<Prefix>>> ebgpMissingLocalIp) {
       _ebgpMissingLocalIp = ebgpMissingLocalIp;
     }
 
-    @JsonProperty(EBGP_NON_UNIQUE_ENDPOINT_VAR)
+    @JsonProperty(PROP_EBGP_NON_UNIQUE_ENDPOINT)
     public void setEbgpNonUniqueEndpoint(
         SortedMap<String, SortedMap<String, SortedSet<Prefix>>> ebgpNonUniqueEndpoint) {
       _ebgpNonUniqueEndpoint = ebgpNonUniqueEndpoint;
     }
 
-    @JsonProperty(EBGP_REMOTE_IP_ON_LOOPBACK_VAR)
+    @JsonProperty(PROP_EBGP_REMOTE_IP_ON_LOOPBACK)
     public void setEbgpRemoteIpOnLoopback(
         SortedMap<String, SortedMap<String, SortedSet<Prefix>>> ebgpRemoteIpOnLoopback) {
       _ebgpRemoteIpOnLoopback = ebgpRemoteIpOnLoopback;
     }
 
-    @JsonProperty(EBGP_REMOTE_IP_UNKNOWN_VAR)
+    @JsonProperty(PROP_EBGP_REMOTE_IP_UNKNOWN)
     public void setEbgpRemoteIpUnknown(
         SortedMap<String, SortedMap<String, SortedSet<Prefix>>> ebgpRemoteIpUnknown) {
       _ebgpRemoteIpUnknown = ebgpRemoteIpUnknown;
     }
 
-    @JsonProperty(HALF_OPEN_VAR)
+    @JsonProperty(PROP_HALF_OPEN)
     public void setHalfOpen(SortedMap<String, SortedMap<String, SortedSet<Prefix>>> halfOpen) {
       _halfOpen = halfOpen;
     }
 
-    @JsonProperty(IBGP_BROKEN_VAR)
+    @JsonProperty(PROP_IBGP_BROKEN)
     public void setIbgpBroken(SortedMap<String, SortedMap<String, SortedSet<Prefix>>> ibgpBroken) {
       _ibgpBroken = ibgpBroken;
     }
 
-    @JsonProperty(IBGP_HALF_OPEN_VAR)
+    @JsonProperty(PROP_IBGP_HALF_OPEN)
     public void setIbgpHalfOpen(
         SortedMap<String, SortedMap<String, SortedSet<Prefix>>> ibgpHalfOpen) {
       _ibgpHalfOpen = ibgpHalfOpen;
     }
 
-    @JsonProperty(IBGP_LOCAL_IP_ON_NON_LOOPBACK_VAR)
+    @JsonProperty(PROP_IBGP_LOCAL_IP_ON_NON_LOOPBACK)
     public void setIbgpLocalIpOnNonLoopback(
         SortedMap<String, SortedMap<String, SortedSet<Prefix>>> ibgpLocalIpOnNonLoopback) {
       _ibgpLocalIpOnNonLoopback = ibgpLocalIpOnNonLoopback;
     }
 
-    @JsonProperty(IBGP_LOCAL_IP_UNKNOWN_VAR)
+    @JsonProperty(PROP_IBGP_LOCAL_IP_UNKNOWN)
     public void setIbgpLocalIpUnknown(
         SortedMap<String, SortedMap<String, SortedSet<Prefix>>> ibgpLocalIpUnknown) {
       _ibgpLocalIpUnknown = ibgpLocalIpUnknown;
     }
 
-    @JsonProperty(IBGP_MISSING_LOCAL_IP_VAR)
+    @JsonProperty(PROP_IBGP_MISSING_LOCAL_IP)
     public void setIbgpMissingLocalIp(
         SortedMap<String, SortedMap<String, SortedSet<Prefix>>> ibgpMissingLocalIp) {
       _ibgpMissingLocalIp = ibgpMissingLocalIp;
     }
 
-    @JsonProperty(IBGP_NON_UNIQUE_ENDPOINT_VAR)
+    @JsonProperty(PROP_IBGP_NON_UNIQUE_ENDPOINT)
     public void setIbgpNonUniqueEndpoint(
         SortedMap<String, SortedMap<String, SortedSet<Prefix>>> ibgpNonUniqueEndpoint) {
       _ibgpNonUniqueEndpoint = ibgpNonUniqueEndpoint;
     }
 
-    @JsonProperty(IBGP_REMOTE_IP_ON_NON_LOOPBACK_VAR)
+    @JsonProperty(PROP_IBGP_REMOTE_IP_ON_NON_LOOPBACK)
     public void setIbgpRemoteIpOnNonLoopback(
         SortedMap<String, SortedMap<String, SortedSet<Prefix>>> ibgpRemoteIpOnNonLoopback) {
       _ibgpRemoteIpOnNonLoopback = ibgpRemoteIpOnNonLoopback;
     }
 
-    @JsonProperty(IBGP_REMOTE_IP_UNKNOWN_VAR)
+    @JsonProperty(PROP_IBGP_REMOTE_IP_UNKNOWN)
     public void setIbgpRemoteIpUnknown(
         SortedMap<String, SortedMap<String, SortedSet<Prefix>>> ibgpRemoteIpUnknown) {
       _ibgpRemoteIpUnknown = ibgpRemoteIpUnknown;
     }
 
-    @JsonProperty(IGNORED_FOREIGN_ENDPOINTS_VAR)
+    @JsonProperty(PROP_IGNORED_FOREIGN_ENDPOINTS)
     public void setIgnoredForeignEndpoints(
         SortedMap<String, SortedMap<String, SortedSet<Prefix>>> ignoredForeignEndpoints) {
       _ignoredForeignEndpoints = ignoredForeignEndpoints;
     }
 
-    @JsonProperty(LOCAL_IP_UNKNOWN_VAR)
+    @JsonProperty(PROP_LOCAL_IP_UNKNOWN)
     public void setLocalIpUnknown(
         SortedMap<String, SortedMap<String, SortedSet<Prefix>>> localIpUnknown) {
       _localIpUnknown = localIpUnknown;
     }
 
-    @JsonProperty(MISSING_LOCAL_IP_VAR)
+    @JsonProperty(PROP_MISSING_LOCAL_IP)
     public void setMissingLocalIp(
         SortedMap<String, SortedMap<String, SortedSet<Prefix>>> missingLocalIp) {
       _missingLocalIp = missingLocalIp;
     }
 
-    @JsonProperty(NON_UNIQUE_ENDPOINT_VAR)
+    @JsonProperty(PROP_NON_UNIQUE_ENDPOINT)
     public void setNonUniqueEndpoint(
         SortedMap<String, SortedMap<String, SortedSet<Prefix>>> nonUniqueEndpoint) {
       _nonUniqueEndpoint = nonUniqueEndpoint;
     }
 
-    @JsonProperty(REMOTE_IP_UNKNOWN_VAR)
+    @JsonProperty(PROP_REMOTE_IP_UNKNOWN)
     public void setRemoteIpUnknown(
         SortedMap<String, SortedMap<String, SortedSet<Prefix>>> remoteIpUnknown) {
       _remoteIpUnknown = remoteIpUnknown;
@@ -778,11 +779,11 @@ public class BgpSessionCheckQuestionPlugin extends QuestionPlugin {
    */
   public static class BgpSessionCheckQuestion extends Question {
 
-    private static final String FOREIGN_BGP_GROUPS_VAR = "foreignBgpGroups";
+    private static final String PROP_FOREIGN_BGP_GROUPS = "foreignBgpGroups";
 
-    private static final String NODE1_REGEX_VAR = "node1Regex";
+    private static final String PROP_NODE1_REGEX = "node1Regex";
 
-    private static final String NODE2_REGEX_VAR = "node2Regex";
+    private static final String PROP_NODE2_REGEX = "node2Regex";
 
     private SortedSet<String> _foreignBgpGroups;
 
@@ -801,7 +802,7 @@ public class BgpSessionCheckQuestionPlugin extends QuestionPlugin {
       return false;
     }
 
-    @JsonProperty(FOREIGN_BGP_GROUPS_VAR)
+    @JsonProperty(PROP_FOREIGN_BGP_GROUPS)
     public SortedSet<String> getForeignBgpGroups() {
       return _foreignBgpGroups;
     }
@@ -811,12 +812,12 @@ public class BgpSessionCheckQuestionPlugin extends QuestionPlugin {
       return "bgpsessioncheck";
     }
 
-    @JsonProperty(NODE1_REGEX_VAR)
+    @JsonProperty(PROP_NODE1_REGEX)
     public String getNode1Regex() {
       return _node1Regex;
     }
 
-    @JsonProperty(NODE2_REGEX_VAR)
+    @JsonProperty(PROP_NODE2_REGEX)
     public String getNode2Regex() {
       return _node2Regex;
     }
@@ -826,17 +827,17 @@ public class BgpSessionCheckQuestionPlugin extends QuestionPlugin {
       return false;
     }
 
-    @JsonProperty(FOREIGN_BGP_GROUPS_VAR)
+    @JsonProperty(PROP_FOREIGN_BGP_GROUPS)
     public void setForeignBgpGroups(SortedSet<String> foreignBgpGroups) {
       _foreignBgpGroups = foreignBgpGroups;
     }
 
-    @JsonProperty(NODE1_REGEX_VAR)
+    @JsonProperty(PROP_NODE1_REGEX)
     public void setNode1Regex(String regex) {
       _node1Regex = regex;
     }
 
-    @JsonProperty(NODE2_REGEX_VAR)
+    @JsonProperty(PROP_NODE2_REGEX)
     public void setNode2Regex(String regex) {
       _node2Regex = regex;
     }

--- a/projects/question/src/main/java/org/batfish/question/ClusterNodesQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/ClusterNodesQuestionPlugin.java
@@ -23,13 +23,13 @@ public class ClusterNodesQuestionPlugin extends QuestionPlugin {
 
   public static class ClusterNodesAnswerElement implements AnswerElement {
 
-    private static final String CLUSTERS_VAR = "clusters";
+    private static final String PROP_CLUSTERS = "clusters";
 
     private List<Set<String>> _clusters;
 
     public ClusterNodesAnswerElement() {}
 
-    @JsonProperty(CLUSTERS_VAR)
+    @JsonProperty(PROP_CLUSTERS)
     public List<Set<String>> getClusters() {
       return _clusters;
     }
@@ -43,7 +43,7 @@ public class ClusterNodesQuestionPlugin extends QuestionPlugin {
       return sb.toString();
     }
 
-    @JsonProperty(CLUSTERS_VAR)
+    @JsonProperty(PROP_CLUSTERS)
     public void setClusters(List<Set<String>> clusters) {
       _clusters = clusters;
     }
@@ -310,13 +310,13 @@ public class ClusterNodesQuestionPlugin extends QuestionPlugin {
    */
   public static final class ClusterNodesQuestion extends Question {
 
-    private static final String NAME_ONLY_VAR = "nameOnly";
+    private static final String PROP_NAME_ONLY = "nameOnly";
 
-    private static final String NAMED_STRUCT_TYPES_VAR = "namedStructTypes";
+    private static final String PROP_NAMED_STRUCT_TYPES = "namedStructTypes";
 
-    private static final String NODE_REGEX_VAR = "nodeRegex";
+    private static final String PROP_NODE_REGEX = "nodeRegex";
 
-    private static final String NUM_CLUSTERS_VAR = "numClusters";
+    private static final String PROP_NUM_CLUSTERS = "numClusters";
 
     private SortedSet<String> _namedStructTypes;
 
@@ -342,22 +342,22 @@ public class ClusterNodesQuestionPlugin extends QuestionPlugin {
       return "ClusterNodes";
     }
 
-    @JsonProperty(NAMED_STRUCT_TYPES_VAR)
+    @JsonProperty(PROP_NAMED_STRUCT_TYPES)
     public SortedSet<String> getNamedStructTypes() {
       return _namedStructTypes;
     }
 
-    @JsonProperty(NAME_ONLY_VAR)
+    @JsonProperty(PROP_NAME_ONLY)
     public boolean getNameOnly() {
       return _nameOnly;
     }
 
-    @JsonProperty(NODE_REGEX_VAR)
+    @JsonProperty(PROP_NODE_REGEX)
     public String getNodeRegex() {
       return _nodeRegex;
     }
 
-    @JsonProperty(NUM_CLUSTERS_VAR)
+    @JsonProperty(PROP_NUM_CLUSTERS)
     public int getNumClusters() {
       return _numClusters;
     }
@@ -367,22 +367,22 @@ public class ClusterNodesQuestionPlugin extends QuestionPlugin {
       return false;
     }
 
-    @JsonProperty(NAMED_STRUCT_TYPES_VAR)
+    @JsonProperty(PROP_NAMED_STRUCT_TYPES)
     public void setNamedStructTypes(SortedSet<String> namedStructTypes) {
       _namedStructTypes = namedStructTypes;
     }
 
-    @JsonProperty(NAME_ONLY_VAR)
+    @JsonProperty(PROP_NAME_ONLY)
     public void setNameOnly(boolean nameOnly) {
       _nameOnly = nameOnly;
     }
 
-    @JsonProperty(NODE_REGEX_VAR)
+    @JsonProperty(PROP_NODE_REGEX)
     public void setNodeRegex(String regex) {
       _nodeRegex = regex;
     }
 
-    @JsonProperty(NUM_CLUSTERS_VAR)
+    @JsonProperty(PROP_NUM_CLUSTERS)
     public void setNumClusters(int numClusters) {
       _numClusters = numClusters;
     }

--- a/projects/question/src/main/java/org/batfish/question/CompareSameNameQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/CompareSameNameQuestionPlugin.java
@@ -39,9 +39,9 @@ public class CompareSameNameQuestionPlugin extends QuestionPlugin {
 
   public static class CompareSameNameAnswerElement implements AnswerElement {
 
-    private static final String EQUIVALENCE_SETS_MAP_VAR = "equivalenceSetsMap";
+    private static final String PROP_EQUIVALENCE_SETS_MAP = "equivalenceSetsMap";
 
-    private static final String NODES_VAR = "nodes";
+    private static final String PROP_NODES = "nodes";
 
     /** Equivalence sets are keyed by classname */
     private SortedMap<String, NamedStructureEquivalenceSets<?>> _equivalenceSets;
@@ -63,12 +63,12 @@ public class CompareSameNameQuestionPlugin extends QuestionPlugin {
       return sb.toString();
     }
 
-    @JsonProperty(EQUIVALENCE_SETS_MAP_VAR)
+    @JsonProperty(PROP_EQUIVALENCE_SETS_MAP)
     public SortedMap<String, NamedStructureEquivalenceSets<?>> getEquivalenceSets() {
       return _equivalenceSets;
     }
 
-    @JsonProperty(NODES_VAR)
+    @JsonProperty(PROP_NODES)
     public List<String> getNodes() {
       return _nodes;
     }
@@ -84,13 +84,13 @@ public class CompareSameNameQuestionPlugin extends QuestionPlugin {
       return sb.toString();
     }
 
-    @JsonProperty(EQUIVALENCE_SETS_MAP_VAR)
+    @JsonProperty(PROP_EQUIVALENCE_SETS_MAP)
     public void setEquivalenceSets(
         SortedMap<String, NamedStructureEquivalenceSets<?>> equivalenceSets) {
       _equivalenceSets = equivalenceSets;
     }
 
-    @JsonProperty(NODES_VAR)
+    @JsonProperty(PROP_NODES)
     public void setNodes(List<String> nodes) {
       _nodes = nodes;
     }
@@ -237,13 +237,13 @@ public class CompareSameNameQuestionPlugin extends QuestionPlugin {
    */
   public static final class CompareSameNameQuestion extends Question implements INodeRegexQuestion {
 
-    private static final String MISSING_VAR = "missing";
+    private static final String PROP_MISSING = "missing";
 
-    private static final String NAMED_STRUCT_TYPES_VAR = "namedStructTypes";
+    private static final String PROP_NAMED_STRUCT_TYPES = "namedStructTypes";
 
-    private static final String NODE_REGEX_VAR = "nodeRegex";
+    private static final String PROP_NODE_REGEX = "nodeRegex";
 
-    private static final String SINGLETONS_VAR = "singletons";
+    private static final String PROP_SINGLETONS = "singletons";
 
     private boolean _missing;
 
@@ -263,7 +263,7 @@ public class CompareSameNameQuestionPlugin extends QuestionPlugin {
       return false;
     }
 
-    @JsonProperty(MISSING_VAR)
+    @JsonProperty(PROP_MISSING)
     public boolean getMissing() {
       return _missing;
     }
@@ -273,18 +273,18 @@ public class CompareSameNameQuestionPlugin extends QuestionPlugin {
       return "comparesamename";
     }
 
-    @JsonProperty(NAMED_STRUCT_TYPES_VAR)
+    @JsonProperty(PROP_NAMED_STRUCT_TYPES)
     public SortedSet<String> getNamedStructTypes() {
       return _namedStructTypes;
     }
 
     @Override
-    @JsonProperty(NODE_REGEX_VAR)
+    @JsonProperty(PROP_NODE_REGEX)
     public String getNodeRegex() {
       return _nodeRegex;
     }
 
-    @JsonProperty(SINGLETONS_VAR)
+    @JsonProperty(PROP_SINGLETONS)
     public boolean getSingletons() {
       return _singletons;
     }
@@ -294,23 +294,23 @@ public class CompareSameNameQuestionPlugin extends QuestionPlugin {
       return false;
     }
 
-    @JsonProperty(MISSING_VAR)
+    @JsonProperty(PROP_MISSING)
     public void setMissing(boolean missing) {
       _missing = missing;
     }
 
-    @JsonProperty(NAMED_STRUCT_TYPES_VAR)
+    @JsonProperty(PROP_NAMED_STRUCT_TYPES)
     public void setNamedStructTypes(SortedSet<String> namedStructTypes) {
       _namedStructTypes = namedStructTypes;
     }
 
     @Override
-    @JsonProperty(NODE_REGEX_VAR)
+    @JsonProperty(PROP_NODE_REGEX)
     public void setNodeRegex(String regex) {
       _nodeRegex = regex;
     }
 
-    @JsonProperty(SINGLETONS_VAR)
+    @JsonProperty(PROP_SINGLETONS)
     public void setSingletons(boolean singletons) {
       _singletons = singletons;
     }

--- a/projects/question/src/main/java/org/batfish/question/CompositeQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/CompositeQuestionPlugin.java
@@ -12,7 +12,7 @@ public class CompositeQuestionPlugin extends QuestionPlugin {
 
   public static class CompositeAnswerElement implements AnswerElement {
 
-    private static final String ANSWERS_VAR = "answers";
+    private static final String PROP_ANSWERS = "answers";
 
     private List<AnswerElement> _answers;
 
@@ -20,12 +20,12 @@ public class CompositeQuestionPlugin extends QuestionPlugin {
       _answers = new ArrayList<>();
     }
 
-    @JsonProperty(ANSWERS_VAR)
+    @JsonProperty(PROP_ANSWERS)
     public List<AnswerElement> getAnswers() {
       return _answers;
     }
 
-    @JsonProperty(ANSWERS_VAR)
+    @JsonProperty(PROP_ANSWERS)
     public void setAnswers(List<AnswerElement> answers) {
       _answers = answers;
     }
@@ -54,7 +54,7 @@ public class CompositeQuestionPlugin extends QuestionPlugin {
 
   public static class CompositeQuestion extends Question {
 
-    private static final String QUESTIONS_VAR = "questions";
+    private static final String PROP_QUESTIONS = "questions";
 
     private List<Question> _questions;
 
@@ -72,7 +72,7 @@ public class CompositeQuestionPlugin extends QuestionPlugin {
       return "composite";
     }
 
-    @JsonProperty(QUESTIONS_VAR)
+    @JsonProperty(PROP_QUESTIONS)
     public List<Question> getQuestions() {
       return _questions;
     }
@@ -82,7 +82,7 @@ public class CompositeQuestionPlugin extends QuestionPlugin {
       return false;
     }
 
-    @JsonProperty(QUESTIONS_VAR)
+    @JsonProperty(PROP_QUESTIONS)
     public void setQuestions(List<Question> questions) {
       _questions = questions;
     }

--- a/projects/question/src/main/java/org/batfish/question/EnvironmentCreationQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/EnvironmentCreationQuestionPlugin.java
@@ -42,13 +42,13 @@ public class EnvironmentCreationQuestionPlugin extends QuestionPlugin {
   public static class EnvironmentCreationQuestion extends Question
       implements IEnvironmentCreationQuestion {
 
-    private static final String EDGE_BLACKLIST_VAR = "edgeBlacklist";
+    private static final String PROP_EDGE_BLACKLIST = "edgeBlacklist";
 
-    private static final String ENVIRONMENT_NAME_VAR = ENVIRONMENT_NAME_KEY;
+    private static final String PROP_ENVIRONMENT_NAME = ENVIRONMENT_NAME_KEY;
 
-    private static final String INTERFACE_BLACKLIST_VAR = "interfaceBlacklist";
+    private static final String PROP_INTERFACE_BLACKLIST = "interfaceBlacklist";
 
-    private static final String NODE_BLACKLIST_VAR = "nodeBlacklist";
+    private static final String PROP_NODE_BLACKLIST = "nodeBlacklist";
 
     private SortedSet<Edge> _edgeBlacklist;
 
@@ -75,17 +75,17 @@ public class EnvironmentCreationQuestionPlugin extends QuestionPlugin {
       return false;
     }
 
-    @JsonProperty(EDGE_BLACKLIST_VAR)
+    @JsonProperty(PROP_EDGE_BLACKLIST)
     public SortedSet<Edge> getEdgeBlacklist() {
       return _edgeBlacklist;
     }
 
-    @JsonProperty(ENVIRONMENT_NAME_VAR)
+    @JsonProperty(PROP_ENVIRONMENT_NAME)
     public String getEnvironmentName() {
       return _environmentName;
     }
 
-    @JsonProperty(INTERFACE_BLACKLIST_VAR)
+    @JsonProperty(PROP_INTERFACE_BLACKLIST)
     public SortedSet<NodeInterfacePair> getInterfaceBlacklist() {
       return _interfaceBlacklist;
     }
@@ -95,7 +95,7 @@ public class EnvironmentCreationQuestionPlugin extends QuestionPlugin {
       return NAME;
     }
 
-    @JsonProperty(NODE_BLACKLIST_VAR)
+    @JsonProperty(PROP_NODE_BLACKLIST)
     public SortedSet<String> getNodeBlacklist() {
       return _nodeBlacklist;
     }
@@ -105,22 +105,22 @@ public class EnvironmentCreationQuestionPlugin extends QuestionPlugin {
       return false;
     }
 
-    @JsonProperty(EDGE_BLACKLIST_VAR)
+    @JsonProperty(PROP_EDGE_BLACKLIST)
     public void setEdgeBlacklist(SortedSet<Edge> edgeBlacklist) {
       _edgeBlacklist = edgeBlacklist;
     }
 
-    @JsonProperty(ENVIRONMENT_NAME_VAR)
+    @JsonProperty(PROP_ENVIRONMENT_NAME)
     public void setEnvironmentName(String environmentName) {
       _environmentName = environmentName;
     }
 
-    @JsonProperty(INTERFACE_BLACKLIST_VAR)
+    @JsonProperty(PROP_INTERFACE_BLACKLIST)
     public void setInterfaceBlacklist(SortedSet<NodeInterfacePair> blacklist) {
       _interfaceBlacklist = blacklist;
     }
 
-    @JsonProperty(NODE_BLACKLIST_VAR)
+    @JsonProperty(PROP_NODE_BLACKLIST)
     public void setNodeBlacklist(NodeSet blacklist) {
       _nodeBlacklist = blacklist;
     }

--- a/projects/question/src/main/java/org/batfish/question/InferRolesQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/InferRolesQuestionPlugin.java
@@ -21,13 +21,13 @@ public class InferRolesQuestionPlugin extends QuestionPlugin {
 
   public static class InferRolesAnswerElement implements AnswerElement {
 
-    private static final String ROLE_SPECIFIER_VAR = "roleSpecifier";
+    private static final String PROP_ROLE_SPECIFIER = "roleSpecifier";
 
-    private static final String ALL_NODES_VAR = "allNodes";
+    private static final String PROP_ALL_NODES = "allNodes";
 
-    private static final String ALL_NODES_COUNT_VAR = "allNodesCount";
+    private static final String PROP_ALL_NODES_COUNT = "allNodesCount";
 
-    private static final String MATCHING_NODES_COUNT_VAR = "matchingNodesCount";
+    private static final String PROP_MATCHING_NODES_COUNT = "matchingNodesCount";
 
     private NodeRoleSpecifier _roleSpecifier;
 
@@ -40,7 +40,7 @@ public class InferRolesQuestionPlugin extends QuestionPlugin {
     public InferRolesAnswerElement() {
     }
 
-    @JsonProperty(ROLE_SPECIFIER_VAR)
+    @JsonProperty(PROP_ROLE_SPECIFIER)
     public NodeRoleSpecifier getRoleSpecifier() {
       return _roleSpecifier;
     }
@@ -73,23 +73,23 @@ public class InferRolesQuestionPlugin extends QuestionPlugin {
       return sb.toString();
     }
 
-    @JsonProperty(ROLE_SPECIFIER_VAR)
+    @JsonProperty(PROP_ROLE_SPECIFIER)
     public void setRoleSpecifier(NodeRoleSpecifier roleSpecifier) {
       _roleSpecifier = roleSpecifier;
     }
 
-    @JsonProperty(ALL_NODES_VAR)
+    @JsonProperty(PROP_ALL_NODES)
     public void setAllNodes(List<String> allNodes) {
       _allNodes = allNodes;
     }
 
-    @JsonProperty(ALL_NODES_COUNT_VAR)
+    @JsonProperty(PROP_ALL_NODES_COUNT)
     public void setAllNodesCount(int allNodesCount) {
       _allNodesCount = allNodesCount;
     }
 
 
-    @JsonProperty(MATCHING_NODES_COUNT_VAR)
+    @JsonProperty(PROP_MATCHING_NODES_COUNT)
     public void setMatchingNodesCount(int matchingNodesCount) {
       _matchingNodesCount = matchingNodesCount;
     }
@@ -175,7 +175,7 @@ public class InferRolesQuestionPlugin extends QuestionPlugin {
    */
   public static final class InferRolesQuestion extends Question {
 
-    private static final String NODE_REGEX_VAR = "nodeRegex";
+    private static final String PROP_NODE_REGEX = "nodeRegex";
 
     private String _nodeRegex;
 
@@ -193,7 +193,7 @@ public class InferRolesQuestionPlugin extends QuestionPlugin {
       return "inferroles";
     }
 
-    @JsonProperty(NODE_REGEX_VAR)
+    @JsonProperty(PROP_NODE_REGEX)
     public String getNodeRegex() {
       return _nodeRegex;
     }
@@ -203,7 +203,7 @@ public class InferRolesQuestionPlugin extends QuestionPlugin {
       return false;
     }
 
-    @JsonProperty(NODE_REGEX_VAR)
+    @JsonProperty(PROP_NODE_REGEX)
     public void setNodeRegex(String regex) {
       _nodeRegex = regex;
     }

--- a/projects/question/src/main/java/org/batfish/question/InitInfoQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/InitInfoQuestionPlugin.java
@@ -33,9 +33,9 @@ public class InitInfoQuestionPlugin extends QuestionPlugin {
    */
   public static class InitInfoQuestion extends Question {
 
-    private static final String SUMMARY_VAR = "summary";
+    private static final String PROP_SUMMARY = "summary";
 
-    private static final String VERBOSE_ERROR_VAR = "verboseError";
+    private static final String PROP_VERBOSE_ERROR = "verboseError";
 
     private boolean _environmentRoutes;
 
@@ -59,7 +59,7 @@ public class InitInfoQuestionPlugin extends QuestionPlugin {
       return "initinfo";
     }
 
-    @JsonProperty(SUMMARY_VAR)
+    @JsonProperty(PROP_SUMMARY)
     public boolean getSummary() {
       return _summary;
     }
@@ -69,7 +69,7 @@ public class InitInfoQuestionPlugin extends QuestionPlugin {
       return false;
     }
 
-    @JsonProperty(VERBOSE_ERROR_VAR)
+    @JsonProperty(PROP_VERBOSE_ERROR)
     public boolean getVerboseError() {
       return _verboseError;
     }
@@ -78,11 +78,11 @@ public class InitInfoQuestionPlugin extends QuestionPlugin {
     public String prettyPrint() {
       return getName()
           + " "
-          + SUMMARY_VAR
+          + PROP_SUMMARY
           + "="
           + _summary
           + " "
-          + VERBOSE_ERROR_VAR
+          + PROP_VERBOSE_ERROR
           + "="
           + _verboseError;
     }
@@ -91,12 +91,12 @@ public class InitInfoQuestionPlugin extends QuestionPlugin {
       _environmentRoutes = environmentRoutes;
     }
 
-    @JsonProperty(SUMMARY_VAR)
+    @JsonProperty(PROP_SUMMARY)
     public void setSummary(boolean summary) {
       _summary = summary;
     }
 
-    @JsonProperty(VERBOSE_ERROR_VAR)
+    @JsonProperty(PROP_VERBOSE_ERROR)
     public void setVerboseError(boolean verboseError) {
       _verboseError = verboseError;
     }

--- a/projects/question/src/main/java/org/batfish/question/IpsecVpnCheckQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/IpsecVpnCheckQuestionPlugin.java
@@ -24,42 +24,42 @@ public class IpsecVpnCheckQuestionPlugin extends QuestionPlugin {
 
     public static class IpsecVpnPair extends Pair<Pair<String, String>, Pair<String, String>> {
 
-      private static final String HOSTNAME1_VAR = "hostname1";
+      private static final String PROP_HOSTNAME1 = "hostname1";
 
-      private static final String HOSTNAME2_VAR = "hostname2";
+      private static final String PROP_HOSTNAME2 = "hostname2";
 
-      private static final String IPSEC_VPN1_VAR = "ipsecVpn1";
+      private static final String PROP_IPSEC_VPN1 = "ipsecVpn1";
 
-      private static final String IPSEC_VPN2_VAR = "ipsecVpn2";
+      private static final String PROP_IPSEC_VPN2 = "ipsecVpn2";
 
       /** */
       private static final long serialVersionUID = 1L;
 
       @JsonCreator
       public IpsecVpnPair(
-          @JsonProperty(HOSTNAME1_VAR) String hostname1,
-          @JsonProperty(IPSEC_VPN1_VAR) String ipsecVpn1,
-          @JsonProperty(HOSTNAME2_VAR) String hostname2,
-          @JsonProperty(IPSEC_VPN2_VAR) String ipsecVpn2) {
+          @JsonProperty(PROP_HOSTNAME1) String hostname1,
+          @JsonProperty(PROP_IPSEC_VPN1) String ipsecVpn1,
+          @JsonProperty(PROP_HOSTNAME2) String hostname2,
+          @JsonProperty(PROP_IPSEC_VPN2) String ipsecVpn2) {
         super(new Pair<>(hostname1, ipsecVpn1), new Pair<>(hostname2, ipsecVpn2));
       }
 
-      @JsonProperty(HOSTNAME1_VAR)
+      @JsonProperty(PROP_HOSTNAME1)
       public String getHostname1() {
         return _first.getFirst();
       }
 
-      @JsonProperty(HOSTNAME2_VAR)
+      @JsonProperty(PROP_HOSTNAME2)
       public String getHostname2() {
         return _second.getFirst();
       }
 
-      @JsonProperty(IPSEC_VPN1_VAR)
+      @JsonProperty(PROP_IPSEC_VPN1)
       public String getIpsecVpn1() {
         return _first.getSecond();
       }
 
-      @JsonProperty(IPSEC_VPN2_VAR)
+      @JsonProperty(PROP_IPSEC_VPN2)
       public String getIpsecVpn2() {
         return _second.getSecond();
       }
@@ -237,9 +237,9 @@ public class IpsecVpnCheckQuestionPlugin extends QuestionPlugin {
    */
   public static class IpsecVpnCheckQuestion extends Question {
 
-    private static final String NODE1_REGEX_VAR = "node1Regex";
+    private static final String PROP_NODE1_REGEX = "node1Regex";
 
-    private static final String NODE2_REGEX_VAR = "node2Regex";
+    private static final String PROP_NODE2_REGEX = "node2Regex";
 
     private String _node1Regex;
 
@@ -260,12 +260,12 @@ public class IpsecVpnCheckQuestionPlugin extends QuestionPlugin {
       return "ipsecvpncheck";
     }
 
-    @JsonProperty(NODE1_REGEX_VAR)
+    @JsonProperty(PROP_NODE1_REGEX)
     public String getNode1Regex() {
       return _node1Regex;
     }
 
-    @JsonProperty(NODE2_REGEX_VAR)
+    @JsonProperty(PROP_NODE2_REGEX)
     public String getNode2Regex() {
       return _node2Regex;
     }
@@ -275,12 +275,12 @@ public class IpsecVpnCheckQuestionPlugin extends QuestionPlugin {
       return false;
     }
 
-    @JsonProperty(NODE1_REGEX_VAR)
+    @JsonProperty(PROP_NODE1_REGEX)
     public void setNode1Regex(String regex) {
       _node1Regex = regex;
     }
 
-    @JsonProperty(NODE2_REGEX_VAR)
+    @JsonProperty(PROP_NODE2_REGEX)
     public void setNode2Regex(String regex) {
       _node2Regex = regex;
     }

--- a/projects/question/src/main/java/org/batfish/question/IsisLoopbacksQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/IsisLoopbacksQuestionPlugin.java
@@ -211,7 +211,7 @@ public class IsisLoopbacksQuestionPlugin extends QuestionPlugin {
    */
   public static class IsisLoopbacksQuestion extends Question {
 
-    private static final String NODE_REGEX_VAR = "nodeRegex";
+    private static final String PROP_NODE_REGEX = "nodeRegex";
 
     private String _nodeRegex;
 
@@ -229,7 +229,7 @@ public class IsisLoopbacksQuestionPlugin extends QuestionPlugin {
       return "isisloopbacks";
     }
 
-    @JsonProperty(NODE_REGEX_VAR)
+    @JsonProperty(PROP_NODE_REGEX)
     public String getNodeRegex() {
       return _nodeRegex;
     }
@@ -239,7 +239,7 @@ public class IsisLoopbacksQuestionPlugin extends QuestionPlugin {
       return false;
     }
 
-    @JsonProperty(NODE_REGEX_VAR)
+    @JsonProperty(PROP_NODE_REGEX)
     public void setNodeRegex(String nodeRegex) {
       _nodeRegex = nodeRegex;
     }

--- a/projects/question/src/main/java/org/batfish/question/NeighborsQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/NeighborsQuestionPlugin.java
@@ -79,29 +79,29 @@ public class NeighborsQuestionPlugin extends QuestionPlugin {
 
   public static class NeighborsAnswerElement implements AnswerElement {
 
-    private static final String EBGP_NEIGHBORS_VAR = "ebgpNeighbors";
+    private static final String PROP_EBGP_NEIGHBORS = "ebgpNeighbors";
 
-    private static final String IBGP_NEIGHBORS_VAR = "ibgpNeighbors";
+    private static final String PROP_IBGP_NEIGHBORS = "ibgpNeighbors";
 
-    private static final String LAN_NEIGHBORS_VAR = "lanNeighbors";
+    private static final String PROP_LAN_NEIGHBORS = "lanNeighbors";
 
-    private static final String OSPF_NEIGHBORS_VAR = "ospfNeighbors";
+    private static final String PROP_OSPF_NEIGHBORS = "ospfNeighbors";
 
-    private static final String ROLE_EBGP_NEIGHBORS_VAR = "roleEbgpNeighbors";
+    private static final String PROP_ROLE_EBGP_NEIGHBORS = "roleEbgpNeighbors";
 
-    private static final String ROLE_IBGP_NEIGHBORS_VAR = "roleIbgpNeighbors";
+    private static final String PROP_ROLE_IBGP_NEIGHBORS = "roleIbgpNeighbors";
 
-    private static final String ROLE_LAN_NEIGHBORS_VAR = "roleLanNeighbors";
+    private static final String PROP_ROLE_LAN_NEIGHBORS = "roleLanNeighbors";
 
-    private static final String ROLE_OSPF_NEIGHBORS_VAR = "roleOspfNeighbors";
+    private static final String PROP_ROLE_OSPF_NEIGHBORS = "roleOspfNeighbors";
 
-    private static final String VERBOSE_EBGP_NEIGHBORS_VAR = "verboseEbgpNeighbors";
+    private static final String PROP_VERBOSE_EBGP_NEIGHBORS = "verboseEbgpNeighbors";
 
-    private static final String VERBOSE_IBGP_NEIGHBORS_VAR = "verboseIbgpNeighbors";
+    private static final String PROP_VERBOSE_IBGP_NEIGHBORS = "verboseIbgpNeighbors";
 
-    private static final String VERBOSE_LAN_NEIGHBORS_VAR = "verboseLanNeighbors";
+    private static final String PROP_VERBOSE_LAN_NEIGHBORS = "verboseLanNeighbors";
 
-    private static final String VERBOSE_OSPF_NEIGHBORS_VAR = "verboseOspfNeighbors";
+    private static final String PROP_VERBOSE_OSPF_NEIGHBORS = "verboseOspfNeighbors";
 
     private SortedSet<IpEdge> _ebgpNeighbors;
 
@@ -131,62 +131,62 @@ public class NeighborsQuestionPlugin extends QuestionPlugin {
       _lanNeighbors.add(edge);
     }
 
-    @JsonProperty(EBGP_NEIGHBORS_VAR)
+    @JsonProperty(PROP_EBGP_NEIGHBORS)
     public SortedSet<IpEdge> getEbgpNeighbors() {
       return _ebgpNeighbors;
     }
 
-    @JsonProperty(IBGP_NEIGHBORS_VAR)
+    @JsonProperty(PROP_IBGP_NEIGHBORS)
     public SortedSet<IpEdge> getIbgpNeighbors() {
       return _ibgpNeighbors;
     }
 
-    @JsonProperty(LAN_NEIGHBORS_VAR)
+    @JsonProperty(PROP_LAN_NEIGHBORS)
     public SortedSet<Edge> getLanNeighbors() {
       return _lanNeighbors;
     }
 
-    @JsonProperty(OSPF_NEIGHBORS_VAR)
+    @JsonProperty(PROP_OSPF_NEIGHBORS)
     public SortedSet<IpEdge> getOspfNeighbors() {
       return _ospfNeighbors;
     }
 
-    @JsonProperty(ROLE_EBGP_NEIGHBORS_VAR)
+    @JsonProperty(PROP_ROLE_EBGP_NEIGHBORS)
     public SortedSet<RoleEdge> getRoleEbgpNeighbors() {
       return _roleEbgpNeighbors;
     }
 
-    @JsonProperty(ROLE_IBGP_NEIGHBORS_VAR)
+    @JsonProperty(PROP_ROLE_IBGP_NEIGHBORS)
     public SortedSet<RoleEdge> getRoleIbgpNeighbors() {
       return _roleIbgpNeighbors;
     }
 
-    @JsonProperty(ROLE_LAN_NEIGHBORS_VAR)
+    @JsonProperty(PROP_ROLE_LAN_NEIGHBORS)
     public SortedSet<RoleEdge> getRoleLanNeighbors() {
       return _roleLanNeighbors;
     }
 
-    @JsonProperty(ROLE_OSPF_NEIGHBORS_VAR)
+    @JsonProperty(PROP_ROLE_OSPF_NEIGHBORS)
     public SortedSet<RoleEdge> getRoleOspfNeighbors() {
       return _roleOspfNeighbors;
     }
 
-    @JsonProperty(VERBOSE_EBGP_NEIGHBORS_VAR)
+    @JsonProperty(PROP_VERBOSE_EBGP_NEIGHBORS)
     public SortedSet<VerboseBgpEdge> getVerboseEbgpNeighbors() {
       return _verboseEbgpNeighbors;
     }
 
-    @JsonProperty(VERBOSE_IBGP_NEIGHBORS_VAR)
+    @JsonProperty(PROP_VERBOSE_IBGP_NEIGHBORS)
     public SortedSet<VerboseBgpEdge> getVerboseIbgpNeighbors() {
       return _verboseIbgpNeighbors;
     }
 
-    @JsonProperty(VERBOSE_LAN_NEIGHBORS_VAR)
+    @JsonProperty(PROP_VERBOSE_LAN_NEIGHBORS)
     public SortedSet<VerboseEdge> getVerboseLanNeighbors() {
       return _verboseLanNeighbors;
     }
 
-    @JsonProperty(VERBOSE_OSPF_NEIGHBORS_VAR)
+    @JsonProperty(PROP_VERBOSE_OSPF_NEIGHBORS)
     public SortedSet<VerboseOspfEdge> getVerboseOspfNeighbors() {
       return _verboseOspfNeighbors;
     }
@@ -302,62 +302,62 @@ public class NeighborsQuestionPlugin extends QuestionPlugin {
       return sb.toString();
     }
 
-    @JsonProperty(EBGP_NEIGHBORS_VAR)
+    @JsonProperty(PROP_EBGP_NEIGHBORS)
     public void setEbgpNeighbors(SortedSet<IpEdge> ebgpNeighbors) {
       _ebgpNeighbors = ebgpNeighbors;
     }
 
-    @JsonProperty(IBGP_NEIGHBORS_VAR)
+    @JsonProperty(PROP_IBGP_NEIGHBORS)
     public void setIbgpNeighbors(SortedSet<IpEdge> ibgpNeighbors) {
       _ibgpNeighbors = ibgpNeighbors;
     }
 
-    @JsonProperty(LAN_NEIGHBORS_VAR)
+    @JsonProperty(PROP_LAN_NEIGHBORS)
     public void setLanNeighbors(SortedSet<Edge> lanNeighbors) {
       _lanNeighbors = lanNeighbors;
     }
 
-    @JsonProperty(OSPF_NEIGHBORS_VAR)
+    @JsonProperty(PROP_OSPF_NEIGHBORS)
     public void setOspfNeighbors(SortedSet<IpEdge> ospfNeighbors) {
       _ospfNeighbors = ospfNeighbors;
     }
 
-    @JsonProperty(ROLE_EBGP_NEIGHBORS_VAR)
+    @JsonProperty(PROP_ROLE_EBGP_NEIGHBORS)
     public void setRoleEbgpNeighbors(SortedSet<RoleEdge> roleEbgpNeighbors) {
       _roleEbgpNeighbors = roleEbgpNeighbors;
     }
 
-    @JsonProperty(ROLE_IBGP_NEIGHBORS_VAR)
+    @JsonProperty(PROP_ROLE_IBGP_NEIGHBORS)
     public void setRoleIbgpNeighbors(SortedSet<RoleEdge> roleIbgpNeighbors) {
       _roleIbgpNeighbors = roleIbgpNeighbors;
     }
 
-    @JsonProperty(ROLE_LAN_NEIGHBORS_VAR)
+    @JsonProperty(PROP_ROLE_LAN_NEIGHBORS)
     public void setRoleLanNeighbors(SortedSet<RoleEdge> roleLanNeighbors) {
       _roleLanNeighbors = roleLanNeighbors;
     }
 
-    @JsonProperty(ROLE_OSPF_NEIGHBORS_VAR)
+    @JsonProperty(PROP_ROLE_OSPF_NEIGHBORS)
     public void setRoleOspfNeighbors(SortedSet<RoleEdge> roleOspfNeighbors) {
       _roleOspfNeighbors = roleOspfNeighbors;
     }
 
-    @JsonProperty(VERBOSE_EBGP_NEIGHBORS_VAR)
+    @JsonProperty(PROP_VERBOSE_EBGP_NEIGHBORS)
     public void setVerboseEbgpNeighbors(SortedSet<VerboseBgpEdge> verboseEbgpNeighbors) {
       _verboseEbgpNeighbors = verboseEbgpNeighbors;
     }
 
-    @JsonProperty(VERBOSE_IBGP_NEIGHBORS_VAR)
+    @JsonProperty(PROP_VERBOSE_IBGP_NEIGHBORS)
     public void setVerboseIbgpNeighbors(SortedSet<VerboseBgpEdge> verboseIbgpNeighbors) {
       _verboseIbgpNeighbors = verboseIbgpNeighbors;
     }
 
-    @JsonProperty(VERBOSE_LAN_NEIGHBORS_VAR)
+    @JsonProperty(PROP_VERBOSE_LAN_NEIGHBORS)
     public void setVerboseLanNeighbors(SortedSet<VerboseEdge> verboseLanNeighbors) {
       _verboseLanNeighbors = verboseLanNeighbors;
     }
 
-    @JsonProperty(VERBOSE_OSPF_NEIGHBORS_VAR)
+    @JsonProperty(PROP_VERBOSE_OSPF_NEIGHBORS)
     public void setVerboseOspfNeighbors(SortedSet<VerboseOspfEdge> verboseOspfNeighbors) {
       _verboseOspfNeighbors = verboseOspfNeighbors;
     }
@@ -688,15 +688,15 @@ public class NeighborsQuestionPlugin extends QuestionPlugin {
    */
   public static class NeighborsQuestion extends Question {
 
-    private static final String NEIGHBOR_TYPES_VAR = "neighborTypes";
+    private static final String PROP_NEIGHBOR_TYPES = "neighborTypes";
 
-    private static final String NODE1_REGEX_VAR = "node1Regex";
+    private static final String PROP_NODE1_REGEX = "node1Regex";
 
-    private static final String NODE2_REGEX_VAR = "node2Regex";
+    private static final String PROP_NODE2_REGEX = "node2Regex";
 
-    private static final String STYLE_VAR = "style";
+    private static final String PROP_STYLE = "style";
 
-    private static final String ROLE_SPECIFIER_VAR = "roleSpecifier";
+    private static final String PROP_ROLE_SPECIFIER = "roleSpecifier";
 
     private SortedSet<NeighborType> _neighborTypes;
 
@@ -725,27 +725,27 @@ public class NeighborsQuestionPlugin extends QuestionPlugin {
       return "neighbors";
     }
 
-    @JsonProperty(NEIGHBOR_TYPES_VAR)
+    @JsonProperty(PROP_NEIGHBOR_TYPES)
     public SortedSet<NeighborType> getNeighborTypes() {
       return _neighborTypes;
     }
 
-    @JsonProperty(NODE1_REGEX_VAR)
+    @JsonProperty(PROP_NODE1_REGEX)
     public String getNode1Regex() {
       return _node1Regex;
     }
 
-    @JsonProperty(NODE2_REGEX_VAR)
+    @JsonProperty(PROP_NODE2_REGEX)
     public String getNode2Regex() {
       return _node2Regex;
     }
 
-    @JsonProperty(STYLE_VAR)
+    @JsonProperty(PROP_STYLE)
     public EdgeStyle getStyle() {
       return _style;
     }
 
-    @JsonProperty(ROLE_SPECIFIER_VAR)
+    @JsonProperty(PROP_ROLE_SPECIFIER)
     public NodeRoleSpecifier getRoleSpecifier() {
       return _roleSpecifier;
     }
@@ -762,13 +762,13 @@ public class NeighborsQuestionPlugin extends QuestionPlugin {
             String.format(
                 "neighbors %s%s=%s | %s=%s | %s=%s | %s=%b",
                 prettyPrintBase(),
-                NODE1_REGEX_VAR,
+                PROP_NODE1_REGEX,
                 _node1Regex,
-                NODE2_REGEX_VAR,
+                PROP_NODE2_REGEX,
                 _node2Regex,
-                NEIGHBOR_TYPES_VAR,
+                PROP_NEIGHBOR_TYPES,
                 _neighborTypes.toString(),
-                STYLE_VAR,
+                PROP_STYLE,
                 _style);
         return retString;
       } catch (Exception e) {
@@ -780,27 +780,27 @@ public class NeighborsQuestionPlugin extends QuestionPlugin {
       }
     }
 
-    @JsonProperty(NEIGHBOR_TYPES_VAR)
+    @JsonProperty(PROP_NEIGHBOR_TYPES)
     public void setNeighborTypes(SortedSet<NeighborType> neighborTypes) {
       _neighborTypes = neighborTypes;
     }
 
-    @JsonProperty(NODE1_REGEX_VAR)
+    @JsonProperty(PROP_NODE1_REGEX)
     public void setNode1Regex(String regex) {
       _node1Regex = regex;
     }
 
-    @JsonProperty(NODE2_REGEX_VAR)
+    @JsonProperty(PROP_NODE2_REGEX)
     public void setNode2Regex(String regex) {
       _node2Regex = regex;
     }
 
-    @JsonProperty(STYLE_VAR)
+    @JsonProperty(PROP_STYLE)
     public void setStyle(EdgeStyle style) {
       _style = style;
     }
 
-    @JsonProperty(ROLE_SPECIFIER_VAR)
+    @JsonProperty(PROP_ROLE_SPECIFIER)
     public void setRoleSpecifier(NodeRoleSpecifier roleSpecifier) {
       _roleSpecifier = roleSpecifier;
     }

--- a/projects/question/src/main/java/org/batfish/question/NodesQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/NodesQuestionPlugin.java
@@ -272,9 +272,9 @@ public class NodesQuestionPlugin extends QuestionPlugin {
       }
     }
 
-    private static final String NODES_SUMMARY_VAR = "nodesSummary";
+    private static final String PROP_NODES_SUMMARY = "nodesSummary";
 
-    private static final String NODES_VAR = "nodes";
+    private static final String PROP_NODES = "nodes";
 
     private final SortedMap<String, Configuration> _nodes;
 
@@ -298,18 +298,18 @@ public class NodesQuestionPlugin extends QuestionPlugin {
 
     @JsonCreator
     public NodesAnswerElement(
-        @JsonProperty(NODES_VAR) SortedMap<String, Configuration> nodes,
-        @JsonProperty(NODES_SUMMARY_VAR) SortedMap<String, NodeSummary> nodesSummary) {
+        @JsonProperty(PROP_NODES) SortedMap<String, Configuration> nodes,
+        @JsonProperty(PROP_NODES_SUMMARY) SortedMap<String, NodeSummary> nodesSummary) {
       _nodes = nodes;
       _nodesSummary = nodesSummary;
     }
 
-    @JsonProperty(NODES_VAR)
+    @JsonProperty(PROP_NODES)
     public SortedMap<String, Configuration> getAnswer() {
       return _nodes;
     }
 
-    @JsonProperty(NODES_SUMMARY_VAR)
+    @JsonProperty(PROP_NODES_SUMMARY)
     public SortedMap<String, NodeSummary> getNodesSummary() {
       return _nodesSummary;
     }
@@ -384,13 +384,13 @@ public class NodesQuestionPlugin extends QuestionPlugin {
 
   public static class NodesDiffAnswerElement implements AnswerElement {
 
-    private static final String CONFIG_DIFF_VAR = "configDiff";
+    private static final String PROP_CONFIG_DIFF = "configDiff";
 
-    // private static final String IDENTICAL_VAR = "identical";
+    // private static final String PROP_IDENTICAL = "identical";
 
-    private static final String IN_AFTER_ONLY_VAR = "inAfterOnly";
+    private static final String PROP_IN_AFTER_ONLY = "inAfterOnly";
 
-    private static final String IN_BEFORE_ONLY_VAR = "inBeforeOnly";
+    private static final String PROP_IN_BEFORE_ONLY = "inBeforeOnly";
 
     private static final int MAX_IDENTICAL = 10;
 
@@ -440,44 +440,44 @@ public class NodesQuestionPlugin extends QuestionPlugin {
     }
 
     /** @return the _configDiff */
-    @JsonProperty(CONFIG_DIFF_VAR)
+    @JsonProperty(PROP_CONFIG_DIFF)
     public SortedMap<String, ConfigurationDiff> getConfigDiff() {
       return _configDiff;
     }
 
-    // @JsonProperty(IDENTICAL_VAR)
+    // @JsonProperty(PROP_IDENTICAL)
     @JsonIgnore
     public SortedSet<String> getIdentical() {
       return _identical;
     }
 
-    @JsonProperty(IN_AFTER_ONLY_VAR)
+    @JsonProperty(PROP_IN_AFTER_ONLY)
     public SortedSet<String> getInAfterOnly() {
       return _inAfterOnly;
     }
 
-    @JsonProperty(IN_BEFORE_ONLY_VAR)
+    @JsonProperty(PROP_IN_BEFORE_ONLY)
     public SortedSet<String> getInBeforeOnly() {
       return _inBeforeOnly;
     }
 
-    @JsonProperty(CONFIG_DIFF_VAR)
+    @JsonProperty(PROP_CONFIG_DIFF)
     public void setConfigDiff(SortedMap<String, ConfigurationDiff> configDiff) {
       _configDiff = configDiff;
     }
 
-    // @JsonProperty(IDENTICAL_VAR)
+    // @JsonProperty(PROP_IDENTICAL)
     @JsonIgnore
     public void setIdentical(SortedSet<String> identical) {
       _identical = identical;
     }
 
-    @JsonProperty(IN_AFTER_ONLY_VAR)
+    @JsonProperty(PROP_IN_AFTER_ONLY)
     public void setInAfterOnly(SortedSet<String> inAfterOnly) {
       _inAfterOnly = inAfterOnly;
     }
 
-    @JsonProperty(IN_BEFORE_ONLY_VAR)
+    @JsonProperty(PROP_IN_BEFORE_ONLY)
     public void setInBeforeOnly(SortedSet<String> inBeforeOnly) {
       _inBeforeOnly = inBeforeOnly;
     }
@@ -511,11 +511,11 @@ public class NodesQuestionPlugin extends QuestionPlugin {
    */
   public static class NodesQuestion extends Question {
 
-    private static final String NODE_REGEX_VAR = "nodeRegex";
+    private static final String PROP_NODE_REGEX = "nodeRegex";
 
-    private static final String NODE_TYPES_VAR = "nodeTypes";
+    private static final String PROP_NODE_TYPES = "nodeTypes";
 
-    private static final String SUMMARY_VAR = "summary";
+    private static final String PROP_SUMMARY = "summary";
 
     private String _nodeRegex;
 
@@ -539,17 +539,17 @@ public class NodesQuestionPlugin extends QuestionPlugin {
       return "nodes";
     }
 
-    @JsonProperty(NODE_REGEX_VAR)
+    @JsonProperty(PROP_NODE_REGEX)
     public String getNodeRegex() {
       return _nodeRegex;
     }
 
-    @JsonProperty(NODE_TYPES_VAR)
+    @JsonProperty(PROP_NODE_TYPES)
     public SortedSet<NodeType> getNodeTypes() {
       return _nodeTypes;
     }
 
-    @JsonProperty(SUMMARY_VAR)
+    @JsonProperty(PROP_SUMMARY)
     public boolean getSummary() {
       return _summary;
     }
@@ -559,17 +559,17 @@ public class NodesQuestionPlugin extends QuestionPlugin {
       return false;
     }
 
-    @JsonProperty(NODE_REGEX_VAR)
+    @JsonProperty(PROP_NODE_REGEX)
     public void setNodeRegex(String regex) {
       _nodeRegex = regex;
     }
 
-    @JsonProperty(NODE_TYPES_VAR)
+    @JsonProperty(PROP_NODE_TYPES)
     public void setNodeTypes(SortedSet<NodeType> nodeTypes) {
       _nodeTypes = nodeTypes;
     }
 
-    @JsonProperty(SUMMARY_VAR)
+    @JsonProperty(PROP_SUMMARY)
     public void setSummary(boolean summary) {
       _summary = summary;
     }

--- a/projects/question/src/main/java/org/batfish/question/OspfLoopbacksQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/OspfLoopbacksQuestionPlugin.java
@@ -230,7 +230,7 @@ public class OspfLoopbacksQuestionPlugin extends QuestionPlugin {
    */
   public static class OspfLoopbacksQuestion extends Question {
 
-    private static final String NODE_REGEX_VAR = "nodeRegex";
+    private static final String PROP_NODE_REGEX = "nodeRegex";
 
     private String _nodeRegex;
 
@@ -248,7 +248,7 @@ public class OspfLoopbacksQuestionPlugin extends QuestionPlugin {
       return "ospfloopbacks";
     }
 
-    @JsonProperty(NODE_REGEX_VAR)
+    @JsonProperty(PROP_NODE_REGEX)
     public String getNodeRegex() {
       return _nodeRegex;
     }
@@ -265,7 +265,7 @@ public class OspfLoopbacksQuestionPlugin extends QuestionPlugin {
       return retString;
     }
 
-    @JsonProperty(NODE_REGEX_VAR)
+    @JsonProperty(PROP_NODE_REGEX)
     public void setNodeRegex(String nodeRegex) {
       _nodeRegex = nodeRegex;
     }

--- a/projects/question/src/main/java/org/batfish/question/OspfSessionCheckQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/OspfSessionCheckQuestionPlugin.java
@@ -33,15 +33,15 @@ public class OspfSessionCheckQuestionPlugin extends QuestionPlugin {
 
   public static class OspfSessionCheckAnswerElement implements AnswerElement {
 
-    private static final String ALL_OSPF_NEIGHBORS_VAR = "allOspfNeighbors";
+    private static final String PROP_ALL_OSPF_NEIGHBORS = "allOspfNeighbors";
 
-    private static final String BROKEN_VAR = "broken";
+    private static final String PROP_BROKEN = "broken";
 
-    private static final String HALF_OPEN_VAR = "halfOpen";
+    private static final String PROP_HALF_OPEN = "halfOpen";
 
-    private static final String IGNORED_FOREIGN_ENDPOINTS_VAR = "ignoredForeignEndpoints";
+    private static final String PROP_IGNORED_FOREIGN_ENDPOINTS = "ignoredForeignEndpoints";
 
-    private static final String MISMATCH_LINK_COST_VAR = "mismatchLinkCost";
+    private static final String PROP_MISMATCH_LINK_COST = "mismatchLinkCost";
 
     private SortedMap<String, SortedMap<String, SortedMap<IpPair, OspfNeighborSummary>>>
         _allOspfNeighbors;
@@ -88,28 +88,28 @@ public class OspfSessionCheckQuestionPlugin extends QuestionPlugin {
       neighborsByIp.put(ipPair, ospfNeighbor);
     }
 
-    @JsonProperty(ALL_OSPF_NEIGHBORS_VAR)
+    @JsonProperty(PROP_ALL_OSPF_NEIGHBORS)
     public SortedMap<String, SortedMap<String, SortedMap<IpPair, OspfNeighborSummary>>>
         getAllOspfNeighbors() {
       return _allOspfNeighbors;
     }
 
-    @JsonProperty(BROKEN_VAR)
+    @JsonProperty(PROP_BROKEN)
     private SortedMap<String, SortedMap<String, SortedSet<IpPair>>> getBroken() {
       return _broken;
     }
 
-    @JsonProperty(HALF_OPEN_VAR)
+    @JsonProperty(PROP_HALF_OPEN)
     private SortedMap<String, SortedMap<String, SortedSet<IpPair>>> getHalfOpen() {
       return _halfOpen;
     }
 
-    @JsonProperty(IGNORED_FOREIGN_ENDPOINTS_VAR)
+    @JsonProperty(PROP_IGNORED_FOREIGN_ENDPOINTS)
     private SortedMap<String, SortedMap<String, SortedSet<IpPair>>> getIgnoredForeignEndpoints() {
       return _ignoredForeignEndpoints;
     }
 
-    @JsonProperty(MISMATCH_LINK_COST_VAR)
+    @JsonProperty(PROP_MISMATCH_LINK_COST)
     private SortedMap<String, SortedMap<String, SortedSet<IpPair>>> getMismatchLinkCost() {
       return _mismatchLinkCost;
     }
@@ -117,8 +117,8 @@ public class OspfSessionCheckQuestionPlugin extends QuestionPlugin {
     @Override
     public String prettyPrint() {
       StringBuilder sb = new StringBuilder();
-      sb.append(prettyPrintCategory(_halfOpen, HALF_OPEN_VAR));
-      sb.append(prettyPrintCategory(_mismatchLinkCost, MISMATCH_LINK_COST_VAR));
+      sb.append(prettyPrintCategory(_halfOpen, PROP_HALF_OPEN));
+      sb.append(prettyPrintCategory(_mismatchLinkCost, PROP_MISMATCH_LINK_COST));
       return sb.toString();
     }
 
@@ -148,30 +148,30 @@ public class OspfSessionCheckQuestionPlugin extends QuestionPlugin {
       return sb;
     }
 
-    @JsonProperty(ALL_OSPF_NEIGHBORS_VAR)
+    @JsonProperty(PROP_ALL_OSPF_NEIGHBORS)
     public void setAllOspfNeighbors(
         SortedMap<String, SortedMap<String, SortedMap<IpPair, OspfNeighborSummary>>>
             allOspfNeighbors) {
       _allOspfNeighbors = allOspfNeighbors;
     }
 
-    @JsonProperty(BROKEN_VAR)
+    @JsonProperty(PROP_BROKEN)
     public void setBroken(SortedMap<String, SortedMap<String, SortedSet<IpPair>>> broken) {
       _broken = broken;
     }
 
-    @JsonProperty(HALF_OPEN_VAR)
+    @JsonProperty(PROP_HALF_OPEN)
     public void setHalfOpen(SortedMap<String, SortedMap<String, SortedSet<IpPair>>> halfOpen) {
       _halfOpen = halfOpen;
     }
 
-    @JsonProperty(IGNORED_FOREIGN_ENDPOINTS_VAR)
+    @JsonProperty(PROP_IGNORED_FOREIGN_ENDPOINTS)
     public void setIgnoredForeignEndpoints(
         SortedMap<String, SortedMap<String, SortedSet<IpPair>>> ignoredForeignEndpoints) {
       _ignoredForeignEndpoints = ignoredForeignEndpoints;
     }
 
-    @JsonProperty(MISMATCH_LINK_COST_VAR)
+    @JsonProperty(PROP_MISMATCH_LINK_COST)
     public void setMismatchLinkCost(
         SortedMap<String, SortedMap<String, SortedSet<IpPair>>> mismatchLinkCost) {
       _mismatchLinkCost = mismatchLinkCost;
@@ -303,11 +303,11 @@ public class OspfSessionCheckQuestionPlugin extends QuestionPlugin {
    */
   public static class OspfSessionCheckQuestion extends Question {
 
-    private static final String FOREIGN_OSPF_NETWORKS_VAR = "foreignOspfNetworks";
+    private static final String PROP_FOREIGN_OSPF_NETWORKS = "foreignOspfNetworks";
 
-    private static final String NODE1_REGEX_VAR = "node1Regex";
+    private static final String PROP_NODE1_REGEX = "node1Regex";
 
-    private static final String NODE2_REGEX_VAR = "node2Regex";
+    private static final String PROP_NODE2_REGEX = "node2Regex";
 
     private SortedSet<Prefix> _foreignOspfNetworks;
 
@@ -326,7 +326,7 @@ public class OspfSessionCheckQuestionPlugin extends QuestionPlugin {
       return false;
     }
 
-    @JsonProperty(FOREIGN_OSPF_NETWORKS_VAR)
+    @JsonProperty(PROP_FOREIGN_OSPF_NETWORKS)
     public SortedSet<Prefix> getForeignOspfNetworks() {
       return _foreignOspfNetworks;
     }
@@ -336,12 +336,12 @@ public class OspfSessionCheckQuestionPlugin extends QuestionPlugin {
       return "ospfsessioncheck";
     }
 
-    @JsonProperty(NODE1_REGEX_VAR)
+    @JsonProperty(PROP_NODE1_REGEX)
     public String getNode1Regex() {
       return _node1Regex;
     }
 
-    @JsonProperty(NODE2_REGEX_VAR)
+    @JsonProperty(PROP_NODE2_REGEX)
     public String getNode2Regex() {
       return _node2Regex;
     }
@@ -351,17 +351,17 @@ public class OspfSessionCheckQuestionPlugin extends QuestionPlugin {
       return false;
     }
 
-    @JsonProperty(FOREIGN_OSPF_NETWORKS_VAR)
+    @JsonProperty(PROP_FOREIGN_OSPF_NETWORKS)
     public void setForeignOspfNetworks(SortedSet<Prefix> foreignOspfNetworks) {
       _foreignOspfNetworks = foreignOspfNetworks;
     }
 
-    @JsonProperty(NODE1_REGEX_VAR)
+    @JsonProperty(PROP_NODE1_REGEX)
     public void setNode1Regex(String regex) {
       _node1Regex = regex;
     }
 
-    @JsonProperty(NODE2_REGEX_VAR)
+    @JsonProperty(PROP_NODE2_REGEX)
     public void setNode2Regex(String regex) {
       _node2Regex = regex;
     }

--- a/projects/question/src/main/java/org/batfish/question/OutliersQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/OutliersQuestionPlugin.java
@@ -20,13 +20,13 @@ public class OutliersQuestionPlugin extends QuestionPlugin {
 
   public static class OutliersAnswerElement implements AnswerElement {
 
-    private static final String RANKED_OUTLIERS_VAR = "rankedOutliers";
+    private static final String PROP_RANKED_OUTLIERS = "rankedOutliers";
 
     private SortedSet<NamedStructureOutlierSet<?>> _rankedOutliers;
 
     public OutliersAnswerElement() {}
 
-    @JsonProperty(RANKED_OUTLIERS_VAR)
+    @JsonProperty(PROP_RANKED_OUTLIERS)
     public SortedSet<NamedStructureOutlierSet<?>> getRankedOutliers() {
       return _rankedOutliers;
     }
@@ -41,7 +41,7 @@ public class OutliersQuestionPlugin extends QuestionPlugin {
       return sb.toString();
     }
 
-    @JsonProperty(RANKED_OUTLIERS_VAR)
+    @JsonProperty(PROP_RANKED_OUTLIERS)
     public void setRankedOutliers(SortedSet<NamedStructureOutlierSet<?>> rankedOutliers) {
       _rankedOutliers = rankedOutliers;
     }
@@ -143,11 +143,11 @@ public class OutliersQuestionPlugin extends QuestionPlugin {
    */
   public static final class OutliersQuestion extends Question implements INodeRegexQuestion {
 
-    private static final String MISSING_VAR = "missing";
+    private static final String PROP_MISSING = "missing";
 
-    private static final String NAMED_STRUCT_TYPES_VAR = "namedStructTypes";
+    private static final String PROP_NAMED_STRUCT_TYPES = "namedStructTypes";
 
-    private static final String NODE_REGEX_VAR = "nodeRegex";
+    private static final String PROP_NODE_REGEX = "nodeRegex";
 
     private boolean _missing;
 
@@ -165,7 +165,7 @@ public class OutliersQuestionPlugin extends QuestionPlugin {
       return false;
     }
 
-    @JsonProperty(MISSING_VAR)
+    @JsonProperty(PROP_MISSING)
     public boolean getMissing() {
       return _missing;
     }
@@ -175,13 +175,13 @@ public class OutliersQuestionPlugin extends QuestionPlugin {
       return "outliers";
     }
 
-    @JsonProperty(NAMED_STRUCT_TYPES_VAR)
+    @JsonProperty(PROP_NAMED_STRUCT_TYPES)
     public SortedSet<String> getNamedStructTypes() {
       return _namedStructTypes;
     }
 
     @Override
-    @JsonProperty(NODE_REGEX_VAR)
+    @JsonProperty(PROP_NODE_REGEX)
     public String getNodeRegex() {
       return _nodeRegex;
     }
@@ -191,18 +191,18 @@ public class OutliersQuestionPlugin extends QuestionPlugin {
       return false;
     }
 
-    @JsonProperty(MISSING_VAR)
+    @JsonProperty(PROP_MISSING)
     public void setMissing(boolean missing) {
       _missing = missing;
     }
 
-    @JsonProperty(NAMED_STRUCT_TYPES_VAR)
+    @JsonProperty(PROP_NAMED_STRUCT_TYPES)
     public void setNamedStructTypes(SortedSet<String> namedStructTypes) {
       _namedStructTypes = namedStructTypes;
     }
 
     @Override
-    @JsonProperty(NODE_REGEX_VAR)
+    @JsonProperty(PROP_NODE_REGEX)
     public void setNodeRegex(String regex) {
       _nodeRegex = regex;
     }

--- a/projects/question/src/main/java/org/batfish/question/PairwiseVpnConnectivityQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/PairwiseVpnConnectivityQuestionPlugin.java
@@ -149,9 +149,9 @@ public class PairwiseVpnConnectivityQuestionPlugin extends QuestionPlugin {
    */
   public static class PairwiseVpnConnectivityQuestion extends Question {
 
-    private static final String NODE1_REGEX_VAR = "node1Regex";
+    private static final String PROP_NODE1_REGEX = "node1Regex";
 
-    private static final String NODE2_REGEX_VAR = "node2Regex";
+    private static final String PROP_NODE2_REGEX = "node2Regex";
 
     private String _node1Regex;
 
@@ -172,12 +172,12 @@ public class PairwiseVpnConnectivityQuestionPlugin extends QuestionPlugin {
       return "pairwisevpnconnectivity";
     }
 
-    @JsonProperty(NODE1_REGEX_VAR)
+    @JsonProperty(PROP_NODE1_REGEX)
     public String getNode1Regex() {
       return _node1Regex;
     }
 
-    @JsonProperty(NODE2_REGEX_VAR)
+    @JsonProperty(PROP_NODE2_REGEX)
     public String getNode2Regex() {
       return _node2Regex;
     }
@@ -187,12 +187,12 @@ public class PairwiseVpnConnectivityQuestionPlugin extends QuestionPlugin {
       return false;
     }
 
-    @JsonProperty(NODE1_REGEX_VAR)
+    @JsonProperty(PROP_NODE1_REGEX)
     public void setNode1Regex(String regex) {
       _node1Regex = regex;
     }
 
-    @JsonProperty(NODE2_REGEX_VAR)
+    @JsonProperty(PROP_NODE2_REGEX)
     public void setNode2Regex(String regex) {
       _node2Regex = regex;
     }

--- a/projects/question/src/main/java/org/batfish/question/PerRoleQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/PerRoleQuestionPlugin.java
@@ -22,7 +22,7 @@ public class PerRoleQuestionPlugin extends QuestionPlugin {
 
   public static class PerRoleAnswerElement implements AnswerElement {
 
-    private static final String ANSWERS_VAR = "answers";
+    private static final String PROP_ANSWERS = "answers";
 
     private SortedMap<String, AnswerElement> _answers;
 
@@ -30,7 +30,7 @@ public class PerRoleQuestionPlugin extends QuestionPlugin {
       _answers = new TreeMap<>();
     }
 
-    @JsonProperty(ANSWERS_VAR)
+    @JsonProperty(PROP_ANSWERS)
     public SortedMap<String, AnswerElement> getAnswers() {
       return _answers;
     }
@@ -45,7 +45,7 @@ public class PerRoleQuestionPlugin extends QuestionPlugin {
       return sb.toString();
     }
 
-    @JsonProperty(ANSWERS_VAR)
+    @JsonProperty(PROP_ANSWERS)
     public void setAnswers(SortedMap<String, AnswerElement> answers) {
       _answers = answers;
     }
@@ -143,11 +143,11 @@ public class PerRoleQuestionPlugin extends QuestionPlugin {
    */
   public static final class PerRoleQuestion extends Question {
 
-    private static final String NODE_REGEX_VAR = "nodeRegex";
+    private static final String PROP_NODE_REGEX = "nodeRegex";
 
-    private static final String QUESTION_VAR = "question";
+    private static final String PROP_QUESTION = "question";
 
-    private static final String ROLES_VAR = "roles";
+    private static final String PROP_ROLES = "roles";
 
     private String _nodeRegex;
 
@@ -169,17 +169,17 @@ public class PerRoleQuestionPlugin extends QuestionPlugin {
       return "perrole";
     }
 
-    @JsonProperty(NODE_REGEX_VAR)
+    @JsonProperty(PROP_NODE_REGEX)
     public String getNodeRegex() {
       return _nodeRegex;
     }
 
-    @JsonProperty(QUESTION_VAR)
+    @JsonProperty(PROP_QUESTION)
     public Question getQuestion() {
       return _question;
     }
 
-    @JsonProperty(ROLES_VAR)
+    @JsonProperty(PROP_ROLES)
     public List<String> getRoles() {
       return _roles;
     }
@@ -189,17 +189,17 @@ public class PerRoleQuestionPlugin extends QuestionPlugin {
       return false;
     }
 
-    @JsonProperty(NODE_REGEX_VAR)
+    @JsonProperty(PROP_NODE_REGEX)
     public void setNodeRegex(String regex) {
       _nodeRegex = regex;
     }
 
-    @JsonProperty(QUESTION_VAR)
+    @JsonProperty(PROP_QUESTION)
     public void setQuestion(Question question) {
       _question = question;
     }
 
-    @JsonProperty(ROLES_VAR)
+    @JsonProperty(PROP_ROLES)
     public void setRoleRegexes(List<String> roles) {
       _roles = roles;
     }

--- a/projects/question/src/main/java/org/batfish/question/ReachabilityQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/ReachabilityQuestionPlugin.java
@@ -106,7 +106,7 @@ public class ReachabilityQuestionPlugin extends QuestionPlugin {
    */
   public static class ReachabilityQuestion extends Question implements IReachabilityQuestion {
 
-    private static final String ACTIONS_VAR = "actions";
+    private static final String PROP_ACTIONS = "actions";
 
     private static final String DEFAULT_FINAL_NODE_REGEX = ".*";
 
@@ -116,67 +116,67 @@ public class ReachabilityQuestionPlugin extends QuestionPlugin {
 
     private static final String DEFAULT_NOT_INGRESS_NODE_REGEX = "";
 
-    private static final String DST_IPS_VAR = "dstIps";
+    private static final String PROP_DST_IPS = "dstIps";
 
-    private static final String DST_PORTS_VAR = "dstPorts";
+    private static final String PROP_DST_PORTS = "dstPorts";
 
-    private static final String DST_PROTOCOLS_VAR = "dstProtocols";
+    private static final String PROP_DST_PROTOCOLS = "dstProtocols";
 
-    private static final String FINAL_NODE_REGEX_VAR = "finalNodeRegex";
+    private static final String PROP_FINAL_NODE_REGEX = "finalNodeRegex";
 
-    private static final String FRAGMENT_OFFSETS_VAR = "fragmentOffsets";
+    private static final String PROP_FRAGMENT_OFFSETS = "fragmentOffsets";
 
-    private static final String ICMP_CODES_VAR = "icmpCodes";
+    private static final String PROP_ICMP_CODES = "icmpCodes";
 
-    private static final String ICMP_TYPES_VAR = "icmpTypes";
+    private static final String PROP_ICMP_TYPES = "icmpTypes";
 
-    private static final String INGRESS_NODE_REGEX_VAR = "ingressNodeRegex";
+    private static final String PROP_INGRESS_NODE_REGEX = "ingressNodeRegex";
 
-    private static final String IP_PROTOCOLS_VAR = "ipProtocols";
+    private static final String PROP_IP_PROTOCOLS = "ipProtocols";
 
-    private static final String NEGATE_HEADER_VAR = "negateHeader";
+    private static final String PROP_NEGATE_HEADER = "negateHeader";
 
-    private static final String NOT_DST_IPS_VAR = "notDstIps";
+    private static final String PROP_NOT_DST_IPS = "notDstIps";
 
-    private static final String NOT_DST_PORTS_VAR = "notDstPorts";
+    private static final String PROP_NOT_DST_PORTS = "notDstPorts";
 
-    private static final String NOT_DST_PROTOCOLS_VAR = "notDstProtocols";
+    private static final String PROP_NOT_DST_PROTOCOLS = "notDstProtocols";
 
-    private static final String NOT_FINAL_NODE_REGEX_VAR = "notFinalNodeRegex";
+    private static final String PROP_NOT_FINAL_NODE_REGEX = "notFinalNodeRegex";
 
-    private static final String NOT_FRAGMENT_OFFSETS_VAR = "notFragmentOffsets";
+    private static final String PROP_NOT_FRAGMENT_OFFSETS = "notFragmentOffsets";
 
-    private static final String NOT_ICMP_CODES_VAR = "notIcmpCodes";
+    private static final String PROP_NOT_ICMP_CODES = "notIcmpCodes";
 
-    private static final String NOT_ICMP_TYPES_VAR = "notIcmpTypes";
+    private static final String PROP_NOT_ICMP_TYPES = "notIcmpTypes";
 
-    private static final String NOT_INGRESS_NODE_REGEX_VAR = "notIngressNodeRegex";
+    private static final String PROP_NOT_INGRESS_NODE_REGEX = "notIngressNodeRegex";
 
-    private static final String NOT_IP_PROTOCOLS_VAR = "notIpProtocols";
+    private static final String PROP_NOT_IP_PROTOCOLS = "notIpProtocols";
 
-    private static final String NOT_PACKET_LENGTHS_VAR = "notPacketLengths";
+    private static final String PROP_NOT_PACKET_LENGTHS = "notPacketLengths";
 
-    private static final String NOT_SRC_IPS_VAR = "notSrcIps";
+    private static final String PROP_NOT_SRC_IPS = "notSrcIps";
 
-    private static final String NOT_SRC_PORTS_VAR = "notSrcPorts";
+    private static final String PROP_NOT_SRC_PORTS = "notSrcPorts";
 
-    private static final String NOT_SRC_PROTOCOLS_VAR = "notSrcProtocols";
+    private static final String PROP_NOT_SRC_PROTOCOLS = "notSrcProtocols";
 
-    private static final String PACKET_LENGTHS_VAR = "packetLengths";
+    private static final String PROP_PACKET_LENGTHS = "packetLengths";
 
-    private static final String REACHABILITY_TYPE_VAR = "type";
+    private static final String PROP_REACHABILITY_TYPE = "type";
 
-    private static final String SRC_IPS_VAR = "srcIps";
+    private static final String PROP_SRC_IPS = "srcIps";
 
-    private static final String SRC_OR_DST_IPS_VAR = "srcOrDstIps";
+    private static final String PROP_SRC_OR_DST_IPS = "srcOrDstIps";
 
-    private static final String SRC_OR_DST_PORTS_VAR = "srcOrDstPorts";
+    private static final String PROP_SRC_OR_DST_PORTS = "srcOrDstPorts";
 
-    private static final String SRC_OR_DST_PROTOCOLS_VAR = "srcOrDstProtocols";
+    private static final String PROP_SRC_OR_DST_PROTOCOLS = "srcOrDstProtocols";
 
-    private static final String SRC_PORTS_VAR = "srcPorts";
+    private static final String PROP_SRC_PORTS = "srcPorts";
 
-    private static final String SRC_PROTOCOLS_VAR = "srcProtocols";
+    private static final String PROP_SRC_PROTOCOLS = "srcProtocols";
 
     private SortedSet<ForwardingAction> _actions;
 
@@ -202,7 +202,7 @@ public class ReachabilityQuestionPlugin extends QuestionPlugin {
       _notIngressNodeRegex = DEFAULT_NOT_INGRESS_NODE_REGEX;
     }
 
-    @JsonProperty(ACTIONS_VAR)
+    @JsonProperty(PROP_ACTIONS)
     public SortedSet<ForwardingAction> getActions() {
       return _actions;
     }
@@ -212,27 +212,27 @@ public class ReachabilityQuestionPlugin extends QuestionPlugin {
       return true;
     }
 
-    @JsonProperty(DST_IPS_VAR)
+    @JsonProperty(PROP_DST_IPS)
     public SortedSet<IpWildcard> getDstIps() {
       return _headerSpace.getDstIps();
     }
 
-    @JsonProperty(DST_PORTS_VAR)
+    @JsonProperty(PROP_DST_PORTS)
     public SortedSet<SubRange> getDstPorts() {
       return _headerSpace.getDstPorts();
     }
 
-    @JsonProperty(DST_PROTOCOLS_VAR)
+    @JsonProperty(PROP_DST_PROTOCOLS)
     public SortedSet<Protocol> getDstProtocols() {
       return _headerSpace.getDstProtocols();
     }
 
-    @JsonProperty(FINAL_NODE_REGEX_VAR)
+    @JsonProperty(PROP_FINAL_NODE_REGEX)
     public String getFinalNodeRegex() {
       return _finalNodeRegex;
     }
 
-    @JsonProperty(FRAGMENT_OFFSETS_VAR)
+    @JsonProperty(PROP_FRAGMENT_OFFSETS)
     public SortedSet<SubRange> getFragmentOffsets() {
       return _headerSpace.getFragmentOffsets();
     }
@@ -242,22 +242,22 @@ public class ReachabilityQuestionPlugin extends QuestionPlugin {
       return _headerSpace;
     }
 
-    @JsonProperty(ICMP_CODES_VAR)
+    @JsonProperty(PROP_ICMP_CODES)
     public SortedSet<SubRange> getIcmpCodes() {
       return _headerSpace.getIcmpCodes();
     }
 
-    @JsonProperty(ICMP_TYPES_VAR)
+    @JsonProperty(PROP_ICMP_TYPES)
     public SortedSet<SubRange> getIcmpTypes() {
       return _headerSpace.getIcmpTypes();
     }
 
-    @JsonProperty(INGRESS_NODE_REGEX_VAR)
+    @JsonProperty(PROP_INGRESS_NODE_REGEX)
     public String getIngressNodeRegex() {
       return _ingressNodeRegex;
     }
 
-    @JsonProperty(IP_PROTOCOLS_VAR)
+    @JsonProperty(PROP_IP_PROTOCOLS)
     public SortedSet<IpProtocol> getIpProtocols() {
       return _headerSpace.getIpProtocols();
     }
@@ -267,112 +267,112 @@ public class ReachabilityQuestionPlugin extends QuestionPlugin {
       return NAME;
     }
 
-    @JsonProperty(NEGATE_HEADER_VAR)
+    @JsonProperty(PROP_NEGATE_HEADER)
     public boolean getNegateHeader() {
       return _headerSpace.getNegate();
     }
 
-    @JsonProperty(NOT_DST_IPS_VAR)
+    @JsonProperty(PROP_NOT_DST_IPS)
     public SortedSet<IpWildcard> getNotDstIps() {
       return _headerSpace.getNotDstIps();
     }
 
-    @JsonProperty(NOT_DST_PORTS_VAR)
+    @JsonProperty(PROP_NOT_DST_PORTS)
     public SortedSet<SubRange> getNotDstPorts() {
       return _headerSpace.getNotDstPorts();
     }
 
-    @JsonProperty(NOT_DST_PROTOCOLS_VAR)
+    @JsonProperty(PROP_NOT_DST_PROTOCOLS)
     public SortedSet<Protocol> getNotDstProtocols() {
       return _headerSpace.getNotDstProtocols();
     }
 
-    @JsonProperty(NOT_FINAL_NODE_REGEX_VAR)
+    @JsonProperty(PROP_NOT_FINAL_NODE_REGEX)
     public String getNotFinalNodeRegex() {
       return _notFinalNodeRegex;
     }
 
-    @JsonProperty(NOT_FRAGMENT_OFFSETS_VAR)
+    @JsonProperty(PROP_NOT_FRAGMENT_OFFSETS)
     private SortedSet<SubRange> getNotFragmentOffsets() {
       return _headerSpace.getNotFragmentOffsets();
     }
 
-    @JsonProperty(NOT_ICMP_CODES_VAR)
+    @JsonProperty(PROP_NOT_ICMP_CODES)
     public SortedSet<SubRange> getNotIcmpCodes() {
       return _headerSpace.getNotIcmpCodes();
     }
 
-    @JsonProperty(NOT_ICMP_TYPES_VAR)
+    @JsonProperty(PROP_NOT_ICMP_TYPES)
     public SortedSet<SubRange> getNotIcmpTypes() {
       return _headerSpace.getNotIcmpTypes();
     }
 
-    @JsonProperty(NOT_INGRESS_NODE_REGEX_VAR)
+    @JsonProperty(PROP_NOT_INGRESS_NODE_REGEX)
     public String getNotIngressNodeRegex() {
       return _notIngressNodeRegex;
     }
 
-    @JsonProperty(NOT_IP_PROTOCOLS_VAR)
+    @JsonProperty(PROP_NOT_IP_PROTOCOLS)
     public SortedSet<IpProtocol> getNotIpProtocols() {
       return _headerSpace.getNotIpProtocols();
     }
 
-    @JsonProperty(NOT_PACKET_LENGTHS_VAR)
+    @JsonProperty(PROP_NOT_PACKET_LENGTHS)
     public SortedSet<SubRange> getNotPacketLengths() {
       return _headerSpace.getNotPacketLengths();
     }
 
-    @JsonProperty(NOT_SRC_IPS_VAR)
+    @JsonProperty(PROP_NOT_SRC_IPS)
     public SortedSet<IpWildcard> getNotSrcIps() {
       return _headerSpace.getNotSrcIps();
     }
 
-    @JsonProperty(NOT_SRC_PORTS_VAR)
+    @JsonProperty(PROP_NOT_SRC_PORTS)
     public SortedSet<SubRange> getNotSrcPorts() {
       return _headerSpace.getNotSrcPorts();
     }
 
-    @JsonProperty(NOT_SRC_PROTOCOLS_VAR)
+    @JsonProperty(PROP_NOT_SRC_PROTOCOLS)
     public SortedSet<Protocol> getNotSrcProtocols() {
       return _headerSpace.getNotSrcProtocols();
     }
 
-    @JsonProperty(PACKET_LENGTHS_VAR)
+    @JsonProperty(PROP_PACKET_LENGTHS)
     public SortedSet<SubRange> getPacketLengths() {
       return _headerSpace.getPacketLengths();
     }
 
-    @JsonProperty(REACHABILITY_TYPE_VAR)
+    @JsonProperty(PROP_REACHABILITY_TYPE)
     public ReachabilityType getReachabilityType() {
       return _reachabilityType;
     }
 
-    @JsonProperty(SRC_IPS_VAR)
+    @JsonProperty(PROP_SRC_IPS)
     public SortedSet<IpWildcard> getSrcIps() {
       return _headerSpace.getSrcIps();
     }
 
-    @JsonProperty(SRC_OR_DST_IPS_VAR)
+    @JsonProperty(PROP_SRC_OR_DST_IPS)
     public SortedSet<IpWildcard> getSrcOrDstIps() {
       return _headerSpace.getSrcOrDstIps();
     }
 
-    @JsonProperty(SRC_OR_DST_PORTS_VAR)
+    @JsonProperty(PROP_SRC_OR_DST_PORTS)
     public SortedSet<SubRange> getSrcOrDstPorts() {
       return _headerSpace.getSrcOrDstPorts();
     }
 
-    @JsonProperty(SRC_OR_DST_PROTOCOLS_VAR)
+    @JsonProperty(PROP_SRC_OR_DST_PROTOCOLS)
     public SortedSet<Protocol> getSrcOrDstProtocols() {
       return _headerSpace.getSrcOrDstProtocols();
     }
 
-    @JsonProperty(SRC_PORTS_VAR)
+    @JsonProperty(PROP_SRC_PORTS)
     public SortedSet<SubRange> getSrcPorts() {
       return _headerSpace.getSrcPorts();
     }
 
-    @JsonProperty(SRC_PROTOCOLS_VAR)
+    @JsonProperty(PROP_SRC_PROTOCOLS)
     public SortedSet<Protocol> getSrcProtocols() {
       return _headerSpace.getSrcProtocols();
     }
@@ -389,99 +389,101 @@ public class ReachabilityQuestionPlugin extends QuestionPlugin {
             String.format("reachability %sactions=%s", prettyPrintBase(), _actions.toString());
         // we only print "interesting" values
         if (_reachabilityType != ReachabilityType.STANDARD) {
-          retString += String.format(" | %s=%s", REACHABILITY_TYPE_VAR, _reachabilityType);
+          retString += String.format(" | %s=%s", PROP_REACHABILITY_TYPE, _reachabilityType);
         }
         if (getNegateHeader()) {
           retString += " | negateHeader=true";
         }
         if (getDstIps() != null && !getDstIps().isEmpty()) {
-          retString += String.format(" | %s=%s", DST_IPS_VAR, getDstIps());
+          retString += String.format(" | %s=%s", PROP_DST_IPS, getDstIps());
         }
         if (getDstPorts() != null && !getDstPorts().isEmpty()) {
-          retString += String.format(" | %s=%s", DST_PORTS_VAR, getDstPorts());
+          retString += String.format(" | %s=%s", PROP_DST_PORTS, getDstPorts());
         }
         if (getDstProtocols() != null && !getDstProtocols().isEmpty()) {
-          retString += String.format(" | %s=%s", DST_PROTOCOLS_VAR, getDstProtocols());
+          retString += String.format(" | %s=%s", PROP_DST_PROTOCOLS, getDstProtocols());
         }
         if (!_finalNodeRegex.equals(DEFAULT_FINAL_NODE_REGEX)) {
-          retString += String.format(" | %s=%s", FINAL_NODE_REGEX_VAR, _finalNodeRegex);
+          retString += String.format(" | %s=%s", PROP_FINAL_NODE_REGEX, _finalNodeRegex);
         }
         if (getFragmentOffsets() != null && !getFragmentOffsets().isEmpty()) {
-          retString += String.format(" | %s=%s", FRAGMENT_OFFSETS_VAR, getFragmentOffsets());
+          retString += String.format(" | %s=%s", PROP_FRAGMENT_OFFSETS, getFragmentOffsets());
         }
         if (getIcmpCodes() != null && !getIcmpCodes().isEmpty()) {
-          retString += String.format(" | %s=%s", ICMP_CODES_VAR, getIcmpCodes());
+          retString += String.format(" | %s=%s", PROP_ICMP_CODES, getIcmpCodes());
         }
         if (getIcmpTypes() != null && !getIcmpTypes().isEmpty()) {
-          retString += String.format(" | %s=%s", ICMP_TYPES_VAR, getIcmpTypes());
+          retString += String.format(" | %s=%s", PROP_ICMP_TYPES, getIcmpTypes());
         }
         if (!_ingressNodeRegex.equals(DEFAULT_INGRESS_NODE_REGEX)) {
-          retString += String.format(" | %s=%s", INGRESS_NODE_REGEX_VAR, _ingressNodeRegex);
+          retString += String.format(" | %s=%s", PROP_INGRESS_NODE_REGEX, _ingressNodeRegex);
         }
         if (getIpProtocols() != null && !getIpProtocols().isEmpty()) {
-          retString += String.format(" | %s=%s", IP_PROTOCOLS_VAR, getIpProtocols().toString());
+          retString += String.format(" | %s=%s", PROP_IP_PROTOCOLS, getIpProtocols().toString());
         }
         if (getPacketLengths() != null && !getPacketLengths().isEmpty()) {
-          retString += String.format(" | %s=%s", PACKET_LENGTHS_VAR, getPacketLengths().toString());
+          retString +=
+              String.format(" | %s=%s", PROP_PACKET_LENGTHS, getPacketLengths().toString());
         }
         if (getSrcIps() != null && !getSrcIps().isEmpty()) {
-          retString += String.format(" | %s=%s", SRC_IPS_VAR, getSrcIps());
+          retString += String.format(" | %s=%s", PROP_SRC_IPS, getSrcIps());
         }
         if (getSrcPorts() != null && !getSrcPorts().isEmpty()) {
-          retString += String.format(" | %s=%s", SRC_PORTS_VAR, getSrcPorts());
+          retString += String.format(" | %s=%s", PROP_SRC_PORTS, getSrcPorts());
         }
         if (getSrcProtocols() != null && !getSrcProtocols().isEmpty()) {
-          retString += String.format(" | %s=%s", SRC_PROTOCOLS_VAR, getSrcProtocols());
+          retString += String.format(" | %s=%s", PROP_SRC_PROTOCOLS, getSrcProtocols());
         }
         if (getSrcOrDstIps() != null && !getSrcOrDstIps().isEmpty()) {
-          retString += String.format(" | %s=%s", SRC_OR_DST_IPS_VAR, getSrcOrDstIps());
+          retString += String.format(" | %s=%s", PROP_SRC_OR_DST_IPS, getSrcOrDstIps());
         }
         if (getSrcOrDstPorts() != null && !getSrcOrDstPorts().isEmpty()) {
-          retString += String.format(" | %s=%s", SRC_OR_DST_PORTS_VAR, getSrcOrDstPorts());
+          retString += String.format(" | %s=%s", PROP_SRC_OR_DST_PORTS, getSrcOrDstPorts());
         }
         if (getSrcOrDstProtocols() != null && !getSrcOrDstProtocols().isEmpty()) {
-          retString += String.format(" | %s=%s", SRC_OR_DST_PROTOCOLS_VAR, getSrcOrDstProtocols());
+          retString += String.format(" | %s=%s", PROP_SRC_OR_DST_PROTOCOLS, getSrcOrDstProtocols());
         }
         if (getNotDstIps() != null && !getNotDstIps().isEmpty()) {
-          retString += String.format(" | %s=%s", NOT_DST_IPS_VAR, getNotDstIps());
+          retString += String.format(" | %s=%s", PROP_NOT_DST_IPS, getNotDstIps());
         }
         if (getNotDstPorts() != null && !getNotDstPorts().isEmpty()) {
-          retString += String.format(" | %s=%s", NOT_DST_PORTS_VAR, getNotDstPorts());
+          retString += String.format(" | %s=%s", PROP_NOT_DST_PORTS, getNotDstPorts());
         }
         if (getNotDstProtocols() != null && !getNotDstProtocols().isEmpty()) {
-          retString += String.format(" | %s=%s", NOT_DST_PROTOCOLS_VAR, getNotDstProtocols());
+          retString += String.format(" | %s=%s", PROP_NOT_DST_PROTOCOLS, getNotDstProtocols());
         }
         if (!_notFinalNodeRegex.equals(DEFAULT_NOT_FINAL_NODE_REGEX)) {
-          retString += String.format(" | %s=%s", NOT_FINAL_NODE_REGEX_VAR, _notFinalNodeRegex);
+          retString += String.format(" | %s=%s", PROP_NOT_FINAL_NODE_REGEX, _notFinalNodeRegex);
         }
         if (getNotFragmentOffsets() != null && !getNotFragmentOffsets().isEmpty()) {
-          retString += String.format(" | %s=%s", NOT_FRAGMENT_OFFSETS_VAR, getNotFragmentOffsets());
+          retString +=
+              String.format(" | %s=%s", PROP_NOT_FRAGMENT_OFFSETS, getNotFragmentOffsets());
         }
         if (getNotIcmpCodes() != null && !getNotIcmpCodes().isEmpty()) {
-          retString += String.format(" | %s=%s", NOT_ICMP_CODES_VAR, getNotIcmpCodes());
+          retString += String.format(" | %s=%s", PROP_NOT_ICMP_CODES, getNotIcmpCodes());
         }
         if (getNotIcmpTypes() != null && !getNotIcmpTypes().isEmpty()) {
-          retString += String.format(" | %s=%s", NOT_ICMP_TYPES_VAR, getNotIcmpTypes());
+          retString += String.format(" | %s=%s", PROP_NOT_ICMP_TYPES, getNotIcmpTypes());
         }
         if (!_notIngressNodeRegex.equals(DEFAULT_NOT_INGRESS_NODE_REGEX)) {
-          retString += String.format(" | %s=%s", NOT_INGRESS_NODE_REGEX_VAR, _notIngressNodeRegex);
+          retString += String.format(" | %s=%s", PROP_NOT_INGRESS_NODE_REGEX, _notIngressNodeRegex);
         }
         if (getNotIpProtocols() != null && !getNotIpProtocols().isEmpty()) {
           retString +=
-              String.format(" | %s=%s", NOT_IP_PROTOCOLS_VAR, getNotIpProtocols().toString());
+              String.format(" | %s=%s", PROP_NOT_IP_PROTOCOLS, getNotIpProtocols().toString());
         }
         if (getNotPacketLengths() != null && !getNotPacketLengths().isEmpty()) {
           retString +=
-              String.format(" | %s=%s", NOT_PACKET_LENGTHS_VAR, getNotPacketLengths().toString());
+              String.format(" | %s=%s", PROP_NOT_PACKET_LENGTHS, getNotPacketLengths().toString());
         }
         if (getNotSrcIps() != null && !getNotSrcIps().isEmpty()) {
-          retString += String.format(" | %s=%s", NOT_SRC_IPS_VAR, getNotSrcIps());
+          retString += String.format(" | %s=%s", PROP_NOT_SRC_IPS, getNotSrcIps());
         }
         if (getNotSrcPorts() != null && !getNotSrcPorts().isEmpty()) {
-          retString += String.format(" | %s=%s", NOT_SRC_PORTS_VAR, getNotSrcPorts());
+          retString += String.format(" | %s=%s", PROP_NOT_SRC_PORTS, getNotSrcPorts());
         }
         if (getNotSrcProtocols() != null && !getNotSrcProtocols().isEmpty()) {
-          retString += String.format(" | %s=%s", NOT_SRC_PROTOCOLS_VAR, getNotSrcProtocols());
+          retString += String.format(" | %s=%s", PROP_NOT_SRC_PROTOCOLS, getNotSrcProtocols());
         }
         return retString;
       } catch (Exception e) {
@@ -494,126 +496,126 @@ public class ReachabilityQuestionPlugin extends QuestionPlugin {
     }
 
     @Override
-    @JsonProperty(ACTIONS_VAR)
+    @JsonProperty(PROP_ACTIONS)
     public void setActions(SortedSet<ForwardingAction> actionSet) {
       _actions = new TreeSet<>(actionSet);
     }
 
     @Override
-    @JsonProperty(DST_IPS_VAR)
+    @JsonProperty(PROP_DST_IPS)
     public void setDstIps(SortedSet<IpWildcard> dstIps) {
       _headerSpace.setDstIps(new TreeSet<>(dstIps));
     }
 
-    @JsonProperty(DST_PORTS_VAR)
+    @JsonProperty(PROP_DST_PORTS)
     public void setDstPorts(SortedSet<SubRange> dstPorts) {
       _headerSpace.setDstPorts(new TreeSet<>(dstPorts));
     }
 
     @Override
-    @JsonProperty(DST_PROTOCOLS_VAR)
+    @JsonProperty(PROP_DST_PROTOCOLS)
     public void setDstProtocols(SortedSet<Protocol> dstProtocols) {
       _headerSpace.setDstProtocols(new TreeSet<>(dstProtocols));
     }
 
-    @JsonProperty(FINAL_NODE_REGEX_VAR)
+    @JsonProperty(PROP_FINAL_NODE_REGEX)
     public void setFinalNodeRegex(String regex) {
       _finalNodeRegex = regex;
     }
 
-    @JsonProperty(ICMP_CODES_VAR)
+    @JsonProperty(PROP_ICMP_CODES)
     public void setIcmpCodes(SortedSet<SubRange> icmpCodes) {
       _headerSpace.setIcmpCodes(new TreeSet<>(icmpCodes));
     }
 
-    @JsonProperty(ICMP_TYPES_VAR)
+    @JsonProperty(PROP_ICMP_TYPES)
     public void setIcmpTypes(SortedSet<SubRange> icmpTypes) {
       _headerSpace.setIcmpTypes(new TreeSet<>(icmpTypes));
     }
 
     @Override
-    @JsonProperty(INGRESS_NODE_REGEX_VAR)
+    @JsonProperty(PROP_INGRESS_NODE_REGEX)
     public void setIngressNodeRegex(String regex) {
       _ingressNodeRegex = regex;
     }
 
-    @JsonProperty(IP_PROTOCOLS_VAR)
+    @JsonProperty(PROP_IP_PROTOCOLS)
     public void setIpProtocols(SortedSet<IpProtocol> ipProtocols) {
       _headerSpace.setIpProtocols(ipProtocols);
     }
 
-    @JsonProperty(NEGATE_HEADER_VAR)
+    @JsonProperty(PROP_NEGATE_HEADER)
     public void setNegateHeader(boolean negateHeader) {
       _headerSpace.setNegate(negateHeader);
     }
 
-    @JsonProperty(NOT_DST_IPS_VAR)
+    @JsonProperty(PROP_NOT_DST_IPS)
     public void setNotDstIps(SortedSet<IpWildcard> notDstIps) {
       _headerSpace.setNotDstIps(new TreeSet<>(notDstIps));
     }
 
-    @JsonProperty(NOT_DST_PORTS_VAR)
+    @JsonProperty(PROP_NOT_DST_PORTS)
     public void setNotDstPorts(SortedSet<SubRange> notDstPorts) {
       _headerSpace.setNotDstPorts(new TreeSet<>(notDstPorts));
     }
 
     @Override
-    @JsonProperty(NOT_DST_PROTOCOLS_VAR)
+    @JsonProperty(PROP_NOT_DST_PROTOCOLS)
     public void setNotDstProtocols(SortedSet<Protocol> notDstProtocols) {
       _headerSpace.setNotDstProtocols(new TreeSet<>(notDstProtocols));
     }
 
-    @JsonProperty(NOT_FINAL_NODE_REGEX_VAR)
+    @JsonProperty(PROP_NOT_FINAL_NODE_REGEX)
     public void setNotFinalNodeRegex(String notFinalNodeRegex) {
       _notFinalNodeRegex = notFinalNodeRegex;
     }
 
-    @JsonProperty(NOT_ICMP_CODES_VAR)
+    @JsonProperty(PROP_NOT_ICMP_CODES)
     public void setNotIcmpCodes(SortedSet<SubRange> notIcmpCodes) {
       _headerSpace.setNotIcmpCodes(new TreeSet<>(notIcmpCodes));
     }
 
-    @JsonProperty(NOT_ICMP_TYPES_VAR)
+    @JsonProperty(PROP_NOT_ICMP_TYPES)
     public void setNotIcmpTypes(SortedSet<SubRange> notIcmpType) {
       _headerSpace.setNotIcmpTypes(new TreeSet<>(notIcmpType));
     }
 
-    @JsonProperty(NOT_INGRESS_NODE_REGEX_VAR)
+    @JsonProperty(PROP_NOT_INGRESS_NODE_REGEX)
     public void setNotIngressNodeRegex(String notIngressNodeRegex) {
       _notIngressNodeRegex = notIngressNodeRegex;
     }
 
-    @JsonProperty(NOT_IP_PROTOCOLS_VAR)
+    @JsonProperty(PROP_NOT_IP_PROTOCOLS)
     public void setNotIpProtocols(SortedSet<IpProtocol> notIpProtocols) {
       _headerSpace.setNotIpProtocols(notIpProtocols);
     }
 
-    @JsonProperty(NOT_PACKET_LENGTHS_VAR)
+    @JsonProperty(PROP_NOT_PACKET_LENGTHS)
     public void setNotPacketLengths(SortedSet<SubRange> notPacketLengths) {
       _headerSpace.setNotPacketLengths(new TreeSet<>(notPacketLengths));
     }
 
-    @JsonProperty(NOT_SRC_IPS_VAR)
+    @JsonProperty(PROP_NOT_SRC_IPS)
     public void setNotSrcIps(SortedSet<IpWildcard> notSrcIps) {
       _headerSpace.setNotSrcIps(new TreeSet<>(notSrcIps));
     }
 
-    @JsonProperty(NOT_SRC_PORTS_VAR)
+    @JsonProperty(PROP_NOT_SRC_PORTS)
     public void setNotSrcPortRange(SortedSet<SubRange> notSrcPorts) {
       _headerSpace.setNotSrcPorts(new TreeSet<>(notSrcPorts));
     }
 
-    @JsonProperty(NOT_SRC_PROTOCOLS_VAR)
+    @JsonProperty(PROP_NOT_SRC_PROTOCOLS)
     public void setNotSrcProtocols(SortedSet<Protocol> notSrcProtocols) {
       _headerSpace.setNotSrcProtocols(new TreeSet<>(notSrcProtocols));
     }
 
-    @JsonProperty(PACKET_LENGTHS_VAR)
+    @JsonProperty(PROP_PACKET_LENGTHS)
     public void setPacketLengths(SortedSet<SubRange> packetLengths) {
       _headerSpace.setPacketLengths(new TreeSet<>(packetLengths));
     }
 
-    @JsonProperty(REACHABILITY_TYPE_VAR)
+    @JsonProperty(PROP_REACHABILITY_TYPE)
     public void setReachabilityType(ReachabilityType reachabilityType) {
       _reachabilityType = reachabilityType;
       switch (reachabilityType) {
@@ -633,32 +635,32 @@ public class ReachabilityQuestionPlugin extends QuestionPlugin {
       }
     }
 
-    @JsonProperty(SRC_IPS_VAR)
+    @JsonProperty(PROP_SRC_IPS)
     public void setSrcIps(SortedSet<IpWildcard> srcIps) {
       _headerSpace.setSrcIps(new TreeSet<>(srcIps));
     }
 
-    @JsonProperty(SRC_OR_DST_IPS_VAR)
+    @JsonProperty(PROP_SRC_OR_DST_IPS)
     public void setSrcOrDstIps(SortedSet<IpWildcard> srcOrDstIps) {
       _headerSpace.setSrcOrDstIps(new TreeSet<>(srcOrDstIps));
     }
 
-    @JsonProperty(SRC_OR_DST_PORTS_VAR)
+    @JsonProperty(PROP_SRC_OR_DST_PORTS)
     public void setSrcOrDstPorts(SortedSet<SubRange> srcOrDstPorts) {
       _headerSpace.setSrcOrDstPorts(new TreeSet<>(srcOrDstPorts));
     }
 
-    @JsonProperty(SRC_OR_DST_PROTOCOLS_VAR)
+    @JsonProperty(PROP_SRC_OR_DST_PROTOCOLS)
     public void setSrcOrDstProtocols(SortedSet<Protocol> srcOrDstProtocols) {
       _headerSpace.setSrcOrDstProtocols(new TreeSet<>(srcOrDstProtocols));
     }
 
-    @JsonProperty(SRC_PORTS_VAR)
+    @JsonProperty(PROP_SRC_PORTS)
     public void setSrcPorts(SortedSet<SubRange> srcPorts) {
       _headerSpace.setSrcPorts(new TreeSet<>(srcPorts));
     }
 
-    @JsonProperty(SRC_PROTOCOLS_VAR)
+    @JsonProperty(PROP_SRC_PROTOCOLS)
     public void setSrcProtocols(SortedSet<Protocol> srcProtocols) {
       _headerSpace.setSrcProtocols(new TreeSet<>(srcProtocols));
     }

--- a/projects/question/src/main/java/org/batfish/question/RoutesQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/RoutesQuestionPlugin.java
@@ -29,17 +29,17 @@ public class RoutesQuestionPlugin extends QuestionPlugin {
 
   public static class RoutesAnswerElement implements AnswerElement {
 
-    private static final String ADDED_VAR = "added";
+    private static final String PROP_ADDED = "added";
 
-    private static final String AGAINST_ENVIRONMENT_VAR = "againstEnvironment";
+    private static final String PROP_AGAINST_ENVIRONMENT = "againstEnvironment";
 
-    private static final String DETAIL_ROUTES_BY_HOSTNAME_VAR = "detailRoutesByHostname";
+    private static final String PROP_DETAIL_ROUTES_BY_HOSTNAME = "detailRoutesByHostname";
 
-    private static final String DETAIL_VAR = "detail";
+    private static final String PROP_DETAIL = "detail";
 
-    private static final String REMOVED_VAR = "removed";
+    private static final String PROP_REMOVED = "removed";
 
-    private static final String ROUTES_BY_HOSTNAME_VAR = "routesByHostname";
+    private static final String PROP_ROUTES_BY_HOSTNAME = "routesByHostname";
 
     private SortedSet<Route> _added;
 
@@ -218,33 +218,33 @@ public class RoutesQuestionPlugin extends QuestionPlugin {
       }
     }
 
-    @JsonProperty(ADDED_VAR)
+    @JsonProperty(PROP_ADDED)
     public SortedSet<Route> getAdded() {
       return _added;
     }
 
-    @JsonProperty(AGAINST_ENVIRONMENT_VAR)
+    @JsonProperty(PROP_AGAINST_ENVIRONMENT)
     public boolean getAgainstEnvironment() {
       return _againstEnvironment;
     }
 
-    @JsonProperty(DETAIL_VAR)
+    @JsonProperty(PROP_DETAIL)
     public boolean getDetail() {
       return _detail;
     }
 
-    @JsonProperty(DETAIL_ROUTES_BY_HOSTNAME_VAR)
+    @JsonProperty(PROP_DETAIL_ROUTES_BY_HOSTNAME)
     public SortedMap<String, SortedMap<String, SortedSet<AbstractRoute>>>
         getDetailRoutesByHostname() {
       return _detailRoutesByHostname;
     }
 
-    @JsonProperty(REMOVED_VAR)
+    @JsonProperty(PROP_REMOVED)
     public SortedSet<Route> getRemoved() {
       return _removed;
     }
 
-    @JsonProperty(ROUTES_BY_HOSTNAME_VAR)
+    @JsonProperty(PROP_ROUTES_BY_HOSTNAME)
     public SortedMap<String, RoutesByVrf> getRoutesByHostname() {
       return _routesByHostname;
     }
@@ -294,33 +294,33 @@ public class RoutesQuestionPlugin extends QuestionPlugin {
       return sb.toString();
     }
 
-    @JsonProperty(ADDED_VAR)
+    @JsonProperty(PROP_ADDED)
     public void setAdded(SortedSet<Route> added) {
       _added = added;
     }
 
-    @JsonProperty(AGAINST_ENVIRONMENT_VAR)
+    @JsonProperty(PROP_AGAINST_ENVIRONMENT)
     public void setAgainstEnvironment(boolean againstEnvironment) {
       _againstEnvironment = againstEnvironment;
     }
 
-    @JsonProperty(DETAIL_VAR)
+    @JsonProperty(PROP_DETAIL)
     public void setDetail(boolean detail) {
       _detail = detail;
     }
 
-    @JsonProperty(DETAIL_ROUTES_BY_HOSTNAME_VAR)
+    @JsonProperty(PROP_DETAIL_ROUTES_BY_HOSTNAME)
     public void setDetailRoutesByHostname(
         SortedMap<String, SortedMap<String, SortedSet<AbstractRoute>>> detailRoutesByHostname) {
       _detailRoutesByHostname = detailRoutesByHostname;
     }
 
-    @JsonProperty(REMOVED_VAR)
+    @JsonProperty(PROP_REMOVED)
     public void setRemoved(SortedSet<Route> removed) {
       _removed = removed;
     }
 
-    @JsonProperty(ROUTES_BY_HOSTNAME_VAR)
+    @JsonProperty(PROP_ROUTES_BY_HOSTNAME)
     public void setRoutesByHostname(SortedMap<String, RoutesByVrf> routesByHostname) {
       _routesByHostname = routesByHostname;
     }
@@ -339,13 +339,13 @@ public class RoutesQuestionPlugin extends QuestionPlugin {
         throw new BatfishException(
             String.format(
                 "%s and %s flags are mutually exclusive",
-                RoutesQuestion.AGAINST_ENVIRONMENT_VAR, RoutesQuestion.FROM_ENVIRONMENT_VAR));
+                RoutesQuestion.PROP_AGAINST_ENVIRONMENT, RoutesQuestion.PROP_AGAINST_ENVIRONMENT));
       }
       if (question._againstEnvironment && question._fromEnvironment) {
         throw new BatfishException(
             String.format(
                 "%s and %s flags together are currently unsupported",
-                RoutesQuestion.AGAINST_ENVIRONMENT_VAR, RoutesQuestion.DETAIL_VAR));
+                RoutesQuestion.PROP_AGAINST_ENVIRONMENT, RoutesQuestion.PROP_DETAIL));
       }
       Pattern nodeRegex;
       try {
@@ -400,7 +400,7 @@ public class RoutesQuestionPlugin extends QuestionPlugin {
             "Differential "
                 + _question.getName()
                 + " routes question unsupported when '"
-                + RoutesQuestion.AGAINST_ENVIRONMENT_VAR
+                + RoutesQuestion.PROP_AGAINST_ENVIRONMENT
                 + "' is set, due to unclear semantics of result.");
       }
       _batfish.pushBaseEnvironment();
@@ -428,17 +428,17 @@ public class RoutesQuestionPlugin extends QuestionPlugin {
    */
   public static class RoutesQuestion extends Question {
 
-    private static final String AGAINST_ENVIRONMENT_VAR = "againstEnvironment";
+    private static final String PROP_AGAINST_ENVIRONMENT = "againstEnvironment";
 
-    private static final String DETAIL_VAR = "detail";
+    private static final String PROP_DETAIL = "detail";
 
-    private static final String FROM_ENVIRONMENT_VAR = "fromEnvironment";
+    private static final String PROP_FROM_ENVIRONMENT = "fromEnvironment";
 
-    private static final String NODE_REGEX_VAR = "nodeRegex";
+    private static final String PROP_NODE_REGEX = "nodeRegex";
 
-    private static final String PREFIX_SPACE_VAR = "prefixSpace";
+    private static final String PROP_PREFIX_SPACE = "prefixSpace";
 
-    private static final String PROTOCOLS_VAR = "protocols";
+    private static final String PROP_PROTOCOLS = "protocols";
 
     private boolean _againstEnvironment;
 
@@ -458,7 +458,7 @@ public class RoutesQuestionPlugin extends QuestionPlugin {
       _protocols = new TreeSet<>();
     }
 
-    @JsonProperty(AGAINST_ENVIRONMENT_VAR)
+    @JsonProperty(PROP_AGAINST_ENVIRONMENT)
     public boolean getAgainstEnvironment() {
       return _againstEnvironment;
     }
@@ -468,12 +468,12 @@ public class RoutesQuestionPlugin extends QuestionPlugin {
       return !_fromEnvironment;
     }
 
-    @JsonProperty(DETAIL_VAR)
+    @JsonProperty(PROP_DETAIL)
     public boolean getDetail() {
       return _detail;
     }
 
-    @JsonProperty(FROM_ENVIRONMENT_VAR)
+    @JsonProperty(PROP_FROM_ENVIRONMENT)
     public boolean getFromEnvironment() {
       return _fromEnvironment;
     }
@@ -483,17 +483,17 @@ public class RoutesQuestionPlugin extends QuestionPlugin {
       return "routes";
     }
 
-    @JsonProperty(NODE_REGEX_VAR)
+    @JsonProperty(PROP_NODE_REGEX)
     public String getNodeRegex() {
       return _nodeRegex;
     }
 
-    @JsonProperty(PREFIX_SPACE_VAR)
+    @JsonProperty(PROP_PREFIX_SPACE)
     public PrefixSpace getPrefixSpace() {
       return _prefixSpace;
     }
 
-    @JsonProperty(PROTOCOLS_VAR)
+    @JsonProperty(PROP_PROTOCOLS)
     public SortedSet<RoutingProtocol> getProtocols() {
       return _protocols;
     }
@@ -503,32 +503,32 @@ public class RoutesQuestionPlugin extends QuestionPlugin {
       return false;
     }
 
-    @JsonProperty(AGAINST_ENVIRONMENT_VAR)
+    @JsonProperty(PROP_AGAINST_ENVIRONMENT)
     public void setAgainstEnvironment(boolean againstEnvironment) {
       _againstEnvironment = againstEnvironment;
     }
 
-    @JsonProperty(DETAIL_VAR)
+    @JsonProperty(PROP_DETAIL)
     public void setDetail(boolean detail) {
       _detail = detail;
     }
 
-    @JsonProperty(FROM_ENVIRONMENT_VAR)
+    @JsonProperty(PROP_FROM_ENVIRONMENT)
     public void setFromEnvironment(boolean fromEnvironment) {
       _fromEnvironment = fromEnvironment;
     }
 
-    @JsonProperty(NODE_REGEX_VAR)
+    @JsonProperty(PROP_NODE_REGEX)
     public void setNodeRegex(String nodeRegex) {
       _nodeRegex = nodeRegex;
     }
 
-    @JsonProperty(PREFIX_SPACE_VAR)
+    @JsonProperty(PROP_PREFIX_SPACE)
     public void setPrefixSpace(PrefixSpace prefixSpace) {
       _prefixSpace = prefixSpace;
     }
 
-    @JsonProperty(PROTOCOLS_VAR)
+    @JsonProperty(PROP_PROTOCOLS)
     public void setProtocols(SortedSet<RoutingProtocol> protocols) {
       _protocols = protocols;
     }

--- a/projects/question/src/main/java/org/batfish/question/SelfAdjacenciesQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/SelfAdjacenciesQuestionPlugin.java
@@ -31,24 +31,24 @@ public class SelfAdjacenciesQuestionPlugin extends QuestionPlugin {
 
     public static class InterfaceIpPair extends Pair<String, Ip> {
 
-      private static final String INTERFACE_NAME_VAR = "interfaceName";
+      private static final String PROP_INTERFACE_NAME = "interfaceName";
 
-      private static final String IP_VAR = "ip";
+      private static final String PROP_IP = "ip";
       /** */
       private static final long serialVersionUID = 1L;
 
       @JsonCreator
       public InterfaceIpPair(
-          @JsonProperty(INTERFACE_NAME_VAR) String t1, @JsonProperty(IP_VAR) Ip t2) {
+          @JsonProperty(PROP_INTERFACE_NAME) String t1, @JsonProperty(PROP_IP) Ip t2) {
         super(t1, t2);
       }
 
-      @JsonProperty(INTERFACE_NAME_VAR)
+      @JsonProperty(PROP_INTERFACE_NAME)
       public String getInterfaceName() {
         return _first;
       }
 
-      @JsonProperty(IP_VAR)
+      @JsonProperty(PROP_IP)
       public Ip getIp() {
         return _second;
       }
@@ -151,7 +151,7 @@ public class SelfAdjacenciesQuestionPlugin extends QuestionPlugin {
    */
   public static class SelfAdjacenciesQuestion extends Question {
 
-    private static final String NODE_REGEX_VAR = "nodeRegex";
+    private static final String PROP_NODE_REGEX = "nodeRegex";
 
     private String _nodeRegex;
 
@@ -169,7 +169,7 @@ public class SelfAdjacenciesQuestionPlugin extends QuestionPlugin {
       return "selfadjacencies";
     }
 
-    @JsonProperty(NODE_REGEX_VAR)
+    @JsonProperty(PROP_NODE_REGEX)
     public String getNodeRegex() {
       return _nodeRegex;
     }
@@ -179,7 +179,7 @@ public class SelfAdjacenciesQuestionPlugin extends QuestionPlugin {
       return false;
     }
 
-    @JsonProperty(NODE_REGEX_VAR)
+    @JsonProperty(PROP_NODE_REGEX)
     public void setNodeRegex(String nodeRegex) {
       _nodeRegex = nodeRegex;
     }

--- a/projects/question/src/main/java/org/batfish/question/TracerouteQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/TracerouteQuestionPlugin.java
@@ -174,53 +174,53 @@ public class TracerouteQuestionPlugin extends QuestionPlugin {
    */
   public static class TracerouteQuestion extends Question implements ITracerouteQuestion {
 
-    private static final String DSCP_VAR = "dscp";
+    private static final String PROP_DSCP = "dscp";
 
-    private static final String DST_IP_VAR = "dstIp";
+    private static final String PROP_DST_IP = "dstIp";
 
-    private static final String DST_PORT_VAR = "dstPort";
+    private static final String PROP_DST_PORT = "dstPort";
 
-    private static final String DST_PROTOCOL_VAR = "dstProtocol";
+    private static final String PROP_DST_PROTOCOL = "dstProtocol";
 
-    private static final String ECN_VAR = "ecn";
+    private static final String PROP_ECN = "ecn";
 
-    private static final String ICMP_CODE_VAR = "icmpCode";
+    private static final String PROP_ICMP_CODE = "icmpCode";
 
-    private static final String ICMP_TYPE_VAR = "icmpType";
+    private static final String PROP_ICMP_TYPE = "icmpType";
 
-    private static final String INGRESS_INTERFACE_VAR = "ingressInterface";
+    private static final String PROP_INGRESS_INTERFACE = "ingressInterface";
 
-    private static final String INGRESS_NODE_VAR = "ingressNode";
+    private static final String PROP_INGRESS_NODE = "ingressNode";
 
-    private static final String INGRESS_VRF_VAR = "ingressVrf";
+    private static final String PROP_INGRESS_VRF = "ingressVrf";
 
-    private static final String IP_PROTOCOL_VAR = "ipProtocol";
+    private static final String PROP_IP_PROTOCOL = "ipProtocol";
 
-    private static final String PACKET_LENGTH_VAR = "packetLength";
+    private static final String PROP_PACKET_LENGTH = "packetLength";
 
-    private static final String SRC_IP_VAR = "srcIp";
+    private static final String PROP_SRC_IP = "srcIp";
 
-    private static final String SRC_PORT_VAR = "srcPort";
+    private static final String PROP_SRC_PORT = "srcPort";
 
-    private static final String SRC_PROTOCOL_VAR = "srcProtocol";
+    private static final String PROP_SRC_PROTOCOL = "srcProtocol";
 
-    private static final String STATE_VAR = "state";
+    private static final String PROP_STATE = "state";
 
-    private static final String TCP_FLAGS_ACK_VAR = "tcpAck";
+    private static final String PROP_TCP_FLAGS_ACK = "tcpAck";
 
-    private static final String TCP_FLAGS_CWR_VAR = "tcpCwr";
+    private static final String PROP_TCP_FLAGS_CWR = "tcpCwr";
 
-    private static final String TCP_FLAGS_ECE_VAR = "tcpEce";
+    private static final String PROP_TCP_FLAGS_ECE = "tcpEce";
 
-    private static final String TCP_FLAGS_FIN_VAR = "tcpFin";
+    private static final String PROP_TCP_FLAGS_FIN = "tcpFin";
 
-    private static final String TCP_FLAGS_PSH_VAR = "tcpPsh";
+    private static final String PROP_TCP_FLAGS_PSH = "tcpPsh";
 
-    private static final String TCP_FLAGS_RST_VAR = "tcpRst";
+    private static final String PROP_TCP_FLAGS_RST = "tcpRst";
 
-    private static final String TCP_FLAGS_SYN_VAR = "tcpSyn";
+    private static final String PROP_TCP_FLAGS_SYN = "tcpSyn";
 
-    private static final String TCP_FLAGS_URG_VAR = "tcpUrg";
+    private static final String PROP_TCP_FLAGS_URG = "tcpUrg";
 
     private Integer _dscp;
 
@@ -367,27 +367,27 @@ public class TracerouteQuestionPlugin extends QuestionPlugin {
       return true;
     }
 
-    @JsonProperty(DSCP_VAR)
+    @JsonProperty(PROP_DSCP)
     public Integer getDscp() {
       return _dscp;
     }
 
-    @JsonProperty(DST_IP_VAR)
+    @JsonProperty(PROP_DST_IP)
     public Ip getDstIp() {
       return _dstIp;
     }
 
-    @JsonProperty(DST_PORT_VAR)
+    @JsonProperty(PROP_DST_PORT)
     public Integer getDstPort() {
       return _dstPort;
     }
 
-    @JsonProperty(DST_PROTOCOL_VAR)
+    @JsonProperty(PROP_DST_PROTOCOL)
     public Protocol getDstProtocol() {
       return _dstProtocol;
     }
 
-    @JsonProperty(ECN_VAR)
+    @JsonProperty(PROP_ECN)
     public Integer getEcn() {
       return _ecn;
     }
@@ -397,32 +397,32 @@ public class TracerouteQuestionPlugin extends QuestionPlugin {
       return Collections.singleton(createFlowBuilder());
     }
 
-    @JsonProperty(ICMP_CODE_VAR)
+    @JsonProperty(PROP_ICMP_CODE)
     public Integer getIcmpCode() {
       return _icmpCode;
     }
 
-    @JsonProperty(ICMP_TYPE_VAR)
+    @JsonProperty(PROP_ICMP_TYPE)
     public Integer getIcmpType() {
       return _icmpType;
     }
 
-    @JsonProperty(INGRESS_INTERFACE_VAR)
+    @JsonProperty(PROP_INGRESS_INTERFACE)
     public String getIngressInterface() {
       return _ingressInterface;
     }
 
-    @JsonProperty(INGRESS_NODE_VAR)
+    @JsonProperty(PROP_INGRESS_NODE)
     public String getIngressNode() {
       return _ingressNode;
     }
 
-    @JsonProperty(INGRESS_VRF_VAR)
+    @JsonProperty(PROP_INGRESS_VRF)
     public String getIngressVrf() {
       return _ingressVrf;
     }
 
-    @JsonProperty(IP_PROTOCOL_VAR)
+    @JsonProperty(PROP_IP_PROTOCOL)
     public IpProtocol getIpProtocol() {
       return _ipProtocol;
     }
@@ -432,67 +432,67 @@ public class TracerouteQuestionPlugin extends QuestionPlugin {
       return NAME;
     }
 
-    @JsonProperty(PACKET_LENGTH_VAR)
+    @JsonProperty(PROP_PACKET_LENGTH)
     public Integer getPacketLength() {
       return _packetLength;
     }
 
-    @JsonProperty(SRC_IP_VAR)
+    @JsonProperty(PROP_SRC_IP)
     public Ip getSrcIp() {
       return _srcIp;
     }
 
-    @JsonProperty(SRC_PORT_VAR)
+    @JsonProperty(PROP_SRC_PORT)
     public Integer getSrcPort() {
       return _srcPort;
     }
 
-    @JsonProperty(SRC_PROTOCOL_VAR)
+    @JsonProperty(PROP_SRC_PROTOCOL)
     public Protocol getSrcProtocol() {
       return _srcProtocol;
     }
 
-    @JsonProperty(STATE_VAR)
+    @JsonProperty(PROP_STATE)
     public State getState() {
       return _state;
     }
 
-    @JsonProperty(TCP_FLAGS_ACK_VAR)
+    @JsonProperty(PROP_TCP_FLAGS_ACK)
     public Boolean getTcpFlagsAck() {
       return _tcpFlagsAck;
     }
 
-    @JsonProperty(TCP_FLAGS_CWR_VAR)
+    @JsonProperty(PROP_TCP_FLAGS_CWR)
     public Boolean getTcpFlagsCwr() {
       return _tcpFlagsCwr;
     }
 
-    @JsonProperty(TCP_FLAGS_ECE_VAR)
+    @JsonProperty(PROP_TCP_FLAGS_ECE)
     public Boolean getTcpFlagsEce() {
       return _tcpFlagsEce;
     }
 
-    @JsonProperty(TCP_FLAGS_FIN_VAR)
+    @JsonProperty(PROP_TCP_FLAGS_FIN)
     public Boolean getTcpFlagsFin() {
       return _tcpFlagsFin;
     }
 
-    @JsonProperty(TCP_FLAGS_PSH_VAR)
+    @JsonProperty(PROP_TCP_FLAGS_PSH)
     public Boolean getTcpFlagsPsh() {
       return _tcpFlagsPsh;
     }
 
-    @JsonProperty(TCP_FLAGS_RST_VAR)
+    @JsonProperty(PROP_TCP_FLAGS_RST)
     public Boolean getTcpFlagsRst() {
       return _tcpFlagsRst;
     }
 
-    @JsonProperty(TCP_FLAGS_SYN_VAR)
+    @JsonProperty(PROP_TCP_FLAGS_SYN)
     public Boolean getTcpFlagsSyn() {
       return _tcpFlagsSyn;
     }
 
-    @JsonProperty(TCP_FLAGS_URG_VAR)
+    @JsonProperty(PROP_TCP_FLAGS_URG)
     public Boolean getTcpFlagsUrg() {
       return _tcpFlagsUrg;
     }
@@ -509,73 +509,73 @@ public class TracerouteQuestionPlugin extends QuestionPlugin {
             String.format("traceroute %singressNode=%s", prettyPrintBase(), _ingressNode);
         // we only print "interesting" values
         if (_ingressInterface != null) {
-          retString += String.format(" | %s=%s", INGRESS_INTERFACE_VAR, _ingressInterface);
+          retString += String.format(" | %s=%s", PROP_INGRESS_INTERFACE, _ingressInterface);
         }
         if (_ingressVrf != null) {
-          retString += String.format(" | %s=%s", INGRESS_VRF_VAR, _ingressVrf);
+          retString += String.format(" | %s=%s", PROP_INGRESS_VRF, _ingressVrf);
         }
         if (_dscp != null) {
-          retString += String.format(" | %s=%s", DSCP_VAR, _dscp);
+          retString += String.format(" | %s=%s", PROP_DSCP, _dscp);
         }
         if (_dstIp != null) {
-          retString += String.format(" | %s=%s", DST_IP_VAR, _dstIp);
+          retString += String.format(" | %s=%s", PROP_DST_IP, _dstIp);
         }
         if (_dstPort != null) {
-          retString += String.format(" | %S=%s", DST_PORT_VAR, _dstPort);
+          retString += String.format(" | %S=%s", PROP_DST_PORT, _dstPort);
         }
         if (_dstProtocol != null) {
-          retString += String.format(" | %s=%s", DST_PROTOCOL_VAR, _dstProtocol);
+          retString += String.format(" | %s=%s", PROP_DST_PROTOCOL, _dstProtocol);
         }
         if (_ecn != null) {
-          retString += String.format(" | %s=%s", ECN_VAR, _ecn);
+          retString += String.format(" | %s=%s", PROP_ECN, _ecn);
         }
         if (_icmpCode != null) {
-          retString += String.format(" | %s=%s", ICMP_CODE_VAR, _icmpCode);
+          retString += String.format(" | %s=%s", PROP_ICMP_CODE, _icmpCode);
         }
         if (_icmpType != null) {
-          retString += String.format(" | %s=%s", ICMP_TYPE_VAR, _icmpType);
+          retString += String.format(" | %s=%s", PROP_ICMP_TYPE, _icmpType);
         }
         if (_ipProtocol != null) {
-          retString += String.format(" | %s=%s", IP_PROTOCOL_VAR, _ipProtocol);
+          retString += String.format(" | %s=%s", PROP_IP_PROTOCOL, _ipProtocol);
         }
         if (_packetLength != null) {
-          retString += String.format(" | %s=%s", PACKET_LENGTH_VAR, _packetLength);
+          retString += String.format(" | %s=%s", PROP_PACKET_LENGTH, _packetLength);
         }
         if (_srcIp != null) {
-          retString += String.format(" | %s=%s", SRC_IP_VAR, _srcIp);
+          retString += String.format(" | %s=%s", PROP_SRC_IP, _srcIp);
         }
         if (_srcPort != null) {
-          retString += String.format(" | %s=%s", SRC_PORT_VAR, _srcPort);
+          retString += String.format(" | %s=%s", PROP_SRC_PORT, _srcPort);
         }
         if (_srcProtocol != null) {
-          retString += String.format(" | %s=%s", SRC_PROTOCOL_VAR, _srcProtocol);
+          retString += String.format(" | %s=%s", PROP_SRC_PROTOCOL, _srcProtocol);
         }
         if (_state != null) {
-          retString += String.format(" | %s=%s", STATE_VAR, _state);
+          retString += String.format(" | %s=%s", PROP_STATE, _state);
         }
         if (_tcpFlagsAck != null) {
-          retString += String.format(" | %s=%s", TCP_FLAGS_ACK_VAR, _tcpFlagsAck);
+          retString += String.format(" | %s=%s", PROP_TCP_FLAGS_ACK, _tcpFlagsAck);
         }
         if (_tcpFlagsCwr != null) {
-          retString += String.format(" | %s=%s", TCP_FLAGS_CWR_VAR, _tcpFlagsCwr);
+          retString += String.format(" | %s=%s", PROP_TCP_FLAGS_CWR, _tcpFlagsCwr);
         }
         if (_tcpFlagsEce != null) {
-          retString += String.format(" | %s=%s", TCP_FLAGS_ECE_VAR, _tcpFlagsEce);
+          retString += String.format(" | %s=%s", PROP_TCP_FLAGS_ECE, _tcpFlagsEce);
         }
         if (_tcpFlagsFin != null) {
-          retString += String.format(" | %s=%s", TCP_FLAGS_FIN_VAR, _tcpFlagsFin);
+          retString += String.format(" | %s=%s", PROP_TCP_FLAGS_FIN, _tcpFlagsFin);
         }
         if (_tcpFlagsPsh != null) {
-          retString += String.format(" | %s=%s", TCP_FLAGS_PSH_VAR, _tcpFlagsPsh);
+          retString += String.format(" | %s=%s", PROP_TCP_FLAGS_PSH, _tcpFlagsPsh);
         }
         if (_tcpFlagsRst != null) {
-          retString += String.format(" | %s=%s", TCP_FLAGS_RST_VAR, _tcpFlagsRst);
+          retString += String.format(" | %s=%s", PROP_TCP_FLAGS_RST, _tcpFlagsRst);
         }
         if (_tcpFlagsSyn != null) {
-          retString += String.format(" | %s=%s", TCP_FLAGS_SYN_VAR, _tcpFlagsSyn);
+          retString += String.format(" | %s=%s", PROP_TCP_FLAGS_SYN, _tcpFlagsSyn);
         }
         if (_tcpFlagsUrg != null) {
-          retString += String.format(" | %s=%s", TCP_FLAGS_URG_VAR, _tcpFlagsUrg);
+          retString += String.format(" | %s=%s", PROP_TCP_FLAGS_URG, _tcpFlagsUrg);
         }
         return retString;
       } catch (Exception e) {
@@ -587,126 +587,126 @@ public class TracerouteQuestionPlugin extends QuestionPlugin {
       }
     }
 
-    @JsonProperty(DSCP_VAR)
+    @JsonProperty(PROP_DSCP)
     public void setDscp(Integer dscp) {
       _dscp = dscp;
     }
 
     @Override
-    @JsonProperty(DST_IP_VAR)
+    @JsonProperty(PROP_DST_IP)
     public void setDstIp(Ip dstIp) {
       _dstIp = dstIp;
     }
 
-    @JsonProperty(DST_PORT_VAR)
+    @JsonProperty(PROP_DST_PORT)
     public void setDstPort(Integer dstPort) {
       _dstPort = dstPort;
     }
 
     @Override
-    @JsonProperty(DST_PROTOCOL_VAR)
+    @JsonProperty(PROP_DST_PROTOCOL)
     public void setDstProtocol(Protocol dstProtocol) {
       _dstProtocol = dstProtocol;
     }
 
-    @JsonProperty(ECN_VAR)
+    @JsonProperty(PROP_ECN)
     public void setEcn(Integer ecn) {
       _ecn = ecn;
     }
 
-    @JsonProperty(ICMP_CODE_VAR)
+    @JsonProperty(PROP_ICMP_CODE)
     public void setIcmpCode(Integer icmpCode) {
       _icmpCode = icmpCode;
     }
 
-    @JsonProperty(ICMP_TYPE_VAR)
+    @JsonProperty(PROP_ICMP_TYPE)
     public void setIcmpType(Integer icmpType) {
       _icmpType = icmpType;
     }
 
-    @JsonProperty(INGRESS_INTERFACE_VAR)
+    @JsonProperty(PROP_INGRESS_INTERFACE)
     public void setIngressInterface(String ingressInterface) {
       _ingressInterface = ingressInterface;
     }
 
     @Override
-    @JsonProperty(INGRESS_NODE_VAR)
+    @JsonProperty(PROP_INGRESS_NODE)
     public void setIngressNode(String ingressNode) {
       _ingressNode = ingressNode;
     }
 
     @Override
-    @JsonProperty(INGRESS_VRF_VAR)
+    @JsonProperty(PROP_INGRESS_VRF)
     public void setIngressVrf(String ingressVrf) {
       _ingressVrf = ingressVrf;
     }
 
-    @JsonProperty(IP_PROTOCOL_VAR)
+    @JsonProperty(PROP_IP_PROTOCOL)
     public void setIpProtocol(IpProtocol ipProtocol) {
       _ipProtocol = ipProtocol;
     }
 
-    @JsonProperty(PACKET_LENGTH_VAR)
+    @JsonProperty(PROP_PACKET_LENGTH)
     public void setPacketLength(Integer packetLength) {
       _packetLength = packetLength;
     }
 
-    @JsonProperty(SRC_IP_VAR)
+    @JsonProperty(PROP_SRC_IP)
     public void setSrcIp(Ip srcIp) {
       _srcIp = srcIp;
     }
 
-    @JsonProperty(SRC_PORT_VAR)
+    @JsonProperty(PROP_SRC_PORT)
     public void setSrcPort(Integer srcPort) {
       _srcPort = srcPort;
     }
 
-    @JsonProperty(SRC_PROTOCOL_VAR)
+    @JsonProperty(PROP_SRC_PROTOCOL)
     public void setSrcProtocol(Protocol srcProtocol) {
       _srcProtocol = srcProtocol;
     }
 
-    @JsonProperty(STATE_VAR)
+    @JsonProperty(PROP_STATE)
     public void setState(State state) {
       _state = state;
     }
 
-    @JsonProperty(TCP_FLAGS_ACK_VAR)
+    @JsonProperty(PROP_TCP_FLAGS_ACK)
     public void setTcpFlagsAck(Boolean tcpFlagsAck) {
       _tcpFlagsAck = tcpFlagsAck;
     }
 
-    @JsonProperty(TCP_FLAGS_CWR_VAR)
+    @JsonProperty(PROP_TCP_FLAGS_CWR)
     public void setTcpFlagsCwr(Boolean tcpFlagsCwr) {
       _tcpFlagsCwr = tcpFlagsCwr;
     }
 
-    @JsonProperty(TCP_FLAGS_ECE_VAR)
+    @JsonProperty(PROP_TCP_FLAGS_ECE)
     public void setTcpFlagsEce(Boolean tcpFlagsEce) {
       _tcpFlagsEce = tcpFlagsEce;
     }
 
-    @JsonProperty(TCP_FLAGS_FIN_VAR)
+    @JsonProperty(PROP_TCP_FLAGS_FIN)
     public void setTcpFlagsFin(Boolean tcpFlagsFin) {
       _tcpFlagsFin = tcpFlagsFin;
     }
 
-    @JsonProperty(TCP_FLAGS_PSH_VAR)
+    @JsonProperty(PROP_TCP_FLAGS_PSH)
     public void setTcpFlagsPsh(Boolean tcpFlagsPsh) {
       _tcpFlagsPsh = tcpFlagsPsh;
     }
 
-    @JsonProperty(TCP_FLAGS_RST_VAR)
+    @JsonProperty(PROP_TCP_FLAGS_RST)
     public void setTcpFlagsRst(Boolean tcpFlagsRst) {
       _tcpFlagsRst = tcpFlagsRst;
     }
 
-    @JsonProperty(TCP_FLAGS_SYN_VAR)
+    @JsonProperty(PROP_TCP_FLAGS_SYN)
     public void setTcpFlagsSyn(Boolean tcpFlagsSyn) {
       _tcpFlagsSyn = tcpFlagsSyn;
     }
 
-    @JsonProperty(TCP_FLAGS_URG_VAR)
+    @JsonProperty(PROP_TCP_FLAGS_URG)
     public void setTcpFlagsUrg(Boolean tcpFlagsUrg) {
       _tcpFlagsUrg = tcpFlagsUrg;
     }

--- a/projects/question/src/main/java/org/batfish/question/UndefinedReferencesQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/UndefinedReferencesQuestionPlugin.java
@@ -147,7 +147,7 @@ public class UndefinedReferencesQuestionPlugin extends QuestionPlugin {
    */
   public static class UndefinedReferencesQuestion extends Question {
 
-    private static final String NODE_REGEX_VAR = "nodeRegex";
+    private static final String PROP_NODE_REGEX = "nodeRegex";
 
     private String _nodeRegex;
 
@@ -165,7 +165,7 @@ public class UndefinedReferencesQuestionPlugin extends QuestionPlugin {
       return "undefinedreferences";
     }
 
-    @JsonProperty(NODE_REGEX_VAR)
+    @JsonProperty(PROP_NODE_REGEX)
     public String getNodeRegex() {
       return _nodeRegex;
     }
@@ -175,7 +175,7 @@ public class UndefinedReferencesQuestionPlugin extends QuestionPlugin {
       return false;
     }
 
-    @JsonProperty(NODE_REGEX_VAR)
+    @JsonProperty(PROP_NODE_REGEX)
     public void setNodeRegex(String nodeRegex) {
       _nodeRegex = nodeRegex;
     }

--- a/projects/question/src/main/java/org/batfish/question/UniqueBgpPrefixOriginationQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/UniqueBgpPrefixOriginationQuestionPlugin.java
@@ -140,7 +140,7 @@ public class UniqueBgpPrefixOriginationQuestionPlugin extends QuestionPlugin {
    */
   public static class UniqueBgpPrefixOriginationQuestion extends Question {
 
-    private static final String NODE_REGEX_VAR = "nodeRegex";
+    private static final String PROP_NODE_REGEX = "nodeRegex";
 
     private String _nodeRegex;
 
@@ -158,7 +158,7 @@ public class UniqueBgpPrefixOriginationQuestionPlugin extends QuestionPlugin {
       return "uniquebgpprefixorigination";
     }
 
-    @JsonProperty(NODE_REGEX_VAR)
+    @JsonProperty(PROP_NODE_REGEX)
     public String getNodeRegex() {
       return _nodeRegex;
     }
@@ -168,7 +168,7 @@ public class UniqueBgpPrefixOriginationQuestionPlugin extends QuestionPlugin {
       return false;
     }
 
-    @JsonProperty(NODE_REGEX_VAR)
+    @JsonProperty(PROP_NODE_REGEX)
     public void setNodeRegex(String nodeRegex) {
       _nodeRegex = nodeRegex;
     }

--- a/projects/question/src/main/java/org/batfish/question/UniqueIpAssignmentsQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/UniqueIpAssignmentsQuestionPlugin.java
@@ -207,9 +207,9 @@ public class UniqueIpAssignmentsQuestionPlugin extends QuestionPlugin {
    */
   public static class UniqueIpAssignmentsQuestion extends Question {
 
-    private static final String NODE_REGEX_VAR = "nodeRegex";
+    private static final String PROP_NODE_REGEX = "nodeRegex";
 
-    private static final String VERBOSE_VAR = "verbose";
+    private static final String PROP_VERBOSE = "verbose";
 
     private String _nodeRegex;
 
@@ -229,7 +229,7 @@ public class UniqueIpAssignmentsQuestionPlugin extends QuestionPlugin {
       return "uniqueipassignments";
     }
 
-    @JsonProperty(NODE_REGEX_VAR)
+    @JsonProperty(PROP_NODE_REGEX)
     public String getNodeRegex() {
       return _nodeRegex;
     }
@@ -239,7 +239,7 @@ public class UniqueIpAssignmentsQuestionPlugin extends QuestionPlugin {
       return false;
     }
 
-    @JsonProperty(VERBOSE_VAR)
+    @JsonProperty(PROP_VERBOSE)
     public boolean getVerbose() {
       return _verbose;
     }
@@ -253,12 +253,12 @@ public class UniqueIpAssignmentsQuestionPlugin extends QuestionPlugin {
       return retString;
     }
 
-    @JsonProperty(NODE_REGEX_VAR)
+    @JsonProperty(PROP_NODE_REGEX)
     public void setNodeRegex(String nodeRegex) {
       _nodeRegex = nodeRegex;
     }
 
-    @JsonProperty(VERBOSE_VAR)
+    @JsonProperty(PROP_VERBOSE)
     public void setVerbose(boolean verbose) {
       _verbose = verbose;
     }

--- a/projects/question/src/main/java/org/batfish/question/UnusedStructuresQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/UnusedStructuresQuestionPlugin.java
@@ -134,7 +134,7 @@ public class UnusedStructuresQuestionPlugin extends QuestionPlugin {
    */
   public static class UnusedStructuresQuestion extends Question {
 
-    private static final String NODE_REGEX_VAR = "nodeRegex";
+    private static final String PROP_NODE_REGEX = "nodeRegex";
 
     private String _nodeRegex;
 
@@ -152,7 +152,7 @@ public class UnusedStructuresQuestionPlugin extends QuestionPlugin {
       return "unusedstructures";
     }
 
-    @JsonProperty(NODE_REGEX_VAR)
+    @JsonProperty(PROP_NODE_REGEX)
     public String getNodeRegex() {
       return _nodeRegex;
     }
@@ -162,7 +162,7 @@ public class UnusedStructuresQuestionPlugin extends QuestionPlugin {
       return false;
     }
 
-    @JsonProperty(NODE_REGEX_VAR)
+    @JsonProperty(PROP_NODE_REGEX)
     public void setNodeRegex(String nodeRegex) {
       _nodeRegex = nodeRegex;
     }

--- a/projects/question/src/main/java/org/batfish/question/assertion/AssertQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/assertion/AssertQuestionPlugin.java
@@ -136,7 +136,7 @@ public class AssertQuestionPlugin extends QuestionPlugin {
    */
   public static class AssertQuestion extends Question {
 
-    private static final String ASSERTIONS_VAR = "assertions";
+    private static final String PROP_ASSERTIONS = "assertions";
 
     private List<Assertion> _assertions;
 
@@ -144,7 +144,7 @@ public class AssertQuestionPlugin extends QuestionPlugin {
       _assertions = new ArrayList<>();
     }
 
-    @JsonProperty(ASSERTIONS_VAR)
+    @JsonProperty(PROP_ASSERTIONS)
     public List<Assertion> getAssertions() {
       return _assertions;
     }
@@ -168,11 +168,11 @@ public class AssertQuestionPlugin extends QuestionPlugin {
     public String prettyPrint() {
       String retString =
           String.format(
-              "assert %s%s=\"%s\"", prettyPrintBase(), ASSERTIONS_VAR, _assertions.toString());
+              "assert %s%s=\"%s\"", prettyPrintBase(), PROP_ASSERTIONS, _assertions.toString());
       return retString;
     }
 
-    @JsonProperty(ASSERTIONS_VAR)
+    @JsonProperty(PROP_ASSERTIONS)
     public void setAssertions(List<Assertion> assertions) {
       _assertions = assertions;
     }

--- a/projects/question/src/main/java/org/batfish/question/jsonpath/JsonPathDiffResult.java
+++ b/projects/question/src/main/java/org/batfish/question/jsonpath/JsonPathDiffResult.java
@@ -11,11 +11,11 @@ import org.batfish.question.jsonpath.JsonPathResult.JsonPathResultEntry;
 
 public class JsonPathDiffResult {
 
-  private static final String ADDED_VAR = "added";
+  private static final String PROP_ADDED = "added";
 
-  private static final String PATH_VAR = "path";
+  private static final String PROP_PATH = "path";
 
-  private static final String REMOVED_VAR = "removed";
+  private static final String PROP_REMOVED = "removed";
 
   private SortedMap<String, JsonPathResultEntry> _added;
 
@@ -52,32 +52,32 @@ public class JsonPathDiffResult {
     }
   }
 
-  @JsonProperty(ADDED_VAR)
+  @JsonProperty(PROP_ADDED)
   public SortedMap<String, JsonPathResultEntry> getAdded() {
     return _added;
   }
 
-  @JsonProperty(PATH_VAR)
+  @JsonProperty(PROP_PATH)
   public JsonPathQuery getPath() {
     return _path;
   }
 
-  @JsonProperty(REMOVED_VAR)
+  @JsonProperty(PROP_REMOVED)
   public SortedMap<String, JsonPathResultEntry> getRemoved() {
     return _removed;
   }
 
-  @JsonProperty(ADDED_VAR)
+  @JsonProperty(PROP_ADDED)
   public void setAdded(SortedMap<String, JsonPathResultEntry> added) {
     _added = added;
   }
 
-  @JsonProperty(PATH_VAR)
+  @JsonProperty(PROP_PATH)
   public void setPath(JsonPathQuery path) {
     _path = path;
   }
 
-  @JsonProperty(REMOVED_VAR)
+  @JsonProperty(PROP_REMOVED)
   public void setRemoved(SortedMap<String, JsonPathResultEntry> removed) {
     _removed = removed;
   }

--- a/projects/question/src/main/java/org/batfish/question/jsonpath/JsonPathQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/jsonpath/JsonPathQuestionPlugin.java
@@ -38,7 +38,7 @@ public class JsonPathQuestionPlugin extends QuestionPlugin {
 
   public static class JsonPathAnswerElement implements AnswerElement {
 
-    private static final String RESULTS_VAR = "results";
+    private static final String PROP_RESULTS = "results";
 
     static String prettyPrint(SortedMap<Integer, JsonPathResult> results) {
       StringBuilder sb = new StringBuilder("Results for nodespath\n");
@@ -68,7 +68,7 @@ public class JsonPathQuestionPlugin extends QuestionPlugin {
       _results = new TreeMap<>();
     }
 
-    @JsonProperty(RESULTS_VAR)
+    @JsonProperty(PROP_RESULTS)
     public SortedMap<Integer, JsonPathResult> getResults() {
       return _results;
     }
@@ -78,7 +78,7 @@ public class JsonPathQuestionPlugin extends QuestionPlugin {
       return prettyPrint(_results);
     }
 
-    @JsonProperty(RESULTS_VAR)
+    @JsonProperty(PROP_RESULTS)
     public void setResults(SortedMap<Integer, JsonPathResult> results) {
       _results = results;
     }
@@ -297,7 +297,7 @@ public class JsonPathQuestionPlugin extends QuestionPlugin {
    */
   public static class JsonPathQuestion extends Question {
 
-    private static final String PATHS_VAR = "paths";
+    private static final String PROP_PATHS = "paths";
 
     private Question _innerQuestion;
 
@@ -312,7 +312,7 @@ public class JsonPathQuestionPlugin extends QuestionPlugin {
       return false;
     }
 
-    @JsonProperty(BfConsts.INNER_QUESTION_VAR)
+    @JsonProperty(BfConsts.PROP_INNER_QUESTION)
     public Question getInnerQuestion() {
       return _innerQuestion;
     }
@@ -322,7 +322,7 @@ public class JsonPathQuestionPlugin extends QuestionPlugin {
       return "jsonpath";
     }
 
-    @JsonProperty(PATHS_VAR)
+    @JsonProperty(PROP_PATHS)
     public List<JsonPathQuery> getPaths() {
       return _paths;
     }
@@ -339,19 +339,19 @@ public class JsonPathQuestionPlugin extends QuestionPlugin {
               "%s %s%s=\"%s\" %s=\"%s\"",
               getName(),
               prettyPrintBase(),
-              PATHS_VAR,
+              PROP_PATHS,
               _paths,
-              BfConsts.INNER_QUESTION_VAR,
+              BfConsts.PROP_INNER_QUESTION,
               _innerQuestion.prettyPrint());
       return retString;
     }
 
-    @JsonProperty(BfConsts.INNER_QUESTION_VAR)
+    @JsonProperty(BfConsts.PROP_INNER_QUESTION)
     public void setInnerQuestion(Question innerQuestion) {
       _innerQuestion = innerQuestion;
     }
 
-    @JsonProperty(PATHS_VAR)
+    @JsonProperty(PROP_PATHS)
     public void setPaths(List<JsonPathQuery> paths) {
       _paths = paths;
     }

--- a/projects/question/src/main/java/org/batfish/question/jsonpath/JsonPathResult.java
+++ b/projects/question/src/main/java/org/batfish/question/jsonpath/JsonPathResult.java
@@ -10,9 +10,9 @@ public class JsonPathResult {
 
   public static class JsonPathResultEntry {
 
-    private static final String CONCRETE_PATH_VAR = "concretePath";
+    private static final String PROP_CONCRETE_PATH = "concretePath";
 
-    private static final String SUFFIX_VAR = "suffix";
+    private static final String PROP_SUFFIX = "suffix";
 
     private final ConcreteJsonPath _concretePath;
 
@@ -20,8 +20,8 @@ public class JsonPathResult {
 
     @JsonCreator
     public JsonPathResultEntry(
-        @JsonProperty(CONCRETE_PATH_VAR) ConcreteJsonPath concretePath,
-        @JsonProperty(SUFFIX_VAR) JsonNode suffix) {
+        @JsonProperty(PROP_CONCRETE_PATH) ConcreteJsonPath concretePath,
+        @JsonProperty(PROP_SUFFIX) JsonNode suffix) {
       _concretePath = concretePath;
       if (suffix != null && suffix.isNull()) {
         _suffix = null;
@@ -30,12 +30,12 @@ public class JsonPathResult {
       }
     }
 
-    @JsonProperty(CONCRETE_PATH_VAR)
+    @JsonProperty(PROP_CONCRETE_PATH)
     public ConcreteJsonPath getConcretePath() {
       return _concretePath;
     }
 
-    @JsonProperty(SUFFIX_VAR)
+    @JsonProperty(PROP_SUFFIX)
     public JsonNode getSuffix() {
       return _suffix;
     }

--- a/projects/question/src/main/java/org/batfish/question/jsonpath/NodesPathQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/jsonpath/NodesPathQuestionPlugin.java
@@ -80,11 +80,11 @@ public class NodesPathQuestionPlugin extends QuestionPlugin {
    */
   public static class NodesPathQuestion extends Question {
 
-    private static final String NODE_REGEX_VAR = "nodeRegex";
+    private static final String PROP_NODE_REGEX = "nodeRegex";
 
-    private static final String NODE_TYPES_VAR = "nodeTypes";
+    private static final String PROP_NODE_TYPES = "nodeTypes";
 
-    private static final String PATHS_VAR = "paths";
+    private static final String PROP_PATHS = "paths";
 
     private String _nodeRegex;
 
@@ -108,17 +108,17 @@ public class NodesPathQuestionPlugin extends QuestionPlugin {
       return "nodespath";
     }
 
-    @JsonProperty(NODE_REGEX_VAR)
+    @JsonProperty(PROP_NODE_REGEX)
     public String getNodeRegex() {
       return _nodeRegex;
     }
 
-    @JsonProperty(NODE_TYPES_VAR)
+    @JsonProperty(PROP_NODE_TYPES)
     public SortedSet<NodeType> getNodeTypes() {
       return _nodeTypes;
     }
 
-    @JsonProperty(PATHS_VAR)
+    @JsonProperty(PROP_PATHS)
     public List<JsonPathQuery> getPaths() {
       return _paths;
     }
@@ -131,21 +131,21 @@ public class NodesPathQuestionPlugin extends QuestionPlugin {
     @Override
     public String prettyPrint() {
       String retString =
-          String.format("%s %s%s=\"%s\"", getName(), prettyPrintBase(), PATHS_VAR, _paths);
+          String.format("%s %s%s=\"%s\"", getName(), prettyPrintBase(), PROP_PATHS, _paths);
       return retString;
     }
 
-    @JsonProperty(NODE_REGEX_VAR)
+    @JsonProperty(PROP_NODE_REGEX)
     public void setNodeRegex(String nodeRegex) {
       _nodeRegex = nodeRegex;
     }
 
-    @JsonProperty(NODE_TYPES_VAR)
+    @JsonProperty(PROP_NODE_TYPES)
     public void setNodeTypes(SortedSet<NodeType> nodeTypes) {
       _nodeTypes = nodeTypes;
     }
 
-    @JsonProperty(PATHS_VAR)
+    @JsonProperty(PROP_PATHS)
     public void setPaths(List<JsonPathQuery> paths) {
       _paths = paths;
     }


### PR DESCRIPTION
Strategy: Use Java regex to replace all '(xxx)_VAR' words under @JsonProperty annotation to PROP_(xxx), then search for '(xxx)_VAR' pattern, for each of them, check whether or not it was used inside a @JsonProperty, replace it if it is. (Actually, the only few exceptions are in org.batfish.grammar, org.batfish.z3 and Warnings.java). This closes #303 