### PR TITLE
assign testrigDir a non-empty value

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
@@ -144,7 +144,7 @@ public class BfConsts {
   public static final String RELPATH_SERIALIZED_ENVIRONMENT_ROUTING_TABLES = "rt_processed";
   public static final String RELPATH_TEST_RIG_DIR = "testrig";
   public static final String RELPATH_TESTRIG_TOPOLOGY_PATH = "testrig_topology";
-  public static final String RELPATH_TESTRIGS_DIR = "";
+  public static final String RELPATH_TESTRIGS_DIR = "testrigs";
   public static final String RELPATH_VENDOR_INDEPENDENT_CONFIG_DIR = "indep";
   public static final String RELPATH_VENDOR_SPECIFIC_CONFIG_DIR = "vendor";
 

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -201,7 +201,7 @@ public class Batfish extends PluginConsumer implements AutoCloseable, IBatfish {
 
   public static void applyBaseDir(
       TestrigSettings settings, Path containerDir, String testrig, String envName) {
-    Path testrigDir = containerDir.resolve(testrig);
+    Path testrigDir = containerDir.resolve(BfConsts.RELPATH_TESTRIGS_DIR).resolve(testrig);
     settings.setName(testrig);
     settings.setBasePath(testrigDir);
     EnvironmentSettings envSettings = settings.getEnvironmentSettings();

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -537,9 +537,6 @@ public class WorkMgr {
 
   /** Return a {@link Container container} contains all testrigs directories inside it */
   public Container getContainer(Path containerDir) {
-    if (!Files.exists(containerDir.resolve(BfConsts.RELPATH_TESTRIGS_DIR))) {
-      return Container.of(containerDir.toFile().getName(), new TreeSet<>());
-    }
     SortedSet<String> testrigs =
         new TreeSet<>(
             CommonUtil.getSubdirectories(containerDir.resolve(BfConsts.RELPATH_TESTRIGS_DIR))
@@ -702,6 +699,14 @@ public class WorkMgr {
     if (!containerDir.toFile().mkdirs()) {
       throw new BatfishException("failed to create directory '" + containerDir + "'");
     }
+    Path testrigsDir = containerDir.resolve(BfConsts.RELPATH_TESTRIGS_DIR);
+    if (!testrigsDir.toFile().mkdir()) {
+      throw new BatfishException("failed to create directory '" + testrigsDir + "'");
+    }
+    Path analysesDir = containerDir.resolve(BfConsts.RELPATH_ANALYSES_DIR);
+    if (!analysesDir.toFile().mkdir()) {
+      throw new BatfishException("failed to create directory '" + analysesDir + "'");
+    }
     return containerName;
   }
 
@@ -834,9 +839,11 @@ public class WorkMgr {
     Path testrigDir =
         Main.getSettings()
             .getContainersLocation()
-            .resolve(workItem.getContainerName())
-            .resolve(BfConsts.RELPATH_TESTRIGS_DIR)
-            .resolve(workItem.getTestrigName());
+            .resolve(
+                Paths.get(
+                    workItem.getContainerName(),
+                    BfConsts.RELPATH_TESTRIGS_DIR,
+                    workItem.getTestrigName()));
     if (workItem.getTestrigName().isEmpty() || !Files.exists(testrigDir)) {
       throw new BatfishException("Non-existent testrig: '" + testrigDir.getFileName() + "'");
     }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -129,7 +129,8 @@ public class WorkMgr {
       Path containerDir =
           Main.getSettings().getContainersLocation().resolve(work.getWorkItem().getContainerName());
       String testrigName = work.getWorkItem().getTestrigName();
-      Path testrigBaseDir = containerDir.resolve(testrigName).toAbsolutePath();
+      Path testrigBaseDir =
+          containerDir.resolve(BfConsts.RELPATH_TESTRIGS_DIR).resolve(testrigName).toAbsolutePath();
       task.put(BfConsts.ARG_CONTAINER_DIR, containerDir.toAbsolutePath().toString());
       task.put(BfConsts.ARG_TESTRIG, testrigName);
       task.put(
@@ -536,6 +537,9 @@ public class WorkMgr {
 
   /** Return a {@link Container container} contains all testrigs directories inside it */
   public Container getContainer(Path containerDir) {
+    if (!Files.exists(containerDir.resolve(BfConsts.RELPATH_TESTRIGS_DIR))) {
+      return Container.of(containerDir.toFile().getName(), new TreeSet<>());
+    }
     SortedSet<String> testrigs =
         new TreeSet<>(
             CommonUtil.getSubdirectories(containerDir.resolve(BfConsts.RELPATH_TESTRIGS_DIR))
@@ -830,7 +834,9 @@ public class WorkMgr {
     Path testrigDir =
         Main.getSettings()
             .getContainersLocation()
-            .resolve(Paths.get(workItem.getContainerName(), workItem.getTestrigName()));
+            .resolve(workItem.getContainerName())
+            .resolve(BfConsts.RELPATH_TESTRIGS_DIR)
+            .resolve(workItem.getTestrigName());
     if (workItem.getTestrigName().isEmpty() || !Files.exists(testrigDir)) {
       throw new BatfishException("Non-existent testrig: '" + testrigDir.getFileName() + "'");
     }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
@@ -623,11 +623,8 @@ public class WorkMgrService {
       checkContainerAccessibility(apiKey, containerName);
 
       Container container = Main.getWorkMgr().getContainer(containerDir);
-      container.setName(containerName);
-      BatfishObjectMapper mapper = new BatfishObjectMapper();
-      String containerString = mapper.writeValueAsString(container);
 
-      return Response.ok(containerString, MediaType.APPLICATION_JSON).build();
+      return Response.ok(container).build();
     } catch (AccessControlException e) {
       return Response.status(Status.FORBIDDEN)
           .entity(e.getMessage())

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrServiceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrServiceTest.java
@@ -9,6 +9,7 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import javax.ws.rs.core.Response;
 import org.batfish.common.BatfishLogger;
+import org.batfish.common.BfConsts;
 import org.batfish.common.Container;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.coordinator.config.Settings;
@@ -43,9 +44,10 @@ public class WorkMgrServiceTest {
   public void getEmptyContainer() throws Exception {
     initContainerEnvironment();
     Response response = _service.getContainer("100", "0.0.0", _containerName);
-    String containerJson = response.getEntity().toString();
-    String expected = "{\n  \"name\" : \"myContainer\"\n}";
-    assertThat(containerJson, equalTo(expected));
+    BatfishObjectMapper mapper = new BatfishObjectMapper();
+    Container container = mapper.readValue(response.getEntity().toString(), Container.class);
+    Container expected = Container.of(_containerName, null);
+    assertThat(container, equalTo(expected));
   }
 
   @Test
@@ -71,10 +73,10 @@ public class WorkMgrServiceTest {
   public void getNonEmptyContainer() throws Exception {
     initContainerEnvironment();
     Path containerPath = _folder.getRoot().toPath().resolve(_containerName);
-    Path testrigPath = containerPath.resolve("testrig1");
-    assertThat(testrigPath.toFile().mkdir(), is(true));
-    Path testrigPath2 = containerPath.resolve("testrig2");
-    assertThat(testrigPath2.toFile().mkdir(), is(true));
+    Path testrigPath = containerPath.resolve(BfConsts.RELPATH_TESTRIGS_DIR).resolve("testrig1");
+    assertThat(testrigPath.toFile().mkdirs(), is(true));
+    Path testrigPath2 = containerPath.resolve(BfConsts.RELPATH_TESTRIGS_DIR).resolve("testrig2");
+    assertThat(testrigPath2.toFile().mkdirs(), is(true));
     Response response = _service.getContainer("100", "0.0.0", _containerName);
     BatfishObjectMapper mapper = new BatfishObjectMapper();
     Container container = mapper.readValue(response.getEntity().toString(), Container.class);

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrServiceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrServiceTest.java
@@ -4,14 +4,14 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 
+import com.google.common.collect.Sets;
 import java.nio.file.Path;
-import java.util.SortedSet;
+import java.util.Collections;
 import java.util.TreeSet;
 import javax.ws.rs.core.Response;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.BfConsts;
 import org.batfish.common.Container;
-import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.coordinator.config.Settings;
 import org.junit.Rule;
 import org.junit.Test;
@@ -30,13 +30,12 @@ public class WorkMgrServiceTest {
   private void initContainerEnvironment() throws Exception {
     Settings settings = new Settings(new String[] {});
     BatfishLogger logger = new BatfishLogger("debug", false);
-    Main.mainInit(new String[] {});
-    _folder.newFolder(_containerName);
     Main.mainInit(new String[] {"-containerslocation", _folder.getRoot().toString()});
     Main.initAuthorizer();
     Main.setLogger(logger);
     _manager = new WorkMgr(settings, logger);
     Main.setWorkMgr(_manager);
+    _manager.initContainer(_containerName, null);
     _service = new WorkMgrService();
   }
 
@@ -44,9 +43,8 @@ public class WorkMgrServiceTest {
   public void getEmptyContainer() throws Exception {
     initContainerEnvironment();
     Response response = _service.getContainer("100", "0.0.0", _containerName);
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
-    Container container = mapper.readValue(response.getEntity().toString(), Container.class);
-    Container expected = Container.of(_containerName, null);
+    Container container = (Container) response.getEntity();
+    Container expected = Container.of(_containerName, new TreeSet<>());
     assertThat(container, equalTo(expected));
   }
 
@@ -73,17 +71,12 @@ public class WorkMgrServiceTest {
   public void getNonEmptyContainer() throws Exception {
     initContainerEnvironment();
     Path containerPath = _folder.getRoot().toPath().resolve(_containerName);
-    Path testrigPath = containerPath.resolve(BfConsts.RELPATH_TESTRIGS_DIR).resolve("testrig1");
+    Path testrigPath = containerPath.resolve(BfConsts.RELPATH_TESTRIGS_DIR).resolve("testrig");
     assertThat(testrigPath.toFile().mkdirs(), is(true));
-    Path testrigPath2 = containerPath.resolve(BfConsts.RELPATH_TESTRIGS_DIR).resolve("testrig2");
-    assertThat(testrigPath2.toFile().mkdirs(), is(true));
     Response response = _service.getContainer("100", "0.0.0", _containerName);
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
-    Container container = mapper.readValue(response.getEntity().toString(), Container.class);
-    assertThat(container.getName(), equalTo(_containerName));
-    SortedSet<String> expectedTestrigs = new TreeSet<>();
-    expectedTestrigs.add("testrig1");
-    expectedTestrigs.add("testrig2");
-    assertThat(container.getTestrigs(), equalTo(expectedTestrigs));
+    Container container = (Container) response.getEntity();
+    Container expected =
+        Container.of(_containerName, Sets.newTreeSet(Collections.singleton("testrig")));
+    assertThat(container, equalTo(expected));
   }
 }

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
@@ -75,19 +75,25 @@ public class WorkMgrTest {
 
   @Test
   public void listEmptyQuestion() throws IOException {
+    Main.mainInit(new String[] {"-containerslocation", _folder.getRoot().toString()});
     String containerPath = _folder.newFolder("container").getPath();
-    String testrigPath = _folder.newFolder("testrigPath").getPath();
-    SortedSet<String> questions = _manager.listQuestions(containerPath, testrigPath);
+    Path testrigPath =
+        Paths.get(containerPath).resolve(BfConsts.RELPATH_TESTRIGS_DIR).resolve("testrigPath");
+    assertThat(testrigPath.toFile().mkdirs(), is(true));
+    SortedSet<String> questions = _manager.listQuestions("container", "testrigPath");
     assertThat(questions.isEmpty(), is(true));
   }
 
   @Test
   public void listQuestionNames() throws IOException {
+    Main.mainInit(new String[] {"-containerslocation", _folder.getRoot().toString()});
     String containerPath = _folder.newFolder("container").getPath();
-    String testrigPath = _folder.newFolder("testrigPath").getPath();
-    Path questionsDir = Paths.get(testrigPath).resolve(BfConsts.RELPATH_QUESTIONS_DIR);
+    Path testrigPath =
+        Paths.get(containerPath).resolve(BfConsts.RELPATH_TESTRIGS_DIR).resolve("testrigPath");
+    assertThat(testrigPath.toFile().mkdirs(), is(true));
+    Path questionsDir = testrigPath.resolve(BfConsts.RELPATH_QUESTIONS_DIR);
     assertThat(questionsDir.resolve("initinfo").toFile().mkdirs(), is(true));
-    SortedSet<String> questions = _manager.listQuestions(containerPath, testrigPath);
+    SortedSet<String> questions = _manager.listQuestions("container", "testrigPath");
     assertThat(questions.size(), is(1));
     assertThat(questions.first(), equalTo("initinfo"));
   }
@@ -111,13 +117,16 @@ public class WorkMgrTest {
 
   @Test
   public void listSortedQuestionNames() throws IOException {
+    Main.mainInit(new String[] {"-containerslocation", _folder.getRoot().toString()});
     String containerPath = _folder.newFolder("container").getPath();
-    String testrigPath = _folder.newFolder("testrigPath").getPath();
-    Path questionsDir = Paths.get(testrigPath).resolve(BfConsts.RELPATH_QUESTIONS_DIR);
+    Path testrigPath =
+        Paths.get(containerPath).resolve(BfConsts.RELPATH_TESTRIGS_DIR).resolve("testrigPath");
+    assertThat(testrigPath.toFile().mkdirs(), is(true));
+    Path questionsDir = testrigPath.resolve(BfConsts.RELPATH_QUESTIONS_DIR);
     assertThat(questionsDir.resolve("nodes").toFile().mkdirs(), is(true));
     assertThat(questionsDir.resolve("access").toFile().mkdirs(), is(true));
     assertThat(questionsDir.resolve("initinfo").toFile().mkdirs(), is(true));
-    SortedSet<String> questions = _manager.listQuestions(containerPath, testrigPath);
+    SortedSet<String> questions = _manager.listQuestions("container", "testrigPath");
     assertThat(questions.size(), is(3));
     assertThat(questions.toString(), equalTo("[access, initinfo, nodes]"));
   }
@@ -141,24 +150,15 @@ public class WorkMgrTest {
     String containerName = "myContainer";
     initContainerEnvironment(containerName);
     Path containerPath = _folder.getRoot().toPath().resolve(containerName);
-    Path testrigPath = containerPath.resolve("testrig1");
-    assertThat(testrigPath.toFile().mkdir(), is(true));
-    Path testrigPath2 = containerPath.resolve("testrig2");
-    assertThat(testrigPath2.toFile().mkdir(), is(true));
+    Path testrigPath = containerPath.resolve(BfConsts.RELPATH_TESTRIGS_DIR).resolve("testrig1");
+    assertThat(testrigPath.toFile().mkdirs(), is(true));
+    Path testrigPath2 = containerPath.resolve(BfConsts.RELPATH_TESTRIGS_DIR).resolve("testrig2");
+    assertThat(testrigPath2.toFile().mkdirs(), is(true));
     Path containerDir = Paths.get(_folder.getRoot().toPath().resolve(containerName).toString());
     Container container = _manager.getContainer(containerDir);
     SortedSet<String> expectedTestrigs = new TreeSet<>();
     expectedTestrigs.add("testrig1");
     expectedTestrigs.add("testrig2");
     assertThat(container.getTestrigs(), equalTo(expectedTestrigs));
-  }
-
-  @Test
-  public void getNonExistContainer() {
-    String containerName = "myContainer";
-    Path containerDir = Paths.get(_folder.getRoot().toPath().resolve(containerName).toString());
-    _thrown.expect(BatfishException.class);
-    _thrown.expectMessage(equalTo("Error listing directory '" + containerDir + "'"));
-    _manager.getContainer(containerDir);
   }
 }

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
@@ -4,10 +4,12 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import org.batfish.common.BatfishException;
@@ -15,6 +17,7 @@ import org.batfish.common.BatfishLogger;
 import org.batfish.common.BfConsts;
 import org.batfish.common.Container;
 import org.batfish.coordinator.config.Settings;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -30,135 +33,122 @@ public class WorkMgrTest {
 
   private WorkMgr _manager;
 
-  @Test
-  public void initContainerWithContainerName() throws IOException {
-    String containerName = "myContainer";
-    Main.mainInit(new String[] {"-containerslocation", _folder.getRoot().toString()});
-    String initResult = _manager.initContainer(containerName, null);
-    assertThat(initResult, equalTo(containerName));
-  }
-
-  @Test
-  public void initContainerWithcontainerPrefix() throws IOException {
-    String containerPrefix = "myContainerPrefix";
-    Main.mainInit(new String[] {"-containerslocation", _folder.getRoot().toString()});
-    String initResult = _manager.initContainer(null, containerPrefix);
-    assertThat(initResult, startsWith(containerPrefix));
-  }
-
-  @Test
-  public void initContainerWithNullInput() throws IOException {
-    Main.mainInit(new String[] {"-containerslocation", _folder.getRoot().toString()});
-    String initResult = _manager.initContainer(null, null);
-    assertThat(initResult, startsWith("null_"));
-  }
-
-  @Test
-  public void initExistingContainer() throws IOException {
-    String containerName = "myContainer";
-    _folder.newFolder(containerName);
-    Main.mainInit(new String[] {"-containerslocation", _folder.getRoot().toString()});
-    String expectedMessage = String.format("Container '%s' already exists!", containerName);
-    _thrown.expect(BatfishException.class);
-    _thrown.expectMessage(equalTo(expectedMessage));
-    _manager.initContainer(containerName, null);
-  }
-
   @Before
   public void initManager() throws Exception {
     Settings settings = new Settings(new String[] {});
     BatfishLogger logger = new BatfishLogger("debug", false);
-    Main.mainInit(new String[] {});
+    Main.mainInit(new String[] {"-containerslocation", _folder.getRoot().toString()});
     Main.setLogger(logger);
     _manager = new WorkMgr(settings, logger);
   }
 
   @Test
-  public void listEmptyQuestion() throws IOException {
-    Main.mainInit(new String[] {"-containerslocation", _folder.getRoot().toString()});
-    String containerPath = _folder.newFolder("container").getPath();
-    Path testrigPath =
-        Paths.get(containerPath).resolve(BfConsts.RELPATH_TESTRIGS_DIR).resolve("testrigPath");
+  public void initContainerWithContainerName() {
+    String initResult = _manager.initContainer("container", null);
+    assertThat(initResult, equalTo("container"));
+  }
+
+  @Test
+  public void initContainerWithcontainerPrefix() {
+    String initResult = _manager.initContainer(null, "containerPrefix");
+    assertThat(initResult, startsWith("containerPrefix"));
+  }
+
+  @Test
+  public void initContainerWithNullInput() {
+    String initResult = _manager.initContainer(null, null);
+    assertThat(initResult, startsWith("null_"));
+  }
+
+  @Test
+  public void initExistingContainer() {
+    _manager.initContainer("container", null);
+    String expectedMessage = "Container 'container' already exists!";
+    _thrown.expect(BatfishException.class);
+    _thrown.expectMessage(equalTo(expectedMessage));
+    _manager.initContainer("container", null);
+  }
+
+  @Test
+  public void listEmptyQuestion() {
+    _manager.initContainer("container", null);
+    Path containerDir =
+        Main.getSettings().getContainersLocation().resolve("container").toAbsolutePath();
+    Path testrigPath = containerDir.resolve(BfConsts.RELPATH_TESTRIGS_DIR).resolve("testrig");
     assertThat(testrigPath.toFile().mkdirs(), is(true));
-    SortedSet<String> questions = _manager.listQuestions("container", "testrigPath");
+    SortedSet<String> questions = _manager.listQuestions("container", "testrig");
     assertThat(questions.isEmpty(), is(true));
   }
 
   @Test
-  public void listQuestionNames() throws IOException {
-    Main.mainInit(new String[] {"-containerslocation", _folder.getRoot().toString()});
-    String containerPath = _folder.newFolder("container").getPath();
-    Path testrigPath =
-        Paths.get(containerPath).resolve(BfConsts.RELPATH_TESTRIGS_DIR).resolve("testrigPath");
+  public void listQuestionNames() {
+    _manager.initContainer("container", null);
+    Path containerDir =
+        Main.getSettings().getContainersLocation().resolve("Container").toAbsolutePath();
+    Path testrigPath = containerDir.resolve(BfConsts.RELPATH_TESTRIGS_DIR).resolve("testrig");
     assertThat(testrigPath.toFile().mkdirs(), is(true));
     Path questionsDir = testrigPath.resolve(BfConsts.RELPATH_QUESTIONS_DIR);
     assertThat(questionsDir.resolve("initinfo").toFile().mkdirs(), is(true));
-    SortedSet<String> questions = _manager.listQuestions("container", "testrigPath");
+    SortedSet<String> questions = _manager.listQuestions("container", "testrig");
     assertThat(questions.size(), is(1));
     assertThat(questions.first(), equalTo("initinfo"));
   }
 
   @Test
   public void listQuestionWithNonExistContainer() {
-    String nonExistingPath = _folder.getRoot().toPath().resolve("non-existing").toString();
     _thrown.expect(BatfishException.class);
-    _thrown.expectMessage(equalTo("Container '" + nonExistingPath + "' does not exist"));
-    _manager.listQuestions(nonExistingPath, "non-existing");
+    _thrown.expectMessage(equalTo("Container 'container' does not exist"));
+    _manager.listQuestions("container", "testrig");
   }
 
   @Test
-  public void listQuestionWithNonExistTestrig() throws IOException {
-    String nonExistingPath = _folder.getRoot().toPath().resolve("non-existing").toString();
-    String containerPath = _folder.newFolder("container").getPath();
+  public void listQuestionWithNonExistTestrig() {
+    _manager.initContainer("container", null);
     _thrown.expect(BatfishException.class);
-    _thrown.expectMessage(equalTo("Testrig '" + nonExistingPath + "' does not exist"));
-    _manager.listQuestions(containerPath, nonExistingPath);
+    _thrown.expectMessage(equalTo("Testrig 'testrig' does not exist"));
+    _manager.listQuestions("container", "testrig");
   }
 
   @Test
-  public void listSortedQuestionNames() throws IOException {
-    Main.mainInit(new String[] {"-containerslocation", _folder.getRoot().toString()});
-    String containerPath = _folder.newFolder("container").getPath();
-    Path testrigPath =
-        Paths.get(containerPath).resolve(BfConsts.RELPATH_TESTRIGS_DIR).resolve("testrigPath");
+  public void listSortedQuestionNames() {
+    _manager.initContainer("container", null);
+    Path containerDir =
+        Main.getSettings().getContainersLocation().resolve("container").toAbsolutePath();
+    Path testrigPath = containerDir.resolve(BfConsts.RELPATH_TESTRIGS_DIR).resolve("testrig");
     assertThat(testrigPath.toFile().mkdirs(), is(true));
     Path questionsDir = testrigPath.resolve(BfConsts.RELPATH_QUESTIONS_DIR);
-    assertThat(questionsDir.resolve("nodes").toFile().mkdirs(), is(true));
-    assertThat(questionsDir.resolve("access").toFile().mkdirs(), is(true));
-    assertThat(questionsDir.resolve("initinfo").toFile().mkdirs(), is(true));
-    SortedSet<String> questions = _manager.listQuestions("container", "testrigPath");
+    assertTrue(questionsDir.resolve("nodes").toFile().mkdirs());
+    assertTrue(questionsDir.resolve("access").toFile().mkdirs());
+    assertTrue(questionsDir.resolve("initinfo").toFile().mkdirs());
+    SortedSet<String> questions = _manager.listQuestions("container", "testrig");
     assertThat(questions.size(), is(3));
     assertThat(questions.toString(), equalTo("[access, initinfo, nodes]"));
   }
 
-  private void initContainerEnvironment(String containerName) throws Exception {
-    _folder.newFolder(containerName);
-    Main.mainInit(new String[] {"-containerslocation", _folder.getRoot().toString()});
+  @Test
+  public void getEmptyContainer() {
+    _manager.initContainer("container", null);
+    Container container = _manager.getContainer("container");
+    assertThat(container, equalTo(Container.of("container", new TreeSet<>())));
   }
 
   @Test
-  public void getEmptyContainer() throws Exception {
-    String containerName = "myContainer";
-    initContainerEnvironment(containerName);
-    Path containerDir = Paths.get(_folder.getRoot().toPath().resolve(containerName).toString());
-    Container container = _manager.getContainer(containerDir);
-    assertThat(container.getTestrigs(), equalTo(new TreeSet<String>()));
-  }
-
-  @Test
-  public void getNonEmptyContainer() throws Exception {
-    String containerName = "myContainer";
-    initContainerEnvironment(containerName);
-    Path containerPath = _folder.getRoot().toPath().resolve(containerName);
-    Path testrigPath = containerPath.resolve(BfConsts.RELPATH_TESTRIGS_DIR).resolve("testrig1");
+  public void getNonEmptyContainer() {
+    _manager.initContainer("container", null);
+    Path containerDir =
+        Main.getSettings().getContainersLocation().resolve("container").toAbsolutePath();
+    Path testrigPath = containerDir.resolve(BfConsts.RELPATH_TESTRIGS_DIR).resolve("testrig");
     assertThat(testrigPath.toFile().mkdirs(), is(true));
-    Path testrigPath2 = containerPath.resolve(BfConsts.RELPATH_TESTRIGS_DIR).resolve("testrig2");
-    assertThat(testrigPath2.toFile().mkdirs(), is(true));
-    Path containerDir = Paths.get(_folder.getRoot().toPath().resolve(containerName).toString());
-    Container container = _manager.getContainer(containerDir);
-    SortedSet<String> expectedTestrigs = new TreeSet<>();
-    expectedTestrigs.add("testrig1");
-    expectedTestrigs.add("testrig2");
-    assertThat(container.getTestrigs(), equalTo(expectedTestrigs));
+    Container container = _manager.getContainer("container");
+    assertThat(
+        container,
+        equalTo(Container.of("container", Sets.newTreeSet(Collections.singleton("testrig")))));
+  }
+
+  @Test
+  public void getNonExistContainer() {
+    _thrown.expect(Exception.class);
+    _thrown.expectMessage(equalTo("Container 'container' does not exist"));
+    _manager.getContainer("container");
   }
 }


### PR DESCRIPTION
Assign "testrigs" to be default directory of testrigs(BfConsts.RELPATH_TESTRIGS_DIR). Notice that some current tests in WorkMgrTest and WorkMgrServiceTest are not useful(for example, get non-exist container should give an error instead of an empty container), will fix them in a later PR. (trying to make each PR small) 