### PR TITLE
Add analysis metadata

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/CoordConsts.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/CoordConsts.java
@@ -96,6 +96,7 @@ public class CoordConsts {
   public static final String SVC_KEY_RESULT = "result";
   public static final String SVC_KEY_SETTINGS = "settings";
   public static final String SVC_KEY_SUCCESS = "success";
+  public static final String SVC_KEY_SUGGESTED = "suggested";
   public static final String SVC_KEY_TASKSTATUS = "taskstatus";
   public static final String SVC_KEY_TESTRIG_INFO = "testriginfo";
   public static final String SVC_KEY_TESTRIG_LIST = "testriglist";

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AnalysisMetadata.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AnalysisMetadata.java
@@ -1,0 +1,36 @@
+package org.batfish.datamodel;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
+
+public class AnalysisMetadata {
+
+  private static final String PROP_CREATIONTIMESTAMP = "creationTimestamp";
+  private static final String PROP_SUGGESTED = "suggested";
+
+  private Instant _creationTimestamp;
+  private boolean _suggested;
+
+  @JsonCreator
+  public AnalysisMetadata(
+      @JsonProperty(PROP_CREATIONTIMESTAMP) Instant creationTimestamp,
+      @JsonProperty(PROP_SUGGESTED) boolean suggested) {
+    _creationTimestamp = creationTimestamp;
+    _suggested = suggested;
+  }
+
+  @JsonProperty(PROP_CREATIONTIMESTAMP)
+  public Instant getCreationTimestamp() {
+    return _creationTimestamp;
+  }
+
+  @JsonProperty(PROP_SUGGESTED)
+  public boolean getSuggested() {
+    return _suggested;
+  }
+
+  public void setSuggested(boolean suggested) {
+    _suggested = suggested;
+  }
+}

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/AnalysisMetadataMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/AnalysisMetadataMgr.java
@@ -1,0 +1,40 @@
+package org.batfish.coordinator;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Instant;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.common.util.CommonUtil;
+import org.batfish.datamodel.AnalysisMetadata;
+
+public class AnalysisMetadataMgr {
+
+  public static Instant getAnalysisCreationTimeOrMin(String container, String analysis) {
+    try {
+      return readMetadata(container, analysis).getCreationTimestamp();
+    } catch (IOException e) {
+      return Instant.MIN;
+    }
+  }
+
+  public static AnalysisMetadata readMetadata(String container, String analysis)
+      throws IOException {
+    return readMetadata(WorkMgr.getpathAnalysisMetadata(container, analysis));
+  }
+
+  public static AnalysisMetadata readMetadata(Path metadataPath) throws IOException {
+    String jsonStr = CommonUtil.readFile(metadataPath);
+    return new BatfishObjectMapper().readValue(jsonStr, AnalysisMetadata.class);
+  }
+
+  public static void writeMetadata(AnalysisMetadata metadata, String container, String analysis)
+      throws JsonProcessingException {
+    writeMetadata(metadata, WorkMgr.getpathAnalysisMetadata(container, analysis));
+  }
+
+  public static synchronized void writeMetadata(AnalysisMetadata metadata, Path metadataPath)
+      throws JsonProcessingException {
+    CommonUtil.writeFile(metadataPath, new BatfishObjectMapper().writeValueAsString(metadata));
+  }
+}

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
@@ -123,6 +123,7 @@ public class WorkMgrService {
    * @param analysisName The name of the analysis to configure
    * @param addQuestionsStream A stream providing the questions for the analysis
    * @param delQuestions A list of questions to delete from the analysis
+   * @param suggested An optional boolean indicating whether analysis is suggested (default: false).
    * @return TODO: document JSON response
    */
   @POST
@@ -136,7 +137,8 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_NEW_ANALYSIS) String newAnalysisStr,
       @FormDataParam(CoordConsts.SVC_KEY_ANALYSIS_NAME) String analysisName,
       @FormDataParam(CoordConsts.SVC_KEY_FILE) InputStream addQuestionsStream,
-      @FormDataParam(CoordConsts.SVC_KEY_DEL_ANALYSIS_QUESTIONS) String delQuestions) {
+      @FormDataParam(CoordConsts.SVC_KEY_DEL_ANALYSIS_QUESTIONS) String delQuestions,
+      @Nullable @FormDataParam(CoordConsts.SVC_KEY_SUGGESTED) Boolean suggested) {
     try {
       _logger.infof(
           "WMS:configureAnalysis %s %s %s %s %s\n",
@@ -177,7 +179,12 @@ public class WorkMgrService {
 
       Main.getWorkMgr()
           .configureAnalysis(
-              containerName, newAnalysis, analysisName, questionsToAdd, questionsToDelete);
+              containerName,
+              newAnalysis,
+              analysisName,
+              questionsToAdd,
+              questionsToDelete,
+              suggested);
 
       return successResponse(new JSONObject().put("result", "successfully configured analysis"));
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrServiceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrServiceTest.java
@@ -119,7 +119,8 @@ public class WorkMgrServiceTest {
         "new",
         "analysis",
         new FileInputStream(analysisFile),
-        "");
+        "",
+        null);
     Path questionPath =
         _containersFolder
             .getRoot()
@@ -141,7 +142,8 @@ public class WorkMgrServiceTest {
         "",
         "analysis",
         null,
-        questionsToDelete);
+        questionsToDelete,
+        null);
     assertFalse(Files.exists(questionPath));
     JSONArray result =
         _service.configureAnalysis(
@@ -151,7 +153,8 @@ public class WorkMgrServiceTest {
             "",
             "analysis",
             null,
-            questionsToDelete);
+            questionsToDelete,
+            null);
     assertThat(result.getString(0), equalTo(CoordConsts.SVC_KEY_FAILURE));
   }
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
@@ -193,11 +193,11 @@ public class WorkMgrTest {
     Map<String, String> questionsToAdd =
         Maps.newHashMap(Collections.singletonMap("question1", "question1Content"));
     _manager.configureAnalysis(
-        containerName, true, "analysis", questionsToAdd, Lists.newArrayList());
+        containerName, true, "analysis", questionsToAdd, Lists.newArrayList(), null);
     questionsToAdd = Maps.newHashMap(Collections.singletonMap("question2", "question2Content"));
     questionsToAdd.put("question3", "question3Content");
     _manager.configureAnalysis(
-        containerName, false, "analysis", questionsToAdd, Lists.newArrayList());
+        containerName, false, "analysis", questionsToAdd, Lists.newArrayList(), null);
     Path questionPath =
         _folder
             .getRoot()
@@ -222,14 +222,14 @@ public class WorkMgrTest {
     // test delete questions
     List<String> questionsToDelete = Lists.newArrayList();
     _manager.configureAnalysis(
-        containerName, false, "analysis", Maps.newHashMap(), questionsToDelete);
+        containerName, false, "analysis", Maps.newHashMap(), questionsToDelete, null);
     assertTrue(
         Files.exists(questionPath.resolve("question1"))
             && Files.exists(questionPath.resolve("question2"))
             && Files.exists(questionPath.resolve("question3")));
     questionsToDelete = Lists.newArrayList("question1", "question2");
     _manager.configureAnalysis(
-        containerName, false, "analysis", Maps.newHashMap(), questionsToDelete);
+        containerName, false, "analysis", Maps.newHashMap(), questionsToDelete, null);
     assertFalse(Files.exists(questionPath.resolve("question1")));
     assertFalse(Files.exists(questionPath.resolve("question2")));
     assertTrue(Files.exists(questionPath.resolve("question3")));
@@ -237,6 +237,51 @@ public class WorkMgrTest {
     _thrown.expectMessage(equalTo("Question question1 does not exist for analysis analysis"));
     questionsToDelete = Lists.newArrayList("question1");
     _manager.configureAnalysis(
-        containerName, false, "analysis", Maps.newHashMap(), questionsToDelete);
+        containerName, false, "analysis", Maps.newHashMap(), questionsToDelete, null);
+  }
+
+  @Test
+  public void testConfigureAnalysisSuggested() {
+    String containerName = "myContainer";
+    _manager.initContainer(containerName, null);
+
+    // Analysis initialized with suggested = null should not be marked as suggested
+    _manager.configureAnalysis(
+        containerName, true, "analysis", Maps.newHashMap(), Lists.newArrayList(), null);
+    assertFalse(getMetadataSuggested(containerName, "analysis"));
+
+    // Analysis initialized with suggested = true should be marked as suggested
+    _manager.configureAnalysis(
+        containerName, true, "analysis2", Maps.newHashMap(), Lists.newArrayList(), true);
+    assertTrue(getMetadataSuggested(containerName, "analysis2"));
+
+    // Analysis initialized with suggested = false should not be marked as suggested
+    _manager.configureAnalysis(
+        containerName, true, "analysis3", Maps.newHashMap(), Lists.newArrayList(), false);
+    assertFalse(getMetadataSuggested(containerName, "analysis3"));
+
+    // Existing analysis should not change suggested if suggested arg is null
+    _manager.configureAnalysis(
+        containerName, false, "analysis2", Maps.newHashMap(), Lists.newArrayList(), null);
+    assertTrue(getMetadataSuggested(containerName, "analysis2"));
+    _manager.configureAnalysis(
+        containerName, false, "analysis3", Maps.newHashMap(), Lists.newArrayList(), null);
+    assertFalse(getMetadataSuggested(containerName, "analysis3"));
+
+    // Existing analysis should update suggested if arg is not null
+    _manager.configureAnalysis(
+        containerName, false, "analysis2", Maps.newHashMap(), Lists.newArrayList(), false);
+    assertFalse(getMetadataSuggested(containerName, "analysis2"));
+    _manager.configureAnalysis(
+        containerName, false, "analysis3", Maps.newHashMap(), Lists.newArrayList(), true);
+    assertTrue(getMetadataSuggested(containerName, "analysis3"));
+  }
+
+  private boolean getMetadataSuggested(String containerName, String analysisName) {
+    try {
+      return AnalysisMetadataMgr.readMetadata(containerName, analysisName).getSuggested();
+    } catch (IOException e) {
+      throw new BatfishException("Failed to read metadata", e);
+    }
   }
 }


### PR DESCRIPTION
Adds analysis metadata (containerName/analyses/analysisName/metadata.json) with a creation timestamp and a boolean `suggested` property. `configureAnalysis` now has an optional boolean argument `suggested`. When `configureAnalysis` is called:
- with `suggested` set to a non-null value:
    - if analysis already has a metadata file, update its `suggested` property
    - otherwise create a metadata file with the given `suggested` value
- with `suggested = null`:
    - if creating a new analysis, create a metadata file with `suggested = false`
    - otherwise do not check or change metadata

Creation timestamps are not currently used but seem like a reasonable thing to include.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/903)
<!-- Reviewable:end -->
