### PR TITLE
adding spans for checktask status in coordinator

### DIFF
--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -270,7 +270,13 @@ public class WorkMgr extends AbstractCoordinator {
     task.setStatus(TaskStatus.UnreachableOrBadResponse);
 
     Client client = null;
-    try {
+    SpanContext queueWorkSpan = work.getWorkItem().getSourceSpan();
+    try (ActiveSpan checkTaskSpan =
+        GlobalTracer.get()
+            .buildSpan("Checking Task Status")
+            .addReference(References.FOLLOWS_FROM, queueWorkSpan)
+            .startActive()) {
+      assert checkTaskSpan != null; // avoid unused warning
       client =
           CommonUtil.createHttpClientBuilder(
                   _settings.getSslPoolDisable(),


### PR DESCRIPTION

<img width="855" alt="screen shot 2018-01-16 at 12 19 03 pm" src="https://user-images.githubusercontent.com/15151202/35010368-864b7c3e-fab7-11e7-91fc-aa67d013b91d.png">


It becomes clearer now why the client is getting the response much later after the job actually completes. The interval between coord's subsequent checktaskstatus calls and also client's get work status calls cause the delay in getting the final answer to generate dataplane.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/856)
<!-- Reviewable:end -->
