### PR TITLE
pom.xml: turn on Maven dependency convergence

### DIFF
--- a/projects/pom.xml
+++ b/projects/pom.xml
@@ -29,7 +29,7 @@
     <maven-checkstyle-plugin.version>2.17</maven-checkstyle-plugin.version>
     <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
     <maven-dependency-plugin.version>3.0.1</maven-dependency-plugin.version>
-    <maven-enforcer-plugin.version>1.4.1</maven-enforcer-plugin.version>
+    <maven-enforcer-plugin.version>3.0.0-M1</maven-enforcer-plugin.version>
     <maven-findbugs-plugin.version>3.0.5</maven-findbugs-plugin.version>
     <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
     <maven-license-plugin.version>1.13</maven-license-plugin.version>
@@ -45,6 +45,7 @@
     <commons-exec.version>1.3</commons-exec.version>
     <commons-io.version>2.4</commons-io.version>
     <commons-lang.version>2.6</commons-lang.version>
+    <commons-lang3.version>3.6</commons-lang3.version>
     <grizzly.version>2.3.18</grizzly.version>
     <guava.version>22.0</guava.version>
     <hamcrest.version>1.3</hamcrest.version>
@@ -258,6 +259,7 @@
             </goals>
             <configuration>
               <rules>
+                <dependencyConvergence/>
                 <requireMavenVersion>
                   <version>3.3.9</version>
                 </requireMavenVersion>
@@ -319,21 +321,25 @@
         <artifactId>jackson-annotations</artifactId>
         <version>${jackson.version}</version>
       </dependency>
+
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
         <version>${jackson.version}</version>
       </dependency>
+
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
         <version>${jackson.version}</version>
       </dependency>
+
       <dependency>
         <groupId>com.fasterxml.jackson.jaxrs</groupId>
         <artifactId>jackson-jaxrs-base</artifactId>
         <version>${jackson.version}</version>
       </dependency>
+
       <dependency>
         <groupId>com.fasterxml.jackson.jaxrs</groupId>
         <artifactId>jackson-jaxrs-json-provider</artifactId>
@@ -461,6 +467,12 @@
       </dependency>
 
       <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>${commons-lang3.version}</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-artifact</artifactId>
         <version>${maven-artifact.version}</version>
@@ -554,6 +566,12 @@
         <groupId>org.skyscreamer</groupId>
         <artifactId>jsonassert</artifactId>
         <version>${jsonassert.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${slf4j.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
From the docs:

> This rule requires that dependency version numbers converge. If a
> project has two dependencies, A and B, both depending on the same
> artifact, C, this rule will fail the build if A depends on a different
> version of C then the version of C depended on by B.

This will generally improve build safety. Also resolve two existing
dependency convergence issues.