### PR TITLE
Allow interfaces to have multiple source nat rules

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
@@ -83,6 +83,10 @@ public class CommonUtil {
 
   private static final int STREAMED_FILE_BUFFER_SIZE = 1024;
 
+  public static boolean isNullOrEmpty(@Nullable Collection<?> collection) {
+    return collection == null || collection.isEmpty();
+  }
+
   public static String applyPrefix(String prefix, String msg) {
     String[] lines = msg.split("\n");
     StringBuilder sb = new StringBuilder();

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -78,7 +78,7 @@ public final class Interface extends ComparableStructure<String> {
 
   private static final long serialVersionUID = 1L;
 
-  private static final String PROP_SOURCE_NAT = "sourceNat";
+  private static final String PROP_SOURCE_NATS = "sourceNats";
 
   private static final String PROP_SPANNING_TREE_PORTFAST = "spanningTreePortfast";
 
@@ -315,7 +315,7 @@ public final class Interface extends ComparableStructure<String> {
 
   private transient String _routingPolicyName;
 
-  private SourceNat _sourceNat;
+  private List<SourceNat> _sourceNats;
 
   private boolean _spanningTreePortfast;
 
@@ -672,9 +672,9 @@ public final class Interface extends ComparableStructure<String> {
     }
   }
 
-  @JsonProperty(PROP_SOURCE_NAT)
-  public SourceNat getSourceNat() {
-    return _sourceNat;
+  @JsonProperty(PROP_SOURCE_NATS)
+  public List<SourceNat> getSourceNats() {
+    return _sourceNats;
   }
 
   @JsonProperty(PROP_SPANNING_TREE_PORTFAST)
@@ -936,9 +936,9 @@ public final class Interface extends ComparableStructure<String> {
     _routingPolicyName = routingPolicyName;
   }
 
-  @JsonProperty(PROP_SOURCE_NAT)
-  public void setSourceNat(SourceNat sourceNat) {
-    _sourceNat = sourceNat;
+  @JsonProperty(PROP_SOURCE_NATS)
+  public void setSourceNats(List<SourceNat> sourceNats) {
+    _sourceNats = sourceNats;
   }
 
   @JsonProperty(PROP_SPANNING_TREE_PORTFAST)

--- a/projects/batfish/.gitignore
+++ b/projects/batfish/.gitignore
@@ -1,4 +1,3 @@
-*.tokens
 /bin
 /cygwin-symlink-restore-data
 /doc

--- a/projects/batfish/src/main/java/org/batfish/bdp/BdpDataPlanePlugin.java
+++ b/projects/batfish/src/main/java/org/batfish/bdp/BdpDataPlanePlugin.java
@@ -74,6 +74,44 @@ public class BdpDataPlanePlugin extends DataPlanePlugin {
     _flowTraces = new HashMap<>();
   }
 
+  /**
+   * Applies the given list of source NAT rules to the given flow and returns the new transformed
+   * flow. If {@code sourceNats} is null, empty, or does not contain any ACL rules matching the
+   * {@link Flow}, the original flow is returned.
+   *
+   * <p>Each {@link SourceNat} is expected to be valid: it must have a NAT IP or pool.
+   */
+  static Flow applySourceNat(Flow flow, @Nullable List<SourceNat> sourceNats) {
+    if (CommonUtil.isNullOrEmpty(sourceNats)) {
+      return flow;
+    }
+
+    for (SourceNat sourceNat : sourceNats) {
+      IpAccessList acl = sourceNat.getAcl();
+      if (acl != null) {
+        FilterResult result = acl.filter(flow);
+        if (result.getAction() == LineAction.REJECT) {
+          // This ACL does not match the flow.
+          continue;
+        }
+      }
+
+      Ip natPoolStartIp = sourceNat.getPoolIpFirst();
+      if (natPoolStartIp == null) {
+        throw new BatfishException(
+            String.format(
+                "Error processing Source NAT rule %s: missing NAT address or pool",
+                sourceNat));
+      }
+      Flow.Builder transformedFlowBuilder = new Flow.Builder(flow);
+      transformedFlowBuilder.setSrcIp(natPoolStartIp);
+      return transformedFlowBuilder.build();
+    }
+
+    // No NAT rule matched.
+    return flow;
+  }
+
   private void collectFlowTraces(
       BdpDataPlane dp,
       String currentNodeName,
@@ -161,25 +199,10 @@ public class BdpDataPlanePlugin extends DataPlanePlugin {
                     ._c
                     .getInterfaces()
                     .get(nextHopInterface.getInterface());
-            SourceNat sourceNat = outgoingInterface.getSourceNat();
-            if (sourceNat != null) {
-              boolean performTranslation = true;
-              IpAccessList acl = sourceNat.getAcl();
-              if (acl != null) {
-                FilterResult result = acl.filter(transformedFlow);
-                if (result.getAction() == LineAction.REJECT) {
-                  performTranslation = false;
-                }
-              }
-              if (performTranslation) {
-                Ip natPoolStartIp = sourceNat.getPoolIpFirst();
-                if (natPoolStartIp != null) {
-                  Flow.Builder transformedFlowBuilder = new Flow.Builder(transformedFlow);
-                  transformedFlowBuilder.setSrcIp(natPoolStartIp);
-                  transformedFlow = transformedFlowBuilder.build();
-                }
-              }
-            }
+
+            // Apply any relevant source NAT rules.
+            transformedFlow = applySourceNat(transformedFlow, outgoingInterface.getSourceNats());
+
             EdgeSet edges = dp._topology.getInterfaceEdges().get(nextHopInterface);
             if (edges != null) {
               boolean continueToNextNextHopInterface = false;

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -483,6 +483,7 @@ import org.batfish.representation.cisco.BgpPeerGroup;
 import org.batfish.representation.cisco.BgpProcess;
 import org.batfish.representation.cisco.BgpRedistributionPolicy;
 import org.batfish.representation.cisco.CiscoConfiguration;
+import org.batfish.representation.cisco.CiscoSourceNat;
 import org.batfish.representation.cisco.CiscoStructureType;
 import org.batfish.representation.cisco.CiscoStructureUsage;
 import org.batfish.representation.cisco.DynamicIpBgpPeerGroup;
@@ -2679,20 +2680,25 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
 
   @Override
   public void exitIf_ip_nat_source(If_ip_nat_sourceContext ctx) {
+    CiscoSourceNat nat = new CiscoSourceNat();
+    String acl = ctx.acl.getText();
+    if (ctx.acl != null) {
+      int aclLine = ctx.acl.getStart().getLine();
+      nat.setAclName(acl);
+      nat.setAclNameLine(aclLine);
+    }
+    if (ctx.pool != null) {
+      String pool = ctx.pool.getText();
+      int poolLine = ctx.pool.getStart().getLine();
+      nat.setNatPool(pool);
+      nat.setNatPoolLine(poolLine);
+    }
+
     for (Interface iface : _currentInterfaces) {
-      iface.setSourceNat(true);
-      String acl = ctx.acl.getText();
-      if (ctx.acl != null) {
-        int aclLine = ctx.acl.getStart().getLine();
-        iface.setSourceNatAcl(acl);
-        iface.setSourceNatAclLine(aclLine);
+      if (iface.getSourceNats() == null) {
+        iface.setSourceNats(new ArrayList<>(1));
       }
-      if (ctx.pool != null) {
-        String pool = ctx.pool.getText();
-        int poolLine = ctx.pool.getStart().getLine();
-        iface.setSourceNatPool(pool);
-        iface.setSourceNatPoolLine(poolLine);
-      }
+      iface.getSourceNats().add(nat);
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -11,11 +11,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NavigableSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import javax.annotation.Nullable;
 import org.batfish.common.BatfishException;
 import org.batfish.common.VendorConversionException;
 import org.batfish.common.util.CommonUtil;
@@ -1759,6 +1761,81 @@ public final class CiscoConfiguration extends VendorConfiguration {
     return new CommunityListLine(eclLine.getAction(), javaRegex);
   }
 
+  /**
+   * Processes a {@link CiscoSourceNat} rule. This function performs two actions:
+   *
+   * <p>1. Record references to ACLs and NAT pools by the various parsed {@link CiscoSourceNat}
+   * objects.
+   *
+   * <p>2. Convert to vendor-independent {@link SourceNat} objects if valid, aka, no undefined ACL
+   * and valid output configuration.
+   *
+   * <p>Returns the vendor-independeng {@link SourceNat}, or {@code null} if the source NAT rule is
+   * invalid.
+   */
+  @Nullable
+  SourceNat processSourceNat(
+      CiscoSourceNat nat, Interface iface, Map<String, IpAccessList> ipAccessLists) {
+    String sourceNatAclName = nat.getAclName();
+    if (sourceNatAclName == null) {
+      // Source NAT rules must have an ACL; this rule is invalid.
+      return null;
+    }
+
+    SourceNat convertedNat = new SourceNat();
+
+    /* source nat acl */
+    IpAccessList sourceNatAcl = ipAccessLists.get(sourceNatAclName);
+    int sourceNatAclLine = nat.getAclNameLine();
+    if (sourceNatAcl == null) {
+      undefined(
+          CiscoStructureType.IP_ACCESS_LIST,
+          sourceNatAclName,
+          CiscoStructureUsage.IP_NAT_SOURCE_ACCESS_LIST,
+          sourceNatAclLine);
+    } else {
+      convertedNat.setAcl(sourceNatAcl);
+      String msg = "source nat acl for interface: " + iface.getName();
+      ExtendedAccessList sourceNatExtendedAccessList = _extendedAccessLists.get(sourceNatAclName);
+      if (sourceNatExtendedAccessList != null) {
+        sourceNatExtendedAccessList.getReferers().put(iface, msg);
+      }
+      StandardAccessList sourceNatStandardAccessList = _standardAccessLists.get(sourceNatAclName);
+      if (sourceNatStandardAccessList != null) {
+        sourceNatStandardAccessList.getReferers().put(iface, msg);
+      }
+    }
+
+    /* source nat pool */
+    String sourceNatPoolName = nat.getNatPool();
+    if (sourceNatPoolName != null) {
+      int sourceNatPoolLine = nat.getNatPoolLine();
+      NatPool sourceNatPool = _natPools.get(sourceNatPoolName);
+      if (sourceNatPool != null) {
+        sourceNatPool.getReferers().put(iface, "source nat pool for interface: " + iface.getName());
+        Ip firstIp = sourceNatPool.getFirst();
+        if (firstIp != null) {
+          Ip lastIp = sourceNatPool.getLast();
+          convertedNat.setPoolIpFirst(firstIp);
+          convertedNat.setPoolIpLast(lastIp);
+        }
+      } else {
+        undefined(
+            CiscoStructureType.NAT_POOL,
+            sourceNatPoolName,
+            CiscoStructureUsage.IP_NAT_SOURCE_POOL,
+            sourceNatPoolLine);
+      }
+    }
+
+    // The source NAT rule is valid iff it has an ACL and a pool of IPs to NAT into.
+    if (convertedNat.getAcl() != null && convertedNat.getPoolIpFirst() != null) {
+      return convertedNat;
+    } else {
+      return null;
+    }
+  }
+
   private org.batfish.datamodel.Interface toInterface(
       Interface iface, Map<String, IpAccessList> ipAccessLists, Configuration c) {
     String name = iface.getName();
@@ -1898,76 +1975,20 @@ public final class CiscoConfiguration extends VendorConfiguration {
       newIface.setOutgoingFilter(outgoingFilter);
     }
     if (!CommonUtil.isNullOrEmpty(iface.getSourceNats())) {
-      List<SourceNat> sourceNats = newIface.getSourceNats();
-      if (sourceNats == null) {
-        sourceNats = new ArrayList<>(iface.getSourceNats().size());
-        newIface.setSourceNats(sourceNats);
+      List<CiscoSourceNat> origSourceNats = iface.getSourceNats();
+
+      if (newIface.getSourceNats() == null) {
+        newIface.setSourceNats(new ArrayList<>(origSourceNats.size()));
       }
 
-      for (CiscoSourceNat nat : iface.getSourceNats()) {
-        String sourceNatAclName = nat.getAclName();
-        if (sourceNatAclName == null) {
-          // Source NAT rules must have an ACL; this rule is invalid.
-          continue;
-        }
-
-        // Start building the SourceNat here, it will be added to the list of valid SourceNat
-        // rules later if valid.
-        SourceNat sourceNat = new SourceNat();
-
-        /* source nat acl */
-        IpAccessList sourceNatAcl = ipAccessLists.get(sourceNatAclName);
-        int sourceNatAclLine = nat.getAclNameLine();
-        if (sourceNatAcl == null) {
-          undefined(
-              CiscoStructureType.IP_ACCESS_LIST,
-              sourceNatAclName,
-              CiscoStructureUsage.IP_NAT_SOURCE_ACCESS_LIST,
-              sourceNatAclLine);
-        } else {
-          sourceNat.setAcl(sourceNatAcl);
-          String msg = "source nat acl for interface: " + iface.getName();
-          ExtendedAccessList sourceNatExtendedAccessList =
-              _extendedAccessLists.get(sourceNatAclName);
-          if (sourceNatExtendedAccessList != null) {
-            sourceNatExtendedAccessList.getReferers().put(iface, msg);
-          }
-          StandardAccessList sourceNatStandardAccessList =
-              _standardAccessLists.get(sourceNatAclName);
-          if (sourceNatStandardAccessList != null) {
-            sourceNatStandardAccessList.getReferers().put(iface, msg);
-          }
-        }
-
-        /* source nat pool */
-        String sourceNatPoolName = nat.getNatPool();
-        if (sourceNatPoolName != null) {
-          int sourceNatPoolLine = nat.getNatPoolLine();
-          NatPool sourceNatPool = _natPools.get(sourceNatPoolName);
-          if (sourceNatPool != null) {
-            sourceNatPool
-                .getReferers()
-                .put(iface, "source nat pool for interface: " + iface.getName());
-            Ip firstIp = sourceNatPool.getFirst();
-            if (firstIp != null) {
-              Ip lastIp = sourceNatPool.getLast();
-              sourceNat.setPoolIpFirst(firstIp);
-              sourceNat.setPoolIpLast(lastIp);
-            }
-          } else {
-            undefined(
-                CiscoStructureType.NAT_POOL,
-                sourceNatPoolName,
-                CiscoStructureUsage.IP_NAT_SOURCE_POOL,
-                sourceNatPoolLine);
-          }
-        }
-
-        // The source NAT rule is valid iff it has an ACL and a pool of IPs to NAT into.
-        if (sourceNat.getAcl() != null && sourceNat.getPoolIpFirst() != null) {
-          sourceNats.add(sourceNat);
-        }
-      }
+      // Process each of the CiscoSourceNats:
+      //   1) Collect references to ACLs and NAT pools.
+      //   2) For valid CiscoSourceNat rules, add them to the newIface source NATs list.
+      origSourceNats
+          .stream()
+          .map(nat -> processSourceNat(nat, iface, ipAccessLists))
+          .filter(Objects::nonNull)
+          .forEach(newIface.getSourceNats()::add);
     }
     String routingPolicyName = iface.getRoutingPolicy();
     if (routingPolicyName != null) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoSourceNat.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoSourceNat.java
@@ -1,0 +1,65 @@
+package org.batfish.representation.cisco;
+
+import java.io.Serializable;
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+public class CiscoSourceNat implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  private @Nullable String _aclName;
+  private int _aclNameLine;
+  private @Nullable String _natPool;
+  private int _natPoolLine;
+
+  @Nullable
+  public String getAclName() {
+    return _aclName;
+  }
+
+  public int getAclNameLine() {
+    return _aclNameLine;
+  }
+
+  @Nullable
+  public String getNatPool() {
+    return _natPool;
+  }
+
+  public int getNatPoolLine() {
+    return _natPoolLine;
+  }
+
+  public void setAclName(@Nullable String aclName) {
+    this._aclName = aclName;
+  }
+
+  public void setAclNameLine(int aclNameLine) {
+    this._aclNameLine = aclNameLine;
+  }
+
+  public void setNatPool(@Nullable String natPool) {
+    this._natPool = natPool;
+  }
+
+  public void setNatPoolLine(int natPoolLine) {
+    this._natPoolLine = natPoolLine;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof CiscoSourceNat)) {
+      return false;
+    }
+    CiscoSourceNat other = (CiscoSourceNat) o;
+    return (_aclNameLine == other._aclNameLine)
+        && (_natPoolLine == other._natPoolLine)
+        && Objects.equals(_aclName, other._aclName)
+        && Objects.equals(_natPool, other._natPool);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_aclName, _aclNameLine, _natPool, _natPoolLine);
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/Interface.java
@@ -117,15 +117,7 @@ public class Interface extends ComparableStructure<String> {
 
   private Set<Prefix> _secondaryPrefixes;
 
-  private boolean _sourceNat;
-
-  private String _sourceNatAcl;
-
-  private int _sourceNatAclLine;
-
-  private String _sourceNatPool;
-
-  private int _sourceNatPoolLine;
+  private List<CiscoSourceNat> _sourceNats;
 
   private boolean _spanningTreePortfast;
 
@@ -296,24 +288,8 @@ public class Interface extends ComparableStructure<String> {
     return _secondaryPrefixes;
   }
 
-  public boolean getSourceNat() {
-    return _sourceNat;
-  }
-
-  public String getSourceNatAcl() {
-    return _sourceNatAcl;
-  }
-
-  public int getSourceNatAclLine() {
-    return _sourceNatAclLine;
-  }
-
-  public String getSourceNatPool() {
-    return _sourceNatPool;
-  }
-
-  public int getSourceNatPoolLine() {
-    return _sourceNatPoolLine;
+  public List<CiscoSourceNat> getSourceNats() {
+    return _sourceNats;
   }
 
   public boolean getSpanningTreePortfast() {
@@ -440,24 +416,8 @@ public class Interface extends ComparableStructure<String> {
     _routingPolicyLine = routingPolicyLine;
   }
 
-  public void setSourceNat(boolean sourceNat) {
-    _sourceNat = sourceNat;
-  }
-
-  public void setSourceNatAcl(String sourceNatAcl) {
-    _sourceNatAcl = sourceNatAcl;
-  }
-
-  public void setSourceNatAclLine(int sourceNatAclLine) {
-    _sourceNatAclLine = sourceNatAclLine;
-  }
-
-  public void setSourceNatPool(String sourceNatPool) {
-    _sourceNatPool = sourceNatPool;
-  }
-
-  public void setSourceNatPoolLine(int sourceNatPoolLine) {
-    _sourceNatPoolLine = sourceNatPoolLine;
+  public void setSourceNats(List<CiscoSourceNat> sourceNats) {
+    _sourceNats = sourceNats;
   }
 
   public void setSpanningTreePortfast(boolean spanningTreePortfast) {

--- a/projects/batfish/src/test/java/org/batfish/bdp/BdpDataPlanePluginTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bdp/BdpDataPlanePluginTest.java
@@ -1,20 +1,35 @@
 package org.batfish.bdp;
 
+import static java.util.Collections.singletonList;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import org.batfish.common.BatfishException;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.Flow;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpAccessList;
+import org.batfish.datamodel.IpAccessListLine;
+import org.batfish.datamodel.LineAction;
+import org.batfish.datamodel.SourceNat;
 import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 /** Tests for {@link BdpDataPlanePlugin}. */
 public class BdpDataPlanePluginTest {
 
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
+  @Rule public ExpectedException _thrown = ExpectedException.none();
 
   @Test(timeout = 5000)
   public void testComputeFixedPoint() throws IOException {
@@ -30,5 +45,93 @@ public class BdpDataPlanePluginTest {
 
     //Test that compute Data Plane finishes in a finite time
     dataPlanePlugin.computeDataPlane(false);
+  }
+
+  private static Flow makeFlow() {
+    Flow.Builder builder = new Flow.Builder();
+    builder.setSrcIp(new Ip("1.2.3.4"));
+    builder.setIngressNode("foo");
+    builder.setTag("TEST");
+    return builder.build();
+  }
+
+  private static IpAccessListLine makeAclLine(LineAction action) {
+    IpAccessListLine aclLine = new IpAccessListLine();
+    aclLine.setAction(action);
+    return aclLine;
+  }
+
+  private static IpAccessList makeAcl(String name, LineAction action) {
+    IpAccessListLine aclLine = new IpAccessListLine();
+    aclLine.setAction(action);
+    return new IpAccessList(name, singletonList(aclLine));
+  }
+
+  @Test
+  public void testApplySourceNatSingleAclMatch() {
+    Flow flow = makeFlow();
+
+    SourceNat nat = new SourceNat();
+    nat.setAcl(makeAcl("accept", LineAction.ACCEPT));
+    nat.setPoolIpFirst(new Ip("4.5.6.7"));
+
+    Flow transformed = BdpDataPlanePlugin.applySourceNat(flow, singletonList(nat));
+    assertThat(transformed.getSrcIp(), equalTo(new Ip("4.5.6.7")));
+  }
+
+  @Test
+  public void testApplySourceNatSingleAclNoMatch() {
+    Flow flow = makeFlow();
+
+    SourceNat nat = new SourceNat();
+    nat.setAcl(makeAcl("reject", LineAction.REJECT));
+    nat.setPoolIpFirst(new Ip("4.5.6.7"));
+
+    Flow transformed = BdpDataPlanePlugin.applySourceNat(flow, singletonList(nat));
+    assertThat(transformed, is(flow));
+  }
+
+  @Test
+  public void testApplySourceNatFirstMatchWins() {
+    Flow flow = makeFlow();
+
+    SourceNat nat = new SourceNat();
+    nat.setAcl(makeAcl("firstAccept", LineAction.ACCEPT));
+    nat.setPoolIpFirst(new Ip("4.5.6.7"));
+
+    SourceNat secondNat = new SourceNat();
+    secondNat.setAcl(makeAcl("secondAccept", LineAction.ACCEPT));
+    secondNat.setPoolIpFirst(new Ip("4.5.6.8"));
+
+    Flow transformed = BdpDataPlanePlugin.applySourceNat(flow, Lists.newArrayList(nat, secondNat));
+    assertThat(transformed.getSrcIp(), equalTo(new Ip("4.5.6.7")));
+  }
+
+  @Test
+  public void testApplySourceNatLateMatchWins() {
+    Flow flow = makeFlow();
+
+    SourceNat nat = new SourceNat();
+    nat.setAcl(makeAcl("rejectAll", LineAction.REJECT));
+    nat.setPoolIpFirst(new Ip("4.5.6.7"));
+
+    SourceNat secondNat = new SourceNat();
+    secondNat.setAcl(makeAcl("acceptAnyway", LineAction.ACCEPT));
+    secondNat.setPoolIpFirst(new Ip("4.5.6.8"));
+
+    Flow transformed = BdpDataPlanePlugin.applySourceNat(flow, Lists.newArrayList(nat, secondNat));
+    assertThat(transformed.getSrcIp(), equalTo(new Ip("4.5.6.8")));
+  }
+
+  @Test
+  public void testApplySourceNatInvalidAclThrows() {
+    Flow flow = makeFlow();
+
+    SourceNat nat = new SourceNat();
+    nat.setAcl(makeAcl("matchAll", LineAction.ACCEPT));
+
+    _thrown.expect(BatfishException.class);
+    _thrown.expectMessage("missing NAT address or pool");
+    BdpDataPlanePlugin.applySourceNat(flow, singletonList(nat));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoConfigurationTest.java
@@ -1,0 +1,150 @@
+package org.batfish.representation.cisco;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import java.util.Collections;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpAccessList;
+import org.batfish.datamodel.SourceNat;
+import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
+import org.batfish.vendor.StructureType;
+import org.batfish.vendor.StructureUsage;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class CiscoConfigurationTest {
+  private CiscoConfiguration _config;
+  private Interface _interface;
+  private static final String ACL = "acl";
+  private static final String POOL = "pool";
+  private static final Ip IP = new Ip("1.2.3.4");
+
+  // Helper to assert that the given structure is defined. Use with caution: arguments matter as
+  // we're simply asserting that the values do not appear as unused structures.
+  private void assertDefined(StructureType type, String name, StructureUsage usage) {
+    SortedMap<String, SortedMap<String, SortedMap<String, SortedSet<Integer>>>> hostRefs =
+        _config.getAnswerElement().getUndefinedReferences().get(_config.getHostname());
+    if (hostRefs == null) {
+      // Nothing undefined for host.
+      return;
+    }
+
+    SortedMap<String, SortedMap<String, SortedSet<Integer>>> typeRefs =
+        hostRefs.get(type.getDescription());
+    if (typeRefs == null) {
+      // Nothing undefined for this type.
+      return;
+    }
+
+    SortedMap<String, SortedSet<Integer>> usageRefs = typeRefs.get(name);
+    if (usage == null) {
+      // Nothing undefined for this usage.
+      return;
+    }
+
+    SortedSet<Integer> linesUsed = usageRefs.get(usage.getDescription());
+    if (linesUsed == null) {
+      // No lines used for this usage.
+      return;
+    }
+
+    fail("Expected reference to be defined, but it appears in the undefined list");
+  }
+
+  // Helper to assert that the given structure is undefined.
+  private void assertUndefined(StructureType type, String name, StructureUsage usage) {
+    assertThat(
+        "no undefined refs for host",
+        _config.getAnswerElement().getUndefinedReferences(),
+        hasKey(_config.getHostname()));
+    SortedMap<String, SortedMap<String, SortedMap<String, SortedSet<Integer>>>> hostRefs =
+        _config.getAnswerElement().getUndefinedReferences().get(_config.getHostname());
+
+    assertThat("no undefined refs for type", hostRefs, hasKey(type.getDescription()));
+    SortedMap<String, SortedMap<String, SortedSet<Integer>>> typeRefs =
+        hostRefs.get(type.getDescription());
+
+    assertThat("no undefined refs for name", typeRefs, hasKey(name));
+    SortedMap<String, SortedSet<Integer>> usageRefs = typeRefs.get(name);
+
+    assertThat("no lines used for usage", usageRefs, hasKey(usage.getDescription()));
+    SortedSet<Integer> linesUsed = usageRefs.get(usage.getDescription());
+
+    assertThat(linesUsed, not(empty()));
+  }
+
+  // Initializes an empty CiscoConfiguration with a single Interface and minimal settings to not
+  // crash.
+  @Before
+  public void before() {
+    _config = new CiscoConfiguration(Collections.emptySet());
+    _config.setVendor(ConfigurationFormat.ARISTA);
+    _config.setHostname("host");
+    _config.setAnswerElement(new ConvertConfigurationAnswerElement());
+    _interface = new Interface("iface", _config);
+  }
+
+  @Test
+  public void processSourceNatDropsRuleMissingAcl() {
+    CiscoSourceNat nat = new CiscoSourceNat();
+    nat.setAclName(ACL);
+    nat.setNatPool(POOL);
+
+    assertThat(_config.processSourceNat(nat, _interface, Collections.emptyMap()), nullValue());
+    assertUndefined(
+        CiscoStructureType.IP_ACCESS_LIST, ACL, CiscoStructureUsage.IP_NAT_SOURCE_ACCESS_LIST);
+    assertUndefined(CiscoStructureType.NAT_POOL, POOL, CiscoStructureUsage.IP_NAT_SOURCE_POOL);
+  }
+
+  @Test
+  public void processSourceNatDropsRuleMissingPool() {
+    CiscoSourceNat nat = new CiscoSourceNat();
+    nat.setAclName(ACL);
+    nat.setNatPool(POOL);
+
+    assertThat(
+        _config.processSourceNat(
+            nat,
+            _interface,
+            Collections.singletonMap(ACL, new IpAccessList(ACL, Collections.emptyList()))),
+        nullValue());
+    assertDefined(
+        CiscoStructureType.IP_ACCESS_LIST, ACL, CiscoStructureUsage.IP_NAT_SOURCE_ACCESS_LIST);
+    assertUndefined(CiscoStructureType.NAT_POOL, POOL, CiscoStructureUsage.IP_NAT_SOURCE_POOL);
+  }
+
+  @Test
+  public void processSourceNatIsConverted() {
+    CiscoSourceNat nat = new CiscoSourceNat();
+    nat.setAclName(ACL);
+    nat.setNatPool(POOL);
+    NatPool pool = new NatPool(POOL, 5);
+    pool.setFirst(IP);
+    pool.setLast(IP);
+    _config.getNatPools().put(POOL, pool);
+
+    SourceNat convertedNat =
+        _config.processSourceNat(
+            nat,
+            _interface,
+            Collections.singletonMap(ACL, new IpAccessList(ACL, Collections.emptyList())));
+
+    assertThat(convertedNat, notNullValue());
+    assertThat(convertedNat.getAcl().getName(), equalTo(ACL));
+    assertThat(convertedNat.getPoolIpFirst(), equalTo(IP));
+    assertThat(_config.getAnswerElement().getUndefinedReferences().size(), equalTo(0));
+  }
+}

--- a/test_rigs/parsing-tests/unit-tests.ref
+++ b/test_rigs/parsing-tests/unit-tests.ref
@@ -32327,6 +32327,11 @@
               "ip nat source dynamic access-list" : [
                 54
               ]
+            },
+            "def" : {
+              "ip nat source dynamic access-list" : [
+                53
+              ]
             }
           },
           "nat pool" : {

--- a/tests/basic/init-unit-tests.ref
+++ b/tests/basic/init-unit-tests.ref
@@ -537,6 +537,11 @@
               "ip nat source dynamic access-list" : [
                 54
               ]
+            },
+            "def" : {
+              "ip nat source dynamic access-list" : [
+                53
+              ]
             }
           },
           "nat pool" : {

--- a/tests/basic/nodes-unit-tests.ref
+++ b/tests/basic/nodes-unit-tests.ref
@@ -2816,7 +2816,6 @@
               "ospfPassive" : false,
               "prefix" : "1.2.3.4/30",
               "proxyArp" : false,
-              "sourceNat" : { },
               "spanningTreePortfast" : true,
               "switchport" : true,
               "switchportMode" : "TRUNK",


### PR DESCRIPTION
- [x] Modify the data model and Cisco parser to support multiple source NAT rules
- [x] Don't translate source NAT rules into the data model if they are invalid (no ACL, e.g.)
- [x] Update BDP to handle multiple source NAT rules -- it stops at the first valid rule.
- [x] Update and add tests.