### PR TITLE
Fix NPE in SMT code due to z3 don't care assignments to variables

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/smt/Encoder.java
+++ b/projects/batfish/src/main/java/org/batfish/smt/Encoder.java
@@ -596,7 +596,7 @@ public class Encoder {
                   .getEnvironmentVars()
                   .forEach(
                       (lge, r) -> {
-                        if (valuation.get(r.getPermitted()).equals("true")) {
+                        if ("true".equals(valuation.get(r.getPermitted()))) {
                           SortedMap<String, String> recordMap = new TreeMap<>();
                           GraphEdge ge = lge.getEdge();
                           String nodeIface =

--- a/projects/batfish/src/main/java/org/batfish/smt/utils/PatternUtils.java
+++ b/projects/batfish/src/main/java/org/batfish/smt/utils/PatternUtils.java
@@ -46,12 +46,14 @@ public class PatternUtils {
               Matcher m2 = p2.matcher(router);
               if (m1.matches() && !m2.matches()) {
                 for (GraphEdge edge : edges) {
-                  Interface i = edge.getStart();
-                  String ifaceName = i.getName();
-                  Matcher m3 = p3.matcher(ifaceName);
-                  Matcher m4 = p4.matcher(ifaceName);
-                  if (m3.matches() && !m4.matches()) {
-                    acc.add(edge);
+                  if (!edge.isAbstract()) {
+                    Interface i = edge.getStart();
+                    String ifaceName = i.getName();
+                    Matcher m3 = p3.matcher(ifaceName);
+                    Matcher m4 = p4.matcher(ifaceName);
+                    if (m3.matches() && !m4.matches()) {
+                      acc.add(edge);
+                    }
                   }
                 }
               }


### PR DESCRIPTION
The fix avoids adding "don't care" variables to the final model. There was also a second issue with iBGP edges being included as valid destination interfaces.

This fixes #444 