### PR TITLE
Display hints flows

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Flow.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Flow.java
@@ -1,13 +1,10 @@
 package org.batfish.datamodel;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import java.io.Serializable;
 import org.batfish.common.BatfishException;
 
-@JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@id")
 public final class Flow implements Comparable<Flow>, Serializable {
   /** */
   private static final long serialVersionUID = 1L;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/DisplayHints.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/DisplayHints.java
@@ -21,32 +21,46 @@ public class DisplayHints {
   public enum ValueType {
     INT,
     INTLIST,
+    FLOW,
+    FLOWLIST,
+    FLOWTRACE,
+    FLOWTRACELIST,
     STRING,
     STRINGLIST;
 
     public ValueType getBaseType() {
       switch (this) {
-        case INT:
-        case INTLIST:
-          return INT;
-        case STRING:
-        case STRINGLIST:
-          return STRING;
-        default:
-          throw new BatfishException("Unknown ValueType " + this);
+      case INT:
+      case INTLIST:
+        return INT;
+      case FLOW:
+      case FLOWLIST:
+        return FLOW;
+      case FLOWTRACE:
+      case FLOWTRACELIST:
+        return FLOWTRACE;
+      case STRING:
+      case STRINGLIST:
+        return STRING;
+      default:
+        throw new BatfishException("Unknown ValueType " + this);
       }
     }
 
     public boolean isListType() {
       switch (this) {
-        case INT:
-        case STRING:
-          return false;
-        case INTLIST:
-        case STRINGLIST:
-          return true;
-        default:
-          throw new BatfishException("Unknown ValueType " + this);
+      case INT:
+      case STRING:
+      case FLOW:
+      case FLOWTRACE:
+        return false;
+      case INTLIST:
+      case FLOWLIST:
+      case FLOWTRACELIST:
+      case STRINGLIST:
+        return true;
+      default:
+        throw new BatfishException("Unknown ValueType " + this);
       }
     }
   }
@@ -325,8 +339,7 @@ public class DisplayHints {
       namesInTextDesc.add(matcher.group(1));
     }
     SetView<String> missingEntities =
-        Sets.difference(
-            namesInTextDesc, Sets.union(entities.keySet(), extractionHints.keySet()));
+        Sets.difference(namesInTextDesc, Sets.union(entities.keySet(), extractionHints.keySet()));
     if (!missingEntities.isEmpty()) {
       throw new BatfishException(
           "textDesc has names that are neither entities nor extractions: " + missingEntities);

--- a/projects/question/src/main/java/org/batfish/question/TracerouteQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/TracerouteQuestionPlugin.java
@@ -51,7 +51,7 @@ public class TracerouteQuestionPlugin extends QuestionPlugin {
       _batfish.popEnvironment();
       FlowHistory history = _batfish.getHistory();
       FlowHistory filteredHistory = new FlowHistory();
-      for (String flowText : history.getFlowsByText().keySet()) {
+      for (String flowText : history.getTraces().keySet()) {
         // String baseEnvId = _batfish.getBaseTestrigSettings().getName() +
         // ":"
         // + _batfish.getBaseTestrigSettings().getEnvironmentSettings()
@@ -67,10 +67,12 @@ public class TracerouteQuestionPlugin extends QuestionPlugin {
         _batfish.pushDeltaEnvironment();
         String deltaEnvId = _batfish.getFlowTag();
         _batfish.popEnvironment();
-        Set<FlowTrace> baseFlowTraces = history.getTraces().get(flowText).get(baseEnvId);
-        Set<FlowTrace> deltaFlowTraces = history.getTraces().get(flowText).get(deltaEnvId);
+        Set<FlowTrace> baseFlowTraces =
+            history.getTraces().get(flowText).getPaths().get(baseEnvId);
+        Set<FlowTrace> deltaFlowTraces =
+            history.getTraces().get(flowText).getPaths().get(deltaEnvId);
         if (!baseFlowTraces.toString().equals(deltaFlowTraces.toString())) {
-          Flow flow = history.getFlowsByText().get(flowText);
+          Flow flow = history.getTraces().get(flowText).getFlow();
           for (FlowTrace flowTrace : baseFlowTraces) {
             filteredHistory.addFlowTrace(flow, baseEnvId, flowTrace);
           }

--- a/projects/question/src/main/java/org/batfish/question/jsonpath/JsonPathExtractionHint.java
+++ b/projects/question/src/main/java/org/batfish/question/jsonpath/JsonPathExtractionHint.java
@@ -1,6 +1,7 @@
 package org.batfish.question.jsonpath;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.jayway.jsonpath.internal.path.PathCompiler;
 import java.io.IOException;
 import org.batfish.common.BatfishException;
 import org.batfish.common.util.BatfishObjectMapper;
@@ -10,6 +11,7 @@ public class JsonPathExtractionHint {
 
   public enum UseType {
     PREFIX,
+    FUNCOFSUFFIX,
     PREFIXOFSUFFIX,
     SUFFIXOFSUFFIX,
   }
@@ -44,6 +46,20 @@ public class JsonPathExtractionHint {
         }
         if (jpExtractionHint.getFilter() != null) {
           throw new BatfishException("Filter should not specified in prefix-based extraction hint");
+        }
+        break;
+      case FUNCOFSUFFIX:
+        if (jpExtractionHint.getIndex() != null) {
+          throw new BatfishException(
+              "Index should not be specified in funcofsuffix-based extraction hint");
+        }
+        if (jpExtractionHint.getFilter() == null) {
+          throw new BatfishException(
+              "Filter should be specified in funcofsuffix-based extraction hint");
+        }
+        if (!PathCompiler.compile(jpExtractionHint.getFilter()).isFunctionPath()) {
+          throw new BatfishException(
+              "Filter should be a path function in funcofsuffix-based extraction hint");
         }
         break;
       case PREFIXOFSUFFIX:

--- a/projects/question/src/main/java/org/batfish/question/jsonpath/NodesPathQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/jsonpath/NodesPathQuestionPlugin.java
@@ -14,7 +14,6 @@ import org.batfish.question.NodesQuestionPlugin.NodesQuestion;
 import org.batfish.question.QuestionPlugin;
 import org.batfish.question.jsonpath.JsonPathQuestionPlugin.JsonPathAnswerElement;
 import org.batfish.question.jsonpath.JsonPathQuestionPlugin.JsonPathAnswerer;
-import org.batfish.question.jsonpath.JsonPathQuestionPlugin.JsonPathDiffAnswerElement;
 import org.batfish.question.jsonpath.JsonPathQuestionPlugin.JsonPathQuestion;
 
 public class NodesPathQuestionPlugin extends QuestionPlugin {

--- a/projects/question/src/main/java/org/batfish/question/jsonpath/NodesPathQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/jsonpath/NodesPathQuestionPlugin.java
@@ -8,6 +8,7 @@ import java.util.TreeSet;
 import org.batfish.common.Answerer;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.datamodel.NodeType;
+import org.batfish.datamodel.answers.AnswerElement;
 import org.batfish.datamodel.questions.Question;
 import org.batfish.question.NodesQuestionPlugin.NodesQuestion;
 import org.batfish.question.QuestionPlugin;
@@ -39,7 +40,7 @@ public class NodesPathQuestionPlugin extends QuestionPlugin {
     }
 
     @Override
-    public JsonPathDiffAnswerElement answerDiff() {
+    public AnswerElement answerDiff() {
       NodesPathQuestion question = (NodesPathQuestion) _question;
       NodesQuestion nq = new NodesQuestion();
       nq.setNodeRegex(question.getNodeRegex());

--- a/projects/question/src/test/java/org/batfish/question/jsonpath/JsonPathDisplayHintsTest.java
+++ b/projects/question/src/test/java/org/batfish/question/jsonpath/JsonPathDisplayHintsTest.java
@@ -132,6 +132,28 @@ public class JsonPathDisplayHintsTest {
   }
 
   @Test
+  public void jsonPathDisplayHintAddressCountFromFuncOfSuffixTest() throws IOException {
+    String displayVariable = "addressCountFromFuncOfSuffix";
+    JsonPathResult result =
+        computeJsonPathResult(
+            "org/batfish/question/jsonpath/jsonPathDisplayHintsTestObject.json",
+            "$.nodes[*].interfaces[*][?(@.mtu < 1600)]", true);
+
+    Map<String, Map<String, JsonNode>> displayValues =
+        result.extractDisplayValues(getDisplayHints(displayVariable));
+
+    String key1 = "'nodes'->'node1'->'interfaces'->'interface1'";
+    String key2 = "'nodes'->'node2'->'interfaces'->'interface1'";
+
+    assertThat(displayValues.size(), equalTo(2));
+    assertThat(displayValues.containsKey(key1), equalTo(true));
+    assertThat(displayValues.containsKey(key2), equalTo(true));
+
+    assertThat(displayValues.get(key1).get(displayVariable).asInt(), equalTo(3));
+    assertThat(displayValues.get(key2).get(displayVariable).asInt(), equalTo(2));
+  }
+
+  @Test
   public void jsonPathDisplayHintNodeFromPrefixTest() throws IOException {
     String displayVariable = "nodeFromPrefix";
     JsonPathResult result =

--- a/projects/question/src/test/resources/org/batfish/question/jsonpath/jsonPathDisplayHintsTestHints.json
+++ b/projects/question/src/test/resources/org/batfish/question/jsonpath/jsonPathDisplayHintsTestHints.json
@@ -25,6 +25,13 @@
         "filter": "$"
       }
     },
+    "addressCountFromFuncOfSuffix": {
+      "valueType": "int",
+      "hints": {
+        "use": "funcOfsuffix",
+        "filter": "$.addresses.length()"
+      }
+    },
     "interfaceListFromPrefixOfSuffix": {
       "valueType": "stringList",
       "hints": {

--- a/projects/question/src/test/resources/org/batfish/question/jsonpath/jsonPathDisplayHintsTestObject.json
+++ b/projects/question/src/test/resources/org/batfish/question/jsonpath/jsonPathDisplayHintsTestObject.json
@@ -4,11 +4,17 @@
       "interfaces": {
         "interface1": {
           "name": "interface1name",
-          "mtu": 1500
+          "mtu": 1500,
+          "addresses": [
+            "a", "b", "c"
+          ]
         },
         "interface2": {
           "name": "interface2name",
-          "mtu": 1600
+          "mtu": 1600,
+          "addresses": [
+            "d", "e", "f"
+          ]
         }
       }
     },
@@ -16,7 +22,10 @@
       "interfaces": {
         "interface1": {
           "name": "interface1name",
-          "mtu": 1550
+          "mtu": 1550,
+          "addresses": [
+            "a", "b"
+          ]
         }
       }
     }

--- a/tests/basic/traceroute-1-2.ref
+++ b/tests/basic/traceroute-1-2.ref
@@ -2,333 +2,329 @@
   "answerElements" : [
     {
       "class" : "org.batfish.datamodel.FlowHistory",
-      "flows" : [
-        {
-          "@id" : 1,
-          "dscp" : 0,
-          "dstIp" : "2.128.0.101",
-          "dstPort" : 0,
-          "ecn" : 0,
-          "fragmentOffset" : 0,
-          "icmpCode" : 255,
-          "icmpVar" : 255,
-          "ingressNode" : "as1core1",
-          "ingressVrf" : "default",
-          "ipProtocol" : "IP",
-          "packetLength" : 0,
-          "srcIp" : "1.0.1.2",
-          "srcPort" : 0,
-          "state" : "NEW",
-          "tag" : "BASE",
-          "tcpFlagsAck" : 0,
-          "tcpFlagsCwr" : 0,
-          "tcpFlagsEce" : 0,
-          "tcpFlagsFin" : 0,
-          "tcpFlagsPsh" : 0,
-          "tcpFlagsRst" : 0,
-          "tcpFlagsSyn" : 0,
-          "tcpFlagsUrg" : 0
-        }
-      ],
-      "flowsByText" : {
-        "Flow<ingressNode:as1core1 ingressVrf:default srcIp:1.0.1.2 dstIp:2.128.0.101 ipProtocol:IP dscp: 0 ecn:0 fragmentOffset:0 packetLength:0 state:NEW tag:BASE>" : 1
-      },
       "traces" : {
         "Flow<ingressNode:as1core1 ingressVrf:default srcIp:1.0.1.2 dstIp:2.128.0.101 ipProtocol:IP dscp: 0 ecn:0 fragmentOffset:0 packetLength:0 state:NEW tag:BASE>" : {
-          "BASE" : [
-            {
-              "disposition" : "DENIED_IN",
-              "hops" : [
-                {
-                  "edge" : {
-                    "node1" : "as1core1",
-                    "node1interface" : "GigabitEthernet1/0",
-                    "node2" : "as1border1",
-                    "node2interface" : "GigabitEthernet0/0"
+          "flow" : {
+            "dscp" : 0,
+            "dstIp" : "2.128.0.101",
+            "dstPort" : 0,
+            "ecn" : 0,
+            "fragmentOffset" : 0,
+            "icmpCode" : 255,
+            "icmpVar" : 255,
+            "ingressNode" : "as1core1",
+            "ingressVrf" : "default",
+            "ipProtocol" : "IP",
+            "packetLength" : 0,
+            "srcIp" : "1.0.1.2",
+            "srcPort" : 0,
+            "state" : "NEW",
+            "tag" : "BASE",
+            "tcpFlagsAck" : 0,
+            "tcpFlagsCwr" : 0,
+            "tcpFlagsEce" : 0,
+            "tcpFlagsFin" : 0,
+            "tcpFlagsPsh" : 0,
+            "tcpFlagsRst" : 0,
+            "tcpFlagsSyn" : 0,
+            "tcpFlagsUrg" : 0
+          },
+          "paths" : {
+            "BASE" : [
+              {
+                "disposition" : "DENIED_IN",
+                "hops" : [
+                  {
+                    "edge" : {
+                      "node1" : "as1core1",
+                      "node1interface" : "GigabitEthernet1/0",
+                      "node2" : "as1border1",
+                      "node2interface" : "GigabitEthernet0/0"
+                    },
+                    "routes" : [
+                      "BgpRoute<2.128.0.0/16,nhip:10.12.11.2,nhint:dynamic>_fnhip:1.0.1.1"
+                    ]
                   },
-                  "routes" : [
-                    "BgpRoute<2.128.0.0/16,nhip:10.12.11.2,nhint:dynamic>_fnhip:1.0.1.1"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as1border1",
-                    "node1interface" : "GigabitEthernet1/0",
-                    "node2" : "as2border1",
-                    "node2interface" : "GigabitEthernet0/0"
+                  {
+                    "edge" : {
+                      "node1" : "as1border1",
+                      "node1interface" : "GigabitEthernet1/0",
+                      "node2" : "as2border1",
+                      "node2interface" : "GigabitEthernet0/0"
+                    },
+                    "routes" : [
+                      "BgpRoute<2.128.0.0/16,nhip:10.12.11.2,nhint:dynamic>_fnhip:10.12.11.2"
+                    ]
                   },
-                  "routes" : [
-                    "BgpRoute<2.128.0.0/16,nhip:10.12.11.2,nhint:dynamic>_fnhip:10.12.11.2"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as2border1",
-                    "node1interface" : "GigabitEthernet1/0",
-                    "node2" : "as2core1",
-                    "node2interface" : "GigabitEthernet0/0"
+                  {
+                    "edge" : {
+                      "node1" : "as2border1",
+                      "node1interface" : "GigabitEthernet1/0",
+                      "node2" : "as2core1",
+                      "node2interface" : "GigabitEthernet0/0"
+                    },
+                    "routes" : [
+                      "BgpRoute<2.128.0.0/24,nhip:2.34.101.4,nhint:dynamic>_fnhip:2.12.11.2",
+                      "BgpRoute<2.128.0.0/24,nhip:2.34.201.4,nhint:dynamic>_fnhip:2.12.11.2"
+                    ]
                   },
-                  "routes" : [
-                    "BgpRoute<2.128.0.0/24,nhip:2.34.101.4,nhint:dynamic>_fnhip:2.12.11.2",
-                    "BgpRoute<2.128.0.0/24,nhip:2.34.201.4,nhint:dynamic>_fnhip:2.12.11.2"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as2core1",
-                    "node1interface" : "GigabitEthernet2/0",
-                    "node2" : "as2dist1",
-                    "node2interface" : "GigabitEthernet0/0"
+                  {
+                    "edge" : {
+                      "node1" : "as2core1",
+                      "node1interface" : "GigabitEthernet2/0",
+                      "node2" : "as2dist1",
+                      "node2interface" : "GigabitEthernet0/0"
+                    },
+                    "routes" : [
+                      "BgpRoute<2.128.0.0/24,nhip:2.34.101.4,nhint:dynamic>_fnhip:2.23.11.3"
+                    ]
                   },
-                  "routes" : [
-                    "BgpRoute<2.128.0.0/24,nhip:2.34.101.4,nhint:dynamic>_fnhip:2.23.11.3"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as2dist1",
-                    "node1interface" : "GigabitEthernet2/0",
-                    "node2" : "as2dept1",
-                    "node2interface" : "GigabitEthernet0/0"
+                  {
+                    "edge" : {
+                      "node1" : "as2dist1",
+                      "node1interface" : "GigabitEthernet2/0",
+                      "node2" : "as2dept1",
+                      "node2interface" : "GigabitEthernet0/0"
+                    },
+                    "routes" : [
+                      "BgpRoute<2.128.0.0/24,nhip:2.34.101.4,nhint:dynamic>_fnhip:2.34.101.4"
+                    ]
                   },
-                  "routes" : [
-                    "BgpRoute<2.128.0.0/24,nhip:2.34.101.4,nhint:dynamic>_fnhip:2.34.101.4"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as2dept1",
-                    "node1interface" : "GigabitEthernet2/0",
-                    "node2" : "host1",
-                    "node2interface" : "eth0"
+                  {
+                    "edge" : {
+                      "node1" : "as2dept1",
+                      "node1interface" : "GigabitEthernet2/0",
+                      "node2" : "host1",
+                      "node2interface" : "eth0"
+                    },
+                    "routes" : [
+                      "ConnectedRoute<2.128.0.0/24,nhip:AUTO/NONE(-1l),nhint:GigabitEthernet2/0>_fnhip:null"
+                    ]
+                  }
+                ],
+                "notes" : "DENIED_IN{filter::INPUT}{default}"
+              },
+              {
+                "disposition" : "DENIED_IN",
+                "hops" : [
+                  {
+                    "edge" : {
+                      "node1" : "as1core1",
+                      "node1interface" : "GigabitEthernet1/0",
+                      "node2" : "as1border1",
+                      "node2interface" : "GigabitEthernet0/0"
+                    },
+                    "routes" : [
+                      "BgpRoute<2.128.0.0/16,nhip:10.12.11.2,nhint:dynamic>_fnhip:1.0.1.1"
+                    ]
                   },
-                  "routes" : [
-                    "ConnectedRoute<2.128.0.0/24,nhip:AUTO/NONE(-1l),nhint:GigabitEthernet2/0>_fnhip:null"
-                  ]
-                }
-              ],
-              "notes" : "DENIED_IN{filter::INPUT}{default}"
-            },
-            {
-              "disposition" : "DENIED_IN",
-              "hops" : [
-                {
-                  "edge" : {
-                    "node1" : "as1core1",
-                    "node1interface" : "GigabitEthernet1/0",
-                    "node2" : "as1border1",
-                    "node2interface" : "GigabitEthernet0/0"
+                  {
+                    "edge" : {
+                      "node1" : "as1border1",
+                      "node1interface" : "GigabitEthernet1/0",
+                      "node2" : "as2border1",
+                      "node2interface" : "GigabitEthernet0/0"
+                    },
+                    "routes" : [
+                      "BgpRoute<2.128.0.0/16,nhip:10.12.11.2,nhint:dynamic>_fnhip:10.12.11.2"
+                    ]
                   },
-                  "routes" : [
-                    "BgpRoute<2.128.0.0/16,nhip:10.12.11.2,nhint:dynamic>_fnhip:1.0.1.1"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as1border1",
-                    "node1interface" : "GigabitEthernet1/0",
-                    "node2" : "as2border1",
-                    "node2interface" : "GigabitEthernet0/0"
+                  {
+                    "edge" : {
+                      "node1" : "as2border1",
+                      "node1interface" : "GigabitEthernet1/0",
+                      "node2" : "as2core1",
+                      "node2interface" : "GigabitEthernet0/0"
+                    },
+                    "routes" : [
+                      "BgpRoute<2.128.0.0/24,nhip:2.34.101.4,nhint:dynamic>_fnhip:2.12.11.2",
+                      "BgpRoute<2.128.0.0/24,nhip:2.34.201.4,nhint:dynamic>_fnhip:2.12.11.2"
+                    ]
                   },
-                  "routes" : [
-                    "BgpRoute<2.128.0.0/16,nhip:10.12.11.2,nhint:dynamic>_fnhip:10.12.11.2"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as2border1",
-                    "node1interface" : "GigabitEthernet1/0",
-                    "node2" : "as2core1",
-                    "node2interface" : "GigabitEthernet0/0"
+                  {
+                    "edge" : {
+                      "node1" : "as2core1",
+                      "node1interface" : "GigabitEthernet3/0",
+                      "node2" : "as2dist2",
+                      "node2interface" : "GigabitEthernet1/0"
+                    },
+                    "routes" : [
+                      "BgpRoute<2.128.0.0/24,nhip:2.34.201.4,nhint:dynamic>_fnhip:2.23.12.3"
+                    ]
                   },
-                  "routes" : [
-                    "BgpRoute<2.128.0.0/24,nhip:2.34.101.4,nhint:dynamic>_fnhip:2.12.11.2",
-                    "BgpRoute<2.128.0.0/24,nhip:2.34.201.4,nhint:dynamic>_fnhip:2.12.11.2"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as2core1",
-                    "node1interface" : "GigabitEthernet3/0",
-                    "node2" : "as2dist2",
-                    "node2interface" : "GigabitEthernet1/0"
+                  {
+                    "edge" : {
+                      "node1" : "as2dist2",
+                      "node1interface" : "GigabitEthernet2/0",
+                      "node2" : "as2dept1",
+                      "node2interface" : "GigabitEthernet1/0"
+                    },
+                    "routes" : [
+                      "BgpRoute<2.128.0.0/24,nhip:2.34.201.4,nhint:dynamic>_fnhip:2.34.201.4"
+                    ]
                   },
-                  "routes" : [
-                    "BgpRoute<2.128.0.0/24,nhip:2.34.201.4,nhint:dynamic>_fnhip:2.23.12.3"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as2dist2",
-                    "node1interface" : "GigabitEthernet2/0",
-                    "node2" : "as2dept1",
-                    "node2interface" : "GigabitEthernet1/0"
+                  {
+                    "edge" : {
+                      "node1" : "as2dept1",
+                      "node1interface" : "GigabitEthernet2/0",
+                      "node2" : "host1",
+                      "node2interface" : "eth0"
+                    },
+                    "routes" : [
+                      "ConnectedRoute<2.128.0.0/24,nhip:AUTO/NONE(-1l),nhint:GigabitEthernet2/0>_fnhip:null"
+                    ]
+                  }
+                ],
+                "notes" : "DENIED_IN{filter::INPUT}{default}"
+              },
+              {
+                "disposition" : "DENIED_IN",
+                "hops" : [
+                  {
+                    "edge" : {
+                      "node1" : "as1core1",
+                      "node1interface" : "GigabitEthernet1/0",
+                      "node2" : "as1border1",
+                      "node2interface" : "GigabitEthernet0/0"
+                    },
+                    "routes" : [
+                      "BgpRoute<2.128.0.0/16,nhip:10.12.11.2,nhint:dynamic>_fnhip:1.0.1.1"
+                    ]
                   },
-                  "routes" : [
-                    "BgpRoute<2.128.0.0/24,nhip:2.34.201.4,nhint:dynamic>_fnhip:2.34.201.4"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as2dept1",
-                    "node1interface" : "GigabitEthernet2/0",
-                    "node2" : "host1",
-                    "node2interface" : "eth0"
+                  {
+                    "edge" : {
+                      "node1" : "as1border1",
+                      "node1interface" : "GigabitEthernet1/0",
+                      "node2" : "as2border1",
+                      "node2interface" : "GigabitEthernet0/0"
+                    },
+                    "routes" : [
+                      "BgpRoute<2.128.0.0/16,nhip:10.12.11.2,nhint:dynamic>_fnhip:10.12.11.2"
+                    ]
                   },
-                  "routes" : [
-                    "ConnectedRoute<2.128.0.0/24,nhip:AUTO/NONE(-1l),nhint:GigabitEthernet2/0>_fnhip:null"
-                  ]
-                }
-              ],
-              "notes" : "DENIED_IN{filter::INPUT}{default}"
-            },
-            {
-              "disposition" : "DENIED_IN",
-              "hops" : [
-                {
-                  "edge" : {
-                    "node1" : "as1core1",
-                    "node1interface" : "GigabitEthernet1/0",
-                    "node2" : "as1border1",
-                    "node2interface" : "GigabitEthernet0/0"
+                  {
+                    "edge" : {
+                      "node1" : "as2border1",
+                      "node1interface" : "GigabitEthernet2/0",
+                      "node2" : "as2core2",
+                      "node2interface" : "GigabitEthernet1/0"
+                    },
+                    "routes" : [
+                      "BgpRoute<2.128.0.0/24,nhip:2.34.101.4,nhint:dynamic>_fnhip:2.12.12.2",
+                      "BgpRoute<2.128.0.0/24,nhip:2.34.201.4,nhint:dynamic>_fnhip:2.12.12.2"
+                    ]
                   },
-                  "routes" : [
-                    "BgpRoute<2.128.0.0/16,nhip:10.12.11.2,nhint:dynamic>_fnhip:1.0.1.1"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as1border1",
-                    "node1interface" : "GigabitEthernet1/0",
-                    "node2" : "as2border1",
-                    "node2interface" : "GigabitEthernet0/0"
+                  {
+                    "edge" : {
+                      "node1" : "as2core2",
+                      "node1interface" : "GigabitEthernet2/0",
+                      "node2" : "as2dist2",
+                      "node2interface" : "GigabitEthernet0/0"
+                    },
+                    "routes" : [
+                      "BgpRoute<2.128.0.0/24,nhip:2.34.201.4,nhint:dynamic>_fnhip:2.23.22.3"
+                    ]
                   },
-                  "routes" : [
-                    "BgpRoute<2.128.0.0/16,nhip:10.12.11.2,nhint:dynamic>_fnhip:10.12.11.2"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as2border1",
-                    "node1interface" : "GigabitEthernet2/0",
-                    "node2" : "as2core2",
-                    "node2interface" : "GigabitEthernet1/0"
+                  {
+                    "edge" : {
+                      "node1" : "as2dist2",
+                      "node1interface" : "GigabitEthernet2/0",
+                      "node2" : "as2dept1",
+                      "node2interface" : "GigabitEthernet1/0"
+                    },
+                    "routes" : [
+                      "BgpRoute<2.128.0.0/24,nhip:2.34.201.4,nhint:dynamic>_fnhip:2.34.201.4"
+                    ]
                   },
-                  "routes" : [
-                    "BgpRoute<2.128.0.0/24,nhip:2.34.101.4,nhint:dynamic>_fnhip:2.12.12.2",
-                    "BgpRoute<2.128.0.0/24,nhip:2.34.201.4,nhint:dynamic>_fnhip:2.12.12.2"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as2core2",
-                    "node1interface" : "GigabitEthernet2/0",
-                    "node2" : "as2dist2",
-                    "node2interface" : "GigabitEthernet0/0"
+                  {
+                    "edge" : {
+                      "node1" : "as2dept1",
+                      "node1interface" : "GigabitEthernet2/0",
+                      "node2" : "host1",
+                      "node2interface" : "eth0"
+                    },
+                    "routes" : [
+                      "ConnectedRoute<2.128.0.0/24,nhip:AUTO/NONE(-1l),nhint:GigabitEthernet2/0>_fnhip:null"
+                    ]
+                  }
+                ],
+                "notes" : "DENIED_IN{filter::INPUT}{default}"
+              },
+              {
+                "disposition" : "DENIED_IN",
+                "hops" : [
+                  {
+                    "edge" : {
+                      "node1" : "as1core1",
+                      "node1interface" : "GigabitEthernet1/0",
+                      "node2" : "as1border1",
+                      "node2interface" : "GigabitEthernet0/0"
+                    },
+                    "routes" : [
+                      "BgpRoute<2.128.0.0/16,nhip:10.12.11.2,nhint:dynamic>_fnhip:1.0.1.1"
+                    ]
                   },
-                  "routes" : [
-                    "BgpRoute<2.128.0.0/24,nhip:2.34.201.4,nhint:dynamic>_fnhip:2.23.22.3"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as2dist2",
-                    "node1interface" : "GigabitEthernet2/0",
-                    "node2" : "as2dept1",
-                    "node2interface" : "GigabitEthernet1/0"
+                  {
+                    "edge" : {
+                      "node1" : "as1border1",
+                      "node1interface" : "GigabitEthernet1/0",
+                      "node2" : "as2border1",
+                      "node2interface" : "GigabitEthernet0/0"
+                    },
+                    "routes" : [
+                      "BgpRoute<2.128.0.0/16,nhip:10.12.11.2,nhint:dynamic>_fnhip:10.12.11.2"
+                    ]
                   },
-                  "routes" : [
-                    "BgpRoute<2.128.0.0/24,nhip:2.34.201.4,nhint:dynamic>_fnhip:2.34.201.4"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as2dept1",
-                    "node1interface" : "GigabitEthernet2/0",
-                    "node2" : "host1",
-                    "node2interface" : "eth0"
+                  {
+                    "edge" : {
+                      "node1" : "as2border1",
+                      "node1interface" : "GigabitEthernet2/0",
+                      "node2" : "as2core2",
+                      "node2interface" : "GigabitEthernet1/0"
+                    },
+                    "routes" : [
+                      "BgpRoute<2.128.0.0/24,nhip:2.34.101.4,nhint:dynamic>_fnhip:2.12.12.2",
+                      "BgpRoute<2.128.0.0/24,nhip:2.34.201.4,nhint:dynamic>_fnhip:2.12.12.2"
+                    ]
                   },
-                  "routes" : [
-                    "ConnectedRoute<2.128.0.0/24,nhip:AUTO/NONE(-1l),nhint:GigabitEthernet2/0>_fnhip:null"
-                  ]
-                }
-              ],
-              "notes" : "DENIED_IN{filter::INPUT}{default}"
-            },
-            {
-              "disposition" : "DENIED_IN",
-              "hops" : [
-                {
-                  "edge" : {
-                    "node1" : "as1core1",
-                    "node1interface" : "GigabitEthernet1/0",
-                    "node2" : "as1border1",
-                    "node2interface" : "GigabitEthernet0/0"
+                  {
+                    "edge" : {
+                      "node1" : "as2core2",
+                      "node1interface" : "GigabitEthernet3/0",
+                      "node2" : "as2dist1",
+                      "node2interface" : "GigabitEthernet1/0"
+                    },
+                    "routes" : [
+                      "BgpRoute<2.128.0.0/24,nhip:2.34.101.4,nhint:dynamic>_fnhip:2.23.21.3"
+                    ]
                   },
-                  "routes" : [
-                    "BgpRoute<2.128.0.0/16,nhip:10.12.11.2,nhint:dynamic>_fnhip:1.0.1.1"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as1border1",
-                    "node1interface" : "GigabitEthernet1/0",
-                    "node2" : "as2border1",
-                    "node2interface" : "GigabitEthernet0/0"
+                  {
+                    "edge" : {
+                      "node1" : "as2dist1",
+                      "node1interface" : "GigabitEthernet2/0",
+                      "node2" : "as2dept1",
+                      "node2interface" : "GigabitEthernet0/0"
+                    },
+                    "routes" : [
+                      "BgpRoute<2.128.0.0/24,nhip:2.34.101.4,nhint:dynamic>_fnhip:2.34.101.4"
+                    ]
                   },
-                  "routes" : [
-                    "BgpRoute<2.128.0.0/16,nhip:10.12.11.2,nhint:dynamic>_fnhip:10.12.11.2"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as2border1",
-                    "node1interface" : "GigabitEthernet2/0",
-                    "node2" : "as2core2",
-                    "node2interface" : "GigabitEthernet1/0"
-                  },
-                  "routes" : [
-                    "BgpRoute<2.128.0.0/24,nhip:2.34.101.4,nhint:dynamic>_fnhip:2.12.12.2",
-                    "BgpRoute<2.128.0.0/24,nhip:2.34.201.4,nhint:dynamic>_fnhip:2.12.12.2"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as2core2",
-                    "node1interface" : "GigabitEthernet3/0",
-                    "node2" : "as2dist1",
-                    "node2interface" : "GigabitEthernet1/0"
-                  },
-                  "routes" : [
-                    "BgpRoute<2.128.0.0/24,nhip:2.34.101.4,nhint:dynamic>_fnhip:2.23.21.3"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as2dist1",
-                    "node1interface" : "GigabitEthernet2/0",
-                    "node2" : "as2dept1",
-                    "node2interface" : "GigabitEthernet0/0"
-                  },
-                  "routes" : [
-                    "BgpRoute<2.128.0.0/24,nhip:2.34.101.4,nhint:dynamic>_fnhip:2.34.101.4"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as2dept1",
-                    "node1interface" : "GigabitEthernet2/0",
-                    "node2" : "host1",
-                    "node2interface" : "eth0"
-                  },
-                  "routes" : [
-                    "ConnectedRoute<2.128.0.0/24,nhip:AUTO/NONE(-1l),nhint:GigabitEthernet2/0>_fnhip:null"
-                  ]
-                }
-              ],
-              "notes" : "DENIED_IN{filter::INPUT}{default}"
-            }
-          ]
+                  {
+                    "edge" : {
+                      "node1" : "as2dept1",
+                      "node1interface" : "GigabitEthernet2/0",
+                      "node2" : "host1",
+                      "node2interface" : "eth0"
+                    },
+                    "routes" : [
+                      "ConnectedRoute<2.128.0.0/24,nhip:AUTO/NONE(-1l),nhint:GigabitEthernet2/0>_fnhip:null"
+                    ]
+                  }
+                ],
+                "notes" : "DENIED_IN{filter::INPUT}{default}"
+              }
+            ]
+          }
         }
       }
     }

--- a/tests/basic/traceroute-2-1.ref
+++ b/tests/basic/traceroute-2-1.ref
@@ -2,285 +2,281 @@
   "answerElements" : [
     {
       "class" : "org.batfish.datamodel.FlowHistory",
-      "flows" : [
-        {
-          "@id" : 1,
-          "dscp" : 0,
-          "dstIp" : "1.0.1.1",
-          "dstPort" : 0,
-          "ecn" : 0,
-          "fragmentOffset" : 0,
-          "icmpCode" : 255,
-          "icmpVar" : 255,
-          "ingressNode" : "host2",
-          "ingressVrf" : "default",
-          "ipProtocol" : "IP",
-          "packetLength" : 0,
-          "srcIp" : "2.128.1.101",
-          "srcPort" : 0,
-          "state" : "NEW",
-          "tag" : "BASE",
-          "tcpFlagsAck" : 0,
-          "tcpFlagsCwr" : 0,
-          "tcpFlagsEce" : 0,
-          "tcpFlagsFin" : 0,
-          "tcpFlagsPsh" : 0,
-          "tcpFlagsRst" : 0,
-          "tcpFlagsSyn" : 0,
-          "tcpFlagsUrg" : 0
-        }
-      ],
-      "flowsByText" : {
-        "Flow<ingressNode:host2 ingressVrf:default srcIp:2.128.1.101 dstIp:1.0.1.1 ipProtocol:IP dscp: 0 ecn:0 fragmentOffset:0 packetLength:0 state:NEW tag:BASE>" : 1
-      },
       "traces" : {
         "Flow<ingressNode:host2 ingressVrf:default srcIp:2.128.1.101 dstIp:1.0.1.1 ipProtocol:IP dscp: 0 ecn:0 fragmentOffset:0 packetLength:0 state:NEW tag:BASE>" : {
-          "BASE" : [
-            {
-              "disposition" : "ACCEPTED",
-              "hops" : [
-                {
-                  "edge" : {
-                    "node1" : "host2",
-                    "node1interface" : "eth0",
-                    "node2" : "as2dept1",
-                    "node2interface" : "GigabitEthernet3/0"
+          "flow" : {
+            "dscp" : 0,
+            "dstIp" : "1.0.1.1",
+            "dstPort" : 0,
+            "ecn" : 0,
+            "fragmentOffset" : 0,
+            "icmpCode" : 255,
+            "icmpVar" : 255,
+            "ingressNode" : "host2",
+            "ingressVrf" : "default",
+            "ipProtocol" : "IP",
+            "packetLength" : 0,
+            "srcIp" : "2.128.1.101",
+            "srcPort" : 0,
+            "state" : "NEW",
+            "tag" : "BASE",
+            "tcpFlagsAck" : 0,
+            "tcpFlagsCwr" : 0,
+            "tcpFlagsEce" : 0,
+            "tcpFlagsFin" : 0,
+            "tcpFlagsPsh" : 0,
+            "tcpFlagsRst" : 0,
+            "tcpFlagsSyn" : 0,
+            "tcpFlagsUrg" : 0
+          },
+          "paths" : {
+            "BASE" : [
+              {
+                "disposition" : "ACCEPTED",
+                "hops" : [
+                  {
+                    "edge" : {
+                      "node1" : "host2",
+                      "node1interface" : "eth0",
+                      "node2" : "as2dept1",
+                      "node2interface" : "GigabitEthernet3/0"
+                    },
+                    "routes" : [
+                      "StaticRoute<0.0.0.0/0,nhip:2.128.1.1,nhint:eth0>_fnhip:2.128.1.1"
+                    ]
                   },
-                  "routes" : [
-                    "StaticRoute<0.0.0.0/0,nhip:2.128.1.1,nhint:eth0>_fnhip:2.128.1.1"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as2dept1",
-                    "node1interface" : "GigabitEthernet0/0",
-                    "node2" : "as2dist1",
-                    "node2interface" : "GigabitEthernet2/0"
+                  {
+                    "edge" : {
+                      "node1" : "as2dept1",
+                      "node1interface" : "GigabitEthernet0/0",
+                      "node2" : "as2dist1",
+                      "node2interface" : "GigabitEthernet2/0"
+                    },
+                    "routes" : [
+                      "BgpRoute<1.0.1.0/24,nhip:2.34.101.3,nhint:dynamic>_fnhip:2.34.101.3"
+                    ]
                   },
-                  "routes" : [
-                    "BgpRoute<1.0.1.0/24,nhip:2.34.101.3,nhint:dynamic>_fnhip:2.34.101.3"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as2dist1",
-                    "node1interface" : "GigabitEthernet0/0",
-                    "node2" : "as2core1",
-                    "node2interface" : "GigabitEthernet2/0"
+                  {
+                    "edge" : {
+                      "node1" : "as2dist1",
+                      "node1interface" : "GigabitEthernet0/0",
+                      "node2" : "as2core1",
+                      "node2interface" : "GigabitEthernet2/0"
+                    },
+                    "routes" : [
+                      "BgpRoute<1.0.1.0/24,nhip:10.12.11.1,nhint:dynamic>_fnhip:2.23.11.2"
+                    ]
                   },
-                  "routes" : [
-                    "BgpRoute<1.0.1.0/24,nhip:10.12.11.1,nhint:dynamic>_fnhip:2.23.11.2"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as2core1",
-                    "node1interface" : "GigabitEthernet0/0",
-                    "node2" : "as2border1",
-                    "node2interface" : "GigabitEthernet1/0"
+                  {
+                    "edge" : {
+                      "node1" : "as2core1",
+                      "node1interface" : "GigabitEthernet0/0",
+                      "node2" : "as2border1",
+                      "node2interface" : "GigabitEthernet1/0"
+                    },
+                    "routes" : [
+                      "BgpRoute<1.0.1.0/24,nhip:10.12.11.1,nhint:dynamic>_fnhip:2.12.11.1"
+                    ]
                   },
-                  "routes" : [
-                    "BgpRoute<1.0.1.0/24,nhip:10.12.11.1,nhint:dynamic>_fnhip:2.12.11.1"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as2border1",
-                    "node1interface" : "GigabitEthernet0/0",
-                    "node2" : "as1border1",
-                    "node2interface" : "GigabitEthernet1/0"
+                  {
+                    "edge" : {
+                      "node1" : "as2border1",
+                      "node1interface" : "GigabitEthernet0/0",
+                      "node2" : "as1border1",
+                      "node2interface" : "GigabitEthernet1/0"
+                    },
+                    "routes" : [
+                      "BgpRoute<1.0.1.0/24,nhip:10.12.11.1,nhint:dynamic>_fnhip:10.12.11.1"
+                    ]
+                  }
+                ],
+                "notes" : "ACCEPTED"
+              },
+              {
+                "disposition" : "ACCEPTED",
+                "hops" : [
+                  {
+                    "edge" : {
+                      "node1" : "host2",
+                      "node1interface" : "eth0",
+                      "node2" : "as2dept1",
+                      "node2interface" : "GigabitEthernet3/0"
+                    },
+                    "routes" : [
+                      "StaticRoute<0.0.0.0/0,nhip:2.128.1.1,nhint:eth0>_fnhip:2.128.1.1"
+                    ]
                   },
-                  "routes" : [
-                    "BgpRoute<1.0.1.0/24,nhip:10.12.11.1,nhint:dynamic>_fnhip:10.12.11.1"
-                  ]
-                }
-              ],
-              "notes" : "ACCEPTED"
-            },
-            {
-              "disposition" : "ACCEPTED",
-              "hops" : [
-                {
-                  "edge" : {
-                    "node1" : "host2",
-                    "node1interface" : "eth0",
-                    "node2" : "as2dept1",
-                    "node2interface" : "GigabitEthernet3/0"
+                  {
+                    "edge" : {
+                      "node1" : "as2dept1",
+                      "node1interface" : "GigabitEthernet0/0",
+                      "node2" : "as2dist1",
+                      "node2interface" : "GigabitEthernet2/0"
+                    },
+                    "routes" : [
+                      "BgpRoute<1.0.1.0/24,nhip:2.34.101.3,nhint:dynamic>_fnhip:2.34.101.3"
+                    ]
                   },
-                  "routes" : [
-                    "StaticRoute<0.0.0.0/0,nhip:2.128.1.1,nhint:eth0>_fnhip:2.128.1.1"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as2dept1",
-                    "node1interface" : "GigabitEthernet0/0",
-                    "node2" : "as2dist1",
-                    "node2interface" : "GigabitEthernet2/0"
+                  {
+                    "edge" : {
+                      "node1" : "as2dist1",
+                      "node1interface" : "GigabitEthernet1/0",
+                      "node2" : "as2core2",
+                      "node2interface" : "GigabitEthernet3/0"
+                    },
+                    "routes" : [
+                      "BgpRoute<1.0.1.0/24,nhip:10.12.11.1,nhint:dynamic>_fnhip:2.23.21.2"
+                    ]
                   },
-                  "routes" : [
-                    "BgpRoute<1.0.1.0/24,nhip:2.34.101.3,nhint:dynamic>_fnhip:2.34.101.3"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as2dist1",
-                    "node1interface" : "GigabitEthernet1/0",
-                    "node2" : "as2core2",
-                    "node2interface" : "GigabitEthernet3/0"
+                  {
+                    "edge" : {
+                      "node1" : "as2core2",
+                      "node1interface" : "GigabitEthernet1/0",
+                      "node2" : "as2border1",
+                      "node2interface" : "GigabitEthernet2/0"
+                    },
+                    "routes" : [
+                      "BgpRoute<1.0.1.0/24,nhip:10.12.11.1,nhint:dynamic>_fnhip:2.12.12.1"
+                    ]
                   },
-                  "routes" : [
-                    "BgpRoute<1.0.1.0/24,nhip:10.12.11.1,nhint:dynamic>_fnhip:2.23.21.2"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as2core2",
-                    "node1interface" : "GigabitEthernet1/0",
-                    "node2" : "as2border1",
-                    "node2interface" : "GigabitEthernet2/0"
+                  {
+                    "edge" : {
+                      "node1" : "as2border1",
+                      "node1interface" : "GigabitEthernet0/0",
+                      "node2" : "as1border1",
+                      "node2interface" : "GigabitEthernet1/0"
+                    },
+                    "routes" : [
+                      "BgpRoute<1.0.1.0/24,nhip:10.12.11.1,nhint:dynamic>_fnhip:10.12.11.1"
+                    ]
+                  }
+                ],
+                "notes" : "ACCEPTED"
+              },
+              {
+                "disposition" : "ACCEPTED",
+                "hops" : [
+                  {
+                    "edge" : {
+                      "node1" : "host2",
+                      "node1interface" : "eth0",
+                      "node2" : "as2dept1",
+                      "node2interface" : "GigabitEthernet3/0"
+                    },
+                    "routes" : [
+                      "StaticRoute<0.0.0.0/0,nhip:2.128.1.1,nhint:eth0>_fnhip:2.128.1.1"
+                    ]
                   },
-                  "routes" : [
-                    "BgpRoute<1.0.1.0/24,nhip:10.12.11.1,nhint:dynamic>_fnhip:2.12.12.1"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as2border1",
-                    "node1interface" : "GigabitEthernet0/0",
-                    "node2" : "as1border1",
-                    "node2interface" : "GigabitEthernet1/0"
+                  {
+                    "edge" : {
+                      "node1" : "as2dept1",
+                      "node1interface" : "GigabitEthernet1/0",
+                      "node2" : "as2dist2",
+                      "node2interface" : "GigabitEthernet2/0"
+                    },
+                    "routes" : [
+                      "BgpRoute<1.0.1.0/24,nhip:2.34.201.3,nhint:dynamic>_fnhip:2.34.201.3"
+                    ]
                   },
-                  "routes" : [
-                    "BgpRoute<1.0.1.0/24,nhip:10.12.11.1,nhint:dynamic>_fnhip:10.12.11.1"
-                  ]
-                }
-              ],
-              "notes" : "ACCEPTED"
-            },
-            {
-              "disposition" : "ACCEPTED",
-              "hops" : [
-                {
-                  "edge" : {
-                    "node1" : "host2",
-                    "node1interface" : "eth0",
-                    "node2" : "as2dept1",
-                    "node2interface" : "GigabitEthernet3/0"
+                  {
+                    "edge" : {
+                      "node1" : "as2dist2",
+                      "node1interface" : "GigabitEthernet0/0",
+                      "node2" : "as2core2",
+                      "node2interface" : "GigabitEthernet2/0"
+                    },
+                    "routes" : [
+                      "BgpRoute<1.0.1.0/24,nhip:10.12.11.1,nhint:dynamic>_fnhip:2.23.22.2"
+                    ]
                   },
-                  "routes" : [
-                    "StaticRoute<0.0.0.0/0,nhip:2.128.1.1,nhint:eth0>_fnhip:2.128.1.1"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as2dept1",
-                    "node1interface" : "GigabitEthernet1/0",
-                    "node2" : "as2dist2",
-                    "node2interface" : "GigabitEthernet2/0"
+                  {
+                    "edge" : {
+                      "node1" : "as2core2",
+                      "node1interface" : "GigabitEthernet1/0",
+                      "node2" : "as2border1",
+                      "node2interface" : "GigabitEthernet2/0"
+                    },
+                    "routes" : [
+                      "BgpRoute<1.0.1.0/24,nhip:10.12.11.1,nhint:dynamic>_fnhip:2.12.12.1"
+                    ]
                   },
-                  "routes" : [
-                    "BgpRoute<1.0.1.0/24,nhip:2.34.201.3,nhint:dynamic>_fnhip:2.34.201.3"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as2dist2",
-                    "node1interface" : "GigabitEthernet0/0",
-                    "node2" : "as2core2",
-                    "node2interface" : "GigabitEthernet2/0"
+                  {
+                    "edge" : {
+                      "node1" : "as2border1",
+                      "node1interface" : "GigabitEthernet0/0",
+                      "node2" : "as1border1",
+                      "node2interface" : "GigabitEthernet1/0"
+                    },
+                    "routes" : [
+                      "BgpRoute<1.0.1.0/24,nhip:10.12.11.1,nhint:dynamic>_fnhip:10.12.11.1"
+                    ]
+                  }
+                ],
+                "notes" : "ACCEPTED"
+              },
+              {
+                "disposition" : "ACCEPTED",
+                "hops" : [
+                  {
+                    "edge" : {
+                      "node1" : "host2",
+                      "node1interface" : "eth0",
+                      "node2" : "as2dept1",
+                      "node2interface" : "GigabitEthernet3/0"
+                    },
+                    "routes" : [
+                      "StaticRoute<0.0.0.0/0,nhip:2.128.1.1,nhint:eth0>_fnhip:2.128.1.1"
+                    ]
                   },
-                  "routes" : [
-                    "BgpRoute<1.0.1.0/24,nhip:10.12.11.1,nhint:dynamic>_fnhip:2.23.22.2"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as2core2",
-                    "node1interface" : "GigabitEthernet1/0",
-                    "node2" : "as2border1",
-                    "node2interface" : "GigabitEthernet2/0"
+                  {
+                    "edge" : {
+                      "node1" : "as2dept1",
+                      "node1interface" : "GigabitEthernet1/0",
+                      "node2" : "as2dist2",
+                      "node2interface" : "GigabitEthernet2/0"
+                    },
+                    "routes" : [
+                      "BgpRoute<1.0.1.0/24,nhip:2.34.201.3,nhint:dynamic>_fnhip:2.34.201.3"
+                    ]
                   },
-                  "routes" : [
-                    "BgpRoute<1.0.1.0/24,nhip:10.12.11.1,nhint:dynamic>_fnhip:2.12.12.1"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as2border1",
-                    "node1interface" : "GigabitEthernet0/0",
-                    "node2" : "as1border1",
-                    "node2interface" : "GigabitEthernet1/0"
+                  {
+                    "edge" : {
+                      "node1" : "as2dist2",
+                      "node1interface" : "GigabitEthernet1/0",
+                      "node2" : "as2core1",
+                      "node2interface" : "GigabitEthernet3/0"
+                    },
+                    "routes" : [
+                      "BgpRoute<1.0.1.0/24,nhip:10.12.11.1,nhint:dynamic>_fnhip:2.23.12.2"
+                    ]
                   },
-                  "routes" : [
-                    "BgpRoute<1.0.1.0/24,nhip:10.12.11.1,nhint:dynamic>_fnhip:10.12.11.1"
-                  ]
-                }
-              ],
-              "notes" : "ACCEPTED"
-            },
-            {
-              "disposition" : "ACCEPTED",
-              "hops" : [
-                {
-                  "edge" : {
-                    "node1" : "host2",
-                    "node1interface" : "eth0",
-                    "node2" : "as2dept1",
-                    "node2interface" : "GigabitEthernet3/0"
+                  {
+                    "edge" : {
+                      "node1" : "as2core1",
+                      "node1interface" : "GigabitEthernet0/0",
+                      "node2" : "as2border1",
+                      "node2interface" : "GigabitEthernet1/0"
+                    },
+                    "routes" : [
+                      "BgpRoute<1.0.1.0/24,nhip:10.12.11.1,nhint:dynamic>_fnhip:2.12.11.1"
+                    ]
                   },
-                  "routes" : [
-                    "StaticRoute<0.0.0.0/0,nhip:2.128.1.1,nhint:eth0>_fnhip:2.128.1.1"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as2dept1",
-                    "node1interface" : "GigabitEthernet1/0",
-                    "node2" : "as2dist2",
-                    "node2interface" : "GigabitEthernet2/0"
-                  },
-                  "routes" : [
-                    "BgpRoute<1.0.1.0/24,nhip:2.34.201.3,nhint:dynamic>_fnhip:2.34.201.3"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as2dist2",
-                    "node1interface" : "GigabitEthernet1/0",
-                    "node2" : "as2core1",
-                    "node2interface" : "GigabitEthernet3/0"
-                  },
-                  "routes" : [
-                    "BgpRoute<1.0.1.0/24,nhip:10.12.11.1,nhint:dynamic>_fnhip:2.23.12.2"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as2core1",
-                    "node1interface" : "GigabitEthernet0/0",
-                    "node2" : "as2border1",
-                    "node2interface" : "GigabitEthernet1/0"
-                  },
-                  "routes" : [
-                    "BgpRoute<1.0.1.0/24,nhip:10.12.11.1,nhint:dynamic>_fnhip:2.12.11.1"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as2border1",
-                    "node1interface" : "GigabitEthernet0/0",
-                    "node2" : "as1border1",
-                    "node2interface" : "GigabitEthernet1/0"
-                  },
-                  "routes" : [
-                    "BgpRoute<1.0.1.0/24,nhip:10.12.11.1,nhint:dynamic>_fnhip:10.12.11.1"
-                  ]
-                }
-              ],
-              "notes" : "ACCEPTED"
-            }
-          ]
+                  {
+                    "edge" : {
+                      "node1" : "as2border1",
+                      "node1interface" : "GigabitEthernet0/0",
+                      "node2" : "as1border1",
+                      "node2interface" : "GigabitEthernet1/0"
+                    },
+                    "routes" : [
+                      "BgpRoute<1.0.1.0/24,nhip:10.12.11.1,nhint:dynamic>_fnhip:10.12.11.1"
+                    ]
+                  }
+                ],
+                "notes" : "ACCEPTED"
+              }
+            ]
+          }
         }
       }
     }
@@ -291,5 +287,10 @@
     "dstIp" : "1.0.1.1",
     "ingressNode" : "host2"
   },
-  "status" : "SUCCESS"
+  "status" : "SUCCESS",
+  "summary" : {
+    "numFailed" : 0,
+    "numPassed" : 0,
+    "numResults" : 0
+  }
 }

--- a/tests/basic/traceroute-snat.ref
+++ b/tests/basic/traceroute-snat.ref
@@ -2,106 +2,101 @@
   "answerElements" : [
     {
       "class" : "org.batfish.datamodel.FlowHistory",
-      "flows" : [
-        {
-          "@id" : 1,
-          "dscp" : 0,
-          "dstIp" : "1.2.3.4",
-          "dstPort" : 0,
-          "ecn" : 0,
-          "fragmentOffset" : 0,
-          "icmpCode" : 255,
-          "icmpVar" : 255,
-          "ingressNode" : "host1",
-          "ingressVrf" : "default",
-          "ipProtocol" : "IP",
-          "packetLength" : 0,
-          "srcIp" : "172.20.0.1",
-          "srcPort" : 0,
-          "state" : "NEW",
-          "tag" : "BASE",
-          "tcpFlagsAck" : 0,
-          "tcpFlagsCwr" : 0,
-          "tcpFlagsEce" : 0,
-          "tcpFlagsFin" : 0,
-          "tcpFlagsPsh" : 0,
-          "tcpFlagsRst" : 0,
-          "tcpFlagsSyn" : 0,
-          "tcpFlagsUrg" : 0
-        }
-      ],
-      "flowsByText" : {
-        "Flow<ingressNode:host1 ingressVrf:default srcIp:172.20.0.1 dstIp:1.2.3.4 ipProtocol:IP dscp: 0 ecn:0 fragmentOffset:0 packetLength:0 state:NEW tag:BASE>" : 1
-      },
       "traces" : {
         "Flow<ingressNode:host1 ingressVrf:default srcIp:172.20.0.1 dstIp:1.2.3.4 ipProtocol:IP dscp: 0 ecn:0 fragmentOffset:0 packetLength:0 state:NEW tag:BASE>" : {
-          "BASE" : [
-            {
-              "disposition" : "NEIGHBOR_UNREACHABLE_OR_EXITS_NETWORK",
-              "hops" : [
-                {
-                  "edge" : {
-                    "node1" : "host1",
-                    "node1interface" : "eth0",
-                    "node2" : "us_switch",
-                    "node2interface" : "Ethernet2"
+          "flow" : {
+            "dscp" : 0,
+            "dstIp" : "1.2.3.4",
+            "dstPort" : 0,
+            "ecn" : 0,
+            "fragmentOffset" : 0,
+            "icmpCode" : 255,
+            "icmpVar" : 255,
+            "ingressNode" : "host1",
+            "ingressVrf" : "default",
+            "ipProtocol" : "IP",
+            "packetLength" : 0,
+            "srcIp" : "172.20.0.1",
+            "srcPort" : 0,
+            "state" : "NEW",
+            "tag" : "BASE",
+            "tcpFlagsAck" : 0,
+            "tcpFlagsCwr" : 0,
+            "tcpFlagsEce" : 0,
+            "tcpFlagsFin" : 0,
+            "tcpFlagsPsh" : 0,
+            "tcpFlagsRst" : 0,
+            "tcpFlagsSyn" : 0,
+            "tcpFlagsUrg" : 0
+          },
+          "paths" : {
+            "BASE" : [
+              {
+                "disposition" : "NEIGHBOR_UNREACHABLE_OR_EXITS_NETWORK",
+                "hops" : [
+                  {
+                    "edge" : {
+                      "node1" : "host1",
+                      "node1interface" : "eth0",
+                      "node2" : "us_switch",
+                      "node2interface" : "Ethernet2"
+                    },
+                    "routes" : [
+                      "StaticRoute<0.0.0.0/0,nhip:172.20.0.0,nhint:eth0>_fnhip:172.20.0.0"
+                    ]
                   },
-                  "routes" : [
-                    "StaticRoute<0.0.0.0/0,nhip:172.20.0.0,nhint:eth0>_fnhip:172.20.0.0"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "us_switch",
-                    "node1interface" : "Ethernet1",
-                    "node2" : "us_border",
-                    "node2interface" : "Ethernet1"
+                  {
+                    "edge" : {
+                      "node1" : "us_switch",
+                      "node1interface" : "Ethernet1",
+                      "node2" : "us_border",
+                      "node2interface" : "Ethernet1"
+                    },
+                    "routes" : [
+                      "StaticRoute<0.0.0.0/0,nhip:172.16.0.0,nhint:dynamic>_fnhip:172.16.0.0"
+                    ]
                   },
-                  "routes" : [
-                    "StaticRoute<0.0.0.0/0,nhip:172.16.0.0,nhint:dynamic>_fnhip:172.16.0.0"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "us_border",
-                    "node1interface" : "Ethernet2",
-                    "node2" : "(none)",
-                    "node2interface" : "null_interface"
-                  },
-                  "routes" : [
-                    "BgpRoute<1.0.0.0/8,nhip:10.0.0.0,nhint:dynamic>_fnhip:10.0.0.0"
-                  ],
-                  "transformedFlow" : {
-                    "@id" : 2,
-                    "dscp" : 0,
-                    "dstIp" : "1.2.3.4",
-                    "dstPort" : 0,
-                    "ecn" : 0,
-                    "fragmentOffset" : 0,
-                    "icmpCode" : 255,
-                    "icmpVar" : 255,
-                    "ingressNode" : "host1",
-                    "ingressVrf" : "default",
-                    "ipProtocol" : "IP",
-                    "packetLength" : 0,
-                    "srcIp" : "10.10.10.10",
-                    "srcPort" : 0,
-                    "state" : "NEW",
-                    "tag" : "BASE",
-                    "tcpFlagsAck" : 0,
-                    "tcpFlagsCwr" : 0,
-                    "tcpFlagsEce" : 0,
-                    "tcpFlagsFin" : 0,
-                    "tcpFlagsPsh" : 0,
-                    "tcpFlagsRst" : 0,
-                    "tcpFlagsSyn" : 0,
-                    "tcpFlagsUrg" : 0
+                  {
+                    "edge" : {
+                      "node1" : "us_border",
+                      "node1interface" : "Ethernet2",
+                      "node2" : "(none)",
+                      "node2interface" : "null_interface"
+                    },
+                    "routes" : [
+                      "BgpRoute<1.0.0.0/8,nhip:10.0.0.0,nhint:dynamic>_fnhip:10.0.0.0"
+                    ],
+                    "transformedFlow" : {
+                      "dscp" : 0,
+                      "dstIp" : "1.2.3.4",
+                      "dstPort" : 0,
+                      "ecn" : 0,
+                      "fragmentOffset" : 0,
+                      "icmpCode" : 255,
+                      "icmpVar" : 255,
+                      "ingressNode" : "host1",
+                      "ingressVrf" : "default",
+                      "ipProtocol" : "IP",
+                      "packetLength" : 0,
+                      "srcIp" : "10.10.10.10",
+                      "srcPort" : 0,
+                      "state" : "NEW",
+                      "tag" : "BASE",
+                      "tcpFlagsAck" : 0,
+                      "tcpFlagsCwr" : 0,
+                      "tcpFlagsEce" : 0,
+                      "tcpFlagsFin" : 0,
+                      "tcpFlagsPsh" : 0,
+                      "tcpFlagsRst" : 0,
+                      "tcpFlagsSyn" : 0,
+                      "tcpFlagsUrg" : 0
+                    }
                   }
-                }
-              ],
-              "notes" : "NEIGHBOR_UNREACHABLE_OR_EXITS_NETWORK"
-            }
-          ]
+                ],
+                "notes" : "NEIGHBOR_UNREACHABLE_OR_EXITS_NETWORK"
+              }
+            ]
+          }
         }
       }
     }
@@ -112,5 +107,10 @@
     "dstIp" : "1.2.3.4",
     "ingressNode" : "host1"
   },
-  "status" : "SUCCESS"
+  "status" : "SUCCESS",
+  "summary" : {
+    "numFailed" : 0,
+    "numPassed" : 0,
+    "numResults" : 0
+  }
 }

--- a/tests/java-smt/acl1-differential.ref
+++ b/tests/java-smt/acl1-differential.ref
@@ -4,110 +4,106 @@
       "class" : "org.batfish.smt.answers.SmtReachabilityAnswerElement",
       "flowHistory" : {
         "class" : "org.batfish.datamodel.FlowHistory",
-        "flows" : [
-          {
-            "@id" : 1,
-            "dscp" : 0,
-            "dstIp" : "70.70.70.70",
-            "dstPort" : 0,
-            "ecn" : 0,
-            "fragmentOffset" : 0,
-            "icmpCode" : 0,
-            "icmpVar" : 0,
-            "ingressNode" : "R0",
-            "ingressVrf" : "default",
-            "ipProtocol" : "HOPOPT",
-            "packetLength" : 0,
-            "srcIp" : "0.0.0.0",
-            "srcPort" : 0,
-            "state" : "NEW",
-            "tag" : "SMT",
-            "tcpFlagsAck" : 1,
-            "tcpFlagsCwr" : 1,
-            "tcpFlagsEce" : 1,
-            "tcpFlagsFin" : 1,
-            "tcpFlagsPsh" : 1,
-            "tcpFlagsRst" : 1,
-            "tcpFlagsSyn" : 1,
-            "tcpFlagsUrg" : 1
-          }
-        ],
-        "flowsByText" : {
-          "Flow<ingressNode:R0 ingressVrf:default srcIp:0.0.0.0 dstIp:70.70.70.70 ipProtocol:HOPOPT dscp: 0 ecn:0 fragmentOffset:0 packetLength:0 state:NEW tag:SMT>" : 1
-        },
         "traces" : {
           "Flow<ingressNode:R0 ingressVrf:default srcIp:0.0.0.0 dstIp:70.70.70.70 ipProtocol:HOPOPT dscp: 0 ecn:0 fragmentOffset:0 packetLength:0 state:NEW tag:SMT>" : {
-            "BASE" : [
-              {
-                "disposition" : "ACCEPTED",
-                "hops" : [
-                  {
-                    "edge" : {
-                      "node1" : "R0",
-                      "node1interface" : "Serial0",
-                      "node2" : "R1",
-                      "node2interface" : "Serial0"
+            "flow" : {
+              "dscp" : 0,
+              "dstIp" : "70.70.70.70",
+              "dstPort" : 0,
+              "ecn" : 0,
+              "fragmentOffset" : 0,
+              "icmpCode" : 0,
+              "icmpVar" : 0,
+              "ingressNode" : "R0",
+              "ingressVrf" : "default",
+              "ipProtocol" : "HOPOPT",
+              "packetLength" : 0,
+              "srcIp" : "0.0.0.0",
+              "srcPort" : 0,
+              "state" : "NEW",
+              "tag" : "SMT",
+              "tcpFlagsAck" : 1,
+              "tcpFlagsCwr" : 1,
+              "tcpFlagsEce" : 1,
+              "tcpFlagsFin" : 1,
+              "tcpFlagsPsh" : 1,
+              "tcpFlagsRst" : 1,
+              "tcpFlagsSyn" : 1,
+              "tcpFlagsUrg" : 1
+            },
+            "paths" : {
+              "BASE" : [
+                {
+                  "disposition" : "ACCEPTED",
+                  "hops" : [
+                    {
+                      "edge" : {
+                        "node1" : "R0",
+                        "node1interface" : "Serial0",
+                        "node2" : "R1",
+                        "node2interface" : "Serial0"
+                      },
+                      "routes" : [
+                        "OspfRoute<70.70.70.70/32,nhip:192.3.64.1/24,nhint:dynamic>"
+                      ]
                     },
-                    "routes" : [
-                      "OspfRoute<70.70.70.70/32,nhip:192.3.64.1/24,nhint:dynamic>"
-                    ]
-                  },
-                  {
-                    "edge" : {
-                      "node1" : "R1",
-                      "node1interface" : "Serial1",
-                      "node2" : "R3",
-                      "node2interface" : "Serial0"
+                    {
+                      "edge" : {
+                        "node1" : "R1",
+                        "node1interface" : "Serial1",
+                        "node2" : "R3",
+                        "node2interface" : "Serial0"
+                      },
+                      "routes" : [
+                        "OspfRoute<70.70.70.70/32,nhip:192.1.64.1/24,nhint:dynamic>"
+                      ]
                     },
-                    "routes" : [
-                      "OspfRoute<70.70.70.70/32,nhip:192.1.64.1/24,nhint:dynamic>"
-                    ]
-                  },
-                  {
-                    "edge" : {
-                      "node1" : "R3",
-                      "node1interface" : "Loopback0",
-                      "node2" : "(none)",
-                      "node2interface" : "null_interface"
+                    {
+                      "edge" : {
+                        "node1" : "R3",
+                        "node1interface" : "Loopback0",
+                        "node2" : "(none)",
+                        "node2interface" : "null_interface"
+                      },
+                      "routes" : [
+                        "ConnectedRoute<70.70.70.70/32,nhip:AUTO/NONE(-1l),nhint:Loopback0>"
+                      ]
+                    }
+                  ],
+                  "notes" : "ACCEPTED"
+                }
+              ],
+              "FAILED" : [
+                {
+                  "disposition" : "DENIED_OUT",
+                  "hops" : [
+                    {
+                      "edge" : {
+                        "node1" : "R0",
+                        "node1interface" : "Serial1",
+                        "node2" : "R2",
+                        "node2interface" : "Serial0"
+                      },
+                      "routes" : [
+                        "OspfRoute<70.70.70.70/32,nhip:192.4.64.1/24,nhint:dynamic>"
+                      ]
                     },
-                    "routes" : [
-                      "ConnectedRoute<70.70.70.70/32,nhip:AUTO/NONE(-1l),nhint:Loopback0>"
-                    ]
-                  }
-                ],
-                "notes" : "ACCEPTED"
-              }
-            ],
-            "FAILED" : [
-              {
-                "disposition" : "DENIED_OUT",
-                "hops" : [
-                  {
-                    "edge" : {
-                      "node1" : "R0",
-                      "node1interface" : "Serial1",
-                      "node2" : "R2",
-                      "node2interface" : "Serial0"
-                    },
-                    "routes" : [
-                      "OspfRoute<70.70.70.70/32,nhip:192.4.64.1/24,nhint:dynamic>"
-                    ]
-                  },
-                  {
-                    "edge" : {
-                      "node1" : "R2",
-                      "node1interface" : "Serial1",
-                      "node2" : "R3",
-                      "node2interface" : "Serial1"
-                    },
-                    "routes" : [
-                      "OspfRoute<70.70.70.70/32,nhip:192.2.64.1/24,nhint:dynamic>"
-                    ]
-                  }
-                ],
-                "notes" : "DENIED_OUT{101}{deny ip any 70.70.70.70  0.0.0.255}"
-              }
-            ]
+                    {
+                      "edge" : {
+                        "node1" : "R2",
+                        "node1interface" : "Serial1",
+                        "node2" : "R3",
+                        "node2interface" : "Serial1"
+                      },
+                      "routes" : [
+                        "OspfRoute<70.70.70.70/32,nhip:192.2.64.1/24,nhint:dynamic>"
+                      ]
+                    }
+                  ],
+                  "notes" : "DENIED_OUT{101}{deny ip any 70.70.70.70  0.0.0.255}"
+                }
+              ]
+            }
           }
         }
       },

--- a/tests/java-smt/differential2.ref
+++ b/tests/java-smt/differential2.ref
@@ -4,86 +4,82 @@
       "class" : "org.batfish.smt.answers.SmtReachabilityAnswerElement",
       "flowHistory" : {
         "class" : "org.batfish.datamodel.FlowHistory",
-        "flows" : [
-          {
-            "@id" : 1,
-            "dscp" : 0,
-            "dstIp" : "70.70.70.0",
-            "dstPort" : 0,
-            "ecn" : 0,
-            "fragmentOffset" : 0,
-            "icmpCode" : 0,
-            "icmpVar" : 0,
-            "ingressNode" : "R0",
-            "ingressVrf" : "default",
-            "ipProtocol" : "HOPOPT",
-            "packetLength" : 0,
-            "srcIp" : "0.0.0.0",
-            "srcPort" : 0,
-            "state" : "NEW",
-            "tag" : "SMT",
-            "tcpFlagsAck" : 1,
-            "tcpFlagsCwr" : 1,
-            "tcpFlagsEce" : 1,
-            "tcpFlagsFin" : 1,
-            "tcpFlagsPsh" : 1,
-            "tcpFlagsRst" : 1,
-            "tcpFlagsSyn" : 1,
-            "tcpFlagsUrg" : 1
-          }
-        ],
-        "flowsByText" : {
-          "Flow<ingressNode:R0 ingressVrf:default srcIp:0.0.0.0 dstIp:70.70.70.0 ipProtocol:HOPOPT dscp: 0 ecn:0 fragmentOffset:0 packetLength:0 state:NEW tag:SMT>" : 1
-        },
         "traces" : {
           "Flow<ingressNode:R0 ingressVrf:default srcIp:0.0.0.0 dstIp:70.70.70.0 ipProtocol:HOPOPT dscp: 0 ecn:0 fragmentOffset:0 packetLength:0 state:NEW tag:SMT>" : {
-            "BASE" : [
-              {
-                "disposition" : "ACCEPTED",
-                "hops" : [
-                  {
-                    "edge" : {
-                      "node1" : "R0",
-                      "node1interface" : "Serial0",
-                      "node2" : "R1",
-                      "node2interface" : "Serial0"
+            "flow" : {
+              "dscp" : 0,
+              "dstIp" : "70.70.70.0",
+              "dstPort" : 0,
+              "ecn" : 0,
+              "fragmentOffset" : 0,
+              "icmpCode" : 0,
+              "icmpVar" : 0,
+              "ingressNode" : "R0",
+              "ingressVrf" : "default",
+              "ipProtocol" : "HOPOPT",
+              "packetLength" : 0,
+              "srcIp" : "0.0.0.0",
+              "srcPort" : 0,
+              "state" : "NEW",
+              "tag" : "SMT",
+              "tcpFlagsAck" : 1,
+              "tcpFlagsCwr" : 1,
+              "tcpFlagsEce" : 1,
+              "tcpFlagsFin" : 1,
+              "tcpFlagsPsh" : 1,
+              "tcpFlagsRst" : 1,
+              "tcpFlagsSyn" : 1,
+              "tcpFlagsUrg" : 1
+            },
+            "paths" : {
+              "BASE" : [
+                {
+                  "disposition" : "ACCEPTED",
+                  "hops" : [
+                    {
+                      "edge" : {
+                        "node1" : "R0",
+                        "node1interface" : "Serial0",
+                        "node2" : "R1",
+                        "node2interface" : "Serial0"
+                      },
+                      "routes" : [
+                        "OspfRoute<70.70.70.0/24,nhip:192.3.64.1/24,nhint:dynamic>"
+                      ]
                     },
-                    "routes" : [
-                      "OspfRoute<70.70.70.0/24,nhip:192.3.64.1/24,nhint:dynamic>"
-                    ]
-                  },
-                  {
-                    "edge" : {
-                      "node1" : "R1",
-                      "node1interface" : "Serial1",
-                      "node2" : "R3",
-                      "node2interface" : "Serial0"
+                    {
+                      "edge" : {
+                        "node1" : "R1",
+                        "node1interface" : "Serial1",
+                        "node2" : "R3",
+                        "node2interface" : "Serial0"
+                      },
+                      "routes" : [
+                        "OspfRoute<70.70.70.0/24,nhip:192.1.64.1/24,nhint:dynamic>"
+                      ]
                     },
-                    "routes" : [
-                      "OspfRoute<70.70.70.0/24,nhip:192.1.64.1/24,nhint:dynamic>"
-                    ]
-                  },
-                  {
-                    "edge" : {
-                      "node1" : "R3",
-                      "node1interface" : "Loopback0",
-                      "node2" : "(none)",
-                      "node2interface" : "null_interface"
-                    },
-                    "routes" : [
-                      "ConnectedRoute<70.70.70.0/24,nhip:AUTO/NONE(-1l),nhint:Loopback0>"
-                    ]
-                  }
-                ],
-                "notes" : "ACCEPTED"
-              }
-            ],
-            "FAILED" : [
-              {
-                "disposition" : "NO_ROUTE",
-                "notes" : "NO_ROUTE"
-              }
-            ]
+                    {
+                      "edge" : {
+                        "node1" : "R3",
+                        "node1interface" : "Loopback0",
+                        "node2" : "(none)",
+                        "node2interface" : "null_interface"
+                      },
+                      "routes" : [
+                        "ConnectedRoute<70.70.70.0/24,nhip:AUTO/NONE(-1l),nhint:Loopback0>"
+                      ]
+                    }
+                  ],
+                  "notes" : "ACCEPTED"
+                }
+              ],
+              "FAILED" : [
+                {
+                  "disposition" : "NO_ROUTE",
+                  "notes" : "NO_ROUTE"
+                }
+              ]
+            }
           }
         }
       },


### PR DESCRIPTION
One thing led to another, and this ended up being a bigger PR than I expected:

1/ Simplified the FlowHistory data structure to make it easy to write JsonPath queries over it. This will be a breaking change for people that are parsing the Json produces by question like traceroute.

2/ New data types in extractionVars. I am back to using complex types in extractionVars. 

3/ Support for using path functions in extractionVars

4/ While putting display hints around reduced reachability, I discovered a poor interaction with different flag in inner question. There is a fix in place but this needs a bit of re-thinking.

5/ debug flag for jsonpath question

6/ Changes to question pre-processing such that optional parameters are wiped out even inside innerQuestions. Otherwise, it is hard to write innerQuestions with many parameters.

I can explain things in person where changes are unclear.