### PR TITLE
Add option to truncate parse tree print

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/BatfishParserErrorListener.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/BatfishParserErrorListener.java
@@ -72,6 +72,10 @@ public class BatfishParserErrorListener extends BatfishGrammarErrorListener {
     sb.append("Offending Token: " + offendingTokenText + "\n");
     sb.append("Error parsing top (leftmost) parser rule in stack: '" + ruleStack + "'.\n");
     String ctxParseTree = ParseTreePrettyPrinter.print(ctx, _combinedParser);
+    // don't overflow a reasonable terminal if there's a runaway rule
+    if (ctxParseTree.length() > 10000) {
+      ctxParseTree = ctxParseTree.substring(0, 10000) + "\n... and lots more";
+    }
     sb.append("Parse tree of current rule:\n" + ctxParseTree + "\n");
     sb.append("Unconsumed tokens:\n");
     int endTokenIndex = tokens.size();

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/BatfishParserErrorListener.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/BatfishParserErrorListener.java
@@ -72,11 +72,10 @@ public class BatfishParserErrorListener extends BatfishGrammarErrorListener {
     sb.append("Offending Token: " + offendingTokenText + "\n");
     sb.append("Error parsing top (leftmost) parser rule in stack: '" + ruleStack + "'.\n");
     String ctxParseTree = ParseTreePrettyPrinter.print(ctx, _combinedParser);
-    // don't overflow a reasonable terminal if there's a runaway rule
-    if (ctxParseTree.length() > 10000) {
-      ctxParseTree = ctxParseTree.substring(0, 10000) + "\n... and lots more";
-    }
-    sb.append("Parse tree of current rule:\n" + ctxParseTree + "\n");
+
+    sb.append("Parse tree of current rule:\n");
+    sb.append(ctxParseTree);
+    sb.append("\n");
     sb.append("Unconsumed tokens:\n");
     int endTokenIndex = tokens.size();
     for (int i = startTokenIndex; i < endTokenIndex; i++) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/GrammarSettings.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/GrammarSettings.java
@@ -28,6 +28,13 @@ public interface GrammarSettings {
   int getMaxParserContextTokens();
 
   /**
+   * The maximum number of characters display of a parse tree when prettyPrinting.
+   *
+   * @return The max number of characters to display
+   */
+  int getMaxParseTreePrintLength();
+
+  /**
    * Controls whether parse trees are stored in parse job results.
    *
    * @return true iff parse trees should be stored in parse job results

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/grammar/ParseTreePrettyPrinterTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/grammar/ParseTreePrettyPrinterTest.java
@@ -1,0 +1,40 @@
+package org.batfish.grammar;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+
+public class ParseTreePrettyPrinterTest {
+
+  @Test
+  public void testParseTreePrettyPrintWithCharacterLimit() throws IOException {
+    List<String> strings = new ArrayList<>();
+    strings.add("1234");
+
+    String string = ParseTreePrettyPrinter.printWithCharacterLimit(strings, 0);
+    assertThat(string, equalTo("1234"));
+
+    string = ParseTreePrettyPrinter.printWithCharacterLimit(strings, 3);
+    assertThat(string, equalTo("1234"));
+
+    string = ParseTreePrettyPrinter.printWithCharacterLimit(strings, 4);
+    assertThat(string, equalTo("1234"));
+
+    strings.add("5678");
+    string = ParseTreePrettyPrinter.printWithCharacterLimit(strings, 0);
+    assertThat(string, equalTo("1234\n5678"));
+
+    string = ParseTreePrettyPrinter.printWithCharacterLimit(strings, 1);
+    assertThat(string, equalTo("1234\nand 1 more line(s)"));
+
+    string = ParseTreePrettyPrinter.printWithCharacterLimit(strings, 5);
+    assertThat(string, equalTo("1234\nand 1 more line(s)"));
+
+    string = ParseTreePrettyPrinter.printWithCharacterLimit(strings, 6);
+    assertThat(string, equalTo("1234\n5678"));
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/grammar/TestGrammarSettings.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/grammar/TestGrammarSettings.java
@@ -12,6 +12,8 @@ public class TestGrammarSettings implements GrammarSettings {
 
   private final int _maxParserContextTokens;
 
+  private final int _maxParseTreePrintLength;
+
   private final boolean _printParseTree;
 
   private final boolean _throwOnLexerError;
@@ -24,6 +26,7 @@ public class TestGrammarSettings implements GrammarSettings {
    * @param disableUnrecognized See {@link GrammarSettings#getDisableUnrecognized()}
    * @param maxParserContextLines See {@link GrammarSettings#getMaxParserContextLines()}
    * @param maxParserContextTokens See {@link GrammarSettings#getMaxParserContextTokens()}
+   * @param maxParseTreePrintLength See {@link GrammarSettings#getMaxParseTreePrintLength()}
    * @param printParseTree See {@link GrammarSettings#getPrintParseTree()}
    * @param throwOnLexerError See {@link GrammarSettings#getThrowOnLexerError()}
    * @param throwOnParserError See {@link GrammarSettings#getThrowOnParserError()}
@@ -32,12 +35,14 @@ public class TestGrammarSettings implements GrammarSettings {
       boolean disableUnrecognized,
       int maxParserContextLines,
       int maxParserContextTokens,
+      int maxParseTreePrintLength,
       boolean printParseTree,
       boolean throwOnLexerError,
       boolean throwOnParserError) {
     _disableUnrecognized = disableUnrecognized;
     _maxParserContextLines = maxParserContextLines;
     _maxParserContextTokens = maxParserContextTokens;
+    _maxParseTreePrintLength = maxParseTreePrintLength;
     _printParseTree = printParseTree;
     _throwOnLexerError = throwOnLexerError;
     _throwOnParserError = throwOnParserError;
@@ -56,6 +61,11 @@ public class TestGrammarSettings implements GrammarSettings {
   @Override
   public int getMaxParserContextTokens() {
     return _maxParserContextTokens;
+  }
+
+  @Override
+  public int getMaxParseTreePrintLength() {
+    return _maxParseTreePrintLength;
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/grammar/recovery/RecoveryGrammarTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/grammar/recovery/RecoveryGrammarTest.java
@@ -18,7 +18,7 @@ public class RecoveryGrammarTest {
   public void testParsingRecovery() throws IOException {
     String recoveryText = CommonUtil.readResource("org/batfish/grammar/recovery/recovery_text");
     int totalLines = recoveryText.split("\n").length;
-    GrammarSettings settings = new TestGrammarSettings(false, 0, 0, false, true, true);
+    GrammarSettings settings = new TestGrammarSettings(false, 0, 0, 0, false, true, true);
     RecoveryCombinedParser cp = new RecoveryCombinedParser(recoveryText, settings);
     RecoveryContext ctx = cp.parse();
     RecoveryExtractor extractor = new RecoveryExtractor();

--- a/projects/batfish/src/main/java/org/batfish/config/Settings.java
+++ b/projects/batfish/src/main/java/org/batfish/config/Settings.java
@@ -437,6 +437,8 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
 
   private static final String ARG_MAX_PARSER_CONTEXT_TOKENS = "maxparsercontexttokens";
 
+  private static final String ARG_MAX_PARSE_TREE_PRINT_LENGTH = "maxparsetreeprintlength";
+
   private static final String ARG_MAX_RUNTIME_MS = "maxruntime";
 
   private static final String ARG_NO_SHUFFLE = "noshuffle";
@@ -598,6 +600,8 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
   private int _maxParserContextLines;
 
   private int _maxParserContextTokens;
+
+  private int _maxParseTreePrintLength;
 
   private int _maxRuntimeMs;
 
@@ -911,6 +915,11 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
     return _maxParserContextTokens;
   }
 
+  @Override
+  public int getMaxParseTreePrintLength() {
+    return _maxParseTreePrintLength;
+  }
+
   public int getMaxRuntimeMs() {
     return _maxRuntimeMs;
   }
@@ -1137,6 +1146,7 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
     setDefaultProperty(BfConsts.ARG_LOG_LEVEL, "debug");
     setDefaultProperty(ARG_MAX_PARSER_CONTEXT_LINES, 10);
     setDefaultProperty(ARG_MAX_PARSER_CONTEXT_TOKENS, 10);
+    setDefaultProperty(ARG_MAX_PARSE_TREE_PRINT_LENGTH, 0);
     setDefaultProperty(ARG_MAX_RUNTIME_MS, 0);
     setDefaultProperty(ARG_NO_SHUFFLE, false);
     setDefaultProperty(BfConsts.ARG_OUTPUT_ENV, null);
@@ -1339,6 +1349,12 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
         "max number of context tokens to print on parser error",
         ARGNAME_NUMBER);
 
+    addOption(
+        ARG_MAX_PARSE_TREE_PRINT_LENGTH,
+        "max number of characters to print for parsetree pretty print "
+            + "(<= 0 is treated as no limit)",
+        ARGNAME_NUMBER);
+
     addOption(ARG_MAX_RUNTIME_MS, "maximum time (in ms) to allow a task to run", ARGNAME_NUMBER);
 
     addBooleanOption(ARG_NO_SHUFFLE, "do not shuffle parallel jobs");
@@ -1520,6 +1536,7 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
     _logTee = getBooleanOptionValue(ARG_LOG_TEE);
     _maxParserContextLines = getIntOptionValue(ARG_MAX_PARSER_CONTEXT_LINES);
     _maxParserContextTokens = getIntOptionValue(ARG_MAX_PARSER_CONTEXT_TOKENS);
+    _maxParseTreePrintLength = getIntOptionValue(ARG_MAX_PARSE_TREE_PRINT_LENGTH);
     _maxRuntimeMs = getIntOptionValue(ARG_MAX_RUNTIME_MS);
     _outputEnvironmentName = getStringOptionValue(BfConsts.ARG_OUTPUT_ENV);
     _pedanticAsError = getBooleanOptionValue(BfConsts.ARG_PEDANTIC_AS_ERROR);
@@ -1650,6 +1667,10 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
 
   public void setMaxParserContextTokens(int maxParserContextTokens) {
     _maxParserContextTokens = maxParserContextTokens;
+  }
+
+  public void setMaxParseTreePrintLength(int maxParseTreePrintLength) {
+    _maxParseTreePrintLength = maxParseTreePrintLength;
   }
 
   public void setMaxRuntimeMs(int runtimeMs) {


### PR DESCRIPTION
Integrating [Dustin's change](https://github.com/batfish/batfish/pull/510)

Added option to specify a maximum number of characters to display for parse tree pretty print (defaults to 0, meaning no maximum) and unit test for new printWithCharacterLimit function

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/675)
<!-- Reviewable:end -->
