### PR TITLE
Add API calls to get parsing or dataplaning work

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/CoordConsts.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/CoordConsts.java
@@ -96,6 +96,7 @@ public class CoordConsts {
   public static final String SVC_KEY_TESTRIG_NAME = "testrigname";
   public static final String SVC_KEY_VERSION = "version";
   public static final String SVC_KEY_WORK_LIST = "worklist";
+  public static final String SVC_KEY_WORK_TYPE = "worktype";
   public static final String SVC_KEY_WORKID = "workid";
   public static final String SVC_KEY_WORKITEM = "workitem";
   public static final String SVC_KEY_WORKSPACE_NAME = "workspace";
@@ -115,7 +116,9 @@ public class CoordConsts {
   public static final String SVC_RSC_GET_ANSWER = "getanswer";
   public static final String SVC_RSC_GET_CONFIGURATION = "getconfiguration";
   public static final String SVC_RSC_GET_CONTAINER = "getcontainer";
+  public static final String SVC_RSC_GET_DATAPLANING_WORK = "getdataplaningwork";
   public static final String SVC_RSC_GET_OBJECT = "getobject";
+  public static final String SVC_RSC_GET_PARSING_WORK = "getparsingwork";
   public static final String SVC_RSC_GET_QUESTION_TEMPLATES = "getquestiontemplates";
   public static final String SVC_RSC_GET_WORKSTATUS = "getworkstatus";
   public static final String SVC_RSC_GETSTATUS = "getstatus";

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -1151,8 +1151,9 @@ public class WorkMgr extends AbstractCoordinator {
     return environments;
   }
 
-  public List<QueuedWork> listIncompleteWork(String containerName) {
-    return _workQueueMgr.listIncompleteWork(containerName);
+  public List<QueuedWork> listIncompleteWork(
+      String containerName, @Nullable String testrigName, @Nullable WorkType workType) {
+    return _workQueueMgr.listIncompleteWork(containerName, testrigName, workType);
   }
 
   public SortedSet<String> listQuestions(String containerName) {

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
@@ -1113,8 +1113,8 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
       @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
-      @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) @Nullable String testrigName, /* optional */
-      @FormDataParam(CoordConsts.SVC_KEY_WORK_TYPE) @Nullable WorkType workType /* optional */) {
+      @Nullable @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String testrigName, /* optional */
+      @Nullable @FormDataParam(CoordConsts.SVC_KEY_WORK_TYPE) WorkType workType /* optional */) {
     try {
       _logger.info("WMS:listIncompleteWork " + apiKey + " " + containerName + "\n");
 

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.SortedSet;
 import java.util.UUID;
+import javax.annotation.Nullable;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -34,6 +35,7 @@ import org.batfish.common.CoordConsts;
 import org.batfish.common.Version;
 import org.batfish.common.WorkItem;
 import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.coordinator.WorkDetails.WorkType;
 import org.batfish.coordinator.WorkQueueMgr.QueueType;
 import org.batfish.coordinator.config.Settings;
 import org.batfish.datamodel.TestrigMetadata;
@@ -1095,11 +1097,13 @@ public class WorkMgrService {
   }
 
   /**
-   * List incomplete work for the specified container
+   * List incomplete work of the specified type for the specified container and testrig
    *
    * @param apiKey The API key of the client
    * @param clientVersion The version of the client
    * @param containerName The name of the container for which to list work
+   * @param testrigName (optional) The name of the testrig for which to list work
+   * @param workType (optional) The type of work to list
    * @return TODO: document JSON response
    */
   @POST
@@ -1108,20 +1112,26 @@ public class WorkMgrService {
   public JSONArray listIncompleteWork(
       @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
-      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName) {
+      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
+      @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) @Nullable String testrigName, /* optional */
+      @FormDataParam(CoordConsts.SVC_KEY_WORK_TYPE) @Nullable WorkType workType /* optional */) {
     try {
       _logger.info("WMS:listIncompleteWork " + apiKey + " " + containerName + "\n");
 
       checkStringParam(apiKey, "API key");
       checkStringParam(clientVersion, "Client version");
       checkStringParam(containerName, "Container name");
+      if (testrigName != null) {
+        checkStringParam(testrigName, "Base testrig name");
+      }
 
       checkApiKeyValidity(apiKey);
       checkClientVersion(clientVersion);
       checkContainerAccessibility(apiKey, containerName);
 
       List<WorkStatus> workList = new LinkedList<>();
-      for (QueuedWork work : Main.getWorkMgr().listIncompleteWork(containerName)) {
+      for (QueuedWork work :
+          Main.getWorkMgr().listIncompleteWork(containerName, testrigName, workType)) {
         WorkStatus workStatus =
             new WorkStatus(work.getWorkItem(), work.getStatus(), work.getLastTaskCheckResult());
         workList.add(workStatus);

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkQueueMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkQueueMgr.java
@@ -350,10 +350,14 @@ public class WorkQueueMgr {
     return workToCheck;
   }
 
-  public synchronized List<QueuedWork> listIncompleteWork(String containerName) {
+  public synchronized List<QueuedWork> listIncompleteWork(
+      String containerName, @Nullable String testrigName, @Nullable WorkType workType) {
     List<QueuedWork> retList = new LinkedList<>();
     for (QueuedWork work : _queueIncompleteWork) {
-      if (work.getWorkItem().getContainerName().equals(containerName)) {
+      // Add to queue if it matches container, testrig if provided, and work type if provided
+      if (work.getWorkItem().getContainerName().equals(containerName)
+          && (testrigName == null || work.getDetails().baseTestrig.equals(testrigName))
+          && (workType == null || work.getDetails().workType == workType)) {
         retList.add(work);
       }
     }

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkQueueMgrTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkQueueMgrTest.java
@@ -311,10 +311,10 @@ public class WorkQueueMgrTest {
     QueuedWork work1 =
         new QueuedWork(
             new WorkItem(CONTAINER, "testrig"),
-            new WorkDetails("testrig", "env", WorkType.PARSING));
+            new WorkDetails("testrig", "env", WorkType.UNKNOWN));
     QueuedWork work2 =
         new QueuedWork(
-            new WorkItem(CONTAINER, "testrig"),
+            new WorkItem(CONTAINER, "testrig2"),
             new WorkDetails("testrig2", "env", WorkType.UNKNOWN));
     _workQueueMgr.queueUnassignedWork(work1);
     _workQueueMgr.queueUnassignedWork(work2);

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkQueueMgrTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkQueueMgrTest.java
@@ -279,9 +279,49 @@ public class WorkQueueMgrTest {
     _workQueueMgr.queueUnassignedWork(work1);
     _workQueueMgr.queueUnassignedWork(work2);
 
-    List<QueuedWork> works = _workQueueMgr.listIncompleteWork(CONTAINER);
+    List<QueuedWork> works = _workQueueMgr.listIncompleteWork(CONTAINER, null, null);
 
     assertThat(works, equalTo(Collections.singletonList(work1)));
+  }
+
+  @Test
+  public void listIncompleteWorkForSpecificStatus() throws Exception {
+    initTestrigMetadata("testrig", "env", ProcessingStatus.UNINITIALIZED);
+    QueuedWork work1 =
+        new QueuedWork(
+            new WorkItem(CONTAINER, "testrig"),
+            new WorkDetails("testrig", "env", WorkType.PARSING));
+    QueuedWork work2 =
+        new QueuedWork(
+            new WorkItem(CONTAINER, "testrig"),
+            new WorkDetails("testrig", "env", WorkType.UNKNOWN));
+    _workQueueMgr.queueUnassignedWork(work1);
+    _workQueueMgr.queueUnassignedWork(work2);
+
+    List<QueuedWork> parsingWorks =
+        _workQueueMgr.listIncompleteWork(CONTAINER, null, WorkType.PARSING);
+
+    assertThat(parsingWorks, equalTo(Collections.singletonList(work1)));
+  }
+
+  @Test
+  public void listIncompleteWorkForSpecificTestrig() throws Exception {
+    initTestrigMetadata("testrig", "env", ProcessingStatus.UNINITIALIZED);
+    initTestrigMetadata("testrig2", "env", ProcessingStatus.UNINITIALIZED);
+    QueuedWork work1 =
+        new QueuedWork(
+            new WorkItem(CONTAINER, "testrig"),
+            new WorkDetails("testrig", "env", WorkType.PARSING));
+    QueuedWork work2 =
+        new QueuedWork(
+            new WorkItem(CONTAINER, "testrig"),
+            new WorkDetails("testrig2", "env", WorkType.UNKNOWN));
+    _workQueueMgr.queueUnassignedWork(work1);
+    _workQueueMgr.queueUnassignedWork(work2);
+
+    List<QueuedWork> parsingWorks = _workQueueMgr.listIncompleteWork(CONTAINER, "testrig", null);
+
+    assertThat(parsingWorks, equalTo(Collections.singletonList(work1)));
   }
 
   // BEGIN: DATAPLANE_INDEPENDENT_ANSWERING TESTS


### PR DESCRIPTION
Adds API calls `getParsingWork` and `getDataplaningWork`. Both take in a testrig name and return the most recent parsing or dataplaning work on that testrig, complete or incomplete, in the same format you would get it from `listIncompleteWork`. Makes progress information more accessible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/885)
<!-- Reviewable:end -->
