### PR TITLE
[Findbugs] Improve @Nullable annotations in route builders

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractRouteBuilder.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractRouteBuilder.java
@@ -2,6 +2,7 @@ package org.batfish.datamodel;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 
+import javax.annotation.Nullable;
 import org.batfish.common.BatfishException;
 
 public abstract class AbstractRouteBuilder<
@@ -56,7 +57,7 @@ public abstract class AbstractRouteBuilder<
     return _nextHopIp;
   }
 
-  public final S setNextHopIp(Ip nextHopIp) {
+  public final S setNextHopIp(@Nullable Ip nextHopIp) {
     _nextHopIp = firstNonNull(nextHopIp, Route.UNSET_ROUTE_NEXT_HOP_IP);
     return getThis();
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/aws_vpcs/Route.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws_vpcs/Route.java
@@ -62,8 +62,8 @@ public class Route implements Serializable {
   public StaticRoute toStaticRoute(
       AwsVpcConfiguration awsVpcConfiguration,
       Ip vpcAddress,
-      Ip igwAddress,
-      Ip vgwAddress,
+      @Nullable Ip igwAddress,
+      @Nullable Ip vgwAddress,
       Subnet subnet,
       Configuration subnetCfgNode) {
     //setting the common properties


### PR DESCRIPTION
AbstractRouteBuilder#setNextHopIp does accept null IPs; it overrides
them with the UNSET value.

Propagate the @Nullability into AWS VPC Route to fix a warning.