### PR TITLE
Modify container object

### DIFF
--- a/projects/batfish-client/src/main/java/org/batfish/client/Client.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/Client.java
@@ -41,6 +41,7 @@ import java.util.TreeSet;
 import java.util.UUID;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+import java.util.stream.Collectors;
 import jline.console.ConsoleReader;
 import jline.console.UserInterruptException;
 import jline.console.completer.Completer;
@@ -80,6 +81,7 @@ import org.batfish.datamodel.Protocol;
 import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.answers.Answer;
 import org.batfish.datamodel.collections.NodeInterfacePair;
+import org.batfish.datamodel.pojo.Testrig;
 import org.batfish.datamodel.questions.Question;
 import org.batfish.datamodel.questions.Question.InstanceData;
 import org.batfish.datamodel.questions.Question.InstanceData.Variable;
@@ -1322,7 +1324,11 @@ public class Client extends AbstractClient implements IClient {
     String containerName = parameters.get(0);
     Container container = _workHelper.getContainer(containerName);
     if (container != null) {
-      _logger.output(container.getTestrigs() + "\n");
+      String testrigNames = container.getTestrigs()
+          .stream()
+          .map(Testrig::getName)
+          .collect(Collectors.joining(", "));
+      _logger.output("[" + testrigNames + "]\n");
       return true;
     }
     return false;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/Container.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/Container.java
@@ -3,29 +3,36 @@ package org.batfish.common;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
-import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
-import java.util.SortedSet;
+import javax.annotation.Nullable;
+import org.batfish.datamodel.pojo.Analysis;
+import org.batfish.datamodel.pojo.Testrig;
 
+/**
+ * The {@link Container Container} is an Object representation of the container for BatFish service.
+ *
+ * <p>Each {@link Container Container} contains a name, a list of {@link Testrig Testrig}, and a
+ * list of {@link Analysis Analysis} inside the container.
+ */
 public final class Container {
   private static final String PROP_NAME = "name";
   private static final String PROP_TESTRIGS = "testrigs";
-  private static final String PROP_ANALYSIS = "analysis";
+  private static final String PROP_ANALYSES = "analyses";
 
-  private String _name;
-  private SortedSet<String> _testrigs;
-  private Path _analysis;
+  private final String _name;
+  private final List<Testrig> _testrigs;
+  private final List<Analysis> _analyses;
 
   @JsonCreator
-  public static Container of(
+  public Container(
       @JsonProperty(PROP_NAME) String name,
-      @JsonProperty(PROP_TESTRIGS) SortedSet<String> testrigs) {
-    return new Container(name, testrigs);
-  }
-
-  private Container(String name, SortedSet<String> testrigs) {
+      @JsonProperty(PROP_TESTRIGS) @Nullable List<Testrig> testrigs,
+      @JsonProperty(PROP_ANALYSES) @Nullable List<Analysis> analyses) {
     this._name = name;
-    this._testrigs = testrigs;
+    this._testrigs = testrigs == null ? new ArrayList<>() : testrigs;
+    this._analyses = analyses == null ? new ArrayList<>() : analyses;
   }
 
   @JsonProperty(PROP_NAME)
@@ -34,28 +41,13 @@ public final class Container {
   }
 
   @JsonProperty(PROP_TESTRIGS)
-  public SortedSet<String> getTestrigs() {
+  public List<Testrig> getTestrigs() {
     return _testrigs;
   }
 
-  @JsonProperty(PROP_ANALYSIS)
-  public Path getAnalysis() {
-    return _analysis;
-  }
-
-  @JsonProperty(PROP_NAME)
-  public void setName(String name) {
-    _name = name;
-  }
-
-  @JsonProperty(PROP_TESTRIGS)
-  public void setTestrigs(SortedSet<String> testrigs) {
-    _testrigs = testrigs;
-  }
-
-  @JsonProperty(PROP_ANALYSIS)
-  public void setAnalysis(Path analysis) {
-    _analysis = analysis;
+  @JsonProperty(PROP_ANALYSES)
+  public List<Analysis> getAnalyses() {
+    return _analyses;
   }
 
   @Override
@@ -63,6 +55,7 @@ public final class Container {
     return MoreObjects.toStringHelper(Container.class)
         .add(PROP_NAME, _name)
         .add(PROP_TESTRIGS, _testrigs)
+        .add(PROP_ANALYSES, _analyses)
         .toString();
   }
 
@@ -72,11 +65,13 @@ public final class Container {
       return false;
     }
     Container other = (Container) o;
-    return Objects.equals(_name, other._name) && Objects.equals(_testrigs, other._testrigs);
+    return Objects.equals(_name, other._name)
+        && Objects.equals(_testrigs, other._testrigs)
+        && Objects.equals(_analyses, other._analyses);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_name, _testrigs);
+    return Objects.hash(_name, _testrigs, _analyses);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/pojo/Testrig.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/pojo/Testrig.java
@@ -1,0 +1,77 @@
+package org.batfish.datamodel.pojo;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/**
+ * The {@link Testrig Testrig} is an Object representation of the testrig for BatFish service.
+ *
+ * <p>Each {@link Testrig Testrig} contains all information inside the testrig {@link #_name},
+ * including environments, raw configuration files, etc.
+ */
+public class Testrig {
+  private static final String PROP_NAME = "name";
+  private static final String PROP_ENVIRONMENTS = "environments";
+  private static final String PROP_CONFIGURATIONS = "configurations";
+
+  private final String _name;
+  private final List<Environment> _environments;
+  private final Map<String, String> _configurations;
+
+  @JsonCreator
+  public Testrig(
+      @JsonProperty(PROP_NAME) String name,
+      @JsonProperty(PROP_ENVIRONMENTS) @Nullable List<Environment> environments,
+      @JsonProperty(PROP_CONFIGURATIONS) @Nullable Map<String, String> configurations) {
+    this._name = name;
+    this._environments = environments == null ? new ArrayList<>() : environments;
+    this._configurations = configurations == null ? new HashMap<>() : configurations;
+  }
+
+  @JsonProperty(PROP_NAME)
+  public String getName() {
+    return _name;
+  }
+
+  @JsonProperty(PROP_ENVIRONMENTS)
+  public List<Environment> getEnvironments() {
+    return _environments;
+  }
+
+  @JsonProperty(PROP_CONFIGURATIONS)
+  public Map<String, String> getConfigurations() {
+    return _configurations;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(Testrig.class)
+        .add(PROP_NAME, _name)
+        .add(PROP_ENVIRONMENTS, _environments)
+        .add(PROP_CONFIGURATIONS, _configurations)
+        .toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof Testrig)) {
+      return false;
+    }
+    Testrig other = (Testrig) o;
+    return Objects.equals(_name, other._name)
+        && Objects.equals(_environments, other._environments)
+        && Objects.equals(_configurations, other._configurations);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_name, _environments, _configurations);
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/ContainerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/ContainerTest.java
@@ -3,36 +3,75 @@ package org.batfish.common;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
-import com.google.common.collect.Sets;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.common.testing.EqualsTester;
-import java.util.Collections;
-import java.util.TreeSet;
+import java.util.List;
+import org.batfish.datamodel.pojo.Analysis;
+import org.batfish.datamodel.pojo.Testrig;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/**
- * Tests for {@link Container}.
- */
+/** Tests for {@link Container}. */
 @RunWith(JUnit4.class)
 public class ContainerTest {
+
+  @Rule public ExpectedException _thrown = ExpectedException.none();
+
+  @Test
+  public void testConstructorAndGetter() {
+    List<Testrig> testrigs =
+        Lists.newArrayList(
+            new Testrig(
+                "testrig",
+                Lists.newArrayList(),
+                Maps.newHashMap()));
+    List<Analysis> analyses = Lists.newArrayList(new Analysis("analysis", Maps.newHashMap()));
+    Container container = new Container("container", testrigs, analyses);
+    assertThat(container.getName(), equalTo("container"));
+    assertThat(container.getTestrigs(), equalTo(testrigs));
+    assertThat(container.getAnalyses(), equalTo(analyses));
+  }
+
   @Test
   public void testToString() {
-    Container c = Container.of("foo", new TreeSet<>());
-    assertThat(c.toString(), equalTo("Container{name=foo, testrigs=[]}"));
+    List<Testrig> testrigs =
+        Lists.newArrayList(
+            new Testrig(
+                "testrig",
+                Lists.newArrayList(),
+                Maps.newHashMap()));
+    List<Analysis> analyses = Lists.newArrayList(new Analysis("analysis", Maps.newHashMap()));
+    Container c = new Container("container", testrigs, analyses);
+    assertThat(
+        c.toString(),
+        equalTo(
+            String.format(
+                "Container{name=container, testrigs=%s, analyses=%s}", testrigs, analyses)));
   }
 
   @Test
   public void testEquals() {
-    Container c = Container.of("foo", new TreeSet<>());
-    Container cCopy = Container.of("foo", new TreeSet<>());
-    Container cWithTestrig =
-        Container.of("foo", Sets.newTreeSet(Collections.singletonList("testrig")));
-    Container cOtherName = Container.of("bar", new TreeSet<>());
+    List<Testrig> testrigs =
+        Lists.newArrayList(
+            new Testrig(
+                "testrig",
+                Lists.newArrayList(),
+                Maps.newHashMap()));
+    List<Analysis> analyses = Lists.newArrayList(new Analysis("analysis", Maps.newHashMap()));
+    Container c = new Container("foo", Lists.newArrayList(), Lists.newArrayList());
+    Container cCopy = new Container("foo", Lists.newArrayList(), Lists.newArrayList());
+    Container cWithTestrig = new Container("foo", testrigs, Lists.newArrayList());
+    Container cWithAnalyses = new Container("foo", Lists.newArrayList(), analyses);
+    Container cOtherName = new Container("bar", Lists.newArrayList(), Lists.newArrayList());
 
     new EqualsTester()
         .addEqualityGroup(c, cCopy)
         .addEqualityGroup(cWithTestrig)
+        .addEqualityGroup(cWithAnalyses)
         .addEqualityGroup(cOtherName)
         .testEquals();
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/pojo/TestrigTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/pojo/TestrigTest.java
@@ -1,0 +1,57 @@
+package org.batfish.datamodel.pojo;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.testing.EqualsTester;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link Testrig}. */
+@RunWith(JUnit4.class)
+public class TestrigTest {
+
+  @Test public void testConstructorAndGetter() {
+    Environment environment = new Environment("environment", null, null, null, null, null, null);
+    List<Environment> environments = Lists.newArrayList(environment);
+    Map<String, String> configurations = Collections.singletonMap("config", "configContent");
+    Testrig testrig = new Testrig("testrig", environments, configurations);
+    assertThat(testrig.getName(), equalTo("testrig"));
+    assertThat(testrig.getEnvironments(), equalTo(environments));
+    assertThat(testrig.getConfigurations(), equalTo(configurations));
+  }
+
+  @Test public void testToString() {
+    Environment environment = new Environment("environment", null, null, null, null, null, null);
+    List<Environment> environments = Lists.newArrayList(environment);
+    Map<String, String> configurations = Collections.singletonMap("config", "configContent");
+    Testrig testrig = new Testrig("testrig", environments, configurations);
+    String expected = String.format("Testrig{name=testrig, environments=%s, configurations=%s}",
+        environments,
+        configurations);
+    assertThat(testrig.toString(), equalTo(expected));
+  }
+
+  @Test public void testEquals() {
+    Environment environment = new Environment("environment", null, null, null, null, null, null);
+    List<Environment> environments = Lists.newArrayList(environment);
+    Map<String, String> configurations = Collections.singletonMap("config", "configContent");
+    Testrig t = new Testrig("foo", Lists.newArrayList(), Maps.newHashMap());
+    Testrig tCopy = new Testrig("foo", Lists.newArrayList(), Maps.newHashMap());
+    Testrig tWithEnvironments = new Testrig("foo", environments, Maps.newHashMap());
+    Testrig tWithConfigurations = new Testrig("foo", Lists.newArrayList(), configurations);
+    Testrig tOtherName = new Testrig("bar", Lists.newArrayList(), Maps.newHashMap());
+
+    new EqualsTester().addEqualityGroup(t, tCopy)
+        .addEqualityGroup(tWithEnvironments)
+        .addEqualityGroup(tWithConfigurations)
+        .addEqualityGroup(tOtherName)
+        .testEquals();
+  }
+}

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -20,7 +21,6 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -39,6 +39,8 @@ import org.batfish.common.util.ZipUtility;
 import org.batfish.coordinator.config.Settings;
 import org.batfish.datamodel.answers.Answer;
 import org.batfish.datamodel.answers.AnswerStatus;
+import org.batfish.datamodel.pojo.Analysis;
+import org.batfish.datamodel.pojo.Testrig;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
@@ -525,21 +527,23 @@ public class WorkMgr {
     return answer;
   }
 
-  /** Return a {@link Container container} contains all testrigs directories inside it. */
+  /**
+   * Returns a {@link Container container} contains all information about the container {@code
+   * containerName}
+   */
   public Container getContainer(String containerName) {
-    return getContainer(getdirContainer(containerName));
-  }
-
-  /** Return a {@link Container container} contains all testrigs directories inside it */
-  public Container getContainer(Path containerDir) {
-    SortedSet<String> testrigs =
-        new TreeSet<>(
-            CommonUtil.getSubdirectories(containerDir.resolve(BfConsts.RELPATH_TESTRIGS_DIR))
-                .stream()
-                .map(dir -> dir.getFileName().toString())
-                .collect(Collectors.toSet()));
-
-    return Container.of(containerDir.toFile().getName(), testrigs);
+    SortedSet<String> testrigNames = listTestrigs(containerName);
+    List<Testrig> testrigs = new ArrayList<>();
+    // TODO use functions like getTestrig, getAnalysis when implemented in storage API
+    for (String testrigName : testrigNames) {
+      testrigs.add(new Testrig(testrigName, null, null));
+    }
+    SortedSet<String> analysisNames = listAnalyses(containerName);
+    List<Analysis> analyses = new ArrayList<>();
+    for (String analysisName : analysisNames) {
+      analyses.add(new Analysis(analysisName, null));
+    }
+    return new Container(containerName, testrigs, analyses);
   }
 
   private Path getdirAnalysisQuestion(String containerName, String analysisName, String qName) {

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
@@ -632,7 +632,7 @@ public class WorkMgrService {
 
       checkContainerAccessibility(apiKey, containerName);
 
-      Container container = Main.getWorkMgr().getContainer(containerDir);
+      Container container = Main.getWorkMgr().getContainer(containerName);
       BatfishObjectMapper mapper = new BatfishObjectMapper();
       String containerString = mapper.writeValueAsString(container);
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrServiceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrServiceTest.java
@@ -6,10 +6,9 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import com.google.common.collect.Sets;
+import com.google.common.collect.Lists;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collections;
 import javax.ws.rs.core.Response;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.BfConsts;
@@ -18,6 +17,7 @@ import org.batfish.common.CoordConsts;
 import org.batfish.common.Version;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.coordinator.config.Settings;
+import org.batfish.datamodel.pojo.Testrig;
 import org.codehaus.jettison.json.JSONArray;
 import org.junit.Rule;
 import org.junit.Test;
@@ -27,8 +27,6 @@ import org.junit.rules.TemporaryFolder;
 public class WorkMgrServiceTest {
 
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
-
-  private WorkMgr _manager;
 
   private WorkMgrService _service;
 
@@ -40,9 +38,9 @@ public class WorkMgrServiceTest {
     Main.mainInit(new String[] {"-containerslocation", _folder.getRoot().toString()});
     Main.initAuthorizer();
     Main.setLogger(logger);
-    _manager = new WorkMgr(settings, logger);
-    Main.setWorkMgr(_manager);
-    _manager.initContainer(_containerName, null);
+    WorkMgr manager = new WorkMgr(settings, logger);
+    Main.setWorkMgr(manager);
+    manager.initContainer(_containerName, null);
     _service = new WorkMgrService();
   }
 
@@ -83,8 +81,10 @@ public class WorkMgrServiceTest {
     Response response = _service.getContainer("100", "0.0.0", _containerName);
     BatfishObjectMapper mapper = new BatfishObjectMapper();
     Container container = mapper.readValue(response.getEntity().toString(), Container.class);
-    Container expected =
-        Container.of(_containerName, Sets.newTreeSet(Collections.singleton("testrig")));
+    Container expected = new Container(
+        _containerName,
+        Lists.newArrayList(new Testrig("testrig", null, null)),
+        Lists.newArrayList());
     assertThat(container, equalTo(expected));
   }
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrServiceV2Test.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrServiceV2Test.java
@@ -8,8 +8,8 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.TreeSet;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
@@ -75,7 +75,7 @@ public class WorkMgrServiceV2Test extends JerseyTest {
   @Test
   public void getContainer() throws Exception {
     String containerName = "some container";
-    Container expected = Container.of(containerName, new TreeSet<>());
+    Container expected = new Container(containerName, new ArrayList<>(), new ArrayList<>());
     Main.getWorkMgr().initContainer(containerName, null);
 
     Response response = target("/v2/container").path(containerName).request().get();

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
@@ -8,18 +8,16 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 import java.util.SortedSet;
-import java.util.TreeSet;
 import org.batfish.common.BatfishException;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.BfConsts;
 import org.batfish.common.Container;
 import org.batfish.coordinator.config.Settings;
+import org.batfish.datamodel.pojo.Testrig;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -131,7 +129,9 @@ public class WorkMgrTest {
   public void getEmptyContainer() {
     _manager.initContainer("container", null);
     Container container = _manager.getContainer("container");
-    assertThat(container, equalTo(Container.of("container", new TreeSet<>())));
+    assertThat(
+        container,
+        equalTo(new Container("container", Lists.newArrayList(), Lists.newArrayList())));
   }
 
   @Test
@@ -144,7 +144,9 @@ public class WorkMgrTest {
     Container container = _manager.getContainer("container");
     assertThat(
         container,
-        equalTo(Container.of("container", Sets.newTreeSet(Collections.singleton("testrig")))));
+        equalTo(new Container("container",
+            Lists.newArrayList(new Testrig("testrig", null, null)),
+            Lists.newArrayList())));
   }
 
   @Test


### PR DESCRIPTION
Dependent on PR #389 
Modify the Container object, modify some tests. Now we should have enough Object types for current client side api calls. Next step will be discuss the actual implementation in storage API, for each function implemented, rewrite functions in WorkMgr, WorkMgrService, add add it to WorkMgrServiceV2.