### PR TITLE
displayhints fixes

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/DisplayHints.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/DisplayHints.java
@@ -28,7 +28,7 @@ public class DisplayHints {
       aMap.put("FileLine", "class:org.batfish.datamodel.collections.FileLinePair");
       aMap.put("Flow", "class:org.batfish.datamodel.Flow");
       aMap.put("FlowTrace", "class:org.batfish.datamodel.FlowTrace");
-      aMap.put("Integer", "class:java.lang.Integer");
+      aMap.put("Integer", "class:java.lang.Long");
       aMap.put("Interface", "class:org.batfish.datamodel.collections.NodeInterfacePair");
       aMap.put("Ip", "class:org.batfish.datamodel.Ip");
       aMap.put("Node", "class:org.batfish.datamodel.pojo.Node");

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/DisplayHints.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/DisplayHints.java
@@ -86,7 +86,7 @@ public class DisplayHints {
     }
 
     public boolean isIntOrIntList() {
-      return _baseType.getCanonicalName().equals("java.lang.Integer");
+      return _baseType.getCanonicalName().equals("java.lang.Long");
     }
   }
 

--- a/projects/question/src/main/java/org/batfish/question/jsonpath/JsonPathResult.java
+++ b/projects/question/src/main/java/org/batfish/question/jsonpath/JsonPathResult.java
@@ -137,7 +137,8 @@ public class JsonPathResult {
       try {
         jpeHint = JsonPathExtractionHint.fromExtractionHint(entry.getValue());
       } catch (IOException e) {
-        throw new BatfishException("Could not extract JsonPathExtractionHint from ExtractionHint");
+        throw new BatfishException(
+            "Could not extract JsonPathExtractionHint from ExtractionHint", e);
       }
       switch (jpeHint.getUse()) {
         case PREFIX:


### PR DESCRIPTION
- use `Long` instead of `Integer` to avoid losing precision
- include inner exception when displayhints extraction fails

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/834)
<!-- Reviewable:end -->
