### PR TITLE
Serialize memory improvement

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -1,6 +1,5 @@
 package org.batfish.main;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -3838,13 +3837,11 @@ public class Batfish extends PluginConsumer implements IBatfish {
   }
 
   private void serializeAsJson(Path outputPath, Object object, String objectName) {
-    String str;
     try {
-      str = new BatfishObjectMapper().writeValueAsString(object);
-    } catch (JsonProcessingException e) {
+      new BatfishObjectMapper().writeValue(outputPath.toFile(), object);
+    } catch (IOException e) {
       throw new BatfishException("Could not serialize " + objectName + " ", e);
     }
-    CommonUtil.writeFile(outputPath, str);
   }
 
   private Answer serializeAwsVpcConfigs(Path testRigPath, Path outputPath) {


### PR DESCRIPTION
Instead of stopping in-memory, serialize directly to disk. On a small-scale testbed (~1100 configs), these two changes let me reduce memory requirements to under 500MiB from a couple of gigs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/729)
<!-- Reviewable:end -->
