### PR TITLE
set up workMgr before starting the workMgrService

### DIFF
--- a/projects/coordinator/src/main/java/org/batfish/coordinator/Main.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/Main.java
@@ -172,6 +172,8 @@ public class Main {
   }
 
   private static void initWorkManager() {
+    _workManager = new WorkMgr(_settings, _logger);
+    _workManager.startWorkManager();
     // Initialize and start the work manager service using the legacy API and Jettison.
     startWorkManagerService(
         WorkMgrService.class, JettisonFeature.class, _settings.getServiceWorkPort());
@@ -179,8 +181,6 @@ public class Main {
     startWorkManagerService(
         WorkMgrServiceV2.class, JacksonFeature.class, _settings.getServiceWorkV2Port());
 
-    _workManager = new WorkMgr(_settings, _logger);
-    _workManager.startWorkManager();
   }
 
   public static void main(String[] args) {


### PR DESCRIPTION
Sets up the workMgr before starting the workMgrService, this will remove the possible condition that the service already started, but the workMgr is not set. 