### PR TITLE
Batfish: use a cache of weak references for the data plane

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.cache.Cache;
 import com.google.common.collect.Sets;
 import java.io.File;
 import java.io.IOException;
@@ -413,7 +414,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
 
   private final Map<TestrigSettings, SortedMap<String, Configuration>> _cachedConfigurations;
 
-  private final Map<TestrigSettings, DataPlane> _cachedDataPlanes;
+  private final Cache<TestrigSettings, DataPlane> _cachedDataPlanes;
 
   private final Map<EnvironmentSettings, SortedMap<String, BgpAdvertisementsByVrf>>
       _cachedEnvironmentBgpTables;
@@ -444,7 +445,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
   public Batfish(
       Settings settings,
       Map<TestrigSettings, SortedMap<String, Configuration>> cachedConfigurations,
-      Map<TestrigSettings, DataPlane> cachedDataPlanes,
+      Cache<TestrigSettings, DataPlane> cachedDataPlanes,
       Map<EnvironmentSettings, SortedMap<String, BgpAdvertisementsByVrf>>
           cachedEnvironmentBgpTables,
       Map<EnvironmentSettings, SortedMap<String, RoutesByVrf>> cachedEnvironmentRoutingTables) {
@@ -2483,7 +2484,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
 
   @Override
   public DataPlane loadDataPlane() {
-    DataPlane dp = _cachedDataPlanes.get(_testrigSettings);
+    DataPlane dp = _cachedDataPlanes.getIfPresent(_testrigSettings);
     if (dp == null) {
       /*
        * Data plane should exist after loading answer element, as it triggers
@@ -2491,7 +2492,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
        * repaired, so we still might need to load it from disk.
        */
       loadDataPlaneAnswerElement();
-      dp = _cachedDataPlanes.get(_testrigSettings);
+      dp = _cachedDataPlanes.getIfPresent(_testrigSettings);
       if (dp == null) {
         newBatch("Loading data plane from disk", 0);
         dp =

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -412,7 +412,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
 
   private SortedMap<BgpTableFormat, BgpTablePlugin> _bgpTablePlugins;
 
-  private final Map<TestrigSettings, SortedMap<String, Configuration>> _cachedConfigurations;
+  private final Cache<TestrigSettings, SortedMap<String, Configuration>> _cachedConfigurations;
 
   private final Cache<TestrigSettings, DataPlane> _cachedDataPlanes;
 
@@ -444,7 +444,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
 
   public Batfish(
       Settings settings,
-      Map<TestrigSettings, SortedMap<String, Configuration>> cachedConfigurations,
+      Cache<TestrigSettings, SortedMap<String, Configuration>> cachedConfigurations,
       Cache<TestrigSettings, DataPlane> cachedDataPlanes,
       Map<EnvironmentSettings, SortedMap<String, BgpAdvertisementsByVrf>>
           cachedEnvironmentBgpTables,
@@ -2444,7 +2444,8 @@ public class Batfish extends PluginConsumer implements IBatfish {
   }
 
   private SortedMap<String, Configuration> loadConfigurationsWithoutValidation() {
-    SortedMap<String, Configuration> configurations = _cachedConfigurations.get(_testrigSettings);
+    SortedMap<String, Configuration> configurations =
+        _cachedConfigurations.getIfPresent(_testrigSettings);
     if (configurations == null) {
       ConvertConfigurationAnswerElement ccae = loadConvertConfigurationAnswerElement();
       if (!Version.isCompatibleVersion(

--- a/projects/batfish/src/main/java/org/batfish/main/Driver.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Driver.java
@@ -1,5 +1,7 @@
 package org.batfish.main;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
@@ -62,7 +64,7 @@ public class Driver {
 
   private static ConcurrentMap<String, Task> _taskLog;
 
-  private static final Map<TestrigSettings, DataPlane> CACHED_DATA_PLANES = buildDataPlaneCache();
+  private static final Cache<TestrigSettings, DataPlane> CACHED_DATA_PLANES = buildDataPlaneCache();
 
   private static final Map<EnvironmentSettings, SortedMap<String, BgpAdvertisementsByVrf>>
       CACHED_ENVIRONMENT_BGP_TABLES = buildEnvironmentBgpTablesCache();
@@ -94,9 +96,8 @@ public class Driver {
   static Logger networkListenerLogger =
       Logger.getLogger("org.glassfish.grizzly.http.server.NetworkListener");
 
-  private static synchronized Map<TestrigSettings, DataPlane> buildDataPlaneCache() {
-    return Collections.synchronizedMap(
-        new LRUMap<TestrigSettings, DataPlane>(MAX_CACHED_DATA_PLANES));
+  private static synchronized Cache<TestrigSettings, DataPlane> buildDataPlaneCache() {
+    return CacheBuilder.newBuilder().maximumSize(MAX_CACHED_DATA_PLANES).weakValues().build();
   }
 
   private static Map<EnvironmentSettings, SortedMap<String, BgpAdvertisementsByVrf>>

--- a/projects/batfish/src/main/java/org/batfish/main/Driver.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Driver.java
@@ -72,7 +72,7 @@ public class Driver {
   private static final Map<EnvironmentSettings, SortedMap<String, RoutesByVrf>>
       CACHED_ENVIRONMENT_ROUTING_TABLES = buildEnvironmentRoutingTablesCache();
 
-  private static final Map<TestrigSettings, SortedMap<String, Configuration>> CACHED_TESTRIGS =
+  private static final Cache<TestrigSettings, SortedMap<String, Configuration>> CACHED_TESTRIGS =
       buildTestrigCache();
 
   private static final int COORDINATOR_POLL_CHECK_INTERVAL_MS = 1 * 60 * 1000;
@@ -114,10 +114,9 @@ public class Driver {
             MAX_CACHED_ENVIRONMENT_ROUTING_TABLES));
   }
 
-  private static synchronized Map<TestrigSettings, SortedMap<String, Configuration>>
+  private static synchronized Cache<TestrigSettings, SortedMap<String, Configuration>>
       buildTestrigCache() {
-    return Collections.synchronizedMap(
-        new LRUMap<TestrigSettings, SortedMap<String, Configuration>>(MAX_CACHED_TESTRIGS));
+    return CacheBuilder.newBuilder().maximumSize(MAX_CACHED_TESTRIGS).build();
   }
 
   private static synchronized boolean claimIdle() {

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
@@ -1,5 +1,7 @@
 package org.batfish.main;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -45,8 +47,8 @@ public class BatfishTestUtils {
       settings.setActiveTestrigSettings(settings.getBaseTestrigSettings());
     }
 
-    final Map<TestrigSettings, DataPlane> CACHED_DATA_PLANES =
-        Collections.synchronizedMap(new LRUMap<TestrigSettings, DataPlane>(2));
+    final Cache<TestrigSettings, DataPlane> CACHED_DATA_PLANES =
+        CacheBuilder.newBuilder().maximumSize(2).weakValues().build();
     final Map<EnvironmentSettings, SortedMap<String, BgpAdvertisementsByVrf>>
         CACHED_ENVIRONMENT_BGP_TABLES =
             Collections.synchronizedMap(
@@ -91,8 +93,8 @@ public class BatfishTestUtils {
           CommonUtil.writeFile(filePath, content);
         });
 
-    final Map<TestrigSettings, DataPlane> CACHED_DATA_PLANES =
-        Collections.synchronizedMap(new LRUMap<TestrigSettings, DataPlane>(2));
+    final Cache<TestrigSettings, DataPlane> CACHED_DATA_PLANES =
+        CacheBuilder.newBuilder().maximumSize(2).weakValues().build();
     final Map<EnvironmentSettings, SortedMap<String, BgpAdvertisementsByVrf>>
         CACHED_ENVIRONMENT_BGP_TABLES =
             Collections.synchronizedMap(

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
@@ -27,8 +27,8 @@ import org.junit.rules.TemporaryFolder;
 
 public class BatfishTestUtils {
 
-  private static Map<TestrigSettings, SortedMap<String, Configuration>> makeTestrigCache() {
-    return Collections.synchronizedMap(new LRUMap<>(5));
+  private static Cache<TestrigSettings, SortedMap<String, Configuration>> makeTestrigCache() {
+    return CacheBuilder.newBuilder().maximumSize(5).weakValues().build();
   }
 
   private static Map<EnvironmentSettings, SortedMap<String, BgpAdvertisementsByVrf>>
@@ -49,7 +49,7 @@ public class BatfishTestUtils {
       throws IOException {
     Settings settings = new Settings(new String[] {});
     settings.setLogger(new BatfishLogger("debug", false));
-    final Map<TestrigSettings, SortedMap<String, Configuration>> testrigs = makeTestrigCache();
+    final Cache<TestrigSettings, SortedMap<String, Configuration>> testrigs = makeTestrigCache();
 
     if (!configurations.isEmpty()) {
       Path containerDir = tempFolder.newFolder("container").toPath();

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
@@ -27,14 +27,30 @@ import org.junit.rules.TemporaryFolder;
 
 public class BatfishTestUtils {
 
+  private static Map<TestrigSettings, SortedMap<String, Configuration>> makeTestrigCache() {
+    return Collections.synchronizedMap(new LRUMap<>(5));
+  }
+
+  private static Map<EnvironmentSettings, SortedMap<String, BgpAdvertisementsByVrf>>
+      makeEnvBgpCache() {
+    return Collections.synchronizedMap(new LRUMap<>(4));
+  }
+
+  private static Map<EnvironmentSettings, SortedMap<String, RoutesByVrf>> makeEnvRouteCache() {
+    return Collections.synchronizedMap(new LRUMap<>(4));
+  }
+
+  private static Cache<TestrigSettings, DataPlane> makeDataPlaneCache() {
+    return CacheBuilder.newBuilder().maximumSize(2).weakValues().build();
+  }
+
   private static Batfish initBatfish(
       SortedMap<String, Configuration> configurations, @Nullable TemporaryFolder tempFolder)
       throws IOException {
     Settings settings = new Settings(new String[] {});
     settings.setLogger(new BatfishLogger("debug", false));
-    final Map<TestrigSettings, SortedMap<String, Configuration>> CACHED_TESTRIGS =
-        Collections.synchronizedMap(
-            new LRUMap<TestrigSettings, SortedMap<String, Configuration>>(5));
+    final Map<TestrigSettings, SortedMap<String, Configuration>> testrigs = makeTestrigCache();
+
     if (!configurations.isEmpty()) {
       Path containerDir = tempFolder.newFolder("container").toPath();
       settings.setContainerDir(containerDir);
@@ -43,28 +59,12 @@ public class BatfishTestUtils {
       Batfish.initTestrigSettings(settings);
       settings.getBaseTestrigSettings().getSerializeIndependentPath().toFile().mkdirs();
       settings.getBaseTestrigSettings().getEnvironmentSettings().getEnvPath().toFile().mkdirs();
-      CACHED_TESTRIGS.put(settings.getBaseTestrigSettings(), configurations);
+      testrigs.put(settings.getBaseTestrigSettings(), configurations);
       settings.setActiveTestrigSettings(settings.getBaseTestrigSettings());
     }
 
-    final Cache<TestrigSettings, DataPlane> CACHED_DATA_PLANES =
-        CacheBuilder.newBuilder().maximumSize(2).weakValues().build();
-    final Map<EnvironmentSettings, SortedMap<String, BgpAdvertisementsByVrf>>
-        CACHED_ENVIRONMENT_BGP_TABLES =
-            Collections.synchronizedMap(
-                new LRUMap<EnvironmentSettings, SortedMap<String, BgpAdvertisementsByVrf>>(4));
-    final Map<EnvironmentSettings, SortedMap<String, RoutesByVrf>>
-        CACHED_ENVIRONMENT_ROUTING_TABLES =
-            Collections.synchronizedMap(
-                new LRUMap<EnvironmentSettings, SortedMap<String, RoutesByVrf>>(4));
-    Batfish batfish =
-        new Batfish(
-            settings,
-            CACHED_TESTRIGS,
-            CACHED_DATA_PLANES,
-            CACHED_ENVIRONMENT_BGP_TABLES,
-            CACHED_ENVIRONMENT_ROUTING_TABLES);
-    return batfish;
+    return new Batfish(
+        settings, testrigs, makeDataPlaneCache(), makeEnvBgpCache(), makeEnvRouteCache());
   }
 
   private static Batfish initBatfishFromConfigurationText(
@@ -93,23 +93,13 @@ public class BatfishTestUtils {
           CommonUtil.writeFile(filePath, content);
         });
 
-    final Cache<TestrigSettings, DataPlane> CACHED_DATA_PLANES =
-        CacheBuilder.newBuilder().maximumSize(2).weakValues().build();
-    final Map<EnvironmentSettings, SortedMap<String, BgpAdvertisementsByVrf>>
-        CACHED_ENVIRONMENT_BGP_TABLES =
-            Collections.synchronizedMap(
-                new LRUMap<EnvironmentSettings, SortedMap<String, BgpAdvertisementsByVrf>>(4));
-    final Map<EnvironmentSettings, SortedMap<String, RoutesByVrf>>
-        CACHED_ENVIRONMENT_ROUTING_TABLES =
-            Collections.synchronizedMap(
-                new LRUMap<EnvironmentSettings, SortedMap<String, RoutesByVrf>>(4));
     Batfish batfish =
         new Batfish(
             settings,
-            CACHED_TESTRIGS,
-            CACHED_DATA_PLANES,
-            CACHED_ENVIRONMENT_BGP_TABLES,
-            CACHED_ENVIRONMENT_ROUTING_TABLES);
+            makeTestrigCache(),
+            makeDataPlaneCache(),
+            makeEnvBgpCache(),
+            makeEnvRouteCache());
     batfish.serializeVendorConfigs(
         testrigPath, settings.getBaseTestrigSettings().getSerializeVendorPath());
     batfish.serializeIndependentConfigs(


### PR DESCRIPTION
This will allow the garbage collector to clear the cache if memory pressure is on.

I tried soft references instead, which in principle should be collected less aggressively, but unfortunately they were not actually garbage collected in practice. This may be OS-related [swap on?] or JRE-related [garbage collector algorithm?], but tl;dr: I was not able to make soft references work.