### PR TITLE
Fixes #345: extends reachability to support checks for transit nodes

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
@@ -156,7 +156,9 @@ public interface IBatfish extends IPluginConsumer {
       String ingressNodeRegexStr,
       String notIngressNodeRegexStr,
       String finalNodeRegexStr,
-      String notFinalNodeRegexStr);
+      String notFinalNodeRegexStr,
+      Set<String> transitNodes,
+      Set<String> notTransitNodes);
 
   void writeDataPlane(DataPlane dp, DataPlaneAnswerElement ae);
 

--- a/projects/batfish/pom.xml
+++ b/projects/batfish/pom.xml
@@ -207,6 +207,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.glassfish.grizzly</groupId>
       <artifactId>grizzly-http-server</artifactId>
     </dependency>

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -3618,8 +3618,8 @@ public class Batfish extends PluginConsumer implements IBatfish {
             new ReachabilityQuerySynthesizer(
                 Collections.singleton(ForwardingAction.ACCEPT),
                 new HeaderSpace(),
-                Collections.<String>emptySet(),
-                nodeVrfs, null, null);
+                Collections.<String>emptySet(), nodeVrfs,
+                Collections.<String>emptySet(), Collections.<String>emptySet());
         notAcceptQuery.setNegate(true);
         NodeVrfSet nodes = new NodeVrfSet();
         nodes.add(new Pair<>(node, vrf));

--- a/projects/batfish/src/main/java/org/batfish/z3/ReachabilityQuerySynthesizer.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/ReachabilityQuerySynthesizer.java
@@ -174,21 +174,16 @@ public class ReachabilityQuerySynthesizer extends BaseQuerySynthesizer {
     queryConditions.addConjunct(SaneExpr.INSTANCE);
 
     // check transit constraints (unordered)
-    if (_transitNodes != null && _transitNodes.size() > 0) {
-      NodeTransitExpr transitExpr = null;
-      for (String nodeName: _transitNodes) {
-        transitExpr = new NodeTransitExpr(nodeName);
-        queryConditions.addConjunct(transitExpr);
-      }
+    NodeTransitExpr transitExpr = null;
+    for (String nodeName: _transitNodes) {
+      transitExpr = new NodeTransitExpr(nodeName);
+      queryConditions.addConjunct(transitExpr);
+    }
+    for (String nodeName: _notTransitNodes) {
+      transitExpr = new NodeTransitExpr(nodeName);
+      queryConditions.addConjunct(new NotExpr(transitExpr));
     }
 
-    if (_notTransitNodes != null && _notTransitNodes.size() > 0) {
-      NodeTransitExpr transitExpr = null;
-      for (String nodeName: _notTransitNodes) {
-        transitExpr = new NodeTransitExpr(nodeName);
-        queryConditions.addConjunct(new NotExpr(transitExpr));
-      }
-    }
 
     // add headerSpace constraints
     BooleanExpr matchHeaderSpace = Synthesizer.matchHeaderSpace(_headerSpace);

--- a/projects/question/src/main/java/org/batfish/question/ReachabilityQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/ReachabilityQuestionPlugin.java
@@ -18,7 +18,6 @@ import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.answers.AnswerElement;
 import org.batfish.datamodel.questions.IReachabilityQuestion;
 import org.batfish.datamodel.questions.Question;
-import scala.collection.generic.Sorted;
 
 public class ReachabilityQuestionPlugin extends QuestionPlugin {
 
@@ -121,6 +120,12 @@ public class ReachabilityQuestionPlugin extends QuestionPlugin {
 
     private static final String DEFAULT_NOT_INGRESS_NODE_REGEX = "";
 
+    private static final SortedSet<String> DEFAULT_TRANSIT_NODES =
+        Collections.<String>emptySortedSet();
+
+    private static final SortedSet<String> DEFAULT_NOT_TRANSIT_NODES =
+        Collections.<String>emptySortedSet();
+
     private static final String PROP_DST_IPS = "dstIps";
 
     private static final String PROP_DST_PORTS = "dstPorts";
@@ -213,6 +218,8 @@ public class ReachabilityQuestionPlugin extends QuestionPlugin {
       _reachabilityType = ReachabilityType.STANDARD;
       _notFinalNodeRegex = DEFAULT_NOT_FINAL_NODE_REGEX;
       _notIngressNodeRegex = DEFAULT_NOT_INGRESS_NODE_REGEX;
+      _transitNodes = DEFAULT_TRANSIT_NODES;
+      _notTransitNodes = DEFAULT_NOT_TRANSIT_NODES;
     }
 
     @JsonProperty(PROP_ACTIONS)

--- a/projects/question/src/main/java/org/batfish/question/ReachabilityQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/ReachabilityQuestionPlugin.java
@@ -18,6 +18,7 @@ import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.answers.AnswerElement;
 import org.batfish.datamodel.questions.IReachabilityQuestion;
 import org.batfish.datamodel.questions.Question;
+import scala.collection.generic.Sorted;
 
 public class ReachabilityQuestionPlugin extends QuestionPlugin {
 
@@ -84,7 +85,9 @@ public class ReachabilityQuestionPlugin extends QuestionPlugin {
           question.getIngressNodeRegex(),
           question.getNotIngressNodeRegex(),
           question.getFinalNodeRegex(),
-          question.getNotFinalNodeRegex());
+          question.getNotFinalNodeRegex(),
+          question.getTransitNodes(),
+          question.getNotTransitNodes());
     }
   }
 
@@ -96,6 +99,8 @@ public class ReachabilityQuestionPlugin extends QuestionPlugin {
    * <p>More details coming.
    *
    * @type Reachability dataplane
+   * @param transitNodes set of transit nodes (packet must transit through all of them)
+   * @param notTransitNodes set of non-transit nodes (packet does not transit through any of them)
    * @param DetailsComing Details coming.
    * @example bf_answer("Reachability", dstIps=["2.128.0.101"], dstPorts=[53], ipProtocols=["UDP"],
    *     actions=["drop"]) Finds all (starting node, packet header) combinations that cannot reach
@@ -178,6 +183,10 @@ public class ReachabilityQuestionPlugin extends QuestionPlugin {
 
     private static final String PROP_SRC_PROTOCOLS = "srcProtocols";
 
+    private static final String PROP_TRANSIT_NODES = "transitNodes";
+
+    private static final String PROP_NOT_TRANSIT_NODES = "notTransitNodes";
+
     private SortedSet<ForwardingAction> _actions;
 
     private String _finalNodeRegex;
@@ -189,6 +198,10 @@ public class ReachabilityQuestionPlugin extends QuestionPlugin {
     private String _notFinalNodeRegex;
 
     private String _notIngressNodeRegex;
+
+    private SortedSet<String> _transitNodes;
+
+    private SortedSet<String> _notTransitNodes;
 
     private ReachabilityType _reachabilityType;
 
@@ -310,6 +323,16 @@ public class ReachabilityQuestionPlugin extends QuestionPlugin {
     @JsonProperty(PROP_NOT_INGRESS_NODE_REGEX)
     public String getNotIngressNodeRegex() {
       return _notIngressNodeRegex;
+    }
+
+    @JsonProperty(PROP_TRANSIT_NODES)
+    public SortedSet<String> getTransitNodes() {
+      return _transitNodes;
+    }
+
+    @JsonProperty(PROP_NOT_TRANSIT_NODES)
+    public SortedSet<String> getNotTransitNodes() {
+      return _notTransitNodes;
     }
 
     @JsonProperty(PROP_NOT_IP_PROTOCOLS)
@@ -443,6 +466,9 @@ public class ReachabilityQuestionPlugin extends QuestionPlugin {
         if (getSrcOrDstProtocols() != null && !getSrcOrDstProtocols().isEmpty()) {
           retString += String.format(" | %s=%s", PROP_SRC_OR_DST_PROTOCOLS, getSrcOrDstProtocols());
         }
+        if (_transitNodes != null && !_transitNodes.isEmpty()) {
+          retString += String.format(" | %s=%s", PROP_TRANSIT_NODES, _transitNodes.toString());
+        }
         if (getNotDstIps() != null && !getNotDstIps().isEmpty()) {
           retString += String.format(" | %s=%s", PROP_NOT_DST_IPS, getNotDstIps());
         }
@@ -485,6 +511,9 @@ public class ReachabilityQuestionPlugin extends QuestionPlugin {
         if (getNotSrcProtocols() != null && !getNotSrcProtocols().isEmpty()) {
           retString += String.format(" | %s=%s", PROP_NOT_SRC_PROTOCOLS, getNotSrcProtocols());
         }
+        if (_notTransitNodes != null && !_notTransitNodes.isEmpty()) {
+          retString += String.format(" | %s=%s", PROP_NOT_TRANSIT_NODES, _notTransitNodes);
+        }
         return retString;
       } catch (Exception e) {
         try {
@@ -521,6 +550,16 @@ public class ReachabilityQuestionPlugin extends QuestionPlugin {
     @JsonProperty(PROP_FINAL_NODE_REGEX)
     public void setFinalNodeRegex(String regex) {
       _finalNodeRegex = regex;
+    }
+
+    @JsonProperty(PROP_TRANSIT_NODES)
+    public void setTransitNodes(SortedSet<String> transitNodes) {
+      _transitNodes = transitNodes;
+    }
+
+    @JsonProperty(PROP_NOT_TRANSIT_NODES)
+    public void setNotTransitNodes(SortedSet<String> notTransitNodes) {
+      _notTransitNodes = notTransitNodes;
     }
 
     @JsonProperty(PROP_ICMP_CODES)


### PR DESCRIPTION
 This adds support for the following:
   - transitNodes: set of transit nodes (packet must transit through all of them)
   - notTransitNodes: set of non-transit nodes (packet does not transit through any of them)

Now one can check that all traffic ingress|egress to a zone goes through a transit node for example by issuing the following query

 ```
get reachability type=standard, ingressNodeRegex=from, srcIps=[1.1.1.0/24], dstIps=[2.2.2.2], actions=[accept], notTransitNodes=[firewall]
```

From @jkhourybbn