### PR TITLE
[Findbugs] Fix a few equals(Object o) methods

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/Pair.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/Pair.java
@@ -2,6 +2,7 @@ package org.batfish.common;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.io.Serializable;
+import java.util.Objects;
 
 public class Pair<T1 extends Comparable<? super T1>, T2 extends Comparable<? super T2>>
     implements Serializable, Comparable<Pair<T1, T2>> {
@@ -31,26 +32,12 @@ public class Pair<T1 extends Comparable<? super T1>, T2 extends Comparable<? sup
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
-    }
-    if (obj == null) {
+    } else if (!(obj instanceof Pair)) {
       return false;
     }
+
     Pair<?, ?> other = (Pair<?, ?>) obj;
-    if (_first == null) {
-      if (other._first != null) {
-        return false;
-      }
-    } else if (!_first.equals(other._first)) {
-      return false;
-    }
-    if (_second == null) {
-      if (other._second != null) {
-        return false;
-      }
-    } else if (!_second.equals(other._second)) {
-      return false;
-    }
-    return true;
+    return Objects.equals(_first, other._first) && Objects.equals(_second, other._second);
   }
 
   @JsonIgnore

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Route6FilterLine.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Route6FilterLine.java
@@ -37,18 +37,14 @@ public class Route6FilterLine implements Serializable {
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
+    } else if (!(obj instanceof Route6FilterLine)) {
+      return false;
     }
+
     Route6FilterLine other = (Route6FilterLine) obj;
-    if (_action != other._action) {
-      return false;
-    }
-    if (!_lengthRange.equals(other._lengthRange)) {
-      return false;
-    }
-    if (!_prefix.equals(other._prefix)) {
-      return false;
-    }
-    return true;
+    return _action == other._action
+        && _lengthRange.equals(other._lengthRange)
+        && _prefix.equals(other._prefix);
   }
 
   @JsonProperty(ACTION_VAR)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Route6FilterList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Route6FilterList.java
@@ -37,11 +37,14 @@ public class Route6FilterList extends ComparableStructure<String> {
   }
 
   @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
+  public boolean equals(Object o) {
+    if (this == o) {
       return true;
+    } else if (!(o instanceof Route6FilterList)) {
+      return false;
     }
-    Route6FilterList other = (Route6FilterList) obj;
+
+    Route6FilterList other = (Route6FilterList) o;
     return other._lines.equals(_lines);
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/StaticRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/StaticRoute.java
@@ -16,11 +16,9 @@ public class StaticRoute extends AbstractRoute {
 
   private final int _administrativeCost;
 
-  @Nonnull
-  private final String _nextHopInterface;
+  @Nonnull private final String _nextHopInterface;
 
-  @Nonnull
-  private final Ip _nextHopIp;
+  @Nonnull private final Ip _nextHopIp;
 
   private final int _tag;
 
@@ -40,6 +38,11 @@ public class StaticRoute extends AbstractRoute {
 
   @Override
   public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    } else if (!(o instanceof StaticRoute)) {
+      return false;
+    }
     StaticRoute rhs = (StaticRoute) o;
     boolean res = _network.equals(rhs._network);
     res = res && _administrativeCost == rhs._administrativeCost;

--- a/projects/batfish/src/main/java/org/batfish/config/Settings.java
+++ b/projects/batfish/src/main/java/org/batfish/config/Settings.java
@@ -256,12 +256,12 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     public boolean equals(Object obj) {
       if (this == obj) {
         return true;
-      }
-      TestrigSettings other = (TestrigSettings) obj;
-      if (!_name.equals(other._name)) {
+      } else if (!(obj instanceof TestrigSettings)) {
         return false;
       }
-      return _environmentSettings._name.equals(other._environmentSettings._name);
+      TestrigSettings other = (TestrigSettings) obj;
+      return _name.equals(other._name)
+          && _environmentSettings._name.equals(other._environmentSettings._name);
     }
 
     public Path getBasePath() {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/BgpAggregateIpv4Network.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/BgpAggregateIpv4Network.java
@@ -14,6 +14,11 @@ public class BgpAggregateIpv4Network extends BgpAggregateNetwork {
 
   @Override
   public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    } else if (!(o instanceof BgpAggregateIpv4Network)) {
+      return false;
+    }
     BgpAggregateIpv4Network rhs = (BgpAggregateIpv4Network) o;
     return _prefix.equals(rhs._prefix);
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/BgpAggregateIpv6Network.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/BgpAggregateIpv6Network.java
@@ -14,6 +14,11 @@ public class BgpAggregateIpv6Network extends BgpAggregateNetwork {
 
   @Override
   public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    } else if (!(o instanceof BgpAggregateIpv6Network)) {
+      return false;
+    }
     BgpAggregateIpv6Network rhs = (BgpAggregateIpv6Network) o;
     return _prefix6.equals(rhs._prefix6);
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/OspfNetwork.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/OspfNetwork.java
@@ -26,6 +26,11 @@ public class OspfNetwork implements Comparable<OspfNetwork>, Serializable {
 
   @Override
   public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    } else if (!(o instanceof OspfNetwork)) {
+      return false;
+    }
     OspfNetwork rhs = (OspfNetwork) o;
     return _prefix.equals(rhs._prefix) && _area == rhs._area;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/OspfWildcardNetwork.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/OspfWildcardNetwork.java
@@ -31,6 +31,11 @@ public class OspfWildcardNetwork implements Comparable<OspfWildcardNetwork>, Ser
 
   @Override
   public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    } else if (!(o instanceof OspfWildcardNetwork)) {
+      return false;
+    }
     OspfWildcardNetwork rhs = (OspfWildcardNetwork) o;
     return _prefix.equals(rhs._prefix) && _wildcard.equals(rhs._wildcard) && _area == rhs._area;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineExact.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineExact.java
@@ -25,12 +25,14 @@ public final class Route4FilterLineExact extends Route4FilterLine {
 
   @Override
   public boolean equals(Object o) {
-    if (!this.getClass().equals(o.getClass())) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof Route4FilterLineExact)) {
       return false;
-    } else {
-      Route4FilterLineExact rhs = (Route4FilterLineExact) o;
-      return _prefix.equals(rhs._prefix);
     }
+
+    Route4FilterLineExact rhs = (Route4FilterLineExact) o;
+    return _prefix.equals(rhs._prefix);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineLengthRange.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineLengthRange.java
@@ -30,14 +30,16 @@ public final class Route4FilterLineLengthRange extends Route4FilterLine {
 
   @Override
   public boolean equals(Object o) {
-    if (!this.getClass().equals(o.getClass())) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof Route4FilterLineLengthRange)) {
       return false;
-    } else {
-      Route4FilterLineLengthRange rhs = (Route4FilterLineLengthRange) o;
-      return _prefix.equals(rhs._prefix)
-          && _minPrefixLength == rhs._minPrefixLength
-          && _maxPrefixLength == rhs._maxPrefixLength;
     }
+
+    Route4FilterLineLengthRange rhs = (Route4FilterLineLengthRange) o;
+    return _prefix.equals(rhs._prefix)
+        && _minPrefixLength == rhs._minPrefixLength
+        && _maxPrefixLength == rhs._maxPrefixLength;
   }
 
   public int getMaxPrefixLength() {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineLonger.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineLonger.java
@@ -29,12 +29,14 @@ public class Route4FilterLineLonger extends Route4FilterLine {
 
   @Override
   public boolean equals(Object o) {
-    if (!this.getClass().equals(o.getClass())) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof Route4FilterLineLonger)) {
       return false;
-    } else {
-      Route4FilterLineLonger rhs = (Route4FilterLineLonger) o;
-      return _prefix.equals(rhs._prefix);
     }
+
+    Route4FilterLineLonger rhs = (Route4FilterLineLonger) o;
+    return _prefix.equals(rhs._prefix);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineOrLonger.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineOrLonger.java
@@ -25,12 +25,14 @@ public class Route4FilterLineOrLonger extends Route4FilterLine {
 
   @Override
   public boolean equals(Object o) {
-    if (!this.getClass().equals(o.getClass())) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof Route4FilterLineOrLonger)) {
       return false;
-    } else {
-      Route4FilterLineOrLonger rhs = (Route4FilterLineOrLonger) o;
-      return _prefix.equals(rhs._prefix);
     }
+
+    Route4FilterLineOrLonger rhs = (Route4FilterLineOrLonger) o;
+    return _prefix.equals(rhs._prefix);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineThrough.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineThrough.java
@@ -34,12 +34,14 @@ public final class Route4FilterLineThrough extends Route4FilterLine {
 
   @Override
   public boolean equals(Object o) {
-    if (!this.getClass().equals(o.getClass())) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof Route4FilterLineThrough)) {
       return false;
-    } else {
-      Route4FilterLineThrough rhs = (Route4FilterLineThrough) o;
-      return _prefix.equals(rhs._prefix) && _throughPrefix.equals(rhs._throughPrefix);
     }
+
+    Route4FilterLineThrough rhs = (Route4FilterLineThrough) o;
+    return _prefix.equals(rhs._prefix) && _throughPrefix.equals(rhs._throughPrefix);
   }
 
   public Prefix getThroughPrefix() {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineUpTo.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineUpTo.java
@@ -28,12 +28,14 @@ public final class Route4FilterLineUpTo extends Route4FilterLine {
 
   @Override
   public boolean equals(Object o) {
-    if (!this.getClass().equals(o.getClass())) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof Route4FilterLineUpTo)) {
       return false;
-    } else {
-      Route4FilterLineUpTo rhs = (Route4FilterLineUpTo) o;
-      return _prefix.equals(rhs._prefix) && _maxPrefixLength == rhs._maxPrefixLength;
     }
+
+    Route4FilterLineUpTo rhs = (Route4FilterLineUpTo) o;
+    return _prefix.equals(rhs._prefix) && _maxPrefixLength == rhs._maxPrefixLength;
   }
 
   public int getMaxPrefixLength() {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Route6FilterLineExact.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Route6FilterLineExact.java
@@ -25,12 +25,14 @@ public final class Route6FilterLineExact extends Route6FilterLine {
 
   @Override
   public boolean equals(Object o) {
-    if (!this.getClass().equals(o.getClass())) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof Route6FilterLineExact)) {
       return false;
-    } else {
-      Route6FilterLineExact rhs = (Route6FilterLineExact) o;
-      return _prefix6.equals(rhs._prefix6);
     }
+
+    Route6FilterLineExact rhs = (Route6FilterLineExact) o;
+    return _prefix6.equals(rhs._prefix6);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Route6FilterLineLengthRange.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Route6FilterLineLengthRange.java
@@ -30,14 +30,16 @@ public final class Route6FilterLineLengthRange extends Route6FilterLine {
 
   @Override
   public boolean equals(Object o) {
-    if (!this.getClass().equals(o.getClass())) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof Route6FilterLineLengthRange)) {
       return false;
-    } else {
-      Route6FilterLineLengthRange rhs = (Route6FilterLineLengthRange) o;
-      return _prefix6.equals(rhs._prefix6)
-          && _minPrefixLength == rhs._minPrefixLength
-          && _maxPrefixLength == rhs._maxPrefixLength;
     }
+
+    Route6FilterLineLengthRange rhs = (Route6FilterLineLengthRange) o;
+    return _prefix6.equals(rhs._prefix6)
+        && _minPrefixLength == rhs._minPrefixLength
+        && _maxPrefixLength == rhs._maxPrefixLength;
   }
 
   public int getMaxPrefixLength() {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Route6FilterLineLonger.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Route6FilterLineLonger.java
@@ -29,12 +29,14 @@ public class Route6FilterLineLonger extends Route6FilterLine {
 
   @Override
   public boolean equals(Object o) {
-    if (!this.getClass().equals(o.getClass())) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof Route6FilterLineLonger)) {
       return false;
-    } else {
-      Route6FilterLineLonger rhs = (Route6FilterLineLonger) o;
-      return _prefix6.equals(rhs._prefix6);
     }
+
+    Route6FilterLineLonger rhs = (Route6FilterLineLonger) o;
+    return _prefix6.equals(rhs._prefix6);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Route6FilterLineOrLonger.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Route6FilterLineOrLonger.java
@@ -25,12 +25,14 @@ public class Route6FilterLineOrLonger extends Route6FilterLine {
 
   @Override
   public boolean equals(Object o) {
-    if (!this.getClass().equals(o.getClass())) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof Route6FilterLineOrLonger)) {
       return false;
-    } else {
-      Route6FilterLineOrLonger rhs = (Route6FilterLineOrLonger) o;
-      return _prefix6.equals(rhs._prefix6);
     }
+
+    Route6FilterLineOrLonger rhs = (Route6FilterLineOrLonger) o;
+    return _prefix6.equals(rhs._prefix6);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Route6FilterLineThrough.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Route6FilterLineThrough.java
@@ -34,12 +34,14 @@ public final class Route6FilterLineThrough extends Route6FilterLine {
 
   @Override
   public boolean equals(Object o) {
-    if (!this.getClass().equals(o.getClass())) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof Route6FilterLineThrough)) {
       return false;
-    } else {
-      Route6FilterLineThrough rhs = (Route6FilterLineThrough) o;
-      return _prefix6.equals(rhs._prefix6) && _throughPrefix6.equals(rhs._throughPrefix6);
     }
+
+    Route6FilterLineThrough rhs = (Route6FilterLineThrough) o;
+    return _prefix6.equals(rhs._prefix6) && _throughPrefix6.equals(rhs._throughPrefix6);
   }
 
   public Prefix6 getThroughPrefix6() {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Route6FilterLineUpTo.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Route6FilterLineUpTo.java
@@ -28,12 +28,14 @@ public final class Route6FilterLineUpTo extends Route6FilterLine {
 
   @Override
   public boolean equals(Object o) {
-    if (!this.getClass().equals(o.getClass())) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof Route6FilterLineUpTo)) {
       return false;
-    } else {
-      Route6FilterLineUpTo rhs = (Route6FilterLineUpTo) o;
-      return _prefix6.equals(rhs._prefix6) && _maxPrefixLength == rhs._maxPrefixLength;
     }
+
+    Route6FilterLineUpTo rhs = (Route6FilterLineUpTo) o;
+    return _prefix6.equals(rhs._prefix6) && _maxPrefixLength == rhs._maxPrefixLength;
   }
 
   public int getMaxPrefixLength() {


### PR DESCRIPTION
* Short-circuit self-equals.
* Handle null and incorrect class (together, as `null instanceof T` is false.)

The only interesting one is Pair, where I used `Objects.equals` to simplify null handling.