### PR TITLE
include the structure definition in the output for named structure outliers

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/NamedStructureOutlierSet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/NamedStructureOutlierSet.java
@@ -1,7 +1,6 @@
 package org.batfish.datamodel.collections;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 import java.util.SortedSet;
@@ -94,7 +93,7 @@ public class NamedStructureOutlierSet<T> extends AbstractOutlierSet
   }
 
   // ignore for now to avoid encoding large amounts of information in answer
-  @JsonIgnore
+  @JsonProperty(PROP_STRUCT_DEFINITION)
   public T getNamedStructure() {
     return _namedStructure;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/IRoleConsistencyQuestion.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/IRoleConsistencyQuestion.java
@@ -1,9 +1,11 @@
 package org.batfish.datamodel.questions;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.util.Optional;
 import org.batfish.datamodel.NodeRoleSpecifier;
 import org.batfish.role.OutliersHypothesis;
 
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "class")
 public interface IRoleConsistencyQuestion extends IQuestion {
 
   OutliersHypothesis getHypothesis();

--- a/projects/question/src/main/java/org/batfish/question/InferPoliciesQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/InferPoliciesQuestionPlugin.java
@@ -114,7 +114,7 @@ public class InferPoliciesQuestionPlugin extends QuestionPlugin {
 
     // the minimum percentage of nodes that must conform to a policy, in order for
     // the policy to be returned
-    private static final double CONFORMERS_THRESHOLD = 0.9;
+    private static final double CONFORMERS_THRESHOLD = 0.75;
 
     public InferPoliciesAnswerer(Question question, IBatfish batfish) {
       super(question, batfish);

--- a/projects/question/src/main/java/org/batfish/question/NamedStructureRoleConsistencyQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/NamedStructureRoleConsistencyQuestionPlugin.java
@@ -1,5 +1,6 @@
 package org.batfish.question;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.service.AutoService;
 import java.util.LinkedList;
@@ -125,6 +126,7 @@ public class NamedStructureRoleConsistencyQuestionPlugin extends QuestionPlugin 
 
     private OutliersHypothesis _hypothesis;
 
+    @JsonCreator
     public NamedStructureRoleConsistencyQuestion() {}
 
     @Override

--- a/projects/question/src/main/java/org/batfish/question/OutliersQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/OutliersQuestionPlugin.java
@@ -283,12 +283,12 @@ public class OutliersQuestionPlugin extends QuestionPlugin {
       SortedSet<NamedStructureOutlierSet<?>> outliers =
           rankNamedStructureOutliers(hypothesis, equivalenceSets);
 
-      // remove outlier sets where the hypothesis is that a particular named structure
-      // should *not* exist (this  happens when more nodes lack such a structure than contain
-      // such a structure).  such hypotheses do not seem to be useful in general.
-      outliers.removeIf(oset -> oset.getNamedStructure() == null);
-
       if (!_verbose) {
+        // remove outlier sets where the hypothesis is that a particular named structure
+        // should *not* exist (this  happens when more nodes lack such a structure than contain
+        // such a structure).  such hypotheses do not seem to be useful in general.
+        outliers.removeIf(oset -> oset.getNamedStructure() == null);
+
         // remove outlier sets that don't meet our threshold
         outliers.removeIf(oset -> !isWithinThreshold(oset.getConformers(), oset.getOutliers()));
       }
@@ -316,6 +316,12 @@ public class OutliersQuestionPlugin extends QuestionPlugin {
         if (accessorF != null) {
           addPropertyOutliers(serverSet, accessorF, rankedOutliers);
         }
+      }
+
+      if (!_verbose) {
+        // remove outlier sets where the hypothesis is that a particular server set
+        // should be empty. such hypotheses do not seem to be useful in general.
+        rankedOutliers.removeIf(oset -> oset.getDefinition().isEmpty());
       }
 
       return rankedOutliers;

--- a/projects/question/src/main/java/org/batfish/question/RoleConsistencyQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/RoleConsistencyQuestionPlugin.java
@@ -1,5 +1,6 @@
 package org.batfish.question;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.service.AutoService;
@@ -134,6 +135,7 @@ public class RoleConsistencyQuestionPlugin extends QuestionPlugin {
 
     private String _propertyName;
 
+    @JsonCreator
     public RoleConsistencyQuestion() {}
 
     @Override

--- a/tests/basic/inferPolicies.ref
+++ b/tests/basic/inferPolicies.ref
@@ -33,6 +33,34 @@
         },
         {
           "differential" : false,
+          "propertyName" : "NtpServers",
+          "roleSpecifier" : {
+            "inferred" : false,
+            "roleMap" : {
+              "border" : [
+                "as2border1",
+                "as2border2"
+              ],
+              "core" : [
+                "as2core1",
+                "as2core2"
+              ],
+              "dept" : [
+                "as2dept1"
+              ],
+              "dist" : [
+                "as2dist1",
+                "as2dist2"
+              ]
+            },
+            "roleRegexes" : [
+              "[a-z]*\\d([a-z]+).*",
+              "([a-z]+)\\d"
+            ]
+          }
+        },
+        {
+          "differential" : false,
           "hypothesis" : "sameName",
           "roleSpecifier" : {
             "inferred" : false,
@@ -233,6 +261,35 @@
             ]
           },
           "structType" : "IpAccessList"
+        },
+        {
+          "differential" : false,
+          "hypothesis" : "sameDefinition",
+          "roleSpecifier" : {
+            "inferred" : false,
+            "roleMap" : {
+              "border" : [
+                "as2border1",
+                "as2border2"
+              ],
+              "core" : [
+                "as2core1",
+                "as2core2"
+              ],
+              "dept" : [
+                "as2dept1"
+              ],
+              "dist" : [
+                "as2dist1",
+                "as2dist2"
+              ]
+            },
+            "roleRegexes" : [
+              "[a-z]*\\d([a-z]+).*",
+              "([a-z]+)\\d"
+            ]
+          },
+          "structType" : "RouteFilterList"
         }
       ]
     }

--- a/tests/basic/inferPolicies.ref
+++ b/tests/basic/inferPolicies.ref
@@ -4,6 +4,7 @@
       "class" : "org.batfish.question.InferPoliciesQuestionPlugin$InferPoliciesAnswerElement",
       "roleConsistencyQuestions" : [
         {
+          "class" : "org.batfish.question.RoleConsistencyQuestionPlugin$RoleConsistencyQuestion",
           "differential" : false,
           "propertyName" : "LoggingServers",
           "roleSpecifier" : {
@@ -32,6 +33,7 @@
           }
         },
         {
+          "class" : "org.batfish.question.RoleConsistencyQuestionPlugin$RoleConsistencyQuestion",
           "differential" : false,
           "propertyName" : "NtpServers",
           "roleSpecifier" : {
@@ -60,6 +62,7 @@
           }
         },
         {
+          "class" : "org.batfish.question.NamedStructureRoleConsistencyQuestionPlugin$NamedStructureRoleConsistencyQuestion",
           "differential" : false,
           "hypothesis" : "sameName",
           "roleSpecifier" : {
@@ -89,6 +92,7 @@
           "structType" : "CommunityList"
         },
         {
+          "class" : "org.batfish.question.NamedStructureRoleConsistencyQuestionPlugin$NamedStructureRoleConsistencyQuestion",
           "differential" : false,
           "hypothesis" : "sameName",
           "roleSpecifier" : {
@@ -118,6 +122,7 @@
           "structType" : "Interface"
         },
         {
+          "class" : "org.batfish.question.NamedStructureRoleConsistencyQuestionPlugin$NamedStructureRoleConsistencyQuestion",
           "differential" : false,
           "hypothesis" : "sameName",
           "roleSpecifier" : {
@@ -147,6 +152,7 @@
           "structType" : "IpAccessList"
         },
         {
+          "class" : "org.batfish.question.NamedStructureRoleConsistencyQuestionPlugin$NamedStructureRoleConsistencyQuestion",
           "differential" : false,
           "hypothesis" : "sameName",
           "roleSpecifier" : {
@@ -176,6 +182,7 @@
           "structType" : "RouteFilterList"
         },
         {
+          "class" : "org.batfish.question.NamedStructureRoleConsistencyQuestionPlugin$NamedStructureRoleConsistencyQuestion",
           "differential" : false,
           "hypothesis" : "sameName",
           "roleSpecifier" : {
@@ -205,6 +212,7 @@
           "structType" : "Vrf"
         },
         {
+          "class" : "org.batfish.question.NamedStructureRoleConsistencyQuestionPlugin$NamedStructureRoleConsistencyQuestion",
           "differential" : false,
           "hypothesis" : "sameDefinition",
           "roleSpecifier" : {
@@ -234,6 +242,7 @@
           "structType" : "CommunityList"
         },
         {
+          "class" : "org.batfish.question.NamedStructureRoleConsistencyQuestionPlugin$NamedStructureRoleConsistencyQuestion",
           "differential" : false,
           "hypothesis" : "sameDefinition",
           "roleSpecifier" : {
@@ -263,6 +272,7 @@
           "structType" : "IpAccessList"
         },
         {
+          "class" : "org.batfish.question.NamedStructureRoleConsistencyQuestionPlugin$NamedStructureRoleConsistencyQuestion",
           "differential" : false,
           "hypothesis" : "sameDefinition",
           "roleSpecifier" : {

--- a/tests/basic/nsRoleConsistency.ref
+++ b/tests/basic/nsRoleConsistency.ref
@@ -77,6 +77,22 @@
         },
         {
           "conformers" : [
+            "as1border1",
+            "as2border1",
+            "as2border2",
+            "as3border1",
+            "as3border2"
+          ],
+          "hypothesis" : "sameName",
+          "name" : "as4_community",
+          "outliers" : [
+            "as1border2"
+          ],
+          "structType" : "CommunityList",
+          "role" : "border"
+        },
+        {
+          "conformers" : [
             "as2dept1"
           ],
           "hypothesis" : "sameName",

--- a/tests/basic/nsRoleConsistency.ref
+++ b/tests/basic/nsRoleConsistency.ref
@@ -14,6 +14,16 @@
           ],
           "hypothesis" : "sameName",
           "name" : "as1_community",
+          "structDefinition" : {
+            "lines" : [
+              {
+                "action" : "ACCEPT",
+                "regex" : "(,|\\{|\\}|^|$| )1:"
+              }
+            ],
+            "name" : "as1_community",
+            "invertMatch" : false
+          },
           "structType" : "CommunityList",
           "role" : "border"
         },
@@ -28,6 +38,16 @@
           ],
           "hypothesis" : "sameName",
           "name" : "as2_community",
+          "structDefinition" : {
+            "lines" : [
+              {
+                "action" : "ACCEPT",
+                "regex" : "(,|\\{|\\}|^|$| )2:"
+              }
+            ],
+            "name" : "as2_community",
+            "invertMatch" : false
+          },
           "structType" : "CommunityList",
           "role" : "border"
         },
@@ -42,6 +62,16 @@
           ],
           "hypothesis" : "sameName",
           "name" : "as3_community",
+          "structDefinition" : {
+            "lines" : [
+              {
+                "action" : "ACCEPT",
+                "regex" : "(,|\\{|\\}|^|$| )3:"
+              }
+            ],
+            "name" : "as3_community",
+            "invertMatch" : false
+          },
           "structType" : "CommunityList",
           "role" : "border"
         },
@@ -51,6 +81,16 @@
           ],
           "hypothesis" : "sameName",
           "name" : "as2_community",
+          "structDefinition" : {
+            "lines" : [
+              {
+                "action" : "ACCEPT",
+                "regex" : "(,|\\{|\\}|^|$| )2:"
+              }
+            ],
+            "name" : "as2_community",
+            "invertMatch" : false
+          },
           "structType" : "CommunityList",
           "role" : "dept"
         },
@@ -61,6 +101,16 @@
           ],
           "hypothesis" : "sameName",
           "name" : "dept_community",
+          "structDefinition" : {
+            "lines" : [
+              {
+                "action" : "ACCEPT",
+                "regex" : "(,|\\{|\\}|^|$| )65001:"
+              }
+            ],
+            "name" : "dept_community",
+            "invertMatch" : false
+          },
           "structType" : "CommunityList",
           "role" : "dist"
         }

--- a/tests/basic/outliers-verbose.ref
+++ b/tests/basic/outliers-verbose.ref
@@ -15,6 +15,16 @@
           ],
           "hypothesis" : "sameDefinition",
           "name" : "as2_community",
+          "structDefinition" : {
+            "lines" : [
+              {
+                "action" : "ACCEPT",
+                "regex" : "(,|\\{|\\}|^|$| )2:"
+              }
+            ],
+            "name" : "as2_community",
+            "invertMatch" : false
+          },
           "structType" : "CommunityList"
         },
         {
@@ -28,6 +38,16 @@
           ],
           "hypothesis" : "sameDefinition",
           "name" : "as1_community",
+          "structDefinition" : {
+            "lines" : [
+              {
+                "action" : "ACCEPT",
+                "regex" : "(,|\\{|\\}|^|$| )1:"
+              }
+            ],
+            "name" : "as1_community",
+            "invertMatch" : false
+          },
           "structType" : "CommunityList"
         },
         {
@@ -41,6 +61,16 @@
           ],
           "hypothesis" : "sameDefinition",
           "name" : "as3_community",
+          "structDefinition" : {
+            "lines" : [
+              {
+                "action" : "ACCEPT",
+                "regex" : "(,|\\{|\\}|^|$| )3:"
+              }
+            ],
+            "name" : "as3_community",
+            "invertMatch" : false
+          },
           "structType" : "CommunityList"
         },
         {
@@ -54,6 +84,33 @@
           ],
           "hypothesis" : "sameDefinition",
           "name" : "101",
+          "structDefinition" : {
+            "name" : "101",
+            "lines" : [
+              {
+                "action" : "ACCEPT",
+                "dstIps" : [
+                  "255.255.255.0"
+                ],
+                "name" : "permit ip host 1.0.1.0 host 255.255.255.0",
+                "negate" : false,
+                "srcIps" : [
+                  "1.0.1.0"
+                ]
+              },
+              {
+                "action" : "ACCEPT",
+                "dstIps" : [
+                  "255.255.255.0"
+                ],
+                "name" : "permit ip host 1.0.2.0 host 255.255.255.0",
+                "negate" : false,
+                "srcIps" : [
+                  "1.0.2.0"
+                ]
+              }
+            ]
+          },
           "structType" : "IpAccessList"
         },
         {
@@ -67,6 +124,21 @@
           ],
           "hypothesis" : "sameDefinition",
           "name" : "101",
+          "structDefinition" : {
+            "name" : "101",
+            "lines" : [
+              {
+                "action" : "ACCEPT",
+                "lengthRange" : "24-24",
+                "prefix" : "1.0.1.0/24"
+              },
+              {
+                "action" : "ACCEPT",
+                "lengthRange" : "24-24",
+                "prefix" : "1.0.2.0/24"
+              }
+            ]
+          },
           "structType" : "RouteFilterList"
         },
         {
@@ -77,6 +149,55 @@
           ],
           "hypothesis" : "sameDefinition",
           "name" : "105",
+          "structDefinition" : {
+            "name" : "105",
+            "lines" : [
+              {
+                "action" : "ACCEPT",
+                "dstIps" : [
+                  "255.255.255.0"
+                ],
+                "name" : "permit ip host 1.0.1.0 host 255.255.255.0",
+                "negate" : false,
+                "srcIps" : [
+                  "1.0.1.0"
+                ]
+              },
+              {
+                "action" : "ACCEPT",
+                "dstIps" : [
+                  "255.255.255.0"
+                ],
+                "name" : "permit ip host 1.0.2.0 host 255.255.255.0",
+                "negate" : false,
+                "srcIps" : [
+                  "1.0.2.0"
+                ]
+              },
+              {
+                "action" : "ACCEPT",
+                "dstIps" : [
+                  "255.255.255.0"
+                ],
+                "name" : "permit ip host 3.0.1.0 host 255.255.255.0",
+                "negate" : false,
+                "srcIps" : [
+                  "3.0.1.0"
+                ]
+              },
+              {
+                "action" : "ACCEPT",
+                "dstIps" : [
+                  "255.255.255.0"
+                ],
+                "name" : "permit ip host 3.0.2.0 host 255.255.255.0",
+                "negate" : false,
+                "srcIps" : [
+                  "3.0.2.0"
+                ]
+              }
+            ]
+          },
           "structType" : "IpAccessList"
         },
         {
@@ -86,6 +207,16 @@
           ],
           "hypothesis" : "sameDefinition",
           "name" : "dept_community",
+          "structDefinition" : {
+            "lines" : [
+              {
+                "action" : "ACCEPT",
+                "regex" : "(,|\\{|\\}|^|$| )65001:"
+              }
+            ],
+            "name" : "dept_community",
+            "invertMatch" : false
+          },
           "structType" : "CommunityList"
         },
         {
@@ -95,6 +226,16 @@
           ],
           "hypothesis" : "sameDefinition",
           "name" : "filter::FORWARD",
+          "structDefinition" : {
+            "name" : "filter::FORWARD",
+            "lines" : [
+              {
+                "action" : "ACCEPT",
+                "name" : "default",
+                "negate" : false
+              }
+            ]
+          },
           "structType" : "IpAccessList"
         },
         {
@@ -104,6 +245,16 @@
           ],
           "hypothesis" : "sameDefinition",
           "name" : "mangle::FORWARD",
+          "structDefinition" : {
+            "name" : "mangle::FORWARD",
+            "lines" : [
+              {
+                "action" : "ACCEPT",
+                "name" : "default",
+                "negate" : false
+              }
+            ]
+          },
           "structType" : "IpAccessList"
         },
         {
@@ -113,6 +264,16 @@
           ],
           "hypothesis" : "sameDefinition",
           "name" : "mangle::INPUT",
+          "structDefinition" : {
+            "name" : "mangle::INPUT",
+            "lines" : [
+              {
+                "action" : "ACCEPT",
+                "name" : "default",
+                "negate" : false
+              }
+            ]
+          },
           "structType" : "IpAccessList"
         },
         {
@@ -122,6 +283,16 @@
           ],
           "hypothesis" : "sameDefinition",
           "name" : "mangle::OUTPUT",
+          "structDefinition" : {
+            "name" : "mangle::OUTPUT",
+            "lines" : [
+              {
+                "action" : "ACCEPT",
+                "name" : "default",
+                "negate" : false
+              }
+            ]
+          },
           "structType" : "IpAccessList"
         },
         {
@@ -131,6 +302,16 @@
           ],
           "hypothesis" : "sameDefinition",
           "name" : "mangle::POSTROUTING",
+          "structDefinition" : {
+            "name" : "mangle::POSTROUTING",
+            "lines" : [
+              {
+                "action" : "ACCEPT",
+                "name" : "default",
+                "negate" : false
+              }
+            ]
+          },
           "structType" : "IpAccessList"
         },
         {
@@ -140,6 +321,16 @@
           ],
           "hypothesis" : "sameDefinition",
           "name" : "mangle::PREROUTING",
+          "structDefinition" : {
+            "name" : "mangle::PREROUTING",
+            "lines" : [
+              {
+                "action" : "ACCEPT",
+                "name" : "default",
+                "negate" : false
+              }
+            ]
+          },
           "structType" : "IpAccessList"
         },
         {
@@ -149,6 +340,16 @@
           ],
           "hypothesis" : "sameDefinition",
           "name" : "nat::OUTPUT",
+          "structDefinition" : {
+            "name" : "nat::OUTPUT",
+            "lines" : [
+              {
+                "action" : "ACCEPT",
+                "name" : "default",
+                "negate" : false
+              }
+            ]
+          },
           "structType" : "IpAccessList"
         },
         {
@@ -158,6 +359,16 @@
           ],
           "hypothesis" : "sameDefinition",
           "name" : "nat::POSTROUTING",
+          "structDefinition" : {
+            "name" : "nat::POSTROUTING",
+            "lines" : [
+              {
+                "action" : "ACCEPT",
+                "name" : "default",
+                "negate" : false
+              }
+            ]
+          },
           "structType" : "IpAccessList"
         },
         {
@@ -167,6 +378,16 @@
           ],
           "hypothesis" : "sameDefinition",
           "name" : "nat::PREROUTING",
+          "structDefinition" : {
+            "name" : "nat::PREROUTING",
+            "lines" : [
+              {
+                "action" : "ACCEPT",
+                "name" : "default",
+                "negate" : false
+              }
+            ]
+          },
           "structType" : "IpAccessList"
         },
         {
@@ -176,6 +397,31 @@
           ],
           "hypothesis" : "sameDefinition",
           "name" : "105",
+          "structDefinition" : {
+            "name" : "105",
+            "lines" : [
+              {
+                "action" : "ACCEPT",
+                "lengthRange" : "24-24",
+                "prefix" : "1.0.1.0/24"
+              },
+              {
+                "action" : "ACCEPT",
+                "lengthRange" : "24-24",
+                "prefix" : "1.0.2.0/24"
+              },
+              {
+                "action" : "ACCEPT",
+                "lengthRange" : "24-24",
+                "prefix" : "3.0.1.0/24"
+              },
+              {
+                "action" : "ACCEPT",
+                "lengthRange" : "24-24",
+                "prefix" : "3.0.2.0/24"
+              }
+            ]
+          },
           "structType" : "RouteFilterList"
         },
         {
@@ -185,6 +431,16 @@
           ],
           "hypothesis" : "sameDefinition",
           "name" : "default_list",
+          "structDefinition" : {
+            "name" : "default_list",
+            "lines" : [
+              {
+                "action" : "ACCEPT",
+                "lengthRange" : "0-0",
+                "prefix" : "0.0.0.0/0"
+              }
+            ]
+          },
           "structType" : "RouteFilterList"
         },
         {
@@ -194,6 +450,16 @@
           ],
           "hypothesis" : "sameDefinition",
           "name" : "outbound_routes",
+          "structDefinition" : {
+            "name" : "outbound_routes",
+            "lines" : [
+              {
+                "action" : "ACCEPT",
+                "lengthRange" : "16-32",
+                "prefix" : "2.128.0.0/9"
+              }
+            ]
+          },
           "structType" : "RouteFilterList"
         },
         {
@@ -203,6 +469,62 @@
           ],
           "hypothesis" : "sameDefinition",
           "name" : "as2dist_to_dept",
+          "structDefinition" : {
+            "name" : "as2dist_to_dept",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as2dist_to_dept~100~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnLocalDefaultAction"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                    "name" : "105"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                    "metric" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                      "value" : 50
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                    "expr" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.InlineCommunitySet",
+                      "communities" : [
+                        {
+                          "prefix" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySetElemHalf",
+                            "value" : 2
+                          },
+                          "suffix" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySetElemHalf",
+                            "value" : 65001
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
           "structType" : "RoutingPolicy"
         },
         {
@@ -212,6 +534,41 @@
           ],
           "hypothesis" : "sameDefinition",
           "name" : "dept_to_as2dist",
+          "structDefinition" : {
+            "name" : "dept_to_as2dist",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~dept_to_as2dist~100~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnLocalDefaultAction"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchCommunitySet",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedCommunitySet",
+                    "name" : "dept_community"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetLocalPreference",
+                    "localPreference" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralInt",
+                      "value" : 350
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
           "structType" : "RoutingPolicy"
         },
         {
@@ -227,6 +584,33 @@
           "outliers" : [
             "as1border2"
           ],
+          "structDefinition" : {
+            "name" : "103",
+            "lines" : [
+              {
+                "action" : "ACCEPT",
+                "dstIps" : [
+                  "255.255.255.0"
+                ],
+                "name" : "permit ip host 3.0.1.0 host 255.255.255.0",
+                "negate" : false,
+                "srcIps" : [
+                  "3.0.1.0"
+                ]
+              },
+              {
+                "action" : "ACCEPT",
+                "dstIps" : [
+                  "255.255.255.0"
+                ],
+                "name" : "permit ip host 3.0.2.0 host 255.255.255.0",
+                "negate" : false,
+                "srcIps" : [
+                  "3.0.2.0"
+                ]
+              }
+            ]
+          },
           "structType" : "IpAccessList"
         },
         {
@@ -242,6 +626,21 @@
           "outliers" : [
             "as1border2"
           ],
+          "structDefinition" : {
+            "name" : "103",
+            "lines" : [
+              {
+                "action" : "ACCEPT",
+                "lengthRange" : "24-24",
+                "prefix" : "3.0.1.0/24"
+              },
+              {
+                "action" : "ACCEPT",
+                "lengthRange" : "24-24",
+                "prefix" : "3.0.2.0/24"
+              }
+            ]
+          },
           "structType" : "RouteFilterList"
         },
         {
@@ -250,6 +649,16 @@
           ],
           "hypothesis" : "sameDefinition",
           "name" : "as4_community",
+          "structDefinition" : {
+            "lines" : [
+              {
+                "action" : "ACCEPT",
+                "regex" : "(,|\\{|\\}|^|$| )4:"
+              }
+            ],
+            "name" : "as4_community",
+            "invertMatch" : false
+          },
           "structType" : "CommunityList"
         },
         {
@@ -258,6 +667,33 @@
           ],
           "hypothesis" : "sameDefinition",
           "name" : "INSIDE_TO_AS1",
+          "structDefinition" : {
+            "name" : "INSIDE_TO_AS1",
+            "lines" : [
+              {
+                "action" : "ACCEPT",
+                "dstIps" : [
+                  "1.0.0.0/8"
+                ],
+                "name" : "permit ip 2.0.0.0 0.255.255.255 1.0.0.0 0.255.255.255",
+                "negate" : false,
+                "srcIps" : [
+                  "2.0.0.0/8"
+                ]
+              },
+              {
+                "action" : "REJECT",
+                "dstIps" : [
+                  "0.0.0.0/0"
+                ],
+                "name" : "deny   ip any any",
+                "negate" : false,
+                "srcIps" : [
+                  "0.0.0.0/0"
+                ]
+              }
+            ]
+          },
           "structType" : "IpAccessList"
         },
         {
@@ -266,6 +702,33 @@
           ],
           "hypothesis" : "sameDefinition",
           "name" : "INSIDE_TO_AS3",
+          "structDefinition" : {
+            "name" : "INSIDE_TO_AS3",
+            "lines" : [
+              {
+                "action" : "ACCEPT",
+                "dstIps" : [
+                  "3.0.0.0/8"
+                ],
+                "name" : "permit ip 2.0.0.0 0.255.255.255 3.0.0.0 0.255.255.255",
+                "negate" : false,
+                "srcIps" : [
+                  "2.0.0.0/8"
+                ]
+              },
+              {
+                "action" : "REJECT",
+                "dstIps" : [
+                  "0.0.0.0/0"
+                ],
+                "name" : "deny   ip any any",
+                "negate" : false,
+                "srcIps" : [
+                  "0.0.0.0/0"
+                ]
+              }
+            ]
+          },
           "structType" : "IpAccessList"
         },
         {
@@ -274,6 +737,47 @@
           ],
           "hypothesis" : "sameDefinition",
           "name" : "RESTRICT_HOST_TRAFFIC_IN",
+          "structDefinition" : {
+            "name" : "RESTRICT_HOST_TRAFFIC_IN",
+            "lines" : [
+              {
+                "action" : "ACCEPT",
+                "dstIps" : [
+                  "0.0.0.0/0"
+                ],
+                "name" : "permit ip 2.128.0.0 0.0.255.255 any",
+                "negate" : false,
+                "srcIps" : [
+                  "2.128.0.0/16"
+                ]
+              },
+              {
+                "action" : "REJECT",
+                "dstIps" : [
+                  "0.0.0.0/0"
+                ],
+                "name" : "deny   ip any any",
+                "negate" : false,
+                "srcIps" : [
+                  "0.0.0.0/0"
+                ]
+              },
+              {
+                "action" : "ACCEPT",
+                "dstIps" : [
+                  "0.0.0.0/0"
+                ],
+                "ipProtocols" : [
+                  "ICMP"
+                ],
+                "name" : "permit icmp any any",
+                "negate" : false,
+                "srcIps" : [
+                  "0.0.0.0/0"
+                ]
+              }
+            ]
+          },
           "structType" : "IpAccessList"
         },
         {
@@ -282,6 +786,44 @@
           ],
           "hypothesis" : "sameDefinition",
           "name" : "RESTRICT_HOST_TRAFFIC_OUT",
+          "structDefinition" : {
+            "name" : "RESTRICT_HOST_TRAFFIC_OUT",
+            "lines" : [
+              {
+                "action" : "ACCEPT",
+                "dstIps" : [
+                  "2.128.0.0/16"
+                ],
+                "name" : "permit ip any 2.128.0.0 0.0.255.255",
+                "negate" : false,
+                "srcIps" : [
+                  "0.0.0.0/0"
+                ]
+              },
+              {
+                "action" : "REJECT",
+                "dstIps" : [
+                  "2.128.0.0/16"
+                ],
+                "name" : "deny   ip 1.128.0.0 0.0.255.255 2.128.0.0 0.0.255.255",
+                "negate" : false,
+                "srcIps" : [
+                  "1.128.0.0/16"
+                ]
+              },
+              {
+                "action" : "REJECT",
+                "dstIps" : [
+                  "0.0.0.0/0"
+                ],
+                "name" : "deny   ip any any",
+                "negate" : false,
+                "srcIps" : [
+                  "0.0.0.0/0"
+                ]
+              }
+            ]
+          },
           "structType" : "IpAccessList"
         },
         {
@@ -290,6 +832,39 @@
           ],
           "hypothesis" : "sameDefinition",
           "name" : "blocktelnet",
+          "structDefinition" : {
+            "name" : "blocktelnet",
+            "lines" : [
+              {
+                "action" : "REJECT",
+                "dstIps" : [
+                  "0.0.0.0/0"
+                ],
+                "dstPorts" : [
+                  "23-23"
+                ],
+                "ipProtocols" : [
+                  "TCP"
+                ],
+                "name" : "deny   tcp any any eq telnet",
+                "negate" : false,
+                "srcIps" : [
+                  "0.0.0.0/0"
+                ]
+              },
+              {
+                "action" : "ACCEPT",
+                "dstIps" : [
+                  "0.0.0.0/0"
+                ],
+                "name" : "permit ip any any",
+                "negate" : false,
+                "srcIps" : [
+                  "0.0.0.0/0"
+                ]
+              }
+            ]
+          },
           "structType" : "IpAccessList"
         },
         {
@@ -298,6 +873,16 @@
           ],
           "hypothesis" : "sameDefinition",
           "name" : "as4-prefixes",
+          "structDefinition" : {
+            "name" : "as4-prefixes",
+            "lines" : [
+              {
+                "action" : "ACCEPT",
+                "lengthRange" : "8-32",
+                "prefix" : "4.0.0.0/8"
+              }
+            ]
+          },
           "structType" : "RouteFilterList"
         },
         {
@@ -306,6 +891,40 @@
           ],
           "hypothesis" : "sameDefinition",
           "name" : "as1_to_as4",
+          "structDefinition" : {
+            "name" : "as1_to_as4",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                "metric" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                  "value" : 50
+                }
+              },
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                "expr" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.InlineCommunitySet",
+                  "communities" : [
+                    {
+                      "prefix" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySetElemHalf",
+                        "value" : 1
+                      },
+                      "suffix" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySetElemHalf",
+                        "value" : 4
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                "type" : "ReturnTrue"
+              }
+            ]
+          },
           "structType" : "RoutingPolicy"
         },
         {
@@ -314,6 +933,41 @@
           ],
           "hypothesis" : "sameDefinition",
           "name" : "as2_to_dept",
+          "structDefinition" : {
+            "name" : "as2_to_dept",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as2_to_dept~100~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnLocalDefaultAction"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchCommunitySet",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedCommunitySet",
+                    "name" : "as2_community"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetLocalPreference",
+                    "localPreference" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralInt",
+                      "value" : 350
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
           "structType" : "RoutingPolicy"
         },
         {
@@ -322,6 +976,56 @@
           ],
           "hypothesis" : "sameDefinition",
           "name" : "as4_to_as1",
+          "structDefinition" : {
+            "name" : "as4_to_as1",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as4_to_as1~100~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnLocalDefaultAction"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                  "conjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchCommunitySet",
+                      "expr" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.NamedCommunitySet",
+                        "name" : "as4_community"
+                      }
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                      "prefix" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                      },
+                      "prefixSet" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                        "name" : "as4-prefixes"
+                      }
+                    }
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetLocalPreference",
+                    "localPreference" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralInt",
+                      "value" : 350
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
           "structType" : "RoutingPolicy"
         },
         {
@@ -330,6 +1034,62 @@
           ],
           "hypothesis" : "sameDefinition",
           "name" : "dept_to_as2",
+          "structDefinition" : {
+            "name" : "dept_to_as2",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~dept_to_as2~100~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnLocalDefaultAction"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                    "name" : "102"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                    "metric" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                      "value" : 50
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                    "expr" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.InlineCommunitySet",
+                      "communities" : [
+                        {
+                          "prefix" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySetElemHalf",
+                            "value" : 65001
+                          },
+                          "suffix" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySetElemHalf",
+                            "value" : 2
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
           "structType" : "RoutingPolicy"
         },
         {
@@ -344,6 +1104,21 @@
           "outliers" : [
             "as2dept1"
           ],
+          "structDefinition" : {
+            "name" : "102",
+            "lines" : [
+              {
+                "action" : "ACCEPT",
+                "lengthRange" : "8-8",
+                "prefix" : "2.0.0.0/8"
+              },
+              {
+                "action" : "ACCEPT",
+                "lengthRange" : "16-16",
+                "prefix" : "2.128.0.0/16"
+              }
+            ]
+          },
           "structType" : "RouteFilterList"
         },
         {
@@ -355,6 +1130,38 @@
           "outliers" : [
             "host2"
           ],
+          "structDefinition" : {
+            "name" : "eth0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.128.0.101/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "eth0"
+            ],
+            "incomingFilter" : "filter::INPUT",
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "outgoingFilter" : "filter::OUTPUT",
+            "prefix" : "2.128.0.101/24",
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
           "structType" : "Interface"
         },
         {
@@ -366,6 +1173,44 @@
           "outliers" : [
             "as2border2"
           ],
+          "structDefinition" : {
+            "name" : "OUTSIDE_TO_INSIDE",
+            "lines" : [
+              {
+                "action" : "REJECT",
+                "dstIps" : [
+                  "0.0.0.0/0"
+                ],
+                "name" : "deny   ip 2.0.0.0 0.255.255.255 any",
+                "negate" : false,
+                "srcIps" : [
+                  "2.0.0.0/8"
+                ]
+              },
+              {
+                "action" : "REJECT",
+                "dstIps" : [
+                  "2.128.1.101"
+                ],
+                "name" : "deny   ip any host 2.128.1.101",
+                "negate" : false,
+                "srcIps" : [
+                  "0.0.0.0/0"
+                ]
+              },
+              {
+                "action" : "ACCEPT",
+                "dstIps" : [
+                  "0.0.0.0/0"
+                ],
+                "name" : "permit ip any any",
+                "negate" : false,
+                "srcIps" : [
+                  "0.0.0.0/0"
+                ]
+              }
+            ]
+          },
           "structType" : "IpAccessList"
         },
         {
@@ -377,6 +1222,38 @@
           "outliers" : [
             "host2"
           ],
+          "structDefinition" : {
+            "name" : "filter::INPUT",
+            "lines" : [
+              {
+                "action" : "ACCEPT",
+                "dstPorts" : [
+                  "53-53"
+                ],
+                "ipProtocols" : [
+                  "UDP"
+                ],
+                "name" : "-p udp --dport 53 -j ACCEPT",
+                "negate" : false
+              },
+              {
+                "action" : "ACCEPT",
+                "dstPorts" : [
+                  "22-22"
+                ],
+                "ipProtocols" : [
+                  "TCP"
+                ],
+                "name" : "-p tcp --dport 22 -j ACCEPT",
+                "negate" : false
+              },
+              {
+                "action" : "REJECT",
+                "name" : "default",
+                "negate" : false
+              }
+            ]
+          },
           "structType" : "IpAccessList"
         },
         {
@@ -388,6 +1265,16 @@
           "outliers" : [
             "host2"
           ],
+          "structDefinition" : {
+            "name" : "filter::OUTPUT",
+            "lines" : [
+              {
+                "action" : "ACCEPT",
+                "name" : "default",
+                "negate" : false
+              }
+            ]
+          },
           "structType" : "IpAccessList"
         },
         {
@@ -404,6 +1291,33 @@
             "as2dist1",
             "as2dist2"
           ],
+          "structDefinition" : {
+            "name" : "102",
+            "lines" : [
+              {
+                "action" : "ACCEPT",
+                "dstIps" : [
+                  "255.0.0.0"
+                ],
+                "name" : "permit ip host 2.0.0.0 host 255.0.0.0",
+                "negate" : false,
+                "srcIps" : [
+                  "2.0.0.0"
+                ]
+              },
+              {
+                "action" : "ACCEPT",
+                "dstIps" : [
+                  "255.255.0.0"
+                ],
+                "name" : "permit ip host 2.128.0.0 host 255.255.0.0",
+                "negate" : false,
+                "srcIps" : [
+                  "2.128.0.0"
+                ]
+              }
+            ]
+          },
           "structType" : "IpAccessList"
         },
         {
@@ -417,6 +1331,59 @@
             "as1border1",
             "as1border2"
           ],
+          "structDefinition" : {
+            "name" : "as1_to_as2",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as1_to_as2~100~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnLocalDefaultAction"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchCommunitySet",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedCommunitySet",
+                    "name" : "as1_community"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetLocalPreference",
+                    "localPreference" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralInt",
+                      "value" : 350
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                    "expr" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.InlineCommunitySet",
+                      "communities" : [
+                        {
+                          "prefix" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySetElemHalf",
+                            "value" : 1
+                          },
+                          "suffix" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySetElemHalf",
+                            "value" : 2
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
           "structType" : "RoutingPolicy"
         },
         {
@@ -430,6 +1397,109 @@
             "as3border1",
             "as3border2"
           ],
+          "structDefinition" : {
+            "name" : "as1_to_as3",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as1_to_as3~1~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                    "comment" : "~RMCLAUSE~as1_to_as3~2~",
+                    "falseStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                        "type" : "ReturnLocalDefaultAction"
+                      }
+                    ],
+                    "guard" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                      "prefix" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                      },
+                      "prefixSet" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                        "name" : "102"
+                      }
+                    },
+                    "trueStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                        "metric" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                          "value" : 50
+                        }
+                      },
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                        "expr" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.InlineCommunitySet",
+                          "communities" : [
+                            {
+                              "prefix" : {
+                                "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySetElemHalf",
+                                "value" : 1
+                              },
+                              "suffix" : {
+                                "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySetElemHalf",
+                                "value" : 3
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                        "type" : "ReturnTrue"
+                      }
+                    ]
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                    "name" : "101"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                    "metric" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                      "value" : 50
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                    "expr" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.InlineCommunitySet",
+                      "communities" : [
+                        {
+                          "prefix" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySetElemHalf",
+                            "value" : 1
+                          },
+                          "suffix" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySetElemHalf",
+                            "value" : 3
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
           "structType" : "RoutingPolicy"
         },
         {
@@ -443,6 +1513,41 @@
             "as2border1",
             "as2border2"
           ],
+          "structDefinition" : {
+            "name" : "as2_to_as1",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as2_to_as1~100~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnLocalDefaultAction"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchCommunitySet",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedCommunitySet",
+                    "name" : "as2_community"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetLocalPreference",
+                    "localPreference" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralInt",
+                      "value" : 350
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
           "structType" : "RoutingPolicy"
         },
         {
@@ -456,6 +1561,109 @@
             "as3border1",
             "as3border2"
           ],
+          "structDefinition" : {
+            "name" : "as2_to_as3",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as2_to_as3~1~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                    "comment" : "~RMCLAUSE~as2_to_as3~2~",
+                    "falseStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                        "type" : "ReturnLocalDefaultAction"
+                      }
+                    ],
+                    "guard" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                      "prefix" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                      },
+                      "prefixSet" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                        "name" : "outbound_routes"
+                      }
+                    },
+                    "trueStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                        "metric" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                          "value" : 50
+                        }
+                      },
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                        "expr" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.InlineCommunitySet",
+                          "communities" : [
+                            {
+                              "prefix" : {
+                                "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySetElemHalf",
+                                "value" : 2
+                              },
+                              "suffix" : {
+                                "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySetElemHalf",
+                                "value" : 3
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                        "type" : "ReturnTrue"
+                      }
+                    ]
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                    "name" : "101"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                    "metric" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                      "value" : 50
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                    "expr" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.InlineCommunitySet",
+                      "communities" : [
+                        {
+                          "prefix" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySetElemHalf",
+                            "value" : 2
+                          },
+                          "suffix" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySetElemHalf",
+                            "value" : 3
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
           "structType" : "RoutingPolicy"
         },
         {
@@ -469,6 +1677,41 @@
             "as3border1",
             "as3border2"
           ],
+          "structDefinition" : {
+            "name" : "as3_to_as1",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as3_to_as1~100~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnLocalDefaultAction"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchCommunitySet",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedCommunitySet",
+                    "name" : "as3_community"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetLocalPreference",
+                    "localPreference" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralInt",
+                      "value" : 350
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
           "structType" : "RoutingPolicy"
         },
         {
@@ -482,6 +1725,59 @@
             "as3border1",
             "as3border2"
           ],
+          "structDefinition" : {
+            "name" : "as3_to_as2",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as3_to_as2~100~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnLocalDefaultAction"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchCommunitySet",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedCommunitySet",
+                    "name" : "as3_community"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetLocalPreference",
+                    "localPreference" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralInt",
+                      "value" : 350
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                    "expr" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.InlineCommunitySet",
+                      "communities" : [
+                        {
+                          "prefix" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySetElemHalf",
+                            "value" : 3
+                          },
+                          "suffix" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySetElemHalf",
+                            "value" : 2
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
           "structType" : "RoutingPolicy"
         },
         {
@@ -497,6 +1793,21 @@
             "as3border1",
             "as3border2"
           ],
+          "structDefinition" : {
+            "name" : "inbound_route_filter",
+            "lines" : [
+              {
+                "action" : "REJECT",
+                "lengthRange" : "8-32",
+                "prefix" : "1.0.0.0/8"
+              },
+              {
+                "action" : "ACCEPT",
+                "lengthRange" : "0-32",
+                "prefix" : "0.0.0.0/0"
+              }
+            ]
+          },
           "structType" : "RouteFilterList"
         },
         {
@@ -510,6 +1821,40 @@
             "as2dept1",
             "as3core1"
           ],
+          "structDefinition" : {
+            "name" : "GigabitEthernet3/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.12.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet3/0"
+            ],
+            "incomingFilter" : "blocktelnet",
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.12.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
           "structType" : "Interface"
         },
         {
@@ -528,6 +1873,37 @@
             "as2dist2",
             "as3core1"
           ],
+          "structDefinition" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "10.14.22.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "10.14.22.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
           "structType" : "Interface"
         },
         {
@@ -550,6 +1926,39 @@
             "as3border2",
             "as3core1"
           ],
+          "structDefinition" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "1.0.1.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "1.0.1.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
           "structType" : "Interface"
         },
         {
@@ -572,6 +1981,37 @@
             "as3border2",
             "as3core1"
           ],
+          "structDefinition" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "10.12.11.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "10.12.11.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
           "structType" : "Interface"
         },
         {
@@ -594,6 +2034,39 @@
             "as3border2",
             "as3core1"
           ],
+          "structDefinition" : {
+            "name" : "Loopback0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "1.1.1.1/32"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E12,
+            "declaredNames" : [
+              "Loopback0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : true,
+            "ospfPointToPoint" : false,
+            "prefix" : "1.1.1.1/32",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "LOOPBACK",
+            "vrf" : "default"
+          },
           "structType" : "Interface"
         },
         {
@@ -618,6 +2091,139 @@
             "host1",
             "host2"
           ],
+          "structDefinition" : {
+            "name" : "default",
+            "bgpProcess" : {
+              "multipathEbgp" : true,
+              "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
+              "multipathIbgp" : true,
+              "neighbors" : {
+                "1.10.1.1/32" : {
+                  "name" : "1.10.1.1/32",
+                  "additionalPathsReceive" : true,
+                  "additionalPathsSelectAll" : true,
+                  "additionalPathsSend" : true,
+                  "address" : "1.10.1.1",
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : false,
+                  "allowRemoteAsOut" : false,
+                  "clusterId" : 16843009,
+                  "defaultMetric" : 0,
+                  "dynamic" : false,
+                  "ebgpMultihop" : false,
+                  "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:1.10.1.1~",
+                  "group" : "as1",
+                  "localAs" : 1,
+                  "localIp" : "1.1.1.1",
+                  "remoteAs" : 1,
+                  "remotePrefix" : "1.10.1.1/32",
+                  "routeReflectorClient" : false,
+                  "sendCommunity" : true,
+                  "vrf" : "default"
+                },
+                "3.2.2.2/32" : {
+                  "name" : "3.2.2.2/32",
+                  "additionalPathsReceive" : true,
+                  "additionalPathsSelectAll" : true,
+                  "additionalPathsSend" : true,
+                  "address" : "3.2.2.2",
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : false,
+                  "allowRemoteAsOut" : false,
+                  "clusterId" : 16843009,
+                  "defaultMetric" : 0,
+                  "dynamic" : false,
+                  "ebgpMultihop" : false,
+                  "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:3.2.2.2~",
+                  "group" : "bad-ebgp",
+                  "localAs" : 1,
+                  "remoteAs" : 666,
+                  "remotePrefix" : "3.2.2.2/32",
+                  "routeReflectorClient" : false,
+                  "sendCommunity" : false,
+                  "vrf" : "default"
+                },
+                "5.6.7.8/32" : {
+                  "name" : "5.6.7.8/32",
+                  "additionalPathsReceive" : true,
+                  "additionalPathsSelectAll" : true,
+                  "additionalPathsSend" : true,
+                  "address" : "5.6.7.8",
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : false,
+                  "allowRemoteAsOut" : false,
+                  "clusterId" : 16843009,
+                  "defaultMetric" : 0,
+                  "dynamic" : false,
+                  "ebgpMultihop" : false,
+                  "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:5.6.7.8~",
+                  "group" : "xanadu",
+                  "localAs" : 1,
+                  "remoteAs" : 555,
+                  "remotePrefix" : "5.6.7.8/32",
+                  "routeReflectorClient" : false,
+                  "sendCommunity" : false,
+                  "vrf" : "default"
+                },
+                "10.12.11.2/32" : {
+                  "name" : "10.12.11.2/32",
+                  "additionalPathsReceive" : true,
+                  "additionalPathsSelectAll" : true,
+                  "additionalPathsSend" : true,
+                  "address" : "10.12.11.2",
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : false,
+                  "allowRemoteAsOut" : false,
+                  "clusterId" : 16843009,
+                  "defaultMetric" : 0,
+                  "dynamic" : false,
+                  "ebgpMultihop" : false,
+                  "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.12.11.2~",
+                  "exportPolicySources" : [
+                    "as1_to_as2"
+                  ],
+                  "group" : "as2",
+                  "importPolicy" : "as2_to_as1",
+                  "importPolicySources" : [
+                    "as2_to_as1"
+                  ],
+                  "localAs" : 1,
+                  "localIp" : "10.12.11.1",
+                  "remoteAs" : 2,
+                  "remotePrefix" : "10.12.11.2/32",
+                  "routeReflectorClient" : false,
+                  "sendCommunity" : true,
+                  "vrf" : "default"
+                }
+              },
+              "routerId" : "1.1.1.1",
+              "tieBreaker" : "ARRIVAL_ORDER"
+            },
+            "interfaces" : [
+              "Ethernet0/0",
+              "GigabitEthernet0/0",
+              "GigabitEthernet1/0",
+              "Loopback0"
+            ],
+            "ospfProcess" : {
+              "areas" : {
+                "1" : {
+                  "name" : 1,
+                  "interfaces" : [
+                    "GigabitEthernet0/0",
+                    "Loopback0"
+                  ]
+                }
+              },
+              "exportPolicy" : "~OSPF_EXPORT_POLICY:default~",
+              "referenceBandwidth" : 1.0E8,
+              "routerId" : "1.1.1.1"
+            }
+          },
           "structType" : "Vrf"
         }
       ]

--- a/tests/basic/outliers.ref
+++ b/tests/basic/outliers.ref
@@ -16,6 +16,33 @@
           "outliers" : [
             "as1border2"
           ],
+          "structDefinition" : {
+            "name" : "103",
+            "lines" : [
+              {
+                "action" : "ACCEPT",
+                "dstIps" : [
+                  "255.255.255.0"
+                ],
+                "name" : "permit ip host 3.0.1.0 host 255.255.255.0",
+                "negate" : false,
+                "srcIps" : [
+                  "3.0.1.0"
+                ]
+              },
+              {
+                "action" : "ACCEPT",
+                "dstIps" : [
+                  "255.255.255.0"
+                ],
+                "name" : "permit ip host 3.0.2.0 host 255.255.255.0",
+                "negate" : false,
+                "srcIps" : [
+                  "3.0.2.0"
+                ]
+              }
+            ]
+          },
           "structType" : "IpAccessList"
         },
         {
@@ -31,6 +58,21 @@
           "outliers" : [
             "as1border2"
           ],
+          "structDefinition" : {
+            "name" : "103",
+            "lines" : [
+              {
+                "action" : "ACCEPT",
+                "lengthRange" : "24-24",
+                "prefix" : "3.0.1.0/24"
+              },
+              {
+                "action" : "ACCEPT",
+                "lengthRange" : "24-24",
+                "prefix" : "3.0.2.0/24"
+              }
+            ]
+          },
           "structType" : "RouteFilterList"
         },
         {
@@ -45,6 +87,21 @@
           "outliers" : [
             "as2dept1"
           ],
+          "structDefinition" : {
+            "name" : "102",
+            "lines" : [
+              {
+                "action" : "ACCEPT",
+                "lengthRange" : "8-8",
+                "prefix" : "2.0.0.0/8"
+              },
+              {
+                "action" : "ACCEPT",
+                "lengthRange" : "16-16",
+                "prefix" : "2.128.0.0/16"
+              }
+            ]
+          },
           "structType" : "RouteFilterList"
         }
       ]
@@ -54,7 +111,8 @@
     "class" : "org.batfish.question.OutliersQuestionPlugin$OutliersQuestion",
     "differential" : false,
     "hypothesis" : "sameDefinition",
-    "nodeRegex" : ".*"
+    "nodeRegex" : ".*",
+    "verbose" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/basic/outliers2.ref
+++ b/tests/basic/outliers2.ref
@@ -25,6 +25,39 @@
             "host1",
             "host2"
           ],
+          "structDefinition" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "1.0.1.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "1.0.1.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
           "structType" : "Interface"
         },
         {
@@ -49,6 +82,37 @@
             "host1",
             "host2"
           ],
+          "structDefinition" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "10.12.11.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "10.12.11.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
           "structType" : "Interface"
         },
         {
@@ -73,6 +137,39 @@
             "host1",
             "host2"
           ],
+          "structDefinition" : {
+            "name" : "Loopback0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "1.1.1.1/32"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E12,
+            "declaredNames" : [
+              "Loopback0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : true,
+            "ospfPointToPoint" : false,
+            "prefix" : "1.1.1.1/32",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "LOOPBACK",
+            "vrf" : "default"
+          },
           "structType" : "Interface"
         }
       ]
@@ -82,7 +179,8 @@
     "class" : "org.batfish.question.OutliersQuestionPlugin$OutliersQuestion",
     "differential" : false,
     "hypothesis" : "sameName",
-    "nodeRegex" : ".*"
+    "nodeRegex" : ".*",
+    "verbose" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/basic/outliers3.ref
+++ b/tests/basic/outliers3.ref
@@ -1,60 +1,15 @@
 {
   "answerElements" : [
     {
-      "class" : "org.batfish.question.OutliersQuestionPlugin$OutliersAnswerElement",
-      "serverOutliers" : [
-        {
-          "conformers" : [
-            "as1border1",
-            "as1border2",
-            "as2border1",
-            "as2border2",
-            "as2dept1",
-            "as2dist1",
-            "as2dist2",
-            "as3border1",
-            "as3border2",
-            "host1",
-            "host2"
-          ],
-          "name" : "LoggingServers",
-          "outliers" : [
-            "as1core1",
-            "as2core1",
-            "as2core2",
-            "as3core1"
-          ]
-        },
-        {
-          "conformers" : [
-            "as1border1",
-            "as1core1",
-            "as2core1",
-            "as2core2",
-            "as2dept1",
-            "as2dist1",
-            "as2dist2",
-            "as3core1",
-            "host1",
-            "host2"
-          ],
-          "name" : "NtpServers",
-          "outliers" : [
-            "as1border2",
-            "as2border1",
-            "as2border2",
-            "as3border1",
-            "as3border2"
-          ]
-        }
-      ]
+      "class" : "org.batfish.question.OutliersQuestionPlugin$OutliersAnswerElement"
     }
   ],
   "question" : {
     "class" : "org.batfish.question.OutliersQuestionPlugin$OutliersQuestion",
     "differential" : false,
     "hypothesis" : "sameServers",
-    "nodeRegex" : ".*"
+    "nodeRegex" : ".*",
+    "verbose" : false
   },
   "status" : "SUCCESS",
   "summary" : {

--- a/tests/basic/perRoleOutliers.ref
+++ b/tests/basic/perRoleOutliers.ref
@@ -14,6 +14,40 @@
           "outliers" : [
             "as1core1"
           ],
+          "structDefinition" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.11.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "incomingFilter" : "blocktelnet",
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.11.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
           "structType" : "Interface",
           "role" : "core"
         },
@@ -28,6 +62,40 @@
           "outliers" : [
             "as1core1"
           ],
+          "structDefinition" : {
+            "name" : "GigabitEthernet3/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.12.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet3/0"
+            ],
+            "incomingFilter" : "blocktelnet",
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.12.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
           "structType" : "Interface",
           "role" : "core"
         },
@@ -44,6 +112,33 @@
             "as2border1",
             "as2border2"
           ],
+          "structDefinition" : {
+            "name" : "102",
+            "lines" : [
+              {
+                "action" : "ACCEPT",
+                "dstIps" : [
+                  "255.0.0.0"
+                ],
+                "name" : "permit ip host 2.0.0.0 host 255.0.0.0",
+                "negate" : false,
+                "srcIps" : [
+                  "2.0.0.0"
+                ]
+              },
+              {
+                "action" : "ACCEPT",
+                "dstIps" : [
+                  "255.255.0.0"
+                ],
+                "name" : "permit ip host 2.128.0.0 host 255.255.0.0",
+                "negate" : false,
+                "srcIps" : [
+                  "2.128.0.0"
+                ]
+              }
+            ]
+          },
           "structType" : "IpAccessList",
           "role" : "border"
         },
@@ -60,6 +155,21 @@
             "as2border1",
             "as2border2"
           ],
+          "structDefinition" : {
+            "name" : "102",
+            "lines" : [
+              {
+                "action" : "ACCEPT",
+                "lengthRange" : "8-8",
+                "prefix" : "2.0.0.0/8"
+              },
+              {
+                "action" : "ACCEPT",
+                "lengthRange" : "16-16",
+                "prefix" : "2.128.0.0/16"
+              }
+            ]
+          },
           "structType" : "RouteFilterList",
           "role" : "border"
         },
@@ -76,6 +186,156 @@
             "as3border1",
             "as3border2"
           ],
+          "structDefinition" : {
+            "name" : "as1_to_as2",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as1_to_as2~1~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                    "comment" : "~RMCLAUSE~as1_to_as2~3~",
+                    "falseStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                        "comment" : "~RMCLAUSE~as1_to_as2~5~",
+                        "falseStatements" : [
+                          {
+                            "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                            "type" : "ReturnLocalDefaultAction"
+                          }
+                        ],
+                        "guard" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                          "prefix" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                          },
+                          "prefixSet" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                            "name" : "default_list"
+                          }
+                        },
+                        "trueStatements" : [
+                          {
+                            "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                            "metric" : {
+                              "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                              "value" : 50
+                            }
+                          },
+                          {
+                            "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                            "expr" : {
+                              "class" : "org.batfish.datamodel.routing_policy.expr.InlineCommunitySet",
+                              "communities" : [
+                                {
+                                  "prefix" : {
+                                    "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySetElemHalf",
+                                    "value" : 1
+                                  },
+                                  "suffix" : {
+                                    "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySetElemHalf",
+                                    "value" : 2
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                            "type" : "ReturnTrue"
+                          }
+                        ]
+                      }
+                    ],
+                    "guard" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                      "prefix" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                      },
+                      "prefixSet" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                        "name" : "103"
+                      }
+                    },
+                    "trueStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                        "metric" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                          "value" : 50
+                        }
+                      },
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                        "expr" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.InlineCommunitySet",
+                          "communities" : [
+                            {
+                              "prefix" : {
+                                "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySetElemHalf",
+                                "value" : 1
+                              },
+                              "suffix" : {
+                                "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySetElemHalf",
+                                "value" : 2
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                        "type" : "ReturnTrue"
+                      }
+                    ]
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                    "name" : "101"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                    "metric" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                      "value" : 50
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                    "expr" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.InlineCommunitySet",
+                      "communities" : [
+                        {
+                          "prefix" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySetElemHalf",
+                            "value" : 1
+                          },
+                          "suffix" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySetElemHalf",
+                            "value" : 2
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
           "structType" : "RoutingPolicy",
           "role" : "border"
         },
@@ -92,6 +352,109 @@
             "as2border1",
             "as2border2"
           ],
+          "structDefinition" : {
+            "name" : "as1_to_as3",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as1_to_as3~1~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                    "comment" : "~RMCLAUSE~as1_to_as3~2~",
+                    "falseStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                        "type" : "ReturnLocalDefaultAction"
+                      }
+                    ],
+                    "guard" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                      "prefix" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                      },
+                      "prefixSet" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                        "name" : "102"
+                      }
+                    },
+                    "trueStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                        "metric" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                          "value" : 50
+                        }
+                      },
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                        "expr" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.InlineCommunitySet",
+                          "communities" : [
+                            {
+                              "prefix" : {
+                                "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySetElemHalf",
+                                "value" : 1
+                              },
+                              "suffix" : {
+                                "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySetElemHalf",
+                                "value" : 3
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                        "type" : "ReturnTrue"
+                      }
+                    ]
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                    "name" : "101"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                    "metric" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                      "value" : 50
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                    "expr" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.InlineCommunitySet",
+                      "communities" : [
+                        {
+                          "prefix" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySetElemHalf",
+                            "value" : 1
+                          },
+                          "suffix" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySetElemHalf",
+                            "value" : 3
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
           "structType" : "RoutingPolicy",
           "role" : "border"
         },
@@ -108,6 +471,41 @@
             "as3border1",
             "as3border2"
           ],
+          "structDefinition" : {
+            "name" : "as2_to_as1",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as2_to_as1~100~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnLocalDefaultAction"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchCommunitySet",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedCommunitySet",
+                    "name" : "as2_community"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetLocalPreference",
+                    "localPreference" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralInt",
+                      "value" : 350
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
           "structType" : "RoutingPolicy",
           "role" : "border"
         },
@@ -124,6 +522,109 @@
             "as1border1",
             "as1border2"
           ],
+          "structDefinition" : {
+            "name" : "as2_to_as3",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as2_to_as3~1~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                    "comment" : "~RMCLAUSE~as2_to_as3~2~",
+                    "falseStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                        "type" : "ReturnLocalDefaultAction"
+                      }
+                    ],
+                    "guard" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                      "prefix" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                      },
+                      "prefixSet" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                        "name" : "outbound_routes"
+                      }
+                    },
+                    "trueStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                        "metric" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                          "value" : 50
+                        }
+                      },
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                        "expr" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.InlineCommunitySet",
+                          "communities" : [
+                            {
+                              "prefix" : {
+                                "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySetElemHalf",
+                                "value" : 2
+                              },
+                              "suffix" : {
+                                "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySetElemHalf",
+                                "value" : 3
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                        "type" : "ReturnTrue"
+                      }
+                    ]
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                    "name" : "101"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                    "metric" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                      "value" : 50
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                    "expr" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.InlineCommunitySet",
+                      "communities" : [
+                        {
+                          "prefix" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySetElemHalf",
+                            "value" : 2
+                          },
+                          "suffix" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySetElemHalf",
+                            "value" : 3
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
           "structType" : "RoutingPolicy",
           "role" : "border"
         },
@@ -140,6 +641,41 @@
             "as2border1",
             "as2border2"
           ],
+          "structDefinition" : {
+            "name" : "as3_to_as1",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as3_to_as1~100~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnLocalDefaultAction"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchCommunitySet",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedCommunitySet",
+                    "name" : "as3_community"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetLocalPreference",
+                    "localPreference" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralInt",
+                      "value" : 350
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
           "structType" : "RoutingPolicy",
           "role" : "border"
         },
@@ -156,6 +692,59 @@
             "as1border1",
             "as1border2"
           ],
+          "structDefinition" : {
+            "name" : "as3_to_as2",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as3_to_as2~100~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnLocalDefaultAction"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchCommunitySet",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedCommunitySet",
+                    "name" : "as3_community"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetLocalPreference",
+                    "localPreference" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralInt",
+                      "value" : 350
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                    "expr" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.InlineCommunitySet",
+                      "communities" : [
+                        {
+                          "prefix" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySetElemHalf",
+                            "value" : 3
+                          },
+                          "suffix" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySetElemHalf",
+                            "value" : 2
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
           "structType" : "RoutingPolicy",
           "role" : "border"
         }


### PR DESCRIPTION
Fixes a bug that caused pretty printing to differ across different clients.

And a few other changes:
- lower threshold for inferring policies
- remove outliers about server sets that should not exist, as they seem likely to be false positives
- add Jackson annotations so that IRoleConsistencyQuestions can be deserialized


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/893)
<!-- Reviewable:end -->
