### PR TITLE
CommonUtil: simplify hashing and matching

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
@@ -1,5 +1,6 @@
 package org.batfish.common.util;
 
+import com.google.common.hash.Hashing;
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -23,11 +24,8 @@ import java.nio.file.Paths;
 import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.FileTime;
 import java.security.KeyStore;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.IdentityHashMap;
@@ -40,9 +38,9 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import javax.net.ssl.HostnameVerifier;
@@ -460,24 +458,16 @@ public class CommonUtil {
   }
 
   public static List<String> getMatchingStrings(String regex, Set<String> allStrings) {
-    List<String> matchingStrings = new ArrayList<>();
     Pattern pattern;
     try {
       pattern = Pattern.compile(regex);
     } catch (PatternSyntaxException e) {
       throw new BatfishException("Supplied regex is not a valid java regex: \"" + regex + "\"", e);
     }
-    if (pattern != null) {
-      for (String s : allStrings) {
-        Matcher matcher = pattern.matcher(s);
-        if (matcher.matches()) {
-          matchingStrings.add(s);
-        }
-      }
-    } else {
-      matchingStrings.addAll(allStrings);
-    }
-    return matchingStrings;
+    return allStrings
+        .stream()
+        .filter(s -> pattern.matcher(s).matches())
+        .collect(Collectors.toList());
   }
 
   public static SortedSet<Path> getSubdirectories(Path directory) {
@@ -542,26 +532,10 @@ public class CommonUtil {
     return upper + ":" + lower;
   }
 
+  /** Returns a hex {@link String} representation of the MD5 hash digest of the input string. */
+  @SuppressWarnings("deprecation") // md5 is deprecated, but used deliberately.
   public static String md5Digest(String saltedSecret) {
-    MessageDigest digest = null;
-    try {
-      digest = MessageDigest.getInstance("MD5");
-    } catch (NoSuchAlgorithmException e) {
-      throw new BatfishException("Could not initialize md5 hasher", e);
-    }
-    byte[] plainTextBytes = null;
-    plainTextBytes = saltedSecret.getBytes(StandardCharsets.UTF_8);
-    byte[] digestBytes = digest.digest(plainTextBytes);
-    StringBuffer sb = new StringBuffer();
-    for (int i = 0; i < digestBytes.length; i++) {
-      int digestByteAsInt = 0xff & digestBytes[i];
-      if (digestByteAsInt < 0x10) {
-        sb.append('0');
-      }
-      sb.append(Integer.toHexString(digestByteAsInt));
-    }
-    String md5 = sb.toString();
-    return md5;
+    return Hashing.md5().hashString(saltedSecret, StandardCharsets.UTF_8).toString();
   }
 
   public static void moveByCopy(Path srcPath, Path dstPath) {
@@ -626,26 +600,9 @@ public class CommonUtil {
     return SALT;
   }
 
+  /** Returns a hex {@link String} representation of the SHA-256 hash digest of the input string. */
   public static String sha256Digest(String saltedSecret) {
-    MessageDigest digest = null;
-    try {
-      digest = MessageDigest.getInstance("SHA-256");
-    } catch (NoSuchAlgorithmException e) {
-      throw new BatfishException("Could not initialize sha256 hasher", e);
-    }
-    byte[] plainTextBytes = null;
-    plainTextBytes = saltedSecret.getBytes(StandardCharsets.UTF_8);
-    byte[] digestBytes = digest.digest(plainTextBytes);
-    StringBuffer sb = new StringBuffer();
-    for (int i = 0; i < digestBytes.length; i++) {
-      int digestByteAsInt = 0xff & digestBytes[i];
-      if (digestByteAsInt < 0x10) {
-        sb.append('0');
-      }
-      sb.append(Integer.toHexString(digestByteAsInt));
-    }
-    String sha256 = sb.toString();
-    return sha256;
+    return Hashing.sha256().hashString(saltedSecret, StandardCharsets.UTF_8).toString();
   }
 
   public static void startSslServer(


### PR DESCRIPTION
Use some useful libraries to do the work for us, cleaner code.

I tested equivalence of the hashing as follows:

```java
  private static final String[] messages =
      new String[] {
        "", "foo", "bar", "éüñ", "thequickbrownfox jumped over the_lazy!dog",
      };

  @Test
  public void testDigestSha256() {
    for (String m : messages) {
      String old = CommonUtil.sha256Digest(m);
      String newH = Hashing.sha256().hashString(m, StandardCharsets.UTF_8).toString();
      assertThat(newH, equalTo(old));
    }
  }
```