### PR TITLE
Prefix: simplify and add tests

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Prefix.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Prefix.java
@@ -16,12 +16,7 @@ public final class Prefix implements Comparable<Prefix>, Serializable {
   public static final Prefix ZERO = new Prefix(Ip.ZERO, 0);
 
   private static long getNetworkEnd(long networkStart, int prefixLength) {
-    long networkEnd = networkStart;
-    int onesLength = 32 - prefixLength;
-    for (int i = 0; i < onesLength; i++) {
-      networkEnd |= ((long) 1 << i);
-    }
-    return networkEnd;
+    return networkStart | ((1L << (32 - prefixLength)) - 1);
   }
 
   private static long numWildcardBitsToWildcardLong(int numBits) {
@@ -79,13 +74,13 @@ public final class Prefix implements Comparable<Prefix>, Serializable {
 
   public boolean contains(Ip ip) {
     long start = _ip.asLong();
-    long end = getEndIp().asLong();
+    long end = getNetworkEnd(start, _prefixLength);
     long ipAsLong = ip.asLong();
     return start <= ipAsLong && ipAsLong <= end;
   }
 
   public boolean containsPrefix(Prefix prefix) {
-    return contains(prefix._ip) && _prefixLength < prefix._prefixLength;
+    return contains(prefix._ip) && _prefixLength <= prefix._prefixLength;
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PrefixTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PrefixTest.java
@@ -1,0 +1,72 @@
+package org.batfish.datamodel;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class PrefixTest {
+  public static class PrefixContainsIp extends TypeSafeDiagnosingMatcher<Prefix> {
+    private final Ip _ip;
+
+    public PrefixContainsIp(Ip ip) {
+      this._ip = ip;
+    }
+
+    @Override
+    protected boolean matchesSafely(Prefix prefix, Description mismatchDescription) {
+      if (prefix.contains(_ip)) {
+        return true;
+      }
+      mismatchDescription
+          .appendText("prefix ")
+          .appendValue(prefix)
+          .appendText(" does not contain ")
+          .appendValue(_ip);
+      return false;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+      description.appendText("contains IP address ").appendValue(_ip);
+    }
+  }
+
+  public static PrefixContainsIp containsIp(Ip ip) {
+    return new PrefixContainsIp(ip);
+  }
+
+  @Test
+  public void testCanonicalization() {
+    Prefix p = Prefix.parse("255.255.255.255/15");
+    assertThat(p.getStartIp(), equalTo(new Ip("255.254.0.0")));
+    assertThat(p.getPrefixLength(), equalTo(15));
+  }
+
+  @Test
+  public void testContains() {
+    Prefix p = Prefix.parse("1.2.3.4/31");
+    assertThat(p, containsIp(new Ip("1.2.3.4")));
+    assertThat(p, containsIp(new Ip("1.2.3.5")));
+    assertThat(p, not(containsIp(new Ip("1.2.3.6"))));
+    assertThat(p, not(containsIp(new Ip("1.2.3.3"))));
+
+    // Edge cases - 32 bit prefix
+    p = Prefix.parse("1.2.3.4/32");
+    assertThat(p, containsIp(new Ip("1.2.3.4")));
+    assertThat(p, not(containsIp(new Ip("1.2.3.5"))));
+    assertThat(p, not(containsIp(new Ip("1.2.3.3"))));
+
+    // Edge cases - 0 bit prefix
+    p = Prefix.parse("0.0.0.0/0");
+    assertThat(p, containsIp(new Ip("0.0.0.0")));
+    assertThat(p, containsIp(new Ip("128.128.128.128")));
+    assertThat(p, containsIp(new Ip("255.255.255.255")));
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/bdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/bdp/VirtualRouter.java
@@ -231,8 +231,7 @@ public class VirtualRouter extends ComparableStructure<String> {
         Prefix matchingRoutePrefix = matchingRoute.getNetwork();
         // check to make sure matching route's prefix does not totally
         // contain this static route's prefix
-        if (matchingRoutePrefix.getStartIp().asLong() > staticRoutePrefix.getStartIp().asLong()
-            || matchingRoutePrefix.getEndIp().asLong() < staticRoutePrefix.getEndIp().asLong()) {
+        if (!matchingRoutePrefix.containsPrefix(staticRoutePrefix)) {
           changed |= _mainRib.mergeRoute(sr);
           break; // break out of the inner loop but continue processing static routes
         }

--- a/projects/batfish/src/main/java/org/batfish/symbolic/abstraction/Abstraction.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/abstraction/Abstraction.java
@@ -167,9 +167,7 @@ public class Abstraction {
           if (PrefixUtils.overlap(p, dstIps) && !PrefixUtils.overlap(p, notDstIps)) {
             Set<Prefix> toAdd = new HashSet<>();
             for (Prefix pfx : dstIps) {
-              if (p.equals(pfx)) {
-                toAdd.add(p);
-              } else if (pfx.containsPrefix(p)) {
+              if (pfx.containsPrefix(p)) {
                 toAdd.add(p);
               } else if (p.containsPrefix(pfx)) {
                 toAdd.add(pfx);

--- a/projects/batfish/src/main/java/org/batfish/symbolic/utils/PrefixUtils.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/utils/PrefixUtils.java
@@ -45,13 +45,4 @@ public class PrefixUtils {
     }
     return false;
   }
-
-  public static boolean containsAny(Prefix p, Collection<Prefix> ps) {
-    for (Prefix p2 : ps) {
-      if (p.containsPrefix(p2)) {
-        return true;
-      }
-    }
-    return false;
-  }
 }


### PR DESCRIPTION
* simplify getNetworkEnd to be O(1) instead of linear time.
* Add tests of canonicalization and also containment.
* Update Prefix#containsPrefix to include equal prefixes
  and update all callers / delete unused callers.

Fixes #644.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/883)
<!-- Reviewable:end -->
