### PR TITLE
Copy over z3 binary in the install script for osx

### DIFF
--- a/tools/install_z3_osx.sh
+++ b/tools/install_z3_osx.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 ## for now, just install the libs in /usr/local/lib and /Library/Java/Extensions
 INSTALL_PREFIX="/usr/local"
+BINDIR="${INSTALL_PREFIX}/bin"
 EXTDIR="/Library/Java/Extensions"
 LIBDIR="${INSTALL_PREFIX}/lib"
 OLD_PWD="${PWD}"
@@ -18,11 +19,11 @@ umask 0022 || exit 1
 curl -L "${Z3_ZIP_URL}" -o "${Z3_ZIP}" || exit 1
 unzip "${Z3_ZIP}" || exit 1
 cd "${Z3_DIR}" || exit 1
-mkdir -p "${LIBDIR}" "${EXTDIR}"
+mkdir -p "${LIBDIR}" "${EXTDIR}" "${BINDIR}"
 cp "bin/libz3.dylib" "bin/libz3java.dylib" "${LIBDIR}/" || exit 1
 ln -s "${LIBDIR}/libz3.dylib" "${EXTDIR}/libz3.dylib"
 ln -s "${LIBDIR}/libz3java.dylib" "${EXTDIR}/libz3java.dylib"
+cp "bin/z3" "${BINDIR}/"
 umask "${OLD_UMASK}" || exit 1
 cd "${OLD_PWD}" || exit 1
 rm -rf "${WORKING}" || exit 1
-


### PR DESCRIPTION
We should install the z3 binary on osx as well as the libraries.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/877)
<!-- Reviewable:end -->
