### PR TITLE
Less verbose warnings for unrecognized lines

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -7596,12 +7596,11 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   @Override
   public void visitErrorNode(ErrorNode errorNode) {
     Token token = errorNode.getSymbol();
-    String lineText = errorNode.getText().replace("\n", "").replace("\r", "");
+    String lineText = errorNode.getText().replace("\n", "").replace("\r", "").trim();
     int line = token.getLine();
     String msg = String.format("Unrecognized Line: %d: %s", line, lineText);
     if (_unrecognizedAsRedFlag) {
-      msg += "\nLINES BELOW LINE " + lineText + " MAY NOT BE PROCESSED CORRECTLY";
-      _w.redFlag(msg);
+      _w.redFlag(msg + " SUBSEQUENT LINES MAY NOT BE PROCESSED CORRECTLY");
       _configuration.setUnrecognized(true);
     } else {
       _parser.getErrors().add(msg);

--- a/test_rigs/parsing-errors-tests/recovery-no-verbose.ref
+++ b/test_rigs/parsing-errors-tests/recovery-no-verbose.ref
@@ -10,8 +10,8 @@
       "warnings" : {
         "as1r1" : {
           "Red flags" : {
-            "1" : "MISCELLANEOUS: Unrecognized Line: 4:  ip address 10.12.11.1 255.255.255.0aaaaa:wq\nLINES BELOW LINE  ip address 10.12.11.1 255.255.255.0aaaaa:wq MAY NOT BE PROCESSED CORRECTLY",
-            "2" : "MISCELLANEOUS: Unrecognized Line: 6: interface Loopback0\nLINES BELOW LINE interface Loopback0 MAY NOT BE PROCESSED CORRECTLY",
+            "1" : "MISCELLANEOUS: Unrecognized Line: 4: ip address 10.12.11.1 255.255.255.0aaaaa:wq SUBSEQUENT LINES MAY NOT BE PROCESSED CORRECTLY",
+            "2" : "MISCELLANEOUS: Unrecognized Line: 6: interface Loopback0 SUBSEQUENT LINES MAY NOT BE PROCESSED CORRECTLY",
             "3" : "MISCELLANEOUS: Could not determine update source for BGP neighbor: '10.12.11.2'"
           }
         }


### PR DESCRIPTION
I noticed we print the line text twice -- that seems unnecessarily verbose.

Also explains why the warnings can't really be linked to a file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/884)
<!-- Reviewable:end -->
