### PR TITLE
AWSVPC/Subnet: fix a mistaken variable assignment

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/aws_vpcs/Subnet.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws_vpcs/Subnet.java
@@ -246,7 +246,7 @@ public class Subnet implements AwsVpcEntity, Serializable {
       vgwSubnetIface.getAllPrefixes().add(vgwSubnetIfacePrefix);
       vgwConfigNode.getInterfaces().put(vgwSubnetIfaceName, vgwSubnetIface);
       vgwConfigNode.getDefaultVrf().getInterfaces().put(vgwSubnetIfaceName, vgwSubnetIface);
-      igwAddress = vgwSubnetIfacePrefix.getAddress();
+      vgwAddress = vgwSubnetIfacePrefix.getAddress();
     }
 
     // lets find the right route table for this subnet


### PR DESCRIPTION
The VPN gateway address was never set; we assigned both internet and VPN
gateways addresses to the igwAddress.

Q: what did this fix, if anything? How should I add a test?