### PR TITLE
fix crash on snats with overlapping ips

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
@@ -89,8 +89,6 @@ public interface IBatfish extends IPluginConsumer {
 
   InitInfoAnswerElement initInfoRoutes(boolean summary, boolean verboseError);
 
-  void initRemoteIpsecVpns(Map<String, Configuration> configurations);
-
   void initRemoteOspfNeighbors(
       Map<String, Configuration> configurations, Map<Ip, Set<String>> ipOwners, Topology topology);
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
@@ -1,5 +1,10 @@
 package org.batfish.common.util;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.SetMultimap;
+import com.google.common.collect.Sets;
 import com.google.common.hash.Hashing;
 import java.io.BufferedReader;
 import java.io.FileInputStream;
@@ -65,6 +70,9 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Edge;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpSpace;
+import org.batfish.datamodel.IpWildcard;
+import org.batfish.datamodel.IpsecVpn;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Route;
 import org.batfish.datamodel.Topology;
@@ -632,6 +640,109 @@ public class CommonUtil {
               && localRemoteAs == remoteLocalAs) {
             bgpNeighbor.getCandidateRemoteBgpNeighbors().add(remoteBgpNeighborCandidate);
             bgpNeighbor.setRemoteBgpNeighbor(remoteBgpNeighborCandidate);
+          }
+        }
+      }
+    }
+  }
+
+  @VisibleForTesting
+  static SetMultimap<Ip, IpSpace> initPrivateIpsByPublicIp(
+      Map<String, Configuration> configurations) {
+    /*
+     * Very hacky mapping from public IP to set of spaces of possible natted private IPs.
+     * Does not currently support source-nat acl.
+     *
+     * The current implementation just considers every IP in every prefix on a non-masquerading
+     * interface (except the local address in each such prefix) to be a possible private IP
+     * match for every public IP referred to by every source-nat pool on a masquerading interface.
+     */
+    ImmutableSetMultimap.Builder<Ip, IpSpace> builder = ImmutableSetMultimap.builder();
+    for (Configuration c : configurations.values()) {
+      Collection<Interface> interfaces = c.getInterfaces().values();
+      Set<Prefix> nonNattedInterfacePrefixes =
+          interfaces
+              .stream()
+              .filter(i -> i.getSourceNats().isEmpty())
+              .flatMap(i -> i.getAllPrefixes().stream())
+              .collect(ImmutableSet.toImmutableSet());
+      Set<IpWildcard> blacklist =
+          nonNattedInterfacePrefixes
+              .stream()
+              .map(p -> new IpWildcard(p.getAddress(), Ip.ZERO))
+              .collect(ImmutableSet.toImmutableSet());
+      Set<IpWildcard> whitelist =
+          nonNattedInterfacePrefixes
+              .stream()
+              .map(IpWildcard::new)
+              .collect(ImmutableSet.toImmutableSet());
+      IpSpace ipSpace = IpSpace.builder().including(whitelist).excluding(blacklist).build();
+      interfaces
+          .stream()
+          .flatMap(i -> i.getSourceNats().stream())
+          .forEach(
+              sourceNat -> {
+                for (long ipAsLong = sourceNat.getPoolIpFirst().asLong();
+                    ipAsLong <= sourceNat.getPoolIpLast().asLong();
+                    ipAsLong++) {
+                  Ip currentPoolIp = new Ip(ipAsLong);
+                  builder.put(currentPoolIp, ipSpace);
+                }
+              });
+    }
+    return builder.build();
+  }
+
+  public static void initRemoteIpsecVpns(Map<String, Configuration> configurations) {
+    Map<IpsecVpn, Ip> remoteAddresses = new IdentityHashMap<>();
+    Map<Ip, Set<IpsecVpn>> externalAddresses = new HashMap<>();
+    SetMultimap<Ip, IpSpace> privateIpsByPublicIp = initPrivateIpsByPublicIp(configurations);
+    for (Configuration c : configurations.values()) {
+      for (IpsecVpn ipsecVpn : c.getIpsecVpns().values()) {
+        Ip remoteAddress = ipsecVpn.getIkeGateway().getAddress();
+        remoteAddresses.put(ipsecVpn, remoteAddress);
+        Set<Prefix> externalPrefixes =
+            ipsecVpn.getIkeGateway().getExternalInterface().getAllPrefixes();
+        for (Prefix externalPrefix : externalPrefixes) {
+          Ip externalAddress = externalPrefix.getAddress();
+          Set<IpsecVpn> vpnsUsingExternalAddress =
+              externalAddresses.computeIfAbsent(externalAddress, k -> Sets.newIdentityHashSet());
+          vpnsUsingExternalAddress.add(ipsecVpn);
+        }
+      }
+    }
+    for (Entry<IpsecVpn, Ip> e : remoteAddresses.entrySet()) {
+      IpsecVpn ipsecVpn = e.getKey();
+      Ip remoteAddress = e.getValue();
+      Ip localAddress = ipsecVpn.getIkeGateway().getLocalAddress();
+      ipsecVpn.initCandidateRemoteVpns();
+      Set<IpsecVpn> remoteIpsecVpnCandidates = externalAddresses.get(remoteAddress);
+      if (remoteIpsecVpnCandidates != null) {
+        for (IpsecVpn remoteIpsecVpnCandidate : remoteIpsecVpnCandidates) {
+          Ip remoteIpsecVpnLocalAddress = remoteIpsecVpnCandidate.getIkeGateway().getLocalAddress();
+          if (remoteIpsecVpnLocalAddress != null
+              && !remoteIpsecVpnLocalAddress.equals(remoteAddress)) {
+            continue;
+          }
+          Ip reciprocalRemoteAddress = remoteAddresses.get(remoteIpsecVpnCandidate);
+          Set<IpsecVpn> reciprocalVpns = externalAddresses.get(reciprocalRemoteAddress);
+          if (reciprocalVpns == null) {
+            Set<IpSpace> privateIpsBehindReciprocalRemoteAddress =
+                privateIpsByPublicIp.get(reciprocalRemoteAddress);
+            if (privateIpsBehindReciprocalRemoteAddress != null
+                && privateIpsBehindReciprocalRemoteAddress
+                    .stream()
+                    .anyMatch(ipSpace -> ipSpace.contains(localAddress))) {
+              reciprocalVpns = externalAddresses.get(localAddress);
+              ipsecVpn.setRemoteIpsecVpn(remoteIpsecVpnCandidate);
+              ipsecVpn.getCandidateRemoteIpsecVpns().add(remoteIpsecVpnCandidate);
+              remoteIpsecVpnCandidate.initCandidateRemoteVpns();
+              remoteIpsecVpnCandidate.setRemoteIpsecVpn(ipsecVpn);
+              remoteIpsecVpnCandidate.getCandidateRemoteIpsecVpns().add(ipsecVpn);
+            }
+          } else if (reciprocalVpns.contains(ipsecVpn)) {
+            ipsecVpn.setRemoteIpsecVpn(remoteIpsecVpnCandidate);
+            ipsecVpn.getCandidateRemoteIpsecVpns().add(remoteIpsecVpnCandidate);
           }
         }
       }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ConfigurationTests.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ConfigurationTests.java
@@ -209,14 +209,14 @@ public class ConfigurationTests {
     Prefix p3to4Physical = new Prefix(ip3to4Physical, 24);
     Interface i3to1 = ib.setOwner(c3).setVrf(v3).setPrefix(p3to1Physical).build();
     ib.setPrefix(p3to4Physical).build();
-    SourceNat snat3_1 = new SourceNat();
-    snat3_1.setPoolIpFirst(ip3to1Physical);
-    snat3_1.setPoolIpLast(ip3to1Physical);
-    SourceNat snat3_2 = new SourceNat();
-    snat3_2.setPoolIpFirst(ip3to1Physical);
-    snat3_2.setPoolIpLast(ip3to1Physical);
+    SourceNat snat3copy1 = new SourceNat();
+    snat3copy1.setPoolIpFirst(ip3to1Physical);
+    snat3copy1.setPoolIpLast(ip3to1Physical);
+    SourceNat snat3copy2 = new SourceNat();
+    snat3copy2.setPoolIpFirst(ip3to1Physical);
+    snat3copy2.setPoolIpLast(ip3to1Physical);
     /* Should not crash with two source-nats aliasing the same public IP */
-    i3to1.setSourceNats(ImmutableList.of(snat3_1, snat3_2));
+    i3to1.setSourceNats(ImmutableList.of(snat3copy1, snat3copy2));
 
     Configuration c4 = cb.build();
     Vrf v4 = vb.setOwner(c4).build();

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ConfigurationTests.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ConfigurationTests.java
@@ -2,15 +2,46 @@ package org.batfish.datamodel;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertThat;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
+import java.util.Map;
 import org.batfish.common.Warnings;
+import org.batfish.common.util.CommonUtil;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
 import org.batfish.datamodel.routing_policy.statement.CallStatement;
+import org.hamcrest.FeatureMatcher;
+import org.hamcrest.Matcher;
+import org.junit.Before;
 import org.junit.Test;
 
 public class ConfigurationTests {
+
+  public static class HasRemoteIpsecVpn extends FeatureMatcher<IpsecVpn, IpsecVpn> {
+
+    public HasRemoteIpsecVpn(Matcher<? super IpsecVpn> subMatcher) {
+      super(subMatcher, "remoteIpsecVpn", "remoteIpsecVpn");
+    }
+
+    @Override
+    protected IpsecVpn featureValueOf(IpsecVpn actual) {
+      return actual.getRemoteIpsecVpn();
+    }
+  }
+
+  public static HasRemoteIpsecVpn hasRemoteIpsecVpn(Matcher<? super IpsecVpn> subMatcher) {
+    return new HasRemoteIpsecVpn(subMatcher);
+  }
+
+  private NetworkFactory _factory;
+
+  @Before
+  public void setup() {
+    _factory = new NetworkFactory();
+  }
 
   @Test
   public void testComputeRoutingPolicySources() {
@@ -104,5 +135,127 @@ public class ConfigurationTests {
     assertThat(
         ospfProcess.getExportPolicySources(),
         containsInAnyOrder(ospfExportPolicyName, ospfExportSubPolicyName));
+  }
+
+  @Test
+  public void testInitRemoteIpsecVpns() {
+    Ip ip1to2Physical = new Ip("10.12.0.1");
+    Ip ip1to2Tunnel = new Ip("10.0.12.1");
+    Ip ip1to3Physical = new Ip("10.13.0.1");
+    Ip ip1to4Tunnel = new Ip("10.0.14.1");
+
+    Ip ip2to1Physical = new Ip("10.12.0.2");
+    Ip ip2to1Tunnel = new Ip("10.0.12.2");
+
+    Ip ip3to1Physical = new Ip("10.13.0.3");
+    Ip ip3to4Physical = new Ip("10.34.0.3");
+
+    Ip ip4to1Tunnel = new Ip("10.0.14.4");
+    Ip ip4to3Physical = new Ip("10.34.0.4");
+
+    Configuration.Builder cb =
+        _factory.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+    Interface.Builder ib = _factory.interfaceBuilder().setActive(true);
+    Vrf.Builder vb = _factory.vrfBuilder().setName(Configuration.DEFAULT_VRF_NAME);
+
+    Configuration c1 = cb.build();
+    Vrf v1 = vb.setOwner(c1).build();
+    Prefix p1to2Physical = new Prefix(ip1to2Physical, 24);
+    Prefix p1to2Tunnel = new Prefix(ip1to2Tunnel, 24);
+    Prefix p1to3Physical = new Prefix(ip1to3Physical, 24);
+    Prefix p1to4Tunnel = new Prefix(ip1to4Tunnel, 24);
+    Interface i1to2 = ib.setOwner(c1).setVrf(v1).setPrefix(p1to2Physical).build();
+    Interface t1to2 = ib.setPrefix(p1to2Tunnel).build();
+    Interface i1to3 = ib.setOwner(c1).setVrf(v1).setPrefix(p1to3Physical).build();
+    Interface t1to4 = ib.setPrefix(p1to4Tunnel).build();
+    IpsecVpn vpn1to2 = new IpsecVpn("vpn1to2", c1);
+    c1.getIpsecVpns().put(vpn1to2.getName(), vpn1to2);
+    vpn1to2.setBindInterface(t1to2);
+    IkeGateway g1to2 = new IkeGateway("g1to2");
+    c1.getIkeGateways().put(g1to2.getName(), g1to2);
+    g1to2.setAddress(ip2to1Physical);
+    g1to2.setLocalAddress(ip1to2Physical);
+    g1to2.setExternalInterface(i1to2);
+    vpn1to2.setIkeGateway(g1to2);
+    IpsecVpn vpn1to4 = new IpsecVpn("vpn1to4", c1);
+    c1.getIpsecVpns().put(vpn1to4.getName(), vpn1to4);
+    vpn1to4.setBindInterface(t1to4);
+    IkeGateway g1to4 = new IkeGateway("g1to4");
+    c1.getIkeGateways().put(g1to4.getName(), g1to4);
+    g1to4.setAddress(ip3to1Physical);
+    g1to4.setLocalAddress(ip1to3Physical);
+    g1to4.setExternalInterface(i1to3);
+    vpn1to4.setIkeGateway(g1to4);
+
+    Configuration c2 = cb.build();
+    Vrf v2 = vb.setOwner(c2).build();
+    Prefix p2to1Physical = new Prefix(ip2to1Physical, 24);
+    Prefix p2to1Tunnel = new Prefix(ip2to1Tunnel, 24);
+    Interface i2to1 = ib.setOwner(c2).setVrf(v2).setPrefix(p2to1Physical).build();
+    Interface t2to1 = ib.setPrefix(p2to1Tunnel).build();
+    IpsecVpn vpn2to1 = new IpsecVpn("vpn2to1", c2);
+    c2.getIpsecVpns().put(vpn2to1.getName(), vpn2to1);
+    vpn2to1.setBindInterface(t2to1);
+    IkeGateway g2to1 = new IkeGateway("g2to1");
+    c2.getIkeGateways().put(g2to1.getName(), g2to1);
+    g2to1.setAddress(ip1to2Physical);
+    g2to1.setLocalAddress(ip2to1Physical);
+    g2to1.setExternalInterface(i2to1);
+    vpn2to1.setIkeGateway(g2to1);
+
+    Configuration c3 = cb.build();
+    Vrf v3 = vb.setOwner(c3).build();
+    Prefix p3to1Physical = new Prefix(ip3to1Physical, 24);
+    Prefix p3to4Physical = new Prefix(ip3to4Physical, 24);
+    Interface i3to1 = ib.setOwner(c3).setVrf(v3).setPrefix(p3to1Physical).build();
+    ib.setPrefix(p3to4Physical).build();
+    SourceNat snat3_1 = new SourceNat();
+    snat3_1.setPoolIpFirst(ip3to1Physical);
+    snat3_1.setPoolIpLast(ip3to1Physical);
+    SourceNat snat3_2 = new SourceNat();
+    snat3_2.setPoolIpFirst(ip3to1Physical);
+    snat3_2.setPoolIpLast(ip3to1Physical);
+    /* Should not crash with two source-nats aliasing the same public IP */
+    i3to1.setSourceNats(ImmutableList.of(snat3_1, snat3_2));
+
+    Configuration c4 = cb.build();
+    Vrf v4 = vb.setOwner(c4).build();
+    Prefix p4to1Tunnel = new Prefix(ip4to1Tunnel, 24);
+    Prefix p4to3Physical = new Prefix(ip4to3Physical, 24);
+    Interface t4to1 = ib.setOwner(c4).setVrf(v4).setPrefix(p4to1Tunnel).build();
+    Interface i4to3 = ib.setPrefix(p4to3Physical).build();
+    IpsecVpn vpn4to1 = new IpsecVpn("vpn4to1", c4);
+    c4.getIpsecVpns().put(vpn4to1.getName(), vpn4to1);
+    vpn4to1.setBindInterface(t4to1);
+    IkeGateway g4 = new IkeGateway("g4to1");
+    c4.getIkeGateways().put(g4.getName(), g4);
+    g4.setAddress(ip1to3Physical);
+    g4.setLocalAddress(ip4to3Physical);
+    g4.setExternalInterface(i4to3);
+    vpn4to1.setIkeGateway(g4);
+
+    Map<String, Configuration> configurations =
+        ImmutableMap.<String, Configuration>builder()
+            .put(c1.getName(), c1)
+            .put(c2.getName(), c2)
+            .put(c3.getName(), c3)
+            .put(c4.getName(), c4)
+            .build();
+    CommonUtil.initRemoteIpsecVpns(configurations);
+
+    /*
+     * vpn1to2 and vpn2to1 should connect to each other in a direct fashion
+     */
+    assertThat(vpn1to2, hasRemoteIpsecVpn(sameInstance(vpn2to1)));
+    assertThat(vpn2to1, hasRemoteIpsecVpn(sameInstance(vpn1to2)));
+
+    /*
+     * vpn1to4 and vpn4to1 should connect over NAT. That is, vpn1to4 points to c1's interface facing
+     * c3. c3's corresponding interface's ip is NAT'ed such that if c4 connects to c1, the reply is
+     * translated back to the IP c4 is listening on for VPN v4to1.
+     *
+     */
+    assertThat(vpn1to4, hasRemoteIpsecVpn(sameInstance(vpn4to1)));
+    assertThat(vpn4to1, hasRemoteIpsecVpn(sameInstance(vpn1to4)));
   }
 }

--- a/projects/batfish/.settings/org.eclipse.core.resources.prefs
+++ b/projects/batfish/.settings/org.eclipse.core.resources.prefs
@@ -1,7 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding//src/main/resources=UTF-8
-encoding//src/test/java=UTF-8
-encoding//src/test/resources=UTF-8
-encoding//target/generated-sources/antlr4=UTF-8
-encoding/<project>=UTF-8

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -5,8 +5,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.cache.Cache;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSetMultimap;
-import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Sets;
 import java.io.File;
 import java.io.IOException;
@@ -21,7 +19,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -91,8 +88,6 @@ import org.batfish.datamodel.InterfaceType;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.IpAccessListLine;
-import org.batfish.datamodel.IpSpace;
-import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.IpsecVpn;
 import org.batfish.datamodel.NodeRoleSpecifier;
 import org.batfish.datamodel.OspfArea;
@@ -1219,7 +1214,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
   }
 
   private void disableUnusableVpnInterfaces(Map<String, Configuration> configurations) {
-    initRemoteIpsecVpns(configurations);
+    CommonUtil.initRemoteIpsecVpns(configurations);
     for (Configuration c : configurations.values()) {
       for (IpsecVpn vpn : c.getIpsecVpns().values()) {
         IpsecVpn remoteVpn = vpn.getRemoteIpsecVpn();
@@ -2072,52 +2067,6 @@ public class Batfish extends PluginConsumer implements IBatfish {
     return answerElement;
   }
 
-  private SetMultimap<Ip, IpSpace> initPrivateIpsByPublicIp(
-      Map<String, Configuration> configurations) {
-    /*
-     * Very hacky mapping from public IP to set of spaces of possible natted private IPs.
-     * Does not currently support source-nat acl.
-     *
-     * The current implementation just considers every IP in every prefix on a non-masquerading
-     * interface (except the local address in each such prefix) to be a possible private IP
-     * match for every public IP referred to by every source-nat pool on a masquerading interface.
-     */
-    ImmutableSetMultimap.Builder<Ip, IpSpace> builder = ImmutableSetMultimap.builder();
-    for (Configuration c : configurations.values()) {
-      Collection<Interface> interfaces = c.getInterfaces().values();
-      Set<Prefix> nonNattedInterfacePrefixes =
-          interfaces
-              .stream()
-              .filter(i -> i.getSourceNats().isEmpty())
-              .flatMap(i -> i.getAllPrefixes().stream())
-              .collect(ImmutableSet.toImmutableSet());
-      Set<IpWildcard> blacklist =
-          nonNattedInterfacePrefixes
-              .stream()
-              .map(p -> new IpWildcard(p.getAddress(), Ip.ZERO))
-              .collect(ImmutableSet.toImmutableSet());
-      Set<IpWildcard> whitelist =
-          nonNattedInterfacePrefixes
-              .stream()
-              .map(IpWildcard::new)
-              .collect(ImmutableSet.toImmutableSet());
-      IpSpace ipSpace = IpSpace.builder().including(whitelist).excluding(blacklist).build();
-      interfaces
-          .stream()
-          .flatMap(i -> i.getSourceNats().stream())
-          .forEach(
-              sourceNat -> {
-                for (long ipAsLong = sourceNat.getPoolIpFirst().asLong();
-                    ipAsLong <= sourceNat.getPoolIpLast().asLong();
-                    ipAsLong++) {
-                  Ip currentPoolIp = new Ip(ipAsLong);
-                  builder.put(currentPoolIp, ipSpace);
-                }
-              });
-    }
-    return builder.build();
-  }
-
   private void initQuestionEnvironment(Question question, boolean dp, boolean differentialContext) {
     EnvironmentSettings envSettings = _testrigSettings.getEnvironmentSettings();
     if (!environmentExists(_testrigSettings)) {
@@ -2147,63 +2096,6 @@ public class Batfish extends PluginConsumer implements IBatfish {
       pushDeltaEnvironment();
       initQuestionEnvironment(question, dp, true);
       popEnvironment();
-    }
-  }
-
-  @Override
-  public void initRemoteIpsecVpns(Map<String, Configuration> configurations) {
-    Map<IpsecVpn, Ip> remoteAddresses = new IdentityHashMap<>();
-    Map<Ip, Set<IpsecVpn>> externalAddresses = new HashMap<>();
-    SetMultimap<Ip, IpSpace> privateIpsByPublicIp = initPrivateIpsByPublicIp(configurations);
-    for (Configuration c : configurations.values()) {
-      for (IpsecVpn ipsecVpn : c.getIpsecVpns().values()) {
-        Ip remoteAddress = ipsecVpn.getIkeGateway().getAddress();
-        remoteAddresses.put(ipsecVpn, remoteAddress);
-        Set<Prefix> externalPrefixes =
-            ipsecVpn.getIkeGateway().getExternalInterface().getAllPrefixes();
-        for (Prefix externalPrefix : externalPrefixes) {
-          Ip externalAddress = externalPrefix.getAddress();
-          Set<IpsecVpn> vpnsUsingExternalAddress =
-              externalAddresses.computeIfAbsent(externalAddress, k -> Sets.newIdentityHashSet());
-          vpnsUsingExternalAddress.add(ipsecVpn);
-        }
-      }
-    }
-    for (Entry<IpsecVpn, Ip> e : remoteAddresses.entrySet()) {
-      IpsecVpn ipsecVpn = e.getKey();
-      Ip remoteAddress = e.getValue();
-      Ip localAddress = ipsecVpn.getIkeGateway().getLocalAddress();
-      ipsecVpn.initCandidateRemoteVpns();
-      Set<IpsecVpn> remoteIpsecVpnCandidates = externalAddresses.get(remoteAddress);
-      if (remoteIpsecVpnCandidates != null) {
-        for (IpsecVpn remoteIpsecVpnCandidate : remoteIpsecVpnCandidates) {
-          Ip remoteIpsecVpnLocalAddress = remoteIpsecVpnCandidate.getIkeGateway().getLocalAddress();
-          if (remoteIpsecVpnLocalAddress != null
-              && !remoteIpsecVpnLocalAddress.equals(remoteAddress)) {
-            continue;
-          }
-          Ip reciprocalRemoteAddress = remoteAddresses.get(remoteIpsecVpnCandidate);
-          Set<IpsecVpn> reciprocalVpns = externalAddresses.get(reciprocalRemoteAddress);
-          if (reciprocalVpns == null) {
-            Set<IpSpace> privateIpsBehindReciprocalRemoteAddress =
-                privateIpsByPublicIp.get(reciprocalRemoteAddress);
-            if (privateIpsBehindReciprocalRemoteAddress != null
-                && privateIpsBehindReciprocalRemoteAddress
-                    .stream()
-                    .anyMatch(ipSpace -> ipSpace.contains(localAddress))) {
-              reciprocalVpns = externalAddresses.get(localAddress);
-              ipsecVpn.setRemoteIpsecVpn(remoteIpsecVpnCandidate);
-              ipsecVpn.getCandidateRemoteIpsecVpns().add(remoteIpsecVpnCandidate);
-              remoteIpsecVpnCandidate.initCandidateRemoteVpns();
-              remoteIpsecVpnCandidate.setRemoteIpsecVpn(ipsecVpn);
-              remoteIpsecVpnCandidate.getCandidateRemoteIpsecVpns().add(ipsecVpn);
-            }
-          } else if (reciprocalVpns.contains(ipsecVpn)) {
-            ipsecVpn.setRemoteIpsecVpn(remoteIpsecVpnCandidate);
-            ipsecVpn.getCandidateRemoteIpsecVpns().add(remoteIpsecVpnCandidate);
-          }
-        }
-      }
     }
   }
 

--- a/projects/question/src/main/java/org/batfish/question/IpsecVpnCheckQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/IpsecVpnCheckQuestionPlugin.java
@@ -15,6 +15,7 @@ import org.batfish.common.BatfishException;
 import org.batfish.common.Pair;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.common.plugin.Plugin;
+import org.batfish.common.util.CommonUtil;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.IpsecVpn;
 import org.batfish.datamodel.answers.AnswerElement;
@@ -178,7 +179,7 @@ public class IpsecVpnCheckQuestionPlugin extends QuestionPlugin {
       }
 
       Map<String, Configuration> configurations = _batfish.loadConfigurations();
-      _batfish.initRemoteIpsecVpns(configurations);
+      CommonUtil.initRemoteIpsecVpns(configurations);
 
       IpsecVpnCheckAnswerElement answerElement = new IpsecVpnCheckAnswerElement();
       for (Configuration c : configurations.values()) {

--- a/projects/question/src/main/java/org/batfish/question/PairwiseVpnConnectivityQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/PairwiseVpnConnectivityQuestionPlugin.java
@@ -15,6 +15,7 @@ import org.batfish.common.Answerer;
 import org.batfish.common.BatfishException;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.common.plugin.Plugin;
+import org.batfish.common.util.CommonUtil;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.IpsecVpn;
 import org.batfish.datamodel.answers.AnswerElement;
@@ -90,7 +91,7 @@ public class PairwiseVpnConnectivityQuestionPlugin extends QuestionPlugin {
 
       Map<String, Configuration> configurations = _batfish.loadConfigurations();
 
-      _batfish.initRemoteIpsecVpns(configurations);
+      CommonUtil.initRemoteIpsecVpns(configurations);
       Set<String> ipsecVpnNodes = answerElement.getIpsecVpnNodes();
       Set<String> node2RegexNodes = new HashSet<>();
 


### PR DESCRIPTION
When two `SourceNat`s share at least one public IP, use the
disjunction of the induced `IpSpace`s when considering whether a
private ip lies behind a given public ip.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/773)
<!-- Reviewable:end -->
