### PR TITLE
clear cached configuration in reachability question

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -2555,6 +2555,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
     getDataPlanePlugin().processFlows(flows);
 
     AnswerElement answerElement = getHistory();
+    _cachedConfigurations.clear();
     return answerElement;
   }
 
@@ -3063,6 +3064,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
     popEnvironment();
 
     AnswerElement answerElement = getHistory();
+    _cachedConfigurations.clear();
     return answerElement;
   }
 
@@ -3568,6 +3570,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
     popEnvironment();
 
     AnswerElement answerElement = getHistory();
+    _cachedConfigurations.clear();
     return answerElement;
   }
 
@@ -4189,6 +4192,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
     getDataPlanePlugin().processFlows(flows);
 
     AnswerElement answerElement = getHistory();
+    _cachedConfigurations.clear();
     return answerElement;
   }
 

--- a/test_rigs/example-reachability/configs/as2border2.cfg
+++ b/test_rigs/example-reachability/configs/as2border2.cfg
@@ -1,0 +1,191 @@
+
+!
+version 15.2
+service timestamps debug datetime msec
+service timestamps log datetime msec
+!
+hostname as2border2
+!
+boot-start-marker
+boot-end-marker
+!
+!
+!
+no aaa new-model
+no ip icmp rate-limit unreachable
+ip cef
+!
+!
+!
+!
+!
+!
+no ip domain lookup
+ip domain name lab.local
+no ipv6 cef
+!
+!
+multilink bundle-name authenticated
+!
+!
+!
+!
+!
+!
+!
+!
+!
+ip tcp synwait-time 5
+! 
+!
+!
+!
+!
+!
+!
+!
+!
+!
+!
+!
+interface Loopback0
+ ip address 2.1.1.2 255.255.255.255
+!
+interface Ethernet0/0
+ no ip address
+ shutdown
+ duplex auto
+!
+interface GigabitEthernet0/0
+ ip address 10.23.21.2 255.255.255.0
+ ip access-group OUTSIDE_TO_INSIDE in
+ ip access-group INSIDE_TO_AS3 out
+ media-type gbic
+ speed 1000
+ duplex full
+ negotiation auto
+!
+interface GigabitEthernet1/0
+ ip address 2.12.22.1 255.255.255.0
+ negotiation auto
+!
+interface GigabitEthernet2/0
+ ip address 2.12.21.1 255.255.255.0
+ negotiation auto
+!
+router ospf 1
+ router-id 2.1.1.2
+ redistribute connected subnets
+ network 2.0.0.0 0.255.255.255 area 1
+!
+router bgp 2
+ bgp router-id 2.1.1.2
+ bgp log-neighbor-changes
+ neighbor as1 peer-group
+ neighbor as1 remote-as 1
+ neighbor as2 peer-group
+ neighbor as2 remote-as 2
+ neighbor as3 peer-group
+ neighbor as3 remote-as 3
+ neighbor 2.1.2.1 peer-group as2
+ neighbor 2.1.2.1 update-source Loopback0
+ neighbor 2.1.2.2 peer-group as2
+ neighbor 2.1.2.2 update-source Loopback0
+ neighbor 10.23.21.3 peer-group as3
+ !
+ address-family ipv4
+  bgp dampening
+  bgp additional-paths select all
+  bgp additional-paths send receive
+  aggregate-address 2.128.0.0 255.255.0.0 summary-only
+  neighbor as1 send-community
+  neighbor as1 route-map as1_to_as2 in
+  neighbor as1 route-map as2_to_as1 out
+  neighbor as2 send-community
+  neighbor as2 advertise additional-paths all
+  neighbor as3 send-community
+  neighbor as3 route-map as3_to_as2 in
+  neighbor as3 route-map as2_to_as3 out
+  neighbor 2.1.2.1 activate
+  neighbor 2.1.2.2 activate
+  neighbor 10.23.21.3 activate
+  maximum-paths 5
+ exit-address-family
+!
+ip forward-protocol nd
+!
+ip bgp-community new-format
+ip community-list expanded as1_community permit _1:
+ip community-list expanded as2_community permit _2:
+ip community-list expanded as3_community permit _3:
+!
+no ip http server
+no ip http secure-server
+!
+ip access-list extended INSIDE_TO_AS3
+ permit ip 2.0.0.0 0.255.255.255 3.0.0.0 0.255.255.255
+ deny   ip any any
+ip access-list extended OUTSIDE_TO_INSIDE
+ deny   ip 2.0.0.0 0.255.255.255 any
+ permit ip any any
+!
+!
+ip prefix-list inbound_route_filter seq 5 deny 2.0.0.0/8 le 32
+ip prefix-list inbound_route_filter seq 10 permit 0.0.0.0/0 le 32
+!
+ip prefix-list outbound_routes seq 5 permit 2.128.0.0/9 ge 16
+access-list 101 permit ip host 1.0.1.0 host 255.255.255.0
+access-list 101 permit ip host 1.0.2.0 host 255.255.255.0
+access-list 103 permit ip host 3.0.1.0 host 255.255.255.0
+access-list 103 permit ip host 3.0.2.0 host 255.255.255.0
+!
+route-map as2_to_as1 permit 2
+ match ip address prefix-list outbound_routes
+ set metric 50
+ set community 2:1 additive
+!
+route-map as2_to_as1 permit 3
+ match ip address 103
+ set metric 50
+ set community 2:1 additive
+!
+route-map as1_to_as2 permit 100
+ match community as1_community
+ set local-preference 350
+ set community 1:2 additive
+!
+route-map as2_to_as3 permit 1
+ match ip address 101
+ set metric 50
+ set community 2:3 additive
+!
+route-map as2_to_as3 permit 2
+ match ip address prefix-list outbound_routes
+ set metric 50
+ set community 2:3 additive
+!
+route-map as3_to_as2 permit 100
+ match community as3_community
+ set local-preference 350
+ set community 3:2 additive
+!
+!
+!
+control-plane
+!
+!
+line con 0
+ exec-timeout 0 0
+ privilege level 15
+ logging synchronous
+ stopbits 1
+line aux 0
+ exec-timeout 0 0
+ privilege level 15
+ logging synchronous
+ stopbits 1
+line vty 0 4
+ login
+!
+!
+end

--- a/test_rigs/example-reachability/configs/as3border1.cfg
+++ b/test_rigs/example-reachability/configs/as3border1.cfg
@@ -1,0 +1,181 @@
+
+!
+version 15.2
+service timestamps debug datetime msec
+service timestamps log datetime msec
+!
+hostname as3border1
+!
+boot-start-marker
+boot-end-marker
+!
+!
+!
+no aaa new-model
+no ip icmp rate-limit unreachable
+ip cef
+!
+!
+!
+!
+!
+!
+no ip domain lookup
+ip domain name lab.local
+no ipv6 cef
+!
+!
+multilink bundle-name authenticated
+!
+!
+!
+!
+!
+!
+!
+!
+!
+ip tcp synwait-time 5
+! 
+!
+!
+!
+!
+!
+!
+!
+!
+!
+!
+!
+interface Loopback0
+ ip address 3.1.1.1 255.255.255.255
+!
+interface Ethernet0/0
+ no ip address
+ shutdown
+ duplex auto
+!
+interface GigabitEthernet0/0
+ ip address 3.0.1.1 255.255.255.0
+ media-type gbic
+ speed 1000
+ duplex full
+ negotiation auto
+!
+interface GigabitEthernet1/0
+ ip address 10.23.21.3 255.255.255.0
+ negotiation auto
+!
+router ospf 1
+ router-id 3.1.1.1
+ redistribute connected subnets
+ network 3.0.0.0 0.255.255.255 area 1
+!
+router bgp 3
+ bgp router-id 3.1.1.1
+ bgp log-neighbor-changes
+ neighbor as1 peer-group
+ neighbor as1 remote-as 1
+ neighbor as2 peer-group
+ neighbor as2 remote-as 2
+ neighbor as3 peer-group
+ neighbor as3 remote-as 3
+ neighbor 3.10.1.1 peer-group as3
+ neighbor 3.10.1.1 update-source Loopback0
+ neighbor 10.23.21.2 peer-group as2
+ !
+ address-family ipv4
+  bgp dampening
+  bgp additional-paths select all
+  bgp additional-paths send receive
+  network 3.0.1.0 mask 255.255.255.0
+  network 3.0.2.0 mask 255.255.255.0
+  neighbor as1 send-community
+  neighbor as1 route-map as1_to_as3 in
+  neighbor as1 route-map as3_to_as1 out
+  neighbor as2 send-community
+  neighbor as2 route-map as2_to_as3 in
+  neighbor as2 route-map as3_to_as2 out
+  neighbor as3 send-community
+  neighbor as3 advertise additional-paths all
+  neighbor 3.10.1.1 activate
+  neighbor 10.23.21.2 activate
+  maximum-paths 5
+ exit-address-family
+!
+ip forward-protocol nd
+!
+ip bgp-community new-format
+ip community-list expanded as1_community permit _1:
+ip community-list expanded as2_community permit _2:
+ip community-list expanded as3_community permit _3:
+!
+no ip http server
+no ip http secure-server
+!
+!
+ip prefix-list default_list seq 5 permit 0.0.0.0/0
+!
+ip prefix-list inbound_route_filter seq 5 deny 3.0.0.0/8 le 32
+ip prefix-list inbound_route_filter seq 10 permit 0.0.0.0/0 le 32
+access-list 101 permit ip host 1.0.1.0 host 255.255.255.0
+access-list 101 permit ip host 1.0.2.0 host 255.255.255.0
+access-list 102 permit ip host 2.0.0.0 host 255.0.0.0
+access-list 102 permit ip host 2.128.0.0 host 255.255.0.0
+access-list 103 permit ip host 3.0.1.0 host 255.255.255.0
+access-list 103 permit ip host 3.0.2.0 host 255.255.255.0
+!
+route-map as3_to_as1 permit 2
+ match ip address 102
+ set metric 50
+ set community 3:1 additive
+!
+route-map as3_to_as1 permit 3
+ match ip address 103
+ set metric 50
+ set community 3:1 additive
+!
+route-map as1_to_as3 permit 100
+ match community as1_community
+ set local-preference 350
+!
+route-map as3_to_as2 permit 1
+ match ip address 101
+ set metric 50
+ set community 3:2 additive
+!
+route-map as3_to_as2 permit 3
+ match ip address 103
+ set metric 50
+ set community 3:2 additive
+!
+route-map as3_to_as2 permit 5
+ match ip address prefix-list default_list
+ set metric 50
+ set community 3:2 additive
+!
+route-map as2_to_as3 permit 100
+ match community as2_community
+ set local-preference 350
+!
+!
+!
+control-plane
+!
+!
+line con 0
+ exec-timeout 0 0
+ privilege level 15
+ logging synchronous
+ stopbits 1
+line aux 0
+ exec-timeout 0 0
+ privilege level 15
+ logging synchronous
+ stopbits 1
+line vty 0 4
+ login
+!
+!
+end

--- a/tests/basic/commands
+++ b/tests/basic/commands
@@ -56,3 +56,9 @@ test tests/basic/traceroute-snat.ref get traceroute ingressNode=host1, dstIp="1.
 test tests/basic/init-unit-tests.ref init-testrig test_rigs/unit-tests
 test tests/basic/nodes-unit-tests.ref get nodes summary=false
 
+# get reduced reachability twice in a row
+test tests/basic/init-reachability.ref init-testrig test_rigs/example-reachability
+init-environment interfaceBlacklist=[{hostname="as2border2",interface="GigabitEthernet0/0"}]
+test tests/basic/reduced-reachability.ref get reachability type=reduced
+test tests/basic/reduced-reachability2.ref get reachability type=reduced
+

--- a/tests/basic/init-reachability.ref
+++ b/tests/basic/init-reachability.ref
@@ -1,0 +1,64 @@
+{
+  "answerElements" : [
+    {
+      "class" : "org.batfish.datamodel.answers.ParseVendorConfigurationAnswerElement",
+      "fileMap" : {
+        "as2border2" : "as2border2.cfg",
+        "as3border1" : "as3border1.cfg"
+      },
+      "parseStatus" : {
+        "as2border2" : "PASSED",
+        "as3border1" : "PASSED"
+      },
+      "version" : "0.29.3"
+    },
+    {
+      "class" : "org.batfish.datamodel.answers.ConvertConfigurationAnswerElement",
+      "unusedStructures" : {
+        "as2border2" : {
+          "bgp group" : {
+            "as1" : [
+              84
+            ]
+          },
+          "expanded community-list" : {
+            "as2_community" : [
+              119
+            ]
+          },
+          "ipv4 prefix-list" : {
+            "inbound_route_filter" : [
+              133
+            ]
+          }
+        },
+        "as3border1" : {
+          "bgp group" : {
+            "as1" : [
+              78
+            ]
+          },
+          "expanded community-list" : {
+            "as3_community" : [
+              112
+            ]
+          },
+          "ipv4 prefix-list" : {
+            "inbound_route_filter" : [
+              120
+            ]
+          }
+        }
+      },
+      "version" : "0.29.3"
+    },
+    {
+      "class" : "org.batfish.datamodel.answers.InitInfoAnswerElement",
+      "parseStatus" : {
+        "as2border2" : "PASSED",
+        "as3border1" : "PASSED"
+      }
+    }
+  ],
+  "status" : "SUCCESS"
+}

--- a/tests/basic/reduced-reachability.ref
+++ b/tests/basic/reduced-reachability.ref
@@ -1,0 +1,79 @@
+{
+  "answerElements" : [
+    {
+      "class" : "org.batfish.datamodel.FlowHistory",
+      "flows" : [
+        {
+          "@id" : 1,
+          "dscp" : 0,
+          "dstIp" : "3.0.1.1",
+          "dstPort" : 0,
+          "ecn" : 0,
+          "fragmentOffset" : 0,
+          "icmpCode" : 255,
+          "icmpVar" : 255,
+          "ingressNode" : "as2border2",
+          "ingressVrf" : "default",
+          "ipProtocol" : "UDP",
+          "packetLength" : 0,
+          "srcIp" : "2.0.0.0",
+          "srcPort" : 0,
+          "state" : "NEW",
+          "tag" : "DIFFERENTIAL",
+          "tcpFlagsAck" : 0,
+          "tcpFlagsCwr" : 0,
+          "tcpFlagsEce" : 0,
+          "tcpFlagsFin" : 0,
+          "tcpFlagsPsh" : 0,
+          "tcpFlagsRst" : 0,
+          "tcpFlagsSyn" : 0,
+          "tcpFlagsUrg" : 0
+        }
+      ],
+      "flowsByText" : {
+        "Flow<ingressNode:as2border2 ingressVrf:default srcIp:2.0.0.0 dstIp:3.0.1.1 ipProtocol:UDP srcPort:0 dstPort:0 dscp: 0 ecn:0 fragmentOffset:0 packetLength:0 state:NEW tag:DIFFERENTIAL>" : 1
+      },
+      "traces" : {
+        "Flow<ingressNode:as2border2 ingressVrf:default srcIp:2.0.0.0 dstIp:3.0.1.1 ipProtocol:UDP srcPort:0 dstPort:0 dscp: 0 ecn:0 fragmentOffset:0 packetLength:0 state:NEW tag:DIFFERENTIAL>" : {
+          "BASE" : [
+            {
+              "disposition" : "ACCEPTED",
+              "hops" : [
+                {
+                  "edge" : {
+                    "node1" : "as2border2",
+                    "node1interface" : "GigabitEthernet0/0",
+                    "node2" : "as3border1",
+                    "node2interface" : "GigabitEthernet1/0"
+                  },
+                  "routes" : [
+                    "BgpRoute<3.0.1.0/24,nhip:10.23.21.3,nhint:dynamic>_fnhip:10.23.21.3"
+                  ]
+                }
+              ],
+              "notes" : "ACCEPTED"
+            }
+          ],
+          "DELTA" : [
+            {
+              "disposition" : "NO_ROUTE",
+              "notes" : "NO_ROUTE"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "question" : {
+    "class" : "org.batfish.question.ReachabilityQuestionPlugin$ReachabilityQuestion",
+    "actions" : [
+      "accept"
+    ],
+    "differential" : true,
+    "finalNodeRegex" : ".*",
+    "ingressNodeRegex" : ".*",
+    "negateHeader" : false,
+    "type" : "reduced"
+  },
+  "status" : "SUCCESS"
+}

--- a/tests/basic/reduced-reachability2.ref
+++ b/tests/basic/reduced-reachability2.ref
@@ -1,0 +1,79 @@
+{
+  "answerElements" : [
+    {
+      "class" : "org.batfish.datamodel.FlowHistory",
+      "flows" : [
+        {
+          "@id" : 1,
+          "dscp" : 0,
+          "dstIp" : "3.0.1.1",
+          "dstPort" : 0,
+          "ecn" : 0,
+          "fragmentOffset" : 0,
+          "icmpCode" : 255,
+          "icmpVar" : 255,
+          "ingressNode" : "as2border2",
+          "ingressVrf" : "default",
+          "ipProtocol" : "UDP",
+          "packetLength" : 0,
+          "srcIp" : "2.0.0.0",
+          "srcPort" : 0,
+          "state" : "NEW",
+          "tag" : "DIFFERENTIAL",
+          "tcpFlagsAck" : 0,
+          "tcpFlagsCwr" : 0,
+          "tcpFlagsEce" : 0,
+          "tcpFlagsFin" : 0,
+          "tcpFlagsPsh" : 0,
+          "tcpFlagsRst" : 0,
+          "tcpFlagsSyn" : 0,
+          "tcpFlagsUrg" : 0
+        }
+      ],
+      "flowsByText" : {
+        "Flow<ingressNode:as2border2 ingressVrf:default srcIp:2.0.0.0 dstIp:3.0.1.1 ipProtocol:UDP srcPort:0 dstPort:0 dscp: 0 ecn:0 fragmentOffset:0 packetLength:0 state:NEW tag:DIFFERENTIAL>" : 1
+      },
+      "traces" : {
+        "Flow<ingressNode:as2border2 ingressVrf:default srcIp:2.0.0.0 dstIp:3.0.1.1 ipProtocol:UDP srcPort:0 dstPort:0 dscp: 0 ecn:0 fragmentOffset:0 packetLength:0 state:NEW tag:DIFFERENTIAL>" : {
+          "BASE" : [
+            {
+              "disposition" : "ACCEPTED",
+              "hops" : [
+                {
+                  "edge" : {
+                    "node1" : "as2border2",
+                    "node1interface" : "GigabitEthernet0/0",
+                    "node2" : "as3border1",
+                    "node2interface" : "GigabitEthernet1/0"
+                  },
+                  "routes" : [
+                    "BgpRoute<3.0.1.0/24,nhip:10.23.21.3,nhint:dynamic>_fnhip:10.23.21.3"
+                  ]
+                }
+              ],
+              "notes" : "ACCEPTED"
+            }
+          ],
+          "DELTA" : [
+            {
+              "disposition" : "NO_ROUTE",
+              "notes" : "NO_ROUTE"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "question" : {
+    "class" : "org.batfish.question.ReachabilityQuestionPlugin$ReachabilityQuestion",
+    "actions" : [
+      "accept"
+    ],
+    "differential" : true,
+    "finalNodeRegex" : ".*",
+    "ingressNodeRegex" : ".*",
+    "negateHeader" : false,
+    "type" : "reduced"
+  },
+  "status" : "SUCCESS"
+}


### PR DESCRIPTION
For issues #335. Cause: The function call [synthesizeDataPlane](https://github.com/batfish/batfish/blob/master/projects/batfish/src/main/java/org/batfish/main/Batfish.java#L3502) calls the constructor of [Synthesizer](https://github.com/batfish/batfish/blob/master/projects/batfish/src/main/java/org/batfish/main/Batfish.java#L4224), which will modify the configurations in cachedConfiguration, [code here](https://github.com/batfish/batfish/blob/master/projects/batfish/src/main/java/org/batfish/z3/Synthesizer.java#L909). The next reachability question loads the configurations from [cachedConfiguration](https://github.com/batfish/batfish/blob/master/projects/batfish/src/main/java/org/batfish/main/Batfish.java#L2311), which is actually been modified in the previous call. Solution: clear cachedConfiguration before returning from methods which could modify the configurations. 
This fixes #335 