### PR TITLE
fix bgp neighbor builder behavior wrt owner and remote ip

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpNeighbor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpNeighbor.java
@@ -41,11 +41,8 @@ public final class BgpNeighbor extends ComparableStructure<Prefix> {
     @Override
     public BgpNeighbor build() {
       BgpNeighbor bgpNeighbor;
-      if (_owner != null && _peerIpAddress != null) {
-        bgpNeighbor = new BgpNeighbor(_peerIpAddress, _owner);
-      } else {
-        bgpNeighbor = new BgpNeighbor();
-      }
+      Ip peerIpAddress = _peerIpAddress != null ? _peerIpAddress : new Ip(generateLong());
+      bgpNeighbor = new BgpNeighbor(peerIpAddress, _owner);
       if (_localIp != null) {
         bgpNeighbor.setLocalIp(_localIp);
       }


### PR DESCRIPTION
- generate peer ip address if none specified
- don't use empty constructor (reserved for Jackson)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/709)
<!-- Reviewable:end -->
