### PR TITLE
generating environment level topology for the default environment

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
@@ -53,7 +53,7 @@ public interface IBatfish extends IPluginConsumer {
   Set<NodeInterfacePair> computeFlowSinks(
       Map<String, Configuration> configurations, boolean differentialContext, Topology topology);
 
-  Topology computeTopology(Map<String, Configuration> configurations);
+  Topology computeEnvironmentTopology(Map<String, Configuration> configurations);
 
   Map<String, BiFunction<Question, IBatfish, Answerer>> getAnswererCreators();
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/role/InferRoles.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/role/InferRoles.java
@@ -239,7 +239,7 @@ public class InferRoles implements Callable<NodeRoleSpecifier> {
     SortedMap<String, SortedSet<String>> nodeRolesMap =
         regexToRoleSpecifier(regex).createNodeRolesMap(new TreeSet<>(_nodes));
 
-    Topology topology = _batfish.computeTopology(_configurations);
+    Topology topology = _batfish.computeEnvironmentTopology(_configurations);
 
     // produce a role-level topology and the list of nodes in each edge's source role
     // that have an edge to some node in the edge's target role

--- a/projects/batfish/src/main/java/org/batfish/bdp/BdpDataPlanePlugin.java
+++ b/projects/batfish/src/main/java/org/batfish/bdp/BdpDataPlanePlugin.java
@@ -40,7 +40,7 @@ public class BdpDataPlanePlugin extends DataPlanePlugin {
     BdpAnswerElement ae = new BdpAnswerElement();
     answer.addAnswerElement(ae);
     Map<String, Configuration> configurations = _batfish.loadConfigurations();
-    Topology topology = _batfish.computeTopology(configurations);
+    Topology topology = _batfish.computeEnvironmentTopology(configurations);
     Set<BgpAdvertisement> externalAdverts = _batfish.loadExternalBgpAnnouncements(configurations);
     Set<NodeInterfacePair> flowSinks =
         _batfish.computeFlowSinks(configurations, differentialContext, topology);

--- a/projects/batfish/src/main/java/org/batfish/config/Settings.java
+++ b/projects/batfish/src/main/java/org/batfish/config/Settings.java
@@ -1134,7 +1134,7 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
     setDefaultProperty(BfConsts.ARG_DIFFERENTIAL, false);
     setDefaultProperty(BfConsts.ARG_DISABLE_UNRECOGNIZED, false);
     setDefaultProperty(ARG_DISABLE_Z3_SIMPLIFICATION, false);
-    setDefaultProperty(BfConsts.ARG_ENVIRONMENT_NAME, null);
+    setDefaultProperty(BfConsts.ARG_ENVIRONMENT_NAME, BfConsts.RELPATH_DEFAULT_ENVIRONMENT_NAME);
     setDefaultProperty(ARG_EXIT_ON_FIRST_ERROR, false);
     setDefaultProperty(ARG_FLATTEN, false);
     setDefaultProperty(ARG_FLATTEN_DESTINATION, null);

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -4028,7 +4028,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
         org.batfish.datamodel.pojo.Topology.create(
             _testrigSettings.getName(), configurations, testrigTopology);
     serializeAsJson(_testrigSettings.getPojoTopologyPath(), pojoTopology, "testrig pojo topology");
-    Topology envTopology = computeEnvironmentTopology(configurations, testrigTopology);
+    Topology envTopology = computeEnvironmentTopology(configurations);
     serializeAsJson(
         _testrigSettings
             .getEnvironmentSettings()

--- a/projects/batfish/src/main/java/org/batfish/symbolic/Graph.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/Graph.java
@@ -278,7 +278,7 @@ public class Graph {
    * create the opposite edge mapping.
    */
   private void initGraph() {
-    Topology topology = _batfish.computeTopology(_configurations);
+    Topology topology = _batfish.computeEnvironmentTopology(_configurations);
     Map<NodeInterfacePair, Interface> ifaceMap = new HashMap<>();
     Map<String, Set<NodeInterfacePair>> routerIfaceMap = new HashMap<>();
 

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
@@ -58,7 +58,13 @@ public class BatfishTestUtils {
       settings.setEnvironmentName("tempEnvironment");
       Batfish.initTestrigSettings(settings);
       settings.getBaseTestrigSettings().getSerializeIndependentPath().toFile().mkdirs();
-      settings.getBaseTestrigSettings().getEnvironmentSettings().getEnvPath().toFile().mkdirs();
+      settings
+          .getBaseTestrigSettings()
+          .getEnvironmentSettings()
+          .getEnvPath()
+          .resolve(BfConsts.RELPATH_ENV_DIR)
+          .toFile()
+          .mkdirs();
       testrigs.put(settings.getBaseTestrigSettings(), configurations);
       settings.setActiveTestrigSettings(settings.getBaseTestrigSettings());
     }
@@ -136,7 +142,7 @@ public class BatfishTestUtils {
     Path testrigPath = settings.getBaseTestrigSettings().getTestRigPath();
     settings.setActiveTestrigSettings(settings.getBaseTestrigSettings());
     EnvironmentSettings envSettings = settings.getBaseTestrigSettings().getEnvironmentSettings();
-    envSettings.getEnvironmentBasePath().toFile().mkdirs();
+    envSettings.getEnvironmentBasePath().resolve(BfConsts.RELPATH_ENV_DIR).toFile().mkdirs();
     writeTemporaryTestrigFiles(
         configurationText, testrigPath.resolve(BfConsts.RELPATH_CONFIGURATIONS_DIR));
     writeTemporaryTestrigFiles(bgpTablesText, envSettings.getEnvironmentBgpTablesPath());

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
@@ -94,7 +94,7 @@ public class BatfishTestUtils {
     Path testrigPath = settings.getBaseTestrigSettings().getTestRigPath();
     settings.setActiveTestrigSettings(settings.getBaseTestrigSettings());
     EnvironmentSettings envSettings = settings.getBaseTestrigSettings().getEnvironmentSettings();
-    envSettings.getEnvironmentBasePath().toFile().mkdirs();
+    envSettings.getEnvironmentBasePath().resolve(BfConsts.RELPATH_ENV_DIR).toFile().mkdirs();
     writeTemporaryTestrigFiles(
         configurationText, testrigPath.resolve(BfConsts.RELPATH_CONFIGURATIONS_DIR));
     writeTemporaryTestrigFiles(awsText, testrigPath.resolve(BfConsts.RELPATH_AWS_VPC_CONFIGS_DIR));

--- a/projects/question/src/main/java/org/batfish/question/NeighborsQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/NeighborsQuestionPlugin.java
@@ -763,7 +763,7 @@ public class NeighborsQuestionPlugin extends QuestionPlugin {
 
     private void initTopology(Map<String, Configuration> configurations) {
       if (_topology == null) {
-        _topology = _batfish.computeTopology(configurations);
+        _topology = _batfish.computeEnvironmentTopology(configurations);
       }
     }
 

--- a/projects/question/src/main/java/org/batfish/question/OspfSessionCheckQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/OspfSessionCheckQuestionPlugin.java
@@ -230,7 +230,7 @@ public class OspfSessionCheckQuestionPlugin extends QuestionPlugin {
           }
         }
       }
-      Topology topology = _batfish.computeTopology(configurations);
+      Topology topology = _batfish.computeEnvironmentTopology(configurations);
       _batfish.initRemoteOspfNeighbors(configurations, ipOwners, topology);
       for (Configuration co : configurations.values()) {
         String hostname = co.getHostname();


### PR DESCRIPTION
environment-level topology is dumped for the default environment as part of testrig initialization. there is no obvious hook for doing that for environments that come later, so punting on that for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/727)
<!-- Reviewable:end -->
