### PR TITLE
WorkMgrService: 404 instead of 500 for missing files

### DIFF
--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
@@ -772,8 +772,16 @@ public class WorkMgrService {
       checkClientVersion(clientVersion);
       checkContainerAccessibility(apiKey, containerName);
 
-      java.nio.file.Path file =
-          Main.getWorkMgr().getTestrigObject(containerName, testrigName, objectName);
+      java.nio.file.Path file;
+      try {
+        file = Main.getWorkMgr().getTestrigObject(containerName, testrigName, objectName);
+      } catch (BatfishException e) {
+        if (e.getMessage().contains("not exist")) {
+          file = null;
+        } else {
+          throw e;
+        }
+      }
 
       if (file == null || !Files.exists(file)) {
         return Response.status(Response.Status.NOT_FOUND)


### PR DESCRIPTION
Fix #554 

Ari, thoughts?

This seems like the wrong solution; throw and catch+handle is a Pythonic,
not a Java pattern. However the relevant functions in WorkMgr seemed too
ingrained -- used in dozens of places -- to change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/670)
<!-- Reviewable:end -->
