### PR TITLE
Ignore base and delta properties of JSON question

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -3265,6 +3265,8 @@ public class Batfish extends PluginConsumer implements IBatfish {
     try {
       JSONObject jobj = new JSONObject(rawQuestionText);
       if (jobj.has(BfConsts.PROP_INSTANCE) && !jobj.isNull(BfConsts.PROP_INSTANCE)) {
+        ((JSONObject) (jobj.get("instance"))).remove("delta");
+        ((JSONObject) (jobj.get("instance"))).remove("base");
         String instanceDataStr = jobj.getString(BfConsts.PROP_INSTANCE);
         BatfishObjectMapper mapper = new BatfishObjectMapper();
         InstanceData instanceData =


### PR DESCRIPTION
This pull request makes Batfish ignore `base` and `delta` properties so that it won't find unexpected properties and return errors to the web UI. Shouldn't break if those properties aren't there because the `remove()` method just returns null if the given key doesn't exist.

In the future we can reformulate Batfish to expect `base` and `delta` properties, but this works for now.