### PR TITLE
Fix Travis checking of unit tests, fix unit tests

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -9,7 +9,7 @@ fi
 trap 'kill -9 $(pgrep -g $$ | grep -v $$) >& /dev/null' EXIT SIGINT SIGTERM
 
 . tools/batfish_functions.sh
-batfish_build_all || exit 1
+batfish_test_all || exit 1
 
 echo -e "\n  ..... Running parsing tests"
 allinone -cmdfile test_rigs/parsing-tests/commands || exit 1

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -3456,7 +3456,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
       inferredRoles = true;
       nodeRolesPath = settings.getInferredNodeRolesPath();
       if (!Files.exists(nodeRolesPath)) {
-        result = new NodeRoleSpecifier();
+        return new NodeRoleSpecifier();
       }
     }
     result = parseNodeRoles(nodeRolesPath);

--- a/tools/common.sh
+++ b/tools/common.sh
@@ -111,6 +111,18 @@ _batfish_build_all() {
 }
 export -f _batfish_build_all
 
+batfish_test_all() {
+   bash -c '_batfish_test_all "$@"' _batfish_test_all "$@" || return 1
+}
+export -f batfish_test_all
+
+_batfish_test_all() {
+   _pre_build || return 1
+   cd "${PROJECTS_PATH}"
+   mvn clean install || return 1
+}
+export -f _batfish_test_all
+
 batfish_confirm() {
    # call with a prompt string or use a default
    read -r -p "${1:-Are you sure? [y/N]} " response < /dev/tty


### PR DESCRIPTION
Travis wasn't running unit tests any more after #383. Fix this by adding a new command `batfish_test_all`, then fix the recently-broken unit test.