### PR TITLE
Smt demo fixes

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/smt/EnvironmentType.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/smt/EnvironmentType.java
@@ -1,0 +1,47 @@
+package org.batfish.datamodel.questions.smt;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.batfish.common.BatfishException;
+
+public enum EnvironmentType {
+  None("none"),
+  ANY("any"),
+  SANE("sane");
+
+  private static final Map<String, EnvironmentType> _map = buildMap();
+
+  private static Map<String, EnvironmentType> buildMap() {
+    Map<String, EnvironmentType> map = new HashMap<>();
+    for (EnvironmentType value : EnvironmentType.values()) {
+      String name = value._name.toLowerCase();
+      map.put(name, value);
+    }
+    return Collections.unmodifiableMap(map);
+  }
+
+  @JsonCreator
+  public static EnvironmentType fromName(String name) {
+    EnvironmentType instance = _map.get(name.toLowerCase());
+    if (instance == null) {
+      throw new BatfishException(
+          "No " + EnvironmentType.class.getSimpleName() + " with name: \"" + name + "\"");
+    }
+    return instance;
+  }
+
+  private final String _name;
+
+  EnvironmentType(String name) {
+    _name = name;
+  }
+
+  @JsonValue
+  public String diffTypeName() {
+    return _name;
+  }
+}
+

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/smt/HeaderQuestion.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/smt/HeaderQuestion.java
@@ -56,13 +56,13 @@ public class HeaderQuestion extends Question implements IQuestion {
 
   private static final String PROP_FULL_MODEL = "fullModel";
 
-  private static final String PROP_NO_ENVIRONMENT = "noEnvironment";
-
   private static final String PROP_MINIMIZE = "minimize";
 
   private static final String PROP_DIFF_TYPE = "diffType";
 
   private static final String PROP_ENV_DIFF = "envDiff";
+
+  private static final String PROP_ENV_TYPE = "envType";
 
   private Set<ForwardingAction> _actions;
 
@@ -80,6 +80,8 @@ public class HeaderQuestion extends Question implements IQuestion {
 
   private boolean _envDiff;
 
+  private EnvironmentType _envType;
+
   public HeaderQuestion() {
     _actions = EnumSet.of(ForwardingAction.ACCEPT);
     _headerSpace = new HeaderSpace();
@@ -89,6 +91,7 @@ public class HeaderQuestion extends Question implements IQuestion {
     _minimize = false;
     _diffType = null;
     _envDiff = false;
+    _envType = EnvironmentType.ANY;
   }
 
   public HeaderQuestion(HeaderQuestion q) {
@@ -100,6 +103,7 @@ public class HeaderQuestion extends Question implements IQuestion {
     _minimize = q._minimize;
     _diffType = q._diffType;
     _envDiff = q._envDiff;
+    _envType = q._envType;
   }
 
   @Override
@@ -217,11 +221,6 @@ public class HeaderQuestion extends Question implements IQuestion {
     return _fullModel;
   }
 
-  @JsonProperty(PROP_NO_ENVIRONMENT)
-  public boolean getNoEnvironment() {
-    return _noEnvironment;
-  }
-
   @JsonProperty(PROP_MINIMIZE)
   public boolean getMinimize() {
     return _minimize;
@@ -236,6 +235,13 @@ public class HeaderQuestion extends Question implements IQuestion {
   public boolean getEnvDiff() {
     return _envDiff;
   }
+
+  @JsonProperty(PROP_ENV_TYPE)
+  public EnvironmentType getEnvironmentType() {
+    return _envType;
+  }
+
+
 
   @Override
   public boolean getTraffic() {
@@ -414,11 +420,6 @@ public class HeaderQuestion extends Question implements IQuestion {
     _fullModel = b;
   }
 
-  @JsonProperty(PROP_NO_ENVIRONMENT)
-  public void setNoEnvironment(boolean b) {
-    _noEnvironment = b;
-  }
-
   @JsonProperty(PROP_MINIMIZE)
   public void setMinimize(boolean b) {
     _minimize = b;
@@ -432,6 +433,11 @@ public class HeaderQuestion extends Question implements IQuestion {
   @JsonProperty(PROP_ENV_DIFF)
   public void setEnvDiff(boolean b) {
     _envDiff = b;
+  }
+
+  @JsonProperty(PROP_ENV_TYPE)
+  public void setEnvironmentType(EnvironmentType e) {
+    _envType = e;
   }
 
 }

--- a/projects/batfish/src/main/java/org/batfish/smt/Encoder.java
+++ b/projects/batfish/src/main/java/org/batfish/smt/Encoder.java
@@ -30,6 +30,7 @@ import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.SubRange;
+import org.batfish.datamodel.questions.smt.EnvironmentType;
 import org.batfish.datamodel.questions.smt.HeaderQuestion;
 import org.batfish.smt.utils.Tuple;
 
@@ -896,8 +897,8 @@ public class Encoder {
     return _allVariables;
   }
 
-  public boolean getNoEnvironment() {
-    return _question.getNoEnvironment();
+  public EnvironmentType getEnvironmentType() {
+    return _question.getEnvironmentType();
   }
 
   public int getId() {

--- a/projects/batfish/src/main/java/org/batfish/smt/EncoderSlice.java
+++ b/projects/batfish/src/main/java/org/batfish/smt/EncoderSlice.java
@@ -3242,7 +3242,9 @@ class EncoderSlice {
             });
 
     // If they don't want the environment modeled
-    if (_encoder.getNoEnvironment()) {
+    switch (_encoder.getEnvironmentType()) {
+    case ANY: break;
+    case None:
       getLogicalGraph()
           .getEnvironmentVars()
           .forEach(
@@ -3250,8 +3252,13 @@ class EncoderSlice {
                 add(mkNot(vars.getPermitted()));
                 add(mkImplies(vars.getPermitted(), mkEq(vars.getMetric(), mkInt(0))));
               });
+      break;
+    case SANE:
+      getLogicalGraph()
+          .getEnvironmentVars().forEach((le, vars) -> add(mkLe(vars.getMetric(), mkInt(50))));
+      break;
+    default: break;
     }
-
   }
 
   /*

--- a/projects/batfish/src/main/java/org/batfish/smt/EncoderSlice.java
+++ b/projects/batfish/src/main/java/org/batfish/smt/EncoderSlice.java
@@ -2740,9 +2740,10 @@ class EncoderSlice {
           BoolExpr usable2 = mkAnd(active, doExport, ospfRedistribVars.getPermitted(), notFailed);
           BoolExpr geq = greaterOrEqual(conf, proto, ospfRedistribVars, varsOther, e);
           BoolExpr isBetter = mkNot(mkAnd(ospfRedistribVars.getPermitted(), geq));
-          BoolExpr shouldTakeOspf = mkAnd(varsOther.getPermitted(), isBetter);
+          BoolExpr usesOspf = mkAnd(varsOther.getPermitted(), isBetter);
           BoolExpr eq = equal(conf, proto, ospfRedistribVars, vars, e, false);
-          acc = mkIf(shouldTakeOspf, mkIf(usable, acc, val), mkIf(usable2, eq, val));
+          BoolExpr eqPer = mkEq(ospfRedistribVars.getPermitted(), vars.getPermitted());
+          acc = mkIf(usesOspf, mkIf(usable, acc, val), mkIf(usable2, mkAnd(eq, eqPer), val));
         } else {
           acc = mkIf(usable, acc, val);
         }

--- a/projects/batfish/src/main/java/org/batfish/smt/PropertyChecker.java
+++ b/projects/batfish/src/main/java/org/batfish/smt/PropertyChecker.java
@@ -41,6 +41,7 @@ import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.StaticRoute;
 import org.batfish.datamodel.answers.AnswerElement;
 import org.batfish.datamodel.pojo.Environment;
+import org.batfish.datamodel.questions.smt.EnvironmentType;
 import org.batfish.datamodel.questions.smt.HeaderLocationQuestion;
 import org.batfish.datamodel.questions.smt.HeaderQuestion;
 import org.batfish.smt.answers.SmtManyAnswerElement;
@@ -974,7 +975,7 @@ public class PropertyChecker {
     HeaderQuestion q = new HeaderQuestion();
     q.setFullModel(fullModel);
     q.setFailures(0);
-    q.setNoEnvironment(false);
+    q.setEnvironmentType(EnvironmentType.ANY);
 
     Collections.sort(routers);
 

--- a/projects/batfish/src/main/java/org/batfish/smt/PropertyChecker.java
+++ b/projects/batfish/src/main/java/org/batfish/smt/PropertyChecker.java
@@ -269,7 +269,9 @@ public class PropertyChecker {
                   Prefix pfx = buildPrefix(r, m, f);
                   Protocol proto = buildProcotol(r, m, slice, router);
                   String route = buildRoute(pfx, proto, ge);
-                  routes.put(ge.toString(), route);
+                  int pathLength = intVal(m, r.getMetric());
+                  String length = "as-path-length=" + pathLength;
+                  routes.put(ge.toString(), route + "," + length);
                 }
               }
             });

--- a/projects/batfish/src/main/java/org/batfish/smt/PropertyChecker.java
+++ b/projects/batfish/src/main/java/org/batfish/smt/PropertyChecker.java
@@ -156,7 +156,9 @@ public class PropertyChecker {
   private static BoolExpr equal(
       Encoder e, Configuration conf, SymbolicRecord r1, SymbolicRecord r2) {
     EncoderSlice main = e.getMainSlice();
-    return main.equal(conf, Protocol.CONNECTED, r1, r2, null, true);
+    BoolExpr eq = main.equal(conf, Protocol.CONNECTED, r1, r2, null, true);
+    BoolExpr samePermitted = e.mkEq(r1.getPermitted(), r2.getPermitted());
+    return e.mkAnd(eq, samePermitted);
   }
 
   /*
@@ -553,6 +555,77 @@ public class PropertyChecker {
   }
 
   /*
+   * Creates a boolean expression that relates the environments of
+   * two separate network copies.
+   */
+  private static BoolExpr relateEnvironments(Encoder enc1, Encoder enc2) {
+    // create a map for enc2 to lookup a related environment variable from enc
+    Table2<GraphEdge, EdgeType, SymbolicRecord> relatedEnv = new Table2<>();
+    enc2.getMainSlice()
+        .getLogicalGraph()
+        .getEnvironmentVars()
+        .forEach((lge, r) -> relatedEnv.put(lge.getEdge(), lge.getEdgeType(), r));
+
+    BoolExpr related = enc1.mkTrue();
+
+    // relate environments if necessary
+    Map<LogicalEdge, SymbolicRecord> map =
+        enc1.getMainSlice().getLogicalGraph().getEnvironmentVars();
+    for (Map.Entry<LogicalEdge, SymbolicRecord> entry : map.entrySet()) {
+      LogicalEdge le = entry.getKey();
+      SymbolicRecord r1 = entry.getValue();
+      String router = le.getEdge().getRouter();
+      Configuration conf = enc1.getMainSlice().getGraph().getConfigurations().get(router);
+
+      // Lookup the same environment variable in the other copy
+      // The copy will have a different name but the same edge and type
+      SymbolicRecord r2 = relatedEnv.get(le.getEdge(), le.getEdgeType());
+      assert r2 != null;
+      BoolExpr x = equal(enc1, conf, r1, r2);
+      related = enc1.mkAnd(related, x);
+    }
+    return related;
+  }
+
+  /*
+   * Relate the two packets from different network copies
+   */
+  private static BoolExpr relatePackets(Encoder enc1, Encoder enc2) {
+    // Ensure packets are equal
+    SymbolicPacket p1 = enc1.getMainSlice().getSymbolicPacket();
+    SymbolicPacket p2 = enc2.getMainSlice().getSymbolicPacket();
+    return p1.mkEqual(p2);
+  }
+
+  /*
+   * Adds additional constraints that certain edges should not be failed to avoid
+   * trivial false positives.
+   */
+  private static void addFailures(Encoder enc, Set<GraphEdge> dstPorts, Set<GraphEdge> failSet) {
+    Graph graph = enc.getMainSlice().getGraph();
+    graph
+        .getEdgeMap()
+        .forEach(
+            (router, edges) -> {
+              for (GraphEdge ge : edges) {
+                ArithExpr f = enc.getSymbolicFailures().getFailedVariable(ge);
+                assert f != null;
+                if (!failSet.contains(ge)) {
+                  enc.add(enc.mkEq(f, enc.mkInt(0)));
+                } else if (dstPorts.contains(ge)) {
+                  // Don't fail an interface if it is for the destination ip we are considering
+                  // Otherwise, any failure can trivially make equivalence false
+                  Prefix pfx = ge.getStart().getPrefix();
+                  ArithExpr dstIp = enc.getMainSlice().getSymbolicPacket().getDstIp();
+                  BoolExpr relevant = enc.getMainSlice().isRelevantFor(pfx, dstIp);
+                  BoolExpr notFailed = enc.mkEq(f, enc.mkInt(0));
+                  enc.add(enc.mkImplies(relevant, notFailed));
+                }
+              }
+            });
+  }
+
+  /*
    * Compute if a collection of source routers can reach a collection of destination
    * ports. This is broken up into multiple queries, one for each destination port.
    */
@@ -572,9 +645,6 @@ public class PropertyChecker {
 
     inferDestinationHeaderSpace(graph, destPorts, q);
     Set<GraphEdge> failOptions = failLinkSet(graph, q);
-
-    // System.out.println("Graph: \n" + graph);
-    // System.out.println("Destination Ports: " + destPorts);
 
     Encoder enc = new Encoder(graph, q);
     enc.computeEncoding();
@@ -609,21 +679,7 @@ public class PropertyChecker {
 
       // relate environments if necessary
       if (!q.getEnvDiff()) {
-        Map<LogicalEdge, SymbolicRecord> map =
-            enc.getMainSlice().getLogicalGraph().getEnvironmentVars();
-        for (Map.Entry<LogicalEdge, SymbolicRecord> entry : map.entrySet()) {
-          LogicalEdge le = entry.getKey();
-          SymbolicRecord r1 = entry.getValue();
-          String router = le.getEdge().getRouter();
-          Configuration conf = enc.getMainSlice().getGraph().getConfigurations().get(router);
-
-          // Lookup the same environment variable in the other copy
-          // The copy will have a different name but the same edge and type
-          SymbolicRecord r2 = relatedEnv.get(le.getEdge(), le.getEdgeType());
-          assert r2 != null;
-          BoolExpr x = equal(enc, conf, r1, r2);
-          related = enc.mkAnd(related, x);
-        }
+        related = relateEnvironments(enc, enc2);
       }
 
       PropertyAdder pa2 = new PropertyAdder(enc2.getMainSlice());
@@ -652,17 +708,11 @@ public class PropertyChecker {
       }
 
       // Ensure packets are equal
-      SymbolicPacket p1 = enc.getMainSlice().getSymbolicPacket();
-      SymbolicPacket p2 = enc2.getMainSlice().getSymbolicPacket();
-      BoolExpr equalPackets = p1.mkEqual(p2);
-      related = enc.mkAnd(related, equalPackets);
+      related = enc.mkAnd(related, relatePackets(enc, enc2));
 
       // Assuming equal packets and environments, is reachability the same
       enc.add(related);
       enc.add(enc.mkNot(required));
-
-      // System.out.println("Related: \n" + related);
-      // System.out.println("Required: \n" + required);
 
     } else {
       BoolExpr allReach = enc.mkTrue();
@@ -674,26 +724,8 @@ public class PropertyChecker {
     }
 
     // Only consider failures for allowed edges
-    graph
-        .getEdgeMap()
-        .forEach(
-            (router, edges) -> {
-              for (GraphEdge ge : edges) {
-                ArithExpr f = enc.getSymbolicFailures().getFailedVariable(ge);
-                assert f != null;
-                if (!failOptions.contains(ge)) {
-                  enc.add(enc.mkEq(f, enc.mkInt(0)));
-                } else if (destPorts.contains(ge)) {
-                  // Don't fail an interface if it is for the destination ip we are considering
-                  // Otherwise, any failure can trivially make equivalence false
-                  Prefix pfx = ge.getStart().getPrefix();
-                  ArithExpr dstIp = enc.getMainSlice().getSymbolicPacket().getDstIp();
-                  BoolExpr relevant = enc.getMainSlice().isRelevantFor(pfx, dstIp);
-                  BoolExpr notFailed = enc.mkEq(f, enc.mkInt(0));
-                  enc.add(enc.mkImplies(relevant, notFailed));
-                }
-              }
-            });
+    addFailures(enc, destPorts, failOptions);
+
 
     Tuple<VerificationResult, Model> result = enc.verify();
     VerificationResult res = result.getFirst();

--- a/projects/batfish/src/main/java/org/batfish/smt/PropertyChecker.java
+++ b/projects/batfish/src/main/java/org/batfish/smt/PropertyChecker.java
@@ -70,7 +70,7 @@ public class PropertyChecker {
     Encoder encoder = new Encoder(batfish, q);
     encoder.computeEncoding();
     VerificationResult result = encoder.verify().getFirst();
-    //result.debug(encoder.getMainSlice(), true, "MAIN_DATA-FORWARDING_host1_eth0");
+    // result.debug(encoder.getMainSlice(), true, null);
     SmtOneAnswerElement answer = new SmtOneAnswerElement();
     answer.setResult(result);
     return answer;

--- a/projects/batfish/src/main/java/org/batfish/smt/PropertyChecker.java
+++ b/projects/batfish/src/main/java/org/batfish/smt/PropertyChecker.java
@@ -699,7 +699,7 @@ public class PropertyChecker {
     VerificationResult res = result.getFirst();
     Model model = result.getSecond();
 
-    // res.debug(enc.getMainSlice(), true, "reachable_host3");
+    // res.debug(enc.getMainSlice(), true, "0_lhr-spine-01_OSPF_SINGLE-EXPORT__permitted");
 
     FlowHistory fh;
     if (q.getDiffType() != null) {

--- a/tests/java-smt/acl1-differential1.ref
+++ b/tests/java-smt/acl1-differential1.ref
@@ -146,6 +146,7 @@
       "192.4.64.2"
     ],
     "envDiff" : false,
+    "envType" : "any",
     "failNode1Regex" : "R2",
     "failNode2Regex" : "R3",
     "failures" : 1,
@@ -153,8 +154,7 @@
     "finalNodeRegex" : ".*",
     "fullModel" : false,
     "ingressNodeRegex" : ".*",
-    "minimize" : false,
-    "noEnvironment" : false
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/java-smt/acl1-differential2.ref
+++ b/tests/java-smt/acl1-differential2.ref
@@ -145,6 +145,7 @@
       "192.4.64.2"
     ],
     "envDiff" : false,
+    "envType" : "any",
     "failNode1Regex" : "R0",
     "failNode2Regex" : "R1",
     "failures" : 1,
@@ -152,8 +153,7 @@
     "finalNodeRegex" : ".*",
     "fullModel" : false,
     "ingressNodeRegex" : ".*",
-    "minimize" : false,
-    "noEnvironment" : false
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/java-smt/acl1-differential3.ref
+++ b/tests/java-smt/acl1-differential3.ref
@@ -146,6 +146,7 @@
       "192.4.64.2"
     ],
     "envDiff" : false,
+    "envType" : "any",
     "failNode1Regex" : ".*",
     "failNode2Regex" : ".*",
     "failures" : 1,
@@ -153,8 +154,7 @@
     "finalNodeRegex" : ".*",
     "fullModel" : false,
     "ingressNodeRegex" : ".*",
-    "minimize" : false,
-    "noEnvironment" : false
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/java-smt/acl1-forwarding.ref
+++ b/tests/java-smt/acl1-forwarding.ref
@@ -95,10 +95,11 @@
     "dstIps" : [
       "70.70.70.70"
     ],
+    "envDiff" : false,
+    "envType" : "any",
     "failures" : 0,
     "fullModel" : true,
-    "minimize" : false,
-    "noEnvironment" : false
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/java-smt/acl1-multipath.ref
+++ b/tests/java-smt/acl1-multipath.ref
@@ -103,6 +103,8 @@
     "dstIps" : [
       "70.70.70.70"
     ],
+    "envDiff" : false,
+    "envType" : "any",
     "failNode1Regex" : ".*",
     "failNode2Regex" : ".*",
     "failures" : 0,
@@ -110,8 +112,7 @@
     "finalNodeRegex" : "R3",
     "fullModel" : true,
     "ingressNodeRegex" : ".*",
-    "minimize" : false,
-    "noEnvironment" : false
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/java-smt/aggregation1-forwarding.ref
+++ b/tests/java-smt/aggregation1-forwarding.ref
@@ -66,10 +66,11 @@
     "dstIps" : [
       "42.42.42.1"
     ],
+    "envDiff" : false,
+    "envType" : "any",
     "failures" : 0,
     "fullModel" : true,
-    "minimize" : false,
-    "noEnvironment" : false
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/java-smt/aggregation2-forwarding.ref
+++ b/tests/java-smt/aggregation2-forwarding.ref
@@ -66,10 +66,11 @@
     "dstIps" : [
       "42.42.42.1"
     ],
+    "envDiff" : false,
+    "envType" : "any",
     "failures" : 0,
     "fullModel" : true,
-    "minimize" : false,
-    "noEnvironment" : false
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/java-smt/area1-forwarding.ref
+++ b/tests/java-smt/area1-forwarding.ref
@@ -99,10 +99,11 @@
     "dstIps" : [
       "70.70.70.70"
     ],
+    "envDiff" : false,
+    "envType" : "any",
     "failures" : 0,
     "fullModel" : true,
-    "minimize" : false,
-    "noEnvironment" : false
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/java-smt/bgp1-bounded-len.ref
+++ b/tests/java-smt/bgp1-bounded-len.ref
@@ -14,6 +14,8 @@
     "dstIps" : [
       "42.42.42.0/24"
     ],
+    "envDiff" : false,
+    "envType" : "any",
     "failNode1Regex" : ".*",
     "failNode2Regex" : ".*",
     "failures" : 0,
@@ -21,8 +23,7 @@
     "finalNodeRegex" : "R1",
     "fullModel" : true,
     "ingressNodeRegex" : ".*",
-    "minimize" : false,
-    "noEnvironment" : false
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/java-smt/bgp1-bounded-len2.ref
+++ b/tests/java-smt/bgp1-bounded-len2.ref
@@ -70,6 +70,8 @@
     "dstIps" : [
       "42.42.42.0/24"
     ],
+    "envDiff" : false,
+    "envType" : "any",
     "failNode1Regex" : ".*",
     "failNode2Regex" : ".*",
     "failures" : 0,
@@ -77,8 +79,7 @@
     "finalNodeRegex" : "R1",
     "fullModel" : true,
     "ingressNodeRegex" : ".*",
-    "minimize" : false,
-    "noEnvironment" : false
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/java-smt/bgp1-forwarding.ref
+++ b/tests/java-smt/bgp1-forwarding.ref
@@ -67,10 +67,11 @@
     "dstIps" : [
       "42.42.42.0"
     ],
+    "envDiff" : false,
+    "envType" : "any",
     "failures" : 0,
     "fullModel" : true,
-    "minimize" : false,
-    "noEnvironment" : false
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/java-smt/bgp1-multipath.ref
+++ b/tests/java-smt/bgp1-multipath.ref
@@ -13,6 +13,8 @@
     "dstIps" : [
       "42.42.42.0/24"
     ],
+    "envDiff" : false,
+    "envType" : "any",
     "failNode1Regex" : ".*",
     "failNode2Regex" : ".*",
     "failures" : 0,
@@ -20,8 +22,7 @@
     "finalNodeRegex" : "R1",
     "fullModel" : true,
     "ingressNodeRegex" : ".*",
-    "minimize" : false,
-    "noEnvironment" : false
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/java-smt/bgp1-reachability.ref
+++ b/tests/java-smt/bgp1-reachability.ref
@@ -16,6 +16,8 @@
     "dstIps" : [
       "42.42.42.0/24"
     ],
+    "envDiff" : false,
+    "envType" : "any",
     "failNode1Regex" : ".*",
     "failNode2Regex" : ".*",
     "failures" : 0,
@@ -23,8 +25,7 @@
     "finalNodeRegex" : "R1",
     "fullModel" : true,
     "ingressNodeRegex" : ".*",
-    "minimize" : false,
-    "noEnvironment" : false
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/java-smt/bgp1-routing-loop.ref
+++ b/tests/java-smt/bgp1-routing-loop.ref
@@ -10,10 +10,11 @@
   "question" : {
     "class" : "org.batfish.question.SmtRoutingLoopQuestionPlugin$RoutingLoopQuestion",
     "differential" : false,
+    "envDiff" : false,
+    "envType" : "any",
     "failures" : 0,
     "fullModel" : true,
-    "minimize" : false,
-    "noEnvironment" : false
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/java-smt/campus2-reachability1.ref
+++ b/tests/java-smt/campus2-reachability1.ref
@@ -16,6 +16,8 @@
     "dstIps" : [
       "2.128.0.0/24"
     ],
+    "envDiff" : false,
+    "envType" : "any",
     "failNode1Regex" : ".*",
     "failNode2Regex" : ".*",
     "failures" : 0,
@@ -23,8 +25,7 @@
     "finalNodeRegex" : "as2dept1",
     "fullModel" : false,
     "ingressNodeRegex" : "as2border.*",
-    "minimize" : false,
-    "noEnvironment" : false
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/java-smt/campus2-reachability2.ref
+++ b/tests/java-smt/campus2-reachability2.ref
@@ -16,6 +16,8 @@
     "dstIps" : [
       "2.128.0.0/24"
     ],
+    "envDiff" : false,
+    "envType" : "any",
     "failNode1Regex" : ".*",
     "failNode2Regex" : ".*",
     "failures" : 1,
@@ -23,8 +25,7 @@
     "finalNodeRegex" : "as2dept1",
     "fullModel" : false,
     "ingressNodeRegex" : "as2border.*",
-    "minimize" : false,
-    "noEnvironment" : false
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/java-smt/commands
+++ b/tests/java-smt/commands
@@ -52,10 +52,10 @@ test tests/java-smt/redistribute1-forwarding4.ref get smt-forwarding dstIps=["14
 init-testrig test_rigs/smt-examples/OSPF1 tr-smt-ospf1
 test tests/java-smt/ospf1-forwarding.ref get smt-forwarding dstIps=["70.70.70.70"], fullModel=True
 
-# Only propagate routes when they are in the FIB
+# OSPF routes propagated even when not in FIB
 init-testrig test_rigs/smt-examples/OSPF2 tr-smt-ospf2
 test tests/java-smt/ospf2-forwarding.ref get smt-forwarding dstIps=["70.70.70.70"], fullModel=True
-init-testrig test_rigs/smt-examples/OSPF4
+init-testrig test_rigs/smt-examples/OSPF4 tr-smt-ospf4
 test tests/java-smt/ospf4-forwarding.ref get smt-forwarding dstIps=["70.70.70.70"], fullModel=True
 
 # Ensure prepending updates path
@@ -119,8 +119,8 @@ test tests/java-smt/campus2-reachability2.ref get smt-reachability ingressNodeRe
 
 # Test differential reachabililty 
 init-testrig test_rigs/smt-examples/OSPF5 tr-smt-ospf5
-test tests/java-smt/differential1.ref get smt-reachability finalNodeRegex="R3", finalIfaceRegex="Loopback.*", failures=1, diffType=any 
-test tests/java-smt/differential2.ref get smt-reachability finalNodeRegex="R3", finalIfaceRegex="Loopback.*", failures=2, diffType=any, ingressNodeRegex="R0", failNode1Regex="R0"
+test tests/java-smt/differential1.ref get smt-reachability finalNodeRegex="R3", finalIfaceRegex="Loopback.*", failures=1, diffType=any, dstIps=["70.70.70.70"]
+test tests/java-smt/differential2.ref get smt-reachability finalNodeRegex="R3", finalIfaceRegex="Loopback.*", failures=2, diffType=any, ingressNodeRegex="R0", failNode1Regex="R0", dstIps=["70.70.70.70"]
 
 # Put everything together in testrigs/example
 #init-testrig test_rigs/example tr-smt-example

--- a/tests/java-smt/commands
+++ b/tests/java-smt/commands
@@ -94,16 +94,16 @@ test tests/java-smt/acl1-differential3.ref get smt-reachability diffType=increas
 
 # Check correctness of iBGP encoding
 init-testrig test_rigs/smt-examples/IBGP1 tr-smt-ibgp1
-test tests/java-smt/ibgp1-forwarding.ref get smt-forwarding dstIps=["20.20.20.20"], fullModel=True, noEnvironment=True
+test tests/java-smt/ibgp1-forwarding.ref get smt-forwarding dstIps=["20.20.20.20"], fullModel=True, envType=none
 
 # Check correctness of multiple ASes using both iBGP and eBGP. Also ensures
 # correct handling of transitivity and path metric update
 init-testrig test_rigs/smt-examples/IBGP2 tr-smt-ibgp2
-test tests/java-smt/ibgp2-forwarding.ref get smt-forwarding dstIps=["4.4.4.4"], fullModel=True, noEnvironment=True
+test tests/java-smt/ibgp2-forwarding.ref get smt-forwarding dstIps=["4.4.4.4"], fullModel=True, envType=none
 
 # Check correct handling of IGP metric cost for iBGP with eBGP
 init-testrig test_rigs/smt-examples/IBGP3 tr-smt-ibgp3
-test tests/java-smt/ibgp3-forwarding.ref get smt-forwarding dstIps=["4.4.4.4"], fullModel=True, noEnvironment=True
+test tests/java-smt/ibgp3-forwarding.ref get smt-forwarding dstIps=["4.4.4.4"], fullModel=True, envType=none
 
 # Putting everything together, check the campus network
 #init-testrig test_rigs/smt-examples/CAMPUS1 tr-smt-campus1

--- a/tests/java-smt/differential1.ref
+++ b/tests/java-smt/differential1.ref
@@ -18,6 +18,7 @@
       "70.70.70.70"
     ],
     "envDiff" : false,
+    "envType" : "any",
     "failNode1Regex" : ".*",
     "failNode2Regex" : ".*",
     "failures" : 1,
@@ -25,8 +26,7 @@
     "finalNodeRegex" : "R3",
     "fullModel" : false,
     "ingressNodeRegex" : ".*",
-    "minimize" : false,
-    "noEnvironment" : false
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/java-smt/differential1.ref
+++ b/tests/java-smt/differential1.ref
@@ -15,8 +15,9 @@
     "diffType" : "any",
     "differential" : false,
     "dstIps" : [
-      "70.70.70.0/24"
+      "70.70.70.70"
     ],
+    "envDiff" : false,
     "failNode1Regex" : ".*",
     "failNode2Regex" : ".*",
     "failures" : 1,

--- a/tests/java-smt/differential2.ref
+++ b/tests/java-smt/differential2.ref
@@ -120,6 +120,7 @@
       "70.70.70.70"
     ],
     "envDiff" : false,
+    "envType" : "any",
     "failNode1Regex" : "R0",
     "failNode2Regex" : ".*",
     "failures" : 2,
@@ -127,8 +128,7 @@
     "finalNodeRegex" : "R3",
     "fullModel" : false,
     "ingressNodeRegex" : "R0",
-    "minimize" : false,
-    "noEnvironment" : false
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/java-smt/differential2.ref
+++ b/tests/java-smt/differential2.ref
@@ -5,7 +5,7 @@
       "flowHistory" : {
         "class" : "org.batfish.datamodel.FlowHistory",
         "traces" : {
-          "Flow<ingressNode:R0 ingressVrf:default srcIp:0.0.0.0 dstIp:70.70.70.0 ipProtocol:HOPOPT dscp: 0 ecn:0 fragmentOffset:0 packetLength:0 state:NEW tag:SMT>" : {
+          "Flow<ingressNode:R0 ingressVrf:default srcIp:0.0.0.0 dstIp:70.70.70.70 ipProtocol:HOPOPT dscp: 0 ecn:0 fragmentOffset:0 packetLength:0 state:NEW tag:SMT>" : {
             "environments" : {
               "BASE" : {
                 "envName" : "BASE",
@@ -32,7 +32,7 @@
             },
             "flow" : {
               "dscp" : 0,
-              "dstIp" : "70.70.70.0",
+              "dstIp" : "70.70.70.70",
               "dstPort" : 0,
               "ecn" : 0,
               "fragmentOffset" : 0,
@@ -81,17 +81,6 @@
                       "routes" : [
                         "OspfRoute<70.70.70.0/24,nhip:192.1.64.1,nhint:dynamic>"
                       ]
-                    },
-                    {
-                      "edge" : {
-                        "node1" : "R3",
-                        "node1interface" : "Loopback0",
-                        "node2" : "(none)",
-                        "node2interface" : "null_interface"
-                      },
-                      "routes" : [
-                        "ConnectedRoute<70.70.70.0/24,nhip:AUTO/NONE(-1l),nhint:Loopback0>"
-                      ]
                     }
                   ],
                   "notes" : "ACCEPTED"
@@ -114,11 +103,10 @@
         ],
         "forwardingModel" : [
           "R1,Serial1 --> R3,Serial0 (OSPF)",
-          "R2,Serial1 --> R3,Serial1 (OSPF)",
-          "R3,Loopback0 --> _,_ (CONNECTED)"
+          "R2,Serial1 --> R3,Serial1 (OSPF)"
         ],
         "packetModel" : {
-          "dstIp" : "70.70.70.0"
+          "dstIp" : "70.70.70.70"
         },
         "verified" : false
       }
@@ -129,7 +117,7 @@
     "diffType" : "any",
     "differential" : false,
     "dstIps" : [
-      "70.70.70.0/24"
+      "70.70.70.70"
     ],
     "envDiff" : false,
     "failNode1Regex" : "R0",

--- a/tests/java-smt/env3-local.ref
+++ b/tests/java-smt/env3-local.ref
@@ -154,10 +154,11 @@
   "question" : {
     "class" : "org.batfish.question.SmtLocalConsistencyQuestionPlugin$LocalConsistencyQuestion",
     "differential" : false,
+    "envDiff" : false,
+    "envType" : "any",
     "failures" : 0,
     "fullModel" : true,
     "minimize" : true,
-    "noEnvironment" : false,
     "nodeRegex" : ".*",
     "strict" : false
   },

--- a/tests/java-smt/ibgp1-forwarding.ref
+++ b/tests/java-smt/ibgp1-forwarding.ref
@@ -176,10 +176,11 @@
     "dstIps" : [
       "20.20.20.20"
     ],
+    "envDiff" : false,
+    "envType" : "none",
     "failures" : 0,
     "fullModel" : true,
-    "minimize" : false,
-    "noEnvironment" : true
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/java-smt/ibgp2-forwarding.ref
+++ b/tests/java-smt/ibgp2-forwarding.ref
@@ -326,10 +326,11 @@
     "dstIps" : [
       "4.4.4.4"
     ],
+    "envDiff" : false,
+    "envType" : "none",
     "failures" : 0,
     "fullModel" : true,
-    "minimize" : false,
-    "noEnvironment" : true
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/java-smt/ibgp3-forwarding.ref
+++ b/tests/java-smt/ibgp3-forwarding.ref
@@ -428,10 +428,11 @@
     "dstIps" : [
       "4.4.4.4"
     ],
+    "envDiff" : false,
+    "envType" : "none",
     "failures" : 0,
     "fullModel" : true,
-    "minimize" : false,
-    "noEnvironment" : true
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/java-smt/ospf1-forwarding.ref
+++ b/tests/java-smt/ospf1-forwarding.ref
@@ -69,10 +69,11 @@
     "dstIps" : [
       "70.70.70.70"
     ],
+    "envDiff" : false,
+    "envType" : "any",
     "failures" : 0,
     "fullModel" : true,
-    "minimize" : false,
-    "noEnvironment" : false
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/java-smt/ospf2-forwarding.ref
+++ b/tests/java-smt/ospf2-forwarding.ref
@@ -73,10 +73,11 @@
     "dstIps" : [
       "70.70.70.70"
     ],
+    "envDiff" : false,
+    "envType" : "any",
     "failures" : 0,
     "fullModel" : true,
-    "minimize" : false,
-    "noEnvironment" : false
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/java-smt/ospf3-bounded-len.ref
+++ b/tests/java-smt/ospf3-bounded-len.ref
@@ -14,6 +14,8 @@
     "dstIps" : [
       "70.70.70.70"
     ],
+    "envDiff" : false,
+    "envType" : "any",
     "failNode1Regex" : ".*",
     "failNode2Regex" : ".*",
     "failures" : 0,
@@ -21,8 +23,7 @@
     "finalNodeRegex" : "R3",
     "fullModel" : true,
     "ingressNodeRegex" : ".*",
-    "minimize" : false,
-    "noEnvironment" : false
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/java-smt/ospf3-bounded-len2.ref
+++ b/tests/java-smt/ospf3-bounded-len2.ref
@@ -101,6 +101,8 @@
     "dstIps" : [
       "70.70.70.70"
     ],
+    "envDiff" : false,
+    "envType" : "any",
     "failNode1Regex" : ".*",
     "failNode2Regex" : ".*",
     "failures" : 0,
@@ -108,8 +110,7 @@
     "finalNodeRegex" : "R3",
     "fullModel" : true,
     "ingressNodeRegex" : ".*",
-    "minimize" : false,
-    "noEnvironment" : false
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/java-smt/ospf3-equal-len.ref
+++ b/tests/java-smt/ospf3-equal-len.ref
@@ -13,6 +13,8 @@
     "dstIps" : [
       "70.70.70.70"
     ],
+    "envDiff" : false,
+    "envType" : "any",
     "failNode1Regex" : ".*",
     "failNode2Regex" : ".*",
     "failures" : 0,
@@ -20,8 +22,7 @@
     "finalNodeRegex" : "R3",
     "fullModel" : true,
     "ingressNodeRegex" : "R(1|2)",
-    "minimize" : false,
-    "noEnvironment" : false
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/java-smt/ospf3-equal-len2.ref
+++ b/tests/java-smt/ospf3-equal-len2.ref
@@ -100,6 +100,8 @@
     "dstIps" : [
       "70.70.70.70"
     ],
+    "envDiff" : false,
+    "envType" : "any",
     "failNode1Regex" : ".*",
     "failNode2Regex" : ".*",
     "failures" : 0,
@@ -107,8 +109,7 @@
     "finalNodeRegex" : "R3",
     "fullModel" : true,
     "ingressNodeRegex" : "R(1|0)",
-    "minimize" : false,
-    "noEnvironment" : false
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/java-smt/ospf3-forward.ref
+++ b/tests/java-smt/ospf3-forward.ref
@@ -96,10 +96,11 @@
     "dstIps" : [
       "70.70.70.70"
     ],
+    "envDiff" : false,
+    "envType" : "any",
     "failures" : 0,
     "fullModel" : true,
-    "minimize" : false,
-    "noEnvironment" : false
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/java-smt/ospf3-multipath.ref
+++ b/tests/java-smt/ospf3-multipath.ref
@@ -13,6 +13,8 @@
     "dstIps" : [
       "70.70.70.70"
     ],
+    "envDiff" : false,
+    "envType" : "any",
     "failNode1Regex" : ".*",
     "failNode2Regex" : ".*",
     "failures" : 0,
@@ -20,8 +22,7 @@
     "finalNodeRegex" : "R3",
     "fullModel" : true,
     "ingressNodeRegex" : ".*",
-    "minimize" : false,
-    "noEnvironment" : false
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/java-smt/ospf3-reachable.ref
+++ b/tests/java-smt/ospf3-reachable.ref
@@ -16,6 +16,8 @@
     "dstIps" : [
       "70.70.70.70"
     ],
+    "envDiff" : false,
+    "envType" : "any",
     "failNode1Regex" : ".*",
     "failNode2Regex" : ".*",
     "failures" : 0,
@@ -23,8 +25,7 @@
     "finalNodeRegex" : "R3",
     "fullModel" : true,
     "ingressNodeRegex" : ".*",
-    "minimize" : false,
-    "noEnvironment" : false
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/java-smt/ospf4-forwarding.ref
+++ b/tests/java-smt/ospf4-forwarding.ref
@@ -107,10 +107,10 @@
       "70.70.70.70"
     ],
     "envDiff" : false,
+    "envType" : "any",
     "failures" : 0,
     "fullModel" : true,
-    "minimize" : false,
-    "noEnvironment" : false
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/java-smt/ospf4-forwarding.ref
+++ b/tests/java-smt/ospf4-forwarding.ref
@@ -4,12 +4,13 @@
       "class" : "org.batfish.smt.answers.SmtOneAnswerElement",
       "result" : {
         "forwardingModel" : [
+          "R0,Serial0 --> R1,Serial0 (OSPF)",
           "R0,Serial1 --> R2,Serial0 (OSPF)",
           "R1,Serial0 --> R0,Serial0 (STATIC)",
           "R2,Serial1 --> R3,Serial1 (OSPF)"
         ],
         "model" : {
-          "|0_CONTROL-FORWARDING_R0_Serial0|" : "false",
+          "|0_CONTROL-FORWARDING_R0_Serial0|" : "true",
           "|0_CONTROL-FORWARDING_R0_Serial1|" : "true",
           "|0_CONTROL-FORWARDING_R1_Serial0|" : "true",
           "|0_CONTROL-FORWARDING_R1_Serial1|" : "false",
@@ -18,7 +19,7 @@
           "|0_CONTROL-FORWARDING_R3_Loopback0|" : "false",
           "|0_CONTROL-FORWARDING_R3_Serial0|" : "false",
           "|0_CONTROL-FORWARDING_R3_Serial1|" : "false",
-          "|0_DATA-FORWARDING_R0_Serial0|" : "false",
+          "|0_DATA-FORWARDING_R0_Serial0|" : "true",
           "|0_DATA-FORWARDING_R0_Serial1|" : "true",
           "|0_DATA-FORWARDING_R1_Serial0|" : "true",
           "|0_DATA-FORWARDING_R1_Serial1|" : "false",
@@ -32,7 +33,7 @@
           "|0_FAILED-EDGE_R1_R3|" : "0",
           "|0_FAILED-EDGE_R2_R3|" : "0",
           "|0_FAILED-EDGE_R3_Loopback0|" : "0",
-          "|0_R0_OSPF_IMPORT_Serial0_choice|" : "false",
+          "|0_R0_OSPF_IMPORT_Serial0_choice|" : "true",
           "|0_R0_OSPF_IMPORT_Serial1_choice|" : "true",
           "|0_R0_OSPF_SINGLE-EXPORT__metric|" : "3",
           "|0_R0_OSPF_SINGLE-EXPORT__permitted|" : "true",
@@ -45,9 +46,9 @@
           "|0_R1_OSPF_BEST_None_prefixLength|" : "32",
           "|0_R1_OSPF_IMPORT_Serial0_choice|" : "false",
           "|0_R1_OSPF_IMPORT_Serial1_choice|" : "true",
-          "|0_R1_OSPF_SINGLE-EXPORT__metric|" : "0",
-          "|0_R1_OSPF_SINGLE-EXPORT__permitted|" : "false",
-          "|0_R1_OSPF_SINGLE-EXPORT__prefixLength|" : "0",
+          "|0_R1_OSPF_SINGLE-EXPORT__metric|" : "2",
+          "|0_R1_OSPF_SINGLE-EXPORT__permitted|" : "true",
+          "|0_R1_OSPF_SINGLE-EXPORT__prefixLength|" : "32",
           "|0_R1_OVERALL_BEST_None_adminDist|" : "1",
           "|0_R1_OVERALL_BEST_None_history|" : "1",
           "|0_R1_OVERALL_BEST_None_metric|" : "0",
@@ -74,7 +75,7 @@
           "|0_R3_OSPF_BEST_None_metric|" : "2",
           "|0_R3_OSPF_BEST_None_permitted|" : "true",
           "|0_R3_OSPF_BEST_None_prefixLength|" : "32",
-          "|0_R3_OSPF_IMPORT_Serial0_choice|" : "false",
+          "|0_R3_OSPF_IMPORT_Serial0_choice|" : "true",
           "|0_R3_OSPF_IMPORT_Serial1_choice|" : "true",
           "|0_R3_OSPF_SINGLE-EXPORT__metric|" : "1",
           "|0_R3_OSPF_SINGLE-EXPORT__permitted|" : "true",
@@ -105,6 +106,7 @@
     "dstIps" : [
       "70.70.70.70"
     ],
+    "envDiff" : false,
     "failures" : 0,
     "fullModel" : true,
     "minimize" : false,

--- a/tests/java-smt/overflow1-forwarding.ref
+++ b/tests/java-smt/overflow1-forwarding.ref
@@ -86,10 +86,11 @@
     "dstIps" : [
       "41.41.41.1"
     ],
+    "envDiff" : false,
+    "envType" : "any",
     "failures" : 0,
     "fullModel" : true,
-    "minimize" : false,
-    "noEnvironment" : false
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/java-smt/prepend1-forwarding.ref
+++ b/tests/java-smt/prepend1-forwarding.ref
@@ -87,10 +87,11 @@
     "dstIps" : [
       "41.41.41.1"
     ],
+    "envDiff" : false,
+    "envType" : "any",
     "failures" : 0,
     "fullModel" : true,
-    "minimize" : false,
-    "noEnvironment" : false
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/java-smt/redistribute1-forwarding1.ref
+++ b/tests/java-smt/redistribute1-forwarding1.ref
@@ -71,10 +71,11 @@
     "dstIps" : [
       "70.70.70.70"
     ],
+    "envDiff" : false,
+    "envType" : "any",
     "failures" : 0,
     "fullModel" : true,
-    "minimize" : false,
-    "noEnvironment" : false
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/java-smt/redistribute1-forwarding2.ref
+++ b/tests/java-smt/redistribute1-forwarding2.ref
@@ -77,10 +77,10 @@
       "69.69.69.0"
     ],
     "envDiff" : false,
+    "envType" : "any",
     "failures" : 0,
     "fullModel" : true,
-    "minimize" : false,
-    "noEnvironment" : false
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/java-smt/redistribute1-forwarding2.ref
+++ b/tests/java-smt/redistribute1-forwarding2.ref
@@ -41,6 +41,10 @@
           "|0_R2_OSPF_BEST_None_permitted|" : "true",
           "|0_R2_OSPF_BEST_None_prefixLength|" : "24",
           "|0_R2_OSPF_IMPORT_Serial0_choice|" : "true",
+          "|0_R2_OSPF_SINGLE-EXPORT__Redistributed_metric|" : "10",
+          "|0_R2_OSPF_SINGLE-EXPORT__Redistributed_ospfType|" : "3",
+          "|0_R2_OSPF_SINGLE-EXPORT__Redistributed_permitted|" : "true",
+          "|0_R2_OSPF_SINGLE-EXPORT__Redistributed_prefixLength|" : "24",
           "|0_R2_OSPF_SINGLE-EXPORT__metric|" : "10",
           "|0_R2_OSPF_SINGLE-EXPORT__ospfType|" : "3",
           "|0_R2_OSPF_SINGLE-EXPORT__permitted|" : "true",
@@ -72,6 +76,7 @@
     "dstIps" : [
       "69.69.69.0"
     ],
+    "envDiff" : false,
     "failures" : 0,
     "fullModel" : true,
     "minimize" : false,

--- a/tests/java-smt/redistribute1-forwarding3.ref
+++ b/tests/java-smt/redistribute1-forwarding3.ref
@@ -41,6 +41,10 @@
           "|0_R2_OSPF_BEST_None_permitted|" : "true",
           "|0_R2_OSPF_BEST_None_prefixLength|" : "24",
           "|0_R2_OSPF_IMPORT_Serial0_choice|" : "true",
+          "|0_R2_OSPF_SINGLE-EXPORT__Redistributed_metric|" : "10",
+          "|0_R2_OSPF_SINGLE-EXPORT__Redistributed_ospfType|" : "3",
+          "|0_R2_OSPF_SINGLE-EXPORT__Redistributed_permitted|" : "true",
+          "|0_R2_OSPF_SINGLE-EXPORT__Redistributed_prefixLength|" : "24",
           "|0_R2_OSPF_SINGLE-EXPORT__metric|" : "10",
           "|0_R2_OSPF_SINGLE-EXPORT__ospfType|" : "3",
           "|0_R2_OSPF_SINGLE-EXPORT__permitted|" : "true",
@@ -72,6 +76,7 @@
     "dstIps" : [
       "180.0.0.0"
     ],
+    "envDiff" : false,
     "failures" : 0,
     "fullModel" : true,
     "minimize" : false,

--- a/tests/java-smt/redistribute1-forwarding3.ref
+++ b/tests/java-smt/redistribute1-forwarding3.ref
@@ -77,10 +77,10 @@
       "180.0.0.0"
     ],
     "envDiff" : false,
+    "envType" : "any",
     "failures" : 0,
     "fullModel" : true,
-    "minimize" : false,
-    "noEnvironment" : false
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/java-smt/redistribute1-forwarding4.ref
+++ b/tests/java-smt/redistribute1-forwarding4.ref
@@ -77,10 +77,10 @@
       "140.0.0.0"
     ],
     "envDiff" : false,
+    "envType" : "any",
     "failures" : 0,
     "fullModel" : true,
-    "minimize" : false,
-    "noEnvironment" : false
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/java-smt/redistribute1-forwarding4.ref
+++ b/tests/java-smt/redistribute1-forwarding4.ref
@@ -36,6 +36,10 @@
           "|0_R2_OSPF_BEST_None_permitted|" : "true",
           "|0_R2_OSPF_BEST_None_prefixLength|" : "24",
           "|0_R2_OSPF_IMPORT_Serial0_choice|" : "true",
+          "|0_R2_OSPF_SINGLE-EXPORT__Redistributed_metric|" : "20",
+          "|0_R2_OSPF_SINGLE-EXPORT__Redistributed_ospfType|" : "3",
+          "|0_R2_OSPF_SINGLE-EXPORT__Redistributed_permitted|" : "true",
+          "|0_R2_OSPF_SINGLE-EXPORT__Redistributed_prefixLength|" : "24",
           "|0_R2_OSPF_SINGLE-EXPORT__metric|" : "20",
           "|0_R2_OSPF_SINGLE-EXPORT__ospfType|" : "3",
           "|0_R2_OSPF_SINGLE-EXPORT__permitted|" : "true",
@@ -72,6 +76,7 @@
     "dstIps" : [
       "140.0.0.0"
     ],
+    "envDiff" : false,
     "failures" : 0,
     "fullModel" : true,
     "minimize" : false,

--- a/tests/java-smt/stable3-forwarding.ref
+++ b/tests/java-smt/stable3-forwarding.ref
@@ -21,10 +21,11 @@
     "dstIps" : [
       "42.42.42.0"
     ],
+    "envDiff" : false,
+    "envType" : "any",
     "failures" : 0,
     "fullModel" : false,
-    "minimize" : false,
-    "noEnvironment" : false
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/java-smt/static2-forward.ref
+++ b/tests/java-smt/static2-forward.ref
@@ -46,10 +46,11 @@
     "dstIps" : [
       "172.0.0.0"
     ],
+    "envDiff" : false,
+    "envType" : "any",
     "failures" : 0,
     "fullModel" : true,
-    "minimize" : false,
-    "noEnvironment" : false
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/java-smt/static2-loop.ref
+++ b/tests/java-smt/static2-loop.ref
@@ -50,10 +50,11 @@
     "dstIps" : [
       "172.0.0.0/8"
     ],
+    "envDiff" : false,
+    "envType" : "any",
     "failures" : 0,
     "fullModel" : true,
-    "minimize" : false,
-    "noEnvironment" : false
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/java-smt/static3-reachability1.ref
+++ b/tests/java-smt/static3-reachability1.ref
@@ -17,6 +17,7 @@
       "192.168.8.0/24"
     ],
     "envDiff" : false,
+    "envType" : "any",
     "failNode1Regex" : ".*",
     "failNode2Regex" : ".*",
     "failures" : 0,
@@ -25,7 +26,6 @@
     "fullModel" : false,
     "ingressNodeRegex" : "host1",
     "minimize" : false,
-    "noEnvironment" : false,
     "notDstIps" : [
       "192.168.8.1"
     ]

--- a/tests/java-smt/static3-reachability2.ref
+++ b/tests/java-smt/static3-reachability2.ref
@@ -17,6 +17,7 @@
       "192.168.8.2"
     ],
     "envDiff" : false,
+    "envType" : "any",
     "failNode1Regex" : ".*",
     "failNode2Regex" : ".*",
     "failures" : 0,
@@ -24,8 +25,7 @@
     "finalNodeRegex" : "host3",
     "fullModel" : false,
     "ingressNodeRegex" : "host1",
-    "minimize" : false,
-    "noEnvironment" : false
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/java-smt/static3-reachability3.ref
+++ b/tests/java-smt/static3-reachability3.ref
@@ -104,6 +104,7 @@
       "192.168.8.1"
     ],
     "envDiff" : false,
+    "envType" : "any",
     "failNode1Regex" : ".*",
     "failNode2Regex" : ".*",
     "failures" : 0,
@@ -111,8 +112,7 @@
     "finalNodeRegex" : "host3",
     "fullModel" : false,
     "ingressNodeRegex" : "host1",
-    "minimize" : false,
-    "noEnvironment" : false
+    "minimize" : false
   },
   "status" : "SUCCESS",
   "summary" : {


### PR DESCRIPTION
* Allows using OSPF routes even when not in the FIB
* Fixes a bug when relating environments
* Removes the noEnvironment=True|False flag
* Adds an envType=any|none|sane flag
* Adds the AS path length to the environment string