### PR TITLE
remove unused constant

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/bdp/VirtualRouterTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bdp/VirtualRouterTest.java
@@ -70,7 +70,6 @@ public class VirtualRouterTest {
 
   private static final String NEIGHBOR_HOST_NAME = "neighbornode";
   private static final int TEST_ADMIN = 100;
-  private static final int TEST_ADMIN_LOWER = 50;
   private static final Long TEST_AREA = 1L;
   private static final int TEST_AS1 = 1;
   private static final int TEST_AS2 = 2;


### PR DESCRIPTION
Removed constant apparently unused in `VirtualRouterTest`. Reviewers should verify this was not meant to be used somewhere.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/742)
<!-- Reviewable:end -->
