### PR TITLE
Infrastructure for container-wide adhoc questions

### DIFF
--- a/projects/batfish-client/src/main/java/org/batfish/client/BfCoordWorkHelper.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/BfCoordWorkHelper.java
@@ -135,6 +135,78 @@ public class BfCoordWorkHelper {
     }
   }
 
+  public boolean configureCompare(
+      String containerName,
+      @Nullable String addQuestionsFileName,
+      @Nullable String delQuestionsStr) {
+    try {
+      WebTarget webTarget = getTarget(CoordConsts.SVC_RSC_CONFIGURE_COMPARE);
+
+      MultiPart multiPart = new MultiPart();
+      multiPart.setMediaType(MediaType.MULTIPART_FORM_DATA_TYPE);
+
+      addTextMultiPart(multiPart, CoordConsts.SVC_KEY_API_KEY, _settings.getApiKey());
+      addTextMultiPart(multiPart, CoordConsts.SVC_KEY_CONTAINER_NAME, containerName);
+      if (addQuestionsFileName != null) {
+        addFileMultiPart(multiPart, CoordConsts.SVC_KEY_FILE, addQuestionsFileName);
+      }
+      if (delQuestionsStr != null) {
+        addTextMultiPart(multiPart, CoordConsts.SVC_KEY_DEL_ANALYSIS_QUESTIONS, delQuestionsStr);
+      }
+
+      return postData(webTarget, multiPart) != null;
+    } catch (Exception e) {
+      if (e.getMessage().contains("FileNotFoundException")) {
+        _logger.errorf("File not found: %s (addQuestionsFile file)\n", addQuestionsFileName);
+      } else {
+        _logger.errorf(
+            "Exception when configuring compare to %s using (%s, %s, %s): %s\n",
+            _coordWorkMgr,
+            containerName,
+            addQuestionsFileName,
+            delQuestionsStr,
+            ExceptionUtils.getStackTrace(e));
+      }
+      return false;
+    }
+  }
+
+  public boolean configureExplore(
+      String containerName,
+      @Nullable String addQuestionsFileName,
+      @Nullable String delQuestionsStr) {
+    try {
+      WebTarget webTarget = getTarget(CoordConsts.SVC_RSC_CONFIGURE_EXPLORE);
+
+      MultiPart multiPart = new MultiPart();
+      multiPart.setMediaType(MediaType.MULTIPART_FORM_DATA_TYPE);
+
+      addTextMultiPart(multiPart, CoordConsts.SVC_KEY_API_KEY, _settings.getApiKey());
+      addTextMultiPart(multiPart, CoordConsts.SVC_KEY_CONTAINER_NAME, containerName);
+      if (addQuestionsFileName != null) {
+        addFileMultiPart(multiPart, CoordConsts.SVC_KEY_FILE, addQuestionsFileName);
+      }
+      if (delQuestionsStr != null) {
+        addTextMultiPart(multiPart, CoordConsts.SVC_KEY_DEL_ANALYSIS_QUESTIONS, delQuestionsStr);
+      }
+
+      return postData(webTarget, multiPart) != null;
+    } catch (Exception e) {
+      if (e.getMessage().contains("FileNotFoundException")) {
+        _logger.errorf("File not found: %s (addQuestionsFile file)\n", addQuestionsFileName);
+      } else {
+        _logger.errorf(
+            "Exception when configuring explore to %s using (%s, %s, %s): %s\n",
+            _coordWorkMgr,
+            containerName,
+            addQuestionsFileName,
+            delQuestionsStr,
+            ExceptionUtils.getStackTrace(e));
+      }
+      return false;
+    }
+  }
+
   public boolean delAnalysis(String containerName, String analysisName) {
     try {
       WebTarget webTarget = getTarget(CoordConsts.SVC_RSC_DEL_ANALYSIS);

--- a/projects/batfish-client/src/main/java/org/batfish/client/Client.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/Client.java
@@ -2414,6 +2414,10 @@ public class Client extends AbstractClient implements IClient {
         return runAnalysis(outWriter, options, parameters, true, false);
       case RUN_ANALYSIS_DIFFERENTIAL:
         return runAnalysis(outWriter, options, parameters, false, true);
+      case RUN_COMPARE:
+        return runCompare(outWriter, options, parameters);
+      case RUN_EXPLORE:
+        return runExplore(outWriter, options, parameters);
       case REINIT_TESTRIG:
         return reinitTestrig(outWriter, options, parameters, false);
       case SET_BATFISH_LOGLEVEL:
@@ -2632,6 +2636,41 @@ public class Client extends AbstractClient implements IClient {
             _currDeltaEnv,
             delta,
             differential);
+
+    return execute(wItemAs, outWriter);
+  }
+
+  private boolean runCompare(
+      @Nullable FileWriter outWriter, List<String> options, List<String> parameters) {
+    Command command = Command.RUN_COMPARE;
+    if (!isValidArgument(options, parameters, 0, 0, 0, command)) {
+      return false;
+    }
+    if (!isSetContainer(true) || !isSetTestrig()) {
+      return false;
+    }
+
+    // answer the question
+    WorkItem wItemAs =
+        WorkItemBuilder.getWorkItemRunCompare(
+            _currContainerName, _currTestrig, _currEnv, _currDeltaTestrig, _currDeltaEnv);
+
+    return execute(wItemAs, outWriter);
+  }
+
+  private boolean runExplore(
+      @Nullable FileWriter outWriter, List<String> options, List<String> parameters) {
+    Command command = Command.RUN_EXPLORE;
+    if (!isValidArgument(options, parameters, 0, 0, 0, command)) {
+      return false;
+    }
+    if (!isSetContainer(true) || !isSetTestrig()) {
+      return false;
+    }
+
+    // answer the question
+    WorkItem wItemAs =
+        WorkItemBuilder.getWorkItemRunExplore(_currContainerName, _currTestrig, _currEnv);
 
     return execute(wItemAs, outWriter);
   }

--- a/projects/batfish-client/src/main/java/org/batfish/client/Command.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/Command.java
@@ -59,6 +59,8 @@ public enum Command {
   RUN_ANALYSIS("run-analysis"),
   RUN_ANALYSIS_DELTA("run-analysis-delta"),
   RUN_ANALYSIS_DIFFERENTIAL("run-analysis-differential"),
+  RUN_COMPARE("run-compare"),
+  RUN_EXPLORE("run-explore"),
   SET_BATFISH_LOGLEVEL("set-batfish-loglevel"),
   SET_CONTAINER("set-container"),
   SET_DELTA_ENV("set-delta-environment"),
@@ -262,6 +264,8 @@ public enum Command {
     descs.put(REINIT_TESTRIG, new Pair<>("", "Reinitialize the testrig with default environment"));
     descs.put(
         RUN_ANALYSIS, new Pair<>("<analysis-name>", "Run the (previously configured) analysis"));
+    descs.put(RUN_COMPARE, new Pair<>("", "Run the (previously configured) compare questions"));
+    descs.put(RUN_EXPLORE, new Pair<>("", "Run the (previously configured) explore questions"));
     descs.put(
         SET_BATFISH_LOGLEVEL,
         new Pair<>("<debug|info|output|warn|error>", "Set the batfish loglevel. Default is warn"));

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
@@ -120,6 +120,7 @@ public class BfConsts {
   public static final String RELPATH_ANSWER_PRETTY_JSON = "answer-pretty.json";
   public static final String RELPATH_AWS_VPC_CONFIGS_DIR = "aws_configs";
   public static final String RELPATH_AWS_VPC_CONFIGS_FILE = "aws_configs";
+  public static final String RELPATH_COMPARE_DIR = "compare";
   public static final String RELPATH_CONFIG_FILE_NAME_ALLINONE = "allinone.properties";
   public static final String RELPATH_CONFIG_FILE_NAME_BATFISH = "batfish.properties";
   public static final String RELPATH_CONFIG_FILE_NAME_CLIENT = "client.properties";
@@ -140,6 +141,7 @@ public class BfConsts {
   public static final String RELPATH_ENVIRONMENT_ROUTING_TABLES = "rt";
   public static final String RELPATH_ENVIRONMENT_ROUTING_TABLES_ANSWER = "rt_answer";
   public static final String RELPATH_ENVIRONMENTS_DIR = "environments";
+  public static final String RELPATH_EXPLORE_DIR = "explore";
   public static final String RELPATH_EXTERNAL_BGP_ANNOUNCEMENTS = "external_bgp_announcements.json";
   public static final String RELPATH_FAILURE_QUERY_PREFIX = "failure-query";
   public static final String RELPATH_FLOWS_DUMP_DIR = "flowdump";

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
@@ -73,8 +73,10 @@ public class BfConsts {
 
   public static final String COMMAND_ANALYZE = "analyze";
   public static final String COMMAND_ANSWER = "answer";
+  public static final String COMMAND_COMPARE = "compare";
   public static final String COMMAND_COMPILE_DIFF_ENVIRONMENT = "diffcompile";
   public static final String COMMAND_DUMP_DP = "dp";
+  public static final String COMMAND_EXPLORE = "explore";
   public static final String COMMAND_INIT_INFO = "initinfo";
   public static final String COMMAND_PARSE_VENDOR_INDEPENDENT = "si";
   public static final String COMMAND_PARSE_VENDOR_SPECIFIC = "sv";

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/CoordConsts.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/CoordConsts.java
@@ -42,8 +42,6 @@ public class CoordConsts {
   public static final String SVC_KEY_AUTO_ANALYZE_TESTRIG = "autoanalyzetestrig";
   public static final String SVC_KEY_BASE_ENV_NAME = "baseenvname";
   public static final String SVC_KEY_CONFIGURATION_NAME = "configurationname";
-  public static final String SVC_KEY_CONFIGURE_COMPARE = "configurecompare";
-  public static final String SVC_KEY_CONFIGURE_EXPLORE = "configureexplore";
   public static final String SVC_KEY_CONTAINERS = "containers";
   public static final String SVC_KEY_CONTAINER_LIST = "containerlist";
   public static final String SVC_KEY_CONTAINER_NAME = "container";
@@ -100,8 +98,10 @@ public class CoordConsts {
   public static final String SVC_RSC_GETSTATUS = "getstatus";
   public static final String SVC_RSC_INIT_CONTAINER = "initcontainer";
   public static final String SVC_RSC_LIST_ANALYSES = "listanalyses";
+  public static final String SVC_RSC_LIST_COMPARE_QS = "listcompareqs";
   public static final String SVC_RSC_LIST_CONTAINERS = "listcontainers";
   public static final String SVC_RSC_LIST_ENVIRONMENTS = "listenvironments";
+  public static final String SVC_RSC_LIST_EXPLORE_QS = "listexploreqs";
   public static final String SVC_RSC_LIST_QUESTIONS = "listquestions";
   public static final String SVC_RSC_LIST_TESTRIGS = "listtestrigs";
   public static final String SVC_RSC_POOL_GET_QUESTION_TEMPLATES = "getquestiontemplates";

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/CoordConsts.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/CoordConsts.java
@@ -42,6 +42,8 @@ public class CoordConsts {
   public static final String SVC_KEY_AUTO_ANALYZE_TESTRIG = "autoanalyzetestrig";
   public static final String SVC_KEY_BASE_ENV_NAME = "baseenvname";
   public static final String SVC_KEY_CONFIGURATION_NAME = "configurationname";
+  public static final String SVC_KEY_CONFIGURE_COMPARE = "configurecompare";
+  public static final String SVC_KEY_CONFIGURE_EXPLORE = "configureexplore";
   public static final String SVC_KEY_CONTAINERS = "containers";
   public static final String SVC_KEY_CONTAINER_LIST = "containerlist";
   public static final String SVC_KEY_CONTAINER_NAME = "container";
@@ -79,6 +81,8 @@ public class CoordConsts {
   public static final String SVC_RSC_CHECK_API_KEY = "checkapikey";
 
   public static final String SVC_RSC_CONFIGURE_ANALYSIS = "configureanalysis";
+  public static final String SVC_RSC_CONFIGURE_COMPARE = "configurecompare";
+  public static final String SVC_RSC_CONFIGURE_EXPLORE = "configureexplore";
   public static final String SVC_RSC_DEL_ANALYSIS = "delanalysis";
   public static final String SVC_RSC_DEL_CONTAINER = "delcontainer";
   public static final String SVC_RSC_DEL_ENVIRONMENT = "delenvironment";

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/CoordConsts.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/CoordConsts.java
@@ -90,8 +90,10 @@ public class CoordConsts {
   public static final String SVC_RSC_DEL_TESTRIG = "deltestrig";
   public static final String SVC_RSC_GET_ANALYSIS_ANSWERS = "getanalysisanswers";
   public static final String SVC_RSC_GET_ANSWER = "getanswer";
+  public static final String SVC_RSC_GET_COMPARE_ANSWERS = "getcompareanswers";
   public static final String SVC_RSC_GET_CONFIGURATION = "getconfiguration";
   public static final String SVC_RSC_GET_CONTAINER = "getcontainer";
+  public static final String SVC_RSC_GET_EXPLORE_ANSWERS = "getexploreanswers";
   public static final String SVC_RSC_GET_OBJECT = "getobject";
   public static final String SVC_RSC_GET_QUESTION_TEMPLATES = "getquestiontemplates";
   public static final String SVC_RSC_GET_WORKSTATUS = "getworkstatus";

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/WorkItemBuilder.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/WorkItemBuilder.java
@@ -102,6 +102,32 @@ public class WorkItemBuilder {
     return wItem;
   }
 
+  public static WorkItem getWorkItemRunCompare(
+      String containerName,
+      String testrigName,
+      String envName,
+      String deltaTestrig,
+      String deltaEnvName) {
+    WorkItem wItem = new WorkItem(containerName, testrigName);
+    wItem.addRequestParam(BfConsts.COMMAND_COMPARE, "");
+    wItem.addRequestParam(BfConsts.ARG_TESTRIG, testrigName);
+    wItem.addRequestParam(BfConsts.ARG_ENVIRONMENT_NAME, envName);
+    wItem.addRequestParam(BfConsts.ARG_DELTA_TESTRIG, deltaTestrig);
+    wItem.addRequestParam(BfConsts.ARG_DELTA_ENVIRONMENT_NAME, deltaEnvName);
+    wItem.addRequestParam(BfConsts.ARG_DIFF_ACTIVE, "");
+    wItem.addRequestParam(BfConsts.ARG_DIFFERENTIAL, "");
+    return wItem;
+  }
+
+  public static WorkItem getWorkItemRunExplore(
+      String containerName, String testrigName, String envName) {
+    WorkItem wItem = new WorkItem(containerName, testrigName);
+    wItem.addRequestParam(BfConsts.COMMAND_EXPLORE, "");
+    wItem.addRequestParam(BfConsts.ARG_TESTRIG, testrigName);
+    wItem.addRequestParam(BfConsts.ARG_ENVIRONMENT_NAME, envName);
+    return wItem;
+  }
+
   public static WorkItem getWorkItemValidateEnvironment(
       String containerName, String testrigName, String envName) {
     WorkItem wItem = new WorkItem(containerName, testrigName);

--- a/projects/batfish/src/main/java/org/batfish/config/Settings.java
+++ b/projects/batfish/src/main/java/org/batfish/config/Settings.java
@@ -521,6 +521,8 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
 
   private boolean _canExecute;
 
+  private boolean _compare;
+
   private boolean _compileDiffEnvironment;
 
   private Path _containerDir;
@@ -552,6 +554,8 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
   private String _environmentName;
 
   private boolean _exitOnFirstError;
+
+  private boolean _explore;
 
   private boolean _flatten;
 
@@ -768,6 +772,10 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
     return _blockNames;
   }
 
+  public boolean getCompare() {
+    return _compare;
+  }
+
   public boolean getCompileEnvironment() {
     return _compileDiffEnvironment;
   }
@@ -831,6 +839,10 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
 
   public boolean getExitOnFirstError() {
     return _exitOnFirstError;
+  }
+
+  public boolean getExplore() {
+    return _explore;
   }
 
   public boolean getFlatten() {
@@ -1174,8 +1186,10 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
     setDefaultProperty(BfConsts.ARG_VERBOSE_PARSE, false);
     setDefaultProperty(BfConsts.COMMAND_ANALYZE, false);
     setDefaultProperty(BfConsts.COMMAND_ANSWER, false);
+    setDefaultProperty(BfConsts.COMMAND_COMPARE, false);
     setDefaultProperty(BfConsts.COMMAND_COMPILE_DIFF_ENVIRONMENT, false);
     setDefaultProperty(BfConsts.COMMAND_DUMP_DP, false);
+    setDefaultProperty(BfConsts.COMMAND_EXPLORE, false);
     setDefaultProperty(BfConsts.COMMAND_INIT_INFO, false);
     setDefaultProperty(BfConsts.COMMAND_PARSE_VENDOR_INDEPENDENT, false);
     setDefaultProperty(BfConsts.COMMAND_PARSE_VENDOR_SPECIFIC, false);
@@ -1440,11 +1454,15 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
 
     addBooleanOption(BfConsts.COMMAND_ANSWER, "answer provided question");
 
+    addBooleanOption(BfConsts.COMMAND_COMPARE, "run compare questions");
+
     addBooleanOption(
         BfConsts.COMMAND_COMPILE_DIFF_ENVIRONMENT,
         "compile configurations for differential environment");
 
     addBooleanOption(BfConsts.COMMAND_DUMP_DP, "compute and serialize data plane");
+
+    addBooleanOption(BfConsts.COMMAND_EXPLORE, "run explore questions");
 
     addBooleanOption(
         BfConsts.COMMAND_PARSE_VENDOR_INDEPENDENT, "serialize vendor-independent configs");
@@ -1486,6 +1504,7 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
     _bdpPrintOscillatingIterations =
         getBooleanOptionValue(BfConsts.ARG_BDP_PRINT_OSCILLATING_ITERATIONS);
     _blockNames = getStringListOptionValue(BfConsts.ARG_BLOCK_NAMES);
+    _compare = getBooleanOptionValue(BfConsts.COMMAND_COMPARE);
     _compileDiffEnvironment = getBooleanOptionValue(BfConsts.COMMAND_COMPILE_DIFF_ENVIRONMENT);
     _containerDir = getPathOptionValue(BfConsts.ARG_CONTAINER_DIR);
     _coordinatorHost = getStringOptionValue(ARG_COORDINATOR_HOST);
@@ -1500,6 +1519,7 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
     _disableUnrecognized = getBooleanOptionValue(BfConsts.ARG_DISABLE_UNRECOGNIZED);
     _environmentName = getStringOptionValue(BfConsts.ARG_ENVIRONMENT_NAME);
     _exitOnFirstError = getBooleanOptionValue(ARG_EXIT_ON_FIRST_ERROR);
+    _explore = getBooleanOptionValue(BfConsts.COMMAND_EXPLORE);
     _flatten = getBooleanOptionValue(ARG_FLATTEN);
     _flattenDestination = getPathOptionValue(ARG_FLATTEN_DESTINATION);
     _flattenOnTheFly = getBooleanOptionValue(ARG_FLATTEN_ON_THE_FLY);

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -522,6 +522,37 @@ public class Batfish extends PluginConsumer implements IBatfish {
     return answer;
   }
 
+  private Answer answerAdhoc(String dir) {
+    Answer answer = new Answer();
+    AnswerSummary summary = new AnswerSummary();
+    Path adhocQuestionsDir =
+        _settings
+            .getContainerDir()
+            .resolve(Paths.get(dir, BfConsts.RELPATH_QUESTIONS_DIR).toString());
+    if (!Files.exists(adhocQuestionsDir)) {
+      throw new BatfishException(
+          "Container-level compare dir does not exist: '" + adhocQuestionsDir + "'");
+    }
+    RunAnalysisAnswerElement ae = new RunAnalysisAnswerElement();
+    try (Stream<Path> questions = CommonUtil.list(adhocQuestionsDir)) {
+      questions.forEach(
+          questionDir -> {
+            String questionName = questionDir.getFileName().toString();
+            Path adhocQuestionPath = questionDir.resolve(BfConsts.RELPATH_QUESTION_FILE);
+            _settings.setQuestionPath(adhocQuestionPath);
+            Answer currentAnswer = answer();
+            initAdhocQuestionPath(questionName, dir);
+            outputAnswer(currentAnswer);
+            ae.getAnswers().put(questionName, currentAnswer);
+            _settings.setQuestionPath(null);
+            summary.combine(currentAnswer.getSummary());
+          });
+    }
+    answer.addAnswerElement(ae);
+    answer.setSummary(summary);
+    return answer;
+  }
+
   private void anonymizeConfigurations() {
     // TODO Auto-generated method stub
 
@@ -1979,6 +2010,16 @@ public class Batfish extends PluginConsumer implements IBatfish {
                         BfConsts.RELPATH_QUESTIONS_DIR,
                         questionName)
                     .toString());
+    questionDir.toFile().mkdirs();
+    Path questionPath = questionDir.resolve(BfConsts.RELPATH_QUESTION_FILE);
+    _settings.setQuestionPath(questionPath);
+  }
+
+  private void initAdhocQuestionPath(String questionName, String dir) {
+    Path questionDir =
+        _testrigSettings
+            .getBasePath()
+            .resolve(Paths.get(dir, BfConsts.RELPATH_QUESTIONS_DIR, questionName).toString());
     questionDir.toFile().mkdirs();
     Path questionPath = questionDir.resolve(BfConsts.RELPATH_QUESTION_FILE);
     _settings.setQuestionPath(questionPath);
@@ -4026,6 +4067,14 @@ public class Batfish extends PluginConsumer implements IBatfish {
     if (_settings.getAnalyze()) {
       answer.append(analyze());
       action = true;
+    }
+
+    if (_settings.getCompare()) {
+      answer.append(answerAdhoc(BfConsts.RELPATH_COMPARE_DIR));
+    }
+
+    if (_settings.getExplore()) {
+      answer.append(answerAdhoc(BfConsts.RELPATH_EXPLORE_DIR));
     }
 
     if (_settings.getDataPlane()) {

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -334,6 +334,51 @@ public class WorkMgr extends AbstractCoordinator {
       List<String> questionsToDelete) {
     Path containerDir = getdirContainer(containerName);
     Path aDir = containerDir.resolve(Paths.get(BfConsts.RELPATH_ANALYSES_DIR, aName));
+    configureAnalysisOrAdhoc(
+        containerName, newAnalysis, aName, questionsToAdd, questionsToDelete, aDir);
+  }
+
+  /**
+   * Update or truncate differential adhoc questions with provided questions or and/or question
+   * names
+   *
+   * @param containerName The container in which the questions reside
+   * @param questionsToAdd The new differential adhoc questions to be added.
+   * @param questionsToDelete A list of question names to be deleted from existing differential
+   *     adhoc questions.
+   */
+  public void configureCompare(
+      String containerName, Map<String, String> questionsToAdd, List<String> questionsToDelete) {
+    Path containerDir = getdirContainer(containerName);
+    Path aDir = containerDir.resolve(BfConsts.RELPATH_COMPARE_DIR);
+    configureAnalysisOrAdhoc(
+        containerName, false, "compare", questionsToAdd, questionsToDelete, aDir);
+  }
+
+  /**
+   * Update or truncate non-differential adhoc questions with provided questions or and/or question
+   * names
+   *
+   * @param containerName The container in which the questions reside
+   * @param questionsToAdd The new non-differential adhoc questions to be added.
+   * @param questionsToDelete A list of question names to be deleted from existing non-differential
+   *     adhoc questions.
+   */
+  public void configureExplore(
+      String containerName, Map<String, String> questionsToAdd, List<String> questionsToDelete) {
+    Path containerDir = getdirContainer(containerName);
+    Path aDir = containerDir.resolve(BfConsts.RELPATH_EXPLORE_DIR);
+    configureAnalysisOrAdhoc(
+        containerName, false, "explore", questionsToAdd, questionsToDelete, aDir);
+  }
+
+  private void configureAnalysisOrAdhoc(
+      String containerName,
+      boolean newAnalysis,
+      String aName,
+      Map<String, String> questionsToAdd,
+      List<String> questionsToDelete,
+      Path aDir) {
     if (Files.exists(aDir) && newAnalysis) {
       throw new BatfishException(
           "Analysis '" + aName + "' already exists for container '" + containerName);

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -835,9 +835,30 @@ public class WorkMgr extends AbstractCoordinator {
 
   public String getTestrigQuestion(String containerName, String testrigName, String questionName) {
     Path questionDir = getdirTestrigQuestion(containerName, testrigName, questionName);
+    return getQuestion(questionDir, questionName);
+  }
+
+  public String getCompareQuestion(String containerName, String questionName) {
+    Path containerDir = getdirContainer(containerName, true);
+    Path questionDir =
+        containerDir.resolve(
+            Paths.get(BfConsts.RELPATH_COMPARE_DIR, BfConsts.RELPATH_QUESTIONS_DIR, questionName));
+    return getQuestion(questionDir, questionName);
+  }
+
+  public String getExploreQuestion(String containerName, String questionName) {
+    Path containerDir = getdirContainer(containerName, true);
+    Path questionDir =
+        containerDir.resolve(
+            Paths.get(BfConsts.RELPATH_EXPLORE_DIR, BfConsts.RELPATH_QUESTIONS_DIR, questionName));
+    return getQuestion(questionDir, questionName);
+  }
+
+  private String getQuestion(Path questionDir, String questionName) {
     Path qFile = questionDir.resolve(BfConsts.RELPATH_QUESTION_FILE);
     if (!Files.exists(qFile)) {
-      throw new BatfishException("Question file not found for " + questionName);
+      throw new BatfishException(
+          "Question file not found for " + questionName + "; trying for path " + qFile.toString());
     }
     return CommonUtil.readFile(qFile);
   }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -456,12 +456,58 @@ public class WorkMgr extends AbstractCoordinator {
       throws JsonProcessingException {
     Path analysisDir = getdirContainerAnalysis(containerName, analysisName);
     Path testrigDir = getdirTestrig(containerName, baseTestrig);
+    Path analysisAnswersDir =
+        testrigDir.resolve(Paths.get(BfConsts.RELPATH_ANALYSES_DIR, analysisName));
     SortedSet<String> questions = listAnalysisQuestions(containerName, analysisName);
+    return getAnalysisOrAdhocAnswers(
+        baseEnv, deltaTestrig, deltaEnv, pretty, analysisDir, analysisAnswersDir, questions);
+  }
+
+  public Map<String, String> getCompareAnswers(
+      String containerName,
+      String baseTestrig,
+      String baseEnv,
+      String deltaTestrig,
+      String deltaEnv,
+      boolean pretty)
+      throws JsonProcessingException {
+    Path containerDir = getdirContainer(containerName);
+    Path cDir = containerDir.resolve(Paths.get(BfConsts.RELPATH_COMPARE_DIR));
+
+    Path testrigDir = getdirTestrig(containerName, baseTestrig);
+    Path compareAnswersDir = testrigDir.resolve(Paths.get(BfConsts.RELPATH_COMPARE_DIR));
+    SortedSet<String> questions = listCompareQuestions(containerName);
+    return getAnalysisOrAdhocAnswers(
+        baseEnv, deltaTestrig, deltaEnv, pretty, cDir, compareAnswersDir, questions);
+  }
+
+  public Map<String, String> getExploreAnswers(
+      String containerName, String baseTestrig, String baseEnv, boolean pretty)
+      throws JsonProcessingException {
+    Path containerDir = getdirContainer(containerName);
+    Path eDir = containerDir.resolve(Paths.get(BfConsts.RELPATH_EXPLORE_DIR));
+
+    Path testrigDir = getdirTestrig(containerName, baseTestrig);
+    Path exploreAnswersDir = testrigDir.resolve(Paths.get(BfConsts.RELPATH_EXPLORE_DIR));
+    SortedSet<String> questions = listExploreQuestions(containerName);
+    return getAnalysisOrAdhocAnswers(
+        baseEnv, null, null, pretty, eDir, exploreAnswersDir, questions);
+  }
+
+  private Map<String, String> getAnalysisOrAdhocAnswers(
+      String baseEnv,
+      String deltaTestrig,
+      String deltaEnv,
+      boolean pretty,
+      Path questionsDir,
+      Path answersDir,
+      SortedSet<String> questions)
+      throws JsonProcessingException {
     Map<String, String> retMap = new TreeMap<>();
     for (String questionName : questions) {
       String answer = "unknown";
       Path questionFile =
-          analysisDir.resolve(
+          questionsDir.resolve(
               Paths.get(
                   BfConsts.RELPATH_QUESTIONS_DIR, questionName, BfConsts.RELPATH_QUESTION_FILE));
       if (!Files.exists(questionFile)) {
@@ -470,10 +516,8 @@ public class WorkMgr extends AbstractCoordinator {
       String answerFilename =
           pretty ? BfConsts.RELPATH_ANSWER_PRETTY_JSON : BfConsts.RELPATH_ANSWER_JSON;
       Path answerDir =
-          testrigDir.resolve(
+          answersDir.resolve(
               Paths.get(
-                  BfConsts.RELPATH_ANALYSES_DIR,
-                  analysisName,
                   BfConsts.RELPATH_QUESTIONS_DIR,
                   questionName,
                   BfConsts.RELPATH_ENVIRONMENTS_DIR,
@@ -821,6 +865,14 @@ public class WorkMgr extends AbstractCoordinator {
     if (!analysesDir.toFile().mkdir()) {
       throw new BatfishException("failed to create directory '" + analysesDir + "'");
     }
+    Path compareDir = containerDir.resolve(BfConsts.RELPATH_COMPARE_DIR);
+    if (!compareDir.toFile().mkdir()) {
+      throw new BatfishException("failed to create directory '" + compareDir + "'");
+    }
+    Path exploreDir = containerDir.resolve(BfConsts.RELPATH_EXPLORE_DIR);
+    if (!exploreDir.toFile().mkdir()) {
+      throw new BatfishException("failed to create directory '" + exploreDir + "'");
+    }
     return containerName;
   }
 
@@ -844,6 +896,15 @@ public class WorkMgr extends AbstractCoordinator {
     Path metadataPath = testrigDir.resolve(BfConsts.RELPATH_METADATA_FILE);
     long time = (new java.util.Date()).getTime();
     CommonUtil.writeFile(metadataPath, "{\n\t\"timestamp\": " + Long.toString(time) + "\n}");
+
+    // Create explore and compare directories with empty question subdirectories
+    // These will store answers, not questions; adhoc questions are container-wide
+    Path compareQuestionDir =
+        testrigDir.resolve(Paths.get(BfConsts.RELPATH_COMPARE_DIR, BfConsts.RELPATH_QUESTIONS_DIR));
+    compareQuestionDir.toFile().mkdirs();
+    Path exploreQuestionDir =
+        testrigDir.resolve(Paths.get(BfConsts.RELPATH_EXPLORE_DIR, BfConsts.RELPATH_QUESTIONS_DIR));
+    exploreQuestionDir.toFile().mkdirs();
 
     Path srcSubdir = srcDirEntries.iterator().next();
     SortedSet<Path> subFileList = CommonUtil.getEntries(srcSubdir);
@@ -933,6 +994,24 @@ public class WorkMgr extends AbstractCoordinator {
   public SortedSet<String> listAnalysisQuestions(String containerName, String analysisName) {
     Path analysisDir = getdirContainerAnalysis(containerName, analysisName);
     Path questionsDir = analysisDir.resolve(BfConsts.RELPATH_QUESTIONS_DIR);
+    return listAnalysisOrAdhocQuestions(questionsDir);
+  }
+
+  public SortedSet<String> listCompareQuestions(String containerName) {
+    Path containerDir = getdirContainer(containerName);
+    Path cDir = containerDir.resolve(Paths.get(BfConsts.RELPATH_COMPARE_DIR));
+    Path questionsDir = cDir.resolve(BfConsts.RELPATH_QUESTIONS_DIR);
+    return listAnalysisOrAdhocQuestions(questionsDir);
+  }
+
+  public SortedSet<String> listExploreQuestions(String containerName) {
+    Path containerDir = getdirContainer(containerName);
+    Path edir = containerDir.resolve(Paths.get(BfConsts.RELPATH_EXPLORE_DIR));
+    Path questionsDir = edir.resolve(BfConsts.RELPATH_QUESTIONS_DIR);
+    return listAnalysisOrAdhocQuestions(questionsDir);
+  }
+
+  private SortedSet<String> listAnalysisOrAdhocQuestions(Path questionsDir) {
     if (!Files.exists(questionsDir)) {
       /** TODO: Something better than returning empty set? */
       return new TreeSet<>();

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -971,6 +971,11 @@ public class WorkMgr extends AbstractCoordinator {
                 false,
                 false);
         autoWorkQueue.add(analyzeWork);
+
+        WorkItem exploreWork =
+            WorkItemBuilder.getWorkItemRunExplore(
+                containerName, testrigName, BfConsts.RELPATH_DEFAULT_ENVIRONMENT_NAME);
+        autoWorkQueue.add(exploreWork);
       }
 
       // NB: This way of doing things only works when we have a single worker; otherwise workitems

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
@@ -1383,7 +1383,8 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
       @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String testrigName) {
     try {
-      _logger.info("WMS:listTestrigQuestions " + apiKey + " " + containerName + "\n");
+      _logger.info(
+          "WMS:listTestrigQuestions " + apiKey + " " + containerName + " " + testrigName + "\n");
 
       checkStringParam(apiKey, "API key");
       checkStringParam(clientVersion, "Client version");
@@ -1413,6 +1414,102 @@ public class WorkMgrService {
     } catch (Exception e) {
       String stackTrace = ExceptionUtils.getFullStackTrace(e);
       _logger.error("WMS:listTestrigQuestions exception: " + stackTrace);
+      return failureResponse(e.getMessage());
+    }
+  }
+
+  /**
+   * List the differential adhoc questions under the specified container
+   *
+   * @param apiKey The API key of the client
+   * @param clientVersion The version of the client
+   * @param containerName The name of the container in which the adhoc questions reside
+   * @return TODO: document JSON response
+   */
+  @POST
+  @Path(CoordConsts.SVC_RSC_LIST_COMPARE_QS)
+  @Produces(MediaType.APPLICATION_JSON)
+  public JSONArray listCompareQuestions(
+      @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
+      @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
+      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName) {
+    try {
+      _logger.info("WMS:listCompareQuestions " + apiKey + " " + containerName + "\n");
+
+      checkStringParam(apiKey, "API key");
+      checkStringParam(clientVersion, "Client version");
+      checkStringParam(containerName, "Container name");
+
+      checkApiKeyValidity(apiKey);
+      checkClientVersion(clientVersion);
+      checkContainerAccessibility(apiKey, containerName);
+
+      JSONObject retObject = new JSONObject();
+
+      for (String questionName : Main.getWorkMgr().listCompareQuestions(containerName)) {
+        String questionText = Main.getWorkMgr().getCompareQuestion(containerName, questionName);
+
+        retObject.put(questionName, new JSONObject(questionText));
+      }
+
+      return successResponse(new JSONObject().put(CoordConsts.SVC_KEY_QUESTION_LIST, retObject));
+    } catch (FileExistsException
+        | FileNotFoundException
+        | IllegalArgumentException
+        | AccessControlException e) {
+      _logger.error("WMS:listCompareQuestions exception: " + e.getMessage() + "\n");
+      return failureResponse(e.getMessage());
+    } catch (Exception e) {
+      String stackTrace = ExceptionUtils.getFullStackTrace(e);
+      _logger.error("WMS:listCompareQuestions exception: " + stackTrace);
+      return failureResponse(e.getMessage());
+    }
+  }
+
+  /**
+   * List the non-differential adhoc questions under the specified container
+   *
+   * @param apiKey The API key of the client
+   * @param clientVersion The version of the client
+   * @param containerName The name of the container in which the adhoc questions reside
+   * @return TODO: document JSON response
+   */
+  @POST
+  @Path(CoordConsts.SVC_RSC_LIST_EXPLORE_QS)
+  @Produces(MediaType.APPLICATION_JSON)
+  public JSONArray listExploreQuestions(
+      @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
+      @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
+      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName) {
+    try {
+      _logger.info("WMS:listExploreQuestions " + apiKey + " " + containerName + "\n");
+
+      checkStringParam(apiKey, "API key");
+      checkStringParam(clientVersion, "Client version");
+      checkStringParam(containerName, "Container name");
+
+      checkApiKeyValidity(apiKey);
+      checkClientVersion(clientVersion);
+      checkContainerAccessibility(apiKey, containerName);
+
+      JSONObject retObject = new JSONObject();
+
+      for (String questionName : Main.getWorkMgr().listExploreQuestions(containerName)) {
+        String questionText = Main.getWorkMgr().getExploreQuestion(containerName, questionName);
+
+        retObject.put(questionName, new JSONObject(questionText));
+      }
+
+      return successResponse(new JSONObject().put(CoordConsts.SVC_KEY_QUESTION_LIST, retObject));
+    } catch (FileExistsException
+        | FileNotFoundException
+        | IllegalArgumentException
+        | AccessControlException e) {
+      _logger.error("WMS:listExploreQuestions exception: " + e.getMessage() + "\n");
+      return failureResponse(e.getMessage());
+    } catch (Exception e) {
+      String stackTrace = ExceptionUtils.getFullStackTrace(e);
+      _logger.error("WMS:listExploreQuestions exception: " + stackTrace);
       return failureResponse(e.getMessage());
     }
   }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
@@ -536,7 +536,7 @@ public class WorkMgrService {
   }
 
   /**
-   * Deletesthe specified testrig under the specified container
+   * Deletes the specified testrig under the specified container
    *
    * @param apiKey The API key of the requester
    * @param clientVersion The version of the client
@@ -582,7 +582,7 @@ public class WorkMgrService {
   }
 
   /**
-   * Get answers for a previously run analysis
+   * Get existing answers for a previously run analysis
    *
    * @param apiKey The API key of the client
    * @param clientVersion The version of the client
@@ -592,7 +592,7 @@ public class WorkMgrService {
    * @param deltaTestrig The name of the delta testrig on which the analysis was run
    * @param deltaEnv The name of the delta environment on which the analysis was run
    * @param analysisName The name of the analysis
-   * @param prettyAnswer Whether or not to pretty&#8208;print the result
+   * @param prettyAnswer Whether or not to pretty-print the result
    * @return TODO: document JSON response
    */
   @POST
@@ -657,6 +657,128 @@ public class WorkMgrService {
     } catch (Exception e) {
       String stackTrace = ExceptionUtils.getFullStackTrace(e);
       _logger.error("WMS:getAnalsysisAnswers exception: " + stackTrace);
+      return failureResponse(e.getMessage());
+    }
+  }
+
+  /**
+   * Get existing answers for differential adhoc questions
+   *
+   * @param apiKey The API key of the client
+   * @param clientVersion The version of the client
+   * @param containerName The name of the container in which the questions reside
+   * @param testrigName The name of the testrig on which to run the questions
+   * @param baseEnv The name of the base environment on which to run the questions
+   * @param deltaTestrig The name of the delta testrig on which to run the questions
+   * @param deltaEnv The name of the delta environment on which to run the questions
+   * @param prettyAnswer Whether or not to pretty-print the result
+   * @return TODO: document JSON response
+   */
+  @POST
+  @Path(CoordConsts.SVC_RSC_GET_COMPARE_ANSWERS)
+  @Produces(MediaType.APPLICATION_JSON)
+  public JSONArray getCompareAnswers(
+      @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
+      @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
+      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
+      @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String testrigName,
+      @FormDataParam(CoordConsts.SVC_KEY_ENV_NAME) String baseEnv,
+      @FormDataParam(CoordConsts.SVC_KEY_DELTA_TESTRIG_NAME) String deltaTestrig,
+      @FormDataParam(CoordConsts.SVC_KEY_DELTA_ENV_NAME) String deltaEnv,
+      @FormDataParam(CoordConsts.SVC_KEY_PRETTY_ANSWER) String prettyAnswer) {
+    try {
+      _logger.info(
+          "WMS:getCompareAnswers " + apiKey + " " + containerName + " " + testrigName + "\n");
+
+      checkStringParam(apiKey, "API key");
+      checkStringParam(clientVersion, "Client version");
+      checkStringParam(containerName, "Container name");
+      checkStringParam(testrigName, "Base testrig name");
+      checkStringParam(baseEnv, "Base environment name");
+      checkStringParam(deltaTestrig, "Delta testrig name");
+      checkStringParam(deltaEnv, "Delta environment name");
+      checkStringParam(prettyAnswer, "Retrieve pretty-printed answers");
+      boolean pretty = Boolean.parseBoolean(prettyAnswer);
+
+      checkApiKeyValidity(apiKey);
+      checkClientVersion(clientVersion);
+      checkContainerAccessibility(apiKey, containerName);
+
+      Map<String, String> answers =
+          Main.getWorkMgr()
+              .getCompareAnswers(
+                  containerName, testrigName, baseEnv, deltaTestrig, deltaEnv, pretty);
+
+      BatfishObjectMapper mapper = new BatfishObjectMapper();
+      String answersStr = mapper.writeValueAsString(answers);
+
+      return successResponse(new JSONObject().put(CoordConsts.SVC_KEY_ANSWERS, answersStr));
+    } catch (FileExistsException
+        | FileNotFoundException
+        | IllegalArgumentException
+        | AccessControlException e) {
+      _logger.error("WMS:getCompareAnswers exception: " + e.getMessage() + "\n");
+      return failureResponse(e.getMessage());
+    } catch (Exception e) {
+      String stackTrace = ExceptionUtils.getFullStackTrace(e);
+      _logger.error("WMS:getCompareAnswers exception: " + stackTrace);
+      return failureResponse(e.getMessage());
+    }
+  }
+
+  /**
+   * Get existing answers for non-differential adhoc questions
+   *
+   * @param apiKey The API key of the client
+   * @param clientVersion The version of the client
+   * @param containerName The name of the container in which the questions reside
+   * @param testrigName The name of the testrig on which to run the questions
+   * @param baseEnv The name of the base environment on which to run the questions
+   * @param prettyAnswer Whether or not to pretty-print the result
+   * @return TODO: document JSON response
+   */
+  @POST
+  @Path(CoordConsts.SVC_RSC_GET_EXPLORE_ANSWERS)
+  @Produces(MediaType.APPLICATION_JSON)
+  public JSONArray getExploreAnswers(
+      @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
+      @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
+      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
+      @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String testrigName,
+      @FormDataParam(CoordConsts.SVC_KEY_ENV_NAME) String baseEnv,
+      @FormDataParam(CoordConsts.SVC_KEY_PRETTY_ANSWER) String prettyAnswer) {
+    try {
+      _logger.info(
+          "WMS:getExploreAnswers " + apiKey + " " + containerName + " " + testrigName + "\n");
+
+      checkStringParam(apiKey, "API key");
+      checkStringParam(clientVersion, "Client version");
+      checkStringParam(containerName, "Container name");
+      checkStringParam(testrigName, "Base testrig name");
+      checkStringParam(baseEnv, "Base environment name");
+      checkStringParam(prettyAnswer, "Retrieve pretty-printed answers");
+      boolean pretty = Boolean.parseBoolean(prettyAnswer);
+
+      checkApiKeyValidity(apiKey);
+      checkClientVersion(clientVersion);
+      checkContainerAccessibility(apiKey, containerName);
+
+      Map<String, String> answers =
+          Main.getWorkMgr().getExploreAnswers(containerName, testrigName, baseEnv, pretty);
+
+      BatfishObjectMapper mapper = new BatfishObjectMapper();
+      String answersStr = mapper.writeValueAsString(answers);
+
+      return successResponse(new JSONObject().put(CoordConsts.SVC_KEY_ANSWERS, answersStr));
+    } catch (FileExistsException
+        | FileNotFoundException
+        | IllegalArgumentException
+        | AccessControlException e) {
+      _logger.error("WMS:getExploreAnswers exception: " + e.getMessage() + "\n");
+      return failureResponse(e.getMessage());
+    } catch (Exception e) {
+      String stackTrace = ExceptionUtils.getFullStackTrace(e);
+      _logger.error("WMS:getExploreAnswers exception: " + stackTrace);
       return failureResponse(e.getMessage());
     }
   }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
@@ -201,6 +201,152 @@ public class WorkMgrService {
   }
 
   /**
+   * Configures new/deleted differential adhoc questions for the container
+   *
+   * @param apiKey The API key of the requester
+   * @param clientVersion The version of the client
+   * @param containerName The name of the container to configure
+   * @param addQuestionsStream A stream providing the new differential questions to add
+   * @param delQuestions A list of existing differential questions to delete
+   * @return TODO: document JSON response
+   */
+  @POST
+  @Path(CoordConsts.SVC_RSC_CONFIGURE_COMPARE)
+  @Consumes(MediaType.MULTIPART_FORM_DATA)
+  @Produces(MediaType.APPLICATION_JSON)
+  public JSONArray configureCompare(
+      @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
+      @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
+      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
+      @FormDataParam(CoordConsts.SVC_KEY_FILE) InputStream addQuestionsStream,
+      @FormDataParam(CoordConsts.SVC_KEY_DEL_ANALYSIS_QUESTIONS) String delQuestions) {
+    try {
+      _logger.info(
+          "WMS:configureCompare " + apiKey + " " + containerName + " " + delQuestions + "\n");
+
+      checkStringParam(apiKey, "API key");
+      checkStringParam(clientVersion, "Client version");
+      checkStringParam(containerName, "Container name");
+
+      checkApiKeyValidity(apiKey);
+      checkClientVersion(clientVersion);
+      checkContainerAccessibility(apiKey, containerName);
+
+      Map<String, String> questionsToAdd = new HashMap<>();
+      if (addQuestionsStream != null) {
+        BatfishObjectMapper mapper = new BatfishObjectMapper();
+        Map<String, Object> streamValue;
+        try {
+          streamValue =
+              mapper.readValue(addQuestionsStream, new TypeReference<Map<String, Object>>() {});
+          for (Entry<String, Object> entry : streamValue.entrySet()) {
+            String textValue = mapper.writeValueAsString(entry.getValue());
+            questionsToAdd.put(entry.getKey(), textValue);
+          }
+        } catch (IOException e) {
+          throw new BatfishException("Failed to read question JSON from input stream", e);
+        }
+      }
+      List<String> questionsToDelete = new ArrayList<>();
+      if (!Strings.isNullOrEmpty(delQuestions)) {
+        JSONArray delQuestionsArray = new JSONArray(delQuestions);
+        for (int i = 0; i < delQuestionsArray.length(); i++) {
+          questionsToDelete.add(delQuestionsArray.getString(i));
+        }
+      }
+
+      Main.getWorkMgr().configureCompare(containerName, questionsToAdd, questionsToDelete);
+
+      return successResponse(new JSONObject().put("result", "successfully configured compare"));
+
+    } catch (FileExistsException
+        | FileNotFoundException
+        | IllegalArgumentException
+        | AccessControlException
+        | ZipException e) {
+      _logger.error("WMS:configureCompare exception: " + e.getMessage() + "\n");
+      return failureResponse(e.getMessage());
+    } catch (Exception e) {
+      String stackTrace = ExceptionUtils.getFullStackTrace(e);
+      _logger.error("WMS:configureCompare exception: " + stackTrace);
+      return failureResponse(e.getMessage());
+    }
+  }
+
+  /**
+   * Configures new/deleted non-differential adhoc questions for the container
+   *
+   * @param apiKey The API key of the requester
+   * @param clientVersion The version of the client
+   * @param containerName The name of the container to configure
+   * @param addQuestionsStream A stream providing the new non-differential questions to add
+   * @param delQuestions A list of existing non-differential questions to delete
+   * @return TODO: document JSON response
+   */
+  @POST
+  @Path(CoordConsts.SVC_RSC_CONFIGURE_EXPLORE)
+  @Consumes(MediaType.MULTIPART_FORM_DATA)
+  @Produces(MediaType.APPLICATION_JSON)
+  public JSONArray configureExplore(
+      @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
+      @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
+      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
+      @FormDataParam(CoordConsts.SVC_KEY_FILE) InputStream addQuestionsStream,
+      @FormDataParam(CoordConsts.SVC_KEY_DEL_ANALYSIS_QUESTIONS) String delQuestions) {
+    try {
+      _logger.info(
+          "WMS:configureExplore " + apiKey + " " + containerName + " " + delQuestions + "\n");
+
+      checkStringParam(apiKey, "API key");
+      checkStringParam(clientVersion, "Client version");
+      checkStringParam(containerName, "Container name");
+
+      checkApiKeyValidity(apiKey);
+      checkClientVersion(clientVersion);
+      checkContainerAccessibility(apiKey, containerName);
+
+      Map<String, String> questionsToAdd = new HashMap<>();
+      if (addQuestionsStream != null) {
+        BatfishObjectMapper mapper = new BatfishObjectMapper();
+        Map<String, Object> streamValue;
+        try {
+          streamValue =
+              mapper.readValue(addQuestionsStream, new TypeReference<Map<String, Object>>() {});
+          for (Entry<String, Object> entry : streamValue.entrySet()) {
+            String textValue = mapper.writeValueAsString(entry.getValue());
+            questionsToAdd.put(entry.getKey(), textValue);
+          }
+        } catch (IOException e) {
+          throw new BatfishException("Failed to read question JSON from input stream", e);
+        }
+      }
+      List<String> questionsToDelete = new ArrayList<>();
+      if (!Strings.isNullOrEmpty(delQuestions)) {
+        JSONArray delQuestionsArray = new JSONArray(delQuestions);
+        for (int i = 0; i < delQuestionsArray.length(); i++) {
+          questionsToDelete.add(delQuestionsArray.getString(i));
+        }
+      }
+
+      Main.getWorkMgr().configureExplore(containerName, questionsToAdd, questionsToDelete);
+
+      return successResponse(new JSONObject().put("result", "successfully configured compare"));
+
+    } catch (FileExistsException
+        | FileNotFoundException
+        | IllegalArgumentException
+        | AccessControlException
+        | ZipException e) {
+      _logger.error("WMS:configureExplore exception: " + e.getMessage() + "\n");
+      return failureResponse(e.getMessage());
+    } catch (Exception e) {
+      String stackTrace = ExceptionUtils.getFullStackTrace(e);
+      _logger.error("WMS:configureExplore exception: " + stackTrace);
+      return failureResponse(e.getMessage());
+    }
+  }
+
+  /**
    * Delete an analysis from the container
    *
    * @param apiKey The API key of the requester


### PR DESCRIPTION
__Definitely should be reviewed commit by commit.__ Can separate each API call into its own PR if that's appropriate; currently they're separated by commit.

Goal: Reformulate adhoc questions as container-level rather than testrig-level.

Introduces API calls that work with container-level `explore` and `compare` directories. The container-level directories have container-wide adhoc questions (differential in `compare`, non-differential in `explore`), while each testrig folder contains its own `explore` and `compare` directories to hold those questions' answers, similar to the current setup for analyses. Example file structure inside container:
![image](https://user-images.githubusercontent.com/24902209/33055161-c39163a8-ce32-11e7-9828-aed1b06d538f.png)

In time we should move towards using only the new API calls for adhoc questions. For now all the old API calls are preserved. Batfish should not need to be changed again in order to start using the new ones.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/678)
<!-- Reviewable:end -->
