### PR TITLE
Batfish: serialize env_topology after disabling unusable interfaces

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -3314,15 +3314,6 @@ public class Batfish extends PluginConsumer implements IBatfish {
     nodeIface.setBlacklisted(true);
   }
 
-  private void processEdgeBlacklist(
-      Map<String, Configuration> configurations, ValidateEnvironmentAnswerElement veae) {
-    Set<Edge> blacklistEdges = getEdgeBlacklist();
-    for (Edge e : blacklistEdges) {
-      blacklistInterface(configurations, veae, e.getInterface1());
-      blacklistInterface(configurations, veae, e.getInterface2());
-    }
-  }
-
   private void processInterfaceBlacklist(
       Map<String, Configuration> configurations, ValidateEnvironmentAnswerElement veae) {
     Set<NodeInterfacePair> blacklistInterfaces = getInterfaceBlacklist();
@@ -3676,7 +3667,9 @@ public class Batfish extends PluginConsumer implements IBatfish {
       Map<String, Configuration> configurations, ValidateEnvironmentAnswerElement veae) {
     processNodeBlacklist(configurations, veae);
     processInterfaceBlacklist(configurations, veae);
-    processEdgeBlacklist(configurations, veae);
+    // We do not process the edge blacklist here. Instead, we rely on these edges being explicitly
+    // deleted from the Topology (aka list of edges) that is used along with configurations in
+    // answering questions.
     disableUnusableVlanInterfaces(configurations);
     disableUnusableVpnInterfaces(configurations);
   }


### PR DESCRIPTION
Includes some refactoring to make the disabling code more accessible.

Also:
* Make getXBlacklist() return empty set instead of null if no blacklist present,
  to simplify caller code.
* And add some Javadoc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/734)
<!-- Reviewable:end -->
