### PR TITLE
remove polling from BatfishJobExecutor

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/graphviz/GraphvizJob.java
+++ b/projects/batfish/src/main/java/org/batfish/graphviz/GraphvizJob.java
@@ -44,7 +44,7 @@ public class GraphvizJob extends BatfishJob<GraphvizResult> {
   }
 
   @Override
-  public GraphvizResult call() throws Exception {
+  public GraphvizResult callBatfishJob() {
     long startTime = System.currentTimeMillis();
     long elapsedTime;
     Throwable failureCause = null;

--- a/projects/batfish/src/main/java/org/batfish/job/BatfishJob.java
+++ b/projects/batfish/src/main/java/org/batfish/job/BatfishJob.java
@@ -23,8 +23,7 @@ public abstract class BatfishJob<R extends BatfishJobResult<?, ?>> implements Ca
     try {
       R r = callBatfishJob();
       return r;
-    }
-    finally {
+    } finally {
       _semaphore.release();
     }
   }

--- a/projects/batfish/src/main/java/org/batfish/job/BatfishJob.java
+++ b/projects/batfish/src/main/java/org/batfish/job/BatfishJob.java
@@ -1,6 +1,7 @@
 package org.batfish.job;
 
 import java.util.concurrent.Callable;
+import java.util.concurrent.Semaphore;
 import org.batfish.common.BatfishLogger;
 import org.batfish.config.Settings;
 
@@ -8,10 +9,29 @@ public abstract class BatfishJob<R extends BatfishJobResult<?, ?>> implements Ca
 
   protected final BatfishLogger _logger;
 
+  protected Semaphore _semaphore;
+
   protected final Settings _settings;
 
   public BatfishJob(Settings settings) {
     _settings = settings;
     _logger = new BatfishLogger(_settings.getLogLevel(), _settings.getTimestamp());
+  }
+
+  @Override
+  public final R call() {
+    try {
+      R r = callBatfishJob();
+      return r;
+    }
+    finally {
+      _semaphore.release();
+    }
+  }
+
+  protected abstract R callBatfishJob();
+
+  public void setSemaphore(Semaphore semaphore) {
+    _semaphore = semaphore;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
@@ -30,7 +30,7 @@ public class ConvertConfigurationJob extends BatfishJob<ConvertConfigurationResu
   }
 
   @Override
-  public ConvertConfigurationResult call() throws Exception {
+  public ConvertConfigurationResult callBatfishJob() {
     long startTime = System.currentTimeMillis();
     long elapsedTime;
     _logger.info("Processing: \"" + _name + "\"");

--- a/projects/batfish/src/main/java/org/batfish/job/FlattenVendorConfigurationJob.java
+++ b/projects/batfish/src/main/java/org/batfish/job/FlattenVendorConfigurationJob.java
@@ -29,7 +29,7 @@ public class FlattenVendorConfigurationJob extends BatfishJob<FlattenVendorConfi
   }
 
   @Override
-  public FlattenVendorConfigurationResult call() throws Exception {
+  public FlattenVendorConfigurationResult callBatfishJob() {
     long startTime = System.currentTimeMillis();
     long elapsedTime;
     String inputFileAsString = _inputFile.toAbsolutePath().toString();

--- a/projects/batfish/src/main/java/org/batfish/job/ParseEnvironmentBgpTableJob.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ParseEnvironmentBgpTableJob.java
@@ -49,7 +49,7 @@ public class ParseEnvironmentBgpTableJob extends BatfishJob<ParseEnvironmentBgpT
   }
 
   @Override
-  public ParseEnvironmentBgpTableResult call() throws Exception {
+  public ParseEnvironmentBgpTableResult callBatfishJob() {
     long startTime = System.currentTimeMillis();
     long elapsedTime;
     String currentPath = _file.toAbsolutePath().toString();

--- a/projects/batfish/src/main/java/org/batfish/job/ParseEnvironmentRoutingTableJob.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ParseEnvironmentRoutingTableJob.java
@@ -50,7 +50,7 @@ public class ParseEnvironmentRoutingTableJob
   }
 
   @Override
-  public ParseEnvironmentRoutingTableResult call() throws Exception {
+  public ParseEnvironmentRoutingTableResult callBatfishJob() {
     long startTime = System.currentTimeMillis();
     long elapsedTime;
     String currentPath = _file.toAbsolutePath().toString();

--- a/projects/batfish/src/main/java/org/batfish/z3/CompositeNodJob.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/CompositeNodJob.java
@@ -57,7 +57,7 @@ public class CompositeNodJob extends BatfishJob<NodJobResult> {
   }
 
   @Override
-  public NodJobResult call() throws Exception {
+  public NodJobResult callBatfishJob() {
     long startTime = System.currentTimeMillis();
     long elapsedTime;
     NodProgram latestProgram = null;

--- a/projects/batfish/src/main/java/org/batfish/z3/NodFirstUnsatJob.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/NodFirstUnsatJob.java
@@ -26,7 +26,7 @@ public class NodFirstUnsatJob<KeyT, ResultT>
   }
 
   @Override
-  public NodFirstUnsatResult<KeyT, ResultT> call() throws Exception {
+  public NodFirstUnsatResult<KeyT, ResultT> callBatfishJob() {
     long startTime = System.currentTimeMillis();
     long elapsedTime;
     try (Context ctx = new Context()) {

--- a/projects/batfish/src/main/java/org/batfish/z3/NodJob.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/NodJob.java
@@ -149,7 +149,7 @@ public final class NodJob extends BatfishJob<NodJobResult> {
   }
 
   @Override
-  public NodJobResult call() throws Exception {
+  public NodJobResult callBatfishJob() {
     long startTime = System.currentTimeMillis();
     long elapsedTime;
     try (Context ctx = new Context()) {

--- a/projects/batfish/src/main/java/org/batfish/z3/NodSatJob.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/NodSatJob.java
@@ -26,7 +26,7 @@ public class NodSatJob<KeyT> extends BatfishJob<NodSatResult<KeyT>> {
   }
 
   @Override
-  public NodSatResult<KeyT> call() throws Exception {
+  public NodSatResult<KeyT> callBatfishJob() {
     Map<KeyT, Boolean> results = new LinkedHashMap<>();
     long startTime = System.currentTimeMillis();
     long elapsedTime;


### PR DESCRIPTION
- Multiple orders of magnitude speedup for small jobs
- Use semaphore instead of polling to process completed jobs
- Don't allow jobs to throw Exception, simplifying handling
- Handle previously-unhandled exceptions possibly thrown during HostConfiguration deserialization during ParseVendorConfiguration job

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/583)
<!-- Reviewable:end -->
