### PR TITLE
Add testrig metadata file with timestamp

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
@@ -146,6 +146,7 @@ public class BfConsts {
   public static final String RELPATH_HOST_CONFIGS_DIR = "hosts";
   public static final String RELPATH_INFERRED_NODE_ROLES_PATH = "node_roles_inferred.json";
   public static final String RELPATH_INTERFACE_BLACKLIST_FILE = "interface_blacklist";
+  public static final String RELPATH_METADATA_FILE = "metadata.json";
   public static final String RELPATH_MULTIPATH_QUERY_PREFIX = "multipath-query";
   public static final String RELPATH_NODE_BLACKLIST_FILE = "node_blacklist";
   public static final String RELPATH_NODE_ROLES_PATH = "node_roles.json";

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -794,6 +794,13 @@ public class WorkMgr extends AbstractCoordinator {
       throw new BatfishException(
           "Unexpected packaging of testrig. There should be just one top-level folder");
     }
+
+    // Create metadata file (RELPATH_METADATA_FILE is "metadata.json")
+    Path metadataPath = testrigDir.resolve(BfConsts.RELPATH_METADATA_FILE);
+    long time = (new java.util.Date()).getTime();
+    CommonUtil.writeFile(metadataPath, "{\n\t\"timestamp\": "+Long.toString(time)+"\n}");
+
+
     Path srcSubdir = srcDirEntries.iterator().next();
     SortedSet<Path> subFileList = CommonUtil.getEntries(srcSubdir);
 


### PR DESCRIPTION
The method `WorkMgr.initTestrig` now creates a metadata.json file in the testrig's base folder. That file looks like:
```
{
	"timestamp": 1510696220687
}
```
where 1510696220687 is the time upon testrig initialization (in milliseconds since 1970).

Let me know if I should make changes to better match existing conventions (e.g. how I'm getting the timestamp, how and when I'm creating the file, where and how I'm storing it).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/668)
<!-- Reviewable:end -->
