### PR TITLE
invalidate cache when repairing environment

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -443,6 +443,8 @@ public class Batfish extends PluginConsumer implements IBatfish {
 
   private long _timerCount;
 
+  private boolean _monotonicCache;
+
   public Batfish(
       Settings settings,
       Cache<TestrigSettings, SortedMap<String, Configuration>> cachedConfigurations,
@@ -3850,7 +3852,9 @@ public class Batfish extends PluginConsumer implements IBatfish {
   }
 
   private void repairEnvironment() {
-    _cachedConfigurations.invalidate(_testrigSettings);
+    if (!_monotonicCache) {
+      _cachedConfigurations.invalidate(_testrigSettings);
+    }
     SortedMap<String, Configuration> configurations = loadConfigurationsWithoutValidation();
     ValidateEnvironmentAnswerElement veae = new ValidateEnvironmentAnswerElement();
     veae.setVersion(Version.getVersion());
@@ -4379,6 +4383,10 @@ public class Batfish extends PluginConsumer implements IBatfish {
   @Override
   public void setDataPlanePlugin(DataPlanePlugin dataPlanePlugin) {
     _dataPlanePlugin = dataPlanePlugin;
+  }
+
+  public void setMonotonicCache(boolean monotonicCache) {
+    _monotonicCache = monotonicCache;
   }
 
   public void setTerminatedWithException(boolean terminatedWithException) {

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -3850,6 +3850,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
   }
 
   private void repairEnvironment() {
+    _cachedConfigurations.invalidate(_testrigSettings);
     SortedMap<String, Configuration> configurations = loadConfigurationsWithoutValidation();
     ValidateEnvironmentAnswerElement veae = new ValidateEnvironmentAnswerElement();
     veae.setVersion(Version.getVersion());

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
@@ -63,9 +63,11 @@ public class BatfishTestUtils {
       testrigs.put(settings.getBaseTestrigSettings(), configurations);
       settings.setActiveTestrigSettings(settings.getBaseTestrigSettings());
     }
-
-    return new Batfish(
-        settings, testrigs, makeDataPlaneCache(), makeEnvBgpCache(), makeEnvRouteCache());
+    Batfish batfish =
+        new Batfish(
+            settings, testrigs, makeDataPlaneCache(), makeEnvBgpCache(), makeEnvRouteCache());
+    batfish.setMonotonicCache(true);
+    return batfish;
   }
 
   private static Batfish initBatfishFromConfigurationText(


### PR DESCRIPTION
Fixes invalid reuse of cache when testrig is replaced (deleted and reinitialized) or otherwise repaired.