### PR TITLE
Client: copy question name to question instance name

### DIFF
--- a/projects/batfish-client/src/main/java/org/batfish/client/Client.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/Client.java
@@ -554,6 +554,7 @@ public class Client extends AbstractClient implements IClient {
     JSONObject instanceJson;
     try {
       instanceJson = questionJson.getJSONObject(BfConsts.PROP_INSTANCE);
+      instanceJson.put(BfConsts.PROP_INSTANCE_NAME, questionName);
     } catch (JSONException e) {
       throw new BatfishException("Question is missing instance data", e);
     }


### PR DESCRIPTION
Since other clients use the instance name as the question name, this makes it so we can find and use these questions later.

This is for the `answer <question>` command.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/797)
<!-- Reviewable:end -->
