### PR TITLE
optimize CompareSameName

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/NamedStructureEquivalenceSet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/NamedStructureEquivalenceSet.java
@@ -3,8 +3,8 @@ package org.batfish.datamodel.collections;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableSortedSet;
 import java.util.SortedSet;
-import java.util.TreeSet;
 import org.batfish.common.util.CommonUtil;
 
 public class NamedStructureEquivalenceSet<T>
@@ -18,19 +18,17 @@ public class NamedStructureEquivalenceSet<T>
 
   private SortedSet<String> _nodes;
 
-  private final String _representativeElement;
-
   @JsonCreator
-  public NamedStructureEquivalenceSet(
-      @JsonProperty(PROP_REPRESENTATIVE_ELEMENT) String representativeElement) {
-    _representativeElement = representativeElement;
-  }
+  private NamedStructureEquivalenceSet() {}
 
   public NamedStructureEquivalenceSet(String node, T namedStructure) {
-    this(node);
     _namedStructure = namedStructure;
-    _nodes = new TreeSet<>();
-    _nodes.add(node);
+    _nodes = ImmutableSortedSet.of(node);
+  }
+
+  public NamedStructureEquivalenceSet(T namedStructure, SortedSet<String> nodes) {
+    _namedStructure = namedStructure;
+    _nodes = nodes;
   }
 
   public boolean compareStructure(T s) {
@@ -43,18 +41,7 @@ public class NamedStructureEquivalenceSet<T>
 
   @Override
   public int compareTo(NamedStructureEquivalenceSet<T> rhs) {
-    return _representativeElement.compareTo(rhs._representativeElement);
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (o == this) {
-      return true;
-    } else if (!(o instanceof NamedStructureEquivalenceSet)) {
-      return false;
-    }
-    NamedStructureEquivalenceSet<?> rhs = (NamedStructureEquivalenceSet<?>) o;
-    return _representativeElement.equals(rhs._representativeElement);
+    return getRepresentativeElement().compareTo(rhs.getRepresentativeElement());
   }
 
   // ignore for now to avoid encoding large amounts of information in answer
@@ -69,18 +56,14 @@ public class NamedStructureEquivalenceSet<T>
 
   @JsonProperty(PROP_REPRESENTATIVE_ELEMENT)
   public String getRepresentativeElement() {
-    return _representativeElement;
-  }
-
-  @Override
-  public int hashCode() {
-    return _representativeElement.hashCode();
+    return _nodes.first();
   }
 
   public String prettyPrint(String indent) {
-    StringBuilder sb = new StringBuilder(indent + _representativeElement);
+    String representativeElement = getRepresentativeElement();
+    StringBuilder sb = new StringBuilder(indent + representativeElement);
     for (String node : _nodes) {
-      if (!node.equals(_representativeElement)) {
+      if (!node.equals(representativeElement)) {
         sb.append(" " + node);
       }
     }
@@ -94,5 +77,13 @@ public class NamedStructureEquivalenceSet<T>
 
   public void setNodes(SortedSet<String> nodes) {
     _nodes = nodes;
+  }
+
+  @JsonProperty(PROP_REPRESENTATIVE_ELEMENT)
+  private void setRepresentativeElement(String representativeElement) {}
+
+  @Override
+  public String toString() {
+    return _nodes.toString();
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/NamedStructureEquivalenceSet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/NamedStructureEquivalenceSet.java
@@ -26,9 +26,9 @@ public class NamedStructureEquivalenceSet<T>
     _nodes = ImmutableSortedSet.of(node);
   }
 
-  public NamedStructureEquivalenceSet(T namedStructure, SortedSet<String> nodes) {
+  public NamedStructureEquivalenceSet(Iterable<String> nodes, T namedStructure) {
     _namedStructure = namedStructure;
-    _nodes = nodes;
+    _nodes = ImmutableSortedSet.copyOf(nodes);
   }
 
   public boolean compareStructure(T s) {
@@ -60,15 +60,7 @@ public class NamedStructureEquivalenceSet<T>
   }
 
   public String prettyPrint(String indent) {
-    String representativeElement = getRepresentativeElement();
-    StringBuilder sb = new StringBuilder(indent + representativeElement);
-    for (String node : _nodes) {
-      if (!node.equals(representativeElement)) {
-        sb.append(" " + node);
-      }
-    }
-    sb.append("\n");
-    return sb.toString();
+    return String.format("%s%s\n", indent, String.join(" ", _nodes));
   }
 
   public void setNamedStructure(T namedStructure) {
@@ -80,7 +72,9 @@ public class NamedStructureEquivalenceSet<T>
   }
 
   @JsonProperty(PROP_REPRESENTATIVE_ELEMENT)
-  private void setRepresentativeElement(String representativeElement) {}
+  private void setRepresentativeElement(String representativeElement) {
+    // No body because this is a virtual property computed from nodes
+  }
 
   @Override
   public String toString() {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/NamedStructureEquivalenceSets.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/NamedStructureEquivalenceSets.java
@@ -1,53 +1,145 @@
 package org.batfish.datamodel.collections;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.ImmutableSortedSet;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
-import java.util.TreeMap;
-import java.util.TreeSet;
+import org.batfish.common.BatfishException;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 public class NamedStructureEquivalenceSets<T> {
 
-  private SortedMap<String, SortedSet<NamedStructureEquivalenceSet<T>>> _sameNamedStructures;
+  public static class Builder<T> {
 
-  private String _structureClassName;
-
-  @JsonCreator
-  public NamedStructureEquivalenceSets() {
-    this("");
-  }
-
-  public NamedStructureEquivalenceSets(String structureClassName) {
-    _structureClassName = structureClassName;
-    _sameNamedStructures = new TreeMap<>();
-  }
-
-  public void add(String node, String name, T namedStructure) {
-    if (!_sameNamedStructures.containsKey(name)) {
-      _sameNamedStructures.put(name, new TreeSet<NamedStructureEquivalenceSet<T>>());
-    }
-    SortedSet<NamedStructureEquivalenceSet<T>> equiClasses = _sameNamedStructures.get(name);
-
-    for (NamedStructureEquivalenceSet<T> equiClass : equiClasses) {
-      if (equiClass.compareStructure(namedStructure)) {
-        equiClass.getNodes().add(node);
-        return;
+    private static boolean checkJsonStringEquals(String lhs, String rhs) {
+      try {
+        JSONAssert.assertEquals(lhs, rhs, false);
+        return true;
+      } catch (Exception e) {
+        throw new BatfishException("JSON equality check failed", e);
+      } catch (AssertionError err) {
+        return false;
       }
     }
-    equiClasses.add(new NamedStructureEquivalenceSet<>(node, namedStructure));
+
+    private final ObjectMapper _mapper;
+
+    private Map<String, Map<Integer, Set<NamedStructureEquivalenceSet<T>>>>
+        _sameNamedStructuresByNameAndHash;
+
+    private final String _structureClassName;
+
+    private Builder(String structureClassName) {
+      _mapper = new BatfishObjectMapper();
+      _sameNamedStructuresByNameAndHash = new HashMap<>();
+      _structureClassName = structureClassName;
+    }
+
+    public void addEntry(String structureName, String hostname, T structure) {
+      Map<Integer, Set<NamedStructureEquivalenceSet<T>>> sameNamedStructuresByHash =
+          _sameNamedStructuresByNameAndHash.computeIfAbsent(structureName, s -> new HashMap<>());
+      String structureJson = writeObject(structure);
+      int hash = structureJson.hashCode();
+      Set<NamedStructureEquivalenceSet<T>> eqSetsWithSameHash =
+          sameNamedStructuresByHash.computeIfAbsent(hash, h -> new HashSet<>());
+      if (eqSetsWithSameHash.isEmpty()) {
+        eqSetsWithSameHash.add(new NamedStructureEquivalenceSet<>(hostname, structure));
+      } else {
+        Optional<NamedStructureEquivalenceSet<T>> potentialMatchingSet =
+            eqSetsWithSameHash
+                .stream()
+                .filter(
+                    s -> checkJsonStringEquals(structureJson, writeObject(s.getNamedStructure())))
+                .findAny();
+        if (potentialMatchingSet.isPresent()) {
+          NamedStructureEquivalenceSet<T> matchingSet = potentialMatchingSet.get();
+          matchingSet.setNodes(
+              new ImmutableSortedSet.Builder<String>(Comparator.naturalOrder())
+                  .addAll(matchingSet.getNodes())
+                  .add(hostname)
+                  .build());
+        } else {
+          eqSetsWithSameHash.add(new NamedStructureEquivalenceSet<>(hostname, structure));
+        }
+      }
+    }
+
+    public NamedStructureEquivalenceSets<T> build() {
+      ImmutableSortedMap.Builder<String, SortedSet<NamedStructureEquivalenceSet<T>>> builder =
+          new ImmutableSortedMap.Builder<>(Comparator.naturalOrder());
+      for (Entry<String, Map<Integer, Set<NamedStructureEquivalenceSet<T>>>> e :
+          _sameNamedStructuresByNameAndHash.entrySet()) {
+        String structureName = e.getKey();
+        Map<Integer, Set<NamedStructureEquivalenceSet<T>>> structuresByHash = e.getValue();
+        SortedSet<NamedStructureEquivalenceSet<T>> newSet =
+            structuresByHash
+                .values()
+                .stream()
+                .flatMap(ss -> ss.stream())
+                .collect(ImmutableSortedSet.toImmutableSortedSet(Comparator.naturalOrder()));
+        builder.put(structureName, newSet);
+      }
+      NamedStructureEquivalenceSets<T> eqSets =
+          new NamedStructureEquivalenceSets<>(_structureClassName);
+      eqSets.setSameNamedStructures(builder.build());
+      return eqSets;
+    }
+
+    private String writeObject(T t) {
+      try {
+        String structureJson = _mapper.writeValueAsString(t);
+        return structureJson;
+      } catch (JsonProcessingException e) {
+        throw new BatfishException("Could not write named structure as JSON", e);
+      }
+    }
+  }
+
+  private static final String PROP_SAME_NAMED_STRUCTURES = "sameNamedStructures";
+
+  private static final String PROP_STRUCTURE_CLASS_NAME = "structureClassName";
+
+  public static <T> Builder<T> builder(String structureClassName) {
+    return new Builder<>(structureClassName);
+  }
+
+  private SortedMap<String, SortedSet<NamedStructureEquivalenceSet<T>>> _sameNamedStructures;
+
+  private final String _structureClassName;
+
+  @JsonCreator
+  public NamedStructureEquivalenceSets(
+      @JsonProperty(PROP_STRUCTURE_CLASS_NAME) String structureClassName) {
+    _structureClassName = structureClassName;
+    _sameNamedStructures = Collections.emptySortedMap();
   }
 
   /** Remove structures with only one equivalence class, since they indicate nothing of note */
   public void clean() {
-    Set<String> structureNames = new TreeSet<>(_sameNamedStructures.keySet());
-    for (String structureName : structureNames) {
-      if (_sameNamedStructures.get(structureName).size() == 1) {
-        _sameNamedStructures.remove(structureName);
-      }
-    }
+    _sameNamedStructures =
+        _sameNamedStructures
+            .entrySet()
+            .stream()
+            .filter(e -> e.getValue().size() != 1)
+            .collect(
+                ImmutableSortedMap.toImmutableSortedMap(
+                    Comparator.naturalOrder(), Entry::getKey, Entry::getValue));
   }
 
+  @JsonProperty(PROP_SAME_NAMED_STRUCTURES)
   public SortedMap<String, SortedSet<NamedStructureEquivalenceSet<T>>> getSameNamedStructures() {
     return _sameNamedStructures;
   }
@@ -67,16 +159,18 @@ public class NamedStructureEquivalenceSets<T> {
     return sb.toString();
   }
 
+  @JsonProperty(PROP_SAME_NAMED_STRUCTURES)
   public void setSameNamedStructures(
       SortedMap<String, SortedSet<NamedStructureEquivalenceSet<T>>> sameNamedStructures) {
     _sameNamedStructures = sameNamedStructures;
   }
 
-  public void setStructureClassName(String structureClassName) {
-    _structureClassName = structureClassName;
-  }
-
   public int size() {
     return _sameNamedStructures.size();
+  }
+
+  @Override
+  public String toString() {
+    return "<" + _structureClassName + ", " + _sameNamedStructures + ">";
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -606,7 +606,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
           || aclName.contains("~INBOUND_ZONE_FILTER~")) {
         continue;
       }
-      SortedSet<?> s = (SortedSet<?>) e.getValue();
+      Set<?> s = (Set<?>) e.getValue();
       for (Object o : s) {
         NamedStructureEquivalenceSet<?> aclEqSet = (NamedStructureEquivalenceSet<?>) o;
         String hostname = aclEqSet.getRepresentativeElement();

--- a/projects/question/src/main/java/org/batfish/question/CompareSameNameQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/CompareSameNameQuestionPlugin.java
@@ -199,9 +199,6 @@ public class CompareSameNameQuestionPlugin extends QuestionPlugin {
         Configuration node = configurations.get(hostname);
         Map<String, T> structureMap = structureMapRetriever.apply(node);
         for (String structName : allNames) {
-          if (structName.startsWith("~")) {
-            continue;
-          }
           T struct = structureMap.get(structName);
           if (struct != null || _missing) {
             builder.addEntry(structName, hostname, struct);

--- a/projects/question/src/main/java/org/batfish/question/CompareSameNameQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/CompareSameNameQuestionPlugin.java
@@ -2,6 +2,7 @@ package org.batfish.question;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.service.AutoService;
+import com.google.common.collect.ImmutableSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -106,11 +107,11 @@ public class CompareSameNameQuestionPlugin extends QuestionPlugin {
 
     private Map<String, Configuration> _configurations;
 
+    private Set<String> _excludedNamedStructTypes;
+
     private boolean _missing;
 
     private Set<String> _namedStructTypes;
-
-    private Set<String> _excludedNamedStructTypes;
 
     private List<String> _nodes;
 
@@ -182,15 +183,18 @@ public class CompareSameNameQuestionPlugin extends QuestionPlugin {
         List<String> hostnames,
         Map<String, Configuration> configurations,
         Function<Configuration, Map<String, T>> structureMapRetriever) {
-      NamedStructureEquivalenceSets<T> ae =
-          new NamedStructureEquivalenceSets<>(structureClass.getSimpleName());
+      String structureClassName = structureClass.getSimpleName();
       // collect the set of all names for structures of type T, across all nodes
-      Set<String> allNames = new TreeSet<>();
-      for (String hostname : hostnames) {
-        Configuration node = configurations.get(hostname);
-        Map<String, T> structureMap = structureMapRetriever.apply(node);
-        allNames.addAll(structureMap.keySet());
-      }
+      Set<String> allNames =
+          hostnames
+              .stream()
+              .map(configurations::get)
+              .map(structureMapRetriever::apply)
+              .flatMap(structureMap -> structureMap.keySet().stream())
+              .filter(structName -> !structName.startsWith("~"))
+              .collect(ImmutableSet.toImmutableSet());
+      NamedStructureEquivalenceSets.Builder<T> builder =
+          NamedStructureEquivalenceSets.builder(structureClassName);
       for (String hostname : hostnames) {
         Configuration node = configurations.get(hostname);
         Map<String, T> structureMap = structureMapRetriever.apply(node);
@@ -200,10 +204,11 @@ public class CompareSameNameQuestionPlugin extends QuestionPlugin {
           }
           T struct = structureMap.get(structName);
           if (struct != null || _missing) {
-            ae.add(hostname, structName, struct);
+            builder.addEntry(structName, hostname, struct);
           }
         }
       }
+      NamedStructureEquivalenceSets<T> ae = builder.build();
       if (!_singletons) {
         ae.clean();
       }
@@ -241,21 +246,21 @@ public class CompareSameNameQuestionPlugin extends QuestionPlugin {
    */
   public static final class CompareSameNameQuestion extends Question implements INodeRegexQuestion {
 
+    private static final String PROP_EXCLUDED_NAMED_STRUCT_TYPES = "excludedNamedStructTypes";
+
     private static final String PROP_MISSING = "missing";
 
     private static final String PROP_NAMED_STRUCT_TYPES = "namedStructTypes";
-
-    private static final String PROP_EXCLUDED_NAMED_STRUCT_TYPES = "excludedNamedStructTypes";
 
     private static final String PROP_NODE_REGEX = "nodeRegex";
 
     private static final String PROP_SINGLETONS = "singletons";
 
+    private SortedSet<String> _excludedNamedStructTypes;
+
     private boolean _missing;
 
     private SortedSet<String> _namedStructTypes;
-
-    private SortedSet<String> _excludedNamedStructTypes;
 
     private String _nodeRegex;
 
@@ -267,18 +272,14 @@ public class CompareSameNameQuestionPlugin extends QuestionPlugin {
       _nodeRegex = ".*";
     }
 
-    // These named structure types seem to be less useful and have many entries
-    // so slow down the computation considerably.  Therefore they are excluded
-    // from the analysis by default.
-    private void initExcludedNamedStructTypes() {
-      _excludedNamedStructTypes = new TreeSet<>();
-      _excludedNamedStructTypes.add(Interface.class.getSimpleName());
-      _excludedNamedStructTypes.add(Vrf.class.getSimpleName());
-    }
-
     @Override
     public boolean getDataPlane() {
       return false;
+    }
+
+    @JsonProperty(PROP_EXCLUDED_NAMED_STRUCT_TYPES)
+    public SortedSet<String> getExcludedNamedStructTypes() {
+      return _excludedNamedStructTypes;
     }
 
     @JsonProperty(PROP_MISSING)
@@ -296,11 +297,6 @@ public class CompareSameNameQuestionPlugin extends QuestionPlugin {
       return _namedStructTypes;
     }
 
-    @JsonProperty(PROP_EXCLUDED_NAMED_STRUCT_TYPES)
-    public SortedSet<String> getExcludedNamedStructTypes() {
-      return _excludedNamedStructTypes;
-    }
-
     @Override
     @JsonProperty(PROP_NODE_REGEX)
     public String getNodeRegex() {
@@ -312,6 +308,20 @@ public class CompareSameNameQuestionPlugin extends QuestionPlugin {
       return _singletons;
     }
 
+    // These named structure types seem to be less useful and have many entries
+    // so slow down the computation considerably.  Therefore they are excluded
+    // from the analysis by default.
+    private void initExcludedNamedStructTypes() {
+      _excludedNamedStructTypes = new TreeSet<>();
+      _excludedNamedStructTypes.add(Interface.class.getSimpleName());
+      _excludedNamedStructTypes.add(Vrf.class.getSimpleName());
+    }
+
+    @JsonProperty(PROP_EXCLUDED_NAMED_STRUCT_TYPES)
+    public void setExcludedNamedStructTypes(SortedSet<String> excludedNamedStructTypes) {
+      _excludedNamedStructTypes = excludedNamedStructTypes;
+    }
+
     @JsonProperty(PROP_MISSING)
     public void setMissing(boolean missing) {
       _missing = missing;
@@ -320,11 +330,6 @@ public class CompareSameNameQuestionPlugin extends QuestionPlugin {
     @JsonProperty(PROP_NAMED_STRUCT_TYPES)
     public void setNamedStructTypes(SortedSet<String> namedStructTypes) {
       _namedStructTypes = namedStructTypes;
-    }
-
-    @JsonProperty(PROP_EXCLUDED_NAMED_STRUCT_TYPES)
-    public void setExcludedNamedStructTypes(SortedSet<String> excludedNamedStructTypes) {
-      _excludedNamedStructTypes = excludedNamedStructTypes;
     }
 
     @Override


### PR DESCRIPTION
`CompareSameName` now runs asymptotically faster by hashing and caching JSON representation of structures.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/787)
<!-- Reviewable:end -->
