### PR TITLE
Support for multiple dataplane plugins

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/DataPlanePlugin.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/DataPlanePlugin.java
@@ -36,7 +36,7 @@ public abstract class DataPlanePlugin extends BatfishPlugin implements IDataPlan
 
   @Override
   protected final void batfishPluginInitialize() {
-    _batfish.setDataPlanePlugin(this);
+    _batfish.registerDataPlanePlugin(this, getName());
     dataPlanePluginInitialize();
   }
 
@@ -55,4 +55,6 @@ public abstract class DataPlanePlugin extends BatfishPlugin implements IDataPlan
   public abstract SortedMap<String, SortedMap<String, SortedSet<AbstractRoute>>> getRoutes();
 
   public abstract void processFlows(Set<Flow> flows);
+
+  public abstract String getName();
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
@@ -149,8 +149,6 @@ public interface IBatfish extends IPluginConsumer {
   void registerExternalBgpAdvertisementPlugin(
       ExternalBgpAdvertisementPlugin externalBgpAdvertisementPlugin);
 
-  void setDataPlanePlugin(DataPlanePlugin dataPlanePlugin);
-
   AnswerElement smtBlackhole(HeaderQuestion q);
 
   AnswerElement smtBoundedLength(HeaderLocationQuestion q, Integer bound);
@@ -184,4 +182,6 @@ public interface IBatfish extends IPluginConsumer {
       Set<String> notTransitNodes);
 
   void writeDataPlane(DataPlane dp, DataPlaneAnswerElement ae);
+
+  void registerDataPlanePlugin(DataPlanePlugin plugin, String name);
 }

--- a/projects/batfish/src/main/java/org/batfish/bdp/BdpDataPlanePlugin.java
+++ b/projects/batfish/src/main/java/org/batfish/bdp/BdpDataPlanePlugin.java
@@ -27,6 +27,8 @@ import org.batfish.datamodel.collections.NodeInterfacePair;
 @AutoService(Plugin.class)
 public class BdpDataPlanePlugin extends DataPlanePlugin {
 
+  public static final String PLUGIN_NAME = "bdp";
+
   private final Map<BdpDataPlane, Map<Flow, Set<FlowTrace>>> _flowTraces;
 
   private BdpEngine _engine;
@@ -146,5 +148,10 @@ public class BdpDataPlanePlugin extends DataPlanePlugin {
   public void processFlows(Set<Flow> flows) {
     BdpDataPlane dp = loadDataPlane();
     _flowTraces.put(dp, _engine.processFlows(dp, flows));
+  }
+
+  @Override
+  public String getName() {
+    return PLUGIN_NAME;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/config/Settings.java
+++ b/projects/batfish/src/main/java/org/batfish/config/Settings.java
@@ -504,6 +504,8 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
 
   private static final String EXECUTABLE_NAME = "batfish";
 
+  private static final String ARG_DATAPLANE_ENGINE_NAME = "dataplaneengine";
+
   private TestrigSettings _activeTestrigSettings;
 
   private String _analysisName;
@@ -701,6 +703,8 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
   private boolean _verboseParse;
 
   private int _z3timeout;
+
+  private String _dataPlaneEngineName;
 
   public Settings() {
     this(new String[] {});
@@ -1114,6 +1118,10 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
     return _z3timeout;
   }
 
+  public String getDataPlaneEngineName() {
+    return _dataPlaneEngineName;
+  }
+
   private void initConfigDefaults() {
     setDefaultProperty(BfConsts.ARG_ANALYSIS_NAME, null);
     setDefaultProperty(BfConsts.ARG_ANSWER_JSON_PATH, null);
@@ -1202,6 +1210,7 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
     setDefaultProperty(BfConsts.COMMAND_REPORT, false);
     setDefaultProperty(BfConsts.COMMAND_VALIDATE_ENVIRONMENT, false);
     setDefaultProperty(ARG_Z3_TIMEOUT, 0);
+    setDefaultProperty(ARG_DATAPLANE_ENGINE_NAME, "bdp");
   }
 
   private void initOptions() {
@@ -1482,6 +1491,11 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
         BfConsts.COMMAND_VALIDATE_ENVIRONMENT, "validate an environment that has been initialized");
 
     addOption(ARG_Z3_TIMEOUT, "set a timeout (in milliseconds) for Z3 queries", "z3timeout");
+
+    addOption(
+        ARG_DATAPLANE_ENGINE_NAME,
+        "name of the dataplane generation engine to use.",
+        "dataplane engine name");
   }
 
   private void parseCommandLine(String[] args) {
@@ -1589,6 +1603,7 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
     _validateEnvironment = getBooleanOptionValue(BfConsts.COMMAND_VALIDATE_ENVIRONMENT);
     _verboseParse = getBooleanOptionValue(BfConsts.ARG_VERBOSE_PARSE);
     _z3timeout = getIntegerOptionValue(ARG_Z3_TIMEOUT);
+    _dataPlaneEngineName = getStringOptionValue(ARG_DATAPLANE_ENGINE_NAME);
   }
 
   public boolean prettyPrintAnswer() {
@@ -1761,5 +1776,9 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
 
   public void setZ3Timeout(int z3Timeout) {
     _z3timeout = z3Timeout;
+  }
+
+  public void setDataplaneEngineName(String name) {
+    _dataPlaneEngineName = name;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -440,8 +440,6 @@ public class Batfish extends PluginConsumer implements IBatfish {
   private final Map<EnvironmentSettings, SortedMap<String, RoutesByVrf>>
       _cachedEnvironmentRoutingTables;
 
-  private DataPlanePlugin _dataPlanePlugin;
-
   private TestrigSettings _deltaTestrigSettings;
 
   private Set<ExternalBgpAdvertisementPlugin> _externalBgpAdvertisementPlugins;
@@ -459,6 +457,8 @@ public class Batfish extends PluginConsumer implements IBatfish {
   private final List<TestrigSettings> _testrigSettingsStack;
 
   private boolean _monotonicCache;
+
+  private Map<String, DataPlanePlugin> _dataPlanePlugins;
 
   public Batfish(
       Settings settings,
@@ -482,6 +482,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
     _terminatedWithException = false;
     _answererCreators = new HashMap<>();
     _testrigSettingsStack = new ArrayList<>();
+    _dataPlanePlugins = new HashMap<>();
   }
 
   private Answer analyze() {
@@ -907,7 +908,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
 
   private Answer computeDataPlane(boolean differentialContext) {
     checkEnvironmentExists();
-    return _dataPlanePlugin.computeDataPlane(differentialContext);
+    return getDataPlanePlugin().computeDataPlane(differentialContext);
   }
 
   private void computeEnvironmentBgpTables() {
@@ -1609,7 +1610,11 @@ public class Batfish extends PluginConsumer implements IBatfish {
   }
 
   public DataPlanePlugin getDataPlanePlugin() {
-    return _dataPlanePlugin;
+    DataPlanePlugin plugin = _dataPlanePlugins.get(_settings.getDataPlaneEngineName());
+    if (plugin == null) {
+      throw new BatfishException("Dataplane engine is unavailable or unsupported");
+    }
+    return plugin;
   }
 
   @Override
@@ -1850,7 +1855,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
 
   @Override
   public SortedMap<String, SortedMap<String, SortedSet<AbstractRoute>>> getRoutes() {
-    return _dataPlanePlugin.getRoutes();
+    return getDataPlanePlugin().getRoutes();
   }
 
   public Settings getSettings() {
@@ -1945,7 +1950,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
 
   @Override
   public void initBgpAdvertisements(Map<String, Configuration> configurations) {
-    Set<BgpAdvertisement> globalBgpAdvertisements = _dataPlanePlugin.getAdvertisements();
+    Set<BgpAdvertisement> globalBgpAdvertisements = getDataPlanePlugin().getAdvertisements();
     for (Configuration node : configurations.values()) {
       node.initBgpAdvertisements();
       for (Vrf vrf : node.getVrfs().values()) {
@@ -3042,8 +3047,9 @@ public class Batfish extends PluginConsumer implements IBatfish {
 
   private void populateFlowHistory(
       FlowHistory flowHistory, String envTag, Environment environment, String flowTag) {
-    List<Flow> flows = _dataPlanePlugin.getHistoryFlows();
-    List<FlowTrace> flowTraces = _dataPlanePlugin.getHistoryFlowTraces();
+    DataPlanePlugin dataPlanePlugin = getDataPlanePlugin();
+    List<Flow> flows = dataPlanePlugin.getHistoryFlows();
+    List<FlowTrace> flowTraces = dataPlanePlugin.getHistoryFlowTraces();
     int numEntries = flows.size();
     for (int i = 0; i < numEntries; i++) {
       Flow flow = flows.get(i);
@@ -3179,7 +3185,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
 
   @Override
   public void processFlows(Set<Flow> flows) {
-    _dataPlanePlugin.processFlows(flows);
+    getDataPlanePlugin().processFlows(flows);
   }
 
   /**
@@ -4101,8 +4107,8 @@ public class Batfish extends PluginConsumer implements IBatfish {
   }
 
   @Override
-  public void setDataPlanePlugin(DataPlanePlugin dataPlanePlugin) {
-    _dataPlanePlugin = dataPlanePlugin;
+  public void registerDataPlanePlugin(DataPlanePlugin plugin, String name) {
+    _dataPlanePlugins.put(name, plugin);
   }
 
   public void setMonotonicCache(boolean monotonicCache) {

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.SortedMap;
 import javax.annotation.Nullable;
 import org.apache.commons.collections4.map.LRUMap;
+import org.batfish.bdp.BdpDataPlanePlugin;
 import org.batfish.common.BatfishException;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.BfConsts;
@@ -103,6 +104,7 @@ public class BatfishTestUtils {
     settings.setContainerDir(containerDir);
     settings.setTestrig("tempTestrig");
     settings.setEnvironmentName("tempEnvironment");
+    settings.setDataplaneEngineName(BdpDataPlanePlugin.PLUGIN_NAME);
     Batfish.initTestrigSettings(settings);
     Path testrigPath = settings.getBaseTestrigSettings().getTestRigPath();
     settings.setActiveTestrigSettings(settings.getBaseTestrigSettings());


### PR DESCRIPTION
This change allows multiple dataplane plugins to register themselves using a unique name.
User can choose a dataplane engine with the `-dataplaneengine` flag. 
Default is "bdp", pointing at the current dataplane engine.