### PR TITLE
Truncate parser error output with really large rules

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/BatfishParserErrorListener.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/BatfishParserErrorListener.java
@@ -73,6 +73,10 @@ public class BatfishParserErrorListener extends BatfishGrammarErrorListener {
     sb.append("Offending Token: " + offendingTokenText + "\n");
     sb.append("Error parsing top (leftmost) parser rule in stack: '" + ruleStack + "'.\n");
     String ctxParseTree = ParseTreePrettyPrinter.print(ctx, _combinedParser);
+    // don't overflow a reasonable terminal if there's a runaway rule
+    if (ctxParseTree.length() > 10000) {
+      ctxParseTree = ctxParseTree.substring(0, 10000) + "\n... and lots more";
+    }
     sb.append("Parse tree of current rule:\n" + ctxParseTree + "\n");
     sb.append("Unconsumed tokens:\n");
     int endTokenIndex = tokens.size();


### PR DESCRIPTION
- Should only be useful for development

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/510)
<!-- Reviewable:end -->
