### PR TITLE
Fixed v2 rest api key extraction from request

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/CoordConstsV2.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/CoordConstsV2.java
@@ -5,7 +5,7 @@ public class CoordConstsV2 {
   ////// HTTP Headers that clients are expected to configure. //////
 
   /** The HTTP Header containing the client's API Key. */
-  public static String HTTP_HEADER_BATFISH_APIKEY = "X-Batfish-Apikey";
+  public static final String HTTP_HEADER_BATFISH_APIKEY = "X-Batfish-Apikey";
   /** The HTTP Header containing the client's version. */
-  public static String HTTP_HEADER_BATFISH_VERSION = "X-Batfish-Version";
+  public static final String HTTP_HEADER_BATFISH_VERSION = "X-Batfish-Version";
 }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrServiceV2.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrServiceV2.java
@@ -15,6 +15,7 @@ import javax.ws.rs.core.UriInfo;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.Container;
 import org.batfish.common.CoordConsts;
+import org.batfish.common.CoordConstsV2;
 import org.batfish.coordinator.resources.ContainerResource;
 
 /**
@@ -31,7 +32,7 @@ public class WorkMgrServiceV2 {
   private BatfishLogger _logger = Main.getLogger();
 
   @DefaultValue(CoordConsts.DEFAULT_API_KEY)
-  @HeaderParam(CoordConsts.SVC_KEY_API_KEY)
+  @HeaderParam(CoordConstsV2.HTTP_HEADER_BATFISH_APIKEY)
   private String _apiKey;
 
   /** Information on the URI of a request, injected by the server framework at runtime. */


### PR DESCRIPTION
Fixed the header field from which ApiKey was extracted in the v2 API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/754)
<!-- Reviewable:end -->
