### PR TITLE
HeaderSpace: use immutable structures internally

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/HeaderSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/HeaderSpace.java
@@ -1,12 +1,13 @@
 package org.batfish.datamodel;
 
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSortedSet;
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.SortedSet;
-import java.util.TreeSet;
 
 public class HeaderSpace implements Serializable {
 
@@ -96,37 +97,37 @@ public class HeaderSpace implements Serializable {
   private List<TcpFlags> _tcpFlags;
 
   public HeaderSpace() {
-    _dscps = new TreeSet<>();
-    _dstIps = new TreeSet<>();
-    _dstPorts = new TreeSet<>();
-    _dstProtocols = new TreeSet<>();
-    _ecns = new TreeSet<>();
-    _fragmentOffsets = new TreeSet<>();
-    _ipProtocols = new TreeSet<>();
-    _packetLengths = new TreeSet<>();
-    _srcIps = new TreeSet<>();
-    _srcOrDstIps = new TreeSet<>();
-    _srcOrDstPorts = new TreeSet<>();
-    _srcOrDstProtocols = new TreeSet<>();
-    _srcPorts = new TreeSet<>();
-    _srcProtocols = new TreeSet<>();
-    _icmpTypes = new TreeSet<>();
-    _icmpCodes = new TreeSet<>();
-    _states = new TreeSet<>();
-    _tcpFlags = new ArrayList<>();
-    _notDscps = new TreeSet<>();
-    _notDstIps = new TreeSet<>();
-    _notDstPorts = new TreeSet<>();
-    _notDstProtocols = new TreeSet<>();
-    _notEcns = new TreeSet<>();
-    _notFragmentOffsets = new TreeSet<>();
-    _notIcmpCodes = new TreeSet<>();
-    _notIcmpTypes = new TreeSet<>();
-    _notIpProtocols = new TreeSet<>();
-    _notPacketLengths = new TreeSet<>();
-    _notSrcIps = new TreeSet<>();
-    _notSrcPorts = new TreeSet<>();
-    _notSrcProtocols = new TreeSet<>();
+    _dscps = Collections.emptySortedSet();
+    _dstIps = Collections.emptySortedSet();
+    _dstPorts = Collections.emptySortedSet();
+    _dstProtocols = Collections.emptySortedSet();
+    _ecns = Collections.emptySortedSet();
+    _fragmentOffsets = Collections.emptySortedSet();
+    _ipProtocols = Collections.emptySortedSet();
+    _packetLengths = Collections.emptySortedSet();
+    _srcIps = Collections.emptySortedSet();
+    _srcOrDstIps = Collections.emptySortedSet();
+    _srcOrDstPorts = Collections.emptySortedSet();
+    _srcOrDstProtocols = Collections.emptySortedSet();
+    _srcPorts = Collections.emptySortedSet();
+    _srcProtocols = Collections.emptySortedSet();
+    _icmpTypes = Collections.emptySortedSet();
+    _icmpCodes = Collections.emptySortedSet();
+    _states = Collections.emptySortedSet();
+    _tcpFlags = Collections.emptyList();
+    _notDscps = Collections.emptySortedSet();
+    _notDstIps = Collections.emptySortedSet();
+    _notDstPorts = Collections.emptySortedSet();
+    _notDstProtocols = Collections.emptySortedSet();
+    _notEcns = Collections.emptySortedSet();
+    _notFragmentOffsets = Collections.emptySortedSet();
+    _notIcmpCodes = Collections.emptySortedSet();
+    _notIcmpTypes = Collections.emptySortedSet();
+    _notIpProtocols = Collections.emptySortedSet();
+    _notPacketLengths = Collections.emptySortedSet();
+    _notSrcIps = Collections.emptySortedSet();
+    _notSrcPorts = Collections.emptySortedSet();
+    _notSrcProtocols = Collections.emptySortedSet();
   }
 
   @Override
@@ -565,132 +566,132 @@ public class HeaderSpace implements Serializable {
     return true;
   }
 
-  public void setDscps(SortedSet<Integer> dscps) {
-    _dscps = dscps;
+  public void setDscps(Iterable<Integer> dscps) {
+    _dscps = ImmutableSortedSet.copyOf(dscps);
   }
 
-  public void setDstIps(SortedSet<IpWildcard> dstIps) {
-    _dstIps = dstIps;
+  public void setDstIps(Iterable<IpWildcard> dstIps) {
+    _dstIps = ImmutableSortedSet.copyOf(dstIps);
   }
 
-  public void setDstPorts(SortedSet<SubRange> dstPorts) {
-    _dstPorts = dstPorts;
+  public void setDstPorts(Iterable<SubRange> dstPorts) {
+    _dstPorts = ImmutableSortedSet.copyOf(dstPorts);
   }
 
-  public void setDstProtocols(SortedSet<Protocol> dstProtocols) {
-    _dstProtocols = dstProtocols;
+  public void setDstProtocols(Iterable<Protocol> dstProtocols) {
+    _dstProtocols = ImmutableSortedSet.copyOf(dstProtocols);
   }
 
-  public void setEcns(SortedSet<Integer> ecns) {
-    _ecns = ecns;
+  public void setEcns(Iterable<Integer> ecns) {
+    _ecns = ImmutableSortedSet.copyOf(ecns);
   }
 
-  public void setFragmentOffsets(SortedSet<SubRange> fragmentOffsets) {
-    _fragmentOffsets = fragmentOffsets;
+  public void setFragmentOffsets(Iterable<SubRange> fragmentOffsets) {
+    _fragmentOffsets = ImmutableSortedSet.copyOf(fragmentOffsets);
   }
 
-  public void setIcmpCodes(SortedSet<SubRange> icmpCodes) {
-    _icmpCodes = icmpCodes;
+  public void setIcmpCodes(Iterable<SubRange> icmpCodes) {
+    _icmpCodes = ImmutableSortedSet.copyOf(icmpCodes);
   }
 
-  public void setIcmpTypes(SortedSet<SubRange> icmpTypes) {
-    _icmpTypes = icmpTypes;
+  public void setIcmpTypes(Iterable<SubRange> icmpTypes) {
+    _icmpTypes = ImmutableSortedSet.copyOf(icmpTypes);
   }
 
-  public void setIpProtocols(SortedSet<IpProtocol> ipProtocols) {
-    _ipProtocols = ipProtocols;
+  public void setIpProtocols(Iterable<IpProtocol> ipProtocols) {
+    _ipProtocols = ImmutableSortedSet.copyOf(ipProtocols);
   }
 
   public void setNegate(boolean negate) {
     _negate = negate;
   }
 
-  public void setNotDscps(SortedSet<Integer> notDscps) {
-    _notDscps = notDscps;
+  public void setNotDscps(Iterable<Integer> notDscps) {
+    _notDscps = ImmutableSortedSet.copyOf(notDscps);
   }
 
-  public void setNotDstIps(SortedSet<IpWildcard> notDstIps) {
-    _notDstIps = notDstIps;
+  public void setNotDstIps(Iterable<IpWildcard> notDstIps) {
+    _notDstIps = ImmutableSortedSet.copyOf(notDstIps);
   }
 
-  public void setNotDstPorts(SortedSet<SubRange> notDstPorts) {
-    _notDstPorts = notDstPorts;
+  public void setNotDstPorts(Iterable<SubRange> notDstPorts) {
+    _notDstPorts = ImmutableSortedSet.copyOf(notDstPorts);
   }
 
-  public void setNotDstProtocols(SortedSet<Protocol> notDstProtocols) {
-    _notDstProtocols = notDstProtocols;
+  public void setNotDstProtocols(Iterable<Protocol> notDstProtocols) {
+    _notDstProtocols = ImmutableSortedSet.copyOf(notDstProtocols);
   }
 
-  public void setNotEcns(SortedSet<Integer> notEcns) {
-    _notEcns = notEcns;
+  public void setNotEcns(Iterable<Integer> notEcns) {
+    _notEcns = ImmutableSortedSet.copyOf(notEcns);
   }
 
-  public void setNotFragmentOffsets(SortedSet<SubRange> notFragmentOffsets) {
-    _notFragmentOffsets = notFragmentOffsets;
+  public void setNotFragmentOffsets(Iterable<SubRange> notFragmentOffsets) {
+    _notFragmentOffsets = ImmutableSortedSet.copyOf(notFragmentOffsets);
   }
 
-  public void setNotIcmpCodes(SortedSet<SubRange> notIcmpCodes) {
-    _notIcmpCodes = notIcmpCodes;
+  public void setNotIcmpCodes(Iterable<SubRange> notIcmpCodes) {
+    _notIcmpCodes = ImmutableSortedSet.copyOf(notIcmpCodes);
   }
 
-  public void setNotIcmpTypes(SortedSet<SubRange> notIcmpTypes) {
-    _notIcmpTypes = notIcmpTypes;
+  public void setNotIcmpTypes(Iterable<SubRange> notIcmpTypes) {
+    _notIcmpTypes = ImmutableSortedSet.copyOf(notIcmpTypes);
   }
 
-  public void setNotIpProtocols(SortedSet<IpProtocol> notIpProtocols) {
-    _notIpProtocols = notIpProtocols;
+  public void setNotIpProtocols(Iterable<IpProtocol> notIpProtocols) {
+    _notIpProtocols = ImmutableSortedSet.copyOf(notIpProtocols);
   }
 
-  public void setNotPacketLengths(SortedSet<SubRange> notPacketLengths) {
-    _notPacketLengths = notPacketLengths;
+  public void setNotPacketLengths(Iterable<SubRange> notPacketLengths) {
+    _notPacketLengths = ImmutableSortedSet.copyOf(notPacketLengths);
   }
 
-  public void setNotSrcIps(SortedSet<IpWildcard> notSrcIps) {
-    _notSrcIps = notSrcIps;
+  public void setNotSrcIps(Iterable<IpWildcard> notSrcIps) {
+    _notSrcIps = ImmutableSortedSet.copyOf(notSrcIps);
   }
 
-  public void setNotSrcPorts(SortedSet<SubRange> notSrcPorts) {
-    _notSrcPorts = notSrcPorts;
+  public void setNotSrcPorts(Iterable<SubRange> notSrcPorts) {
+    _notSrcPorts = ImmutableSortedSet.copyOf(notSrcPorts);
   }
 
-  public void setNotSrcProtocols(SortedSet<Protocol> notSrcProtocols) {
-    _notSrcProtocols = notSrcProtocols;
+  public void setNotSrcProtocols(Iterable<Protocol> notSrcProtocols) {
+    _notSrcProtocols = ImmutableSortedSet.copyOf(notSrcProtocols);
   }
 
-  public void setPacketLengths(SortedSet<SubRange> packetLengths) {
-    _packetLengths = packetLengths;
+  public void setPacketLengths(Iterable<SubRange> packetLengths) {
+    _packetLengths = ImmutableSortedSet.copyOf(packetLengths);
   }
 
-  public void setSrcIps(SortedSet<IpWildcard> srcIps) {
-    _srcIps = srcIps;
+  public void setSrcIps(Iterable<IpWildcard> srcIps) {
+    _srcIps = ImmutableSortedSet.copyOf(srcIps);
   }
 
-  public void setSrcOrDstIps(SortedSet<IpWildcard> srcOrDstIps) {
-    _srcOrDstIps = srcOrDstIps;
+  public void setSrcOrDstIps(Iterable<IpWildcard> srcOrDstIps) {
+    _srcOrDstIps = ImmutableSortedSet.copyOf(srcOrDstIps);
   }
 
-  public void setSrcOrDstPorts(SortedSet<SubRange> srcOrDstPorts) {
-    _srcOrDstPorts = srcOrDstPorts;
+  public void setSrcOrDstPorts(Iterable<SubRange> srcOrDstPorts) {
+    _srcOrDstPorts = ImmutableSortedSet.copyOf(srcOrDstPorts);
   }
 
-  public void setSrcOrDstProtocols(SortedSet<Protocol> srcOrDstProtocols) {
-    _srcOrDstProtocols = srcOrDstProtocols;
+  public void setSrcOrDstProtocols(Iterable<Protocol> srcOrDstProtocols) {
+    _srcOrDstProtocols = ImmutableSortedSet.copyOf(srcOrDstProtocols);
   }
 
-  public void setSrcPorts(SortedSet<SubRange> srcPorts) {
-    _srcPorts = srcPorts;
+  public void setSrcPorts(Iterable<SubRange> srcPorts) {
+    _srcPorts = ImmutableSortedSet.copyOf(srcPorts);
   }
 
-  public void setSrcProtocols(SortedSet<Protocol> srcProtocols) {
-    _srcProtocols = srcProtocols;
+  public void setSrcProtocols(Iterable<Protocol> srcProtocols) {
+    _srcProtocols = ImmutableSortedSet.copyOf(srcProtocols);
   }
 
-  public void setStates(SortedSet<State> states) {
-    _states = states;
+  public void setStates(Iterable<State> states) {
+    _states = ImmutableSortedSet.copyOf(states);
   }
 
-  public void setTcpFlags(List<TcpFlags> tcpFlags) {
-    _tcpFlags = tcpFlags;
+  public void setTcpFlags(Iterable<TcpFlags> tcpFlags) {
+    _tcpFlags = ImmutableList.copyOf(tcpFlags);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -4,14 +4,15 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.google.common.collect.ImmutableSortedSet;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.SortedSet;
 import java.util.TreeMap;
-import java.util.TreeSet;
 import org.batfish.common.BatfishException;
 import org.batfish.common.util.ComparableStructure;
 import org.batfish.datamodel.NetworkFactory.NetworkFactoryBuilder;
@@ -67,7 +68,7 @@ public final class Interface extends ComparableStructure<String> {
       }
       iface.setPrefix(_prefix);
       if (_prefix != null) {
-        iface.getAllPrefixes().add(_prefix);
+        iface.setAllPrefixes(Collections.singleton(_prefix));
       }
       iface.setVrf(_vrf);
       if (_vrf != null) {
@@ -374,7 +375,7 @@ public final class Interface extends ComparableStructure<String> {
 
   private List<SubRange> _allowedVlans;
 
-  private Set<Prefix> _allPrefixes;
+  private SortedSet<Prefix> _allPrefixes;
 
   private boolean _autoState;
 
@@ -475,7 +476,7 @@ public final class Interface extends ComparableStructure<String> {
     _active = true;
     _autoState = true;
     _allowedVlans = new ArrayList<>();
-    _allPrefixes = new TreeSet<>();
+    _allPrefixes = ImmutableSortedSet.of();
     _dhcpRelayAddresses = new ArrayList<>();
     _interfaceType = InterfaceType.UNKNOWN;
     _mtu = DEFAULT_MTU;
@@ -931,8 +932,8 @@ public final class Interface extends ComparableStructure<String> {
   }
 
   @JsonProperty(PROP_ALL_PREFIXES)
-  public void setAllPrefixes(Set<Prefix> allPrefixes) {
-    _allPrefixes = allPrefixes;
+  public void setAllPrefixes(Iterable<Prefix> allPrefixes) {
+    _allPrefixes = ImmutableSortedSet.copyOf(allPrefixes);
   }
 
   @JsonProperty(PROP_AUTOSTATE)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpAccessList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpAccessList.java
@@ -3,6 +3,7 @@ package org.batfish.datamodel;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.google.common.collect.ImmutableList;
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDescription;
 import java.util.List;
 import org.batfish.common.util.ComparableStructure;
@@ -43,7 +44,7 @@ public class IpAccessList extends ComparableStructure<String> {
 
   public IpAccessList(String name, List<IpAccessListLine> lines) {
     super(name);
-    _lines = lines;
+    _lines = ImmutableList.copyOf(lines);
   }
 
   @Override
@@ -86,7 +87,7 @@ public class IpAccessList extends ComparableStructure<String> {
 
   @JsonProperty(PROP_LINES)
   public void setLines(List<IpAccessListLine> lines) {
-    _lines = lines;
+    _lines = ImmutableList.copyOf(lines);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/aws_vpcs/Instance.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws_vpcs/Instance.java
@@ -125,14 +125,6 @@ public class Instance implements AwsVpcEntity, Serializable {
 
     List<IpAccessListLine> inboundRules = new LinkedList<>();
     List<IpAccessListLine> outboundRules = new LinkedList<>();
-    // create ACLs from inboundRules and outboundRules
-    IpAccessList inAcl = new IpAccessList(sgIngressAclName, inboundRules);
-    IpAccessList outAcl = new IpAccessList(sgEgressAclName, outboundRules);
-    cfgNode.getIpAccessLists().put(sgIngressAclName, inAcl);
-    cfgNode.getIpAccessLists().put(sgEgressAclName, outAcl);
-    _inAcl = inAcl;
-    _outAcl = outAcl;
-
     for (String sGroupId : _securityGroups) {
       SecurityGroup sGroup = awsVpcConfig.getSecurityGroups().get(sGroupId);
 
@@ -143,6 +135,12 @@ public class Instance implements AwsVpcEntity, Serializable {
 
       sGroup.addInOutAccessLines(inboundRules, outboundRules);
     }
+
+    // create ACLs from inboundRules and outboundRules
+    _inAcl = new IpAccessList(sgIngressAclName, inboundRules);
+    _outAcl = new IpAccessList(sgEgressAclName, outboundRules);
+    cfgNode.getIpAccessLists().put(sgIngressAclName, _inAcl);
+    cfgNode.getIpAccessLists().put(sgEgressAclName, _outAcl);
 
     for (String interfaceId : _networkInterfaces) {
 
@@ -185,8 +183,8 @@ public class Instance implements AwsVpcEntity, Serializable {
       iface.setAllPrefixes(ifacePrefixes);
 
       // apply ACLs to interface
-      iface.setIncomingFilter(inAcl);
-      iface.setOutgoingFilter(outAcl);
+      iface.setIncomingFilter(_inAcl);
+      iface.setOutgoingFilter(_outAcl);
 
       cfgNode.getVendorFamily().getAws().setVpcId(_vpcId);
       cfgNode.getVendorFamily().getAws().setSubnetId(_subnetId);

--- a/projects/batfish/src/main/java/org/batfish/representation/aws_vpcs/IpPermissions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws_vpcs/IpPermissions.java
@@ -1,6 +1,9 @@
 package org.batfish.representation.aws_vpcs;
 
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Ordering;
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -69,19 +72,21 @@ public class IpPermissions implements Serializable {
 
   public IpAccessListLine toEgressIpAccessListLine() {
     IpAccessListLine line = toIpAccessListLine();
-    for (Prefix ipRange : _ipRanges) {
-      IpWildcard wildcard = new IpWildcard(ipRange);
-      line.getDstIps().add(wildcard);
-    }
+    line.setDstIps(
+        _ipRanges
+            .stream()
+            .map(IpWildcard::new)
+            .collect(ImmutableSortedSet.toImmutableSortedSet(Ordering.natural())));
     return line;
   }
 
   public IpAccessListLine toIngressIpAccessListLine() {
     IpAccessListLine line = toIpAccessListLine();
-    for (Prefix ipRange : _ipRanges) {
-      IpWildcard wildcard = new IpWildcard(ipRange);
-      line.getSrcIps().add(wildcard);
-    }
+    line.setSrcIps(
+        _ipRanges
+            .stream()
+            .map(IpWildcard::new)
+            .collect(ImmutableSortedSet.toImmutableSortedSet(Ordering.natural())));
     return line;
   }
 
@@ -90,13 +95,13 @@ public class IpPermissions implements Serializable {
     line.setAction(LineAction.ACCEPT);
     IpProtocol protocol = toIpProtocol(_ipProtocol);
     if (protocol != null) {
-      line.getIpProtocols().add(protocol);
+      line.setIpProtocols(Collections.singleton(protocol));
     }
     if (_fromPort != -1) {
-      line.getSrcPorts().add(new SubRange(_fromPort, _fromPort));
+      line.setSrcPorts(Collections.singleton(new SubRange(_fromPort, _fromPort)));
     }
     if (_toPort != -1) {
-      line.getDstPorts().add(new SubRange(_toPort, _toPort));
+      line.setDstPorts(Collections.singleton(new SubRange(_toPort, _toPort)));
     }
     return line;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/aws_vpcs/NetworkAcl.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws_vpcs/NetworkAcl.java
@@ -1,5 +1,6 @@
 package org.batfish.representation.aws_vpcs;
 
+import com.google.common.collect.ImmutableSortedSet;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -53,15 +54,15 @@ public class NetworkAcl implements AwsVpcEntity, Serializable {
         Prefix prefix = entry.getCidrBlock();
         if (!prefix.equals(Prefix.ZERO)) {
           if (isEgress) {
-            line.getDstIps().add(new IpWildcard(prefix));
+            line.setDstIps(ImmutableSortedSet.of(new IpWildcard(prefix)));
           } else {
-            line.getSrcIps().add(new IpWildcard(prefix));
+            line.setSrcIps(ImmutableSortedSet.of(new IpWildcard(prefix)));
           }
         }
         IpProtocol protocol = IpPermissions.toIpProtocol(entry.getProtocol());
         String protocolStr = protocol != null ? protocol.toString() : "ALL";
         if (protocol != null) {
-          line.getIpProtocols().add(protocol);
+          line.setIpProtocols(ImmutableSortedSet.of(protocol));
         }
         int fromPort = entry.getFromPort();
         int toPort = entry.getToPort();
@@ -73,7 +74,7 @@ public class NetworkAcl implements AwsVpcEntity, Serializable {
           if (toPort == -1) {
             toPort = 65535;
           }
-          line.getDstPorts().add(portRange);
+          line.setDstPorts(ImmutableSortedSet.of(portRange));
         }
         String portStr;
         if (protocol == IpProtocol.ICMP) {
@@ -91,8 +92,7 @@ public class NetworkAcl implements AwsVpcEntity, Serializable {
         lineMap.put(key, line);
       }
     }
-    List<IpAccessListLine> lines = new ArrayList<>();
-    lines.addAll(lineMap.values());
+    List<IpAccessListLine> lines = new ArrayList<>(lineMap.values());
     IpAccessList list = new IpAccessList(listName, lines);
     return list;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/aws_vpcs/NetworkAcl.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws_vpcs/NetworkAcl.java
@@ -1,8 +1,8 @@
 package org.batfish.representation.aws_vpcs;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -92,7 +92,7 @@ public class NetworkAcl implements AwsVpcEntity, Serializable {
         lineMap.put(key, line);
       }
     }
-    List<IpAccessListLine> lines = new ArrayList<>(lineMap.values());
+    List<IpAccessListLine> lines = ImmutableList.copyOf(lineMap.values());
     IpAccessList list = new IpAccessList(listName, lines);
     return list;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -3269,14 +3269,12 @@ public final class CiscoConfiguration extends VendorConfiguration {
 
   private RouteFilterList toRouteFilterList(PrefixList list) {
     RouteFilterList newRouteFilterList = new RouteFilterList(list.getName());
-    for (PrefixListLine prefixListLine : list.getLines()) {
-      RouteFilterLine newRouteFilterListLine =
-          new RouteFilterLine(
-              prefixListLine.getAction(),
-              prefixListLine.getPrefix(),
-              prefixListLine.getLengthRange());
-      newRouteFilterList.addLine(newRouteFilterListLine);
-    }
+    List<RouteFilterLine> newLines =
+        list.getLines()
+            .stream()
+            .map(l -> new RouteFilterLine(l.getAction(), l.getPrefix(), l.getLengthRange()))
+            .collect(ImmutableList.toImmutableList());
+    newRouteFilterList.setLines(newLines);
     return newRouteFilterList;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -3260,12 +3260,10 @@ public final class CiscoConfiguration extends VendorConfiguration {
   private RouteFilterList toRouteFilterList(ExtendedAccessList eaList) {
     String name = eaList.getName();
     RouteFilterList newList = new RouteFilterList(name);
-    List<RouteFilterLine> lines = new ArrayList<>();
     for (ExtendedAccessListLine fromLine : eaList.getLines()) {
       RouteFilterLine newLine = toRouteFilterLine(fromLine);
-      lines.add(newLine);
+      newList.addLine(newLine);
     }
-    newList.getLines().addAll(lines);
     return newList;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -1,6 +1,8 @@
 package org.batfish.representation.cisco;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -2114,13 +2116,17 @@ public final class CiscoConfiguration extends VendorConfiguration {
     newIface.setProxyArp(iface.getProxyArp());
     newIface.setSpanningTreePortfast(iface.getSpanningTreePortfast());
     newIface.setSwitchport(iface.getSwitchport());
+
+    // All prefixes is the combination of the interface prefix + any secondary prefixes.
+    ImmutableSet.Builder<Prefix> allPrefixes = ImmutableSet.builder();
     if (iface.getPrefix() != null) {
       newIface.setPrefix(iface.getPrefix());
-      newIface.getAllPrefixes().add(iface.getPrefix());
+      allPrefixes.add(iface.getPrefix());
     }
-    newIface.getAllPrefixes().addAll(iface.getSecondaryPrefixes());
-    Long ospfAreaLong = iface.getOspfArea();
+    allPrefixes.addAll(iface.getSecondaryPrefixes());
+    newIface.setAllPrefixes(allPrefixes.build());
 
+    Long ospfAreaLong = iface.getOspfArea();
     if (ospfAreaLong != null) {
       OspfProcess proc = vrf.getOspfProcess();
       if (proc != null) {
@@ -2320,35 +2326,35 @@ public final class CiscoConfiguration extends VendorConfiguration {
       newLine.setAction(fromLine.getAction());
       IpWildcard srcIpWildcard = fromLine.getSourceIpWildcard();
       if (srcIpWildcard != null) {
-        newLine.getSrcIps().add(srcIpWildcard);
+        newLine.setSrcIps(ImmutableSortedSet.of(srcIpWildcard));
       }
       IpWildcard dstIpWildcard = fromLine.getDestinationIpWildcard();
       if (dstIpWildcard != null) {
-        newLine.getDstIps().add(dstIpWildcard);
+        newLine.setDstIps(ImmutableSortedSet.of(dstIpWildcard));
       }
       // TODO: src/dst address group
       IpProtocol protocol = fromLine.getProtocol();
       if (protocol != IpProtocol.IP) {
-        newLine.getIpProtocols().add(protocol);
+        newLine.setIpProtocols(ImmutableSortedSet.of(protocol));
       }
-      newLine.getDstPorts().addAll(fromLine.getDstPorts());
-      newLine.getSrcPorts().addAll(fromLine.getSrcPorts());
+      newLine.setDstPorts(fromLine.getDstPorts());
+      newLine.setSrcPorts(fromLine.getSrcPorts());
       Integer icmpType = fromLine.getIcmpType();
       if (icmpType != null) {
-        newLine.setIcmpTypes(new TreeSet<>(Collections.singleton(new SubRange(icmpType))));
+        newLine.setIcmpTypes(ImmutableSortedSet.of(new SubRange(icmpType)));
       }
       Integer icmpCode = fromLine.getIcmpCode();
       if (icmpCode != null) {
-        newLine.setIcmpCodes(new TreeSet<>(Collections.singleton(new SubRange(icmpCode))));
+        newLine.setIcmpCodes(ImmutableSortedSet.of(new SubRange(icmpCode)));
       }
       Set<State> states = fromLine.getStates();
-      newLine.getStates().addAll(states);
+      newLine.setStates(states);
       List<TcpFlags> tcpFlags = fromLine.getTcpFlags();
-      newLine.getTcpFlags().addAll(tcpFlags);
+      newLine.setTcpFlags(tcpFlags);
       Set<Integer> dscps = fromLine.getDscps();
-      newLine.getDscps().addAll(dscps);
+      newLine.setDscps(dscps);
       Set<Integer> ecns = fromLine.getEcns();
-      newLine.getEcns().addAll(ecns);
+      newLine.setEcns(ecns);
       lines.add(newLine);
     }
     return new IpAccessList(name, lines);

--- a/projects/batfish/src/main/java/org/batfish/representation/host/HostInterface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/host/HostInterface.java
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.Set;
 import java.util.TreeSet;
 import org.batfish.common.Warnings;
@@ -135,8 +137,7 @@ public class HostInterface implements Serializable {
     Interface iface = new Interface(_canonicalName, configuration);
     iface.setBandwidth(_bandwidth);
     iface.setPrefix(_prefix);
-    iface.getAllPrefixes().add(_prefix);
-    iface.getAllPrefixes().addAll(_otherPrefixes);
+    iface.setAllPrefixes(Iterables.concat(Collections.singleton(_prefix), _otherPrefixes));
     iface.setVrf(configuration.getDefaultVrf());
     if (_shared) {
       SourceNat sourceNat = new SourceNat();

--- a/projects/batfish/src/main/java/org/batfish/representation/iptables/IptablesVendorConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/iptables/IptablesVendorConfiguration.java
@@ -1,8 +1,9 @@
 package org.batfish.representation.iptables;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import java.util.Collections;
 import java.util.IdentityHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -17,9 +18,7 @@ import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.IpAccessListLine;
-import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.LineAction;
-import org.batfish.datamodel.SubRange;
 import org.batfish.vendor.VendorConfiguration;
 
 public class IptablesVendorConfiguration extends IptablesConfiguration {
@@ -179,12 +178,11 @@ public class IptablesVendorConfiguration extends IptablesConfiguration {
 
         switch (match.getMatchType()) {
           case DESTINATION:
-            IpWildcard dstWildCard = match.toIpWildcard();
-            aclLine.getDstIps().add(dstWildCard);
+            aclLine.setDstIps(
+                Iterables.concat(aclLine.getDstIps(), Collections.singleton(match.toIpWildcard())));
             break;
           case DESTINATION_PORT:
-            List<SubRange> dstPortRanges = match.toPortRanges();
-            aclLine.getDstPorts().addAll(dstPortRanges);
+            aclLine.setDstPorts(Iterables.concat(aclLine.getDstPorts(), match.toPortRanges()));
             break;
           case IN_INTERFACE:
             _lineInInterfaces.put(aclLine, vc.canonicalizeInterfaceName(match.toInterfaceName()));
@@ -195,15 +193,16 @@ public class IptablesVendorConfiguration extends IptablesConfiguration {
             anyInterface = false;
             break;
           case PROTOCOL:
-            aclLine.getIpProtocols().add(match.toIpProtocol());
+            aclLine.setIpProtocols(
+                Iterables.concat(
+                    aclLine.getIpProtocols(), Collections.singleton(match.toIpProtocol())));
             break;
           case SOURCE:
-            IpWildcard srcWildCard = match.toIpWildcard();
-            aclLine.getSrcIps().add(srcWildCard);
+            aclLine.setSrcIps(
+                Iterables.concat(aclLine.getSrcIps(), Collections.singleton(match.toIpWildcard())));
             break;
           case SOURCE_PORT:
-            List<SubRange> srcPortRanges = match.toPortRanges();
-            aclLine.getSrcPorts().addAll(srcPortRanges);
+            aclLine.setSrcPorts(Iterables.concat(aclLine.getSrcPorts(), match.toPortRanges()));
             break;
           default:
             throw new BatfishException("Unknown match type: " + match.getMatchType());

--- a/projects/batfish/src/main/java/org/batfish/representation/iptables/IptablesVendorConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/iptables/IptablesVendorConfiguration.java
@@ -1,5 +1,6 @@
 package org.batfish.representation.iptables;
 
+import com.google.common.collect.ImmutableList;
 import java.util.IdentityHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -168,7 +169,7 @@ public class IptablesVendorConfiguration extends IptablesConfiguration {
   }
 
   private IpAccessList toIpAccessList(String aclName, IptablesChain chain, VendorConfiguration vc) {
-    IpAccessList acl = new IpAccessList(aclName, new LinkedList<>());
+    ImmutableList.Builder<IpAccessListLine> lines = ImmutableList.builder();
 
     for (IptablesRule rule : chain.getRules()) {
       IpAccessListLine aclLine = new IpAccessListLine();
@@ -216,7 +217,7 @@ public class IptablesVendorConfiguration extends IptablesConfiguration {
 
       aclLine.setName(rule.getName());
       aclLine.setAction(rule.getIpAccessListLineAction());
-      acl.getLines().add(aclLine);
+      lines.add(aclLine);
     }
 
     // add a final line corresponding to default chain policy
@@ -224,8 +225,9 @@ public class IptablesVendorConfiguration extends IptablesConfiguration {
     IpAccessListLine defaultLine = new IpAccessListLine();
     defaultLine.setAction(chainAction);
     defaultLine.setName("default");
-    acl.getLines().add(defaultLine);
+    lines.add(defaultLine);
 
+    IpAccessList acl = new IpAccessList(aclName, lines.build());
     return acl;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/BaseApplication.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/BaseApplication.java
@@ -1,5 +1,6 @@
 package org.batfish.representation.juniper;
 
+import com.google.common.collect.Iterables;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -24,9 +25,12 @@ public class BaseApplication extends ComparableStructure<String> implements Appl
     }
 
     public void applyTo(IpAccessListLine destinationLine) {
-      destinationLine.getIpProtocols().addAll(_line.getIpProtocols());
-      destinationLine.getDstPorts().addAll(_line.getDstPorts());
-      destinationLine.getSrcPorts().addAll(_line.getSrcPorts());
+      destinationLine.setIpProtocols(
+          Iterables.concat(destinationLine.getIpProtocols(), _line.getIpProtocols()));
+      destinationLine.setDstPorts(
+          Iterables.concat(destinationLine.getDstPorts(), _line.getDstPorts()));
+      destinationLine.setSrcPorts(
+          Iterables.concat(destinationLine.getSrcPorts(), _line.getSrcPorts()));
     }
 
     public IpAccessListLine getLine() {
@@ -59,8 +63,8 @@ public class BaseApplication extends ComparableStructure<String> implements Appl
     }
     for (Term term : terms) {
       IpAccessListLine newLine = new IpAccessListLine();
-      newLine.getDstIps().addAll(srcLine.getDstIps());
-      newLine.getSrcIps().addAll(srcLine.getSrcIps());
+      newLine.setDstIps(srcLine.getDstIps());
+      newLine.setSrcIps(srcLine.getSrcIps());
       newLine.setAction(srcLine.getAction());
       term.applyTo(newLine);
       lines.add(newLine);

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromDestinationAddress.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromDestinationAddress.java
@@ -1,5 +1,7 @@
 package org.batfish.representation.juniper;
 
+import com.google.common.collect.Iterables;
+import java.util.Collections;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.IpAccessListLine;
@@ -19,7 +21,8 @@ public final class FwFromDestinationAddress extends FwFrom {
 
   @Override
   public void applyTo(IpAccessListLine line, JuniperConfiguration jc, Warnings w, Configuration c) {
-    line.getDstIps().add(new IpWildcard(_prefix));
+    line.setDstIps(
+        Iterables.concat(line.getDstIps(), Collections.singleton(new IpWildcard(_prefix))));
   }
 
   public Prefix getPrefix() {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromDestinationAddressBookEntry.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromDestinationAddressBookEntry.java
@@ -1,6 +1,9 @@
 package org.batfish.representation.juniper;
 
+import com.google.common.collect.Iterables;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.IpAccessListLine;
@@ -25,9 +28,8 @@ public final class FwFromDestinationAddressBookEntry extends FwFrom {
   @Override
   public void applyTo(IpAccessListLine line, JuniperConfiguration jc, Warnings w, Configuration c) {
     Set<Prefix> prefixes = _localAddressBook.getPrefixes(_addressBookEntryName, w);
-    for (Prefix prefix : prefixes) {
-      IpWildcard wildcard = new IpWildcard(prefix);
-      line.getDstIps().add(wildcard);
-    }
+    List<IpWildcard> wildcards =
+        prefixes.stream().map(IpWildcard::new).collect(Collectors.toList());
+    line.setDstIps(Iterables.concat(line.getDstIps(), wildcards));
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromDestinationAddressExcept.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromDestinationAddressExcept.java
@@ -1,5 +1,7 @@
 package org.batfish.representation.juniper;
 
+import com.google.common.collect.Iterables;
+import java.util.Collections;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.IpAccessListLine;
@@ -19,7 +21,8 @@ public final class FwFromDestinationAddressExcept extends FwFrom {
 
   @Override
   public void applyTo(IpAccessListLine line, JuniperConfiguration jc, Warnings w, Configuration c) {
-    line.getNotDstIps().add(new IpWildcard(_prefix));
+    line.setNotDstIps(
+        Iterables.concat(line.getNotDstIps(), Collections.singleton(new IpWildcard(_prefix))));
   }
 
   public Prefix getPrefix() {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromDestinationPort.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromDestinationPort.java
@@ -1,5 +1,7 @@
 package org.batfish.representation.juniper;
 
+import com.google.common.collect.Iterables;
+import java.util.Collections;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.IpAccessListLine;
@@ -22,7 +24,7 @@ public final class FwFromDestinationPort extends FwFrom {
 
   @Override
   public void applyTo(IpAccessListLine line, JuniperConfiguration jc, Warnings w, Configuration c) {
-    line.getDstPorts().add(_portRange);
+    line.setDstPorts(Iterables.concat(line.getDstPorts(), Collections.singleton(_portRange)));
   }
 
   public SubRange getPortRange() {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromDestinationPrefixList.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromDestinationPrefixList.java
@@ -2,13 +2,10 @@ package org.batfish.representation.juniper;
 
 import com.google.common.collect.Iterables;
 import java.util.List;
-import java.util.stream.Collectors;
-import org.batfish.common.BatfishException;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.IpAccessListLine;
 import org.batfish.datamodel.IpWildcard;
-import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.RouteFilterList;
 
 public final class FwFromDestinationPrefixList extends FwFrom {
@@ -31,20 +28,7 @@ public final class FwFromDestinationPrefixList extends FwFrom {
         return;
       }
       RouteFilterList destinationPrefixList = c.getRouteFilterLists().get(_name);
-      List<IpWildcard> wildcards =
-          destinationPrefixList
-              .getLines()
-              .stream()
-              .map(
-                  rfLine -> {
-                    if (rfLine.getAction() != LineAction.ACCEPT) {
-                      throw new BatfishException(
-                          "Expected accept action for routerfilterlist from juniper");
-                    } else {
-                      return new IpWildcard(rfLine.getPrefix());
-                    }
-                  })
-              .collect(Collectors.toList());
+      List<IpWildcard> wildcards = destinationPrefixList.getMatchingIps();
       line.setDstIps(Iterables.concat(line.getDstIps(), wildcards));
     } else {
       w.redFlag("Reference to undefined source prefix-list: \"" + _name + "\"");

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromDestinationPrefixList.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromDestinationPrefixList.java
@@ -1,12 +1,14 @@
 package org.batfish.representation.juniper;
 
+import com.google.common.collect.Iterables;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.batfish.common.BatfishException;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.IpAccessListLine;
 import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.LineAction;
-import org.batfish.datamodel.RouteFilterLine;
 import org.batfish.datamodel.RouteFilterList;
 
 public final class FwFromDestinationPrefixList extends FwFrom {
@@ -29,13 +31,21 @@ public final class FwFromDestinationPrefixList extends FwFrom {
         return;
       }
       RouteFilterList destinationPrefixList = c.getRouteFilterLists().get(_name);
-      for (RouteFilterLine rfLine : destinationPrefixList.getLines()) {
-        if (rfLine.getAction() != LineAction.ACCEPT) {
-          throw new BatfishException("Expected accept action for routerfilterlist from juniper");
-        } else {
-          line.getDstIps().add(new IpWildcard(rfLine.getPrefix()));
-        }
-      }
+      List<IpWildcard> wildcards =
+          destinationPrefixList
+              .getLines()
+              .stream()
+              .map(
+                  rfLine -> {
+                    if (rfLine.getAction() != LineAction.ACCEPT) {
+                      throw new BatfishException(
+                          "Expected accept action for routerfilterlist from juniper");
+                    } else {
+                      return new IpWildcard(rfLine.getPrefix());
+                    }
+                  })
+              .collect(Collectors.toList());
+      line.setDstIps(Iterables.concat(line.getDstIps(), wildcards));
     } else {
       w.redFlag("Reference to undefined source prefix-list: \"" + _name + "\"");
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromDestinationPrefixListExcept.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromDestinationPrefixListExcept.java
@@ -2,13 +2,10 @@ package org.batfish.representation.juniper;
 
 import com.google.common.collect.Iterables;
 import java.util.List;
-import java.util.stream.Collectors;
-import org.batfish.common.BatfishException;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.IpAccessListLine;
 import org.batfish.datamodel.IpWildcard;
-import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.RouteFilterList;
 
 public final class FwFromDestinationPrefixListExcept extends FwFrom {
@@ -31,20 +28,7 @@ public final class FwFromDestinationPrefixListExcept extends FwFrom {
         return;
       }
       RouteFilterList destinationPrefixList = c.getRouteFilterLists().get(_name);
-      List<IpWildcard> wildcards =
-          destinationPrefixList
-              .getLines()
-              .stream()
-              .map(
-                  rfLine -> {
-                    if (rfLine.getAction() != LineAction.ACCEPT) {
-                      throw new BatfishException(
-                          "Expected accept action for routerfilterlist from juniper");
-                    } else {
-                      return new IpWildcard(rfLine.getPrefix());
-                    }
-                  })
-              .collect(Collectors.toList());
+      List<IpWildcard> wildcards = destinationPrefixList.getMatchingIps();
       line.setNotDstIps(Iterables.concat(line.getNotDstIps(), wildcards));
     } else {
       w.redFlag("Reference to undefined source prefix-list: \"" + _name + "\"");

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromDestinationPrefixListExcept.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromDestinationPrefixListExcept.java
@@ -1,12 +1,14 @@
 package org.batfish.representation.juniper;
 
+import com.google.common.collect.Iterables;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.batfish.common.BatfishException;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.IpAccessListLine;
 import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.LineAction;
-import org.batfish.datamodel.RouteFilterLine;
 import org.batfish.datamodel.RouteFilterList;
 
 public final class FwFromDestinationPrefixListExcept extends FwFrom {
@@ -29,13 +31,21 @@ public final class FwFromDestinationPrefixListExcept extends FwFrom {
         return;
       }
       RouteFilterList destinationPrefixList = c.getRouteFilterLists().get(_name);
-      for (RouteFilterLine rfLine : destinationPrefixList.getLines()) {
-        if (rfLine.getAction() != LineAction.ACCEPT) {
-          throw new BatfishException("Expected accept action for routerfilterlist from juniper");
-        } else {
-          line.getNotDstIps().add(new IpWildcard(rfLine.getPrefix()));
-        }
-      }
+      List<IpWildcard> wildcards =
+          destinationPrefixList
+              .getLines()
+              .stream()
+              .map(
+                  rfLine -> {
+                    if (rfLine.getAction() != LineAction.ACCEPT) {
+                      throw new BatfishException(
+                          "Expected accept action for routerfilterlist from juniper");
+                    } else {
+                      return new IpWildcard(rfLine.getPrefix());
+                    }
+                  })
+              .collect(Collectors.toList());
+      line.setNotDstIps(Iterables.concat(line.getNotDstIps(), wildcards));
     } else {
       w.redFlag("Reference to undefined source prefix-list: \"" + _name + "\"");
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromFragmentOffset.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromFragmentOffset.java
@@ -1,8 +1,7 @@
 package org.batfish.representation.juniper;
 
 import java.util.Collections;
-import java.util.SortedSet;
-import java.util.TreeSet;
+import java.util.Set;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.IpAccessListLine;
@@ -24,7 +23,7 @@ public class FwFromFragmentOffset extends FwFrom {
 
   @Override
   public void applyTo(IpAccessListLine line, JuniperConfiguration jc, Warnings w, Configuration c) {
-    SortedSet<SubRange> offsets = new TreeSet<>(Collections.singleton(_offsetRange));
+    Set<SubRange> offsets = Collections.singleton(_offsetRange);
     if (_except) {
       line.setNotFragmentOffsets(offsets);
     } else {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromIcmpCode.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromIcmpCode.java
@@ -1,5 +1,7 @@
 package org.batfish.representation.juniper;
 
+import com.google.common.collect.Iterables;
+import java.util.Collections;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.IpAccessListLine;
@@ -18,6 +20,6 @@ public class FwFromIcmpCode extends FwFrom {
 
   @Override
   public void applyTo(IpAccessListLine line, JuniperConfiguration jc, Warnings w, Configuration c) {
-    line.getIcmpCodes().add(_icmpCodeRange);
+    line.setIcmpCodes(Iterables.concat(line.getIcmpCodes(), Collections.singleton(_icmpCodeRange)));
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromIcmpType.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromIcmpType.java
@@ -1,5 +1,7 @@
 package org.batfish.representation.juniper;
 
+import com.google.common.collect.Iterables;
+import java.util.Collections;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.IpAccessListLine;
@@ -18,6 +20,6 @@ public class FwFromIcmpType extends FwFrom {
 
   @Override
   public void applyTo(IpAccessListLine line, JuniperConfiguration jc, Warnings w, Configuration c) {
-    line.getIcmpTypes().add(_icmpTypeRange);
+    line.setIcmpTypes(Iterables.concat(line.getIcmpTypes(), Collections.singleton(_icmpTypeRange)));
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromPacketLength.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromPacketLength.java
@@ -1,5 +1,6 @@
 package org.batfish.representation.juniper;
 
+import com.google.common.collect.Iterables;
 import java.util.List;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
@@ -23,9 +24,9 @@ public class FwFromPacketLength extends FwFrom {
   @Override
   public void applyTo(IpAccessListLine line, JuniperConfiguration jc, Warnings w, Configuration c) {
     if (_except) {
-      line.getNotPacketLengths().addAll(_range);
+      line.setNotPacketLengths(Iterables.concat(line.getNotPacketLengths(), _range));
     } else {
-      line.getPacketLengths().addAll(_range);
+      line.setPacketLengths(Iterables.concat(line.getPacketLengths(), _range));
     }
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromPort.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromPort.java
@@ -1,5 +1,7 @@
 package org.batfish.representation.juniper;
 
+import com.google.common.collect.Iterables;
+import java.util.Collections;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.IpAccessListLine;
@@ -22,7 +24,8 @@ public final class FwFromPort extends FwFrom {
 
   @Override
   public void applyTo(IpAccessListLine line, JuniperConfiguration jc, Warnings w, Configuration c) {
-    line.getSrcOrDstPorts().add(_portRange);
+    line.setSrcOrDstPorts(
+        Iterables.concat(line.getSrcOrDstPorts(), Collections.singleton(_portRange)));
   }
 
   public SubRange getPortRange() {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromPrefixList.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromPrefixList.java
@@ -1,12 +1,14 @@
 package org.batfish.representation.juniper;
 
+import com.google.common.collect.Iterables;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.batfish.common.BatfishException;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.IpAccessListLine;
 import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.LineAction;
-import org.batfish.datamodel.RouteFilterLine;
 import org.batfish.datamodel.RouteFilterList;
 
 public final class FwFromPrefixList extends FwFrom {
@@ -29,13 +31,21 @@ public final class FwFromPrefixList extends FwFrom {
         return;
       }
       RouteFilterList sourcePrefixList = c.getRouteFilterLists().get(_name);
-      for (RouteFilterLine rfLine : sourcePrefixList.getLines()) {
-        if (rfLine.getAction() != LineAction.ACCEPT) {
-          throw new BatfishException("Expected accept action for routerfilterlist from juniper");
-        } else {
-          line.getSrcOrDstIps().add(new IpWildcard(rfLine.getPrefix()));
-        }
-      }
+      List<IpWildcard> wildcards =
+          sourcePrefixList
+              .getLines()
+              .stream()
+              .map(
+                  rfLine -> {
+                    if (rfLine.getAction() != LineAction.ACCEPT) {
+                      throw new BatfishException(
+                          "Expected accept action for routerfilterlist from juniper");
+                    } else {
+                      return new IpWildcard(rfLine.getPrefix());
+                    }
+                  })
+              .collect(Collectors.toList());
+      line.setSrcOrDstIps(Iterables.concat(line.getSrcOrDstIps(), wildcards));
     } else {
       w.redFlag("Reference to undefined source prefix-list: \"" + _name + "\"");
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromPrefixList.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromPrefixList.java
@@ -2,13 +2,10 @@ package org.batfish.representation.juniper;
 
 import com.google.common.collect.Iterables;
 import java.util.List;
-import java.util.stream.Collectors;
-import org.batfish.common.BatfishException;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.IpAccessListLine;
 import org.batfish.datamodel.IpWildcard;
-import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.RouteFilterList;
 
 public final class FwFromPrefixList extends FwFrom {
@@ -31,20 +28,7 @@ public final class FwFromPrefixList extends FwFrom {
         return;
       }
       RouteFilterList sourcePrefixList = c.getRouteFilterLists().get(_name);
-      List<IpWildcard> wildcards =
-          sourcePrefixList
-              .getLines()
-              .stream()
-              .map(
-                  rfLine -> {
-                    if (rfLine.getAction() != LineAction.ACCEPT) {
-                      throw new BatfishException(
-                          "Expected accept action for routerfilterlist from juniper");
-                    } else {
-                      return new IpWildcard(rfLine.getPrefix());
-                    }
-                  })
-              .collect(Collectors.toList());
+      List<IpWildcard> wildcards = sourcePrefixList.getMatchingIps();
       line.setSrcOrDstIps(Iterables.concat(line.getSrcOrDstIps(), wildcards));
     } else {
       w.redFlag("Reference to undefined source prefix-list: \"" + _name + "\"");

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromProtocol.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromProtocol.java
@@ -1,5 +1,7 @@
 package org.batfish.representation.juniper;
 
+import com.google.common.collect.Iterables;
+import java.util.Collections;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.IpAccessListLine;
@@ -18,7 +20,7 @@ public final class FwFromProtocol extends FwFrom {
 
   @Override
   public void applyTo(IpAccessListLine line, JuniperConfiguration jc, Warnings w, Configuration c) {
-    line.getIpProtocols().add(_protocol);
+    line.setIpProtocols(Iterables.concat(line.getIpProtocols(), Collections.singleton(_protocol)));
   }
 
   public IpProtocol getProtocol() {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromSourceAddress.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromSourceAddress.java
@@ -1,5 +1,7 @@
 package org.batfish.representation.juniper;
 
+import com.google.common.collect.Iterables;
+import java.util.Collections;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.IpAccessListLine;
@@ -20,7 +22,7 @@ public final class FwFromSourceAddress extends FwFrom {
   @Override
   public void applyTo(IpAccessListLine line, JuniperConfiguration jc, Warnings w, Configuration c) {
     IpWildcard wildcard = new IpWildcard(_prefix);
-    line.getSrcIps().add(wildcard);
+    line.setSrcIps(Iterables.concat(line.getSrcIps(), Collections.singleton(wildcard)));
   }
 
   public Prefix getPrefix() {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromSourceAddressBookEntry.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromSourceAddressBookEntry.java
@@ -1,6 +1,9 @@
 package org.batfish.representation.juniper;
 
+import com.google.common.collect.Iterables;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.IpAccessListLine;
@@ -24,9 +27,8 @@ public final class FwFromSourceAddressBookEntry extends FwFrom {
   @Override
   public void applyTo(IpAccessListLine line, JuniperConfiguration jc, Warnings w, Configuration c) {
     Set<Prefix> prefixes = _localAddressBook.getPrefixes(_addressBookEntryName, w);
-    for (Prefix prefix : prefixes) {
-      IpWildcard wildcard = new IpWildcard(prefix);
-      line.getSrcIps().add(wildcard);
-    }
+    List<IpWildcard> wildcards =
+        prefixes.stream().map(IpWildcard::new).collect(Collectors.toList());
+    line.setSrcIps(Iterables.concat(line.getSrcIps(), wildcards));
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromSourceAddressExcept.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromSourceAddressExcept.java
@@ -1,5 +1,7 @@
 package org.batfish.representation.juniper;
 
+import com.google.common.collect.Iterables;
+import java.util.Collections;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.IpAccessListLine;
@@ -20,7 +22,7 @@ public final class FwFromSourceAddressExcept extends FwFrom {
   @Override
   public void applyTo(IpAccessListLine line, JuniperConfiguration jc, Warnings w, Configuration c) {
     IpWildcard wildcard = new IpWildcard(_prefix);
-    line.getNotSrcIps().add(wildcard);
+    line.setNotSrcIps(Iterables.concat(line.getNotSrcIps(), Collections.singleton(wildcard)));
   }
 
   public Prefix getPrefix() {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromSourcePort.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromSourcePort.java
@@ -1,5 +1,7 @@
 package org.batfish.representation.juniper;
 
+import com.google.common.collect.Iterables;
+import java.util.Collections;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.IpAccessListLine;
@@ -22,7 +24,7 @@ public final class FwFromSourcePort extends FwFrom {
 
   @Override
   public void applyTo(IpAccessListLine line, JuniperConfiguration jc, Warnings w, Configuration c) {
-    line.getSrcPorts().add(_portRange);
+    line.setSrcPorts(Iterables.concat(line.getSrcPorts(), Collections.singleton(_portRange)));
   }
 
   public SubRange getPortRange() {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromSourcePrefixList.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromSourcePrefixList.java
@@ -2,13 +2,10 @@ package org.batfish.representation.juniper;
 
 import com.google.common.collect.Iterables;
 import java.util.List;
-import java.util.stream.Collectors;
-import org.batfish.common.BatfishException;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.IpAccessListLine;
 import org.batfish.datamodel.IpWildcard;
-import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.RouteFilterList;
 
 public final class FwFromSourcePrefixList extends FwFrom {
@@ -31,20 +28,7 @@ public final class FwFromSourcePrefixList extends FwFrom {
         return;
       }
       RouteFilterList sourcePrefixList = c.getRouteFilterLists().get(_name);
-      List<IpWildcard> wildcards =
-          sourcePrefixList
-              .getLines()
-              .stream()
-              .map(
-                  rfLine -> {
-                    if (rfLine.getAction() != LineAction.ACCEPT) {
-                      throw new BatfishException(
-                          "Expected accept action for routerfilterlist from juniper");
-                    } else {
-                      return new IpWildcard(rfLine.getPrefix());
-                    }
-                  })
-              .collect(Collectors.toList());
+      List<IpWildcard> wildcards = sourcePrefixList.getMatchingIps();
       line.setSrcIps(Iterables.concat(line.getSrcIps(), wildcards));
     } else {
       w.redFlag("Reference to undefined source prefix-list: \"" + _name + "\"");

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromSourcePrefixList.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromSourcePrefixList.java
@@ -1,12 +1,14 @@
 package org.batfish.representation.juniper;
 
+import com.google.common.collect.Iterables;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.batfish.common.BatfishException;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.IpAccessListLine;
 import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.LineAction;
-import org.batfish.datamodel.RouteFilterLine;
 import org.batfish.datamodel.RouteFilterList;
 
 public final class FwFromSourcePrefixList extends FwFrom {
@@ -29,13 +31,21 @@ public final class FwFromSourcePrefixList extends FwFrom {
         return;
       }
       RouteFilterList sourcePrefixList = c.getRouteFilterLists().get(_name);
-      for (RouteFilterLine rfLine : sourcePrefixList.getLines()) {
-        if (rfLine.getAction() != LineAction.ACCEPT) {
-          throw new BatfishException("Expected accept action for routerfilterlist from juniper");
-        } else {
-          line.getSrcIps().add(new IpWildcard(rfLine.getPrefix()));
-        }
-      }
+      List<IpWildcard> wildcards =
+          sourcePrefixList
+              .getLines()
+              .stream()
+              .map(
+                  rfLine -> {
+                    if (rfLine.getAction() != LineAction.ACCEPT) {
+                      throw new BatfishException(
+                          "Expected accept action for routerfilterlist from juniper");
+                    } else {
+                      return new IpWildcard(rfLine.getPrefix());
+                    }
+                  })
+              .collect(Collectors.toList());
+      line.setSrcIps(Iterables.concat(line.getSrcIps(), wildcards));
     } else {
       w.redFlag("Reference to undefined source prefix-list: \"" + _name + "\"");
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromSourcePrefixListExcept.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromSourcePrefixListExcept.java
@@ -1,12 +1,14 @@
 package org.batfish.representation.juniper;
 
+import com.google.common.collect.Iterables;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.batfish.common.BatfishException;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.IpAccessListLine;
 import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.LineAction;
-import org.batfish.datamodel.RouteFilterLine;
 import org.batfish.datamodel.RouteFilterList;
 
 public class FwFromSourcePrefixListExcept extends FwFrom {
@@ -29,13 +31,21 @@ public class FwFromSourcePrefixListExcept extends FwFrom {
         return;
       }
       RouteFilterList sourcePrefixList = c.getRouteFilterLists().get(_name);
-      for (RouteFilterLine rfLine : sourcePrefixList.getLines()) {
-        if (rfLine.getAction() != LineAction.ACCEPT) {
-          throw new BatfishException("Expected accept action for routerfilterlist from juniper");
-        } else {
-          line.getNotSrcIps().add(new IpWildcard(rfLine.getPrefix()));
-        }
-      }
+      List<IpWildcard> wildcards =
+          sourcePrefixList
+              .getLines()
+              .stream()
+              .map(
+                  rfLine -> {
+                    if (rfLine.getAction() != LineAction.ACCEPT) {
+                      throw new BatfishException(
+                          "Expected accept action for routerfilterlist from juniper");
+                    } else {
+                      return new IpWildcard(rfLine.getPrefix());
+                    }
+                  })
+              .collect(Collectors.toList());
+      line.setNotSrcIps(Iterables.concat(line.getNotSrcIps(), wildcards));
     } else {
       w.redFlag("Reference to undefined source prefix-list: \"" + _name + "\"");
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromSourcePrefixListExcept.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromSourcePrefixListExcept.java
@@ -2,13 +2,10 @@ package org.batfish.representation.juniper;
 
 import com.google.common.collect.Iterables;
 import java.util.List;
-import java.util.stream.Collectors;
-import org.batfish.common.BatfishException;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.IpAccessListLine;
 import org.batfish.datamodel.IpWildcard;
-import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.RouteFilterList;
 
 public class FwFromSourcePrefixListExcept extends FwFrom {
@@ -31,20 +28,7 @@ public class FwFromSourcePrefixListExcept extends FwFrom {
         return;
       }
       RouteFilterList sourcePrefixList = c.getRouteFilterLists().get(_name);
-      List<IpWildcard> wildcards =
-          sourcePrefixList
-              .getLines()
-              .stream()
-              .map(
-                  rfLine -> {
-                    if (rfLine.getAction() != LineAction.ACCEPT) {
-                      throw new BatfishException(
-                          "Expected accept action for routerfilterlist from juniper");
-                    } else {
-                      return new IpWildcard(rfLine.getPrefix());
-                    }
-                  })
-              .collect(Collectors.toList());
+      List<IpWildcard> wildcards = sourcePrefixList.getMatchingIps();
       line.setNotSrcIps(Iterables.concat(line.getNotSrcIps(), wildcards));
     } else {
       w.redFlag("Reference to undefined source prefix-list: \"" + _name + "\"");

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromTcpFlags.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromTcpFlags.java
@@ -1,5 +1,6 @@
 package org.batfish.representation.juniper;
 
+import com.google.common.collect.Iterables;
 import java.util.List;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
@@ -19,6 +20,6 @@ public final class FwFromTcpFlags extends FwFrom {
 
   @Override
   public void applyTo(IpAccessListLine line, JuniperConfiguration jc, Warnings w, Configuration c) {
-    line.getTcpFlags().addAll(_tcpFlags);
+    line.setTcpFlags(Iterables.concat(line.getTcpFlags(), _tcpFlags));
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/HostProtocol.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/HostProtocol.java
@@ -1,6 +1,8 @@
 package org.batfish.representation.juniper;
 
+import com.google.common.collect.ImmutableSortedSet;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.batfish.common.BatfishException;
 import org.batfish.datamodel.IpAccessListLine;
@@ -61,10 +63,10 @@ public enum HostProtocol {
         {
           IpAccessListLine line = new IpAccessListLine();
           _lines.add(line);
-          line.getIpProtocols().add(IpProtocol.TCP);
-          line.getIpProtocols().add(IpProtocol.UDP);
-          line.getDstPorts()
-              .add(new SubRange(NamedPort.BFD_CONTROL.number(), NamedPort.BFD_ECHO.number()));
+          line.setIpProtocols(ImmutableSortedSet.of(IpProtocol.TCP, IpProtocol.UDP));
+          line.setDstPorts(
+              Collections.singleton(
+                  new SubRange(NamedPort.BFD_CONTROL.number(), NamedPort.BFD_ECHO.number())));
           break;
         }
 
@@ -72,8 +74,9 @@ public enum HostProtocol {
         {
           IpAccessListLine line = new IpAccessListLine();
           _lines.add(line);
-          line.getIpProtocols().add(IpProtocol.TCP);
-          line.getDstPorts().add(new SubRange(NamedPort.BGP.number(), NamedPort.BGP.number()));
+          line.setIpProtocols(Collections.singleton(IpProtocol.TCP));
+          line.setDstPorts(
+              Collections.singleton(new SubRange(NamedPort.BGP.number(), NamedPort.BGP.number())));
           break;
         }
 
@@ -83,7 +86,7 @@ public enum HostProtocol {
           // for IGMP types in packet headers
           IpAccessListLine line = new IpAccessListLine();
           _lines.add(line);
-          line.getIpProtocols().add(IpProtocol.IGMP);
+          line.setIpProtocols(Collections.singleton(IpProtocol.IGMP));
           break;
         }
 
@@ -91,7 +94,7 @@ public enum HostProtocol {
         {
           IpAccessListLine line = new IpAccessListLine();
           _lines.add(line);
-          line.getIpProtocols().add(IpProtocol.IGMP);
+          line.setIpProtocols(Collections.singleton(IpProtocol.IGMP));
           break;
         }
 
@@ -99,9 +102,9 @@ public enum HostProtocol {
         {
           IpAccessListLine line = new IpAccessListLine();
           _lines.add(line);
-          line.getIpProtocols().add(IpProtocol.TCP);
-          line.getIpProtocols().add(IpProtocol.UDP);
-          line.getDstPorts().add(new SubRange(NamedPort.LDP.number(), NamedPort.LDP.number()));
+          line.setIpProtocols(ImmutableSortedSet.of(IpProtocol.TCP, IpProtocol.UDP));
+          line.setDstPorts(
+              Collections.singleton(new SubRange(NamedPort.LDP.number(), NamedPort.LDP.number())));
           break;
         }
 
@@ -109,8 +112,10 @@ public enum HostProtocol {
         {
           IpAccessListLine line = new IpAccessListLine();
           _lines.add(line);
-          line.getIpProtocols().add(IpProtocol.TCP);
-          line.getDstPorts().add(new SubRange(NamedPort.MSDP.number(), NamedPort.MSDP.number()));
+          line.setIpProtocols(Collections.singleton(IpProtocol.TCP));
+          line.setDstPorts(
+              Collections.singleton(
+                  new SubRange(NamedPort.MSDP.number(), NamedPort.MSDP.number())));
           break;
         }
 
@@ -118,7 +123,7 @@ public enum HostProtocol {
         {
           IpAccessListLine line = new IpAccessListLine();
           _lines.add(line);
-          line.getIpProtocols().add(IpProtocol.NARP);
+          line.setIpProtocols(Collections.singleton(IpProtocol.NARP));
           break;
         }
 
@@ -126,7 +131,7 @@ public enum HostProtocol {
         {
           IpAccessListLine line = new IpAccessListLine();
           _lines.add(line);
-          line.getIpProtocols().add(IpProtocol.OSPF);
+          line.setIpProtocols(Collections.singleton(IpProtocol.OSPF));
           break;
         }
 
@@ -140,7 +145,7 @@ public enum HostProtocol {
         {
           IpAccessListLine line = new IpAccessListLine();
           _lines.add(line);
-          line.getIpProtocols().add(IpProtocol.PGM);
+          line.setIpProtocols(Collections.singleton(IpProtocol.PGM));
           break;
         }
 
@@ -148,7 +153,7 @@ public enum HostProtocol {
         {
           IpAccessListLine line = new IpAccessListLine();
           _lines.add(line);
-          line.getIpProtocols().add(IpProtocol.PIM);
+          line.setIpProtocols(Collections.singleton(IpProtocol.PIM));
           break;
         }
 
@@ -156,8 +161,9 @@ public enum HostProtocol {
         {
           IpAccessListLine line = new IpAccessListLine();
           _lines.add(line);
-          line.getIpProtocols().add(IpProtocol.UDP);
-          line.getDstPorts().add(new SubRange(NamedPort.RIP.number(), NamedPort.RIP.number()));
+          line.setIpProtocols(Collections.singleton(IpProtocol.UDP));
+          line.setDstPorts(
+              Collections.singleton(new SubRange(NamedPort.RIP.number(), NamedPort.RIP.number())));
           break;
         }
 
@@ -174,7 +180,7 @@ public enum HostProtocol {
           // for ICMP types in packet headers
           IpAccessListLine line = new IpAccessListLine();
           _lines.add(line);
-          line.getIpProtocols().add(IpProtocol.ICMP);
+          line.setIpProtocols(Collections.singleton(IpProtocol.ICMP));
           break;
         }
 
@@ -182,8 +188,7 @@ public enum HostProtocol {
         {
           IpAccessListLine line = new IpAccessListLine();
           _lines.add(line);
-          line.getIpProtocols().add(IpProtocol.RSVP);
-          line.getIpProtocols().add(IpProtocol.RSVP_E2E_IGNORE);
+          line.setIpProtocols(ImmutableSortedSet.of(IpProtocol.RSVP, IpProtocol.RSVP_E2E_IGNORE));
           break;
         }
 
@@ -191,9 +196,10 @@ public enum HostProtocol {
         {
           IpAccessListLine line = new IpAccessListLine();
           _lines.add(line);
-          line.getIpProtocols().add(IpProtocol.UDP);
-          line.getDstPorts().add(new SubRange(NamedPort.SAP.number(), NamedPort.SAP.number()));
-          line.getDstIps().add(new IpWildcard(new Prefix("224.2.127.285/32")));
+          line.setIpProtocols(Collections.singleton(IpProtocol.UDP));
+          line.setDstPorts(
+              Collections.singleton(new SubRange(NamedPort.SAP.number(), NamedPort.SAP.number())));
+          line.setDstIps(Collections.singleton(new IpWildcard(new Prefix("224.2.127.285/32"))));
           break;
         }
 
@@ -201,7 +207,7 @@ public enum HostProtocol {
         {
           IpAccessListLine line = new IpAccessListLine();
           _lines.add(line);
-          line.getIpProtocols().add(IpProtocol.VRRP);
+          line.setIpProtocols(Collections.singleton(IpProtocol.VRRP));
           break;
         }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/HostSystemService.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/HostSystemService.java
@@ -1,6 +1,8 @@
 package org.batfish.representation.juniper;
 
+import com.google.common.collect.ImmutableSortedSet;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.batfish.common.BatfishException;
 import org.batfish.datamodel.IpAccessListLine;
@@ -70,8 +72,7 @@ public enum HostSystemService {
         {
           IpAccessListLine line = new IpAccessListLine();
           _lines.add(line);
-          line.getIpProtocols().add(IpProtocol.TCP);
-          line.getIpProtocols().add(IpProtocol.UDP);
+          line.setIpProtocols(ImmutableSortedSet.of(IpProtocol.TCP, IpProtocol.UDP));
           break;
         }
 
@@ -79,9 +80,10 @@ public enum HostSystemService {
         {
           IpAccessListLine line = new IpAccessListLine();
           _lines.add(line);
-          line.getIpProtocols().add(IpProtocol.UDP);
-          line.getDstPorts()
-              .add(new SubRange(NamedPort.BOOTPS_OR_DHCP.number(), NamedPort.BOOTPC.number()));
+          line.setIpProtocols(Collections.singleton(IpProtocol.UDP));
+          line.setDstPorts(
+              Collections.singleton(
+                  new SubRange(NamedPort.BOOTPS_OR_DHCP.number(), NamedPort.BOOTPC.number())));
           break;
         }
 
@@ -89,10 +91,10 @@ public enum HostSystemService {
         {
           IpAccessListLine line = new IpAccessListLine();
           _lines.add(line);
-          line.getIpProtocols().add(IpProtocol.TCP);
-          line.getIpProtocols().add(IpProtocol.UDP);
-          line.getDstPorts()
-              .add(new SubRange(NamedPort.DOMAIN.number(), NamedPort.DOMAIN.number()));
+          line.setIpProtocols(ImmutableSortedSet.of(IpProtocol.TCP, IpProtocol.UDP));
+          line.setDstPorts(
+              Collections.singleton(
+                  new SubRange(NamedPort.DOMAIN.number(), NamedPort.DOMAIN.number())));
           break;
         }
 
@@ -100,9 +102,10 @@ public enum HostSystemService {
         {
           IpAccessListLine line = new IpAccessListLine();
           _lines.add(line);
-          line.getIpProtocols().add(IpProtocol.TCP);
-          line.getDstPorts()
-              .add(new SubRange(NamedPort.FINGER.number(), NamedPort.FINGER.number()));
+          line.setIpProtocols(Collections.singleton(IpProtocol.TCP));
+          line.setDstPorts(
+              Collections.singleton(
+                  new SubRange(NamedPort.FINGER.number(), NamedPort.FINGER.number())));
           break;
         }
 
@@ -110,8 +113,9 @@ public enum HostSystemService {
         {
           IpAccessListLine line = new IpAccessListLine();
           _lines.add(line);
-          line.getIpProtocols().add(IpProtocol.TCP);
-          line.getDstPorts().add(new SubRange(NamedPort.FTP.number(), NamedPort.FTP.number()));
+          line.setIpProtocols(Collections.singleton(IpProtocol.TCP));
+          line.setDstPorts(
+              Collections.singleton(new SubRange(NamedPort.FTP.number(), NamedPort.FTP.number())));
           break;
         }
 
@@ -119,8 +123,10 @@ public enum HostSystemService {
         {
           IpAccessListLine line = new IpAccessListLine();
           _lines.add(line);
-          line.getIpProtocols().add(IpProtocol.TCP);
-          line.getDstPorts().add(new SubRange(NamedPort.HTTP.number(), NamedPort.HTTP.number()));
+          line.setIpProtocols(Collections.singleton(IpProtocol.TCP));
+          line.setDstPorts(
+              Collections.singleton(
+                  new SubRange(NamedPort.HTTP.number(), NamedPort.HTTP.number())));
           break;
         }
 
@@ -128,8 +134,10 @@ public enum HostSystemService {
         {
           IpAccessListLine line = new IpAccessListLine();
           _lines.add(line);
-          line.getIpProtocols().add(IpProtocol.TCP);
-          line.getDstPorts().add(new SubRange(NamedPort.HTTPS.number(), NamedPort.HTTPS.number()));
+          line.setIpProtocols(Collections.singleton(IpProtocol.TCP));
+          line.setDstPorts(
+              Collections.singleton(
+                  new SubRange(NamedPort.HTTPS.number(), NamedPort.HTTPS.number())));
           break;
         }
 
@@ -143,12 +151,12 @@ public enum HostSystemService {
         {
           IpAccessListLine line = new IpAccessListLine();
           _lines.add(line);
-          line.getIpProtocols().add(IpProtocol.UDP);
-          line.getDstPorts()
-              .add(new SubRange(NamedPort.ISAKMP.number(), NamedPort.ISAKMP.number()));
-          line.getDstPorts()
-              .add(
-                  new SubRange(NamedPort.NON500_ISAKMP.number(), NamedPort.NON500_ISAKMP.number()));
+          line.setIpProtocols(Collections.singleton(IpProtocol.UDP));
+          line.setDstPorts(
+              ImmutableSortedSet.of(
+                  new SubRange(NamedPort.ISAKMP.number(), NamedPort.ISAKMP.number()),
+                  new SubRange(
+                      NamedPort.NON500_ISAKMP.number(), NamedPort.NON500_ISAKMP.number())));
           break;
         }
 
@@ -163,9 +171,10 @@ public enum HostSystemService {
         {
           IpAccessListLine line = new IpAccessListLine();
           _lines.add(line);
-          line.getIpProtocols().add(IpProtocol.TCP);
-          line.getDstPorts()
-              .add(new SubRange(NamedPort.NETCONF_SSH.number(), NamedPort.NETCONF_SSH.number()));
+          line.setIpProtocols(Collections.singleton(IpProtocol.TCP));
+          line.setDstPorts(
+              Collections.singleton(
+                  new SubRange(NamedPort.NETCONF_SSH.number(), NamedPort.NETCONF_SSH.number())));
           break;
         }
 
@@ -173,8 +182,9 @@ public enum HostSystemService {
         {
           IpAccessListLine line = new IpAccessListLine();
           _lines.add(line);
-          line.getIpProtocols().add(IpProtocol.UDP);
-          line.getDstPorts().add(new SubRange(NamedPort.NTP.number(), NamedPort.NTP.number()));
+          line.setIpProtocols(Collections.singleton(IpProtocol.UDP));
+          line.setDstPorts(
+              Collections.singleton(new SubRange(NamedPort.NTP.number(), NamedPort.NTP.number())));
           break;
         }
 
@@ -182,7 +192,7 @@ public enum HostSystemService {
         {
           IpAccessListLine line = new IpAccessListLine();
           _lines.add(line);
-          line.getIpProtocols().add(IpProtocol.ICMP);
+          line.setIpProtocols(Collections.singleton(IpProtocol.ICMP));
           // TODO: PING (ECHO REQUEST) uses ICMP (an IP Protocol) type 8. need to
           // add support for ICMP types in packet headers
           break;
@@ -192,8 +202,10 @@ public enum HostSystemService {
         {
           IpAccessListLine line = new IpAccessListLine();
           _lines.add(line);
-          line.getIpProtocols().add(IpProtocol.UDP);
-          line.getDstPorts().add(new SubRange(NamedPort.R2CP.number(), NamedPort.R2CP.number()));
+          line.setIpProtocols(Collections.singleton(IpProtocol.UDP));
+          line.setDstPorts(
+              Collections.singleton(
+                  new SubRange(NamedPort.R2CP.number(), NamedPort.R2CP.number())));
           break;
         }
 
@@ -201,9 +213,10 @@ public enum HostSystemService {
         {
           IpAccessListLine line = new IpAccessListLine();
           _lines.add(line);
-          line.getIpProtocols().add(IpProtocol.TCP);
-          line.getDstPorts()
-              .add(new SubRange(NamedPort.REVERSE_SSH.number(), NamedPort.REVERSE_SSH.number()));
+          line.setIpProtocols(Collections.singleton(IpProtocol.TCP));
+          line.setDstPorts(
+              Collections.singleton(
+                  new SubRange(NamedPort.REVERSE_SSH.number(), NamedPort.REVERSE_SSH.number())));
           break;
         }
 
@@ -211,11 +224,11 @@ public enum HostSystemService {
         {
           IpAccessListLine line = new IpAccessListLine();
           _lines.add(line);
-          line.getIpProtocols().add(IpProtocol.TCP);
-          line.getDstPorts()
-              .add(
+          line.setIpProtocols(Collections.singleton(IpProtocol.TCP));
+          line.setDstPorts(
+              Collections.singleton(
                   new SubRange(
-                      NamedPort.REVERSE_TELNET.number(), NamedPort.REVERSE_TELNET.number()));
+                      NamedPort.REVERSE_TELNET.number(), NamedPort.REVERSE_TELNET.number())));
           break;
         }
 
@@ -223,12 +236,12 @@ public enum HostSystemService {
         {
           IpAccessListLine line = new IpAccessListLine();
           _lines.add(line);
-          line.getIpProtocols().add(IpProtocol.TCP);
-          line.getDstPorts()
-              .add(
+          line.setIpProtocols(Collections.singleton(IpProtocol.TCP));
+          line.setDstPorts(
+              Collections.singleton(
                   new SubRange(
                       NamedPort.LOGINtcp_OR_WHOudp.number(),
-                      NamedPort.LOGINtcp_OR_WHOudp.number()));
+                      NamedPort.LOGINtcp_OR_WHOudp.number())));
           break;
         }
 
@@ -243,12 +256,12 @@ public enum HostSystemService {
         {
           IpAccessListLine line = new IpAccessListLine();
           _lines.add(line);
-          line.getIpProtocols().add(IpProtocol.TCP);
-          line.getDstPorts()
-              .add(
+          line.setIpProtocols(Collections.singleton(IpProtocol.TCP));
+          line.setDstPorts(
+              Collections.singleton(
                   new SubRange(
                       NamedPort.CMDtcp_OR_SYSLOGudp.number(),
-                      NamedPort.CMDtcp_OR_SYSLOGudp.number()));
+                      NamedPort.CMDtcp_OR_SYSLOGudp.number())));
           break;
         }
 
@@ -256,10 +269,10 @@ public enum HostSystemService {
         {
           IpAccessListLine line = new IpAccessListLine();
           _lines.add(line);
-          line.getIpProtocols().add(IpProtocol.TCP);
-          line.getIpProtocols().add(IpProtocol.UDP);
-          line.getDstPorts()
-              .add(new SubRange(NamedPort.SIP_5060.number(), NamedPort.SIP_5061.number()));
+          line.setIpProtocols(ImmutableSortedSet.of(IpProtocol.TCP, IpProtocol.UDP));
+          line.setDstPorts(
+              Collections.singleton(
+                  new SubRange(NamedPort.SIP_5060.number(), NamedPort.SIP_5061.number())));
           break;
         }
 
@@ -267,8 +280,10 @@ public enum HostSystemService {
         {
           IpAccessListLine line = new IpAccessListLine();
           _lines.add(line);
-          line.getIpProtocols().add(IpProtocol.UDP);
-          line.getDstPorts().add(new SubRange(NamedPort.SNMP.number(), NamedPort.SNMP.number()));
+          line.setIpProtocols(Collections.singleton(IpProtocol.UDP));
+          line.setDstPorts(
+              Collections.singleton(
+                  new SubRange(NamedPort.SNMP.number(), NamedPort.SNMP.number())));
           break;
         }
 
@@ -276,9 +291,10 @@ public enum HostSystemService {
         {
           IpAccessListLine line = new IpAccessListLine();
           _lines.add(line);
-          line.getIpProtocols().add(IpProtocol.UDP);
-          line.getDstPorts()
-              .add(new SubRange(NamedPort.SNMPTRAP.number(), NamedPort.SNMPTRAP.number()));
+          line.setIpProtocols(Collections.singleton(IpProtocol.UDP));
+          line.setDstPorts(
+              Collections.singleton(
+                  new SubRange(NamedPort.SNMPTRAP.number(), NamedPort.SNMPTRAP.number())));
           break;
         }
 
@@ -286,8 +302,9 @@ public enum HostSystemService {
         {
           IpAccessListLine line = new IpAccessListLine();
           _lines.add(line);
-          line.getIpProtocols().add(IpProtocol.TCP);
-          line.getDstPorts().add(new SubRange(NamedPort.SSH.number(), NamedPort.SSH.number()));
+          line.setIpProtocols(Collections.singleton(IpProtocol.TCP));
+          line.setDstPorts(
+              Collections.singleton(new SubRange(NamedPort.SSH.number(), NamedPort.SSH.number())));
           break;
         }
 
@@ -295,9 +312,10 @@ public enum HostSystemService {
         {
           IpAccessListLine line = new IpAccessListLine();
           _lines.add(line);
-          line.getIpProtocols().add(IpProtocol.TCP);
-          line.getDstPorts()
-              .add(new SubRange(NamedPort.TELNET.number(), NamedPort.TELNET.number()));
+          line.setIpProtocols(Collections.singleton(IpProtocol.TCP));
+          line.setDstPorts(
+              Collections.singleton(
+                  new SubRange(NamedPort.TELNET.number(), NamedPort.TELNET.number())));
           break;
         }
 
@@ -305,8 +323,10 @@ public enum HostSystemService {
         {
           IpAccessListLine line = new IpAccessListLine();
           _lines.add(line);
-          line.getIpProtocols().add(IpProtocol.UDP);
-          line.getDstPorts().add(new SubRange(NamedPort.TFTP.number(), NamedPort.TFTP.number()));
+          line.setIpProtocols(Collections.singleton(IpProtocol.UDP));
+          line.setDstPorts(
+              Collections.singleton(
+                  new SubRange(NamedPort.TFTP.number(), NamedPort.TFTP.number())));
           break;
         }
 
@@ -314,9 +334,10 @@ public enum HostSystemService {
         {
           IpAccessListLine line = new IpAccessListLine();
           _lines.add(line);
-          line.getIpProtocols().add(IpProtocol.UDP);
-          line.getDstPorts()
-              .add(new SubRange(NamedPort.TRACEROUTE.number(), NamedPort.TRACEROUTE.number()));
+          line.setIpProtocols(Collections.singleton(IpProtocol.UDP));
+          line.setDstPorts(
+              Collections.singleton(
+                  new SubRange(NamedPort.TRACEROUTE.number(), NamedPort.TRACEROUTE.number())));
           break;
         }
 
@@ -324,11 +345,11 @@ public enum HostSystemService {
         {
           IpAccessListLine line = new IpAccessListLine();
           _lines.add(line);
-          line.getIpProtocols().add(IpProtocol.TCP);
-          line.getDstPorts()
-              .add(
+          line.setIpProtocols(Collections.singleton(IpProtocol.TCP));
+          line.setDstPorts(
+              Collections.singleton(
                   new SubRange(
-                      NamedPort.XNM_CLEAR_TEXT.number(), NamedPort.XNM_CLEAR_TEXT.number()));
+                      NamedPort.XNM_CLEAR_TEXT.number(), NamedPort.XNM_CLEAR_TEXT.number())));
           break;
         }
 
@@ -336,9 +357,10 @@ public enum HostSystemService {
         {
           IpAccessListLine line = new IpAccessListLine();
           _lines.add(line);
-          line.getIpProtocols().add(IpProtocol.TCP);
-          line.getDstPorts()
-              .add(new SubRange(NamedPort.XNM_SSL.number(), NamedPort.XNM_SSL.number()));
+          line.setIpProtocols(Collections.singleton(IpProtocol.TCP));
+          line.setDstPorts(
+              Collections.singleton(
+                  new SubRange(NamedPort.XNM_SSL.number(), NamedPort.XNM_SSL.number())));
           break;
         }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -1207,7 +1207,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
     if (iface.getPrimaryPrefix() != null) {
       newIface.setPrefix(iface.getPrimaryPrefix());
     }
-    newIface.getAllPrefixes().addAll(iface.getAllPrefixes());
+    newIface.setAllPrefixes(iface.getAllPrefixes());
     newIface.setActive(iface.getActive());
     newIface.setAccessVlan(iface.getAccessVlan());
     newIface.setNativeVlan(iface.getNativeVlan());

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JunosApplication.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JunosApplication.java
@@ -1,5 +1,6 @@
 package org.batfish.representation.juniper;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.batfish.common.BatfishException;
@@ -232,9 +233,9 @@ public enum JunosApplication implements Application {
           String t1Name = "t1";
           Term t1 = new Term(t1Name);
           IpAccessListLine l1 = t1.getLine();
-          l1.getIpProtocols().add(IpProtocol.TCP);
+          l1.setIpProtocols(Collections.singleton(IpProtocol.TCP));
           int portNum = NamedPort.FTP.number();
-          l1.getDstPorts().add(new SubRange(portNum, portNum));
+          l1.setDstPorts(Collections.singleton(new SubRange(portNum, portNum)));
           terms.put(t1Name, t1);
           break;
         }
@@ -244,9 +245,9 @@ public enum JunosApplication implements Application {
           String t1Name = "t1";
           Term t1 = new Term(t1Name);
           IpAccessListLine l1 = t1.getLine();
-          l1.getIpProtocols().add(IpProtocol.TCP);
+          l1.setIpProtocols(Collections.singleton(IpProtocol.TCP));
           int portNum = NamedPort.HTTP.number();
-          l1.getDstPorts().add(new SubRange(portNum, portNum));
+          l1.setDstPorts(Collections.singleton(new SubRange(portNum, portNum)));
           terms.put(t1Name, t1);
           break;
         }
@@ -256,9 +257,9 @@ public enum JunosApplication implements Application {
           String t1Name = "t1";
           Term t1 = new Term(t1Name);
           IpAccessListLine l1 = t1.getLine();
-          l1.getIpProtocols().add(IpProtocol.TCP);
+          l1.setIpProtocols(Collections.singleton(IpProtocol.TCP));
           int portNum = NamedPort.HTTPS.number();
-          l1.getDstPorts().add(new SubRange(portNum, portNum));
+          l1.setDstPorts(Collections.singleton(new SubRange(portNum, portNum)));
           terms.put(t1Name, t1);
           break;
         }
@@ -268,7 +269,7 @@ public enum JunosApplication implements Application {
           String t1Name = "t1";
           Term t1 = new Term(t1Name);
           IpAccessListLine l1 = t1.getLine();
-          l1.getIpProtocols().add(IpProtocol.ICMP);
+          l1.setIpProtocols(Collections.singleton(IpProtocol.ICMP));
           terms.put(t1Name, t1);
           break;
         }
@@ -285,9 +286,9 @@ public enum JunosApplication implements Application {
           String t1Name = "t1";
           Term t1 = new Term(t1Name);
           IpAccessListLine l1 = t1.getLine();
-          l1.getIpProtocols().add(IpProtocol.TCP);
+          l1.setIpProtocols(Collections.singleton(IpProtocol.TCP));
           int portNum = NamedPort.NNTP.number();
-          l1.getDstPorts().add(new SubRange(portNum, portNum));
+          l1.setDstPorts(Collections.singleton(new SubRange(portNum, portNum)));
           terms.put(t1Name, t1);
           break;
         }
@@ -297,9 +298,9 @@ public enum JunosApplication implements Application {
           String t1Name = "t1";
           Term t1 = new Term(t1Name);
           IpAccessListLine l1 = t1.getLine();
-          l1.getIpProtocols().add(IpProtocol.UDP);
+          l1.setIpProtocols(Collections.singleton(IpProtocol.UDP));
           int portNum = NamedPort.NTP.number();
-          l1.getDstPorts().add(new SubRange(portNum, portNum));
+          l1.setDstPorts(Collections.singleton(new SubRange(portNum, portNum)));
           terms.put(t1Name, t1);
           break;
         }
@@ -309,9 +310,9 @@ public enum JunosApplication implements Application {
           String t1Name = "t1";
           Term t1 = new Term(t1Name);
           IpAccessListLine l1 = t1.getLine();
-          l1.getIpProtocols().add(IpProtocol.TCP);
+          l1.setIpProtocols(Collections.singleton(IpProtocol.TCP));
           int portNum = NamedPort.PPTP.number();
-          l1.getDstPorts().add(new SubRange(portNum, portNum));
+          l1.setDstPorts(Collections.singleton(new SubRange(portNum, portNum)));
           terms.put(t1Name, t1);
           break;
         }
@@ -321,9 +322,9 @@ public enum JunosApplication implements Application {
           String t1Name = "t1";
           Term t1 = new Term(t1Name);
           IpAccessListLine l1 = t1.getLine();
-          l1.getIpProtocols().add(IpProtocol.TCP);
+          l1.setIpProtocols(Collections.singleton(IpProtocol.TCP));
           int portNum = NamedPort.SSH.number();
-          l1.getDstPorts().add(new SubRange(portNum, portNum));
+          l1.setDstPorts(Collections.singleton(new SubRange(portNum, portNum)));
           terms.put(t1Name, t1);
           break;
         }

--- a/projects/batfish/src/main/java/org/batfish/representation/vyos/VyosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/vyos/VyosConfiguration.java
@@ -321,7 +321,7 @@ public class VyosConfiguration extends VendorConfiguration {
     for (PrefixListRule rule : prefixList.getRules().values()) {
       RouteFilterLine newLine =
           new RouteFilterLine(rule.getAction(), rule.getPrefix(), rule.getLengthRange());
-      newList.getLines().add(newLine);
+      newList.addLine(newLine);
     }
     return newList;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/vyos/VyosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/vyos/VyosConfiguration.java
@@ -1,5 +1,6 @@
 package org.batfish.representation.vyos;
 
+import com.google.common.collect.ImmutableList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -318,11 +319,14 @@ public class VyosConfiguration extends VendorConfiguration {
   private RouteFilterList toRouteFilterList(PrefixList prefixList) {
     String name = prefixList.getName();
     RouteFilterList newList = new RouteFilterList(name);
-    for (PrefixListRule rule : prefixList.getRules().values()) {
-      RouteFilterLine newLine =
-          new RouteFilterLine(rule.getAction(), rule.getPrefix(), rule.getLengthRange());
-      newList.addLine(newLine);
-    }
+    List<RouteFilterLine> newLines =
+        prefixList
+            .getRules()
+            .values()
+            .stream()
+            .map(l -> new RouteFilterLine(l.getAction(), l.getPrefix(), l.getLengthRange()))
+            .collect(ImmutableList.toImmutableList());
+    newList.setLines(newLines);
     return newList;
   }
 


### PR DESCRIPTION
It looks we're spending an obscene amount of memory in empty `TreeSet` and `ArrayList` classes in `HeaderSpace`-related classes.

There are a few good ways to move forward:

1. Allow `null` for empty collections. Callers should wrap `getX` with null-checks. When they want to add an item to a set, they have to initialize.
    * IMO this is an unfortunate amount of work for the caller.

1. Switch to empty/immutable collections internally. These are generally (much) more memory-efficient. Empty collections are in fact singletons Java-wide; and if we use the Guava classes, we'll likely save some copies when structures are copied/used in multiple places.
    * we can copy-on-set, which also means we could relax the `setX` contract to accept un-sorted sets or even arbitrary collections.
    * Callers only need to write annoying code where they used to modify the result of a getter: i.e.around `getX().add(x)` -> `setX(...make a new collection containing getX and x)`.
    * we could add `addX` forms that are internally equivalent to the above, but callers may have smarter logic (e.g., most of these are in the same function that allocates the interface)

I opted to go with the second.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/780)
<!-- Reviewable:end -->
