### PR TITLE
assign a value to testrigs path constant

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
@@ -144,7 +144,7 @@ public class BfConsts {
   public static final String RELPATH_SERIALIZED_ENVIRONMENT_ROUTING_TABLES = "rt_processed";
   public static final String RELPATH_TEST_RIG_DIR = "testrig";
   public static final String RELPATH_TESTRIG_TOPOLOGY_PATH = "testrig_topology";
-  public static final String RELPATH_TESTRIGS_DIR = "";
+  public static final String RELPATH_TESTRIGS_DIR = "testrigs";
   public static final String RELPATH_VENDOR_INDEPENDENT_CONFIG_DIR = "indep";
   public static final String RELPATH_VENDOR_SPECIFIC_CONFIG_DIR = "vendor";
 

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -204,7 +204,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
 
   public static void applyBaseDir(
       TestrigSettings settings, Path containerDir, String testrig, String envName) {
-    Path testrigDir = containerDir.resolve(testrig);
+    Path testrigDir = containerDir.resolve(Paths.get(BfConsts.RELPATH_TESTRIGS_DIR, testrig));
     settings.setName(testrig);
     settings.setBasePath(testrigDir);
     EnvironmentSettings envSettings = settings.getEnvironmentSettings();
@@ -1928,8 +1928,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
   }
 
   private NodeRoleSpecifier inferNodeRoles(Map<String, Configuration> configurations) {
-    InferRoles ir =
-        new InferRoles(new ArrayList<>(configurations.keySet()), configurations, this);
+    InferRoles ir = new InferRoles(new ArrayList<>(configurations.keySet()), configurations, this);
     return ir.call();
   }
 
@@ -3396,8 +3395,8 @@ public class Batfish extends PluginConsumer implements IBatfish {
   }
 
   /* Set the roles of each configuration.  Use an explicitly provided NodeRoleSpecifier
-     if one exists; otherwise use the results of our node-role inference.
-   */
+    if one exists; otherwise use the results of our node-role inference.
+  */
   private void processNodeRoles(Map<String, Configuration> configurations) {
     TestrigSettings settings = _settings.getActiveTestrigSettings();
     Path nodeRolesPath = settings.getNodeRolesPath();
@@ -3414,8 +3413,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
       String hostname = nodeRolesEntry.getKey();
       Configuration config = configurations.get(hostname);
       if (config == null) {
-        throw new BatfishException(
-            "role set assigned to non-existent node: \"" + hostname + "\"");
+        throw new BatfishException("role set assigned to non-existent node: \"" + hostname + "\"");
       }
       SortedSet<String> roles = nodeRolesEntry.getValue();
       config.setRoles(roles);
@@ -4038,8 +4036,8 @@ public class Batfish extends PluginConsumer implements IBatfish {
     serializeAsJson(_testrigSettings.getTopologyPath(), topology, "testrig topology");
     checkTopology(configurations, topology);
     NodeRoleSpecifier roleSpecifier = inferNodeRoles(configurations);
-    serializeAsJson(_testrigSettings.getInferredNodeRolesPath(), roleSpecifier,
-        "inferred node roles");
+    serializeAsJson(
+        _testrigSettings.getInferredNodeRolesPath(), roleSpecifier, "inferred node roles");
     serializeIndependentConfigs(configurations, outputPath);
     serializeObject(answerElement, _testrigSettings.getConvertAnswerPath());
     return answer;
@@ -4495,5 +4493,4 @@ public class Batfish extends PluginConsumer implements IBatfish {
   public AnswerElement smtLocalConsistency(Pattern routerRegex, boolean strict, boolean fullModel) {
     return PropertyChecker.computeLocalConsistency(this, routerRegex, strict, fullModel);
   }
-
 }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -129,7 +129,10 @@ public class WorkMgr {
       Path containerDir =
           Main.getSettings().getContainersLocation().resolve(work.getWorkItem().getContainerName());
       String testrigName = work.getWorkItem().getTestrigName();
-      Path testrigBaseDir = containerDir.resolve(testrigName).toAbsolutePath();
+      Path testrigBaseDir =
+          containerDir
+              .resolve(Paths.get(BfConsts.RELPATH_TESTRIGS_DIR, testrigName))
+              .toAbsolutePath();
       task.put(BfConsts.ARG_CONTAINER_DIR, containerDir.toAbsolutePath().toString());
       task.put(BfConsts.ARG_TESTRIG, testrigName);
       task.put(
@@ -706,6 +709,14 @@ public class WorkMgr {
     if (!containerDir.toFile().mkdirs()) {
       throw new BatfishException("failed to create directory '" + containerDir + "'");
     }
+    Path testrigsDir = containerDir.resolve(BfConsts.RELPATH_TESTRIGS_DIR);
+    if (!testrigsDir.toFile().mkdir()) {
+      throw new BatfishException("failed to create directory '" + testrigsDir + "'");
+    }
+    Path analysesDir = containerDir.resolve(BfConsts.RELPATH_ANALYSES_DIR);
+    if (!analysesDir.toFile().mkdir()) {
+      throw new BatfishException("failed to create directory '" + analysesDir + "'");
+    }
     return containerName;
   }
 
@@ -838,7 +849,11 @@ public class WorkMgr {
     Path testrigDir =
         Main.getSettings()
             .getContainersLocation()
-            .resolve(Paths.get(workItem.getContainerName(), workItem.getTestrigName()));
+            .resolve(
+                Paths.get(
+                    workItem.getContainerName(),
+                    BfConsts.RELPATH_TESTRIGS_DIR,
+                    workItem.getTestrigName()));
     if (workItem.getTestrigName().isEmpty() || !Files.exists(testrigDir)) {
       throw new BatfishException("Non-existent testrig: '" + testrigDir.getFileName() + "'");
     }


### PR DESCRIPTION
BfConst.RELPATH_TESTRIGS_DIR is empty now, the function call 'listTestrigs' will also include the analyses path in the result. Also, I modified initContainer to also create the path for testrigs and analyses(these were created when first time the client upload a testrig/analysis). Notice I didn't remove the existence check in listTestrigs and listAnalyses, they can't be empty from now on. (assume no direct operations on file system)