### PR TITLE
Tests for WorkMgrServiceV2, ensure correct api key header is used

### DIFF
--- a/projects/coordinator/src/main/java/org/batfish/coordinator/authorizer/MapAuthorizer.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/authorizer/MapAuthorizer.java
@@ -1,0 +1,36 @@
+package org.batfish.coordinator.authorizer;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+/** An {@link Authorizer} backed by an in-memory map. Useful for testing. */
+public class MapAuthorizer implements Authorizer {
+  private HashMap<String, List<String>> _permissionMap;
+
+  public MapAuthorizer() {
+    _permissionMap = new HashMap<>();
+  }
+
+  @Override
+  public void authorizeContainer(String apiKey, String containerName) {
+    _permissionMap.computeIfAbsent(
+        apiKey,
+        val -> {
+          List<String> list = new ArrayList<>();
+          list.add(containerName);
+          return list;
+        });
+  }
+
+  @Override
+  public boolean isAccessibleContainer(String apiKey, String containerName, boolean logError) {
+    List<String> list = _permissionMap.get(apiKey);
+    return list != null && list.contains(containerName);
+  }
+
+  @Override
+  public boolean isValidWorkApiKey(String apiKey) {
+    return _permissionMap.containsKey(apiKey);
+  }
+}

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/MapAuthorizer.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/MapAuthorizer.java
@@ -1,14 +1,15 @@
-package org.batfish.coordinator.authorizer;
+package org.batfish.coordinator;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import org.batfish.coordinator.authorizer.Authorizer;
 
 /** An {@link Authorizer} backed by an in-memory map. Useful for testing. */
 public class MapAuthorizer implements Authorizer {
   private HashMap<String, List<String>> _permissionMap;
 
-  public MapAuthorizer() {
+  MapAuthorizer() {
     _permissionMap = new HashMap<>();
   }
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrServiceV2Test.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrServiceV2Test.java
@@ -21,7 +21,6 @@ import org.batfish.common.Container;
 import org.batfish.common.CoordConsts;
 import org.batfish.common.CoordConstsV2;
 import org.batfish.coordinator.authorizer.Authorizer;
-import org.batfish.coordinator.authorizer.MapAuthorizer;
 import org.batfish.coordinator.config.Settings;
 import org.glassfish.jersey.jackson.JacksonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -129,21 +128,12 @@ public class WorkMgrServiceV2Test extends JerseyTest {
             .get();
     assertThat(resp.getStatus(), equalTo(OK.getStatusCode()));
 
-    // Test that subsequent calls return 200 with correct API key
+    // Test that subsequent calls return 403 forbidden with wrong API key
     resp =
         getContainersTarget()
             .path(containerName)
             .request()
             .header(CoordConstsV2.HTTP_HEADER_BATFISH_APIKEY, "wrongKey")
-            .get();
-    assertThat(resp.getStatus(), equalTo(FORBIDDEN.getStatusCode()));
-
-    // And ensure that right key, but in the wrong (old) header field does not work either
-    resp =
-        getContainersTarget()
-            .path(containerName)
-            .request()
-            .header(CoordConsts.SVC_KEY_API_KEY, myKey)
             .get();
     assertThat(resp.getStatus(), equalTo(FORBIDDEN.getStatusCode()));
   }

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrServiceV2Test.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrServiceV2Test.java
@@ -1,5 +1,6 @@
 package org.batfish.coordinator;
 
+import static javax.ws.rs.core.Response.Status.FORBIDDEN;
 import static javax.ws.rs.core.Response.Status.MOVED_PERMANENTLY;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.NO_CONTENT;
@@ -18,6 +19,9 @@ import javax.ws.rs.core.Response;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.Container;
 import org.batfish.common.CoordConsts;
+import org.batfish.common.CoordConstsV2;
+import org.batfish.coordinator.authorizer.Authorizer;
+import org.batfish.coordinator.authorizer.MapAuthorizer;
 import org.batfish.coordinator.config.Settings;
 import org.glassfish.jersey.jackson.JacksonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -103,5 +107,44 @@ public class WorkMgrServiceV2Test extends JerseyTest {
   public void deleteNonExistingContainer() {
     Response response = getContainersTarget().path("nonExistingContainer").request().delete();
     assertThat(response.getStatus(), equalTo(NOT_FOUND.getStatusCode()));
+  }
+
+  /** Test that the ApiKey is extracted from the correct header */
+  @Test
+  public void correctApiKeyHeader() {
+    // Set up by making a call to authorize container
+    String containerName = "someContainer";
+    String myKey = "ApiKey";
+    Authorizer auth = new MapAuthorizer();
+    Main.setAuthorizer(auth);
+    auth.authorizeContainer(myKey, containerName);
+    Main.getWorkMgr().initContainer(containerName, null);
+
+    // Test that subsequent calls return 200 with correct API key
+    Response resp =
+        getContainersTarget()
+            .path(containerName)
+            .request()
+            .header(CoordConstsV2.HTTP_HEADER_BATFISH_APIKEY, myKey)
+            .get();
+    assertThat(resp.getStatus(), equalTo(OK.getStatusCode()));
+
+    // Test that subsequent calls return 200 with correct API key
+    resp =
+        getContainersTarget()
+            .path(containerName)
+            .request()
+            .header(CoordConstsV2.HTTP_HEADER_BATFISH_APIKEY, "wrongKey")
+            .get();
+    assertThat(resp.getStatus(), equalTo(FORBIDDEN.getStatusCode()));
+
+    // And ensure that right key, but in the wrong (old) header field does not work either
+    resp =
+        getContainersTarget()
+            .path(containerName)
+            .request()
+            .header(CoordConsts.SVC_KEY_API_KEY, myKey)
+            .get();
+    assertThat(resp.getStatus(), equalTo(FORBIDDEN.getStatusCode()));
   }
 }


### PR DESCRIPTION
As promised, adding tests for #754. Combining a straight-forward in-memory authorizer with jersey tests to check that the API key is extracted from the correct HTTP header.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/764)
<!-- Reviewable:end -->
