### PR TITLE
pom.xml: add fast profile and use it everywhere but batfish_test_all

### DIFF
--- a/projects/pom.xml
+++ b/projects/pom.xml
@@ -74,6 +74,23 @@
     <xstream.version>1.4.7</xstream.version>
   </properties>
 
+
+  <profiles>
+    <profile>
+      <id>fast</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <cpd.skip>true</cpd.skip>
+        <checkstyle.skip>true</checkstyle.skip>
+        <findbugs.skip>true</findbugs.skip>
+        <pmd.skip>true</pmd.skip>
+        <skipTests>true</skipTests>
+      </properties>
+    </profile>
+  </profiles>
+
   <build>
     <pluginManagement>
       <plugins>

--- a/tools/common.sh
+++ b/tools/common.sh
@@ -69,7 +69,7 @@ export -f batfish_build
 
 _batfish_build() {
    _pre_build || return 1
-   mvn install -DskipTests -pl batfish -am || return 1
+   mvn install -pl batfish -am || return 1
    if [ "$BATFISH_COMPLETION_FILE" -ot "$BATFISH_PATH/target/batfish-${BATFISH_VERSION}.jar" -a -e "$BATFISH_PATH/target/batfish-${BATFISH_VERSION}.jar" ]; then
       echo -n "Generating bash completion file (after batfish_build) ..."
       BATFISH_PRINT_CMDLINE=no batfish -help | grep -o '^ *-[a-zA-Z0-9]*' | tr -d ' ' | tr '\n' ' ' > "$BATFISH_COMPLETION_FILE"
@@ -108,7 +108,7 @@ export -f batfish_build_all
 _batfish_build_all() {
    _pre_build || return 1
    cd "${PROJECTS_PATH}"
-   mvn install -DskipTests || return 1
+   mvn install || return 1
 }
 export -f _batfish_build_all
 
@@ -132,7 +132,7 @@ export -f batfish_test_all
 _batfish_test_all() {
    _pre_build || return 1
    cd "${PROJECTS_PATH}"
-   mvn clean install || return 1
+   mvn clean install -P '!fast' || return 1
 }
 export -f _batfish_test_all
 
@@ -353,7 +353,7 @@ allinone_build() {
 
 _allinone_build() {
    _pre_build || return 1
-   mvn install -DskipTests -pl allinone -am || return 1
+   mvn install -pl allinone -am || return 1
    if [ "$ALLINONE_COMPLETION_FILE" -ot "$ALLINONE_PATH/target/allinone-${BATFISH_VERSION}.jar" -a -e "$ALLINONE_PATH/target/allinone-${BATFISH_VERSION}.jar" ]; then
       echo -n "Generating bash completion file for allinone (via allinone_build) ..."
       BATFISH_PRINT_CMDLINE=no allinone -help | grep -o '^ *-[a-zA-Z0-9]*' | tr -d ' ' | tr '\n' ' ' > "$ALLINONE_COMPLETION_FILE"
@@ -370,7 +370,7 @@ export -f coordinator_build
 
 _coordinator_build() {
    _pre_build || return 1
-   mvn install -DskipTests -pl coordinator -am || return 1
+   mvn install -pl coordinator -am || return 1
    if [ "$COORDINATOR_COMPLETION_FILE" -ot "$COORDINATOR_PATH/target/coordinator-${BATFISH_VERSION}.jar" -a -e "$COORDINATOR_PATH/target/coordinator-${BATFISH_VERSION}.jar" ]; then
       echo -n "Generating bash completion file for coordinator (via coordinator_build) ..."
       BATFISH_PRINT_CMDLINE=no coordinator -help | grep -o '^ *-[a-zA-Z0-9]*' | tr -d ' ' | tr '\n' ' ' > "$COORDINATOR_COMPLETION_FILE"
@@ -386,7 +386,7 @@ export -f common_build
 
 _common_build() {
    _pre_build || return 1
-   mvn install -DskipTests -pl batfish-common-protocol -am || return 1
+   mvn install -pl batfish-common-protocol -am || return 1
 }
 export -f _common_build
 


### PR DESCRIPTION
* Adds a Maven profile called 'fast' that disables checkstyle, findbugs,
  PMD, CPD, and tests and which is enabled by default.

  It can be disabled by using '-P !fast'.

* This profile is automatically activated unless the user explicitly
  opts out. This was requested by the team.

* Make sure that Travis and related still execute the full tests by
  ensuring that the fast profile is disabled in `batfish_test_all`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/686)
<!-- Reviewable:end -->
