### PR TITLE
Change == to equals for some important strings

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/WorkItem.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/WorkItem.java
@@ -125,8 +125,8 @@ public class WorkItem {
    */
   public boolean matches(WorkItem workItem) {
     return (workItem != null
-        && workItem._containerName == _containerName
-        && workItem._testrigName == _testrigName
+        && workItem._containerName.equals(_containerName)
+        && workItem._testrigName.equals(_testrigName)
         && workItem._requestParams.equals(_requestParams));
   }
 


### PR DESCRIPTION
It was never finding any matching workitems because it was comparing container and testrig names using `==` instead of `.equals`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/776)
<!-- Reviewable:end -->
