### PR TITLE
NodeRoleSpecifier: add a missing deep copy

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/NodeRoleSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/NodeRoleSpecifier.java
@@ -3,6 +3,7 @@ package org.batfish.datamodel;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
@@ -81,9 +82,12 @@ public class NodeRoleSpecifier {
 
   // return a map from each role name to the set of nodes that play that role
   public SortedMap<String, SortedSet<String>> createRoleNodesMap(Set<String> allNodes) {
+    // Make a deep copy of _roleMap so that updating roleNodesMap does not mutate _roleMap.
     SortedMap<String, SortedSet<String>> roleNodesMap = new TreeMap<>();
+    for (Map.Entry<String, SortedSet<String>> entry : _roleMap.entrySet()) {
+      roleNodesMap.put(entry.getKey(), new TreeSet<>(entry.getValue()));
+    }
 
-    roleNodesMap.putAll(_roleMap);
     addToRoleNodesMap(roleNodesMap, allNodes);
 
     return roleNodesMap;

--- a/tests/basic/roles.ref
+++ b/tests/basic/roles.ref
@@ -6,18 +6,12 @@
         "inferred" : false,
         "roleMap" : {
           "border" : [
-            "as1border1",
-            "as1border2",
             "as2border1",
-            "as2border2",
-            "as3border1",
-            "as3border2"
+            "as2border2"
           ],
           "core" : [
-            "as1core1",
             "as2core1",
-            "as2core2",
-            "as3core1"
+            "as2core2"
           ],
           "dept" : [
             "as2dept1"


### PR DESCRIPTION
The act of pretty printing the answer would change the role map from
the user's input. This seem like undesired behavior.

Note that the failing test aimed to test the case when roles were provided
and role inference was off. But the ref did not match the input roles
(and now does).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/721)
<!-- Reviewable:end -->
