### PR TITLE
handing queue failure status separately from abnormal termination

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
@@ -13,6 +13,7 @@ public class BfConsts {
     TerminatedAbnormally,
     TerminatedByUser,
     TerminatedNormally,
+    TerminatedQueueFail,
     Unknown,
     UnreachableOrBadResponse,
     Unscheduled;
@@ -20,7 +21,8 @@ public class BfConsts {
     public boolean isTerminated() {
       return (this == TaskStatus.TerminatedAbnormally
           || this == TaskStatus.TerminatedByUser
-          || this == TaskStatus.TerminatedNormally);
+          || this == TaskStatus.TerminatedNormally
+          || this == TaskStatus.TerminatedQueueFail);
     }
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
@@ -10,10 +10,10 @@ public class BfConsts {
 
   public enum TaskStatus {
     InProgress,
+    RequeueFailure,
     TerminatedAbnormally,
     TerminatedByUser,
     TerminatedNormally,
-    TerminatedQueueFail,
     Unknown,
     UnreachableOrBadResponse,
     Unscheduled;
@@ -22,7 +22,7 @@ public class BfConsts {
       return (this == TaskStatus.TerminatedAbnormally
           || this == TaskStatus.TerminatedByUser
           || this == TaskStatus.TerminatedNormally
-          || this == TaskStatus.TerminatedQueueFail);
+          || this == TaskStatus.RequeueFailure);
     }
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/CoordConsts.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/CoordConsts.java
@@ -16,6 +16,7 @@ public class CoordConsts {
     TERMINATEDABNORMALLY,
     TERMINATEDBYUSER,
     TERMINATEDNORMALLY,
+    TERMINATEDQUEUEFAIL,
     TRYINGTOASSIGN,
     UNASSIGNED;
 
@@ -27,6 +28,8 @@ public class CoordConsts {
           return TERMINATEDBYUSER;
         case TerminatedNormally:
           return TERMINATEDNORMALLY;
+        case TerminatedQueueFail:
+          return TERMINATEDQUEUEFAIL;
         default:
           throw new IllegalArgumentException(
               "Cannot convert from " + status + " to WorkStatusCode");
@@ -37,7 +40,8 @@ public class CoordConsts {
       return (this == ASSIGNMENTERROR // because we don't attempt assignment of this work
           || this == WorkStatusCode.TERMINATEDABNORMALLY
           || this == WorkStatusCode.TERMINATEDBYUSER
-          || this == WorkStatusCode.TERMINATEDNORMALLY);
+          || this == WorkStatusCode.TERMINATEDNORMALLY
+          || this == WorkStatusCode.TERMINATEDQUEUEFAIL);
     }
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/CoordConsts.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/CoordConsts.java
@@ -13,10 +13,10 @@ public class CoordConsts {
     ASSIGNMENTERROR,
     BLOCKED,
     CHECKINGSTATUS,
+    REQUEUEFAILURE,
     TERMINATEDABNORMALLY,
     TERMINATEDBYUSER,
     TERMINATEDNORMALLY,
-    TERMINATEDQUEUEFAIL,
     TRYINGTOASSIGN,
     UNASSIGNED;
 
@@ -28,8 +28,8 @@ public class CoordConsts {
           return TERMINATEDBYUSER;
         case TerminatedNormally:
           return TERMINATEDNORMALLY;
-        case TerminatedQueueFail:
-          return TERMINATEDQUEUEFAIL;
+        case RequeueFailure:
+          return REQUEUEFAILURE;
         default:
           throw new IllegalArgumentException(
               "Cannot convert from " + status + " to WorkStatusCode");
@@ -41,7 +41,7 @@ public class CoordConsts {
           || this == WorkStatusCode.TERMINATEDABNORMALLY
           || this == WorkStatusCode.TERMINATEDBYUSER
           || this == WorkStatusCode.TERMINATEDNORMALLY
-          || this == WorkStatusCode.TERMINATEDQUEUEFAIL);
+          || this == WorkStatusCode.REQUEUEFAILURE);
     }
   }
 

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkQueueMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkQueueMgr.java
@@ -599,16 +599,7 @@ public class WorkQueueMgr {
 
     QueuedWork blocker = getBlockerForDataplaningWork(work);
     if (blocker == null) {
-      //      EnvironmentMetadata envMetadata =
-      //          TestrigMetadataMgr.getEnvironmentMetadata(
-      //              wItem.getContainerName(), wDetails.baseTestrig, wDetails.baseEnv);
-      //      if (envMetadata.getProcessingStatus() == ProcessingStatus.UNINITIALIZED
-      //          || envMetadata.getProcessingStatus() == ProcessingStatus.PARSING_FAIL) {
-      //        throw new BatfishException(
-      //            "Cannot queue dataplaning work while other dependent work exists");
-      //      } else {
       return _queueIncompleteWork.enque(work);
-      //      }
     } else {
       return queueBlockedWork(work, blocker);
     }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkQueueMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkQueueMgr.java
@@ -415,7 +415,7 @@ public class WorkQueueMgr {
       case TerminatedAbnormally:
       case TerminatedByUser:
       case TerminatedNormally:
-      case TerminatedQueueFail:
+      case RequeueFailure:
         {
           // move the work to completed queue
           _queueIncompleteWork.delete(work);
@@ -434,7 +434,7 @@ public class WorkQueueMgr {
             TestrigMetadataMgr.updateEnvironmentStatus(
                 wItem.getContainerName(), wDetails.baseTestrig, wDetails.baseEnv, status);
           } else if (wDetails.workType == WorkType.DATAPLANING) {
-            // no change in status needed if task.getStatus() is TerminatedQueueFail
+            // no change in status needed if task.getStatus() is RequeueFailure
             if (task.getStatus() == TaskStatus.TerminatedAbnormally
                 || task.getStatus() == TaskStatus.TerminatedByUser) {
               TestrigMetadataMgr.updateEnvironmentStatus(
@@ -479,7 +479,7 @@ public class WorkQueueMgr {
                 // people may be checking its status and this work may be blocking others
                 _queueIncompleteWork.enque(requeueWork);
                 Task fakeTask =
-                    new Task(TaskStatus.TerminatedQueueFail, "Couldn't requeue after unblocking");
+                    new Task(TaskStatus.RequeueFailure, "Couldn't requeue after unblocking");
                 processTaskCheckResult(requeueWork, fakeTask);
               }
             }

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkQueueMgrTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkQueueMgrTest.java
@@ -976,6 +976,31 @@ public class WorkQueueMgrTest {
     workIsQueued(ProcessingStatus.PARSED, WorkType.DATAPLANING, WorkStatusCode.UNASSIGNED, 2);
   }
 
+  @Test
+  public void dataplaningAfterParsingFailure() throws Exception {
+    initTestrigMetadata("other", "other", ProcessingStatus.UNINITIALIZED);
+    QueuedWork work1 =
+        new QueuedWork(
+            new WorkItem(CONTAINER, "other"), new WorkDetails("other", "other", WorkType.PARSING));
+    _workQueueMgr.queueUnassignedWork(work1);
+    QueuedWork work2 =
+        new QueuedWork(
+            new WorkItem(CONTAINER, "other"),
+            new WorkDetails("other", "other", WorkType.DATAPLANING));
+    _workQueueMgr.queueUnassignedWork(work2);
+
+    QueuedWork aWork1 =
+        doAction(new Action(ActionType.ASSIGN_SUCCESS, null)); // should be parsing work (work1)
+    doAction(new Action(ActionType.STATUS_TERMINATED_ABNORMALLY, aWork1));
+
+    // work2 should be left with terminatedqueuefail status and the testrig in parsing_fail state
+    assertThat(work2.getStatus(), equalTo(WorkStatusCode.TERMINATEDQUEUEFAIL));
+    assertThat(
+        TestrigMetadataMgr.getEnvironmentMetadata(CONTAINER, "other", "other")
+            .getProcessingStatus(),
+        equalTo(ProcessingStatus.PARSING_FAIL));
+  }
+
   // END: DATAPLANING work tests
 
   @Test

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkQueueMgrTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkQueueMgrTest.java
@@ -994,7 +994,7 @@ public class WorkQueueMgrTest {
     doAction(new Action(ActionType.STATUS_TERMINATED_ABNORMALLY, aWork1));
 
     // work2 should be left with terminatedqueuefail status and the testrig in parsing_fail state
-    assertThat(work2.getStatus(), equalTo(WorkStatusCode.TERMINATEDQUEUEFAIL));
+    assertThat(work2.getStatus(), equalTo(WorkStatusCode.REQUEUEFAILURE));
     assertThat(
         TestrigMetadataMgr.getEnvironmentMetadata(CONTAINER, "other", "other")
             .getProcessingStatus(),


### PR DESCRIPTION
Fixes the issue where testrig is left in dataplaning_failed state after parsing fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/900)
<!-- Reviewable:end -->
