### PR TITLE
Use output stream when writing task log files

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
@@ -10,10 +10,12 @@ import io.opentracing.contrib.jaxrs2.client.ClientTracingFeature;
 import io.opentracing.util.GlobalTracer;
 import java.io.BufferedReader;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
@@ -972,8 +974,11 @@ public class CommonUtil {
   }
 
   public static void writeFile(Path outputPath, String output) {
-    try {
-      Files.write(outputPath, output.getBytes(StandardCharsets.UTF_8));
+    try (FileOutputStream fs = new FileOutputStream(outputPath.toFile());
+        OutputStreamWriter os = new OutputStreamWriter(fs, StandardCharsets.UTF_8)) {
+      os.write(output);
+    } catch (FileNotFoundException e) {
+      throw new BatfishException("Failed to write file (file not found): " + outputPath, e);
     } catch (IOException e) {
       throw new BatfishException("Failed to write file: " + outputPath, e);
     }


### PR DESCRIPTION
Currently workers can crash when logging very large answer strings, because we are doing an in-memory utf-8 encoding.

This fixes the crash by switching the encoding to be done using streams

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/895)
<!-- Reviewable:end -->
