### PR TITLE
Check status for all incomplete, assigned tasks

### DIFF
--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -254,7 +254,7 @@ public class WorkMgr extends AbstractCoordinator {
         if (assignedWorker == null) {
           _logger.error("WM:CheckWork no assigned worker for " + work + "\n");
           _workQueueMgr.makeWorkUnassigned(work);
-          return;
+          continue;
         }
         checkTask(work, assignedWorker);
       }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -65,15 +65,8 @@ public class WorkMgr extends AbstractCoordinator {
   static final class AssignWorkTask implements Runnable {
     @Override
     public void run() {
-      Main.getWorkMgr().checkTask();
+      Main.getWorkMgr().checkTasks();
       Main.getWorkMgr().assignWork();
-    }
-  }
-
-  static final class CheckTaskTask implements Runnable {
-    @Override
-    public void run() {
-      Main.getWorkMgr().checkTask();
     }
   }
 
@@ -253,22 +246,20 @@ public class WorkMgr extends AbstractCoordinator {
     Main.getPoolMgr().markAssignmentResult(worker, assigned);
   }
 
-  private void checkTask() {
+  private void checkTasks() {
     try {
-      QueuedWork work = _workQueueMgr.getWorkForChecking();
-      if (work == null) {
-        // _logger.info("WM:checkTask: No assigned work\n");
-        return;
+      List<QueuedWork> workToCheck = _workQueueMgr.getWorkForChecking();
+      for (QueuedWork work : workToCheck) {
+        String assignedWorker = work.getAssignedWorker();
+        if (assignedWorker == null) {
+          _logger.error("WM:CheckWork no assigned worker for " + work + "\n");
+          _workQueueMgr.makeWorkUnassigned(work);
+          return;
+        }
+        checkTask(work, assignedWorker);
       }
-      String assignedWorker = work.getAssignedWorker();
-      if (assignedWorker == null) {
-        _logger.error("WM:CheckWork no assinged worker for " + work + "\n");
-        _workQueueMgr.makeWorkUnassigned(work);
-        return;
-      }
-      checkTask(work, assignedWorker);
     } catch (Exception e) {
-      _logger.error("Got exception in assignWork: " + e.getMessage());
+      _logger.error("Got exception in checkTasks: " + e.getMessage());
     }
   }
 

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkQueueMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkQueueMgr.java
@@ -7,6 +7,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.batfish.common.BatfishException;
@@ -319,6 +320,7 @@ public class WorkQueueMgr {
     return null;
   }
 
+  @Nonnull
   public List<QueuedWork> getWorkForChecking() {
     List<QueuedWork> workToCheck = new ArrayList<>();
     for (QueuedWork work : _queueIncompleteWork) {

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkQueueMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkQueueMgr.java
@@ -319,7 +319,6 @@ public class WorkQueueMgr {
     return null;
   }
 
-  @Nullable
   public List<QueuedWork> getWorkForChecking() {
     List<QueuedWork> workToCheck = new ArrayList<>();
     for (QueuedWork work : _queueIncompleteWork) {

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkQueueMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkQueueMgr.java
@@ -1,6 +1,7 @@
 package org.batfish.coordinator;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -319,14 +320,15 @@ public class WorkQueueMgr {
   }
 
   @Nullable
-  public QueuedWork getWorkForChecking() {
+  public List<QueuedWork> getWorkForChecking() {
+    List<QueuedWork> workToCheck = new ArrayList<>();
     for (QueuedWork work : _queueIncompleteWork) {
       if (work.getStatus() == WorkStatusCode.ASSIGNED) {
         work.setStatus(WorkStatusCode.CHECKINGSTATUS);
-        return work;
+        workToCheck.add(work);
       }
     }
-    return null;
+    return workToCheck;
   }
 
   public synchronized void makeWorkUnassigned(QueuedWork work) {

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkQueueMgrTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkQueueMgrTest.java
@@ -930,23 +930,22 @@ public class WorkQueueMgrTest {
 
   @Test
   public void testGetWorkForChecking() throws Exception {
-    WorkQueueMgr workQueueMgr = new WorkQueueMgr(Type.memory);
-    List<QueuedWork> workToCheck = workQueueMgr.getWorkForChecking();
+    List<QueuedWork> workToCheck = _workQueueMgr.getWorkForChecking();
 
     // Make sure getWorkForChecking() returns no elements when the incomplete work queue is empty
     assertThat(workToCheck, empty());
 
-    QueuedWork work1 = new QueuedWork(new WorkItem("container", "testrig"));
-    QueuedWork work2 = new QueuedWork(new WorkItem("container", "testrig"));
-    workQueueMgr.queueUnassignedWork(work1);
-    workQueueMgr.queueUnassignedWork(work2);
-    workToCheck = workQueueMgr.getWorkForChecking();
+    QueuedWork work1 = new QueuedWork(new WorkItem(CONTAINER, "testrig"), new WorkDetails());
+    QueuedWork work2 = new QueuedWork(new WorkItem(CONTAINER, "testrig"), new WorkDetails());
+    _workQueueMgr.queueUnassignedWork(work1);
+    _workQueueMgr.queueUnassignedWork(work2);
+    workToCheck = _workQueueMgr.getWorkForChecking();
 
     // Make sure unassigned items on the queue are not returned in getWorkForChecking()
     assertThat(workToCheck, empty());
 
     work2.setStatus(WorkStatusCode.ASSIGNED);
-    workToCheck = workQueueMgr.getWorkForChecking();
+    workToCheck = _workQueueMgr.getWorkForChecking();
 
     // Make sure only one item is returned from getWorkForChecking() when there is only one assigned
     // item on the queue
@@ -958,7 +957,7 @@ public class WorkQueueMgrTest {
     // When getWorkForChecking() is called, work2 should transition from ASSIGNED to CHECKINGSTATUS
     assertThat(work2.getStatus(), equalTo(WorkStatusCode.CHECKINGSTATUS));
 
-    workToCheck = workQueueMgr.getWorkForChecking();
+    workToCheck = _workQueueMgr.getWorkForChecking();
 
     // Since work2 status is CHECKINGSTATUS (and work1 is UNASSIGNED), nothing should show up in
     // getWorkForChecking()
@@ -966,21 +965,10 @@ public class WorkQueueMgrTest {
 
     work1.setStatus(WorkStatusCode.ASSIGNED);
     work2.setStatus(WorkStatusCode.ASSIGNED);
-    workToCheck = workQueueMgr.getWorkForChecking();
+    workToCheck = _workQueueMgr.getWorkForChecking();
 
     // With multiple assigned items now queued, getWorkForChecking() should return multiple items
     assertThat(workToCheck, iterableWithSize(2));
-  }
-
-  @Test
-  public void queueUnassignedWork() throws Exception {
-    WorkQueueMgr workQueueMgr = new WorkQueueMgr(Type.memory);
-    QueuedWork work1 = new QueuedWork(new WorkItem("container", "testrig"));
-    workQueueMgr.queueUnassignedWork(work1);
-    assertThat(workQueueMgr.getLength(QueueType.INCOMPLETE), equalTo(1L));
-    QueuedWork work2 = new QueuedWork(new WorkItem("container", "testrig"));
-    workQueueMgr.queueUnassignedWork(work2);
-    assertThat(workQueueMgr.getLength(QueueType.INCOMPLETE), equalTo(2L));
   }
 
   @Test

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkQueueMgrTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkQueueMgrTest.java
@@ -1,6 +1,9 @@
 package org.batfish.coordinator;
 
+import static org.hamcrest.Matchers.iterableWithSize;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -928,11 +931,10 @@ public class WorkQueueMgrTest {
   @Test
   public void testGetWorkForChecking() throws Exception {
     WorkQueueMgr workQueueMgr = new WorkQueueMgr(Type.memory);
-
     List<QueuedWork> workToCheck = workQueueMgr.getWorkForChecking();
 
     // Make sure getWorkForChecking() returns no elements when the incomplete work queue is empty
-    assertThat(workToCheck.size(), equalTo(0));
+    assertThat(workToCheck, empty());
 
     QueuedWork work1 = new QueuedWork(new WorkItem("container", "testrig"));
     QueuedWork work2 = new QueuedWork(new WorkItem("container", "testrig"));
@@ -941,17 +943,17 @@ public class WorkQueueMgrTest {
     workToCheck = workQueueMgr.getWorkForChecking();
 
     // Make sure unassigned items on the queue are not returned in getWorkForChecking()
-    assertThat(workToCheck.size(), equalTo(0));
+    assertThat(workToCheck, empty());
 
     work2.setStatus(WorkStatusCode.ASSIGNED);
     workToCheck = workQueueMgr.getWorkForChecking();
 
     // Make sure only one item is returned from getWorkForChecking() when there is only one assigned
     // item on the queue
-    assertThat(workToCheck.size(), equalTo(1));
+    assertThat(workToCheck, iterableWithSize(1));
 
-    // Make sure the correct item was returned
-    assertThat(workToCheck.get(0), equalTo(work2));
+    // Make sure the correct work item was returned
+    assertSame(workToCheck.get(0), work2);
 
     // When getWorkForChecking() is called, work2 should transition from ASSIGNED to CHECKINGSTATUS
     assertThat(work2.getStatus(), equalTo(WorkStatusCode.CHECKINGSTATUS));
@@ -960,14 +962,14 @@ public class WorkQueueMgrTest {
 
     // Since work2 status is CHECKINGSTATUS (and work1 is UNASSIGNED), nothing should show up in
     // getWorkForChecking()
-    assertThat(workToCheck.size(), equalTo(0));
+    assertThat(workToCheck, empty());
 
     work1.setStatus(WorkStatusCode.ASSIGNED);
     work2.setStatus(WorkStatusCode.ASSIGNED);
     workToCheck = workQueueMgr.getWorkForChecking();
 
     // With multiple assigned items now queued, getWorkForChecking() should return multiple items
-    assertThat(workToCheck.size(), equalTo(2));
+    assertThat(workToCheck, iterableWithSize(2));
   }
 
   @Test

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkQueueMgrTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkQueueMgrTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertThat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.List;
 import org.batfish.common.BatfishException;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.BfConsts.TaskStatus;
@@ -922,6 +923,47 @@ public class WorkQueueMgrTest {
     QueuedWork work2 = new QueuedWork(new WorkItem(CONTAINER, "testrig"), new WorkDetails());
     _workQueueMgr.queueUnassignedWork(work2);
     assertThat(_workQueueMgr.getLength(QueueType.INCOMPLETE), equalTo(2L));
+  }
+
+  @Test
+  public void testGetWorkForChecking() throws Exception {
+    WorkQueueMgr workQueueMgr = new WorkQueueMgr(Type.memory);
+
+    List<QueuedWork> workToCheck = workQueueMgr.getWorkForChecking();
+    assertThat(workToCheck.size(), equalTo(0));
+
+    QueuedWork work1 = new QueuedWork(new WorkItem("container", "testrig"));
+    QueuedWork work2 = new QueuedWork(new WorkItem("container", "testrig"));
+    workQueueMgr.queueUnassignedWork(work1);
+    workQueueMgr.queueUnassignedWork(work2);
+    workToCheck = workQueueMgr.getWorkForChecking();
+    assertThat(workToCheck.size(), equalTo(0));
+
+    work2.setStatus(WorkStatusCode.ASSIGNED);
+    workToCheck = workQueueMgr.getWorkForChecking();
+    assertThat(workToCheck.size(), equalTo(1));
+
+    // After getWorkForChecking(), work2 should have status CHECKINGSTATUS and
+    // therefore no longer show up in the workListToCheck
+    assertThat(work2.getStatus(), equalTo(WorkStatusCode.CHECKINGSTATUS));
+    workToCheck = workQueueMgr.getWorkForChecking();
+    assertThat(workToCheck.size(), equalTo(0));
+
+    work1.setStatus(WorkStatusCode.ASSIGNED);
+    work2.setStatus(WorkStatusCode.ASSIGNED);
+    workToCheck = workQueueMgr.getWorkForChecking();
+    assertThat(workToCheck.size(), equalTo(2));
+  }
+
+  @Test
+  public void queueUnassignedWork() throws Exception {
+    WorkQueueMgr workQueueMgr = new WorkQueueMgr(Type.memory);
+    QueuedWork work1 = new QueuedWork(new WorkItem("container", "testrig"));
+    workQueueMgr.queueUnassignedWork(work1);
+    assertThat(workQueueMgr.getLength(QueueType.INCOMPLETE), equalTo(1L));
+    QueuedWork work2 = new QueuedWork(new WorkItem("container", "testrig"));
+    workQueueMgr.queueUnassignedWork(work2);
+    assertThat(workQueueMgr.getLength(QueueType.INCOMPLETE), equalTo(2L));
   }
 
   @Test

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkQueueMgrTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkQueueMgrTest.java
@@ -930,6 +930,8 @@ public class WorkQueueMgrTest {
     WorkQueueMgr workQueueMgr = new WorkQueueMgr(Type.memory);
 
     List<QueuedWork> workToCheck = workQueueMgr.getWorkForChecking();
+
+    // Make sure getWorkForChecking() returns no elements when the incomplete work queue is empty
     assertThat(workToCheck.size(), equalTo(0));
 
     QueuedWork work1 = new QueuedWork(new WorkItem("container", "testrig"));
@@ -937,21 +939,34 @@ public class WorkQueueMgrTest {
     workQueueMgr.queueUnassignedWork(work1);
     workQueueMgr.queueUnassignedWork(work2);
     workToCheck = workQueueMgr.getWorkForChecking();
+
+    // Make sure unassigned items on the queue are not returned in getWorkForChecking()
     assertThat(workToCheck.size(), equalTo(0));
 
     work2.setStatus(WorkStatusCode.ASSIGNED);
     workToCheck = workQueueMgr.getWorkForChecking();
+
+    // Make sure only one item is returned from getWorkForChecking() when there is only one assigned
+    // item on the queue
     assertThat(workToCheck.size(), equalTo(1));
 
-    // After getWorkForChecking(), work2 should have status CHECKINGSTATUS and
-    // therefore no longer show up in the workListToCheck
+    // Make sure the correct item was returned
+    assertThat(workToCheck.get(0), equalTo(work2));
+
+    // When getWorkForChecking() is called, work2 should transition from ASSIGNED to CHECKINGSTATUS
     assertThat(work2.getStatus(), equalTo(WorkStatusCode.CHECKINGSTATUS));
+
     workToCheck = workQueueMgr.getWorkForChecking();
+
+    // Since work2 status is CHECKINGSTATUS (and work1 is UNASSIGNED), nothing should show up in
+    // getWorkForChecking()
     assertThat(workToCheck.size(), equalTo(0));
 
     work1.setStatus(WorkStatusCode.ASSIGNED);
     work2.setStatus(WorkStatusCode.ASSIGNED);
     workToCheck = workQueueMgr.getWorkForChecking();
+
+    // With multiple assigned items now queued, getWorkForChecking() should return multiple items
     assertThat(workToCheck.size(), equalTo(2));
   }
 


### PR DESCRIPTION
Updated checkTasks in the work manager to check on all incomplete, assigned work (and updated the work queue manager to support providing a list of these work items).

This fixes #775 where only the first incomplete, assigned work item is checked.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/777)
<!-- Reviewable:end -->
