### PR TITLE
Inline community set - bugfix and cleanup

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
@@ -639,7 +639,7 @@ public class CommonUtil {
   }
 
   public static <S extends Set<T>, T> S intersection(
-      Set<T> set1, Set<T> set2, Supplier<S> setConstructor) {
+      Set<T> set1, Collection<T> set2, Supplier<S> setConstructor) {
     S intersectionSet = setConstructor.get();
     intersectionSet.addAll(set1);
     intersectionSet.retainAll(set2);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/CommunitySetElem.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/CommunitySetElem.java
@@ -3,7 +3,6 @@ package org.batfish.datamodel.routing_policy.expr;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.io.Serializable;
 import org.batfish.common.BatfishException;
-import org.batfish.datamodel.routing_policy.Environment;
 
 public class CommunitySetElem implements Serializable {
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/CommunitySetElem.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/CommunitySetElem.java
@@ -29,7 +29,7 @@ public class CommunitySetElem implements Serializable {
     _suffix = new LiteralCommunitySetElemHalf(suffixInt);
   }
 
-  public long community(Environment environment) {
+  public long community() {
     if (_prefix instanceof LiteralCommunitySetElemHalf
         && _suffix instanceof LiteralCommunitySetElemHalf) {
       LiteralCommunitySetElemHalf prefix = (LiteralCommunitySetElemHalf) _prefix;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/CommunitySetExpr.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/CommunitySetExpr.java
@@ -2,6 +2,7 @@ package org.batfish.datamodel.routing_policy.expr;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.io.Serializable;
+import java.util.Collection;
 import java.util.SortedSet;
 import org.batfish.datamodel.routing_policy.Environment;
 
@@ -11,10 +12,17 @@ public abstract class CommunitySetExpr implements Serializable {
   /** */
   private static final long serialVersionUID = 1L;
 
-  public abstract SortedSet<Long> communities(Environment environment);
+  /** Returns the set of all communities that match this {@link CommunitySetExpr}. */
+  public abstract SortedSet<Long> allCommunities(Environment environment);
 
+  /** Returns the subset of the given communities that match this {@link CommunitySetExpr}. */
   public abstract SortedSet<Long> communities(
-      Environment environment, SortedSet<Long> communityCandidates);
+      Environment environment, Collection<Long> communityCandidates);
+
+  /** Return true iff this {@link CommunitySetExpr} matches any community in the given set. */
+  public final boolean matchSingleCommunity(Environment environment, Collection<Long> communities) {
+    return !this.communities(environment, communities).isEmpty();
+  }
 
   @Override
   public abstract boolean equals(Object obj);
@@ -22,7 +30,4 @@ public abstract class CommunitySetExpr implements Serializable {
   @Override
   public abstract int hashCode();
 
-  /** Return true iff this {@link CommunitySetExpr} matches any community in the given set. */
-  public abstract boolean matchSingleCommunity(
-      Environment environment, SortedSet<Long> communities);
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/CommunitySetExpr.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/CommunitySetExpr.java
@@ -29,5 +29,4 @@ public abstract class CommunitySetExpr implements Serializable {
 
   @Override
   public abstract int hashCode();
-
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/CommunitySetExpr.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/CommunitySetExpr.java
@@ -22,6 +22,7 @@ public abstract class CommunitySetExpr implements Serializable {
   @Override
   public abstract int hashCode();
 
+  /** Return true iff this {@link CommunitySetExpr} matches any community in the given set. */
   public abstract boolean matchSingleCommunity(
       Environment environment, SortedSet<Long> communities);
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/InlineCommunitySet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/InlineCommunitySet.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
@@ -25,7 +26,7 @@ public class InlineCommunitySet extends CommunitySetExpr {
 
   public InlineCommunitySet(Collection<Long> communities) {
     _communities =
-        communities.stream().map(l -> new CommunitySetElem(l)).collect(Collectors.toList());
+        communities.stream().map(CommunitySetElem::new).collect(Collectors.toList());
   }
 
   public InlineCommunitySet(List<CommunitySetElem> communities) {
@@ -51,21 +52,11 @@ public class InlineCommunitySet extends CommunitySetExpr {
     if (this == obj) {
       return true;
     }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    if (!(obj instanceof InlineCommunitySet)) {
       return false;
     }
     InlineCommunitySet other = (InlineCommunitySet) obj;
-    if (_communities == null) {
-      if (other._communities != null) {
-        return false;
-      }
-    } else if (!_communities.equals(other._communities)) {
-      return false;
-    }
-    return true;
+    return Objects.equals(_communities, other._communities);
   }
 
   public List<CommunitySetElem> getCommunities() {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/InlineCommunitySet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/InlineCommunitySet.java
@@ -91,13 +91,7 @@ public class InlineCommunitySet extends CommunitySetExpr {
 
   @Override
   public boolean matchSingleCommunity(Environment environment, SortedSet<Long> communities) {
-    for (Long community : communities) {
-      // BAD
-      if (_communities.contains(community)) {
-        return true;
-      }
-    }
-    return false;
+    return _communities.stream().anyMatch(c -> communities.contains(c.community(environment)));
   }
 
   public void setCommunities(List<CommunitySetElem> communities) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/InlineCommunitySet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/InlineCommunitySet.java
@@ -3,7 +3,9 @@ package org.batfish.datamodel.routing_policy.expr;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSortedSet;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.SortedSet;
@@ -66,19 +68,14 @@ public class InlineCommunitySet extends CommunitySetExpr {
 
   @Override
   public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((_communities == null) ? 0 : _communities.hashCode());
-    return result;
+    return Objects.hash(_communities);
   }
 
   private SortedSet<Long> initCommunities() {
-    SortedSet<Long> out = new TreeSet<>();
-    for (CommunitySetElem elem : _communities) {
-      long c = elem.community();
-      out.add(c);
-    }
-    return out;
+    return _communities
+        .stream()
+        .map(CommunitySetElem::community)
+        .collect(ImmutableSortedSet.toImmutableSortedSet(Comparator.naturalOrder()));
   }
 
   public void setCommunities(List<CommunitySetElem> communities) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/NamedCommunitySet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/NamedCommunitySet.java
@@ -1,6 +1,7 @@
 package org.batfish.datamodel.routing_policy.expr;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -23,7 +24,7 @@ public class NamedCommunitySet extends CommunitySetExpr {
   }
 
   @Override
-  public SortedSet<Long> communities(Environment environment) {
+  public SortedSet<Long> allCommunities(Environment environment) {
     SortedSet<Long> out = new TreeSet<>();
     CommunityList cl = environment.getConfiguration().getCommunityLists().get(_name);
     for (CommunityListLine line : cl.getLines()) {
@@ -34,7 +35,8 @@ public class NamedCommunitySet extends CommunitySetExpr {
   }
 
   @Override
-  public SortedSet<Long> communities(Environment environment, SortedSet<Long> communityCandidates) {
+  public SortedSet<Long> communities(
+      Environment environment, Collection<Long> communityCandidates) {
     SortedSet<Long> matchingCommunities = new TreeSet<>();
     for (Long community : communityCandidates) {
       CommunityList cl = environment.getConfiguration().getCommunityLists().get(_name);
@@ -77,17 +79,6 @@ public class NamedCommunitySet extends CommunitySetExpr {
     int result = 1;
     result = prime * result + ((_name == null) ? 0 : _name.hashCode());
     return result;
-  }
-
-  @Override
-  public boolean matchSingleCommunity(Environment environment, SortedSet<Long> communities) {
-    CommunityList cl = environment.getConfiguration().getCommunityLists().get(_name);
-    for (Long community : communities) {
-      if (cl.permits(community)) {
-        return true;
-      }
-    }
-    return false;
   }
 
   public void setName(String name) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/AddCommunity.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/AddCommunity.java
@@ -46,7 +46,7 @@ public class AddCommunity extends Statement {
   @Override
   public Result execute(Environment environment) {
     BgpRoute.Builder bgpRoute = (BgpRoute.Builder) environment.getOutputRoute();
-    SortedSet<Long> communities = _expr.communities(environment);
+    SortedSet<Long> communities = _expr.allCommunities(environment);
     bgpRoute.getCommunities().addAll(communities);
     if (environment.getWriteToIntermediateBgpAttributes()) {
       environment.getIntermediateBgpAttributes().getCommunities().addAll(communities);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/SetCommunity.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/SetCommunity.java
@@ -47,7 +47,7 @@ public class SetCommunity extends Statement {
   public Result execute(Environment environment) {
     Result result = new Result();
     BgpRoute.Builder bgpRoute = (BgpRoute.Builder) environment.getOutputRoute();
-    SortedSet<Long> communities = _expr.communities(environment);
+    SortedSet<Long> communities = _expr.allCommunities(environment);
     bgpRoute.getCommunities().clear();
     bgpRoute.getCommunities().addAll(communities);
     if (environment.getWriteToIntermediateBgpAttributes()) {

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/InlineCommunitySetTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/InlineCommunitySetTest.java
@@ -1,0 +1,36 @@
+package org.batfish.datamodel.routing_policy.expr;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class InlineCommunitySetTest {
+  @Test
+  public void testCommunities() {
+    InlineCommunitySet set = new InlineCommunitySet(ImmutableList.of(1L, 2L, 3L));
+
+    assertThat(set.allCommunities(null), equalTo(ImmutableSet.of(2L, 3L, 1L)));
+  }
+
+  @Test
+  public void testMatchSingleCommunity() {
+    InlineCommunitySet set = new InlineCommunitySet(ImmutableList.of(1L, 2L, 3L));
+
+    assertTrue(set.matchSingleCommunity(null, ImmutableList.of(2L)));
+    assertTrue(set.matchSingleCommunity(null, ImmutableList.of(1L, 2L, 3L)));
+    assertTrue(set.matchSingleCommunity(null, ImmutableList.of(4L, 1L)));
+
+    assertFalse(set.matchSingleCommunity(null, ImmutableList.of(4L)));
+  }
+
+  @Test
+  public void testNoMatches() {}
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/RouteMapMatchCommunityListLine.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/RouteMapMatchCommunityListLine.java
@@ -10,6 +10,10 @@ import org.batfish.datamodel.routing_policy.expr.Disjunction;
 import org.batfish.datamodel.routing_policy.expr.MatchCommunitySet;
 import org.batfish.datamodel.routing_policy.expr.NamedCommunitySet;
 
+/**
+ * Handles the "route-map match community-list" command, which matches when at least one of the
+ * named lists matches at least one community in the advertisement.
+ */
 public class RouteMapMatchCommunityListLine extends RouteMapMatchLine {
 
   private static final long serialVersionUID = 1L;


### PR DESCRIPTION
Focus on `InlineCommunitySetExpr`, but cleanup and testability went a little farther.

* Add some Javadoc and slightly cleanup one function name.
* Remove unnecessary `Experiment` from functions that won't use it.
* Reimplement a few bulky pieces of code (equals, hashCode, init) and use Suppliers.memoize to do some dirty work for us.
* Add tests for `InlineCommunitySetExpr`.