### PR TITLE
WorkMgr: Connect to the client via the pool manager settings

### DIFF
--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -145,14 +145,14 @@ public class WorkMgr {
       // Client client = ClientBuilder.newClient();
       Client client =
           CommonUtil.createHttpClientBuilder(
-                  _settings.getSslWorkDisable(),
-                  _settings.getSslWorkTrustAllCerts(),
-                  _settings.getSslWorkKeystoreFile(),
-                  _settings.getSslWorkKeystorePassword(),
-                  _settings.getSslWorkTruststoreFile(),
-                  _settings.getSslWorkTruststorePassword())
+                  _settings.getSslPoolDisable(),
+                  _settings.getSslPoolTrustAllCerts(),
+                  _settings.getSslPoolKeystoreFile(),
+                  _settings.getSslPoolKeystorePassword(),
+                  _settings.getSslPoolTruststoreFile(),
+                  _settings.getSslPoolTruststorePassword())
               .build();
-      String protocol = _settings.getSslWorkDisable() ? "http" : "https";
+      String protocol = _settings.getSslPoolDisable() ? "http" : "https";
       WebTarget webTarget =
           client
               .target(


### PR DESCRIPTION
The intended invariant is that the Coordinator pool manager and Worker server are
either both using SSL or neither using SSL. Fix this for the connection that
the Coordinator's work maanger uses when opening a connection to the Worker server.