### PR TITLE
assign a name for accessListLine that from an iptable file

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/iptables/IptablesControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/iptables/IptablesControlPlaneExtractor.java
@@ -186,8 +186,15 @@ public class IptablesControlPlaneExtractor extends IptablesParserBaseListener
     } else {
       todo(ctx, "Unknown rule action");
     }
-
+    rule.setName(getFullText(ctx));
     return rule;
+  }
+
+  private String getFullText(ParserRuleContext ctx) {
+    int start = ctx.getStart().getStartIndex();
+    int end = ctx.getStop().getStopIndex();
+    String text = _text.substring(start, end + 1);
+    return text;
   }
 
   @Nullable

--- a/projects/batfish/src/main/java/org/batfish/representation/iptables/IptablesRule.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/iptables/IptablesRule.java
@@ -35,10 +35,11 @@ public class IptablesRule implements Serializable {
     }
   }
 
-  IptablesActionType _actionType;
-  List<IptablesMatch> _matchList;
+  private IptablesActionType _actionType;
+  private List<IptablesMatch> _matchList;
 
-  String _nextChain;
+  private String _name;
+  private String _nextChain;
 
   public IptablesRule() {
     _matchList = new LinkedList<>();
@@ -70,6 +71,14 @@ public class IptablesRule implements Serializable {
 
   public String getNextChain() {
     return _nextChain;
+  }
+
+  public String getName() {
+    return _name;
+  }
+
+  public void setName(String name) {
+    _name = name;
   }
 
   public void setAction(ChainPolicy policy) {

--- a/projects/batfish/src/main/java/org/batfish/representation/iptables/IptablesVendorConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/iptables/IptablesVendorConfiguration.java
@@ -76,7 +76,7 @@ public class IptablesVendorConfiguration extends IptablesConfiguration {
   }
 
   private IpAccessList toIpAccessList(String aclName, IptablesChain chain) {
-    IpAccessList acl = new IpAccessList(aclName, new LinkedList<IpAccessListLine>());
+    IpAccessList acl = new IpAccessList(aclName, new LinkedList<>());
 
     for (IptablesRule rule : chain.getRules()) {
       IpAccessListLine aclLine = new IpAccessListLine();
@@ -92,11 +92,6 @@ public class IptablesVendorConfiguration extends IptablesConfiguration {
             List<SubRange> dstPortRanges = match.toPortRanges();
             aclLine.getDstPorts().addAll(dstPortRanges);
             break;
-            // case IN_INTERFACE:
-            // case OUT_INTERFACE:
-            // _warnings.unimplemented("Matching on incoming and outgoing
-            // interface not supported");
-            // break;
           case PROTOCOL:
             aclLine.getIpProtocols().add(match.toIpProtocol());
             break;
@@ -115,6 +110,7 @@ public class IptablesVendorConfiguration extends IptablesConfiguration {
         }
       }
 
+      aclLine.setName(rule.getName());
       aclLine.setAction(rule.getIpAccessListLineAction());
       acl.getLines().add(aclLine);
     }
@@ -123,6 +119,7 @@ public class IptablesVendorConfiguration extends IptablesConfiguration {
     LineAction chainAction = chain.getIpAccessListLineAction();
     IpAccessListLine defaultLine = new IpAccessListLine();
     defaultLine.setAction(chainAction);
+    defaultLine.setName("default");
     acl.getLines().add(defaultLine);
 
     return acl;

--- a/tests/basic/aclReachability.ref
+++ b/tests/basic/aclReachability.ref
@@ -425,6 +425,7 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
+                "name" : "default",
                 "negate" : false
               }
             ]
@@ -440,6 +441,7 @@
                 "ipProtocols" : [
                   "UDP"
                 ],
+                "name" : "-p udp --dport 53 -j ACCEPT",
                 "negate" : false
               },
               {
@@ -450,10 +452,12 @@
                 "ipProtocols" : [
                   "TCP"
                 ],
+                "name" : "-p tcp --dport 22 -j ACCEPT",
                 "negate" : false
               },
               {
                 "action" : "REJECT",
+                "name" : "default",
                 "negate" : false
               }
             ]
@@ -463,6 +467,7 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
+                "name" : "default",
                 "negate" : false
               }
             ]
@@ -472,6 +477,7 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
+                "name" : "default",
                 "negate" : false
               }
             ]
@@ -481,6 +487,7 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
+                "name" : "default",
                 "negate" : false
               }
             ]
@@ -490,6 +497,7 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
+                "name" : "default",
                 "negate" : false
               }
             ]
@@ -499,6 +507,7 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
+                "name" : "default",
                 "negate" : false
               }
             ]
@@ -508,6 +517,7 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
+                "name" : "default",
                 "negate" : false
               }
             ]
@@ -517,6 +527,7 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
+                "name" : "default",
                 "negate" : false
               }
             ]
@@ -526,6 +537,7 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
+                "name" : "default",
                 "negate" : false
               }
             ]
@@ -535,6 +547,7 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
+                "name" : "default",
                 "negate" : false
               }
             ]
@@ -552,10 +565,12 @@
                 "ipProtocols" : [
                   "TCP"
                 ],
+                "name" : "-p tcp --dport 22 -j ACCEPT",
                 "negate" : false
               },
               {
                 "action" : "REJECT",
+                "name" : "default",
                 "negate" : false
               }
             ]
@@ -568,10 +583,12 @@
                 "dstIps" : [
                   "2.128.0.101"
                 ],
+                "name" : "-d 2.128.0.101 -j DROP",
                 "negate" : false
               },
               {
                 "action" : "ACCEPT",
+                "name" : "default",
                 "negate" : false
               }
             ]
@@ -908,74 +925,87 @@
           "filter::FORWARD" : [
             {
               "index" : 0,
+              "name" : "default",
               "differentAction" : false
             }
           ],
           "filter::INPUT" : [
             {
               "index" : 0,
+              "name" : "-p udp --dport 53 -j ACCEPT",
               "differentAction" : false
             },
             {
               "index" : 1,
+              "name" : "-p tcp --dport 22 -j ACCEPT",
               "differentAction" : false
             },
             {
               "index" : 2,
+              "name" : "default",
               "differentAction" : false
             }
           ],
           "filter::OUTPUT" : [
             {
               "index" : 0,
+              "name" : "default",
               "differentAction" : false
             }
           ],
           "mangle::FORWARD" : [
             {
               "index" : 0,
+              "name" : "default",
               "differentAction" : false
             }
           ],
           "mangle::INPUT" : [
             {
               "index" : 0,
+              "name" : "default",
               "differentAction" : false
             }
           ],
           "mangle::OUTPUT" : [
             {
               "index" : 0,
+              "name" : "default",
               "differentAction" : false
             }
           ],
           "mangle::POSTROUTING" : [
             {
               "index" : 0,
+              "name" : "default",
               "differentAction" : false
             }
           ],
           "mangle::PREROUTING" : [
             {
               "index" : 0,
+              "name" : "default",
               "differentAction" : false
             }
           ],
           "nat::OUTPUT" : [
             {
               "index" : 0,
+              "name" : "default",
               "differentAction" : false
             }
           ],
           "nat::POSTROUTING" : [
             {
               "index" : 0,
+              "name" : "default",
               "differentAction" : false
             }
           ],
           "nat::PREROUTING" : [
             {
               "index" : 0,
+              "name" : "default",
               "differentAction" : false
             }
           ]
@@ -984,20 +1014,24 @@
           "filter::INPUT" : [
             {
               "index" : 0,
+              "name" : "-p tcp --dport 22 -j ACCEPT",
               "differentAction" : false
             },
             {
               "index" : 1,
+              "name" : "default",
               "differentAction" : false
             }
           ],
           "filter::OUTPUT" : [
             {
               "index" : 0,
+              "name" : "-d 2.128.0.101 -j DROP",
               "differentAction" : false
             },
             {
               "index" : 1,
+              "name" : "default",
               "differentAction" : false
             }
           ]
@@ -1033,5 +1067,10 @@
     "differential" : false,
     "nodeRegex" : ".*"
   },
-  "status" : "SUCCESS"
+  "status" : "SUCCESS",
+  "summary" : {
+    "numFailed" : 0,
+    "numPassed" : 0,
+    "numResults" : 0
+  }
 }

--- a/tests/basic/nodes-unit-tests.ref
+++ b/tests/basic/nodes-unit-tests.ref
@@ -7746,6 +7746,7 @@
                   "ipProtocols" : [
                     "TCP"
                   ],
+                  "name" : "-s 1.2.3.4/32 -p tcp -m tcp --dport 22 -j ACCEPT",
                   "negate" : false,
                   "srcIps" : [
                     "1.2.3.4"
@@ -7759,6 +7760,7 @@
                   "ipProtocols" : [
                     "TCP"
                   ],
+                  "name" : "-s 11.22.33.44/32 -p tcp -m tcp --dport 25 -j ACCEPT",
                   "negate" : false,
                   "srcIps" : [
                     "11.22.33.44"
@@ -7772,6 +7774,7 @@
                   "ipProtocols" : [
                     "TCP"
                   ],
+                  "name" : "-s 111.222.111.222/32 -p tcp -m tcp --dport 80 -j ACCEPT",
                   "negate" : false,
                   "srcIps" : [
                     "111.222.111.222"
@@ -7785,6 +7788,7 @@
                   "ipProtocols" : [
                     "TCP"
                   ],
+                  "name" : "-s 4.3.2.1/32 -p tcp -m tcp --dport 110 -j ACCEPT",
                   "negate" : false,
                   "srcIps" : [
                     "4.3.2.1"
@@ -7798,6 +7802,7 @@
                   "ipProtocols" : [
                     "TCP"
                   ],
+                  "name" : "-s 44.22.33.11/32 -p tcp -m tcp --dport 143 -j ACCEPT",
                   "negate" : false,
                   "srcIps" : [
                     "44.22.33.11"
@@ -7805,6 +7810,7 @@
                 },
                 {
                   "action" : "ACCEPT",
+                  "name" : "default",
                   "negate" : false
                 }
               ]
@@ -7814,6 +7820,7 @@
               "lines" : [
                 {
                   "action" : "ACCEPT",
+                  "name" : "default",
                   "negate" : false
                 }
               ]
@@ -7823,6 +7830,7 @@
               "lines" : [
                 {
                   "action" : "ACCEPT",
+                  "name" : "default",
                   "negate" : false
                 }
               ]
@@ -7832,6 +7840,7 @@
               "lines" : [
                 {
                   "action" : "ACCEPT",
+                  "name" : "default",
                   "negate" : false
                 }
               ]
@@ -7841,6 +7850,7 @@
               "lines" : [
                 {
                   "action" : "ACCEPT",
+                  "name" : "default",
                   "negate" : false
                 }
               ]
@@ -7850,6 +7860,7 @@
               "lines" : [
                 {
                   "action" : "ACCEPT",
+                  "name" : "default",
                   "negate" : false
                 }
               ]
@@ -7859,6 +7870,7 @@
               "lines" : [
                 {
                   "action" : "ACCEPT",
+                  "name" : "default",
                   "negate" : false
                 }
               ]
@@ -7868,6 +7880,7 @@
               "lines" : [
                 {
                   "action" : "ACCEPT",
+                  "name" : "default",
                   "negate" : false
                 }
               ]
@@ -7877,6 +7890,7 @@
               "lines" : [
                 {
                   "action" : "ACCEPT",
+                  "name" : "default",
                   "negate" : false
                 }
               ]
@@ -7886,6 +7900,7 @@
               "lines" : [
                 {
                   "action" : "ACCEPT",
+                  "name" : "default",
                   "negate" : false
                 }
               ]

--- a/tests/basic/nodes.ref
+++ b/tests/basic/nodes.ref
@@ -10947,6 +10947,7 @@
               "lines" : [
                 {
                   "action" : "ACCEPT",
+                  "name" : "default",
                   "negate" : false
                 }
               ]
@@ -10962,6 +10963,7 @@
                   "ipProtocols" : [
                     "UDP"
                   ],
+                  "name" : "-p udp --dport 53 -j ACCEPT",
                   "negate" : false
                 },
                 {
@@ -10972,10 +10974,12 @@
                   "ipProtocols" : [
                     "TCP"
                   ],
+                  "name" : "-p tcp --dport 22 -j ACCEPT",
                   "negate" : false
                 },
                 {
                   "action" : "REJECT",
+                  "name" : "default",
                   "negate" : false
                 }
               ]
@@ -10985,6 +10989,7 @@
               "lines" : [
                 {
                   "action" : "ACCEPT",
+                  "name" : "default",
                   "negate" : false
                 }
               ]
@@ -10994,6 +10999,7 @@
               "lines" : [
                 {
                   "action" : "ACCEPT",
+                  "name" : "default",
                   "negate" : false
                 }
               ]
@@ -11003,6 +11009,7 @@
               "lines" : [
                 {
                   "action" : "ACCEPT",
+                  "name" : "default",
                   "negate" : false
                 }
               ]
@@ -11012,6 +11019,7 @@
               "lines" : [
                 {
                   "action" : "ACCEPT",
+                  "name" : "default",
                   "negate" : false
                 }
               ]
@@ -11021,6 +11029,7 @@
               "lines" : [
                 {
                   "action" : "ACCEPT",
+                  "name" : "default",
                   "negate" : false
                 }
               ]
@@ -11030,6 +11039,7 @@
               "lines" : [
                 {
                   "action" : "ACCEPT",
+                  "name" : "default",
                   "negate" : false
                 }
               ]
@@ -11039,6 +11049,7 @@
               "lines" : [
                 {
                   "action" : "ACCEPT",
+                  "name" : "default",
                   "negate" : false
                 }
               ]
@@ -11048,6 +11059,7 @@
               "lines" : [
                 {
                   "action" : "ACCEPT",
+                  "name" : "default",
                   "negate" : false
                 }
               ]
@@ -11057,6 +11069,7 @@
               "lines" : [
                 {
                   "action" : "ACCEPT",
+                  "name" : "default",
                   "negate" : false
                 }
               ]
@@ -11126,6 +11139,7 @@
               "lines" : [
                 {
                   "action" : "ACCEPT",
+                  "name" : "default",
                   "negate" : false
                 }
               ]
@@ -11141,10 +11155,12 @@
                   "ipProtocols" : [
                     "TCP"
                   ],
+                  "name" : "-p tcp --dport 22 -j ACCEPT",
                   "negate" : false
                 },
                 {
                   "action" : "REJECT",
+                  "name" : "default",
                   "negate" : false
                 }
               ]
@@ -11157,10 +11173,12 @@
                   "dstIps" : [
                     "2.128.0.101"
                   ],
+                  "name" : "-d 2.128.0.101 -j DROP",
                   "negate" : false
                 },
                 {
                   "action" : "ACCEPT",
+                  "name" : "default",
                   "negate" : false
                 }
               ]
@@ -11170,6 +11188,7 @@
               "lines" : [
                 {
                   "action" : "ACCEPT",
+                  "name" : "default",
                   "negate" : false
                 }
               ]
@@ -11179,6 +11198,7 @@
               "lines" : [
                 {
                   "action" : "ACCEPT",
+                  "name" : "default",
                   "negate" : false
                 }
               ]
@@ -11188,6 +11208,7 @@
               "lines" : [
                 {
                   "action" : "ACCEPT",
+                  "name" : "default",
                   "negate" : false
                 }
               ]
@@ -11197,6 +11218,7 @@
               "lines" : [
                 {
                   "action" : "ACCEPT",
+                  "name" : "default",
                   "negate" : false
                 }
               ]
@@ -11206,6 +11228,7 @@
               "lines" : [
                 {
                   "action" : "ACCEPT",
+                  "name" : "default",
                   "negate" : false
                 }
               ]
@@ -11215,6 +11238,7 @@
               "lines" : [
                 {
                   "action" : "ACCEPT",
+                  "name" : "default",
                   "negate" : false
                 }
               ]
@@ -11224,6 +11248,7 @@
               "lines" : [
                 {
                   "action" : "ACCEPT",
+                  "name" : "default",
                   "negate" : false
                 }
               ]
@@ -11233,6 +11258,7 @@
               "lines" : [
                 {
                   "action" : "ACCEPT",
+                  "name" : "default",
                   "negate" : false
                 }
               ]

--- a/tests/basic/traceroute-1-2.ref
+++ b/tests/basic/traceroute-1-2.ref
@@ -107,7 +107,7 @@
                   ]
                 }
               ],
-              "notes" : "DENIED_IN{filter::INPUT}{line:2}"
+              "notes" : "DENIED_IN{filter::INPUT}{default}"
             },
             {
               "disposition" : "DENIED_IN",
@@ -180,7 +180,7 @@
                   ]
                 }
               ],
-              "notes" : "DENIED_IN{filter::INPUT}{line:2}"
+              "notes" : "DENIED_IN{filter::INPUT}{default}"
             },
             {
               "disposition" : "DENIED_IN",
@@ -253,7 +253,7 @@
                   ]
                 }
               ],
-              "notes" : "DENIED_IN{filter::INPUT}{line:2}"
+              "notes" : "DENIED_IN{filter::INPUT}{default}"
             },
             {
               "disposition" : "DENIED_IN",
@@ -326,7 +326,7 @@
                   ]
                 }
               ],
-              "notes" : "DENIED_IN{filter::INPUT}{line:2}"
+              "notes" : "DENIED_IN{filter::INPUT}{default}"
             }
           ]
         }
@@ -339,5 +339,10 @@
     "dstIp" : "2.128.0.101",
     "ingressNode" : "as1core1"
   },
-  "status" : "SUCCESS"
+  "status" : "SUCCESS",
+  "summary" : {
+    "numFailed" : 0,
+    "numPassed" : 0,
+    "numResults" : 0
+  }
 }


### PR DESCRIPTION
Assign a name to each accessListLine that read from iptable files for host configuration format.
Mimic the way how we set the name for accessListLine in `.config` file, for example: 
for line: `access-list 101 permit ip host 1.0.1.0 host 255.255.255.0`, we set the name to `101 permit ip host 1.0.1.0 host 255.255.255.0`. 
What current solution does:
for line: `-A INPUT -p udp --dport 53 -j ACCEPT` in iptable file, we set the name to `-p udp --dport 53 -j ACCEPT`. 
This closes #437 