### PR TITLE
disable xtext builder by default for batfish project

### DIFF
--- a/projects/batfish/.externalToolBuilders/.gitignore
+++ b/projects/batfish/.externalToolBuilders/.gitignore
@@ -1,1 +1,0 @@
-/org.eclipse.xtext.ui.shared.xtextBuilder.launch

--- a/projects/batfish/.externalToolBuilders/org.eclipse.xtext.ui.shared.xtextBuilder.launch
+++ b/projects/batfish/.externalToolBuilders/org.eclipse.xtext.ui.shared.xtextBuilder.launch
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.ui.externaltools.ProgramBuilderLaunchConfigurationType">
+<booleanAttribute key="org.eclipse.ui.externaltools.ATTR_BUILDER_ENABLED" value="false"/>
+<stringAttribute key="org.eclipse.ui.externaltools.ATTR_DISABLED_BUILDER" value="org.eclipse.xtext.ui.shared.xtextBuilder"/>
+<mapAttribute key="org.eclipse.ui.externaltools.ATTR_TOOL_ARGUMENTS"/>
+<booleanAttribute key="org.eclipse.ui.externaltools.ATTR_TRIGGERS_CONFIGURED" value="true"/>
+</launchConfiguration>

--- a/projects/batfish/.project
+++ b/projects/batfish/.project
@@ -6,8 +6,13 @@
 	</projects>
 	<buildSpec>
 		<buildCommand>
-			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<name>org.eclipse.ui.externaltools.ExternalToolBuilder</name>
+			<triggers>full,incremental,</triggers>
 			<arguments>
+				<dictionary>
+					<key>LaunchConfigHandle</key>
+					<value>&lt;project&gt;/.externalToolBuilders/org.eclipse.xtext.ui.shared.xtextBuilder.launch</value>
+				</dictionary>
 			</arguments>
 		</buildCommand>
 		<buildCommand>


### PR DESCRIPTION
- just too slow to use other than in exceptional circumstances
- may be re-added later if parsers are broken up and xtext index refresh
  no longer takes forever