### PR TITLE
Batfish: don't recompute env topology path

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -4027,10 +4027,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
     serializeAsJson(_testrigSettings.getPojoTopologyPath(), pojoTopology, "testrig pojo topology");
     Topology envTopology = computeEnvironmentTopology(configurations);
     serializeAsJson(
-        _testrigSettings
-            .getEnvironmentSettings()
-            .getEnvPath()
-            .resolve(BfConsts.RELPATH_ENV_TOPOLOGY_FILE),
+        _testrigSettings.getEnvironmentSettings().getSerializedTopologyPath(),
         envTopology,
         "environment topology");
     NodeRoleSpecifier roleSpecifier = inferNodeRoles(configurations);


### PR DESCRIPTION
We already have computed it in settings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/730)
<!-- Reviewable:end -->
