### PR TITLE
add allowed_values validation

### DIFF
--- a/projects/batfish-client/src/main/java/org/batfish/client/Client.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/Client.java
@@ -241,7 +241,13 @@ public class Client extends AbstractClient implements IClient {
 
   /**
    * This method calls {@link Client#validateType(JsonNode, Variable)} to check that the contents
-   * encoded in {@code value} match the requirement specified in {@code variable}.
+   * encoded in {@code value} match the requirement specified in {@code variable}. Also, this
+   * method validates the input {@code value} is allowed according to {@link
+   * Question.InstanceData.Variable#_allowedValues allowedValues} specified in {@code variable}.
+   *
+   * @throws BatfishException if the content type encoded in input {@code value} does not satisfy
+   *     the type requirements specified in {@code variable}, or the input {@code value} is not an
+   *     allowed value for {@code variable}.
    */
   static void validateNode(JsonNode value, Variable variable, String parameterName)
       throws BatfishException {
@@ -251,6 +257,13 @@ public class Client extends AbstractClient implements IClient {
       String errorMessage =
           String.format("Invalid value for parameter %s: %s", parameterName, value);
       throw new BatfishException(errorMessage, e);
+    }
+    if (!(variable.getAllowedValues().isEmpty() || variable.getAllowedValues()
+        .contains(value.asText()))) {
+      throw new BatfishException(String.format(
+          "Invalid value: %s, allowed values are: %s",
+          value.asText(),
+          variable.getAllowedValues()));
     }
   }
 

--- a/projects/batfish-client/src/test/java/org/batfish/client/ClientTest.java
+++ b/projects/batfish-client/src/test/java/org/batfish/client/ClientTest.java
@@ -86,6 +86,8 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import org.apache.commons.lang.ArrayUtils;
 import org.batfish.common.BatfishException;
 import org.batfish.common.BatfishLogger;
@@ -1323,11 +1325,29 @@ public class ClientTest {
   }
 
   @Test
+  public void testValidateNodeNotAllowedValue() throws IOException {
+    String parameterName = "boolean";
+    JsonNode invalidNode = _mapper.readTree("false");
+    Question.InstanceData.Variable variable = new Question.InstanceData.Variable();
+    variable.setType(Question.InstanceData.Variable.Type.BOOLEAN);
+    SortedSet<String> allowedValues = new TreeSet<>();
+    allowedValues.add("true");
+    variable.setAllowedValues(allowedValues);
+    _thrown.expect(BatfishException.class);
+    _thrown.expectMessage(
+        String.format("Invalid value: false, allowed values are: %s", allowedValues));
+    Client.validateNode(invalidNode, variable, parameterName);
+  }
+
+  @Test
   public void testValidateValidNode() throws IOException {
     String parameterName = "boolean";
     JsonNode invalidNode = _mapper.readTree("false");
     Question.InstanceData.Variable variable = new Question.InstanceData.Variable();
     variable.setType(Question.InstanceData.Variable.Type.BOOLEAN);
+    SortedSet<String> allowedValues = new TreeSet<>();
+    allowedValues.add("false");
+    variable.setAllowedValues(allowedValues);
     Client.validateNode(invalidNode, variable, parameterName);
   }
 


### PR DESCRIPTION
Missed allowed values validation in client's validate function. After the type is verified, we should also check the value is allowed for the variable if specified.