### PR TITLE
Alter where API stores/finds adhoc questions and answers

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
@@ -118,6 +118,7 @@ public class BfConsts {
   public static final String RELPATH_ANSWER_HTML = "answer.html";
   public static final String RELPATH_ANSWER_JSON = "answer.json";
   public static final String RELPATH_ANSWER_PRETTY_JSON = "answer-pretty.json";
+  public static final String RELPATH_ANSWERS_DIR = "answers";
   public static final String RELPATH_AWS_VPC_CONFIGS_DIR = "aws_configs";
   public static final String RELPATH_AWS_VPC_CONFIGS_FILE = "aws_configs";
   public static final String RELPATH_CONFIG_FILE_NAME_ALLINONE = "allinone.properties";
@@ -130,7 +131,7 @@ public class BfConsts {
   public static final String RELPATH_DATA_PLANE_ANSWER_PATH = "dp_answer";
   public static final String RELPATH_DEFAULT_ENVIRONMENT_NAME = "env_default";
   public static final String RELPATH_DELTA = "delta";
-  public static final String RELPATH_DIFF = "diff";
+  public static final String RELPATH_DIFF_DIR = "differential";
   public static final String RELPATH_EDGE_BLACKLIST_FILE = "edge_blacklist";
   public static final String RELPATH_ENV_DIR = "env";
   public static final String RELPATH_ENV_NODE_SET = "env-node-set";
@@ -157,6 +158,7 @@ public class BfConsts {
   public static final String RELPATH_QUESTIONS_DIR = "questions";
   public static final String RELPATH_SERIALIZED_ENVIRONMENT_BGP_TABLES = "bgp_processed";
   public static final String RELPATH_SERIALIZED_ENVIRONMENT_ROUTING_TABLES = "rt_processed";
+  public static final String RELPATH_STANDARD_DIR = "standard";
   public static final String RELPATH_SYNC_TESTRIGS_DIR = "testrig_sync";
   public static final String RELPATH_TEST_RIG_DIR = "testrig";
   public static final String RELPATH_TESTRIG_TOPOLOGY_PATH = "testrig_topology";

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -315,9 +315,10 @@ public class Batfish extends PluginConsumer implements IBatfish {
 
   public static void initQuestionSettings(Settings settings) {
     String questionName = settings.getQuestionName();
-    Path testrigDir = settings.getActiveTestrigSettings().getBasePath();
+    Path containerDir = settings.getContainerDir();
     if (questionName != null) {
-      Path questionPath = testrigDir.resolve(BfConsts.RELPATH_QUESTIONS_DIR).resolve(questionName);
+      Path questionPath =
+          containerDir.resolve(BfConsts.RELPATH_QUESTIONS_DIR).resolve(questionName);
       settings.setQuestionPath(questionPath.resolve(BfConsts.RELPATH_QUESTION_FILE));
     }
   }
@@ -4443,32 +4444,26 @@ public class Batfish extends PluginConsumer implements IBatfish {
   }
 
   private void writeJsonAnswer(String structuredAnswerString, String prettyAnswerString) {
-    Path questionPath = _settings.getQuestionPath();
-    if (questionPath != null) {
-      Path questionDir = questionPath.getParent();
-      if (!Files.exists(questionDir)) {
-        throw new BatfishException(
-            "Could not write JSON answer to question dir '"
-                + questionDir
-                + "' because it does not exist");
-      }
-      boolean diff = _settings.getDiffQuestion();
-      String baseEnvName = _testrigSettings.getEnvironmentSettings().getName();
-      Path answerDir =
-          questionDir.resolve(Paths.get(BfConsts.RELPATH_ENVIRONMENTS_DIR, baseEnvName).toString());
-      if (diff) {
-        String deltaTestrigName = _deltaTestrigSettings.getName();
-        String deltaEnvName = _deltaTestrigSettings.getEnvironmentSettings().getName();
-        answerDir =
-            answerDir.resolve(
-                Paths.get(BfConsts.RELPATH_DELTA, deltaTestrigName, deltaEnvName).toString());
-      }
-      Path structuredAnswerPath = answerDir.resolve(BfConsts.RELPATH_ANSWER_JSON);
-      Path prettyAnswerPath = answerDir.resolve(BfConsts.RELPATH_ANSWER_PRETTY_JSON);
-      answerDir.toFile().mkdirs();
-      CommonUtil.writeFile(structuredAnswerPath, structuredAnswerString);
-      CommonUtil.writeFile(prettyAnswerPath, prettyAnswerString);
+    boolean diff = _settings.getDiffQuestion();
+    String baseEnvName = _testrigSettings.getEnvironmentSettings().getName();
+    Path testrigDir = _testrigSettings.getBasePath();
+    Path answerDir =
+        testrigDir.resolve(
+            Paths.get(BfConsts.RELPATH_ANSWERS_DIR, _settings.getQuestionName(), baseEnvName));
+    if (diff) {
+      String deltaTestrigName = _deltaTestrigSettings.getName();
+      String deltaEnvName = _deltaTestrigSettings.getEnvironmentSettings().getName();
+      answerDir =
+          answerDir.resolve(Paths.get(BfConsts.RELPATH_DIFF_DIR, deltaTestrigName, deltaEnvName));
+    } else {
+      answerDir = answerDir.resolve(Paths.get(BfConsts.RELPATH_STANDARD_DIR));
     }
+    System.out.println(answerDir);
+    Path structuredAnswerPath = answerDir.resolve(BfConsts.RELPATH_ANSWER_JSON);
+    Path prettyAnswerPath = answerDir.resolve(BfConsts.RELPATH_ANSWER_PRETTY_JSON);
+    answerDir.toFile().mkdirs();
+    CommonUtil.writeFile(structuredAnswerPath, structuredAnswerString);
+    CommonUtil.writeFile(prettyAnswerPath, prettyAnswerString);
   }
 
   private void writeJsonAnswerWithLog(
@@ -4477,32 +4472,25 @@ public class Batfish extends PluginConsumer implements IBatfish {
     if (jsonPath != null) {
       CommonUtil.writeFile(jsonPath, answerString);
     }
-    Path questionPath = _settings.getQuestionPath();
-    if (questionPath != null) {
-      Path questionDir = questionPath.getParent();
-      if (!Files.exists(questionDir)) {
-        throw new BatfishException(
-            "Could not write JSON answer to question dir '"
-                + questionDir
-                + "' because it does not exist");
-      }
-      boolean diff = _settings.getDiffQuestion();
-      String baseEnvName = _testrigSettings.getEnvironmentSettings().getName();
-      Path answerDir =
-          questionDir.resolve(Paths.get(BfConsts.RELPATH_ENVIRONMENTS_DIR, baseEnvName).toString());
-      if (diff) {
-        String deltaTestrigName = _deltaTestrigSettings.getName();
-        String deltaEnvName = _deltaTestrigSettings.getEnvironmentSettings().getName();
-        answerDir =
-            answerDir.resolve(
-                Paths.get(BfConsts.RELPATH_DELTA, deltaTestrigName, deltaEnvName).toString());
-      }
-      Path structuredAnswerPath = answerDir.resolve(BfConsts.RELPATH_ANSWER_JSON);
-      Path prettyAnswerPath = answerDir.resolve(BfConsts.RELPATH_ANSWER_PRETTY_JSON);
-      answerDir.toFile().mkdirs();
-      CommonUtil.writeFile(structuredAnswerPath, structuredAnswerString);
-      CommonUtil.writeFile(prettyAnswerPath, prettyAnswerString);
+    boolean diff = _settings.getDiffQuestion();
+    String baseEnvName = _testrigSettings.getEnvironmentSettings().getName();
+    Path testrigDir = _testrigSettings.getBasePath();
+    Path answerDir =
+        testrigDir.resolve(
+            Paths.get(BfConsts.RELPATH_ANSWERS_DIR, _settings.getQuestionName(), baseEnvName));
+    if (diff) {
+      String deltaTestrigName = _deltaTestrigSettings.getName();
+      String deltaEnvName = _deltaTestrigSettings.getEnvironmentSettings().getName();
+      answerDir =
+          answerDir.resolve(Paths.get(BfConsts.RELPATH_DIFF_DIR, deltaTestrigName, deltaEnvName));
+    } else {
+      answerDir = answerDir.resolve(Paths.get(BfConsts.RELPATH_STANDARD_DIR));
     }
+    Path structuredAnswerPath = answerDir.resolve(BfConsts.RELPATH_ANSWER_JSON);
+    Path prettyAnswerPath = answerDir.resolve(BfConsts.RELPATH_ANSWER_PRETTY_JSON);
+    answerDir.toFile().mkdirs();
+    CommonUtil.writeFile(structuredAnswerPath, structuredAnswerString);
+    CommonUtil.writeFile(prettyAnswerPath, prettyAnswerString);
   }
 
   private void writeJsonTopology() {

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -4465,8 +4465,8 @@ public class Batfish extends PluginConsumer implements IBatfish {
       } else {
         answerDir = answerDir.resolve(Paths.get(BfConsts.RELPATH_STANDARD_DIR));
       }
-    } else if (_settings.getAnalysisName() != null) {
-      // If settings has an analysis name, we're answering an analysis question
+    } else if (_settings.getAnalysisName() != null && _settings.getQuestionPath() != null) {
+      // If settings has an analysis name and question path, we're answering an analysis question
       Path questionDir = _settings.getQuestionPath().getParent();
       answerDir = questionDir.resolve(Paths.get(BfConsts.RELPATH_ENVIRONMENTS_DIR, baseEnvName));
       if (diff) {

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
@@ -341,7 +341,7 @@ public class WorkMgrService {
   }
 
   /**
-   * Delete the specified question under the specified container, testrig
+   * Delete the specified question under the specified container
    *
    * @param apiKey The API key of the requester
    * @param clientVersion The version of the client
@@ -365,14 +365,13 @@ public class WorkMgrService {
       checkStringParam(apiKey, "API key");
       checkStringParam(clientVersion, "Client version");
       checkStringParam(containerName, "Container name");
-      checkStringParam(testrigName, "Testrig name");
       checkStringParam(questionName, "Question name");
 
       checkApiKeyValidity(apiKey);
       checkClientVersion(clientVersion);
       checkContainerAccessibility(apiKey, containerName);
 
-      Main.getWorkMgr().delTestrigQuestion(containerName, testrigName, questionName);
+      Main.getWorkMgr().delQuestion(containerName, questionName);
 
       return successResponse(new JSONObject().put("result", "true"));
 
@@ -1109,18 +1108,17 @@ public class WorkMgrService {
   @POST
   @Path(CoordConsts.SVC_RSC_LIST_QUESTIONS)
   @Produces(MediaType.APPLICATION_JSON)
-  public JSONArray listTestrigQuestions(
+  public JSONArray listQuestions(
       @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
       @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
       @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String testrigName) {
     try {
-      _logger.info("WMS:listTestrigQuestions " + apiKey + " " + containerName + "\n");
+      _logger.info("WMS:listQuestions " + apiKey + " " + containerName + "\n");
 
       checkStringParam(apiKey, "API key");
       checkStringParam(clientVersion, "Client version");
       checkStringParam(containerName, "Container name");
-      checkStringParam(testrigName, "Testrig name");
 
       checkApiKeyValidity(apiKey);
       checkClientVersion(clientVersion);
@@ -1128,9 +1126,8 @@ public class WorkMgrService {
 
       JSONObject retObject = new JSONObject();
 
-      for (String questionName : Main.getWorkMgr().listQuestions(containerName, testrigName)) {
-        String questionText =
-            Main.getWorkMgr().getTestrigQuestion(containerName, testrigName, questionName);
+      for (String questionName : Main.getWorkMgr().listQuestions(containerName)) {
+        String questionText = Main.getWorkMgr().getQuestion(containerName, questionName);
 
         retObject.put(questionName, new JSONObject(questionText));
       }
@@ -1140,11 +1137,11 @@ public class WorkMgrService {
         | FileNotFoundException
         | IllegalArgumentException
         | AccessControlException e) {
-      _logger.error("WMS:listTestrigQuestions exception: " + e.getMessage() + "\n");
+      _logger.error("WMS:listQuestions exception: " + e.getMessage() + "\n");
       return failureResponse(e.getMessage());
     } catch (Exception e) {
       String stackTrace = ExceptionUtils.getFullStackTrace(e);
-      _logger.error("WMS:listTestrigQuestions exception: " + stackTrace);
+      _logger.error("WMS:listQuestions exception: " + stackTrace);
       return failureResponse(e.getMessage());
     }
   }
@@ -1539,15 +1536,13 @@ public class WorkMgrService {
       checkStringParam(apiKey, "API key");
       checkStringParam(clientVersion, "Client version");
       checkStringParam(containerName, "Container name");
-      checkStringParam(testrigName, "Testrig name");
       checkStringParam(qName, "Question name");
 
       checkApiKeyValidity(apiKey);
       checkClientVersion(clientVersion);
       checkContainerAccessibility(apiKey, containerName);
 
-      Main.getWorkMgr()
-          .uploadQuestion(containerName, testrigName, qName, fileStream, paramFileStream);
+      Main.getWorkMgr().uploadQuestion(containerName, qName, fileStream, paramFileStream);
 
       return successResponse(new JSONObject().put("result", "successfully uploaded question"));
 

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
@@ -347,7 +347,6 @@ public class WorkMgrService {
    * @param clientVersion The version of the client
    * @param containerName The name of the container in which the question resides
    * @param questionName The name of the question to delete
-   * @param testrigName The name of the testrig for which the question was asked
    * @return TODO: document JSON response
    */
   @POST
@@ -357,8 +356,7 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
       @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
-      @FormDataParam(CoordConsts.SVC_KEY_QUESTION_NAME) String questionName,
-      @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String testrigName) {
+      @FormDataParam(CoordConsts.SVC_KEY_QUESTION_NAME) String questionName) {
     try {
       _logger.info("WMS:delQuestion " + containerName + "\n");
 
@@ -1102,7 +1100,6 @@ public class WorkMgrService {
    * @param apiKey The API key of the client
    * @param clientVersion The version of the client
    * @param containerName The name of the container in which the testrig and questions reside
-   * @param testrigName The name of the testrig, the questions on which are to be listed
    * @return TODO: document JSON response
    */
   @POST
@@ -1111,8 +1108,7 @@ public class WorkMgrService {
   public JSONArray listQuestions(
       @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
-      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
-      @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String testrigName) {
+      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName) {
     try {
       _logger.info("WMS:listQuestions " + apiKey + " " + containerName + "\n");
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
@@ -83,7 +83,7 @@ public class WorkMgrTest {
         Main.getSettings().getContainersLocation().resolve("container").toAbsolutePath();
     Path testrigPath = containerDir.resolve(BfConsts.RELPATH_TESTRIGS_DIR).resolve("testrig");
     assertThat(testrigPath.toFile().mkdirs(), is(true));
-    SortedSet<String> questions = _manager.listQuestions("container", "testrig");
+    SortedSet<String> questions = _manager.listQuestions("container");
     assertThat(questions.isEmpty(), is(true));
   }
 
@@ -96,7 +96,7 @@ public class WorkMgrTest {
     assertThat(testrigPath.toFile().mkdirs(), is(true));
     Path questionsDir = testrigPath.resolve(BfConsts.RELPATH_QUESTIONS_DIR);
     assertThat(questionsDir.resolve("initinfo").toFile().mkdirs(), is(true));
-    SortedSet<String> questions = _manager.listQuestions("container", "testrig");
+    SortedSet<String> questions = _manager.listQuestions("container");
     assertThat(questions.size(), is(1));
     assertThat(questions.first(), equalTo("initinfo"));
   }
@@ -105,7 +105,7 @@ public class WorkMgrTest {
   public void listQuestionWithNonExistContainer() {
     _thrown.expect(BatfishException.class);
     _thrown.expectMessage(equalTo("Container 'container' does not exist"));
-    _manager.listQuestions("container", "testrig");
+    _manager.listQuestions("container");
   }
 
   @Test
@@ -113,7 +113,7 @@ public class WorkMgrTest {
     _manager.initContainer("container", null);
     _thrown.expect(BatfishException.class);
     _thrown.expectMessage(equalTo("Testrig 'testrig' does not exist"));
-    _manager.listQuestions("container", "testrig");
+    _manager.listQuestions("container");
   }
 
   @Test
@@ -127,7 +127,7 @@ public class WorkMgrTest {
     assertTrue(questionsDir.resolve("nodes").toFile().mkdirs());
     assertTrue(questionsDir.resolve("access").toFile().mkdirs());
     assertTrue(questionsDir.resolve("initinfo").toFile().mkdirs());
-    SortedSet<String> questions = _manager.listQuestions("container", "testrig");
+    SortedSet<String> questions = _manager.listQuestions("container");
     assertThat(questions.size(), is(3));
     assertThat(questions.toString(), equalTo("[access, initinfo, nodes]"));
   }

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
@@ -79,10 +79,6 @@ public class WorkMgrTest {
   @Test
   public void listEmptyQuestion() {
     _manager.initContainer("container", null);
-    Path containerDir =
-        Main.getSettings().getContainersLocation().resolve("container").toAbsolutePath();
-    Path testrigPath = containerDir.resolve(BfConsts.RELPATH_TESTRIGS_DIR).resolve("testrig");
-    assertThat(testrigPath.toFile().mkdirs(), is(true));
     SortedSet<String> questions = _manager.listQuestions("container");
     assertThat(questions.isEmpty(), is(true));
   }
@@ -92,9 +88,7 @@ public class WorkMgrTest {
     _manager.initContainer("container", null);
     Path containerDir =
         Main.getSettings().getContainersLocation().resolve("container").toAbsolutePath();
-    Path testrigPath = containerDir.resolve(BfConsts.RELPATH_TESTRIGS_DIR).resolve("testrig");
-    assertThat(testrigPath.toFile().mkdirs(), is(true));
-    Path questionsDir = testrigPath.resolve(BfConsts.RELPATH_QUESTIONS_DIR);
+    Path questionsDir = containerDir.resolve(BfConsts.RELPATH_QUESTIONS_DIR);
     assertThat(questionsDir.resolve("initinfo").toFile().mkdirs(), is(true));
     SortedSet<String> questions = _manager.listQuestions("container");
     assertThat(questions.size(), is(1));
@@ -109,21 +103,11 @@ public class WorkMgrTest {
   }
 
   @Test
-  public void listQuestionWithNonExistTestrig() {
-    _manager.initContainer("container", null);
-    _thrown.expect(BatfishException.class);
-    _thrown.expectMessage(equalTo("Testrig 'testrig' does not exist"));
-    _manager.listQuestions("container");
-  }
-
-  @Test
   public void listSortedQuestionNames() {
     _manager.initContainer("container", null);
     Path containerDir =
         Main.getSettings().getContainersLocation().resolve("container").toAbsolutePath();
-    Path testrigPath = containerDir.resolve(BfConsts.RELPATH_TESTRIGS_DIR).resolve("testrig");
-    assertThat(testrigPath.toFile().mkdirs(), is(true));
-    Path questionsDir = testrigPath.resolve(BfConsts.RELPATH_QUESTIONS_DIR);
+    Path questionsDir = containerDir.resolve(BfConsts.RELPATH_QUESTIONS_DIR);
     assertTrue(questionsDir.resolve("nodes").toFile().mkdirs());
     assertTrue(questionsDir.resolve("access").toFile().mkdirs());
     assertTrue(questionsDir.resolve("initinfo").toFile().mkdirs());


### PR DESCRIPTION
Improved alternative to #678. No new API calls, but the existing API calls have been modified to anticipate this storage setup:
```
myContainer
    |- analyses (contents unchanged)
    |- questions
        |- myAdhocQuestion
            |- question.json
    |- testrigs
        |- myTestrig
            |- answers
                |- myAdhocQuestion
                    |- myTestrigEnv
                        |- standard
                            |- answer.json
                        |- differential
                            |- myDeltaTestrig
                                |- myDeltaEnv
                                    |- answer.json
```
Testrig directories are no longer expected to contain a folder called `questions`, so old testrigs will lose track of their existing adhoc questions when this is merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/690)
<!-- Reviewable:end -->
