### PR TITLE
Logs for data-plane generation meta-data and additional test-rigs data

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/bdp/BdpDataPlanePlugin.java
+++ b/projects/batfish/src/main/java/org/batfish/bdp/BdpDataPlanePlugin.java
@@ -47,6 +47,17 @@ public class BdpDataPlanePlugin extends DataPlanePlugin {
     BdpDataPlane dp =
         _engine.computeDataPlane(
             differentialContext, configurations, topology, externalAdverts, flowSinks, ae);
+    double averageRoutes =
+        dp.getNodes()
+            .values()
+            .stream()
+            .flatMap(n -> n._virtualRouters.values().stream())
+            .mapToInt(vr -> vr._mainRib.getRoutes().size())
+            .average()
+            .orElse(0.00d);
+    _logger.infof(
+        "Generated data-plane for testrig %s; iterations:%s, avg entries per node:%.2f\n",
+        _batfish.getTestrigName(), ae.getDependentRoutesIterations(), averageRoutes);
     _logger.resetTimer();
     _batfish.newBatch("Writing data plane to disk", 0);
     _batfish.writeDataPlane(dp, ae);

--- a/projects/batfish/src/main/java/org/batfish/bdp/BdpDataPlanePlugin.java
+++ b/projects/batfish/src/main/java/org/batfish/bdp/BdpDataPlanePlugin.java
@@ -56,7 +56,7 @@ public class BdpDataPlanePlugin extends DataPlanePlugin {
             .average()
             .orElse(0.00d);
     _logger.infof(
-        "Generated data-plane for testrig %s; iterations:%s, avg entries per node:%.2f\n",
+        "Generated data-plane for testrig:%s; iterations:%s, avg entries per node:%.2f\n",
         _batfish.getTestrigName(), ae.getDependentRoutesIterations(), averageRoutes);
     _logger.resetTimer();
     _batfish.newBatch("Writing data plane to disk", 0);

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -1012,7 +1012,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
     // Get generated facts from topology file
     if (Files.exists(topologyFilePath)) {
       topology = processTopologyFile(topologyFilePath);
-      _logger.infof("Testrig %s has topology file", _settings.getTestrig());
+      _logger.infof("Testrig:%s has topology file", _settings.getTestrig());
     } else {
       // guess adjacencies based on interface subnetworks
       _logger.info("*** (GUESSING TOPOLOGY IN ABSENCE OF EXPLICIT FILE) ***\n");
@@ -3853,8 +3853,8 @@ public class Batfish extends PluginConsumer implements IBatfish {
     SortedMap<String, VendorConfiguration> allHostConfigurations =
         parseVendorConfigurations(configurationData, answerElement, ConfigurationFormat.HOST);
     _logger.infof(
-        "Found %d host configs in testrig:%s",
-        allHostConfigurations.size(), _settings.getTestrig());
+        "Testrig:%s has total number of host configs:%d ",
+        _settings.getTestrig(), allHostConfigurations.size());
     if (allHostConfigurations == null) {
       throw new BatfishException("Exiting due to parser errors");
     }

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -1012,6 +1012,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
     // Get generated facts from topology file
     if (Files.exists(topologyFilePath)) {
       topology = processTopologyFile(topologyFilePath);
+      _logger.infof("Testrig %s has topology file", _settings.getTestrig());
     } else {
       // guess adjacencies based on interface subnetworks
       _logger.info("*** (GUESSING TOPOLOGY IN ABSENCE OF EXPLICIT FILE) ***\n");
@@ -3851,6 +3852,9 @@ public class Batfish extends PluginConsumer implements IBatfish {
     // read the host files
     SortedMap<String, VendorConfiguration> allHostConfigurations =
         parseVendorConfigurations(configurationData, answerElement, ConfigurationFormat.HOST);
+    _logger.infof(
+        "Found %d host configs in testrig:%s",
+        allHostConfigurations.size(), _settings.getTestrig());
     if (allHostConfigurations == null) {
       throw new BatfishException("Exiting due to parser errors");
     }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -951,15 +951,27 @@ public class WorkMgr extends AbstractCoordinator {
     defaultEnvironmentLeafDir.toFile().mkdirs();
 
     // things look ok, now make the move
+    boolean routingTables = false;
+    boolean bgpTables = false;
     for (Path subFile : subFileList) {
       Path target;
       if (isEnvFile(subFile)) {
+        String name = subFile.getFileName().toString();
+        if (name.equals(BfConsts.RELPATH_ENVIRONMENT_ROUTING_TABLES)) {
+          routingTables = true;
+        }
+        if (name.equals(BfConsts.RELPATH_ENVIRONMENT_BGP_TABLES)) {
+          bgpTables = true;
+        }
         target = defaultEnvironmentLeafDir.resolve(subFile.getFileName());
       } else {
         target = srcTestrigDir.resolve(subFile.getFileName());
       }
       CommonUtil.copy(subFile, target);
     }
+    _logger.infof(
+        "Environment data for testrig %s; bgpTables:%s, routingTables:%s\n",
+        testrigName, bgpTables, routingTables);
 
     if (autoAnalyze) {
       List<WorkItem> autoWorkQueue = new LinkedList<>();

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -970,7 +970,7 @@ public class WorkMgr extends AbstractCoordinator {
       CommonUtil.copy(subFile, target);
     }
     _logger.infof(
-        "Environment data for testrig %s; bgpTables:%s, routingTables:%s\n",
+        "Environment data for testrig:%s; bgpTables:%s, routingTables:%s\n",
         testrigName, bgpTables, routingTables);
 
     if (autoAnalyze) {


### PR DESCRIPTION
Logs to capture info about
1. Number of data-plane iterations and # log entries per node
2. Whether hosts config, topology, bgp, routing tables provided with testrig

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/801)
<!-- Reviewable:end -->
