### PR TITLE
Batfish-Client: poll ramping up using exponential backoff

### DIFF
--- a/projects/batfish-client/src/main/java/org/batfish/client/Client.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/Client.java
@@ -25,6 +25,7 @@ import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -61,6 +62,7 @@ import org.batfish.common.Version;
 import org.batfish.common.WorkItem;
 import org.batfish.common.plugin.AbstractClient;
 import org.batfish.common.plugin.IClient;
+import org.batfish.common.util.Backoff;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.common.util.CommonUtil;
 import org.batfish.common.util.ZipUtility;
@@ -913,19 +915,24 @@ public class Client extends AbstractClient implements IClient {
     if (!queueWorkResult) {
       return queueWorkResult;
     }
+
+    // Poll the work item until it finishes or fails.
     Pair<WorkStatusCode, String> response = _workHelper.getWorkStatus(wItem.getId());
     if (response == null) {
       return false;
     }
+
     WorkStatusCode status = response.getFirst();
+    Backoff backoff = Backoff.builder().withMaximumBackoff(Duration.ofSeconds(1)).build();
     while (status != WorkStatusCode.TERMINATEDABNORMALLY
         && status != WorkStatusCode.TERMINATEDNORMALLY
-        && status != WorkStatusCode.ASSIGNMENTERROR) {
+        && status != WorkStatusCode.ASSIGNMENTERROR
+        && backoff.hasNext()) {
       printWorkStatusResponse(response);
       try {
-        Thread.sleep(1 * 1000);
+        Thread.sleep(backoff.nextBackoff().toMillis());
       } catch (InterruptedException e) {
-        throw new BatfishException("Interrupted while waiting for response", e);
+        throw new BatfishException("Interrupted while waiting for work item to complete", e);
       }
       response = _workHelper.getWorkStatus(wItem.getId());
       if (response == null) {
@@ -934,6 +941,7 @@ public class Client extends AbstractClient implements IClient {
       status = response.getFirst();
     }
     printWorkStatusResponse(response);
+
     // get the answer
     String ansFileName = wItem.getId() + BfConsts.SUFFIX_ANSWER_JSON_FILE;
     String downloadedAnsFile =

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/Backoff.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/Backoff.java
@@ -1,0 +1,132 @@
+package org.batfish.common.util;
+
+import java.time.Duration;
+import java.util.NoSuchElementException;
+
+/** Provides a simple interface for an implementation of various types of temporal backoff. */
+public abstract class Backoff {
+  /**
+   * Returns {@code true} if this {@link Backoff} is able to continue, i.e., the number of attempts
+   * has not been exceeded and the maximum cumulative backoff time has not been reached.
+   */
+  public abstract boolean hasNext();
+
+  /**
+   * Returns a {@link Duration} representing the next amount of time to back off. If this {@link
+   * Backoff} is not able to continue, i.e. {@link #hasNext()} would return {@code false}, throws
+   * {@link java.util.NoSuchElementException}.
+   */
+  public abstract Duration nextBackoff() throws NoSuchElementException;
+
+  public static final Duration DEFAULT_INITIAL_BACKOFF = Duration.ofMillis(1);
+  public static final Duration DEFAULT_MAXIMUM_BACKOFF = Duration.ofMinutes(1);
+  public static final Duration DEFAULT_CUMULATIVE_BACKOFF_LIMIT = Duration.ofDays(365);
+  public static final int DEFAULT_ATTEMPT_LIMIT = Integer.MAX_VALUE;
+  public static final double DEFAULT_EXPANSION = 1.5;
+
+  public static Builder builder() {
+    return new Builder(
+        DEFAULT_INITIAL_BACKOFF,
+        DEFAULT_MAXIMUM_BACKOFF,
+        DEFAULT_CUMULATIVE_BACKOFF_LIMIT,
+        DEFAULT_ATTEMPT_LIMIT,
+        DEFAULT_EXPANSION);
+  }
+
+  public static class Builder {
+    private final Duration _initialBackoff;
+    private final Duration _maximumBackoff;
+    private final Duration _cumulativeBackoffLimit;
+    private final int _attemptLimit;
+    private final double _expansion;
+
+    public Backoff build() {
+      return new BackoffImpl(this);
+    }
+
+    // Prevent instantiation
+    private Builder(
+        Duration initialBackoff,
+        Duration maximumBackoff,
+        Duration cumulativeBackoffLimit,
+        int attempts,
+        double expansion) {
+      this._initialBackoff = initialBackoff;
+      this._maximumBackoff = maximumBackoff;
+      this._cumulativeBackoffLimit = cumulativeBackoffLimit;
+      this._attemptLimit = attempts;
+      this._expansion = expansion;
+    }
+
+    public Builder withInitialBackoff(Duration initialBackoff) {
+      return new Builder(
+          initialBackoff, _maximumBackoff, _cumulativeBackoffLimit, _attemptLimit, _expansion);
+    }
+
+    public Builder withMaximumBackoff(Duration maximumBackoff) {
+      return new Builder(
+          _initialBackoff, maximumBackoff, _cumulativeBackoffLimit, _attemptLimit, _expansion);
+    }
+
+    public Builder withCumulativeBackoffLimit(Duration cumulativeBackoffLimit) {
+      return new Builder(
+          _initialBackoff, _maximumBackoff, cumulativeBackoffLimit, _attemptLimit, _expansion);
+    }
+
+    public Builder withAttemptLimit(int attemptLimit) {
+      return new Builder(
+          _initialBackoff, _maximumBackoff, _cumulativeBackoffLimit, attemptLimit, _expansion);
+    }
+
+    public Builder withExpansion(double expansion) {
+      return new Builder(
+          _initialBackoff, _maximumBackoff, _cumulativeBackoffLimit, _attemptLimit, expansion);
+    }
+  }
+
+  // Only visible for testing.
+  static class BackoffImpl extends Backoff {
+    private Builder _builder;
+    private Duration _nextBackoff;
+    private Duration _cumulativeBackoff;
+    private int _attempts;
+
+    private BackoffImpl(Builder builder) {
+      this._builder = builder;
+      _nextBackoff = builder._initialBackoff;
+      _cumulativeBackoff = Duration.ZERO;
+      _attempts = 0;
+    }
+
+    public boolean hasNext() {
+      return ((_attempts + 1) < _builder._attemptLimit)
+          && (_cumulativeBackoff.compareTo(_builder._cumulativeBackoffLimit) < 0);
+    }
+
+    @Override
+    public Duration nextBackoff() {
+      if (!hasNext()) {
+        throw new NoSuchElementException("Not able to continue backing off");
+      }
+
+      // By calling nextBackoff, the caller is recording a prior attempt.
+      ++_attempts;
+
+      // Save the current backoff to be returned.
+      Duration ret = _nextBackoff;
+      _cumulativeBackoff = _cumulativeBackoff.plus(ret);
+
+      // Scale up the next backoff.
+      Duration nextDuration =
+          Duration.ofMillis((long) (0.5 + _nextBackoff.toMillis() * _builder._expansion));
+
+      // Limit it by the maximum total backoff.
+      _nextBackoff =
+          nextDuration.compareTo(_builder._maximumBackoff) < 0
+              ? nextDuration
+              : _builder._maximumBackoff;
+
+      return ret;
+    }
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/BackoffTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/BackoffTest.java
@@ -1,0 +1,79 @@
+package org.batfish.common.util;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.time.Duration;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class BackoffTest {
+  @Test
+  public void testAttemptLimited() {
+    int attemptLimit = 5;
+    Backoff backoff = Backoff.builder().withAttemptLimit(attemptLimit).build();
+    int i = 1;
+    while (backoff.hasNext()) {
+      ++i;
+      backoff.nextBackoff();
+    }
+    assertThat(i, equalTo(attemptLimit));
+  }
+
+  @Test
+  public void testTimeLimited() {
+    Duration cumulativeLimit = Duration.ofMinutes(1);
+    Backoff backoff = Backoff.builder().withCumulativeBackoffLimit(cumulativeLimit).build();
+    Duration totalSoFar = Duration.ZERO;
+
+    while (backoff.hasNext()) {
+      assertThat(totalSoFar, lessThan(cumulativeLimit));
+      totalSoFar = totalSoFar.plus(backoff.nextBackoff());
+    }
+    assertThat(totalSoFar, greaterThanOrEqualTo(cumulativeLimit));
+  }
+
+  @Test
+  public void testExpansion() {
+    Backoff backoff = Backoff.builder().withExpansion(2.0).withAttemptLimit(5).build();
+    assertTrue(backoff.hasNext());
+    Duration lastBackoff = backoff.nextBackoff();
+    assertTrue(backoff.hasNext());
+
+    while (backoff.hasNext()) {
+      Duration nextBackoff = backoff.nextBackoff();
+      assertThat(nextBackoff, equalTo(lastBackoff.plus(lastBackoff)));
+      lastBackoff = nextBackoff;
+    }
+  }
+
+  @Test
+  public void testInitialBackoff() {
+    Backoff backoff = Backoff.builder().withInitialBackoff(Duration.ofSeconds(17)).build();
+    assertTrue(backoff.hasNext());
+    assertThat(backoff.nextBackoff(), equalTo(Duration.ofSeconds(17)));
+  }
+
+  @Test
+  public void testMaximumBackoffAndSeveralSteps() {
+    Backoff backoff =
+        Backoff.builder()
+            .withInitialBackoff(Duration.ofSeconds(1))
+            .withMaximumBackoff(Duration.ofSeconds(11))
+            .withExpansion(2.0)
+            .withAttemptLimit(8)
+            .build();
+    int[] expected = {1, 2, 4, 8, 11, 11, 11};
+    for (int seconds : expected) {
+      assertTrue(backoff.hasNext());
+      assertThat(backoff.nextBackoff(), equalTo(Duration.ofSeconds(seconds)));
+    }
+    assertFalse(backoff.hasNext());
+  }
+}


### PR DESCRIPTION
The existing code checks to see if the work item is done every 1s. The new code ramps up from 1ms to 1s, so very fast work items are handled quickly.

We should consider the time constants + how often we print... with current constants and behavior the Java client may be spammy at the beginning.

The efficiency of this improvement is obviously limited by coordinator-side latency. I think right now the coordinator still polls every 1s.