### PR TITLE
rework VI structures generated from AWS

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/aws_vpcs/InternetGateway.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws_vpcs/InternetGateway.java
@@ -61,7 +61,7 @@ public class InternetGateway implements AwsVpcEntity, Serializable {
               .setNetwork(vpc.getCidrBlock())
               .setNextHopIp(vpcIfaceIp)
               .setAdministrativeCost(Route.DEFAULT_STATIC_ROUTE_ADMIN)
-              .setTag(Route.DEFAULT_STATIC_ROUTE_COST)
+              .setMetric(Route.DEFAULT_STATIC_ROUTE_COST)
               .build();
       cfgNode.getDefaultVrf().getStaticRoutes().add(igwVpcRoute);
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/aws_vpcs/Route.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws_vpcs/Route.java
@@ -84,7 +84,7 @@ public class Route implements Serializable {
         StaticRoute.builder()
             .setNetwork(_destinationCidrBlock)
             .setAdministrativeCost(DEFAULT_STATIC_ROUTE_ADMIN)
-            .setTag(DEFAULT_STATIC_ROUTE_COST);
+            .setMetric(DEFAULT_STATIC_ROUTE_COST);
 
     if (_state == State.BLACKHOLE) {
       srBuilder.setNextHopInterface(Interface.NULL_INTERFACE_NAME);

--- a/projects/batfish/src/main/java/org/batfish/representation/aws_vpcs/Subnet.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws_vpcs/Subnet.java
@@ -35,6 +35,10 @@ public class Subnet implements AwsVpcEntity, Serializable {
     _vpcId = jObj.getString(JSON_KEY_VPC_ID);
   }
 
+  Ip computeInstancesIfaceAddress() {
+    return new Ip(_cidrBlock.getNetworkAddress().asLong() + 1L);
+  }
+
   private NetworkAcl findMyNetworkAcl(Map<String, NetworkAcl> networkAcls) {
     List<NetworkAcl> matchingAcls =
         networkAcls
@@ -141,8 +145,8 @@ public class Subnet implements AwsVpcEntity, Serializable {
 
     // add one interface that faces the instances
     String instancesIfaceName = _subnetId;
-    Prefix instancesIfacePrefix =
-        new Prefix(_cidrBlock.getEndAddress(), _cidrBlock.getPrefixLength());
+    Ip instancesIfaceAddress = computeInstancesIfaceAddress();
+    Prefix instancesIfacePrefix = new Prefix(instancesIfaceAddress, _cidrBlock.getPrefixLength());
     Utils.newInterface(instancesIfaceName, cfgNode, instancesIfacePrefix);
 
     // generate a prefix for the link between the VPC router and the subnet

--- a/projects/batfish/src/main/java/org/batfish/representation/aws_vpcs/Subnet.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws_vpcs/Subnet.java
@@ -161,18 +161,16 @@ public class Subnet implements AwsVpcEntity, Serializable {
     Utils.newInterface(vpcIfaceName, vpcConfigNode, vpcIfacePrefix);
 
     // add a static route on the vpc router for this subnet
-    StaticRoute vpcToSubnetRoute =
+    StaticRoute.Builder sb =
         StaticRoute.builder()
-            .setNetwork(_cidrBlock)
-            .setNextHopIp(subnetIfacePrefix.getAddress())
             .setAdministrativeCost(Route.DEFAULT_STATIC_ROUTE_ADMIN)
-            .setTag(Route.DEFAULT_STATIC_ROUTE_COST)
-            .build();
+            .setMetric(Route.DEFAULT_STATIC_ROUTE_COST);
+    StaticRoute vpcToSubnetRoute =
+        sb.setNetwork(_cidrBlock).setNextHopIp(subnetIfacePrefix.getAddress()).build();
     vpcConfigNode.getDefaultVrf().getStaticRoutes().add(vpcToSubnetRoute);
 
     // Install a default static route towards the VPC router.
-    StaticRoute defaultRoute =
-        StaticRoute.builder().setNetwork(Prefix.ZERO).setNextHopIp(vpcIfaceAddress).build();
+    StaticRoute defaultRoute = sb.setNetwork(Prefix.ZERO).setNextHopIp(vpcIfaceAddress).build();
     cfgNode.getDefaultVrf().getStaticRoutes().add(defaultRoute);
 
     NetworkAcl myNetworkAcl = findMyNetworkAcl(awsVpcConfiguration.getNetworkAcls());

--- a/projects/batfish/src/main/java/org/batfish/representation/aws_vpcs/Vpc.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws_vpcs/Vpc.java
@@ -59,6 +59,8 @@ public class Vpc implements AwsVpcEntity, Serializable {
         .getStaticRoutes()
         .add(
             StaticRoute.builder()
+                .setAdministrativeCost(Route.DEFAULT_STATIC_ROUTE_ADMIN)
+                .setMetric(Route.DEFAULT_STATIC_ROUTE_COST)
                 .setNetwork(_cidrBlock)
                 .setNextHopInterface(Interface.NULL_INTERFACE_NAME)
                 .build());

--- a/projects/batfish/src/main/java/org/batfish/representation/aws_vpcs/Vpc.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws_vpcs/Vpc.java
@@ -3,7 +3,9 @@ package org.batfish.representation.aws_vpcs;
 import java.io.Serializable;
 import org.batfish.common.BatfishLogger;
 import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.StaticRoute;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
 
@@ -52,6 +54,14 @@ public class Vpc implements AwsVpcEntity, Serializable {
   public Configuration toConfigurationNode(AwsVpcConfiguration awsVpcConfiguration) {
     Configuration cfgNode = Utils.newAwsConfiguration(_vpcId);
     cfgNode.getVendorFamily().getAws().setVpcId(_vpcId);
+    cfgNode
+        .getDefaultVrf()
+        .getStaticRoutes()
+        .add(
+            StaticRoute.builder()
+                .setNetwork(_cidrBlock)
+                .setNextHopInterface(Interface.NULL_INTERFACE_NAME)
+                .build());
 
     // we only create a node here
     // interfaces are added to this node as we traverse subnets and

--- a/projects/batfish/src/main/java/org/batfish/representation/aws_vpcs/VpnConnection.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws_vpcs/VpnConnection.java
@@ -390,7 +390,7 @@ public class VpnConnection implements AwsVpcEntity, Serializable {
                 .setNetwork(staticRoutePrefix)
                 .setNextHopIp(ipsecTunnel.getCgwInsideAddress())
                 .setAdministrativeCost(Route.DEFAULT_STATIC_ROUTE_ADMIN)
-                .setTag(Route.DEFAULT_STATIC_ROUTE_COST)
+                .setMetric(Route.DEFAULT_STATIC_ROUTE_COST)
                 .build();
 
         vpnGatewayCfgNode.getDefaultVrf().getStaticRoutes().add(staticRoute);

--- a/projects/batfish/src/main/java/org/batfish/representation/aws_vpcs/VpnConnection.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws_vpcs/VpnConnection.java
@@ -331,7 +331,8 @@ public class VpnConnection implements AwsVpcEntity, Serializable {
         acceptIffEbgp.setFalseStatements(
             ImmutableList.of(Statements.ExitReject.toStaticStatement()));
 
-        RoutingPolicy vgwRpAcceptAllBgp = new RoutingPolicy(rpAcceptAllEbgpAndSetNextHopSelfName, vpnGatewayCfgNode);
+        RoutingPolicy vgwRpAcceptAllBgp =
+            new RoutingPolicy(rpAcceptAllEbgpAndSetNextHopSelfName, vpnGatewayCfgNode);
         vpnGatewayCfgNode.getRoutingPolicies().put(vgwRpAcceptAllBgp.getName(), vgwRpAcceptAllBgp);
         vgwRpAcceptAllBgp.setStatements(
             ImmutableList.of(new SetNextHop(new SelfNextHop(), false), acceptIffEbgp));

--- a/projects/batfish/src/main/java/org/batfish/representation/aws_vpcs/VpnConnection.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws_vpcs/VpnConnection.java
@@ -1,5 +1,6 @@
 package org.batfish.representation.aws_vpcs;
 
+import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.io.Serializable;
 import java.io.StringReader;
@@ -21,6 +22,7 @@ import org.batfish.datamodel.IkeGateway;
 import org.batfish.datamodel.IkePolicy;
 import org.batfish.datamodel.IkeProposal;
 import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpsecAuthenticationAlgorithm;
 import org.batfish.datamodel.IpsecPolicy;
 import org.batfish.datamodel.IpsecProposal;
@@ -42,7 +44,9 @@ import org.batfish.datamodel.routing_policy.expr.LiteralOrigin;
 import org.batfish.datamodel.routing_policy.expr.MatchPrefixSet;
 import org.batfish.datamodel.routing_policy.expr.MatchProtocol;
 import org.batfish.datamodel.routing_policy.expr.NamedPrefixSet;
+import org.batfish.datamodel.routing_policy.expr.SelfNextHop;
 import org.batfish.datamodel.routing_policy.statement.If;
+import org.batfish.datamodel.routing_policy.statement.SetNextHop;
 import org.batfish.datamodel.routing_policy.statement.SetOrigin;
 import org.batfish.datamodel.routing_policy.statement.Statement;
 import org.batfish.datamodel.routing_policy.statement.Statements;
@@ -275,6 +279,7 @@ public class VpnConnection implements AwsVpcEntity, Serializable {
         cgBgpNeighbor.setLocalIp(ipsecTunnel.getVgwInsideAddress());
         cgBgpNeighbor.setDefaultMetric(BGP_NEIGHBOR_DEFAULT_METRIC);
         cgBgpNeighbor.setSendCommunity(false);
+
         VpnGateway vpnGateway = awsVpcConfiguration.getVpnGateways().get(_vpnGatewayId);
         List<String> attachmentVpcIds = vpnGateway.getAttachmentVpcIds();
         if (attachmentVpcIds.size() != 1) {
@@ -286,6 +291,64 @@ public class VpnConnection implements AwsVpcEntity, Serializable {
                   + "\" is linked to multiple VPCs");
         }
         String vpcId = attachmentVpcIds.get(0);
+
+        // iBGP connection to VPC
+        Configuration vpcNode = awsVpcConfiguration.getConfigurationNodes().get(vpcId);
+        Ip vpcIfaceAddress = vpcNode.getInterfaces().get(_vpnGatewayId).getPrefix().getAddress();
+        Ip vgwToVpcIfaceAddress =
+            vpnGatewayCfgNode.getInterfaces().get(vpcId).getPrefix().getAddress();
+        BgpNeighbor vgwToVpcBgpNeighbor = new BgpNeighbor(vpcIfaceAddress, vpnGatewayCfgNode);
+        proc.getNeighbors().put(vgwToVpcBgpNeighbor.getPrefix(), vgwToVpcBgpNeighbor);
+        vgwToVpcBgpNeighbor.setVrf(Configuration.DEFAULT_VRF_NAME);
+        vgwToVpcBgpNeighbor.setLocalAs(ipsecTunnel.getVgwBgpAsn());
+        vgwToVpcBgpNeighbor.setLocalIp(vgwToVpcIfaceAddress);
+        vgwToVpcBgpNeighbor.setRemoteAs(ipsecTunnel.getVgwBgpAsn());
+        vgwToVpcBgpNeighbor.setDefaultMetric(BGP_NEIGHBOR_DEFAULT_METRIC);
+        vgwToVpcBgpNeighbor.setSendCommunity(true);
+
+        // iBGP connection from VPC
+        BgpNeighbor vpcToVgwBgpNeighbor = new BgpNeighbor(vgwToVpcIfaceAddress, vpcNode);
+        BgpProcess vpcProc = new BgpProcess();
+        vpcNode.getDefaultVrf().setBgpProcess(vpcProc);
+        vpcProc.setMultipathEquivalentAsPathMatchMode(
+            MultipathEquivalentAsPathMatchMode.EXACT_PATH);
+        vpcProc.setRouterId(vpcIfaceAddress);
+        vpcProc.getNeighbors().put(vpcToVgwBgpNeighbor.getPrefix(), vpcToVgwBgpNeighbor);
+        vpcToVgwBgpNeighbor.setVrf(Configuration.DEFAULT_VRF_NAME);
+        vpcToVgwBgpNeighbor.setLocalAs(ipsecTunnel.getVgwBgpAsn());
+        vpcToVgwBgpNeighbor.setLocalIp(vpcIfaceAddress);
+        vpcToVgwBgpNeighbor.setRemoteAs(ipsecTunnel.getVgwBgpAsn());
+        vpcToVgwBgpNeighbor.setDefaultMetric(BGP_NEIGHBOR_DEFAULT_METRIC);
+        vpcToVgwBgpNeighbor.setSendCommunity(true);
+
+        String rpRejectAllName = "~REJECT_ALL~";
+
+        String rpAcceptAllEbgpAndSetNextHopSelfName = "~ACCEPT_ALL_EBGP_AND_SET_NEXT_HOP_SELF~";
+        If acceptIffEbgp = new If();
+        acceptIffEbgp.setGuard(new MatchProtocol(RoutingProtocol.BGP));
+        acceptIffEbgp.setTrueStatements(
+            ImmutableList.of(Statements.ExitAccept.toStaticStatement()));
+        acceptIffEbgp.setFalseStatements(
+            ImmutableList.of(Statements.ExitReject.toStaticStatement()));
+
+        RoutingPolicy vgwRpAcceptAllBgp = new RoutingPolicy(rpAcceptAllEbgpAndSetNextHopSelfName, vpnGatewayCfgNode);
+        vpnGatewayCfgNode.getRoutingPolicies().put(vgwRpAcceptAllBgp.getName(), vgwRpAcceptAllBgp);
+        vgwRpAcceptAllBgp.setStatements(
+            ImmutableList.of(new SetNextHop(new SelfNextHop(), false), acceptIffEbgp));
+        vgwToVpcBgpNeighbor.setExportPolicy(rpAcceptAllEbgpAndSetNextHopSelfName);
+        RoutingPolicy vgwRpRejectAll = new RoutingPolicy(rpRejectAllName, vpnGatewayCfgNode);
+        vpnGatewayCfgNode.getRoutingPolicies().put(rpRejectAllName, vgwRpRejectAll);
+        vgwToVpcBgpNeighbor.setImportPolicy(rpRejectAllName);
+
+        String rpAcceptAllName = "~ACCEPT_ALL~";
+        RoutingPolicy vpcRpAcceptAll = new RoutingPolicy(rpAcceptAllName, vpcNode);
+        vpcNode.getRoutingPolicies().put(rpAcceptAllName, vpcRpAcceptAll);
+        vpcRpAcceptAll.setStatements(ImmutableList.of(Statements.ExitAccept.toStaticStatement()));
+        vpcToVgwBgpNeighbor.setImportPolicy(rpAcceptAllName);
+        RoutingPolicy vpcRpRejectAll = new RoutingPolicy(rpRejectAllName, vpcNode);
+        vpcNode.getRoutingPolicies().put(rpRejectAllName, vpcRpRejectAll);
+        vpcToVgwBgpNeighbor.setExportPolicy(rpRejectAllName);
+
         Vpc vpc = awsVpcConfiguration.getVpcs().get(vpcId);
         Prefix outgoingPrefix = vpc.getCidrBlock();
         int outgoingPrefixLength = outgoingPrefix.getPrefixLength();

--- a/projects/batfish/src/main/java/org/batfish/representation/aws_vpcs/VpnGateway.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws_vpcs/VpnGateway.java
@@ -68,7 +68,7 @@ public class VpnGateway implements AwsVpcEntity, Serializable {
               .setNetwork(vpc.getCidrBlock())
               .setNextHopIp(vpcIfaceIp)
               .setAdministrativeCost(Route.DEFAULT_STATIC_ROUTE_ADMIN)
-              .setTag(Route.DEFAULT_STATIC_ROUTE_COST)
+              .setMetric(Route.DEFAULT_STATIC_ROUTE_COST)
               .build();
       cfgNode.getDefaultVrf().getStaticRoutes().add(vgwVpcRoute);
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/aws_vpcs/VpnGateway.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws_vpcs/VpnGateway.java
@@ -56,8 +56,7 @@ public class VpnGateway implements AwsVpcEntity, Serializable {
       Ip vpcIfaceIp = vgwIfacePrefix.getEndAddress();
       Prefix vpcIfacePrefix = new Prefix(vpcIfaceIp, vgwIfacePrefix.getPrefixLength());
       vpcIface.setPrefix(vpcIfacePrefix);
-      vpcConfigNode.getInterfaces().put(vpcIfaceName, vpcIface);
-      vpcConfigNode.getDefaultVrf().getInterfaces().put(vpcIfaceName, vpcIface);
+      Utils.newInterface(vpcIfaceName, vpcConfigNode, vpcIfacePrefix);
 
       // associate this gateway with the vpc
       awsVpcConfiguration.getVpcs().get(vpcId).setVpnGatewayId(_vpnGatewayId);

--- a/tests/basic/nodes-example-aws.ref
+++ b/tests/basic/nodes-example-aws.ref
@@ -107,6 +107,16 @@
               "name" : "default",
               "interfaces" : [
                 "eni-d2b094fc"
+              ],
+              "staticRoutes" : [
+                {
+                  "class" : "org.batfish.datamodel.StaticRoute",
+                  "administrativeCost" : 1,
+                  "network" : "0.0.0.0/0",
+                  "nextHopInterface" : "dynamic",
+                  "nextHopIp" : "192.168.1.1",
+                  "tag" : -1
+                }
               ]
             }
           }
@@ -245,6 +255,24 @@
               "interfaces" : [
                 "eni-4b466165",
                 "eni-8c7753a2"
+              ],
+              "staticRoutes" : [
+                {
+                  "class" : "org.batfish.datamodel.StaticRoute",
+                  "administrativeCost" : 1,
+                  "network" : "0.0.0.0/0",
+                  "nextHopInterface" : "dynamic",
+                  "nextHopIp" : "192.168.1.1",
+                  "tag" : -1
+                },
+                {
+                  "class" : "org.batfish.datamodel.StaticRoute",
+                  "administrativeCost" : 1,
+                  "network" : "0.0.0.0/0",
+                  "nextHopInterface" : "dynamic",
+                  "nextHopIp" : "192.168.2.17",
+                  "tag" : -1
+                }
               ]
             }
           }
@@ -383,6 +411,24 @@
               "interfaces" : [
                 "eni-6b705445",
                 "eni-a50c2b8b"
+              ],
+              "staticRoutes" : [
+                {
+                  "class" : "org.batfish.datamodel.StaticRoute",
+                  "administrativeCost" : 1,
+                  "network" : "0.0.0.0/0",
+                  "nextHopInterface" : "dynamic",
+                  "nextHopIp" : "192.168.1.1",
+                  "tag" : -1
+                },
+                {
+                  "class" : "org.batfish.datamodel.StaticRoute",
+                  "administrativeCost" : 1,
+                  "network" : "0.0.0.0/0",
+                  "nextHopInterface" : "dynamic",
+                  "nextHopIp" : "192.168.2.49",
+                  "tag" : -1
+                }
               ]
             }
           }
@@ -521,6 +567,24 @@
               "interfaces" : [
                 "eni-297b5c07",
                 "eni-707e5a5e"
+              ],
+              "staticRoutes" : [
+                {
+                  "class" : "org.batfish.datamodel.StaticRoute",
+                  "administrativeCost" : 1,
+                  "network" : "0.0.0.0/0",
+                  "nextHopInterface" : "dynamic",
+                  "nextHopIp" : "192.168.1.1",
+                  "tag" : -1
+                },
+                {
+                  "class" : "org.batfish.datamodel.StaticRoute",
+                  "administrativeCost" : 1,
+                  "network" : "0.0.0.0/0",
+                  "nextHopInterface" : "dynamic",
+                  "nextHopIp" : "192.168.2.17",
+                  "tag" : -1
+                }
               ]
             }
           }
@@ -2075,7 +2139,7 @@
               "accessVlan" : 0,
               "active" : true,
               "allPrefixes" : [
-                "192.168.2.31/28"
+                "192.168.2.17/28"
               ],
               "autostate" : true,
               "bandwidth" : 1.0E12,
@@ -2088,7 +2152,7 @@
               "ospfHelloMultiplier" : 0,
               "ospfPassive" : false,
               "ospfPointToPoint" : false,
-              "prefix" : "192.168.2.31/28",
+              "prefix" : "192.168.2.17/28",
               "ripEnabled" : false,
               "ripPassive" : false,
               "spanningTreePortfast" : false,
@@ -2196,7 +2260,7 @@
               "accessVlan" : 0,
               "active" : true,
               "allPrefixes" : [
-                "192.168.1.255/24"
+                "192.168.1.1/24"
               ],
               "autostate" : true,
               "bandwidth" : 1.0E12,
@@ -2209,7 +2273,7 @@
               "ospfHelloMultiplier" : 0,
               "ospfPassive" : false,
               "ospfPointToPoint" : false,
-              "prefix" : "192.168.1.255/24",
+              "prefix" : "192.168.1.1/24",
               "ripEnabled" : false,
               "ripPassive" : false,
               "spanningTreePortfast" : false,
@@ -2317,7 +2381,7 @@
               "accessVlan" : 0,
               "active" : true,
               "allPrefixes" : [
-                "172.31.15.255/20"
+                "172.31.0.1/20"
               ],
               "autostate" : true,
               "bandwidth" : 1.0E12,
@@ -2330,7 +2394,7 @@
               "ospfHelloMultiplier" : 0,
               "ospfPassive" : false,
               "ospfPointToPoint" : false,
-              "prefix" : "172.31.15.255/20",
+              "prefix" : "172.31.0.1/20",
               "ripEnabled" : false,
               "ripPassive" : false,
               "spanningTreePortfast" : false,
@@ -2447,7 +2511,7 @@
               "accessVlan" : 0,
               "active" : true,
               "allPrefixes" : [
-                "192.168.2.47/28"
+                "192.168.2.33/28"
               ],
               "autostate" : true,
               "bandwidth" : 1.0E12,
@@ -2460,7 +2524,7 @@
               "ospfHelloMultiplier" : 0,
               "ospfPassive" : false,
               "ospfPointToPoint" : false,
-              "prefix" : "192.168.2.47/28",
+              "prefix" : "192.168.2.33/28",
               "ripEnabled" : false,
               "ripPassive" : false,
               "spanningTreePortfast" : false,
@@ -2568,7 +2632,7 @@
               "accessVlan" : 0,
               "active" : true,
               "allPrefixes" : [
-                "10.0.0.255/24"
+                "10.0.0.1/24"
               ],
               "autostate" : true,
               "bandwidth" : 1.0E12,
@@ -2581,7 +2645,7 @@
               "ospfHelloMultiplier" : 0,
               "ospfPassive" : false,
               "ospfPointToPoint" : false,
-              "prefix" : "10.0.0.255/24",
+              "prefix" : "10.0.0.1/24",
               "ripEnabled" : false,
               "ripPassive" : false,
               "spanningTreePortfast" : false,
@@ -2689,7 +2753,7 @@
               "accessVlan" : 0,
               "active" : true,
               "allPrefixes" : [
-                "192.168.2.15/28"
+                "192.168.2.1/28"
               ],
               "autostate" : true,
               "bandwidth" : 1.0E12,
@@ -2702,7 +2766,7 @@
               "ospfHelloMultiplier" : 0,
               "ospfPassive" : false,
               "ospfPointToPoint" : false,
-              "prefix" : "192.168.2.15/28",
+              "prefix" : "192.168.2.1/28",
               "ripEnabled" : false,
               "ripPassive" : false,
               "spanningTreePortfast" : false,
@@ -2810,7 +2874,7 @@
               "accessVlan" : 0,
               "active" : true,
               "allPrefixes" : [
-                "10.0.1.255/24"
+                "10.0.1.1/24"
               ],
               "autostate" : true,
               "bandwidth" : 1.0E12,
@@ -2823,7 +2887,7 @@
               "ospfHelloMultiplier" : 0,
               "ospfPassive" : false,
               "ospfPointToPoint" : false,
-              "prefix" : "10.0.1.255/24",
+              "prefix" : "10.0.1.1/24",
               "ripEnabled" : false,
               "ripPassive" : false,
               "spanningTreePortfast" : false,
@@ -2931,7 +2995,7 @@
               "accessVlan" : 0,
               "active" : true,
               "allPrefixes" : [
-                "172.31.47.255/20"
+                "172.31.32.1/20"
               ],
               "autostate" : true,
               "bandwidth" : 1.0E12,
@@ -2944,7 +3008,7 @@
               "ospfHelloMultiplier" : 0,
               "ospfPassive" : false,
               "ospfPointToPoint" : false,
-              "prefix" : "172.31.47.255/20",
+              "prefix" : "172.31.32.1/20",
               "ripEnabled" : false,
               "ripPassive" : false,
               "spanningTreePortfast" : false,
@@ -3061,7 +3125,7 @@
               "accessVlan" : 0,
               "active" : true,
               "allPrefixes" : [
-                "172.31.31.255/20"
+                "172.31.16.1/20"
               ],
               "autostate" : true,
               "bandwidth" : 1.0E12,
@@ -3074,7 +3138,7 @@
               "ospfHelloMultiplier" : 0,
               "ospfPassive" : false,
               "ospfPointToPoint" : false,
-              "prefix" : "172.31.31.255/20",
+              "prefix" : "172.31.16.1/20",
               "ripEnabled" : false,
               "ripPassive" : false,
               "spanningTreePortfast" : false,
@@ -3191,7 +3255,7 @@
               "accessVlan" : 0,
               "active" : true,
               "allPrefixes" : [
-                "192.168.2.63/28"
+                "192.168.2.49/28"
               ],
               "autostate" : true,
               "bandwidth" : 1.0E12,
@@ -3204,7 +3268,7 @@
               "ospfHelloMultiplier" : 0,
               "ospfPassive" : false,
               "ospfPointToPoint" : false,
-              "prefix" : "192.168.2.63/28",
+              "prefix" : "192.168.2.49/28",
               "ripEnabled" : false,
               "ripPassive" : false,
               "spanningTreePortfast" : false,

--- a/tests/basic/nodes-example-aws.ref
+++ b/tests/basic/nodes-example-aws.ref
@@ -532,87 +532,6 @@
           "defaultInboundAction" : "ACCEPT",
           "deviceType" : "SWITCH",
           "interfaces" : {
-            "subnet-1f315846" : {
-              "name" : "subnet-1f315846",
-              "accessVlan" : 0,
-              "active" : true,
-              "allPrefixes" : [
-                "240.0.0.19/31"
-              ],
-              "autostate" : true,
-              "bandwidth" : 1.0E12,
-              "isisL1InterfaceMode" : "unset",
-              "isisL2InterfaceMode" : "unset",
-              "mtu" : 1500,
-              "nativeVlan" : 1,
-              "ospfDeadInterval" : 0,
-              "ospfEnabled" : false,
-              "ospfHelloMultiplier" : 0,
-              "ospfPassive" : false,
-              "ospfPointToPoint" : false,
-              "prefix" : "240.0.0.19/31",
-              "ripEnabled" : false,
-              "ripPassive" : false,
-              "spanningTreePortfast" : false,
-              "switchportMode" : "NONE",
-              "switchportTrunkEncapsulation" : "DOT1Q",
-              "type" : "PHYSICAL",
-              "vrf" : "default"
-            },
-            "subnet-9c8adceb" : {
-              "name" : "subnet-9c8adceb",
-              "accessVlan" : 0,
-              "active" : true,
-              "allPrefixes" : [
-                "240.0.0.27/31"
-              ],
-              "autostate" : true,
-              "bandwidth" : 1.0E12,
-              "isisL1InterfaceMode" : "unset",
-              "isisL2InterfaceMode" : "unset",
-              "mtu" : 1500,
-              "nativeVlan" : 1,
-              "ospfDeadInterval" : 0,
-              "ospfEnabled" : false,
-              "ospfHelloMultiplier" : 0,
-              "ospfPassive" : false,
-              "ospfPointToPoint" : false,
-              "prefix" : "240.0.0.27/31",
-              "ripEnabled" : false,
-              "ripPassive" : false,
-              "spanningTreePortfast" : false,
-              "switchportMode" : "NONE",
-              "switchportTrunkEncapsulation" : "DOT1Q",
-              "type" : "PHYSICAL",
-              "vrf" : "default"
-            },
-            "subnet-d9cafabc" : {
-              "name" : "subnet-d9cafabc",
-              "accessVlan" : 0,
-              "active" : true,
-              "allPrefixes" : [
-                "240.0.0.43/31"
-              ],
-              "autostate" : true,
-              "bandwidth" : 1.0E12,
-              "isisL1InterfaceMode" : "unset",
-              "isisL2InterfaceMode" : "unset",
-              "mtu" : 1500,
-              "nativeVlan" : 1,
-              "ospfDeadInterval" : 0,
-              "ospfEnabled" : false,
-              "ospfHelloMultiplier" : 0,
-              "ospfPassive" : false,
-              "ospfPointToPoint" : false,
-              "prefix" : "240.0.0.43/31",
-              "ripEnabled" : false,
-              "ripPassive" : false,
-              "spanningTreePortfast" : false,
-              "switchportMode" : "NONE",
-              "switchportTrunkEncapsulation" : "DOT1Q",
-              "type" : "PHYSICAL",
-              "vrf" : "default"
-            },
             "vpc-f8fad69d" : {
               "name" : "vpc-f8fad69d",
               "accessVlan" : 0,
@@ -642,7 +561,7 @@
             }
           },
           "roles" : [
-            "igw"
+            "igw-068fee63"
           ],
           "vendorFamily" : {
             "aws" : { }
@@ -651,9 +570,6 @@
             "default" : {
               "name" : "default",
               "interfaces" : [
-                "subnet-1f315846",
-                "subnet-9c8adceb",
-                "subnet-d9cafabc",
                 "vpc-f8fad69d"
               ],
               "staticRoutes" : [
@@ -663,7 +579,7 @@
                   "network" : "172.31.0.0/16",
                   "nextHopInterface" : "dynamic",
                   "nextHopIp" : "240.0.0.3",
-                  "tag" : 0
+                  "tag" : -1
                 }
               ]
             }
@@ -676,141 +592,6 @@
           "defaultInboundAction" : "ACCEPT",
           "deviceType" : "SWITCH",
           "interfaces" : {
-            "subnet-073b8061" : {
-              "name" : "subnet-073b8061",
-              "accessVlan" : 0,
-              "active" : true,
-              "allPrefixes" : [
-                "240.0.0.15/31"
-              ],
-              "autostate" : true,
-              "bandwidth" : 1.0E12,
-              "isisL1InterfaceMode" : "unset",
-              "isisL2InterfaceMode" : "unset",
-              "mtu" : 1500,
-              "nativeVlan" : 1,
-              "ospfDeadInterval" : 0,
-              "ospfEnabled" : false,
-              "ospfHelloMultiplier" : 0,
-              "ospfPassive" : false,
-              "ospfPointToPoint" : false,
-              "prefix" : "240.0.0.15/31",
-              "ripEnabled" : false,
-              "ripPassive" : false,
-              "spanningTreePortfast" : false,
-              "switchportMode" : "NONE",
-              "switchportTrunkEncapsulation" : "DOT1Q",
-              "type" : "PHYSICAL",
-              "vrf" : "default"
-            },
-            "subnet-1641fa70" : {
-              "name" : "subnet-1641fa70",
-              "accessVlan" : 0,
-              "active" : true,
-              "allPrefixes" : [
-                "240.0.0.31/31"
-              ],
-              "autostate" : true,
-              "bandwidth" : 1.0E12,
-              "isisL1InterfaceMode" : "unset",
-              "isisL2InterfaceMode" : "unset",
-              "mtu" : 1500,
-              "nativeVlan" : 1,
-              "ospfDeadInterval" : 0,
-              "ospfEnabled" : false,
-              "ospfHelloMultiplier" : 0,
-              "ospfPassive" : false,
-              "ospfPointToPoint" : false,
-              "prefix" : "240.0.0.31/31",
-              "ripEnabled" : false,
-              "ripPassive" : false,
-              "spanningTreePortfast" : false,
-              "switchportMode" : "NONE",
-              "switchportTrunkEncapsulation" : "DOT1Q",
-              "type" : "PHYSICAL",
-              "vrf" : "default"
-            },
-            "subnet-30398256" : {
-              "name" : "subnet-30398256",
-              "accessVlan" : 0,
-              "active" : true,
-              "allPrefixes" : [
-                "240.0.0.47/31"
-              ],
-              "autostate" : true,
-              "bandwidth" : 1.0E12,
-              "isisL1InterfaceMode" : "unset",
-              "isisL2InterfaceMode" : "unset",
-              "mtu" : 1500,
-              "nativeVlan" : 1,
-              "ospfDeadInterval" : 0,
-              "ospfEnabled" : false,
-              "ospfHelloMultiplier" : 0,
-              "ospfPassive" : false,
-              "ospfPointToPoint" : false,
-              "prefix" : "240.0.0.47/31",
-              "ripEnabled" : false,
-              "ripPassive" : false,
-              "spanningTreePortfast" : false,
-              "switchportMode" : "NONE",
-              "switchportTrunkEncapsulation" : "DOT1Q",
-              "type" : "PHYSICAL",
-              "vrf" : "default"
-            },
-            "subnet-7044ff16" : {
-              "name" : "subnet-7044ff16",
-              "accessVlan" : 0,
-              "active" : true,
-              "allPrefixes" : [
-                "240.0.0.23/31"
-              ],
-              "autostate" : true,
-              "bandwidth" : 1.0E12,
-              "isisL1InterfaceMode" : "unset",
-              "isisL2InterfaceMode" : "unset",
-              "mtu" : 1500,
-              "nativeVlan" : 1,
-              "ospfDeadInterval" : 0,
-              "ospfEnabled" : false,
-              "ospfHelloMultiplier" : 0,
-              "ospfPassive" : false,
-              "ospfPointToPoint" : false,
-              "prefix" : "240.0.0.23/31",
-              "ripEnabled" : false,
-              "ripPassive" : false,
-              "spanningTreePortfast" : false,
-              "switchportMode" : "NONE",
-              "switchportTrunkEncapsulation" : "DOT1Q",
-              "type" : "PHYSICAL",
-              "vrf" : "default"
-            },
-            "subnet-f73a8191" : {
-              "name" : "subnet-f73a8191",
-              "accessVlan" : 0,
-              "active" : true,
-              "allPrefixes" : [
-                "240.0.0.35/31"
-              ],
-              "autostate" : true,
-              "bandwidth" : 1.0E12,
-              "isisL1InterfaceMode" : "unset",
-              "isisL2InterfaceMode" : "unset",
-              "mtu" : 1500,
-              "nativeVlan" : 1,
-              "ospfDeadInterval" : 0,
-              "ospfEnabled" : false,
-              "ospfHelloMultiplier" : 0,
-              "ospfPassive" : false,
-              "ospfPointToPoint" : false,
-              "prefix" : "240.0.0.35/31",
-              "ripEnabled" : false,
-              "ripPassive" : false,
-              "spanningTreePortfast" : false,
-              "switchportMode" : "NONE",
-              "switchportTrunkEncapsulation" : "DOT1Q",
-              "type" : "PHYSICAL",
-              "vrf" : "default"
-            },
             "vpc-b390fad5" : {
               "name" : "vpc-b390fad5",
               "accessVlan" : 0,
@@ -840,7 +621,7 @@
             }
           },
           "roles" : [
-            "igw"
+            "igw-9b93ddfc"
           ],
           "vendorFamily" : {
             "aws" : { }
@@ -849,11 +630,6 @@
             "default" : {
               "name" : "default",
               "interfaces" : [
-                "subnet-073b8061",
-                "subnet-1641fa70",
-                "subnet-30398256",
-                "subnet-7044ff16",
-                "subnet-f73a8191",
                 "vpc-b390fad5"
               ],
               "staticRoutes" : [
@@ -863,7 +639,7 @@
                   "network" : "192.168.0.0/16",
                   "nextHopInterface" : "dynamic",
                   "nextHopIp" : "240.0.0.5",
-                  "tag" : 0
+                  "tag" : -1
                 }
               ]
             }
@@ -876,60 +652,6 @@
           "defaultInboundAction" : "ACCEPT",
           "deviceType" : "SWITCH",
           "interfaces" : {
-            "subnet-62f14104" : {
-              "name" : "subnet-62f14104",
-              "accessVlan" : 0,
-              "active" : true,
-              "allPrefixes" : [
-                "240.0.0.39/31"
-              ],
-              "autostate" : true,
-              "bandwidth" : 1.0E12,
-              "isisL1InterfaceMode" : "unset",
-              "isisL2InterfaceMode" : "unset",
-              "mtu" : 1500,
-              "nativeVlan" : 1,
-              "ospfDeadInterval" : 0,
-              "ospfEnabled" : false,
-              "ospfHelloMultiplier" : 0,
-              "ospfPassive" : false,
-              "ospfPointToPoint" : false,
-              "prefix" : "240.0.0.39/31",
-              "ripEnabled" : false,
-              "ripPassive" : false,
-              "spanningTreePortfast" : false,
-              "switchportMode" : "NONE",
-              "switchportTrunkEncapsulation" : "DOT1Q",
-              "type" : "PHYSICAL",
-              "vrf" : "default"
-            },
-            "subnet-8d0cbdeb" : {
-              "name" : "subnet-8d0cbdeb",
-              "accessVlan" : 0,
-              "active" : true,
-              "allPrefixes" : [
-                "240.0.0.11/31"
-              ],
-              "autostate" : true,
-              "bandwidth" : 1.0E12,
-              "isisL1InterfaceMode" : "unset",
-              "isisL2InterfaceMode" : "unset",
-              "mtu" : 1500,
-              "nativeVlan" : 1,
-              "ospfDeadInterval" : 0,
-              "ospfEnabled" : false,
-              "ospfHelloMultiplier" : 0,
-              "ospfPassive" : false,
-              "ospfPointToPoint" : false,
-              "prefix" : "240.0.0.11/31",
-              "ripEnabled" : false,
-              "ripPassive" : false,
-              "spanningTreePortfast" : false,
-              "switchportMode" : "NONE",
-              "switchportTrunkEncapsulation" : "DOT1Q",
-              "type" : "PHYSICAL",
-              "vrf" : "default"
-            },
             "vpc-925131f4" : {
               "name" : "vpc-925131f4",
               "accessVlan" : 0,
@@ -959,7 +681,7 @@
             }
           },
           "roles" : [
-            "igw"
+            "igw-fac5839d"
           ],
           "vendorFamily" : {
             "aws" : { }
@@ -968,8 +690,6 @@
             "default" : {
               "name" : "default",
               "interfaces" : [
-                "subnet-62f14104",
-                "subnet-8d0cbdeb",
                 "vpc-925131f4"
               ],
               "staticRoutes" : [
@@ -979,7 +699,7 @@
                   "network" : "10.0.0.0/16",
                   "nextHopInterface" : "dynamic",
                   "nextHopIp" : "240.0.0.1",
-                  "tag" : 0
+                  "tag" : -1
                 }
               ]
             }
@@ -2350,35 +2070,6 @@
           "defaultInboundAction" : "ACCEPT",
           "deviceType" : "SWITCH",
           "interfaces" : {
-            "igw-9b93ddfc" : {
-              "name" : "igw-9b93ddfc",
-              "accessVlan" : 0,
-              "active" : true,
-              "allPrefixes" : [
-                "240.0.0.14/31"
-              ],
-              "autostate" : true,
-              "bandwidth" : 1.0E12,
-              "incomingFilter" : "acl-7b78771d_ingress",
-              "isisL1InterfaceMode" : "unset",
-              "isisL2InterfaceMode" : "unset",
-              "mtu" : 1500,
-              "nativeVlan" : 1,
-              "ospfDeadInterval" : 0,
-              "ospfEnabled" : false,
-              "ospfHelloMultiplier" : 0,
-              "ospfPassive" : false,
-              "ospfPointToPoint" : false,
-              "outgoingFilter" : "acl-7b78771d_egress",
-              "prefix" : "240.0.0.14/31",
-              "ripEnabled" : false,
-              "ripPassive" : false,
-              "spanningTreePortfast" : false,
-              "switchportMode" : "NONE",
-              "switchportTrunkEncapsulation" : "DOT1Q",
-              "type" : "PHYSICAL",
-              "vrf" : "default"
-            },
             "subnet-073b8061" : {
               "name" : "subnet-073b8061",
               "accessVlan" : 0,
@@ -2411,7 +2102,7 @@
               "accessVlan" : 0,
               "active" : true,
               "allPrefixes" : [
-                "240.0.0.12/31"
+                "240.0.0.10/31"
               ],
               "autostate" : true,
               "bandwidth" : 1.0E12,
@@ -2426,7 +2117,7 @@
               "ospfPassive" : false,
               "ospfPointToPoint" : false,
               "outgoingFilter" : "acl-7b78771d_egress",
-              "prefix" : "240.0.0.12/31",
+              "prefix" : "240.0.0.10/31",
               "ripEnabled" : false,
               "ripPassive" : false,
               "spanningTreePortfast" : false,
@@ -2465,7 +2156,7 @@
             }
           },
           "roles" : [
-            "subnet"
+            "subnet-073b8061"
           ],
           "vendorFamily" : {
             "aws" : {
@@ -2477,7 +2168,6 @@
             "default" : {
               "name" : "default",
               "interfaces" : [
-                "igw-9b93ddfc",
                 "subnet-073b8061",
                 "vpc-b390fad5"
               ],
@@ -2487,16 +2177,8 @@
                   "administrativeCost" : 1,
                   "network" : "0.0.0.0/0",
                   "nextHopInterface" : "dynamic",
-                  "nextHopIp" : "240.0.0.15",
-                  "tag" : 0
-                },
-                {
-                  "class" : "org.batfish.datamodel.StaticRoute",
-                  "administrativeCost" : 1,
-                  "network" : "192.168.0.0/16",
-                  "nextHopInterface" : "dynamic",
-                  "nextHopIp" : "240.0.0.13",
-                  "tag" : 0
+                  "nextHopIp" : "240.0.0.11",
+                  "tag" : -1
                 }
               ]
             }
@@ -2509,35 +2191,6 @@
           "defaultInboundAction" : "ACCEPT",
           "deviceType" : "SWITCH",
           "interfaces" : {
-            "igw-9b93ddfc" : {
-              "name" : "igw-9b93ddfc",
-              "accessVlan" : 0,
-              "active" : true,
-              "allPrefixes" : [
-                "240.0.0.30/31"
-              ],
-              "autostate" : true,
-              "bandwidth" : 1.0E12,
-              "incomingFilter" : "acl-7b78771d_ingress",
-              "isisL1InterfaceMode" : "unset",
-              "isisL2InterfaceMode" : "unset",
-              "mtu" : 1500,
-              "nativeVlan" : 1,
-              "ospfDeadInterval" : 0,
-              "ospfEnabled" : false,
-              "ospfHelloMultiplier" : 0,
-              "ospfPassive" : false,
-              "ospfPointToPoint" : false,
-              "outgoingFilter" : "acl-7b78771d_egress",
-              "prefix" : "240.0.0.30/31",
-              "ripEnabled" : false,
-              "ripPassive" : false,
-              "spanningTreePortfast" : false,
-              "switchportMode" : "NONE",
-              "switchportTrunkEncapsulation" : "DOT1Q",
-              "type" : "PHYSICAL",
-              "vrf" : "default"
-            },
             "subnet-1641fa70" : {
               "name" : "subnet-1641fa70",
               "accessVlan" : 0,
@@ -2570,7 +2223,7 @@
               "accessVlan" : 0,
               "active" : true,
               "allPrefixes" : [
-                "240.0.0.28/31"
+                "240.0.0.18/31"
               ],
               "autostate" : true,
               "bandwidth" : 1.0E12,
@@ -2585,7 +2238,7 @@
               "ospfPassive" : false,
               "ospfPointToPoint" : false,
               "outgoingFilter" : "acl-7b78771d_egress",
-              "prefix" : "240.0.0.28/31",
+              "prefix" : "240.0.0.18/31",
               "ripEnabled" : false,
               "ripPassive" : false,
               "spanningTreePortfast" : false,
@@ -2624,7 +2277,7 @@
             }
           },
           "roles" : [
-            "subnet"
+            "subnet-1641fa70"
           ],
           "vendorFamily" : {
             "aws" : {
@@ -2636,7 +2289,6 @@
             "default" : {
               "name" : "default",
               "interfaces" : [
-                "igw-9b93ddfc",
                 "subnet-1641fa70",
                 "vpc-b390fad5"
               ],
@@ -2646,16 +2298,8 @@
                   "administrativeCost" : 1,
                   "network" : "0.0.0.0/0",
                   "nextHopInterface" : "dynamic",
-                  "nextHopIp" : "240.0.0.31",
-                  "tag" : 0
-                },
-                {
-                  "class" : "org.batfish.datamodel.StaticRoute",
-                  "administrativeCost" : 1,
-                  "network" : "192.168.0.0/16",
-                  "nextHopInterface" : "dynamic",
-                  "nextHopIp" : "240.0.0.29",
-                  "tag" : 0
+                  "nextHopIp" : "240.0.0.19",
+                  "tag" : -1
                 }
               ]
             }
@@ -2668,35 +2312,6 @@
           "defaultInboundAction" : "ACCEPT",
           "deviceType" : "SWITCH",
           "interfaces" : {
-            "igw-068fee63" : {
-              "name" : "igw-068fee63",
-              "accessVlan" : 0,
-              "active" : true,
-              "allPrefixes" : [
-                "240.0.0.18/31"
-              ],
-              "autostate" : true,
-              "bandwidth" : 1.0E12,
-              "incomingFilter" : "acl-4db39c28_ingress",
-              "isisL1InterfaceMode" : "unset",
-              "isisL2InterfaceMode" : "unset",
-              "mtu" : 1500,
-              "nativeVlan" : 1,
-              "ospfDeadInterval" : 0,
-              "ospfEnabled" : false,
-              "ospfHelloMultiplier" : 0,
-              "ospfPassive" : false,
-              "ospfPointToPoint" : false,
-              "outgoingFilter" : "acl-4db39c28_egress",
-              "prefix" : "240.0.0.18/31",
-              "ripEnabled" : false,
-              "ripPassive" : false,
-              "spanningTreePortfast" : false,
-              "switchportMode" : "NONE",
-              "switchportTrunkEncapsulation" : "DOT1Q",
-              "type" : "PHYSICAL",
-              "vrf" : "default"
-            },
             "subnet-1f315846" : {
               "name" : "subnet-1f315846",
               "accessVlan" : 0,
@@ -2729,7 +2344,7 @@
               "accessVlan" : 0,
               "active" : true,
               "allPrefixes" : [
-                "240.0.0.16/31"
+                "240.0.0.12/31"
               ],
               "autostate" : true,
               "bandwidth" : 1.0E12,
@@ -2744,7 +2359,7 @@
               "ospfPassive" : false,
               "ospfPointToPoint" : false,
               "outgoingFilter" : "acl-4db39c28_egress",
-              "prefix" : "240.0.0.16/31",
+              "prefix" : "240.0.0.12/31",
               "ripEnabled" : false,
               "ripPassive" : false,
               "spanningTreePortfast" : false,
@@ -2792,7 +2407,7 @@
             }
           },
           "roles" : [
-            "subnet"
+            "subnet-1f315846"
           ],
           "vendorFamily" : {
             "aws" : {
@@ -2804,7 +2419,6 @@
             "default" : {
               "name" : "default",
               "interfaces" : [
-                "igw-068fee63",
                 "subnet-1f315846",
                 "vpc-f8fad69d"
               ],
@@ -2814,16 +2428,8 @@
                   "administrativeCost" : 1,
                   "network" : "0.0.0.0/0",
                   "nextHopInterface" : "dynamic",
-                  "nextHopIp" : "240.0.0.19",
-                  "tag" : 0
-                },
-                {
-                  "class" : "org.batfish.datamodel.StaticRoute",
-                  "administrativeCost" : 1,
-                  "network" : "172.31.0.0/16",
-                  "nextHopInterface" : "dynamic",
-                  "nextHopIp" : "240.0.0.17",
-                  "tag" : 0
+                  "nextHopIp" : "240.0.0.13",
+                  "tag" : -1
                 }
               ]
             }
@@ -2836,35 +2442,6 @@
           "defaultInboundAction" : "ACCEPT",
           "deviceType" : "SWITCH",
           "interfaces" : {
-            "igw-9b93ddfc" : {
-              "name" : "igw-9b93ddfc",
-              "accessVlan" : 0,
-              "active" : true,
-              "allPrefixes" : [
-                "240.0.0.46/31"
-              ],
-              "autostate" : true,
-              "bandwidth" : 1.0E12,
-              "incomingFilter" : "acl-7b78771d_ingress",
-              "isisL1InterfaceMode" : "unset",
-              "isisL2InterfaceMode" : "unset",
-              "mtu" : 1500,
-              "nativeVlan" : 1,
-              "ospfDeadInterval" : 0,
-              "ospfEnabled" : false,
-              "ospfHelloMultiplier" : 0,
-              "ospfPassive" : false,
-              "ospfPointToPoint" : false,
-              "outgoingFilter" : "acl-7b78771d_egress",
-              "prefix" : "240.0.0.46/31",
-              "ripEnabled" : false,
-              "ripPassive" : false,
-              "spanningTreePortfast" : false,
-              "switchportMode" : "NONE",
-              "switchportTrunkEncapsulation" : "DOT1Q",
-              "type" : "PHYSICAL",
-              "vrf" : "default"
-            },
             "subnet-30398256" : {
               "name" : "subnet-30398256",
               "accessVlan" : 0,
@@ -2897,7 +2474,7 @@
               "accessVlan" : 0,
               "active" : true,
               "allPrefixes" : [
-                "240.0.0.44/31"
+                "240.0.0.26/31"
               ],
               "autostate" : true,
               "bandwidth" : 1.0E12,
@@ -2912,7 +2489,7 @@
               "ospfPassive" : false,
               "ospfPointToPoint" : false,
               "outgoingFilter" : "acl-7b78771d_egress",
-              "prefix" : "240.0.0.44/31",
+              "prefix" : "240.0.0.26/31",
               "ripEnabled" : false,
               "ripPassive" : false,
               "spanningTreePortfast" : false,
@@ -2951,7 +2528,7 @@
             }
           },
           "roles" : [
-            "subnet"
+            "subnet-30398256"
           ],
           "vendorFamily" : {
             "aws" : {
@@ -2963,7 +2540,6 @@
             "default" : {
               "name" : "default",
               "interfaces" : [
-                "igw-9b93ddfc",
                 "subnet-30398256",
                 "vpc-b390fad5"
               ],
@@ -2973,16 +2549,8 @@
                   "administrativeCost" : 1,
                   "network" : "0.0.0.0/0",
                   "nextHopInterface" : "dynamic",
-                  "nextHopIp" : "240.0.0.47",
-                  "tag" : 0
-                },
-                {
-                  "class" : "org.batfish.datamodel.StaticRoute",
-                  "administrativeCost" : 1,
-                  "network" : "192.168.0.0/16",
-                  "nextHopInterface" : "dynamic",
-                  "nextHopIp" : "240.0.0.45",
-                  "tag" : 0
+                  "nextHopIp" : "240.0.0.27",
+                  "tag" : -1
                 }
               ]
             }
@@ -2995,35 +2563,6 @@
           "defaultInboundAction" : "ACCEPT",
           "deviceType" : "SWITCH",
           "interfaces" : {
-            "igw-fac5839d" : {
-              "name" : "igw-fac5839d",
-              "accessVlan" : 0,
-              "active" : true,
-              "allPrefixes" : [
-                "240.0.0.38/31"
-              ],
-              "autostate" : true,
-              "bandwidth" : 1.0E12,
-              "incomingFilter" : "acl-3d4f745b_ingress",
-              "isisL1InterfaceMode" : "unset",
-              "isisL2InterfaceMode" : "unset",
-              "mtu" : 1500,
-              "nativeVlan" : 1,
-              "ospfDeadInterval" : 0,
-              "ospfEnabled" : false,
-              "ospfHelloMultiplier" : 0,
-              "ospfPassive" : false,
-              "ospfPointToPoint" : false,
-              "outgoingFilter" : "acl-3d4f745b_egress",
-              "prefix" : "240.0.0.38/31",
-              "ripEnabled" : false,
-              "ripPassive" : false,
-              "spanningTreePortfast" : false,
-              "switchportMode" : "NONE",
-              "switchportTrunkEncapsulation" : "DOT1Q",
-              "type" : "PHYSICAL",
-              "vrf" : "default"
-            },
             "subnet-62f14104" : {
               "name" : "subnet-62f14104",
               "accessVlan" : 0,
@@ -3056,7 +2595,7 @@
               "accessVlan" : 0,
               "active" : true,
               "allPrefixes" : [
-                "240.0.0.36/31"
+                "240.0.0.22/31"
               ],
               "autostate" : true,
               "bandwidth" : 1.0E12,
@@ -3071,7 +2610,7 @@
               "ospfPassive" : false,
               "ospfPointToPoint" : false,
               "outgoingFilter" : "acl-3d4f745b_egress",
-              "prefix" : "240.0.0.36/31",
+              "prefix" : "240.0.0.22/31",
               "ripEnabled" : false,
               "ripPassive" : false,
               "spanningTreePortfast" : false,
@@ -3110,7 +2649,7 @@
             }
           },
           "roles" : [
-            "subnet"
+            "subnet-62f14104"
           ],
           "vendorFamily" : {
             "aws" : {
@@ -3122,7 +2661,6 @@
             "default" : {
               "name" : "default",
               "interfaces" : [
-                "igw-fac5839d",
                 "subnet-62f14104",
                 "vpc-925131f4"
               ],
@@ -3132,16 +2670,8 @@
                   "administrativeCost" : 1,
                   "network" : "0.0.0.0/0",
                   "nextHopInterface" : "dynamic",
-                  "nextHopIp" : "240.0.0.39",
-                  "tag" : 0
-                },
-                {
-                  "class" : "org.batfish.datamodel.StaticRoute",
-                  "administrativeCost" : 1,
-                  "network" : "10.0.0.0/16",
-                  "nextHopInterface" : "dynamic",
-                  "nextHopIp" : "240.0.0.37",
-                  "tag" : 0
+                  "nextHopIp" : "240.0.0.23",
+                  "tag" : -1
                 }
               ]
             }
@@ -3154,35 +2684,6 @@
           "defaultInboundAction" : "ACCEPT",
           "deviceType" : "SWITCH",
           "interfaces" : {
-            "igw-9b93ddfc" : {
-              "name" : "igw-9b93ddfc",
-              "accessVlan" : 0,
-              "active" : true,
-              "allPrefixes" : [
-                "240.0.0.22/31"
-              ],
-              "autostate" : true,
-              "bandwidth" : 1.0E12,
-              "incomingFilter" : "acl-7b78771d_ingress",
-              "isisL1InterfaceMode" : "unset",
-              "isisL2InterfaceMode" : "unset",
-              "mtu" : 1500,
-              "nativeVlan" : 1,
-              "ospfDeadInterval" : 0,
-              "ospfEnabled" : false,
-              "ospfHelloMultiplier" : 0,
-              "ospfPassive" : false,
-              "ospfPointToPoint" : false,
-              "outgoingFilter" : "acl-7b78771d_egress",
-              "prefix" : "240.0.0.22/31",
-              "ripEnabled" : false,
-              "ripPassive" : false,
-              "spanningTreePortfast" : false,
-              "switchportMode" : "NONE",
-              "switchportTrunkEncapsulation" : "DOT1Q",
-              "type" : "PHYSICAL",
-              "vrf" : "default"
-            },
             "subnet-7044ff16" : {
               "name" : "subnet-7044ff16",
               "accessVlan" : 0,
@@ -3215,7 +2716,7 @@
               "accessVlan" : 0,
               "active" : true,
               "allPrefixes" : [
-                "240.0.0.20/31"
+                "240.0.0.14/31"
               ],
               "autostate" : true,
               "bandwidth" : 1.0E12,
@@ -3230,7 +2731,7 @@
               "ospfPassive" : false,
               "ospfPointToPoint" : false,
               "outgoingFilter" : "acl-7b78771d_egress",
-              "prefix" : "240.0.0.20/31",
+              "prefix" : "240.0.0.14/31",
               "ripEnabled" : false,
               "ripPassive" : false,
               "spanningTreePortfast" : false,
@@ -3269,7 +2770,7 @@
             }
           },
           "roles" : [
-            "subnet"
+            "subnet-7044ff16"
           ],
           "vendorFamily" : {
             "aws" : {
@@ -3281,7 +2782,6 @@
             "default" : {
               "name" : "default",
               "interfaces" : [
-                "igw-9b93ddfc",
                 "subnet-7044ff16",
                 "vpc-b390fad5"
               ],
@@ -3291,16 +2791,8 @@
                   "administrativeCost" : 1,
                   "network" : "0.0.0.0/0",
                   "nextHopInterface" : "dynamic",
-                  "nextHopIp" : "240.0.0.23",
-                  "tag" : 0
-                },
-                {
-                  "class" : "org.batfish.datamodel.StaticRoute",
-                  "administrativeCost" : 1,
-                  "network" : "192.168.0.0/16",
-                  "nextHopInterface" : "dynamic",
-                  "nextHopIp" : "240.0.0.21",
-                  "tag" : 0
+                  "nextHopIp" : "240.0.0.15",
+                  "tag" : -1
                 }
               ]
             }
@@ -3313,35 +2805,6 @@
           "defaultInboundAction" : "ACCEPT",
           "deviceType" : "SWITCH",
           "interfaces" : {
-            "igw-fac5839d" : {
-              "name" : "igw-fac5839d",
-              "accessVlan" : 0,
-              "active" : true,
-              "allPrefixes" : [
-                "240.0.0.10/31"
-              ],
-              "autostate" : true,
-              "bandwidth" : 1.0E12,
-              "incomingFilter" : "acl-3d4f745b_ingress",
-              "isisL1InterfaceMode" : "unset",
-              "isisL2InterfaceMode" : "unset",
-              "mtu" : 1500,
-              "nativeVlan" : 1,
-              "ospfDeadInterval" : 0,
-              "ospfEnabled" : false,
-              "ospfHelloMultiplier" : 0,
-              "ospfPassive" : false,
-              "ospfPointToPoint" : false,
-              "outgoingFilter" : "acl-3d4f745b_egress",
-              "prefix" : "240.0.0.10/31",
-              "ripEnabled" : false,
-              "ripPassive" : false,
-              "spanningTreePortfast" : false,
-              "switchportMode" : "NONE",
-              "switchportTrunkEncapsulation" : "DOT1Q",
-              "type" : "PHYSICAL",
-              "vrf" : "default"
-            },
             "subnet-8d0cbdeb" : {
               "name" : "subnet-8d0cbdeb",
               "accessVlan" : 0,
@@ -3428,7 +2891,7 @@
             }
           },
           "roles" : [
-            "subnet"
+            "subnet-8d0cbdeb"
           ],
           "vendorFamily" : {
             "aws" : {
@@ -3440,7 +2903,6 @@
             "default" : {
               "name" : "default",
               "interfaces" : [
-                "igw-fac5839d",
                 "subnet-8d0cbdeb",
                 "vpc-925131f4"
               ],
@@ -3449,17 +2911,9 @@
                   "class" : "org.batfish.datamodel.StaticRoute",
                   "administrativeCost" : 1,
                   "network" : "0.0.0.0/0",
-                  "nextHopInterface" : "null_interface",
-                  "nextHopIp" : "AUTO/NONE(-1l)",
-                  "tag" : 0
-                },
-                {
-                  "class" : "org.batfish.datamodel.StaticRoute",
-                  "administrativeCost" : 1,
-                  "network" : "10.0.0.0/16",
                   "nextHopInterface" : "dynamic",
                   "nextHopIp" : "240.0.0.9",
-                  "tag" : 0
+                  "tag" : -1
                 }
               ]
             }
@@ -3472,35 +2926,6 @@
           "defaultInboundAction" : "ACCEPT",
           "deviceType" : "SWITCH",
           "interfaces" : {
-            "igw-068fee63" : {
-              "name" : "igw-068fee63",
-              "accessVlan" : 0,
-              "active" : true,
-              "allPrefixes" : [
-                "240.0.0.26/31"
-              ],
-              "autostate" : true,
-              "bandwidth" : 1.0E12,
-              "incomingFilter" : "acl-4db39c28_ingress",
-              "isisL1InterfaceMode" : "unset",
-              "isisL2InterfaceMode" : "unset",
-              "mtu" : 1500,
-              "nativeVlan" : 1,
-              "ospfDeadInterval" : 0,
-              "ospfEnabled" : false,
-              "ospfHelloMultiplier" : 0,
-              "ospfPassive" : false,
-              "ospfPointToPoint" : false,
-              "outgoingFilter" : "acl-4db39c28_egress",
-              "prefix" : "240.0.0.26/31",
-              "ripEnabled" : false,
-              "ripPassive" : false,
-              "spanningTreePortfast" : false,
-              "switchportMode" : "NONE",
-              "switchportTrunkEncapsulation" : "DOT1Q",
-              "type" : "PHYSICAL",
-              "vrf" : "default"
-            },
             "subnet-9c8adceb" : {
               "name" : "subnet-9c8adceb",
               "accessVlan" : 0,
@@ -3520,6 +2945,136 @@
               "ospfPassive" : false,
               "ospfPointToPoint" : false,
               "prefix" : "172.31.47.255/20",
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vpc-f8fad69d" : {
+              "name" : "vpc-f8fad69d",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "240.0.0.16/31"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E12,
+              "incomingFilter" : "acl-4db39c28_ingress",
+              "isisL1InterfaceMode" : "unset",
+              "isisL2InterfaceMode" : "unset",
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : false,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "outgoingFilter" : "acl-4db39c28_egress",
+              "prefix" : "240.0.0.16/31",
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "VPN",
+              "vrf" : "default"
+            }
+          },
+          "ipAccessLists" : {
+            "acl-4db39c28_egress" : {
+              "name" : "acl-4db39c28_egress",
+              "lines" : [
+                {
+                  "action" : "ACCEPT",
+                  "negate" : false
+                },
+                {
+                  "action" : "REJECT",
+                  "negate" : false
+                }
+              ]
+            },
+            "acl-4db39c28_ingress" : {
+              "name" : "acl-4db39c28_ingress",
+              "lines" : [
+                {
+                  "action" : "ACCEPT",
+                  "dstPorts" : [
+                    "3306-3306"
+                  ],
+                  "ipProtocols" : [
+                    "TCP"
+                  ],
+                  "negate" : false,
+                  "srcIps" : [
+                    "162.243.144.192"
+                  ]
+                },
+                {
+                  "action" : "REJECT",
+                  "negate" : false
+                }
+              ]
+            }
+          },
+          "roles" : [
+            "subnet-9c8adceb"
+          ],
+          "vendorFamily" : {
+            "aws" : {
+              "subnetId" : "subnet-9c8adceb",
+              "vpcId" : "vpc-f8fad69d"
+            }
+          },
+          "vrfs" : {
+            "default" : {
+              "name" : "default",
+              "interfaces" : [
+                "subnet-9c8adceb",
+                "vpc-f8fad69d"
+              ],
+              "staticRoutes" : [
+                {
+                  "class" : "org.batfish.datamodel.StaticRoute",
+                  "administrativeCost" : 1,
+                  "network" : "0.0.0.0/0",
+                  "nextHopInterface" : "dynamic",
+                  "nextHopIp" : "240.0.0.17",
+                  "tag" : -1
+                }
+              ]
+            }
+          }
+        },
+        "subnet-d9cafabc" : {
+          "configurationFormat" : "AWS_VPC",
+          "name" : "subnet-d9cafabc",
+          "defaultCrossZoneAction" : "ACCEPT",
+          "defaultInboundAction" : "ACCEPT",
+          "deviceType" : "SWITCH",
+          "interfaces" : {
+            "subnet-d9cafabc" : {
+              "name" : "subnet-d9cafabc",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "172.31.31.255/20"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E12,
+              "isisL1InterfaceMode" : "unset",
+              "isisL2InterfaceMode" : "unset",
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : false,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "172.31.31.255/20",
               "ripEnabled" : false,
               "ripPassive" : false,
               "spanningTreePortfast" : false,
@@ -3596,175 +3151,7 @@
             }
           },
           "roles" : [
-            "subnet"
-          ],
-          "vendorFamily" : {
-            "aws" : {
-              "subnetId" : "subnet-9c8adceb",
-              "vpcId" : "vpc-f8fad69d"
-            }
-          },
-          "vrfs" : {
-            "default" : {
-              "name" : "default",
-              "interfaces" : [
-                "igw-068fee63",
-                "subnet-9c8adceb",
-                "vpc-f8fad69d"
-              ],
-              "staticRoutes" : [
-                {
-                  "class" : "org.batfish.datamodel.StaticRoute",
-                  "administrativeCost" : 1,
-                  "network" : "0.0.0.0/0",
-                  "nextHopInterface" : "dynamic",
-                  "nextHopIp" : "240.0.0.27",
-                  "tag" : 0
-                },
-                {
-                  "class" : "org.batfish.datamodel.StaticRoute",
-                  "administrativeCost" : 1,
-                  "network" : "172.31.0.0/16",
-                  "nextHopInterface" : "dynamic",
-                  "nextHopIp" : "240.0.0.25",
-                  "tag" : 0
-                }
-              ]
-            }
-          }
-        },
-        "subnet-d9cafabc" : {
-          "configurationFormat" : "AWS_VPC",
-          "name" : "subnet-d9cafabc",
-          "defaultCrossZoneAction" : "ACCEPT",
-          "defaultInboundAction" : "ACCEPT",
-          "deviceType" : "SWITCH",
-          "interfaces" : {
-            "igw-068fee63" : {
-              "name" : "igw-068fee63",
-              "accessVlan" : 0,
-              "active" : true,
-              "allPrefixes" : [
-                "240.0.0.42/31"
-              ],
-              "autostate" : true,
-              "bandwidth" : 1.0E12,
-              "incomingFilter" : "acl-4db39c28_ingress",
-              "isisL1InterfaceMode" : "unset",
-              "isisL2InterfaceMode" : "unset",
-              "mtu" : 1500,
-              "nativeVlan" : 1,
-              "ospfDeadInterval" : 0,
-              "ospfEnabled" : false,
-              "ospfHelloMultiplier" : 0,
-              "ospfPassive" : false,
-              "ospfPointToPoint" : false,
-              "outgoingFilter" : "acl-4db39c28_egress",
-              "prefix" : "240.0.0.42/31",
-              "ripEnabled" : false,
-              "ripPassive" : false,
-              "spanningTreePortfast" : false,
-              "switchportMode" : "NONE",
-              "switchportTrunkEncapsulation" : "DOT1Q",
-              "type" : "PHYSICAL",
-              "vrf" : "default"
-            },
-            "subnet-d9cafabc" : {
-              "name" : "subnet-d9cafabc",
-              "accessVlan" : 0,
-              "active" : true,
-              "allPrefixes" : [
-                "172.31.31.255/20"
-              ],
-              "autostate" : true,
-              "bandwidth" : 1.0E12,
-              "isisL1InterfaceMode" : "unset",
-              "isisL2InterfaceMode" : "unset",
-              "mtu" : 1500,
-              "nativeVlan" : 1,
-              "ospfDeadInterval" : 0,
-              "ospfEnabled" : false,
-              "ospfHelloMultiplier" : 0,
-              "ospfPassive" : false,
-              "ospfPointToPoint" : false,
-              "prefix" : "172.31.31.255/20",
-              "ripEnabled" : false,
-              "ripPassive" : false,
-              "spanningTreePortfast" : false,
-              "switchportMode" : "NONE",
-              "switchportTrunkEncapsulation" : "DOT1Q",
-              "type" : "PHYSICAL",
-              "vrf" : "default"
-            },
-            "vpc-f8fad69d" : {
-              "name" : "vpc-f8fad69d",
-              "accessVlan" : 0,
-              "active" : true,
-              "allPrefixes" : [
-                "240.0.0.40/31"
-              ],
-              "autostate" : true,
-              "bandwidth" : 1.0E12,
-              "incomingFilter" : "acl-4db39c28_ingress",
-              "isisL1InterfaceMode" : "unset",
-              "isisL2InterfaceMode" : "unset",
-              "mtu" : 1500,
-              "nativeVlan" : 1,
-              "ospfDeadInterval" : 0,
-              "ospfEnabled" : false,
-              "ospfHelloMultiplier" : 0,
-              "ospfPassive" : false,
-              "ospfPointToPoint" : false,
-              "outgoingFilter" : "acl-4db39c28_egress",
-              "prefix" : "240.0.0.40/31",
-              "ripEnabled" : false,
-              "ripPassive" : false,
-              "spanningTreePortfast" : false,
-              "switchportMode" : "NONE",
-              "switchportTrunkEncapsulation" : "DOT1Q",
-              "type" : "VPN",
-              "vrf" : "default"
-            }
-          },
-          "ipAccessLists" : {
-            "acl-4db39c28_egress" : {
-              "name" : "acl-4db39c28_egress",
-              "lines" : [
-                {
-                  "action" : "ACCEPT",
-                  "negate" : false
-                },
-                {
-                  "action" : "REJECT",
-                  "negate" : false
-                }
-              ]
-            },
-            "acl-4db39c28_ingress" : {
-              "name" : "acl-4db39c28_ingress",
-              "lines" : [
-                {
-                  "action" : "ACCEPT",
-                  "dstPorts" : [
-                    "3306-3306"
-                  ],
-                  "ipProtocols" : [
-                    "TCP"
-                  ],
-                  "negate" : false,
-                  "srcIps" : [
-                    "162.243.144.192"
-                  ]
-                },
-                {
-                  "action" : "REJECT",
-                  "negate" : false
-                }
-              ]
-            }
-          },
-          "roles" : [
-            "subnet"
+            "subnet-d9cafabc"
           ],
           "vendorFamily" : {
             "aws" : {
@@ -3776,7 +3163,6 @@
             "default" : {
               "name" : "default",
               "interfaces" : [
-                "igw-068fee63",
                 "subnet-d9cafabc",
                 "vpc-f8fad69d"
               ],
@@ -3786,16 +3172,8 @@
                   "administrativeCost" : 1,
                   "network" : "0.0.0.0/0",
                   "nextHopInterface" : "dynamic",
-                  "nextHopIp" : "240.0.0.43",
-                  "tag" : 0
-                },
-                {
-                  "class" : "org.batfish.datamodel.StaticRoute",
-                  "administrativeCost" : 1,
-                  "network" : "172.31.0.0/16",
-                  "nextHopInterface" : "dynamic",
-                  "nextHopIp" : "240.0.0.41",
-                  "tag" : 0
+                  "nextHopIp" : "240.0.0.25",
+                  "tag" : -1
                 }
               ]
             }
@@ -3808,35 +3186,6 @@
           "defaultInboundAction" : "ACCEPT",
           "deviceType" : "SWITCH",
           "interfaces" : {
-            "igw-9b93ddfc" : {
-              "name" : "igw-9b93ddfc",
-              "accessVlan" : 0,
-              "active" : true,
-              "allPrefixes" : [
-                "240.0.0.34/31"
-              ],
-              "autostate" : true,
-              "bandwidth" : 1.0E12,
-              "incomingFilter" : "acl-7b78771d_ingress",
-              "isisL1InterfaceMode" : "unset",
-              "isisL2InterfaceMode" : "unset",
-              "mtu" : 1500,
-              "nativeVlan" : 1,
-              "ospfDeadInterval" : 0,
-              "ospfEnabled" : false,
-              "ospfHelloMultiplier" : 0,
-              "ospfPassive" : false,
-              "ospfPointToPoint" : false,
-              "outgoingFilter" : "acl-7b78771d_egress",
-              "prefix" : "240.0.0.34/31",
-              "ripEnabled" : false,
-              "ripPassive" : false,
-              "spanningTreePortfast" : false,
-              "switchportMode" : "NONE",
-              "switchportTrunkEncapsulation" : "DOT1Q",
-              "type" : "PHYSICAL",
-              "vrf" : "default"
-            },
             "subnet-f73a8191" : {
               "name" : "subnet-f73a8191",
               "accessVlan" : 0,
@@ -3869,7 +3218,7 @@
               "accessVlan" : 0,
               "active" : true,
               "allPrefixes" : [
-                "240.0.0.32/31"
+                "240.0.0.20/31"
               ],
               "autostate" : true,
               "bandwidth" : 1.0E12,
@@ -3884,7 +3233,7 @@
               "ospfPassive" : false,
               "ospfPointToPoint" : false,
               "outgoingFilter" : "acl-7b78771d_egress",
-              "prefix" : "240.0.0.32/31",
+              "prefix" : "240.0.0.20/31",
               "ripEnabled" : false,
               "ripPassive" : false,
               "spanningTreePortfast" : false,
@@ -3923,7 +3272,7 @@
             }
           },
           "roles" : [
-            "subnet"
+            "subnet-f73a8191"
           ],
           "vendorFamily" : {
             "aws" : {
@@ -3935,7 +3284,6 @@
             "default" : {
               "name" : "default",
               "interfaces" : [
-                "igw-9b93ddfc",
                 "subnet-f73a8191",
                 "vpc-b390fad5"
               ],
@@ -3945,16 +3293,8 @@
                   "administrativeCost" : 1,
                   "network" : "0.0.0.0/0",
                   "nextHopInterface" : "dynamic",
-                  "nextHopIp" : "240.0.0.35",
-                  "tag" : 0
-                },
-                {
-                  "class" : "org.batfish.datamodel.StaticRoute",
-                  "administrativeCost" : 1,
-                  "network" : "192.168.0.0/16",
-                  "nextHopInterface" : "dynamic",
-                  "nextHopIp" : "240.0.0.33",
-                  "tag" : 0
+                  "nextHopIp" : "240.0.0.21",
+                  "tag" : -1
                 }
               ]
             }
@@ -4202,7 +3542,7 @@
             }
           },
           "roles" : [
-            "vgw"
+            "vgw-81fd279f"
           ],
           "routeFilterLists" : {
             "vpn-ba2e34a8-1_origination" : {
@@ -4314,6 +3654,40 @@
                   "type" : "ExitReject"
                 }
               ]
+            },
+            "~ACCEPT_ALL_EBGP_AND_SET_NEXT_HOP_SELF~" : {
+              "name" : "~ACCEPT_ALL_EBGP_AND_SET_NEXT_HOP_SELF~",
+              "statements" : [
+                {
+                  "class" : "org.batfish.datamodel.routing_policy.statement.SetNextHop",
+                  "destinationVrf" : false,
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.SelfNextHop"
+                  }
+                },
+                {
+                  "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                  "falseStatements" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                      "type" : "ExitReject"
+                    }
+                  ],
+                  "guard" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                    "protocol" : "bgp"
+                  },
+                  "trueStatements" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                      "type" : "ExitAccept"
+                    }
+                  ]
+                }
+              ]
+            },
+            "~REJECT_ALL~" : {
+              "name" : "~REJECT_ALL~"
             }
           },
           "vendorFamily" : {
@@ -4370,6 +3744,29 @@
                     "routeReflectorClient" : false,
                     "sendCommunity" : false,
                     "vrf" : "default"
+                  },
+                  "240.0.0.7/32" : {
+                    "name" : "240.0.0.7/32",
+                    "additionalPathsReceive" : false,
+                    "additionalPathsSelectAll" : false,
+                    "additionalPathsSend" : false,
+                    "address" : "240.0.0.7",
+                    "advertiseExternal" : false,
+                    "advertiseInactive" : false,
+                    "allowLocalAsIn" : false,
+                    "allowRemoteAsOut" : false,
+                    "defaultMetric" : 0,
+                    "dynamic" : false,
+                    "ebgpMultihop" : false,
+                    "exportPolicy" : "~ACCEPT_ALL_EBGP_AND_SET_NEXT_HOP_SELF~",
+                    "importPolicy" : "~REJECT_ALL~",
+                    "localAs" : 65401,
+                    "localIp" : "240.0.0.6",
+                    "remoteAs" : 65401,
+                    "remotePrefix" : "240.0.0.7/32",
+                    "routeReflectorClient" : false,
+                    "sendCommunity" : true,
+                    "vrf" : "default"
                   }
                 },
                 "routerId" : "169.254.15.193",
@@ -4389,7 +3786,7 @@
                   "network" : "10.100.0.0/16",
                   "nextHopInterface" : "dynamic",
                   "nextHopIp" : "240.0.0.7",
-                  "tag" : 0
+                  "tag" : -1
                 }
               ]
             }
@@ -4400,12 +3797,15 @@
           "name" : "vpc-815775e7",
           "defaultCrossZoneAction" : "ACCEPT",
           "defaultInboundAction" : "ACCEPT",
-          "deviceType" : "SWITCH",
+          "deviceType" : "ROUTER",
           "interfaces" : {
             "vgw-81fd279f" : {
               "name" : "vgw-81fd279f",
               "accessVlan" : 0,
               "active" : true,
+              "allPrefixes" : [
+                "240.0.0.7/31"
+              ],
               "autostate" : true,
               "bandwidth" : 1.0E12,
               "isisL1InterfaceMode" : "unset",
@@ -4423,12 +3823,27 @@
               "spanningTreePortfast" : false,
               "switchportMode" : "NONE",
               "switchportTrunkEncapsulation" : "DOT1Q",
-              "type" : "VPN"
+              "type" : "VPN",
+              "vrf" : "default"
             }
           },
           "roles" : [
-            "vpc"
+            "vpc-815775e7"
           ],
+          "routingPolicies" : {
+            "~ACCEPT_ALL~" : {
+              "name" : "~ACCEPT_ALL~",
+              "statements" : [
+                {
+                  "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                  "type" : "ExitAccept"
+                }
+              ]
+            },
+            "~REJECT_ALL~" : {
+              "name" : "~REJECT_ALL~"
+            }
+          },
           "vendorFamily" : {
             "aws" : {
               "vpcId" : "vpc-815775e7"
@@ -4437,8 +3852,50 @@
           "vrfs" : {
             "default" : {
               "name" : "default",
+              "bgpProcess" : {
+                "multipathEbgp" : false,
+                "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
+                "multipathIbgp" : false,
+                "neighbors" : {
+                  "240.0.0.6/32" : {
+                    "name" : "240.0.0.6/32",
+                    "additionalPathsReceive" : false,
+                    "additionalPathsSelectAll" : false,
+                    "additionalPathsSend" : false,
+                    "address" : "240.0.0.6",
+                    "advertiseExternal" : false,
+                    "advertiseInactive" : false,
+                    "allowLocalAsIn" : false,
+                    "allowRemoteAsOut" : false,
+                    "defaultMetric" : 0,
+                    "dynamic" : false,
+                    "ebgpMultihop" : false,
+                    "exportPolicy" : "~REJECT_ALL~",
+                    "importPolicy" : "~ACCEPT_ALL~",
+                    "localAs" : 65401,
+                    "localIp" : "240.0.0.7",
+                    "remoteAs" : 65401,
+                    "remotePrefix" : "240.0.0.6/32",
+                    "routeReflectorClient" : false,
+                    "sendCommunity" : true,
+                    "vrf" : "default"
+                  }
+                },
+                "routerId" : "240.0.0.7",
+                "tieBreaker" : "ARRIVAL_ORDER"
+              },
               "interfaces" : [
                 "vgw-81fd279f"
+              ],
+              "staticRoutes" : [
+                {
+                  "class" : "org.batfish.datamodel.StaticRoute",
+                  "administrativeCost" : 1,
+                  "network" : "10.100.0.0/16",
+                  "nextHopInterface" : "null_interface",
+                  "nextHopIp" : "AUTO/NONE(-1l)",
+                  "tag" : -1
+                }
               ]
             }
           }
@@ -4482,7 +3939,7 @@
               "accessVlan" : 0,
               "active" : true,
               "allPrefixes" : [
-                "240.0.0.37/31"
+                "240.0.0.23/31"
               ],
               "autostate" : true,
               "bandwidth" : 1.0E12,
@@ -4495,7 +3952,7 @@
               "ospfHelloMultiplier" : 0,
               "ospfPassive" : false,
               "ospfPointToPoint" : false,
-              "prefix" : "240.0.0.37/31",
+              "prefix" : "240.0.0.23/31",
               "ripEnabled" : false,
               "ripPassive" : false,
               "spanningTreePortfast" : false,
@@ -4533,7 +3990,7 @@
             }
           },
           "roles" : [
-            "vpc"
+            "vpc-925131f4"
           ],
           "vendorFamily" : {
             "aws" : {
@@ -4552,10 +4009,18 @@
                 {
                   "class" : "org.batfish.datamodel.StaticRoute",
                   "administrativeCost" : 1,
+                  "network" : "10.0.0.0/16",
+                  "nextHopInterface" : "null_interface",
+                  "nextHopIp" : "AUTO/NONE(-1l)",
+                  "tag" : -1
+                },
+                {
+                  "class" : "org.batfish.datamodel.StaticRoute",
+                  "administrativeCost" : 1,
                   "network" : "10.0.0.0/24",
                   "nextHopInterface" : "dynamic",
-                  "nextHopIp" : "240.0.0.36",
-                  "tag" : 0
+                  "nextHopIp" : "240.0.0.22",
+                  "tag" : -1
                 },
                 {
                   "class" : "org.batfish.datamodel.StaticRoute",
@@ -4563,7 +4028,7 @@
                   "network" : "10.0.1.0/24",
                   "nextHopInterface" : "dynamic",
                   "nextHopIp" : "240.0.0.8",
-                  "tag" : 0
+                  "tag" : -1
                 }
               ]
             }
@@ -4608,7 +4073,7 @@
               "accessVlan" : 0,
               "active" : true,
               "allPrefixes" : [
-                "240.0.0.13/31"
+                "240.0.0.11/31"
               ],
               "autostate" : true,
               "bandwidth" : 1.0E12,
@@ -4621,7 +4086,7 @@
               "ospfHelloMultiplier" : 0,
               "ospfPassive" : false,
               "ospfPointToPoint" : false,
-              "prefix" : "240.0.0.13/31",
+              "prefix" : "240.0.0.11/31",
               "ripEnabled" : false,
               "ripPassive" : false,
               "spanningTreePortfast" : false,
@@ -4635,7 +4100,7 @@
               "accessVlan" : 0,
               "active" : true,
               "allPrefixes" : [
-                "240.0.0.29/31"
+                "240.0.0.19/31"
               ],
               "autostate" : true,
               "bandwidth" : 1.0E12,
@@ -4648,7 +4113,7 @@
               "ospfHelloMultiplier" : 0,
               "ospfPassive" : false,
               "ospfPointToPoint" : false,
-              "prefix" : "240.0.0.29/31",
+              "prefix" : "240.0.0.19/31",
               "ripEnabled" : false,
               "ripPassive" : false,
               "spanningTreePortfast" : false,
@@ -4662,7 +4127,7 @@
               "accessVlan" : 0,
               "active" : true,
               "allPrefixes" : [
-                "240.0.0.45/31"
+                "240.0.0.27/31"
               ],
               "autostate" : true,
               "bandwidth" : 1.0E12,
@@ -4675,7 +4140,7 @@
               "ospfHelloMultiplier" : 0,
               "ospfPassive" : false,
               "ospfPointToPoint" : false,
-              "prefix" : "240.0.0.45/31",
+              "prefix" : "240.0.0.27/31",
               "ripEnabled" : false,
               "ripPassive" : false,
               "spanningTreePortfast" : false,
@@ -4686,6 +4151,33 @@
             },
             "subnet-7044ff16" : {
               "name" : "subnet-7044ff16",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "240.0.0.15/31"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E12,
+              "isisL1InterfaceMode" : "unset",
+              "isisL2InterfaceMode" : "unset",
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : false,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "240.0.0.15/31",
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "subnet-f73a8191" : {
+              "name" : "subnet-f73a8191",
               "accessVlan" : 0,
               "active" : true,
               "allPrefixes" : [
@@ -4710,37 +4202,10 @@
               "switchportTrunkEncapsulation" : "DOT1Q",
               "type" : "PHYSICAL",
               "vrf" : "default"
-            },
-            "subnet-f73a8191" : {
-              "name" : "subnet-f73a8191",
-              "accessVlan" : 0,
-              "active" : true,
-              "allPrefixes" : [
-                "240.0.0.33/31"
-              ],
-              "autostate" : true,
-              "bandwidth" : 1.0E12,
-              "isisL1InterfaceMode" : "unset",
-              "isisL2InterfaceMode" : "unset",
-              "mtu" : 1500,
-              "nativeVlan" : 1,
-              "ospfDeadInterval" : 0,
-              "ospfEnabled" : false,
-              "ospfHelloMultiplier" : 0,
-              "ospfPassive" : false,
-              "ospfPointToPoint" : false,
-              "prefix" : "240.0.0.33/31",
-              "ripEnabled" : false,
-              "ripPassive" : false,
-              "spanningTreePortfast" : false,
-              "switchportMode" : "NONE",
-              "switchportTrunkEncapsulation" : "DOT1Q",
-              "type" : "PHYSICAL",
-              "vrf" : "default"
             }
           },
           "roles" : [
-            "vpc"
+            "vpc-b390fad5"
           ],
           "vendorFamily" : {
             "aws" : {
@@ -4762,42 +4227,50 @@
                 {
                   "class" : "org.batfish.datamodel.StaticRoute",
                   "administrativeCost" : 1,
+                  "network" : "192.168.0.0/16",
+                  "nextHopInterface" : "null_interface",
+                  "nextHopIp" : "AUTO/NONE(-1l)",
+                  "tag" : -1
+                },
+                {
+                  "class" : "org.batfish.datamodel.StaticRoute",
+                  "administrativeCost" : 1,
                   "network" : "192.168.1.0/24",
                   "nextHopInterface" : "dynamic",
-                  "nextHopIp" : "240.0.0.28",
-                  "tag" : 0
+                  "nextHopIp" : "240.0.0.18",
+                  "tag" : -1
                 },
                 {
                   "class" : "org.batfish.datamodel.StaticRoute",
                   "administrativeCost" : 1,
                   "network" : "192.168.2.0/28",
                   "nextHopInterface" : "dynamic",
-                  "nextHopIp" : "240.0.0.20",
-                  "tag" : 0
+                  "nextHopIp" : "240.0.0.14",
+                  "tag" : -1
                 },
                 {
                   "class" : "org.batfish.datamodel.StaticRoute",
                   "administrativeCost" : 1,
                   "network" : "192.168.2.16/28",
                   "nextHopInterface" : "dynamic",
-                  "nextHopIp" : "240.0.0.12",
-                  "tag" : 0
+                  "nextHopIp" : "240.0.0.10",
+                  "tag" : -1
                 },
                 {
                   "class" : "org.batfish.datamodel.StaticRoute",
                   "administrativeCost" : 1,
                   "network" : "192.168.2.32/28",
                   "nextHopInterface" : "dynamic",
-                  "nextHopIp" : "240.0.0.44",
-                  "tag" : 0
+                  "nextHopIp" : "240.0.0.26",
+                  "tag" : -1
                 },
                 {
                   "class" : "org.batfish.datamodel.StaticRoute",
                   "administrativeCost" : 1,
                   "network" : "192.168.2.48/28",
                   "nextHopInterface" : "dynamic",
-                  "nextHopIp" : "240.0.0.32",
-                  "tag" : 0
+                  "nextHopIp" : "240.0.0.20",
+                  "tag" : -1
                 }
               ]
             }
@@ -4842,6 +4315,33 @@
               "accessVlan" : 0,
               "active" : true,
               "allPrefixes" : [
+                "240.0.0.13/31"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E12,
+              "isisL1InterfaceMode" : "unset",
+              "isisL2InterfaceMode" : "unset",
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : false,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "240.0.0.13/31",
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "subnet-9c8adceb" : {
+              "name" : "subnet-9c8adceb",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
                 "240.0.0.17/31"
               ],
               "autostate" : true,
@@ -4864,8 +4364,8 @@
               "type" : "PHYSICAL",
               "vrf" : "default"
             },
-            "subnet-9c8adceb" : {
-              "name" : "subnet-9c8adceb",
+            "subnet-d9cafabc" : {
+              "name" : "subnet-d9cafabc",
               "accessVlan" : 0,
               "active" : true,
               "allPrefixes" : [
@@ -4890,37 +4390,10 @@
               "switchportTrunkEncapsulation" : "DOT1Q",
               "type" : "PHYSICAL",
               "vrf" : "default"
-            },
-            "subnet-d9cafabc" : {
-              "name" : "subnet-d9cafabc",
-              "accessVlan" : 0,
-              "active" : true,
-              "allPrefixes" : [
-                "240.0.0.41/31"
-              ],
-              "autostate" : true,
-              "bandwidth" : 1.0E12,
-              "isisL1InterfaceMode" : "unset",
-              "isisL2InterfaceMode" : "unset",
-              "mtu" : 1500,
-              "nativeVlan" : 1,
-              "ospfDeadInterval" : 0,
-              "ospfEnabled" : false,
-              "ospfHelloMultiplier" : 0,
-              "ospfPassive" : false,
-              "ospfPointToPoint" : false,
-              "prefix" : "240.0.0.41/31",
-              "ripEnabled" : false,
-              "ripPassive" : false,
-              "spanningTreePortfast" : false,
-              "switchportMode" : "NONE",
-              "switchportTrunkEncapsulation" : "DOT1Q",
-              "type" : "PHYSICAL",
-              "vrf" : "default"
             }
           },
           "roles" : [
-            "vpc"
+            "vpc-f8fad69d"
           ],
           "vendorFamily" : {
             "aws" : {
@@ -4940,26 +4413,34 @@
                 {
                   "class" : "org.batfish.datamodel.StaticRoute",
                   "administrativeCost" : 1,
+                  "network" : "172.31.0.0/16",
+                  "nextHopInterface" : "null_interface",
+                  "nextHopIp" : "AUTO/NONE(-1l)",
+                  "tag" : -1
+                },
+                {
+                  "class" : "org.batfish.datamodel.StaticRoute",
+                  "administrativeCost" : 1,
                   "network" : "172.31.0.0/20",
                   "nextHopInterface" : "dynamic",
-                  "nextHopIp" : "240.0.0.16",
-                  "tag" : 0
+                  "nextHopIp" : "240.0.0.12",
+                  "tag" : -1
                 },
                 {
                   "class" : "org.batfish.datamodel.StaticRoute",
                   "administrativeCost" : 1,
                   "network" : "172.31.16.0/20",
                   "nextHopInterface" : "dynamic",
-                  "nextHopIp" : "240.0.0.40",
-                  "tag" : 0
+                  "nextHopIp" : "240.0.0.24",
+                  "tag" : -1
                 },
                 {
                   "class" : "org.batfish.datamodel.StaticRoute",
                   "administrativeCost" : 1,
                   "network" : "172.31.32.0/20",
                   "nextHopInterface" : "dynamic",
-                  "nextHopIp" : "240.0.0.24",
-                  "tag" : 0
+                  "nextHopIp" : "240.0.0.16",
+                  "tag" : -1
                 }
               ]
             }

--- a/tests/basic/topology-example-aws.ref
+++ b/tests/basic/topology-example-aws.ref
@@ -37,6 +37,14 @@
       "type" : "SUBNET"
     },
     {
+      "name" : "vpc-815775e7",
+      "contents" : [
+        "node-vpc-815775e7"
+      ],
+      "id" : "aggregate-vpc-815775e7",
+      "type" : "VNET"
+    },
+    {
       "name" : "subnet-073b8061",
       "contents" : [
         "node-subnet-073b8061"
@@ -58,6 +66,7 @@
         "node-vpc-b390fad5",
         "node-border_01",
         "node-border_02",
+        "node-vpc-815775e7",
         "node-subnet-d9cafabc",
         "node-subnet-30398256",
         "node-igw-9b93ddfc",
@@ -167,333 +176,15 @@
       "type" : "UNKNOWN"
     },
     {
-      "name" : "subnet-f73a8191",
-      "nodeId" : "node-border_02",
-      "id" : "interface-node-border_02-subnet-f73a8191",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "subnet-f73a8191",
-      "nodeId" : "node-igw-9b93ddfc",
-      "id" : "interface-node-igw-9b93ddfc-subnet-f73a8191",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "vpc-f8fad69d",
-      "nodeId" : "node-subnet-9c8adceb",
-      "id" : "interface-node-subnet-9c8adceb-vpc-f8fad69d",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "subnet-1641fa70",
-      "nodeId" : "node-CVP Server Test",
-      "id" : "interface-node-CVP Server Test-subnet-1641fa70",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "igw-fac5839d",
-      "nodeId" : "node-igw-fac5839d",
-      "id" : "interface-node-igw-fac5839d-igw-fac5839d",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "subnet-1f315846",
-      "nodeId" : "node-vpc-f8fad69d",
-      "id" : "interface-node-vpc-f8fad69d-subnet-1f315846",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "eni-d2b094fc",
-      "nodeId" : "node-border_01",
-      "id" : "interface-node-border_01-eni-d2b094fc",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "vpc-f8fad69d",
-      "nodeId" : "node-igw-068fee63",
-      "id" : "interface-node-igw-068fee63-vpc-f8fad69d",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "vpc-925131f4",
-      "nodeId" : "node-subnet-62f14104",
-      "id" : "interface-node-subnet-62f14104-vpc-925131f4",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "igw-9b93ddfc",
-      "nodeId" : "node-igw-9b93ddfc",
-      "id" : "interface-node-igw-9b93ddfc-igw-9b93ddfc",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "eni-d2b094fc",
-      "nodeId" : "node-subnet-1641fa70",
-      "id" : "interface-node-subnet-1641fa70-eni-d2b094fc",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "subnet-073b8061",
-      "nodeId" : "node-vpc-b390fad5",
-      "id" : "interface-node-vpc-b390fad5-subnet-073b8061",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "igw-9b93ddfc",
-      "nodeId" : "node-subnet-f73a8191",
-      "id" : "interface-node-subnet-f73a8191-igw-9b93ddfc",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "igw-068fee63",
-      "nodeId" : "node-subnet-1f315846",
-      "id" : "interface-node-subnet-1f315846-igw-068fee63",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "vpc-b390fad5",
-      "nodeId" : "node-subnet-1641fa70",
-      "id" : "interface-node-subnet-1641fa70-vpc-b390fad5",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "vpc-b390fad5",
-      "nodeId" : "node-subnet-073b8061",
-      "id" : "interface-node-subnet-073b8061-vpc-b390fad5",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "subnet-1f315846",
-      "nodeId" : "node-subnet-1f315846",
-      "id" : "interface-node-subnet-1f315846-subnet-1f315846",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "subnet-1f315846",
-      "nodeId" : "node-igw-068fee63",
-      "id" : "interface-node-igw-068fee63-subnet-1f315846",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "subnet-30398256",
-      "nodeId" : "node-subnet-30398256",
-      "id" : "interface-node-subnet-30398256-subnet-30398256",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "subnet-073b8061",
-      "nodeId" : "node-subnet-073b8061",
-      "id" : "interface-node-subnet-073b8061-subnet-073b8061",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "subnet-7044ff16",
-      "nodeId" : "node-vpc-b390fad5",
-      "id" : "interface-node-vpc-b390fad5-subnet-7044ff16",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "eni-a50c2b8b",
-      "nodeId" : "node-subnet-f73a8191",
-      "id" : "interface-node-subnet-f73a8191-eni-a50c2b8b",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "igw-068fee63",
-      "nodeId" : "node-subnet-d9cafabc",
-      "id" : "interface-node-subnet-d9cafabc-igw-068fee63",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "igw-fac5839d",
-      "nodeId" : "node-subnet-62f14104",
-      "id" : "interface-node-subnet-62f14104-igw-fac5839d",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "vpn1",
-      "nodeId" : "node-vgw-81fd279f",
-      "id" : "interface-node-vgw-81fd279f-vpn1",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "vpn1",
-      "nodeId" : "node-lhr-border-02",
-      "id" : "interface-node-lhr-border-02-vpn1",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "vpn2",
-      "nodeId" : "node-vgw-81fd279f",
-      "id" : "interface-node-vgw-81fd279f-vpn2",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "subnet-9c8adceb",
-      "nodeId" : "node-vpc-f8fad69d",
-      "id" : "interface-node-vpc-f8fad69d-subnet-9c8adceb",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "vpn2",
-      "nodeId" : "node-lhr-border-02",
-      "id" : "interface-node-lhr-border-02-vpn2",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "subnet-9c8adceb",
-      "nodeId" : "node-igw-068fee63",
-      "id" : "interface-node-igw-068fee63-subnet-9c8adceb",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "subnet-d9cafabc",
-      "nodeId" : "node-subnet-d9cafabc",
-      "id" : "interface-node-subnet-d9cafabc-subnet-d9cafabc",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "subnet-7044ff16",
-      "nodeId" : "node-igw-9b93ddfc",
-      "id" : "interface-node-igw-9b93ddfc-subnet-7044ff16",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "eni-4b466165",
-      "nodeId" : "node-border_01",
-      "id" : "interface-node-border_01-eni-4b466165",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "subnet-073b8061",
-      "nodeId" : "node-igw-9b93ddfc",
-      "id" : "interface-node-igw-9b93ddfc-subnet-073b8061",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "eni-4b466165",
-      "nodeId" : "node-core_01",
-      "id" : "interface-node-core_01-eni-4b466165",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "igw-9b93ddfc",
-      "nodeId" : "node-subnet-30398256",
-      "id" : "interface-node-subnet-30398256-igw-9b93ddfc",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "eni-d2b094fc",
-      "nodeId" : "node-border_02",
-      "id" : "interface-node-border_02-eni-d2b094fc",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "eni-6b705445",
-      "nodeId" : "node-border_02",
-      "id" : "interface-node-border_02-eni-6b705445",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "eni-707e5a5e",
-      "nodeId" : "node-core_01",
-      "id" : "interface-node-core_01-eni-707e5a5e",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "subnet-62f14104",
-      "nodeId" : "node-vpc-925131f4",
-      "id" : "interface-node-vpc-925131f4-subnet-62f14104",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "subnet-f73a8191",
-      "nodeId" : "node-vpc-b390fad5",
-      "id" : "interface-node-vpc-b390fad5-subnet-f73a8191",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "Tunnel1",
-      "nodeId" : "node-lhr-border-02",
-      "id" : "interface-node-lhr-border-02-Tunnel1",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "eni-d2b094fc",
-      "nodeId" : "node-core_01",
-      "id" : "interface-node-core_01-eni-d2b094fc",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "Tunnel2",
-      "nodeId" : "node-lhr-border-02",
-      "id" : "interface-node-lhr-border-02-Tunnel2",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "subnet-f73a8191",
-      "nodeId" : "node-subnet-f73a8191",
-      "id" : "interface-node-subnet-f73a8191-subnet-f73a8191",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "igw-068fee63",
-      "nodeId" : "node-subnet-9c8adceb",
-      "id" : "interface-node-subnet-9c8adceb-igw-068fee63",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "eni-707e5a5e",
-      "nodeId" : "node-border_02",
-      "id" : "interface-node-border_02-eni-707e5a5e",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "vpc-b390fad5",
-      "nodeId" : "node-subnet-7044ff16",
-      "id" : "interface-node-subnet-7044ff16-vpc-b390fad5",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "vpc-925131f4",
-      "nodeId" : "node-subnet-8d0cbdeb",
-      "id" : "interface-node-subnet-8d0cbdeb-vpc-925131f4",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "eni-d2b094fc",
-      "nodeId" : "node-CVP Server Test",
-      "id" : "interface-node-CVP Server Test-eni-d2b094fc",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "vpc-b390fad5",
-      "nodeId" : "node-vpc-b390fad5",
-      "id" : "interface-node-vpc-b390fad5-vpc-b390fad5",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "eni-4b466165",
-      "nodeId" : "node-subnet-073b8061",
-      "id" : "interface-node-subnet-073b8061-eni-4b466165",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "eni-707e5a5e",
-      "nodeId" : "node-CVP Server Test",
-      "id" : "interface-node-CVP Server Test-eni-707e5a5e",
-      "type" : "UNKNOWN"
-    },
-    {
       "name" : "eni-6b705445",
       "nodeId" : "node-CVP Server Test",
       "id" : "interface-node-CVP Server Test-eni-6b705445",
       "type" : "UNKNOWN"
     },
     {
-      "name" : "subnet-8d0cbdeb",
-      "nodeId" : "node-igw-fac5839d",
-      "id" : "interface-node-igw-fac5839d-subnet-8d0cbdeb",
+      "name" : "subnet-f73a8191",
+      "nodeId" : "node-border_02",
+      "id" : "interface-node-border_02-subnet-f73a8191",
       "type" : "UNKNOWN"
     },
     {
@@ -527,9 +218,15 @@
       "type" : "UNKNOWN"
     },
     {
-      "name" : "igw-9b93ddfc",
-      "nodeId" : "node-subnet-1641fa70",
-      "id" : "interface-node-subnet-1641fa70-igw-9b93ddfc",
+      "name" : "vpc-f8fad69d",
+      "nodeId" : "node-subnet-9c8adceb",
+      "id" : "interface-node-subnet-9c8adceb-vpc-f8fad69d",
+      "type" : "UNKNOWN"
+    },
+    {
+      "name" : "subnet-1641fa70",
+      "nodeId" : "node-CVP Server Test",
+      "id" : "interface-node-CVP Server Test-subnet-1641fa70",
       "type" : "UNKNOWN"
     },
     {
@@ -540,14 +237,20 @@
     },
     {
       "name" : "igw-fac5839d",
-      "nodeId" : "node-subnet-8d0cbdeb",
-      "id" : "interface-node-subnet-8d0cbdeb-igw-fac5839d",
+      "nodeId" : "node-igw-fac5839d",
+      "id" : "interface-node-igw-fac5839d-igw-fac5839d",
       "type" : "UNKNOWN"
     },
     {
-      "name" : "subnet-1641fa70",
-      "nodeId" : "node-igw-9b93ddfc",
-      "id" : "interface-node-igw-9b93ddfc-subnet-1641fa70",
+      "name" : "subnet-1f315846",
+      "nodeId" : "node-vpc-f8fad69d",
+      "id" : "interface-node-vpc-f8fad69d-subnet-1f315846",
+      "type" : "UNKNOWN"
+    },
+    {
+      "name" : "eni-d2b094fc",
+      "nodeId" : "node-border_01",
+      "id" : "interface-node-border_01-eni-d2b094fc",
       "type" : "UNKNOWN"
     },
     {
@@ -563,6 +266,36 @@
       "type" : "UNKNOWN"
     },
     {
+      "name" : "vpc-f8fad69d",
+      "nodeId" : "node-igw-068fee63",
+      "id" : "interface-node-igw-068fee63-vpc-f8fad69d",
+      "type" : "UNKNOWN"
+    },
+    {
+      "name" : "vpc-925131f4",
+      "nodeId" : "node-subnet-62f14104",
+      "id" : "interface-node-subnet-62f14104-vpc-925131f4",
+      "type" : "UNKNOWN"
+    },
+    {
+      "name" : "igw-9b93ddfc",
+      "nodeId" : "node-igw-9b93ddfc",
+      "id" : "interface-node-igw-9b93ddfc-igw-9b93ddfc",
+      "type" : "UNKNOWN"
+    },
+    {
+      "name" : "eni-d2b094fc",
+      "nodeId" : "node-subnet-1641fa70",
+      "id" : "interface-node-subnet-1641fa70-eni-d2b094fc",
+      "type" : "UNKNOWN"
+    },
+    {
+      "name" : "subnet-073b8061",
+      "nodeId" : "node-vpc-b390fad5",
+      "id" : "interface-node-vpc-b390fad5-subnet-073b8061",
+      "type" : "UNKNOWN"
+    },
+    {
       "name" : "subnet-1641fa70",
       "nodeId" : "node-border_02",
       "id" : "interface-node-border_02-subnet-1641fa70",
@@ -572,6 +305,18 @@
       "name" : "eni-8c7753a2",
       "nodeId" : "node-core_01",
       "id" : "interface-node-core_01-eni-8c7753a2",
+      "type" : "UNKNOWN"
+    },
+    {
+      "name" : "vpc-b390fad5",
+      "nodeId" : "node-subnet-1641fa70",
+      "id" : "interface-node-subnet-1641fa70-vpc-b390fad5",
+      "type" : "UNKNOWN"
+    },
+    {
+      "name" : "vpc-b390fad5",
+      "nodeId" : "node-subnet-073b8061",
+      "id" : "interface-node-subnet-073b8061-vpc-b390fad5",
       "type" : "UNKNOWN"
     },
     {
@@ -593,6 +338,12 @@
       "type" : "UNKNOWN"
     },
     {
+      "name" : "vgw-81fd279f",
+      "nodeId" : "node-vgw-81fd279f",
+      "id" : "interface-node-vgw-81fd279f-vgw-81fd279f",
+      "type" : "UNKNOWN"
+    },
+    {
       "name" : "vpc-f8fad69d",
       "nodeId" : "node-vpc-f8fad69d",
       "id" : "interface-node-vpc-f8fad69d-vpc-f8fad69d",
@@ -611,6 +362,12 @@
       "type" : "UNKNOWN"
     },
     {
+      "name" : "subnet-1f315846",
+      "nodeId" : "node-subnet-1f315846",
+      "id" : "interface-node-subnet-1f315846-subnet-1f315846",
+      "type" : "UNKNOWN"
+    },
+    {
       "name" : "vpc-925131f4",
       "nodeId" : "node-vpc-925131f4",
       "id" : "interface-node-vpc-925131f4-vpc-925131f4",
@@ -623,15 +380,51 @@
       "type" : "UNKNOWN"
     },
     {
-      "name" : "igw-9b93ddfc",
-      "nodeId" : "node-subnet-073b8061",
-      "id" : "interface-node-subnet-073b8061-igw-9b93ddfc",
+      "name" : "subnet-30398256",
+      "nodeId" : "node-subnet-30398256",
+      "id" : "interface-node-subnet-30398256-subnet-30398256",
       "type" : "UNKNOWN"
     },
     {
-      "name" : "subnet-62f14104",
-      "nodeId" : "node-igw-fac5839d",
-      "id" : "interface-node-igw-fac5839d-subnet-62f14104",
+      "name" : "subnet-073b8061",
+      "nodeId" : "node-subnet-073b8061",
+      "id" : "interface-node-subnet-073b8061-subnet-073b8061",
+      "type" : "UNKNOWN"
+    },
+    {
+      "name" : "vpc-815775e7",
+      "nodeId" : "node-vpc-815775e7",
+      "id" : "interface-node-vpc-815775e7-vpc-815775e7",
+      "type" : "UNKNOWN"
+    },
+    {
+      "name" : "subnet-7044ff16",
+      "nodeId" : "node-vpc-b390fad5",
+      "id" : "interface-node-vpc-b390fad5-subnet-7044ff16",
+      "type" : "UNKNOWN"
+    },
+    {
+      "name" : "eni-a50c2b8b",
+      "nodeId" : "node-subnet-f73a8191",
+      "id" : "interface-node-subnet-f73a8191-eni-a50c2b8b",
+      "type" : "UNKNOWN"
+    },
+    {
+      "name" : "vpn1",
+      "nodeId" : "node-vgw-81fd279f",
+      "id" : "interface-node-vgw-81fd279f-vpn1",
+      "type" : "UNKNOWN"
+    },
+    {
+      "name" : "vpn1",
+      "nodeId" : "node-lhr-border-02",
+      "id" : "interface-node-lhr-border-02-vpn1",
+      "type" : "UNKNOWN"
+    },
+    {
+      "name" : "vpn2",
+      "nodeId" : "node-vgw-81fd279f",
+      "id" : "interface-node-vgw-81fd279f-vpn2",
       "type" : "UNKNOWN"
     },
     {
@@ -641,15 +434,33 @@
       "type" : "UNKNOWN"
     },
     {
+      "name" : "subnet-9c8adceb",
+      "nodeId" : "node-vpc-f8fad69d",
+      "id" : "interface-node-vpc-f8fad69d-subnet-9c8adceb",
+      "type" : "UNKNOWN"
+    },
+    {
       "name" : "subnet-1641fa70",
       "nodeId" : "node-core_01",
       "id" : "interface-node-core_01-subnet-1641fa70",
       "type" : "UNKNOWN"
     },
     {
+      "name" : "vpn2",
+      "nodeId" : "node-lhr-border-02",
+      "id" : "interface-node-lhr-border-02-vpn2",
+      "type" : "UNKNOWN"
+    },
+    {
       "name" : "subnet-d9cafabc",
       "nodeId" : "node-vpc-f8fad69d",
       "id" : "interface-node-vpc-f8fad69d-subnet-d9cafabc",
+      "type" : "UNKNOWN"
+    },
+    {
+      "name" : "vgw-81fd279f",
+      "nodeId" : "node-vpc-815775e7",
+      "id" : "interface-node-vpc-815775e7-vgw-81fd279f",
       "type" : "UNKNOWN"
     },
     {
@@ -665,6 +476,12 @@
       "type" : "UNKNOWN"
     },
     {
+      "name" : "vpc-815775e7",
+      "nodeId" : "node-vgw-81fd279f",
+      "id" : "interface-node-vgw-81fd279f-vpc-815775e7",
+      "type" : "UNKNOWN"
+    },
+    {
       "name" : "Tunnel1",
       "nodeId" : "node-vgw-81fd279f",
       "id" : "interface-node-vgw-81fd279f-Tunnel1",
@@ -677,15 +494,39 @@
       "type" : "UNKNOWN"
     },
     {
+      "name" : "subnet-d9cafabc",
+      "nodeId" : "node-subnet-d9cafabc",
+      "id" : "interface-node-subnet-d9cafabc-subnet-d9cafabc",
+      "type" : "UNKNOWN"
+    },
+    {
       "name" : "igw-fac5839d",
       "nodeId" : "node-vpc-925131f4",
       "id" : "interface-node-vpc-925131f4-igw-fac5839d",
       "type" : "UNKNOWN"
     },
     {
+      "name" : "eni-4b466165",
+      "nodeId" : "node-border_01",
+      "id" : "interface-node-border_01-eni-4b466165",
+      "type" : "UNKNOWN"
+    },
+    {
       "name" : "eni-707e5a5e",
       "nodeId" : "node-border_01",
       "id" : "interface-node-border_01-eni-707e5a5e",
+      "type" : "UNKNOWN"
+    },
+    {
+      "name" : "eni-4b466165",
+      "nodeId" : "node-core_01",
+      "id" : "interface-node-core_01-eni-4b466165",
+      "type" : "UNKNOWN"
+    },
+    {
+      "name" : "eni-d2b094fc",
+      "nodeId" : "node-border_02",
+      "id" : "interface-node-border_02-eni-d2b094fc",
       "type" : "UNKNOWN"
     },
     {
@@ -707,27 +548,63 @@
       "type" : "UNKNOWN"
     },
     {
+      "name" : "eni-6b705445",
+      "nodeId" : "node-border_02",
+      "id" : "interface-node-border_02-eni-6b705445",
+      "type" : "UNKNOWN"
+    },
+    {
+      "name" : "eni-707e5a5e",
+      "nodeId" : "node-core_01",
+      "id" : "interface-node-core_01-eni-707e5a5e",
+      "type" : "UNKNOWN"
+    },
+    {
       "name" : "eni-8c7753a2",
       "nodeId" : "node-border_02",
       "id" : "interface-node-border_02-eni-8c7753a2",
       "type" : "UNKNOWN"
     },
     {
-      "name" : "subnet-d9cafabc",
-      "nodeId" : "node-igw-068fee63",
-      "id" : "interface-node-igw-068fee63-subnet-d9cafabc",
-      "type" : "UNKNOWN"
-    },
-    {
-      "name" : "igw-9b93ddfc",
-      "nodeId" : "node-subnet-7044ff16",
-      "id" : "interface-node-subnet-7044ff16-igw-9b93ddfc",
+      "name" : "subnet-62f14104",
+      "nodeId" : "node-vpc-925131f4",
+      "id" : "interface-node-vpc-925131f4-subnet-62f14104",
       "type" : "UNKNOWN"
     },
     {
       "name" : "eni-297b5c07",
       "nodeId" : "node-core_01",
       "id" : "interface-node-core_01-eni-297b5c07",
+      "type" : "UNKNOWN"
+    },
+    {
+      "name" : "subnet-f73a8191",
+      "nodeId" : "node-vpc-b390fad5",
+      "id" : "interface-node-vpc-b390fad5-subnet-f73a8191",
+      "type" : "UNKNOWN"
+    },
+    {
+      "name" : "Tunnel1",
+      "nodeId" : "node-lhr-border-02",
+      "id" : "interface-node-lhr-border-02-Tunnel1",
+      "type" : "UNKNOWN"
+    },
+    {
+      "name" : "eni-d2b094fc",
+      "nodeId" : "node-core_01",
+      "id" : "interface-node-core_01-eni-d2b094fc",
+      "type" : "UNKNOWN"
+    },
+    {
+      "name" : "Tunnel2",
+      "nodeId" : "node-lhr-border-02",
+      "id" : "interface-node-lhr-border-02-Tunnel2",
+      "type" : "UNKNOWN"
+    },
+    {
+      "name" : "subnet-f73a8191",
+      "nodeId" : "node-subnet-f73a8191",
+      "id" : "interface-node-subnet-f73a8191-subnet-f73a8191",
       "type" : "UNKNOWN"
     },
     {
@@ -755,6 +632,36 @@
       "type" : "UNKNOWN"
     },
     {
+      "name" : "eni-707e5a5e",
+      "nodeId" : "node-border_02",
+      "id" : "interface-node-border_02-eni-707e5a5e",
+      "type" : "UNKNOWN"
+    },
+    {
+      "name" : "vpc-b390fad5",
+      "nodeId" : "node-subnet-7044ff16",
+      "id" : "interface-node-subnet-7044ff16-vpc-b390fad5",
+      "type" : "UNKNOWN"
+    },
+    {
+      "name" : "vpc-925131f4",
+      "nodeId" : "node-subnet-8d0cbdeb",
+      "id" : "interface-node-subnet-8d0cbdeb-vpc-925131f4",
+      "type" : "UNKNOWN"
+    },
+    {
+      "name" : "eni-d2b094fc",
+      "nodeId" : "node-CVP Server Test",
+      "id" : "interface-node-CVP Server Test-eni-d2b094fc",
+      "type" : "UNKNOWN"
+    },
+    {
+      "name" : "vpc-b390fad5",
+      "nodeId" : "node-vpc-b390fad5",
+      "id" : "interface-node-vpc-b390fad5-vpc-b390fad5",
+      "type" : "UNKNOWN"
+    },
+    {
       "name" : "subnet-30398256",
       "nodeId" : "node-vpc-b390fad5",
       "id" : "interface-node-vpc-b390fad5-subnet-30398256",
@@ -767,9 +674,9 @@
       "type" : "UNKNOWN"
     },
     {
-      "name" : "subnet-30398256",
-      "nodeId" : "node-igw-9b93ddfc",
-      "id" : "interface-node-igw-9b93ddfc-subnet-30398256",
+      "name" : "eni-4b466165",
+      "nodeId" : "node-subnet-073b8061",
+      "id" : "interface-node-subnet-073b8061-eni-4b466165",
       "type" : "UNKNOWN"
     },
     {
@@ -782,6 +689,12 @@
       "name" : "subnet-7044ff16",
       "nodeId" : "node-subnet-7044ff16",
       "id" : "interface-node-subnet-7044ff16-subnet-7044ff16",
+      "type" : "UNKNOWN"
+    },
+    {
+      "name" : "eni-707e5a5e",
+      "nodeId" : "node-CVP Server Test",
+      "id" : "interface-node-CVP Server Test-eni-707e5a5e",
       "type" : "UNKNOWN"
     }
   ],
@@ -796,18 +709,6 @@
       "dstId" : "interface-node-subnet-1f315846-vpc-f8fad69d",
       "srcId" : "interface-node-subnet-1f315846-subnet-1f315846",
       "id" : "link-interface-node-subnet-1f315846-subnet-1f315846-interface-node-subnet-1f315846-vpc-f8fad69d",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-igw-9b93ddfc-subnet-30398256",
-      "srcId" : "interface-node-igw-9b93ddfc-igw-9b93ddfc",
-      "id" : "link-interface-node-igw-9b93ddfc-igw-9b93ddfc-interface-node-igw-9b93ddfc-subnet-30398256",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-subnet-8d0cbdeb-igw-fac5839d",
-      "srcId" : "interface-node-igw-fac5839d-subnet-8d0cbdeb",
-      "id" : "link-interface-node-igw-fac5839d-subnet-8d0cbdeb-interface-node-subnet-8d0cbdeb-igw-fac5839d",
       "type" : "UNKNOWN"
     },
     {
@@ -877,12 +778,6 @@
       "type" : "UNKNOWN"
     },
     {
-      "dstId" : "interface-node-igw-fac5839d-subnet-62f14104",
-      "srcId" : "interface-node-igw-fac5839d-igw-fac5839d",
-      "id" : "link-interface-node-igw-fac5839d-igw-fac5839d-interface-node-igw-fac5839d-subnet-62f14104",
-      "type" : "UNKNOWN"
-    },
-    {
       "dstId" : "interface-node-vpc-b390fad5-subnet-f73a8191",
       "srcId" : "interface-node-subnet-f73a8191-vpc-b390fad5",
       "id" : "link-interface-node-subnet-f73a8191-vpc-b390fad5-interface-node-vpc-b390fad5-subnet-f73a8191",
@@ -937,12 +832,6 @@
       "type" : "UNKNOWN"
     },
     {
-      "dstId" : "interface-node-igw-fac5839d-subnet-8d0cbdeb",
-      "srcId" : "interface-node-igw-fac5839d-igw-fac5839d",
-      "id" : "link-interface-node-igw-fac5839d-igw-fac5839d-interface-node-igw-fac5839d-subnet-8d0cbdeb",
-      "type" : "UNKNOWN"
-    },
-    {
       "dstId" : "interface-node-lhr-border-02-Tunnel1",
       "srcId" : "interface-node-vgw-81fd279f-vpn1",
       "id" : "link-interface-node-vgw-81fd279f-vpn1-interface-node-lhr-border-02-Tunnel1",
@@ -955,9 +844,9 @@
       "type" : "UNKNOWN"
     },
     {
-      "dstId" : "interface-node-igw-068fee63-subnet-1f315846",
-      "srcId" : "interface-node-igw-068fee63-igw-068fee63",
-      "id" : "link-interface-node-igw-068fee63-igw-068fee63-interface-node-igw-068fee63-subnet-1f315846",
+      "dstId" : "interface-node-vgw-81fd279f-vpc-815775e7",
+      "srcId" : "interface-node-vgw-81fd279f-vgw-81fd279f",
+      "id" : "link-interface-node-vgw-81fd279f-vgw-81fd279f-interface-node-vgw-81fd279f-vpc-815775e7",
       "type" : "UNKNOWN"
     },
     {
@@ -991,27 +880,15 @@
       "type" : "UNKNOWN"
     },
     {
-      "dstId" : "interface-node-igw-9b93ddfc-subnet-f73a8191",
-      "srcId" : "interface-node-subnet-f73a8191-igw-9b93ddfc",
-      "id" : "link-interface-node-subnet-f73a8191-igw-9b93ddfc-interface-node-igw-9b93ddfc-subnet-f73a8191",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-igw-9b93ddfc-subnet-f73a8191",
-      "srcId" : "interface-node-igw-9b93ddfc-igw-9b93ddfc",
-      "id" : "link-interface-node-igw-9b93ddfc-igw-9b93ddfc-interface-node-igw-9b93ddfc-subnet-f73a8191",
-      "type" : "UNKNOWN"
-    },
-    {
       "dstId" : "interface-node-border_01-eni-4b466165",
       "srcId" : "interface-node-border_01-eni-297b5c07",
       "id" : "link-interface-node-border_01-eni-297b5c07-interface-node-border_01-eni-4b466165",
       "type" : "UNKNOWN"
     },
     {
-      "dstId" : "interface-node-subnet-8d0cbdeb-igw-fac5839d",
-      "srcId" : "interface-node-subnet-8d0cbdeb-subnet-8d0cbdeb",
-      "id" : "link-interface-node-subnet-8d0cbdeb-subnet-8d0cbdeb-interface-node-subnet-8d0cbdeb-igw-fac5839d",
+      "dstId" : "interface-node-vpc-815775e7-vgw-81fd279f",
+      "srcId" : "interface-node-vgw-81fd279f-vpc-815775e7",
+      "id" : "link-interface-node-vgw-81fd279f-vpc-815775e7-interface-node-vpc-815775e7-vgw-81fd279f",
       "type" : "UNKNOWN"
     },
     {
@@ -1021,21 +898,9 @@
       "type" : "UNKNOWN"
     },
     {
-      "dstId" : "interface-node-igw-068fee63-subnet-9c8adceb",
-      "srcId" : "interface-node-igw-068fee63-igw-068fee63",
-      "id" : "link-interface-node-igw-068fee63-igw-068fee63-interface-node-igw-068fee63-subnet-9c8adceb",
-      "type" : "UNKNOWN"
-    },
-    {
       "dstId" : "interface-node-CVP Server Test-eni-d2b094fc",
       "srcId" : "interface-node-CVP Server Test-eni-8c7753a2",
       "id" : "link-interface-node-CVP Server Test-eni-8c7753a2-interface-node-CVP Server Test-eni-d2b094fc",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-subnet-9c8adceb-igw-068fee63",
-      "srcId" : "interface-node-igw-068fee63-subnet-9c8adceb",
-      "id" : "link-interface-node-igw-068fee63-subnet-9c8adceb-interface-node-subnet-9c8adceb-igw-068fee63",
       "type" : "UNKNOWN"
     },
     {
@@ -1057,27 +922,9 @@
       "type" : "UNKNOWN"
     },
     {
-      "dstId" : "interface-node-subnet-1f315846-igw-068fee63",
-      "srcId" : "interface-node-igw-068fee63-subnet-1f315846",
-      "id" : "link-interface-node-igw-068fee63-subnet-1f315846-interface-node-subnet-1f315846-igw-068fee63",
-      "type" : "UNKNOWN"
-    },
-    {
       "dstId" : "interface-node-subnet-073b8061-vpc-b390fad5",
       "srcId" : "interface-node-subnet-073b8061-subnet-073b8061",
       "id" : "link-interface-node-subnet-073b8061-subnet-073b8061-interface-node-subnet-073b8061-vpc-b390fad5",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-subnet-1f315846-igw-068fee63",
-      "srcId" : "interface-node-subnet-1f315846-subnet-1f315846",
-      "id" : "link-interface-node-subnet-1f315846-subnet-1f315846-interface-node-subnet-1f315846-igw-068fee63",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-subnet-62f14104-igw-fac5839d",
-      "srcId" : "interface-node-igw-fac5839d-subnet-62f14104",
-      "id" : "link-interface-node-igw-fac5839d-subnet-62f14104-interface-node-subnet-62f14104-igw-fac5839d",
       "type" : "UNKNOWN"
     },
     {
@@ -1099,33 +946,9 @@
       "type" : "UNKNOWN"
     },
     {
-      "dstId" : "interface-node-subnet-9c8adceb-igw-068fee63",
-      "srcId" : "interface-node-subnet-9c8adceb-subnet-9c8adceb",
-      "id" : "link-interface-node-subnet-9c8adceb-subnet-9c8adceb-interface-node-subnet-9c8adceb-igw-068fee63",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-igw-9b93ddfc-subnet-7044ff16",
-      "srcId" : "interface-node-igw-9b93ddfc-igw-9b93ddfc",
-      "id" : "link-interface-node-igw-9b93ddfc-igw-9b93ddfc-interface-node-igw-9b93ddfc-subnet-7044ff16",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-igw-068fee63-subnet-9c8adceb",
-      "srcId" : "interface-node-subnet-9c8adceb-igw-068fee63",
-      "id" : "link-interface-node-subnet-9c8adceb-igw-068fee63-interface-node-igw-068fee63-subnet-9c8adceb",
-      "type" : "UNKNOWN"
-    },
-    {
       "dstId" : "interface-node-border_01-eni-8c7753a2",
       "srcId" : "interface-node-border_01-eni-d2b094fc",
       "id" : "link-interface-node-border_01-eni-d2b094fc-interface-node-border_01-eni-8c7753a2",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-subnet-d9cafabc-igw-068fee63",
-      "srcId" : "interface-node-igw-068fee63-subnet-d9cafabc",
-      "id" : "link-interface-node-igw-068fee63-subnet-d9cafabc-interface-node-subnet-d9cafabc-igw-068fee63",
       "type" : "UNKNOWN"
     },
     {
@@ -1138,6 +961,12 @@
       "dstId" : "interface-node-vpc-b390fad5-igw-9b93ddfc",
       "srcId" : "interface-node-igw-9b93ddfc-vpc-b390fad5",
       "id" : "link-interface-node-igw-9b93ddfc-vpc-b390fad5-interface-node-vpc-b390fad5-igw-9b93ddfc",
+      "type" : "UNKNOWN"
+    },
+    {
+      "dstId" : "interface-node-vgw-81fd279f-vpc-815775e7",
+      "srcId" : "interface-node-vpc-815775e7-vgw-81fd279f",
+      "id" : "link-interface-node-vpc-815775e7-vgw-81fd279f-interface-node-vgw-81fd279f-vpc-815775e7",
       "type" : "UNKNOWN"
     },
     {
@@ -1159,33 +988,15 @@
       "type" : "UNKNOWN"
     },
     {
-      "dstId" : "interface-node-subnet-30398256-igw-9b93ddfc",
-      "srcId" : "interface-node-igw-9b93ddfc-subnet-30398256",
-      "id" : "link-interface-node-igw-9b93ddfc-subnet-30398256-interface-node-subnet-30398256-igw-9b93ddfc",
-      "type" : "UNKNOWN"
-    },
-    {
       "dstId" : "interface-node-border_01-eni-4b466165",
       "srcId" : "interface-node-border_01-subnet-073b8061",
       "id" : "link-interface-node-border_01-subnet-073b8061-interface-node-border_01-eni-4b466165",
       "type" : "UNKNOWN"
     },
     {
-      "dstId" : "interface-node-subnet-f73a8191-igw-9b93ddfc",
-      "srcId" : "interface-node-subnet-f73a8191-subnet-f73a8191",
-      "id" : "link-interface-node-subnet-f73a8191-subnet-f73a8191-interface-node-subnet-f73a8191-igw-9b93ddfc",
-      "type" : "UNKNOWN"
-    },
-    {
       "dstId" : "interface-node-vgw-81fd279f-vpn2",
       "srcId" : "interface-node-vgw-81fd279f-Tunnel2",
       "id" : "link-interface-node-vgw-81fd279f-Tunnel2-interface-node-vgw-81fd279f-vpn2",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-igw-fac5839d-subnet-62f14104",
-      "srcId" : "interface-node-subnet-62f14104-igw-fac5839d",
-      "id" : "link-interface-node-subnet-62f14104-igw-fac5839d-interface-node-igw-fac5839d-subnet-62f14104",
       "type" : "UNKNOWN"
     },
     {
@@ -1213,21 +1024,9 @@
       "type" : "UNKNOWN"
     },
     {
-      "dstId" : "interface-node-igw-9b93ddfc-subnet-7044ff16",
-      "srcId" : "interface-node-subnet-7044ff16-igw-9b93ddfc",
-      "id" : "link-interface-node-subnet-7044ff16-igw-9b93ddfc-interface-node-igw-9b93ddfc-subnet-7044ff16",
-      "type" : "UNKNOWN"
-    },
-    {
       "dstId" : "interface-node-subnet-30398256-vpc-b390fad5",
       "srcId" : "interface-node-subnet-30398256-subnet-30398256",
       "id" : "link-interface-node-subnet-30398256-subnet-30398256-interface-node-subnet-30398256-vpc-b390fad5",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-subnet-7044ff16-igw-9b93ddfc",
-      "srcId" : "interface-node-subnet-7044ff16-subnet-7044ff16",
-      "id" : "link-interface-node-subnet-7044ff16-subnet-7044ff16-interface-node-subnet-7044ff16-igw-9b93ddfc",
       "type" : "UNKNOWN"
     },
     {
@@ -1243,21 +1042,9 @@
       "type" : "UNKNOWN"
     },
     {
-      "dstId" : "interface-node-subnet-7044ff16-igw-9b93ddfc",
-      "srcId" : "interface-node-igw-9b93ddfc-subnet-7044ff16",
-      "id" : "link-interface-node-igw-9b93ddfc-subnet-7044ff16-interface-node-subnet-7044ff16-igw-9b93ddfc",
-      "type" : "UNKNOWN"
-    },
-    {
       "dstId" : "interface-node-border_02-eni-6b705445",
       "srcId" : "interface-node-border_02-eni-d2b094fc",
       "id" : "link-interface-node-border_02-eni-d2b094fc-interface-node-border_02-eni-6b705445",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-subnet-62f14104-igw-fac5839d",
-      "srcId" : "interface-node-subnet-62f14104-subnet-62f14104",
-      "id" : "link-interface-node-subnet-62f14104-subnet-62f14104-interface-node-subnet-62f14104-igw-fac5839d",
       "type" : "UNKNOWN"
     },
     {
@@ -1279,21 +1066,9 @@
       "type" : "UNKNOWN"
     },
     {
-      "dstId" : "interface-node-igw-9b93ddfc-subnet-073b8061",
-      "srcId" : "interface-node-igw-9b93ddfc-igw-9b93ddfc",
-      "id" : "link-interface-node-igw-9b93ddfc-igw-9b93ddfc-interface-node-igw-9b93ddfc-subnet-073b8061",
-      "type" : "UNKNOWN"
-    },
-    {
       "dstId" : "interface-node-vpc-b390fad5-subnet-1641fa70",
       "srcId" : "interface-node-vpc-b390fad5-vpc-b390fad5",
       "id" : "link-interface-node-vpc-b390fad5-vpc-b390fad5-interface-node-vpc-b390fad5-subnet-1641fa70",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-igw-9b93ddfc-subnet-1641fa70",
-      "srcId" : "interface-node-subnet-1641fa70-igw-9b93ddfc",
-      "id" : "link-interface-node-subnet-1641fa70-igw-9b93ddfc-interface-node-igw-9b93ddfc-subnet-1641fa70",
       "type" : "UNKNOWN"
     },
     {
@@ -1354,18 +1129,6 @@
       "dstId" : "interface-node-lhr-border-02-Tunnel2",
       "srcId" : "interface-node-vgw-81fd279f-vpn2",
       "id" : "link-interface-node-vgw-81fd279f-vpn2-interface-node-lhr-border-02-Tunnel2",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-igw-9b93ddfc-subnet-073b8061",
-      "srcId" : "interface-node-subnet-073b8061-igw-9b93ddfc",
-      "id" : "link-interface-node-subnet-073b8061-igw-9b93ddfc-interface-node-igw-9b93ddfc-subnet-073b8061",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-subnet-f73a8191-igw-9b93ddfc",
-      "srcId" : "interface-node-igw-9b93ddfc-subnet-f73a8191",
-      "id" : "link-interface-node-igw-9b93ddfc-subnet-f73a8191-interface-node-subnet-f73a8191-igw-9b93ddfc",
       "type" : "UNKNOWN"
     },
     {
@@ -1432,6 +1195,12 @@
       "dstId" : "interface-node-vpc-f8fad69d-igw-068fee63",
       "srcId" : "interface-node-igw-068fee63-vpc-f8fad69d",
       "id" : "link-interface-node-igw-068fee63-vpc-f8fad69d-interface-node-vpc-f8fad69d-igw-068fee63",
+      "type" : "UNKNOWN"
+    },
+    {
+      "dstId" : "interface-node-vpc-815775e7-vgw-81fd279f",
+      "srcId" : "interface-node-vpc-815775e7-vpc-815775e7",
+      "id" : "link-interface-node-vpc-815775e7-vpc-815775e7-interface-node-vpc-815775e7-vgw-81fd279f",
       "type" : "UNKNOWN"
     },
     {
@@ -1513,12 +1282,6 @@
       "type" : "UNKNOWN"
     },
     {
-      "dstId" : "interface-node-igw-fac5839d-subnet-8d0cbdeb",
-      "srcId" : "interface-node-subnet-8d0cbdeb-igw-fac5839d",
-      "id" : "link-interface-node-subnet-8d0cbdeb-igw-fac5839d-interface-node-igw-fac5839d-subnet-8d0cbdeb",
-      "type" : "UNKNOWN"
-    },
-    {
       "dstId" : "interface-node-core_01-eni-707e5a5e",
       "srcId" : "interface-node-border_02-eni-6b705445",
       "id" : "link-interface-node-border_02-eni-6b705445-interface-node-core_01-eni-707e5a5e",
@@ -1549,27 +1312,9 @@
       "type" : "UNKNOWN"
     },
     {
-      "dstId" : "interface-node-subnet-073b8061-igw-9b93ddfc",
-      "srcId" : "interface-node-subnet-073b8061-subnet-073b8061",
-      "id" : "link-interface-node-subnet-073b8061-subnet-073b8061-interface-node-subnet-073b8061-igw-9b93ddfc",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-igw-068fee63-subnet-d9cafabc",
-      "srcId" : "interface-node-igw-068fee63-igw-068fee63",
-      "id" : "link-interface-node-igw-068fee63-igw-068fee63-interface-node-igw-068fee63-subnet-d9cafabc",
-      "type" : "UNKNOWN"
-    },
-    {
       "dstId" : "interface-node-vpc-b390fad5-subnet-073b8061",
       "srcId" : "interface-node-vpc-b390fad5-vpc-b390fad5",
       "id" : "link-interface-node-vpc-b390fad5-vpc-b390fad5-interface-node-vpc-b390fad5-subnet-073b8061",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-igw-9b93ddfc-subnet-1641fa70",
-      "srcId" : "interface-node-igw-9b93ddfc-igw-9b93ddfc",
-      "id" : "link-interface-node-igw-9b93ddfc-igw-9b93ddfc-interface-node-igw-9b93ddfc-subnet-1641fa70",
       "type" : "UNKNOWN"
     },
     {
@@ -1615,18 +1360,6 @@
       "type" : "UNKNOWN"
     },
     {
-      "dstId" : "interface-node-igw-9b93ddfc-subnet-30398256",
-      "srcId" : "interface-node-subnet-30398256-igw-9b93ddfc",
-      "id" : "link-interface-node-subnet-30398256-igw-9b93ddfc-interface-node-igw-9b93ddfc-subnet-30398256",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-igw-068fee63-subnet-d9cafabc",
-      "srcId" : "interface-node-subnet-d9cafabc-igw-068fee63",
-      "id" : "link-interface-node-subnet-d9cafabc-igw-068fee63-interface-node-igw-068fee63-subnet-d9cafabc",
-      "type" : "UNKNOWN"
-    },
-    {
       "dstId" : "interface-node-subnet-1641fa70-subnet-1641fa70",
       "srcId" : "interface-node-border_02-eni-6b705445",
       "id" : "link-interface-node-border_02-eni-6b705445-interface-node-subnet-1641fa70-subnet-1641fa70",
@@ -1657,12 +1390,6 @@
       "type" : "UNKNOWN"
     },
     {
-      "dstId" : "interface-node-subnet-30398256-igw-9b93ddfc",
-      "srcId" : "interface-node-subnet-30398256-subnet-30398256",
-      "id" : "link-interface-node-subnet-30398256-subnet-30398256-interface-node-subnet-30398256-igw-9b93ddfc",
-      "type" : "UNKNOWN"
-    },
-    {
       "dstId" : "interface-node-vpc-f8fad69d-igw-068fee63",
       "srcId" : "interface-node-vpc-f8fad69d-vpc-f8fad69d",
       "id" : "link-interface-node-vpc-f8fad69d-vpc-f8fad69d-interface-node-vpc-f8fad69d-igw-068fee63",
@@ -1675,39 +1402,9 @@
       "type" : "UNKNOWN"
     },
     {
-      "dstId" : "interface-node-subnet-1641fa70-igw-9b93ddfc",
-      "srcId" : "interface-node-subnet-1641fa70-subnet-1641fa70",
-      "id" : "link-interface-node-subnet-1641fa70-subnet-1641fa70-interface-node-subnet-1641fa70-igw-9b93ddfc",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-subnet-1641fa70-igw-9b93ddfc",
-      "srcId" : "interface-node-igw-9b93ddfc-subnet-1641fa70",
-      "id" : "link-interface-node-igw-9b93ddfc-subnet-1641fa70-interface-node-subnet-1641fa70-igw-9b93ddfc",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-igw-068fee63-subnet-1f315846",
-      "srcId" : "interface-node-subnet-1f315846-igw-068fee63",
-      "id" : "link-interface-node-subnet-1f315846-igw-068fee63-interface-node-igw-068fee63-subnet-1f315846",
-      "type" : "UNKNOWN"
-    },
-    {
       "dstId" : "interface-node-subnet-1641fa70-subnet-1641fa70",
       "srcId" : "interface-node-border_01-eni-8c7753a2",
       "id" : "link-interface-node-border_01-eni-8c7753a2-interface-node-subnet-1641fa70-subnet-1641fa70",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-subnet-d9cafabc-igw-068fee63",
-      "srcId" : "interface-node-subnet-d9cafabc-subnet-d9cafabc",
-      "id" : "link-interface-node-subnet-d9cafabc-subnet-d9cafabc-interface-node-subnet-d9cafabc-igw-068fee63",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-subnet-073b8061-igw-9b93ddfc",
-      "srcId" : "interface-node-igw-9b93ddfc-subnet-073b8061",
-      "id" : "link-interface-node-igw-9b93ddfc-subnet-073b8061-interface-node-subnet-073b8061-igw-9b93ddfc",
       "type" : "UNKNOWN"
     },
     {
@@ -1742,7 +1439,7 @@
     {
       "name" : "vpc-815775e7",
       "id" : "node-vpc-815775e7",
-      "type" : "SWITCH"
+      "type" : "ROUTER"
     },
     {
       "name" : "subnet-d9cafabc",


### PR DESCRIPTION
- add iBGP sessions between VPN gateways and VPC router
  - only send routes from VPN gateway to VPC router
- Subnet "router"s are now only connected to their instances and VPC
  router
- Add null route for each VPC CIDR block on VPC router
- Add static routes pointing to each subnet "router" on VPC router
- Apply network ACL only to subnet "router" interface facing VPC router

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/756)
<!-- Reviewable:end -->
