### PR TITLE
Connecting the Worker service runTask API to the trace of the client and the coordinator

### DIFF
--- a/projects/batfish-common-protocol/pom.xml
+++ b/projects/batfish-common-protocol/pom.xml
@@ -31,7 +31,8 @@
               <goals><goal>analyze-only</goal></goals>
               <configuration>
                 <ignoredUnusedDeclaredDependencies>
-                  commons-beanutils:commons-beanutils
+                  <ignoredUnusedDeclaredDependency>commons-beanutils:commons-beanutils</ignoredUnusedDeclaredDependency>
+                  <ignoredUnusedDeclaredDependency>org.slf4j:slf4j-jdk14</ignoredUnusedDeclaredDependency>
                 </ignoredUnusedDeclaredDependencies>
               </configuration>
             </execution>
@@ -138,6 +139,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.uber.jaeger</groupId>
+      <artifactId>jaeger-core</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
       <scope>runtime</scope>
@@ -165,7 +171,7 @@
 
     <dependency>
       <groupId>io.opentracing</groupId>
-      <artifactId>opentracing-noop</artifactId>
+      <artifactId>opentracing-util</artifactId>
     </dependency>
 
     <dependency>
@@ -211,6 +217,13 @@
     <dependency>
       <groupId>org.skyscreamer</groupId>
       <artifactId>jsonassert</artifactId>
+    </dependency>
+
+    <!-- Runtime dependencies to add logging. -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-jdk14</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- Test dependencies. -->

--- a/projects/batfish-common-protocol/pom.xml
+++ b/projects/batfish-common-protocol/pom.xml
@@ -139,11 +139,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.uber.jaeger</groupId>
-      <artifactId>jaeger-core</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
       <scope>runtime</scope>
@@ -167,6 +162,16 @@
     <dependency>
       <groupId>io.opentracing</groupId>
       <artifactId>opentracing-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-mock</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-noop</artifactId>
     </dependency>
 
     <dependency>
@@ -219,13 +224,6 @@
       <artifactId>jsonassert</artifactId>
     </dependency>
 
-    <!-- Runtime dependencies to add logging. -->
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-jdk14</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-
     <!-- Test dependencies. -->
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -248,6 +246,12 @@
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-jdk14</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/projects/batfish-common-protocol/pom.xml
+++ b/projects/batfish-common-protocol/pom.xml
@@ -159,6 +159,16 @@
     </dependency>
 
     <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-noop</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-configuration2</artifactId>
     </dependency>

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/WorkItem.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/WorkItem.java
@@ -2,6 +2,7 @@ package org.batfish.common;
 
 import io.opentracing.ActiveSpan;
 import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
 import io.opentracing.propagation.Format.Builtin;
 import io.opentracing.propagation.TextMapExtractAdapter;
 import io.opentracing.propagation.TextMapInjectAdapter;
@@ -100,7 +101,12 @@ public class WorkItem {
    */
   @Nullable
   public SpanContext getSourceSpan() {
-    return GlobalTracer.get().extract(Builtin.TEXT_MAP, new TextMapExtractAdapter(_spanData));
+    return getSourceSpan(GlobalTracer.get());
+  }
+
+  // visible for testing
+  SpanContext getSourceSpan(Tracer tracer) {
+    return tracer.extract(Builtin.TEXT_MAP, new TextMapExtractAdapter(_spanData));
   }
 
   public HashMap<String, String> getRequestParams() {
@@ -116,11 +122,15 @@ public class WorkItem {
    * using {@link WorkItem#getSourceSpan()}
    */
   public void setSourceSpan(@Nullable ActiveSpan activeSpan) {
+    setSourceSpan(activeSpan, GlobalTracer.get());
+  }
+
+  // visible for testing
+  void setSourceSpan(@Nullable ActiveSpan activeSpan, Tracer tracer) {
     if (activeSpan == null) {
       return;
     }
-    GlobalTracer.get()
-        .inject(activeSpan.context(), Builtin.TEXT_MAP, new TextMapInjectAdapter(_spanData));
+    tracer.inject(activeSpan.context(), Builtin.TEXT_MAP, new TextMapInjectAdapter(_spanData));
   }
 
   public void setId(String idString) {

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/WorkItemTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/WorkItemTest.java
@@ -1,0 +1,94 @@
+package org.batfish.common;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import com.uber.jaeger.Configuration;
+import com.uber.jaeger.Configuration.ReporterConfiguration;
+import com.uber.jaeger.Configuration.SamplerConfiguration;
+import com.uber.jaeger.samplers.ConstSampler;
+import io.opentracing.ActiveSpan;
+import io.opentracing.References;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.util.GlobalTracer;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/** Tests for {@link WorkItem}. */
+public class WorkItemTest {
+
+  private WorkItem _workItem;
+  private static Tracer _tracer;
+
+  @Before
+  public void initWorkItem() {
+    _workItem = new WorkItem("testContainer", "testTestrig");
+  }
+
+  @BeforeClass
+  public static void initTracer() {
+    _tracer =
+        new Configuration(
+                "work-item-test",
+                new SamplerConfiguration(ConstSampler.TYPE, 1),
+                new ReporterConfiguration(
+                    false,
+                    "localhost",
+                    14267,
+                    /* flush interval in ms */ 1000,
+                    /* max buffered Spans */ 10000))
+            .getTracer();
+  }
+
+  @Test
+  public void testExtractOnlyNoop() {
+    SpanContext sourceSpanContext = _workItem.getSourceSpan();
+    ActiveSpan childSpan =
+        GlobalTracer.get()
+            .buildSpan("test dangling child")
+            .addReference(References.FOLLOWS_FROM, sourceSpanContext)
+            .startActive();
+
+    assertNotNull(childSpan);
+  }
+
+  @Test
+  public void testInjectExtractNoop() {
+    ActiveSpan activeSpan = GlobalTracer.get().buildSpan("test span").startActive();
+    _workItem.setSourceSpan(activeSpan);
+    ActiveSpan childSpan =
+        GlobalTracer.get()
+            .buildSpan("test span")
+            .addReference(References.FOLLOWS_FROM, _workItem.getSourceSpan())
+            .startActive();
+
+    assertNotNull(childSpan);
+  }
+
+  @Test
+  public void testExtractOnly() {
+    GlobalTracer.register(_tracer);
+    SpanContext sourceSpanContext = _workItem.getSourceSpan();
+    ActiveSpan childSpan =
+        GlobalTracer.get()
+            .buildSpan("test dangling child")
+            .addReference(References.FOLLOWS_FROM, sourceSpanContext)
+            .startActive();
+
+    assertNotNull(childSpan);
+  }
+
+  @Test
+  public void testInjectExtract() {
+    GlobalTracer.register(_tracer);
+    ActiveSpan activeSpan = GlobalTracer.get().buildSpan("test span").startActive();
+    _workItem.setSourceSpan(activeSpan);
+    SpanContext sourceSpan = _workItem.getSourceSpan();
+
+    // test that injected and extracted spans have same span context, (traceId, spanId, parentId,
+    // flags)
+    assertEquals(activeSpan.context().toString(), sourceSpan.toString());
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/WorkItemTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/WorkItemTest.java
@@ -1,17 +1,22 @@
 package org.batfish.common;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
 
-import com.uber.jaeger.Configuration;
-import com.uber.jaeger.Configuration.ReporterConfiguration;
-import com.uber.jaeger.Configuration.SamplerConfiguration;
-import com.uber.jaeger.samplers.ConstSampler;
 import io.opentracing.ActiveSpan;
+import io.opentracing.NoopActiveSpanSource.NoopActiveSpan;
+import io.opentracing.NoopTracerFactory;
 import io.opentracing.References;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
-import io.opentracing.util.GlobalTracer;
+import io.opentracing.mock.MockSpan.MockContext;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.mock.MockTracer.Propagator;
+import io.opentracing.util.ThreadLocalActiveSpan;
+import io.opentracing.util.ThreadLocalActiveSpanSource;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -20,7 +25,8 @@ import org.junit.Test;
 public class WorkItemTest {
 
   private WorkItem _workItem;
-  private static Tracer _tracer;
+  private static Tracer _mockTracer;
+  private static Tracer _noopTracer;
 
   @Before
   public void initWorkItem() {
@@ -29,66 +35,111 @@ public class WorkItemTest {
 
   @BeforeClass
   public static void initTracer() {
-    _tracer =
-        new Configuration(
-                "work-item-test",
-                new SamplerConfiguration(ConstSampler.TYPE, 1),
-                new ReporterConfiguration(
-                    false,
-                    "localhost",
-                    14267,
-                    /* flush interval in ms */ 1000,
-                    /* max buffered Spans */ 10000))
-            .getTracer();
+    _mockTracer = new MockTracer(new ThreadLocalActiveSpanSource(), Propagator.TEXT_MAP);
+    _noopTracer = NoopTracerFactory.create();
+  }
+
+  @Test
+  public void testNullActiveSpanNoop() {
+    _workItem.setSourceSpan(null, _noopTracer);
+    SpanContext sourceSpanContext = _workItem.getSourceSpan(_noopTracer);
+
+    try (ActiveSpan childSpan =
+        _noopTracer
+            .buildSpan("test dangling child")
+            .addReference(References.FOLLOWS_FROM, sourceSpanContext)
+            .startActive()) {
+
+      assertThat(childSpan, notNullValue());
+      assertThat(childSpan, instanceOf(NoopActiveSpan.class));
+    }
   }
 
   @Test
   public void testExtractOnlyNoop() {
-    SpanContext sourceSpanContext = _workItem.getSourceSpan();
-    ActiveSpan childSpan =
-        GlobalTracer.get()
+    SpanContext sourceSpanContext = _workItem.getSourceSpan(_noopTracer);
+
+    try (ActiveSpan childSpan =
+        _noopTracer
             .buildSpan("test dangling child")
             .addReference(References.FOLLOWS_FROM, sourceSpanContext)
-            .startActive();
+            .startActive()) {
 
-    assertNotNull(childSpan);
+      assertThat(childSpan, notNullValue());
+      assertThat(childSpan, instanceOf(NoopActiveSpan.class));
+    }
   }
 
   @Test
   public void testInjectExtractNoop() {
-    ActiveSpan activeSpan = GlobalTracer.get().buildSpan("test span").startActive();
-    _workItem.setSourceSpan(activeSpan);
-    ActiveSpan childSpan =
-        GlobalTracer.get()
-            .buildSpan("test span")
-            .addReference(References.FOLLOWS_FROM, _workItem.getSourceSpan())
-            .startActive();
+    ActiveSpan activeSpan = _noopTracer.buildSpan("test span").startActive();
+    _workItem.setSourceSpan(activeSpan, _noopTracer);
 
-    assertNotNull(childSpan);
+    try (ActiveSpan childSpan =
+        _noopTracer
+            .buildSpan("test span")
+            .addReference(References.FOLLOWS_FROM, _workItem.getSourceSpan(_noopTracer))
+            .startActive()) {
+
+      assertThat(childSpan, notNullValue());
+      assertThat(childSpan, instanceOf(NoopActiveSpan.class));
+    }
+  }
+
+  @Test
+  public void testNullActiveSpan() {
+    _workItem.setSourceSpan(null, _mockTracer);
+    SpanContext sourceSpanContext = _workItem.getSourceSpan(_mockTracer);
+
+    assertThat(sourceSpanContext, nullValue());
+
+    try (ActiveSpan childSpan =
+        _mockTracer
+            .buildSpan("test dangling child")
+            .addReference(References.FOLLOWS_FROM, sourceSpanContext)
+            .startActive()) {
+
+      assertThat(childSpan, notNullValue());
+      assertThat(childSpan, instanceOf(ThreadLocalActiveSpan.class));
+    }
   }
 
   @Test
   public void testExtractOnly() {
-    GlobalTracer.register(_tracer);
-    SpanContext sourceSpanContext = _workItem.getSourceSpan();
-    ActiveSpan childSpan =
-        GlobalTracer.get()
+    SpanContext sourceSpanContext = _workItem.getSourceSpan(_mockTracer);
+
+    assertThat(sourceSpanContext, nullValue());
+
+    try (ActiveSpan childSpan =
+        _mockTracer
             .buildSpan("test dangling child")
             .addReference(References.FOLLOWS_FROM, sourceSpanContext)
-            .startActive();
+            .startActive()) {
 
-    assertNotNull(childSpan);
+      assertThat(childSpan, notNullValue());
+      assertThat(childSpan, instanceOf(ThreadLocalActiveSpan.class));
+    }
   }
 
   @Test
   public void testInjectExtract() {
-    GlobalTracer.register(_tracer);
-    ActiveSpan activeSpan = GlobalTracer.get().buildSpan("test span").startActive();
-    _workItem.setSourceSpan(activeSpan);
-    SpanContext sourceSpan = _workItem.getSourceSpan();
+    MockContext sourceContext;
 
-    // test that injected and extracted spans have same span context, (traceId, spanId, parentId,
-    // flags)
-    assertEquals(activeSpan.context().toString(), sourceSpan.toString());
+    try (ActiveSpan activeSpan = _mockTracer.buildSpan("test span").startActive()) {
+      SpanContext sourceContextTmp = activeSpan.context();
+      assertThat(sourceContextTmp, instanceOf(MockContext.class));
+      sourceContext = (MockContext) sourceContextTmp;
+
+      _workItem.setSourceSpan(activeSpan, _mockTracer);
+    }
+
+    SpanContext extractedContextTmp = _workItem.getSourceSpan(_mockTracer);
+    assertThat(extractedContextTmp, notNullValue());
+    assertThat(extractedContextTmp, instanceOf(MockContext.class));
+    MockContext extractedContext = (MockContext) extractedContextTmp;
+
+    // test that injected and extracted spans have same span context data
+    assertThat(extractedContext.traceId(), equalTo(sourceContext.traceId()));
+    assertThat(extractedContext.spanId(), equalTo(sourceContext.spanId()));
   }
 }

--- a/projects/batfish/pom.xml
+++ b/projects/batfish/pom.xml
@@ -190,12 +190,7 @@
       <groupId>io.opentracing</groupId>
       <artifactId>opentracing-api</artifactId>
     </dependency>
-
-    <dependency>
-      <groupId>io.opentracing</groupId>
-      <artifactId>opentracing-noop</artifactId>
-    </dependency>
-
+    
     <dependency>
       <groupId>io.opentracing</groupId>
       <artifactId>opentracing-util</artifactId>

--- a/projects/batfish/pom.xml
+++ b/projects/batfish/pom.xml
@@ -188,6 +188,16 @@
 
     <dependency>
       <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-noop</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.opentracing</groupId>
       <artifactId>opentracing-util</artifactId>
     </dependency>
 

--- a/projects/batfish/src/main/java/org/batfish/main/Driver.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Driver.java
@@ -467,7 +467,7 @@ public class Driver {
                   try (ActiveSpan runBatfishSpan =
                       GlobalTracer.get()
                           .buildSpan("Run Batfish Service")
-                          .asChildOf(runTaskSpanContext)
+                          .addReference("follows_from", runTaskSpanContext)
                           .startActive()) {
                     assert runBatfishSpan != null; // avoid unused warning
                     task.setStatus(TaskStatus.InProgress);

--- a/projects/coordinator/pom.xml
+++ b/projects/coordinator/pom.xml
@@ -107,6 +107,11 @@
 
     <dependency>
       <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.opentracing</groupId>
       <artifactId>opentracing-util</artifactId>
     </dependency>
 

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -2,6 +2,7 @@ package org.batfish.coordinator;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.opentracing.ActiveSpan;
+import io.opentracing.References;
 import io.opentracing.SpanContext;
 import io.opentracing.contrib.jaxrs2.client.ClientTracingFeature;
 import io.opentracing.util.GlobalTracer;
@@ -135,11 +136,11 @@ public class WorkMgr extends AbstractCoordinator {
     boolean assigned = false;
 
     Client client = null;
-    SpanContext queueWorkSpan = work.getWorkItem().getSourceSpan(GlobalTracer.get());
+    SpanContext queueWorkSpan = work.getWorkItem().getSourceSpan();
     try (ActiveSpan assignWorkSpan =
         GlobalTracer.get()
             .buildSpan("Assign Work")
-            .addReference("follows_from", queueWorkSpan)
+            .addReference(References.FOLLOWS_FROM, queueWorkSpan)
             .startActive()) {
       assert assignWorkSpan != null; // avoid unused warning
       // get the task and add other standard stuff
@@ -1015,7 +1016,7 @@ public class WorkMgr extends AbstractCoordinator {
     }
     boolean success;
     try {
-      workItem.setSourceSpan(GlobalTracer.get(), GlobalTracer.isRegistered());
+      workItem.setSourceSpan(GlobalTracer.get().activeSpan());
       success = _workQueueMgr.queueUnassignedWork(new QueuedWork(workItem));
     } catch (Exception e) {
       throw new BatfishException("Failed to queue work", e);

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -137,8 +137,11 @@ public class WorkMgr extends AbstractCoordinator {
     Client client = null;
     SpanContext queueWorkSpan = work.getWorkItem().getSourceSpan(GlobalTracer.get());
     try (ActiveSpan assignWorkSpan =
-        GlobalTracer.get().buildSpan("Assign Work").asChildOf(queueWorkSpan).startActive()) {
-      assert assignWorkSpan != null;
+        GlobalTracer.get()
+            .buildSpan("Assign Work")
+            .addReference("follows_from", queueWorkSpan)
+            .startActive()) {
+      assert assignWorkSpan != null; // avoid unused warning
       // get the task and add other standard stuff
       JSONObject task = work.getWorkItem().toTask();
       Path containerDir =

--- a/projects/pom.xml
+++ b/projects/pom.xml
@@ -582,6 +582,12 @@
 
       <dependency>
         <groupId>io.opentracing</groupId>
+        <artifactId>opentracing-noop</artifactId>
+        <version>${opentracing.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.opentracing</groupId>
         <artifactId>opentracing-util</artifactId>
         <version>${opentracing.version}</version>
       </dependency>

--- a/projects/pom.xml
+++ b/projects/pom.xml
@@ -582,6 +582,12 @@
 
       <dependency>
         <groupId>io.opentracing</groupId>
+        <artifactId>opentracing-mock</artifactId>
+        <version>${opentracing.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.opentracing</groupId>
         <artifactId>opentracing-noop</artifactId>
         <version>${opentracing.version}</version>
       </dependency>


### PR DESCRIPTION
1.) Updating workItem to pass on the spancontext between different threads
2.) Currently using a child_of relationships for all spawned threads, other alternative is follows_from

<img width="1657" alt="screen shot 2017-11-22 at 10 00 37 am" src="https://user-images.githubusercontent.com/15151202/33143737-a661bbb4-cf6f-11e7-9b6c-f33c1e9f7ec8.png">
<img width="1680" alt="screen shot 2017-11-22 at 10 04 33 am" src="https://user-images.githubusercontent.com/15151202/33143738-a674f0c6-cf6f-11e7-8da3-cf4a94a393c6.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/683)
<!-- Reviewable:end -->
