### PR TITLE
Minor fix for handling of BGP network statement

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/smt/EncoderSlice.java
+++ b/projects/batfish/src/main/java/org/batfish/smt/EncoderSlice.java
@@ -797,7 +797,7 @@ class EncoderSlice {
               (areaID, area) -> {
                 for (Interface iface : area.getInterfaces()) {
                   if (iface.getActive() && iface.getOspfEnabled()) {
-                    acc.add(iface.getPrefix());
+                    acc.add(iface.getPrefix().getNetworkPrefix());
                   }
                 }
               });
@@ -829,7 +829,7 @@ class EncoderSlice {
                           ExplicitPrefixSet eps = (ExplicitPrefixSet) e;
                           Set<PrefixRange> ranges = eps.getPrefixSpace().getPrefixRanges();
                           for (PrefixRange r : ranges) {
-                            acc.add(r.getPrefix());
+                            acc.add(r.getPrefix().getNetworkPrefix());
                           }
                         }
                       }
@@ -848,7 +848,7 @@ class EncoderSlice {
               (name, iface) -> {
                 Prefix p = iface.getPrefix();
                 if (p != null) {
-                  acc.add(p);
+                  acc.add(p.getNetworkPrefix());
                 }
               });
       return acc;
@@ -857,7 +857,7 @@ class EncoderSlice {
     if (proto.isStatic()) {
       for (StaticRoute sr : conf.getDefaultVrf().getStaticRoutes()) {
         if (sr.getNetwork() != null) {
-          acc.add(sr.getNetwork());
+          acc.add(sr.getNetwork().getNetworkPrefix());
         }
       }
       return acc;

--- a/tests/java-smt/stable3-forwarding.ref
+++ b/tests/java-smt/stable3-forwarding.ref
@@ -5,8 +5,8 @@
       "result" : {
         "forwardingModel" : [
           "R1,Loopback0 --> _,_ (CONNECTED)",
-          "R2,Serial1 --> R3,Serial0 (BGP)",
-          "R3,Serial1 --> R1,Serial1 (BGP)"
+          "R2,Serial0 --> R1,Serial0 (BGP)",
+          "R3,Serial0 --> R2,Serial1 (BGP)"
         ],
         "packetModel" : {
           "dstIp" : "42.42.42.0"

--- a/tests/java-smt/stable3-nondeterministic.ref
+++ b/tests/java-smt/stable3-nondeterministic.ref
@@ -4,7 +4,7 @@
       "class" : "org.batfish.smt.answers.SmtDeterminismAnswerElement",
       "flow" : {
         "dscp" : 0,
-        "dstIp" : "42.42.42.65",
+        "dstIp" : "42.42.42.1",
         "dstPort" : 0,
         "ecn" : 0,
         "fragmentOffset" : 0,
@@ -28,21 +28,20 @@
         "tcpFlagsUrg" : 1
       },
       "forwardingCase1" : [
-        "R2,Serial1 --> R3,Serial0 -- BgpRoute<42.42.42.0/24,nhip:192.168.43.1,nhint:dynamic>",
-        "R3,Serial1 --> R1,Serial1 -- BgpRoute<42.42.42.0/24,nhip:192.168.44.2,nhint:dynamic>"
-      ],
-      "forwardingCase2" : [
         "R2,Serial0 --> R1,Serial0 -- BgpRoute<42.42.42.0/24,nhip:192.168.42.2,nhint:dynamic>",
         "R3,Serial0 --> R2,Serial1 -- BgpRoute<42.42.42.0/24,nhip:192.168.43.2,nhint:dynamic>"
       ],
+      "forwardingCase2" : [
+        "R2,Serial1 --> R3,Serial0 -- BgpRoute<42.42.42.0/24,nhip:192.168.43.1,nhint:dynamic>",
+        "R3,Serial1 --> R1,Serial1 -- BgpRoute<42.42.42.0/24,nhip:192.168.44.2,nhint:dynamic>"
+      ],
       "result" : {
         "forwardingModel" : [
-          "R1,Loopback0 --> _,_ (CONNECTED)",
-          "R2,Serial1 --> R3,Serial0 (BGP)",
-          "R3,Serial1 --> R1,Serial1 (BGP)"
+          "R2,Serial0 --> R1,Serial0 (BGP)",
+          "R3,Serial0 --> R2,Serial1 (BGP)"
         ],
         "packetModel" : {
-          "dstIp" : "42.42.42.65"
+          "dstIp" : "42.42.42.1"
         },
         "verified" : false
       }


### PR DESCRIPTION
Need to use the canonical network prefix so that set membership queries work properly.

Should fix the issues with the demo queries.

