### PR TITLE
Fix some missing structure references

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -2960,12 +2960,19 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
       int aclLine = ctx.acl.getStart().getLine();
       nat.setAclName(acl);
       nat.setAclNameLine(aclLine);
+      _configuration.referenceStructure(
+          CiscoStructureType.IP_ACCESS_LIST,
+          acl,
+          CiscoStructureUsage.IP_NAT_SOURCE_ACCESS_LIST,
+          aclLine);
     }
     if (ctx.pool != null) {
       String pool = ctx.pool.getText();
       int poolLine = ctx.pool.getStart().getLine();
       nat.setNatPool(pool);
       nat.setNatPoolLine(poolLine);
+      _configuration.referenceStructure(
+          CiscoStructureType.NAT_POOL, pool, CiscoStructureUsage.IP_NAT_SOURCE_POOL, poolLine);
     }
 
     for (Interface iface : _currentInterfaces) {
@@ -4779,9 +4786,13 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
     if (ctx.acl != null) {
       name = ctx.acl.getText();
       acl = true;
+      _configuration.referenceStructure(
+          CiscoStructureType.IP_ACCESS_LIST, name, CiscoStructureUsage.RIP_DISTRIBUTE_LIST, line);
     } else {
       name = ctx.prefix_list.getText();
       acl = false;
+      _configuration.referenceStructure(
+          CiscoStructureType.PREFIX_LIST, name, CiscoStructureUsage.RIP_DISTRIBUTE_LIST, line);
     }
     if (in) {
       proc.setDistributeListIn(name);

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -3570,6 +3570,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
     markIpv4Acls(CiscoStructureUsage.PIM_SEND_RP_ANNOUNCE_ACL, c);
     markIpv4Acls(CiscoStructureUsage.PIM_SPT_THRESHOLD_ACL, c);
     markIpv4Acls(CiscoStructureUsage.PIM_SSM_ACL, c);
+    markAcls(CiscoStructureUsage.RIP_DISTRIBUTE_LIST, c);
     markAcls(CiscoStructureUsage.ROUTER_ISIS_DISTRIBUTE_LIST_ACL, c);
     markAcls(CiscoStructureUsage.SNMP_SERVER_FILE_TRANSFER_ACL, c);
     markAcls(CiscoStructureUsage.SNMP_SERVER_TFTP_SERVER_LIST, c);

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoStructureUsage.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoStructureUsage.java
@@ -65,6 +65,7 @@ public enum CiscoStructureUsage implements StructureUsage {
   PIM_SSM_ACL("pim ssl acl"),
   QOS_ENFORCE_RULE_SERVICE_CLASS("cable qos enforce-rule service-class"),
   RIP_DEFAULT_ORIGINATE_ROUTE_MAP("rip default-information originate route-map"),
+  RIP_DISTRIBUTE_LIST("router rip distribute-list"),
   RIP_REDISTRIBUTE_BGP_MAP("router rip redistribute bgp route-map"),
   RIP_REDISTRIBUTE_CONNECTED_MAP("router rip redistribute connected route-map"),
   RIP_REDISTRIBUTE_STATIC_MAP("router rip redistribute static route-map"),

--- a/test_rigs/parsing-tests/unit-tests.ref
+++ b/test_rigs/parsing-tests/unit-tests.ref
@@ -13637,6 +13637,24 @@
             "      VARIABLE:'cisco_interface'  <== mode:DEFAULT_MODE",
             "      NEWLINE:'\\n'  <== mode:DEFAULT_MODE))",
             "  (stanza",
+            "    (extended_access_list_stanza",
+            "      IP:'ip'  <== mode:DEFAULT_MODE",
+            "      ACCESS_LIST:'access-list'  <== mode:DEFAULT_MODE",
+            "      (variable",
+            "        VARIABLE:'abc'  <== mode:DEFAULT_MODE)",
+            "      NEWLINE:'\\n'  <== mode:DEFAULT_MODE",
+            "      (extended_access_list_tail",
+            "        DEC:'10'  <== mode:DEFAULT_MODE",
+            "        (access_list_action",
+            "          PERMIT:'permit'  <== mode:DEFAULT_MODE)",
+            "        (protocol",
+            "          TCP:'tcp'  <== mode:DEFAULT_MODE)",
+            "        (access_list_ip_range",
+            "          ANY:'any'  <== mode:DEFAULT_MODE)",
+            "        (access_list_ip_range",
+            "          ANY:'any'  <== mode:DEFAULT_MODE)",
+            "        NEWLINE:'\\n'  <== mode:DEFAULT_MODE)))",
+            "  (stanza",
             "    (s_interface",
             "      INTERFACE:'interface'  <== mode:DEFAULT_MODE",
             "      (interface_name",
@@ -38802,46 +38820,41 @@
           "ipv4 acl" : {
             "167" : {
               "interface ip verify access-list" : [
-                69
+                72
               ]
             },
             "mynatacl" : {
               "ip nat destination acl" : [
-                55
+                58
               ]
             }
           },
           "ipv4/6 acl" : {
             "1" : {
               "interface igmp access-group acl" : [
-                53
+                56
               ]
             },
             "310-systems" : {
               "interface outgoing ip access-list" : [
-                72
-              ]
-            },
-            "abc" : {
-              "ip nat source dynamic access-list" : [
-                59
+                75
               ]
             },
             "ag1" : {
               "interface incoming ip access-list" : [
-                42
+                45
               ]
             },
             "def" : {
               "ip nat source dynamic access-list" : [
-                58
+                61
               ]
             }
           },
           "nat pool" : {
             "beeble" : {
               "ip nat source pool" : [
-                59
+                62
               ]
             }
           }

--- a/test_rigs/parsing-tests/unit-tests.ref
+++ b/test_rigs/parsing-tests/unit-tests.ref
@@ -21507,7 +21507,7 @@
             "      (rr_distribute_list",
             "        DISTRIBUTE_LIST:'distribute-list'  <== mode:DEFAULT_MODE",
             "        (variable",
-            "          VARIABLE:'CBN-RIP-allowed'  <== mode:DEFAULT_MODE)",
+            "          VARIABLE:'some-ACL'  <== mode:DEFAULT_MODE)",
             "        IN:'in'  <== mode:DEFAULT_MODE",
             "        NEWLINE:'\\n'  <== mode:DEFAULT_MODE)",
             "      (rr_network",
@@ -38713,6 +38713,15 @@
             }
           }
         },
+        "cadant_rip" : {
+          "ipv4/6 acl" : {
+            "blah-std-acl" : {
+              "router rip distribute-list" : [
+                6
+              ]
+            }
+          }
+        },
         "cadant_route_map" : {
           "ipv4 prefix-list" : {
             "bar-prefix-list" : {
@@ -38920,6 +38929,15 @@
             "boop" : {
               "class-map access-group" : [
                 14
+              ]
+            }
+          }
+        },
+        "cisco_rip" : {
+          "ipv4/6 acl" : {
+            "some-ACL" : {
+              "router rip distribute-list" : [
+                6
               ]
             }
           }

--- a/test_rigs/unit-tests/configs/cisco_interface
+++ b/test_rigs/unit-tests/configs/cisco_interface
@@ -1,6 +1,9 @@
 !
 hostname cisco_interface
 !
+ip access-list abc
+   10 permit tcp any any
+!
 interface Ethernet0
  antenna gain 6
  arp timeout 240

--- a/test_rigs/unit-tests/configs/cisco_rip
+++ b/test_rigs/unit-tests/configs/cisco_rip
@@ -3,7 +3,7 @@ hostname cisco_rip
 !
 router rip
  no auto-summary
- distribute-list CBN-RIP-allowed in
+ distribute-list some-ACL in
  network 1.2.3.0
  passive-interface default
  no passive-interface Bundle1.23

--- a/tests/basic/init-unit-tests.ref
+++ b/tests/basic/init-unit-tests.ref
@@ -569,6 +569,15 @@
             }
           }
         },
+        "cadant_rip" : {
+          "ipv4/6 acl" : {
+            "blah-std-acl" : {
+              "router rip distribute-list" : [
+                6
+              ]
+            }
+          }
+        },
         "cadant_route_map" : {
           "ipv4 prefix-list" : {
             "bar-prefix-list" : {
@@ -776,6 +785,15 @@
             "boop" : {
               "class-map access-group" : [
                 14
+              ]
+            }
+          }
+        },
+        "cisco_rip" : {
+          "ipv4/6 acl" : {
+            "some-ACL" : {
+              "router rip distribute-list" : [
+                6
               ]
             }
           }

--- a/tests/basic/init-unit-tests.ref
+++ b/tests/basic/init-unit-tests.ref
@@ -658,46 +658,41 @@
           "ipv4 acl" : {
             "167" : {
               "interface ip verify access-list" : [
-                69
+                72
               ]
             },
             "mynatacl" : {
               "ip nat destination acl" : [
-                55
+                58
               ]
             }
           },
           "ipv4/6 acl" : {
             "1" : {
               "interface igmp access-group acl" : [
-                53
+                56
               ]
             },
             "310-systems" : {
               "interface outgoing ip access-list" : [
-                72
-              ]
-            },
-            "abc" : {
-              "ip nat source dynamic access-list" : [
-                59
+                75
               ]
             },
             "ag1" : {
               "interface incoming ip access-list" : [
-                42
+                45
               ]
             },
             "def" : {
               "ip nat source dynamic access-list" : [
-                58
+                61
               ]
             }
           },
           "nat pool" : {
             "beeble" : {
               "ip nat source pool" : [
-                59
+                62
               ]
             }
           }

--- a/tests/basic/nodes-unit-tests.ref
+++ b/tests/basic/nodes-unit-tests.ref
@@ -4611,6 +4611,27 @@
               "vrf" : "default"
             }
           },
+          "ipAccessLists" : {
+            "abc" : {
+              "name" : "abc",
+              "lines" : [
+                {
+                  "action" : "ACCEPT",
+                  "dstIps" : [
+                    "0.0.0.0/0"
+                  ],
+                  "ipProtocols" : [
+                    "TCP"
+                  ],
+                  "name" : "10 permit tcp any any",
+                  "negate" : false,
+                  "srcIps" : [
+                    "0.0.0.0/0"
+                  ]
+                }
+              ]
+            }
+          },
           "roles" : [
             "cisco"
           ],


### PR DESCRIPTION
Questions:

* When do we use CiscoStructureType.IPV4_ACCESS_LIST vs IP_ACCESS_LIST? It looks like CiscoStructureType.IP_ACCESS_LIST_EXTENDED is never used, nor is CiscoStructureType.IP_ACCESS_LIST_STANDARD.
* (aka, should these be registered as IPV4 or IP)

* What determines which types of structures we "mark references to IPv4/6 ACLs that may not appear in data model". Why do we not mark all references, regardless of whether they appear in the data model? Only mildly redundant work.