### PR TITLE
Checkstyle: add back in unused import checks

### DIFF
--- a/projects/batfish-client/src/main/java/org/batfish/client/BfCoordWorkHelper.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/BfCoordWorkHelper.java
@@ -1,6 +1,5 @@
 package org.batfish.client;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Iterators;
 import java.io.File;
 import java.nio.file.Files;
@@ -1074,8 +1073,8 @@ public class BfCoordWorkHelper {
   }
 
   @Nullable
-  public boolean syncTestrigsUpdateSettings(String pluginId, String containerName,
-                                            Map<String, String> settings) {
+  public boolean syncTestrigsUpdateSettings(
+      String pluginId, String containerName, Map<String, String> settings) {
     try {
       BatfishObjectMapper mapper = new BatfishObjectMapper();
       String settingsStr = mapper.writeValueAsString(settings);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AclLinesAnswerElement.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AclLinesAnswerElement.java
@@ -7,7 +7,6 @@ import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import org.batfish.datamodel.IpAccessList;
-import org.batfish.datamodel.RouteFilterLine;
 
 public class AclLinesAnswerElement implements AnswerElement {
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/RoutingPolicy.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/RoutingPolicy.java
@@ -12,7 +12,6 @@ import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.AbstractRouteBuilder;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Ip;
-import org.batfish.datamodel.collections.NamedStructureOutlierSet;
 import org.batfish.datamodel.routing_policy.Environment.Direction;
 import org.batfish.datamodel.routing_policy.statement.Statement;
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/StaticRoute.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/StaticRoute.java
@@ -3,7 +3,6 @@ package org.batfish.representation.cisco;
 import java.io.Serializable;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
-import org.batfish.datamodel.routing_policy.RoutingPolicy;
 
 public class StaticRoute implements Serializable {
 

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
-import javax.annotation.Nullable;
 import org.batfish.common.util.ComparableStructure;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IsoAddress;

--- a/projects/batfish/src/main/java/org/batfish/smt/LogicalGraph.java
+++ b/projects/batfish/src/main/java/org/batfish/smt/LogicalGraph.java
@@ -5,7 +5,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nullable;
 import org.batfish.common.BatfishException;
 import org.batfish.datamodel.BgpNeighbor;
 import org.batfish.datamodel.Configuration;

--- a/projects/checkstyle.xml
+++ b/projects/checkstyle.xml
@@ -28,6 +28,7 @@
         </module>
 
     <module name="TreeWalker">
+        <module name="UnusedImports"/>
         <module name="OuterTypeFilename"/>
         <module name="IllegalTokenText">
             <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>

--- a/projects/question/src/main/java/org/batfish/question/RolesQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/RolesQuestionPlugin.java
@@ -1,8 +1,6 @@
 package org.batfish.question;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
@@ -28,8 +26,7 @@ public class RolesQuestionPlugin extends QuestionPlugin {
 
     private List<String> _nodes;
 
-    public RolesAnswerElement() {
-    }
+    public RolesAnswerElement() {}
 
     @JsonProperty(PROP_ROLE_SPECIFIER)
     public NodeRoleSpecifier getRoleSpecifier() {
@@ -40,11 +37,12 @@ public class RolesQuestionPlugin extends QuestionPlugin {
     public String prettyPrint() {
 
       StringBuilder sb;
-      sb = new StringBuilder(
-          "Results for roles\n");
+      sb = new StringBuilder("Results for roles\n");
 
-      sb.append("The following role specifier was "
-          + (_roleSpecifier.getInferred() ? "inferred" : "user-provided") + ":\n");
+      sb.append(
+          "The following role specifier was "
+              + (_roleSpecifier.getInferred() ? "inferred" : "user-provided")
+              + ":\n");
 
       sb.append("Role regexes: \n");
       for (String regex : _roleSpecifier.getRoleRegexes()) {
@@ -77,9 +75,7 @@ public class RolesQuestionPlugin extends QuestionPlugin {
     public void setNodes(List<String> nodes) {
       _nodes = nodes;
     }
-
   }
-
 
   public static class RolesAnswerer extends Answerer {
 
@@ -93,11 +89,10 @@ public class RolesQuestionPlugin extends QuestionPlugin {
       RolesQuestion question = (RolesQuestion) _question;
       RolesAnswerElement answerElement = new RolesAnswerElement();
 
-      Map<String,Configuration> configurations = _batfish.loadConfigurations();
+      Map<String, Configuration> configurations = _batfish.loadConfigurations();
       // collect relevant nodes in a list.
-      List<String> nodes = CommonUtil.getMatchingStrings(
-          question.getNodeRegex(),
-          configurations.keySet());
+      List<String> nodes =
+          CommonUtil.getMatchingStrings(question.getNodeRegex(), configurations.keySet());
 
       answerElement.setNodes(nodes);
 
@@ -105,23 +100,19 @@ public class RolesQuestionPlugin extends QuestionPlugin {
       answerElement.setRoleSpecifier(roleSpecifier);
 
       return answerElement;
-      }
     }
+  }
 
   // <question_page_comment>
   /**
    * List the roles of each node.
    *
    * @type Roles multifile
-   *
-   * @param nodeRegex
-   *           Regular expression for names of nodes to include. Default value
-   *           is '.*' (all nodes).
-   *
-   * @param inferred
-   *          Boolean indicating whether to show the roles that were automatically
-   *          inferred, even if an explicit NodeRoleSpecifier was provided when the
-   *          testrig was uploaded.  Default value is false.
+   * @param nodeRegex Regular expression for names of nodes to include. Default value is '.*' (all
+   *     nodes).
+   * @param inferred Boolean indicating whether to show the roles that were automatically inferred,
+   *     even if an explicit NodeRoleSpecifier was provided when the testrig was uploaded. Default
+   *     value is false.
    */
   public static final class RolesQuestion extends Question {
 
@@ -171,7 +162,6 @@ public class RolesQuestionPlugin extends QuestionPlugin {
     public void setInferred(boolean inferred) {
       _inferred = inferred;
     }
-
   }
 
   @Override
@@ -183,5 +173,4 @@ public class RolesQuestionPlugin extends QuestionPlugin {
   protected Question createQuestion() {
     return new RolesQuestion();
   }
-
 }


### PR DESCRIPTION
We actually used to fail the build on unused import statements, but @arifogel deleted it in https://github.com/batfish/batfish/commit/99ee00da221f82dabc96075cb4642c004165f1aa#diff-c8602ac9b6ac80a8ed85c9dfcc308e79L14.

Re-add these checks, and fix the existing bugs.