### PR TITLE
PrependAsPath: optimize algorithm and fix bug

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/Environment.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/Environment.java
@@ -1,5 +1,6 @@
 package org.batfish.datamodel.routing_policy;
 
+import javax.annotation.Nonnull;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.AbstractRoute6;
 import org.batfish.datamodel.AbstractRouteBuilder;
@@ -46,7 +47,7 @@ public class Environment {
   private boolean _writeToIntermediateBgpAttributes;
 
   public Environment(
-      Configuration configuration,
+      @Nonnull Configuration configuration,
       String vrf,
       AbstractRoute originalRoute,
       AbstractRoute6 originalRoute6,

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/LiteralAsList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/LiteralAsList.java
@@ -43,7 +43,7 @@ public class LiteralAsList extends AsPathListExpr {
 
   @Override
   public List<Integer> evaluate(Environment environment) {
-    List<Integer> list = new ArrayList<>();
+    List<Integer> list = new ArrayList<>(_list.size());
     for (AsExpr expr : _list) {
       int as = expr.evaluate(environment);
       list.add(as);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/statement/PrependAsPathTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/statement/PrependAsPathTest.java
@@ -1,0 +1,63 @@
+package org.batfish.datamodel.routing_policy.statement;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Lists;
+import java.util.Arrays;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.stream.Collectors;
+import org.batfish.datamodel.BgpRoute;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.routing_policy.Environment;
+import org.batfish.datamodel.routing_policy.expr.AsExpr;
+import org.batfish.datamodel.routing_policy.expr.ExplicitAs;
+import org.batfish.datamodel.routing_policy.expr.LiteralAsList;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class PrependAsPathTest {
+
+  private static Environment newTestEnvironment(BgpRoute.Builder outputRoute) {
+    Configuration c = new Configuration("host");
+    return new Environment(c, "vrf", null, null, outputRoute, null);
+  }
+
+  private static List<SortedSet<Integer>> mkAsPath(Integer... explicitAs) {
+    return Arrays.stream(explicitAs).map(ImmutableSortedSet::of).collect(Collectors.toList());
+  }
+
+  @Test
+  public void testPrepend() {
+    List<AsExpr> prepend = Lists.newArrayList(new ExplicitAs(1), new ExplicitAs(2));
+    PrependAsPath operation = new PrependAsPath(new LiteralAsList(prepend));
+    BgpRoute.Builder builder = new BgpRoute.Builder();
+    builder.setAsPath(mkAsPath(3, 4));
+    Environment env = newTestEnvironment(builder);
+
+    operation.execute(env);
+    assertThat(builder.getAsPath(), equalTo(mkAsPath(1, 2, 3, 4)));
+  }
+
+  @Test
+  public void testPrependWithIntermediateAttributes() {
+    List<AsExpr> prepend = Lists.newArrayList(new ExplicitAs(1), new ExplicitAs(2));
+    PrependAsPath operation = new PrependAsPath(new LiteralAsList(prepend));
+    BgpRoute.Builder outputRoute = new BgpRoute.Builder();
+    outputRoute.setAsPath(mkAsPath(3, 4));
+
+    BgpRoute.Builder intermediateAttributes = new BgpRoute.Builder();
+    intermediateAttributes.setAsPath(mkAsPath(5, 6));
+    Environment env = newTestEnvironment(outputRoute);
+    env.setIntermediateBgpAttributes(intermediateAttributes);
+    env.setWriteToIntermediateBgpAttributes(true);
+
+    operation.execute(env);
+    assertThat(outputRoute.getAsPath(), equalTo(mkAsPath(1, 2, 3, 4)));
+    assertThat(intermediateAttributes.getAsPath(), equalTo(mkAsPath(1, 2, 5, 6)));
+  }
+}


### PR DESCRIPTION
When prepending a path of N nodes, we used to insert each node at the front of existing lists.
For something like an array list, this is N full shifts of the array. Optimize this by
computing the entire prefix to be appended first, then doing a single array shift.