### PR TITLE
Query for determinism

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
@@ -188,4 +188,6 @@ public interface IBatfish extends IPluginConsumer {
   AnswerElement smtLoadBalance(HeaderLocationQuestion q, int threshold);
 
   AnswerElement smtLocalConsistency(Pattern routerRegex, boolean strict, boolean fullModel);
+
+  AnswerElement smtDeterminism(HeaderQuestion q);
 }

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -4752,4 +4752,9 @@ public class Batfish extends PluginConsumer implements IBatfish {
   public AnswerElement smtLocalConsistency(Pattern routerRegex, boolean strict, boolean fullModel) {
     return PropertyChecker.computeLocalConsistency(this, routerRegex, strict, fullModel);
   }
+
+  @Override
+  public AnswerElement smtDeterminism(HeaderQuestion q) {
+    return PropertyChecker.computeDeterminism(this, q);
+  }
 }

--- a/projects/batfish/src/main/java/org/batfish/smt/Graph.java
+++ b/projects/batfish/src/main/java/org/batfish/smt/Graph.java
@@ -53,6 +53,10 @@ public class Graph {
 
   private Map<String, List<GraphEdge>> _edgeMap;
 
+  private Set<GraphEdge> _allRealEdges;
+
+  private Set<GraphEdge> _allEdges;
+
   private Map<GraphEdge, GraphEdge> _otherEnd;
 
   private Map<GraphEdge, BgpNeighbor> _ebgpNeighbors;
@@ -83,6 +87,8 @@ public class Graph {
     _batfish = batfish;
     _configurations = new HashMap<>(_batfish.loadConfigurations());
     _edgeMap = new HashMap<>();
+    _allEdges = new HashSet<>();
+    _allRealEdges = new HashSet<>();
     _otherEnd = new HashMap<>();
     _areaIds = new HashMap<>();
     _staticRoutes = new HashMap<>();
@@ -184,6 +190,8 @@ public class Graph {
                 }
               });
 
+          _allRealEdges.addAll(graphEdges);
+          _allEdges.addAll(graphEdges);
           _edgeMap.put(router, new ArrayList<>(graphEdges));
           _neighbors.put(router, neighs);
         });
@@ -370,6 +378,7 @@ public class Graph {
             ge = new GraphEdge(iface1, null, r1, null, true);
           }
 
+          _allEdges.add(ge);
           _ibgpNeighbors.put(ge, n1);
 
           reverse.put(r1, r2, ge);
@@ -782,5 +791,13 @@ public class Graph {
 
   public IBatfish getBatfish() {
     return _batfish;
+  }
+
+  public Set<GraphEdge> getAllRealEdges() {
+    return _allRealEdges;
+  }
+
+  public Set<GraphEdge> getAllEdges() {
+    return _allEdges;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/smt/PropertyChecker.java
+++ b/projects/batfish/src/main/java/org/batfish/smt/PropertyChecker.java
@@ -46,6 +46,7 @@ import org.batfish.datamodel.questions.smt.EnvironmentType;
 import org.batfish.datamodel.questions.smt.HeaderLocationQuestion;
 import org.batfish.datamodel.questions.smt.HeaderQuestion;
 import org.batfish.smt.answers.SmtManyAnswerElement;
+import org.batfish.smt.answers.SmtNondeterminismAnswerElement;
 import org.batfish.smt.answers.SmtOneAnswerElement;
 import org.batfish.smt.answers.SmtReachabilityAnswerElement;
 import org.batfish.smt.collections.Table2;
@@ -312,6 +313,20 @@ public class PropertyChecker {
       nhint = "dynamic";
     }
     return String.format("%s<%s,nhip:%s,nhint:%s>", type, pfx.getNetworkPrefix(), nhip, nhint);
+  }
+
+  /*
+   * Create a route from a graph edge
+   */
+  private static String buildRoute(EncoderSlice slice, Model m, GraphEdge ge) {
+    String router = ge.getRouter();
+    SymbolicDecisions decisions = slice.getSymbolicDecisions();
+    SymbolicRecord r = decisions.getBestNeighbor().get(router);
+    SymbolicPacket pkt = slice.getSymbolicPacket();
+    Flow f = buildFlow(m, pkt, router);
+    Prefix pfx = buildPrefix(r, m, f);
+    Protocol proto = buildProcotol(r, m, slice, router);
+    return buildRoute(pfx, proto, ge);
   }
 
   /*
@@ -587,6 +602,23 @@ public class PropertyChecker {
   }
 
   /*
+ * Creates a boolean expression that relates the environments of
+ * two separate network copies.
+ */
+  private static BoolExpr relateFailures(Encoder enc1, Encoder enc2) {
+    BoolExpr related = enc1.mkTrue();
+    for (GraphEdge ge : enc1.getMainSlice().getGraph().getAllRealEdges()) {
+      ArithExpr a1 = enc1.getSymbolicFailures().getFailedVariable(ge);
+      ArithExpr a2 = enc2.getSymbolicFailures().getFailedVariable(ge);
+      assert a1 != null;
+      assert a2 != null;
+      related = enc1.mkEq(a1, a2);
+    }
+    return related;
+  }
+
+
+  /*
    * Relate the two packets from different network copies
    */
   private static BoolExpr relatePackets(Encoder enc1, Encoder enc2) {
@@ -774,6 +806,76 @@ public class PropertyChecker {
     answer.setFlowHistory(fh);
     return answer;
   }
+
+
+  /*
+   * Check if there exist multiple stable solutions to the netowrk.
+   * If so, reports the forwarding differences between the two cases.
+   */
+  public static AnswerElement computeDeterminism(IBatfish batfish, HeaderQuestion q) {
+    Graph graph = new Graph(batfish);
+    Encoder enc1 = new Encoder(graph, q);
+    Encoder enc2 = new Encoder(enc1, graph, q);
+    enc1.computeEncoding();
+    enc2.computeEncoding();
+    addEnvironmentConstraints(enc1, q.getBaseEnvironmentType());
+
+    BoolExpr relatedFailures = relateFailures(enc1, enc2);
+    BoolExpr relatedEnvs = relateEnvironments(enc1, enc2);
+    BoolExpr relatedPkts = relatePackets(enc1, enc2);
+    BoolExpr related = enc1.mkAnd(relatedFailures, relatedEnvs, relatedPkts);
+    BoolExpr required = enc1.mkTrue();
+    for (GraphEdge ge : graph.getAllRealEdges()) {
+      SymbolicDecisions d1 = enc1.getMainSlice().getSymbolicDecisions();
+      SymbolicDecisions d2 = enc2.getMainSlice().getSymbolicDecisions();
+      BoolExpr dataFwd1 = d1.getDataForwarding().get(ge.getRouter(), ge);
+      BoolExpr dataFwd2 = d2.getDataForwarding().get(ge.getRouter(), ge);
+      assert dataFwd1 != null;
+      assert dataFwd2 != null;
+      required = enc1.mkAnd(required, enc1.mkEq(dataFwd1, dataFwd2));
+    }
+
+    enc1.add(related);
+    enc1.add(enc1.mkNot(required));
+
+    Tuple<VerificationResult, Model> tup = enc1.verify();
+    VerificationResult res = tup.getFirst();
+    Model model = tup.getSecond();
+
+    SortedSet<String> case1 = null;
+    SortedSet<String> case2 = null;
+    if (!res.isVerified()) {
+      case1 = new TreeSet<>();
+      case2 = new TreeSet<>();
+      for (GraphEdge ge : graph.getAllRealEdges()) {
+        SymbolicDecisions d1 = enc1.getMainSlice().getSymbolicDecisions();
+        SymbolicDecisions d2 = enc2.getMainSlice().getSymbolicDecisions();
+        BoolExpr dataFwd1 = d1.getDataForwarding().get(ge.getRouter(), ge);
+        BoolExpr dataFwd2 = d2.getDataForwarding().get(ge.getRouter(), ge);
+        String s1 = evaluate(model, dataFwd1);
+        String s2 = evaluate(model, dataFwd2);
+        if (!Objects.equals(s1, s2)) {
+          if ("true".equals(s1)) {
+            String route = buildRoute(enc1.getMainSlice(), model, ge);
+            String msg = ge + " -- " + route;
+            case1.add(msg);
+          }
+          if ("true".equals(s2)) {
+            String route = buildRoute(enc2.getMainSlice(), model, ge);
+            String msg = ge + " -- " + route;
+            case2.add(msg);
+          }
+        }
+      }
+    }
+
+    SmtNondeterminismAnswerElement answer = new SmtNondeterminismAnswerElement();
+    answer.setResult(res);
+    answer.setForwardingCase1(case1);
+    answer.setForwardingCase2(case2);
+    return answer;
+  }
+
 
   /*
    * Compute if there can ever be a black hole for routers that are

--- a/projects/batfish/src/main/java/org/batfish/smt/PropertyChecker.java
+++ b/projects/batfish/src/main/java/org/batfish/smt/PropertyChecker.java
@@ -45,8 +45,8 @@ import org.batfish.datamodel.pojo.Environment;
 import org.batfish.datamodel.questions.smt.EnvironmentType;
 import org.batfish.datamodel.questions.smt.HeaderLocationQuestion;
 import org.batfish.datamodel.questions.smt.HeaderQuestion;
+import org.batfish.smt.answers.SmtDeterminismAnswerElement;
 import org.batfish.smt.answers.SmtManyAnswerElement;
-import org.batfish.smt.answers.SmtNondeterminismAnswerElement;
 import org.batfish.smt.answers.SmtOneAnswerElement;
 import org.batfish.smt.answers.SmtReachabilityAnswerElement;
 import org.batfish.smt.collections.Table2;
@@ -846,9 +846,11 @@ public class PropertyChecker {
 
     SortedSet<String> case1 = null;
     SortedSet<String> case2 = null;
+    Flow flow = null;
     if (!res.isVerified()) {
       case1 = new TreeSet<>();
       case2 = new TreeSet<>();
+      flow = buildFlow(model, enc1.getMainSlice().getSymbolicPacket(), "(none)");
       for (GraphEdge ge : graph.getAllRealEdges()) {
         SymbolicDecisions d1 = enc1.getMainSlice().getSymbolicDecisions();
         SymbolicDecisions d2 = enc2.getMainSlice().getSymbolicDecisions();
@@ -871,8 +873,9 @@ public class PropertyChecker {
       }
     }
 
-    SmtNondeterminismAnswerElement answer = new SmtNondeterminismAnswerElement();
+    SmtDeterminismAnswerElement answer = new SmtDeterminismAnswerElement();
     answer.setResult(res);
+    answer.setFlow(flow);
     answer.setForwardingCase1(case1);
     answer.setForwardingCase2(case2);
     return answer;

--- a/projects/batfish/src/main/java/org/batfish/smt/answers/SmtDeterminismAnswerElement.java
+++ b/projects/batfish/src/main/java/org/batfish/smt/answers/SmtDeterminismAnswerElement.java
@@ -1,12 +1,15 @@
 package org.batfish.smt.answers;
 
 import java.util.SortedSet;
+import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.answers.AnswerElement;
 import org.batfish.smt.VerificationResult;
 
-public class SmtNondeterminismAnswerElement implements AnswerElement {
+public class SmtDeterminismAnswerElement implements AnswerElement {
 
   private VerificationResult _result;
+
+  private Flow _flow;
 
   private SortedSet<String> _forwardingCase1;
 
@@ -14,6 +17,10 @@ public class SmtNondeterminismAnswerElement implements AnswerElement {
 
   public VerificationResult getResult() {
     return _result;
+  }
+
+  public Flow getFlow() {
+    return _flow;
   }
 
   public SortedSet<String> getForwardingCase1() {
@@ -28,6 +35,10 @@ public class SmtNondeterminismAnswerElement implements AnswerElement {
     this._result = x;
   }
 
+  public void setFlow(Flow x) {
+    this._flow = x;
+  }
+
   public void setForwardingCase1(SortedSet<String> x) {
     this._forwardingCase1 = x;
   }
@@ -39,9 +50,11 @@ public class SmtNondeterminismAnswerElement implements AnswerElement {
   @Override
   public String prettyPrint() {
     StringBuilder sb = new StringBuilder();
+    sb.append("\n");
     if (_result.isVerified()) {
-      sb.append("\nVerified\n");
+      sb.append("Verified\n");
     } else {
+      sb.append(_flow).append("\n\n");
       sb.append("Delta forwarding case 1:\n");
       for (String s : _forwardingCase1) {
         sb.append("   ").append(s).append("\n");

--- a/projects/batfish/src/main/java/org/batfish/smt/answers/SmtNondeterminismAnswerElement.java
+++ b/projects/batfish/src/main/java/org/batfish/smt/answers/SmtNondeterminismAnswerElement.java
@@ -1,0 +1,56 @@
+package org.batfish.smt.answers;
+
+import java.util.SortedSet;
+import org.batfish.datamodel.answers.AnswerElement;
+import org.batfish.smt.VerificationResult;
+
+public class SmtNondeterminismAnswerElement implements AnswerElement {
+
+  private VerificationResult _result;
+
+  private SortedSet<String> _forwardingCase1;
+
+  private SortedSet<String> _forwardingCase2;
+
+  public VerificationResult getResult() {
+    return _result;
+  }
+
+  public SortedSet<String> getForwardingCase1() {
+    return _forwardingCase1;
+  }
+
+  public SortedSet<String> getForwardingCase2() {
+    return _forwardingCase2;
+  }
+
+  public void setResult(VerificationResult x) {
+    this._result = x;
+  }
+
+  public void setForwardingCase1(SortedSet<String> x) {
+    this._forwardingCase1 = x;
+  }
+
+  public void setForwardingCase2(SortedSet<String> x) {
+    this._forwardingCase2 = x;
+  }
+
+  @Override
+  public String prettyPrint() {
+    StringBuilder sb = new StringBuilder();
+    if (_result.isVerified()) {
+      sb.append("\nVerified\n");
+    } else {
+      sb.append("Delta forwarding case 1:\n");
+      for (String s : _forwardingCase1) {
+        sb.append("   ").append(s).append("\n");
+      }
+      sb.append("\nDelta forwarding case 2:\n");
+      for (String s : _forwardingCase2) {
+        sb.append("   ").append(s).append("\n");
+      }
+    }
+    return sb.toString();
+  }
+}

--- a/projects/question/src/main/java/org/batfish/question/SmtDeterministicQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/SmtDeterministicQuestionPlugin.java
@@ -1,0 +1,53 @@
+package org.batfish.question;
+
+import org.batfish.common.Answerer;
+import org.batfish.common.plugin.IBatfish;
+import org.batfish.datamodel.answers.AnswerElement;
+import org.batfish.datamodel.questions.Question;
+import org.batfish.datamodel.questions.smt.HeaderQuestion;
+
+public class SmtDeterministicQuestionPlugin extends QuestionPlugin {
+
+
+  public static class DeterministicAnswerer extends Answerer {
+
+    public DeterministicAnswerer(Question question, IBatfish batfish) {
+      super(question, batfish);
+    }
+
+    @Override
+    public AnswerElement answer() {
+      DeterministicQuestion q = (DeterministicQuestion) _question;
+      return _batfish.smtDeterminism(q);
+    }
+  }
+
+  public static class DeterministicQuestion extends HeaderQuestion {
+
+    @Override
+    public boolean getDataPlane() {
+      return false;
+    }
+
+    @Override
+    public String getName() {
+      return "smt-deterministic";
+    }
+
+    @Override
+    public boolean getTraffic() {
+      return false;
+    }
+  }
+
+  @Override
+  protected Answerer createAnswerer(Question question, IBatfish batfish) {
+    return new DeterministicAnswerer(question, batfish);
+  }
+
+  @Override
+  protected Question createQuestion() {
+    return new DeterministicQuestion();
+  }
+
+}

--- a/tests/java-smt/commands
+++ b/tests/java-smt/commands
@@ -24,6 +24,7 @@ test tests/java-smt/ospf3-equal-len.ref get smt-equal-length finalNodeRegex="R3"
 test tests/java-smt/ospf3-equal-len2.ref get smt-equal-length finalNodeRegex="R3", finalIfaceRegex="Loopback.*", ingressNodeRegex="R(1|0)", fullModel=True
 test tests/java-smt/ospf3-routing-loop.ref get smt-routing-loop fullModel=True
 test tests/java-smt/ospf3-multipath.ref get smt-multipath-consistency finalNodeRegex="R3", finalIfaceRegex="Loopback.*", fullModel=True
+test tests/java-smt/ospf3-deterministic.ref get smt-deterministic
 
 # local consistency with bgp + environment
 init-testrig test_rigs/smt-examples/ENV2 tr-smt-env2
@@ -65,6 +66,7 @@ test tests/java-smt/prepend1-forwarding.ref get smt-forwarding dstIps=["41.41.41
 # Ensure we can find one of multiple stable solutions
 init-testrig test_rigs/smt-examples/STABLE3 tr-smt-stable3
 test tests/java-smt/stable3-forwarding.ref get smt-forwarding dstIps=["42.42.42.0"]
+test tests/java-smt/stable3-nondeterministic.ref get smt-deterministic
 
 # Check proper dropping behavior when the metric has overflow
 init-testrig test_rigs/smt-examples/OVERFLOW1 tr-smt-overflow1

--- a/tests/java-smt/ospf3-deterministic.ref
+++ b/tests/java-smt/ospf3-deterministic.ref
@@ -1,0 +1,26 @@
+{
+  "answerElements" : [
+    {
+      "class" : "org.batfish.smt.answers.SmtNondeterminismAnswerElement",
+      "result" : {
+        "verified" : true
+      }
+    }
+  ],
+  "question" : {
+    "class" : "org.batfish.question.SmtDeterministicQuestionPlugin$DeterministicQuestion",
+    "baseEnvType" : "any",
+    "deltaEnvType" : "any",
+    "differential" : false,
+    "envDiff" : false,
+    "failures" : 0,
+    "fullModel" : false,
+    "minimize" : false
+  },
+  "status" : "SUCCESS",
+  "summary" : {
+    "numFailed" : 0,
+    "numPassed" : 0,
+    "numResults" : 0
+  }
+}

--- a/tests/java-smt/ospf3-deterministic.ref
+++ b/tests/java-smt/ospf3-deterministic.ref
@@ -1,7 +1,7 @@
 {
   "answerElements" : [
     {
-      "class" : "org.batfish.smt.answers.SmtNondeterminismAnswerElement",
+      "class" : "org.batfish.smt.answers.SmtDeterminismAnswerElement",
       "result" : {
         "verified" : true
       }

--- a/tests/java-smt/stable3-nondeterministic.ref
+++ b/tests/java-smt/stable3-nondeterministic.ref
@@ -1,7 +1,32 @@
 {
   "answerElements" : [
     {
-      "class" : "org.batfish.smt.answers.SmtNondeterminismAnswerElement",
+      "class" : "org.batfish.smt.answers.SmtDeterminismAnswerElement",
+      "flow" : {
+        "dscp" : 0,
+        "dstIp" : "42.42.42.1",
+        "dstPort" : 0,
+        "ecn" : 0,
+        "fragmentOffset" : 0,
+        "icmpCode" : 0,
+        "icmpVar" : 0,
+        "ingressNode" : "(none)",
+        "ingressVrf" : "default",
+        "ipProtocol" : "HOPOPT",
+        "packetLength" : 0,
+        "srcIp" : "0.0.0.0",
+        "srcPort" : 0,
+        "state" : "NEW",
+        "tag" : "SMT",
+        "tcpFlagsAck" : 1,
+        "tcpFlagsCwr" : 1,
+        "tcpFlagsEce" : 1,
+        "tcpFlagsFin" : 1,
+        "tcpFlagsPsh" : 1,
+        "tcpFlagsRst" : 1,
+        "tcpFlagsSyn" : 1,
+        "tcpFlagsUrg" : 1
+      },
       "forwardingCase1" : [
         "R2,Serial1 --> R3,Serial0 -- BgpRoute<42.42.42.0/24,nhip:192.168.43.1,nhint:dynamic>",
         "R3,Serial1 --> R1,Serial1 -- BgpRoute<42.42.42.0/24,nhip:192.168.44.2,nhint:dynamic>"

--- a/tests/java-smt/stable3-nondeterministic.ref
+++ b/tests/java-smt/stable3-nondeterministic.ref
@@ -1,0 +1,41 @@
+{
+  "answerElements" : [
+    {
+      "class" : "org.batfish.smt.answers.SmtNondeterminismAnswerElement",
+      "forwardingCase1" : [
+        "R2,Serial1 --> R3,Serial0 -- BgpRoute<42.42.42.0/24,nhip:192.168.43.1,nhint:dynamic>",
+        "R3,Serial1 --> R1,Serial1 -- BgpRoute<42.42.42.0/24,nhip:192.168.44.2,nhint:dynamic>"
+      ],
+      "forwardingCase2" : [
+        "R2,Serial0 --> R1,Serial0 -- BgpRoute<42.42.42.0/24,nhip:192.168.42.2,nhint:dynamic>",
+        "R3,Serial0 --> R2,Serial1 -- BgpRoute<42.42.42.0/24,nhip:192.168.43.2,nhint:dynamic>"
+      ],
+      "result" : {
+        "forwardingModel" : [
+          "R2,Serial1 --> R3,Serial0 (BGP)",
+          "R3,Serial1 --> R1,Serial1 (BGP)"
+        ],
+        "packetModel" : {
+          "dstIp" : "42.42.42.1"
+        },
+        "verified" : false
+      }
+    }
+  ],
+  "question" : {
+    "class" : "org.batfish.question.SmtDeterministicQuestionPlugin$DeterministicQuestion",
+    "baseEnvType" : "any",
+    "deltaEnvType" : "any",
+    "differential" : false,
+    "envDiff" : false,
+    "failures" : 0,
+    "fullModel" : false,
+    "minimize" : false
+  },
+  "status" : "SUCCESS",
+  "summary" : {
+    "numFailed" : 0,
+    "numPassed" : 0,
+    "numResults" : 0
+  }
+}


### PR DESCRIPTION
Adds an "smt-deterministic" question that implements #525 to check if there can be more than one stable network solution. If the can be, it will show the different forwarding behavior for the two cases. The question takes the usual headerspace, number of failures, baseEnvType etc as parameters. The output for the classic bi-stable BGP network:

init-testrig test_rigs/smt-examples/STABLE3
get smt-deterministic

Flow<ingressNode:(none) ingressVrf:default srcIp:0.0.0.0 dstIp:42.42.42.1 ipProtocol:HOPOPT dscp: 0 ecn:0 fragmentOffset:0 packetLength:0 state:NEW tag:SMT>

Delta forwarding case 1:
   R2,Serial1 --> R3,Serial0 -- BgpRoute<42.42.42.0/24,nhip:192.168.43.1,nhint:dynamic>
   R3,Serial1 --> R1,Serial1 -- BgpRoute<42.42.42.0/24,nhip:192.168.44.2,nhint:dynamic>

Delta forwarding case 2:
   R2,Serial0 --> R1,Serial0 -- BgpRoute<42.42.42.0/24,nhip:192.168.42.2,nhint:dynamic>
   R3,Serial0 --> R2,Serial1 -- BgpRoute<42.42.42.0/24,nhip:192.168.43.2,nhint:dynamic>

