### PR TITLE
Moved signal handling from worker to client

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/main/Driver.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Driver.java
@@ -70,8 +70,6 @@ import org.codehaus.jettison.json.JSONArray;
 import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory;
 import org.glassfish.jersey.jettison.JettisonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
-import sun.misc.Signal;
-import sun.misc.SignalHandler;
 
 @SuppressWarnings("restriction")
 public class Driver {
@@ -415,14 +413,7 @@ public class Driver {
     if (_mainSettings.getTracingEnable() && !GlobalTracer.isRegistered()) {
       initTracer();
     }
-    SignalHandler handler =
-        new SignalHandler() {
-          @Override
-          public void handle(Signal signal) {
-            _mainLogger.debugf("WorkService: Ignoring signal: %s\n", signal);
-          }
-        };
-    Signal.handle(new Signal("INT"), handler);
+
     String protocol = _mainSettings.getSslDisable() ? "http" : "https";
     String baseUrl = String.format("%s://%s", protocol, _mainSettings.getServiceBindHost());
     URI baseUri = UriBuilder.fromUri(baseUrl).port(_mainSettings.getServicePort()).build();


### PR DESCRIPTION
Moved `sigint` handling from the worker to the client. 
I believe this more closely matches the expected `ctrl+c` behavior: if the mode is interactive (or client only): the signal is ignored and request to kill work is sent.

If the mode is coordinator or worker, the interrupt will kill the process.
Tested locally with intellij.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/896)
<!-- Reviewable:end -->
