### PR TITLE
Add "suggested" filtering to listAnalyses

### DIFF
--- a/projects/coordinator/src/main/java/org/batfish/coordinator/AnalysisMetadataMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/AnalysisMetadataMgr.java
@@ -2,8 +2,10 @@ package org.batfish.coordinator;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
+import org.batfish.common.BatfishException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.common.util.CommonUtil;
 import org.batfish.datamodel.AnalysisMetadata;
@@ -15,6 +17,25 @@ public class AnalysisMetadataMgr {
       return readMetadata(container, analysis).getCreationTimestamp();
     } catch (IOException e) {
       return Instant.MIN;
+    }
+  }
+
+  /**
+   * Returns suggested property of given analysis's metadata, or false if no metadata exists.
+   *
+   * @param container Container in which to find analysis
+   * @param analysis Analysis whose suggested property to return
+   * @return suggested property of given analysis's metadata, or false if no metadata exists
+   */
+  public static boolean getAnalysisSuggestedOrFalse(String container, String analysis) {
+    // If metadata file doesn't exist, assume analysis is not suggested
+    if (!Files.exists(WorkMgr.getpathAnalysisMetadata(container, analysis))) {
+      return false;
+    }
+    try {
+      return readMetadata(container, analysis).getSuggested();
+    } catch (IOException e) {
+      throw new BatfishException("Unable to read metadata for analysis '" + analysis + "'", e);
     }
   }
 

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -1007,7 +1007,7 @@ public class WorkMgr extends AbstractCoordinator {
       WorkItem parseWork = WorkItemBuilder.getWorkItemParse(containerName, testrigName);
       autoWorkQueue.add(parseWork);
 
-      Set<String> analysisNames = listAnalyses(containerName);
+      Set<String> analysisNames = listAnalyses(containerName, null);
       for (String analysis : analysisNames) {
         WorkItem analyzeWork =
             WorkItemBuilder.getWorkItemRunAnalysis(
@@ -1123,7 +1123,7 @@ public class WorkMgr extends AbstractCoordinator {
     return killed;
   }
 
-  public SortedSet<String> listAnalyses(String containerName) {
+  public SortedSet<String> listAnalyses(String containerName, @Nullable Boolean suggested) {
     Path containerDir = getdirContainer(containerName);
     Path analysesDir = containerDir.resolve(BfConsts.RELPATH_ANALYSES_DIR);
     if (!Files.exists(analysesDir)) {
@@ -1134,6 +1134,13 @@ public class WorkMgr extends AbstractCoordinator {
             CommonUtil.getSubdirectories(analysesDir)
                 .stream()
                 .map(subdir -> subdir.getFileName().toString())
+                .filter(
+                    aName -> {
+                      // Include the analysis if suggested is null or matches metadata.suggested
+                      return suggested == null
+                          || AnalysisMetadataMgr.getAnalysisSuggestedOrFalse(containerName, aName)
+                              == suggested;
+                    })
                 .collect(Collectors.toSet()));
     return analyses;
   }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
@@ -1021,6 +1021,8 @@ public class WorkMgrService {
    * @param apiKey The API key of the client
    * @param clientVersion The version of the client
    * @param containerName The name of the container whose analyses are to be listed
+   * @param suggested Optional Boolean indicating which analyses to list: true = only suggested
+   *     analyses, false = only user's analyses, null = all analyses
    * @return TODO: document JSON response
    */
   @POST
@@ -1029,7 +1031,8 @@ public class WorkMgrService {
   public JSONArray listAnalyses(
       @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
-      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName) {
+      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
+      @Nullable @FormDataParam(CoordConsts.SVC_KEY_SUGGESTED) Boolean suggested) {
     try {
       _logger.info("WMS:listAnalyses " + apiKey + " " + containerName + "\n");
 
@@ -1043,7 +1046,7 @@ public class WorkMgrService {
 
       JSONObject retObject = new JSONObject();
 
-      for (String analysisName : Main.getWorkMgr().listAnalyses(containerName)) {
+      for (String analysisName : Main.getWorkMgr().listAnalyses(containerName, suggested)) {
 
         JSONObject analysisJson = new JSONObject();
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
@@ -186,6 +186,31 @@ public class WorkMgrTest {
   }
 
   @Test
+  public void testListAnalysesSuggested() {
+    String containerName = "myContainer";
+    _manager.initContainer(containerName, null);
+
+    // Create analysis1 (user analysis) and analysis2 (suggested analysis)
+    _manager.configureAnalysis(
+        containerName, true, "analysis1", Maps.newHashMap(), Lists.newArrayList(), false);
+    _manager.configureAnalysis(
+        containerName, true, "analysis2", Maps.newHashMap(), Lists.newArrayList(), true);
+
+    SortedSet<String> analyses = _manager.listAnalyses(containerName, null);
+    assertTrue("User analyses listed if suggested is null", analyses.contains("analysis1"));
+    assertTrue("Suggested analyses listed if suggested is null", analyses.contains("analysis2"));
+
+    analyses = _manager.listAnalyses(containerName, false);
+    assertTrue("User analyses listed if suggested is false", analyses.contains("analysis1"));
+    assertFalse(
+        "Suggested analyses not listed if suggested is false", analyses.contains("analysis2"));
+
+    analyses = _manager.listAnalyses(containerName, true);
+    assertFalse("User analyses not listed if suggested is true", analyses.contains("analysis1"));
+    assertTrue("Suggested analyses listed if suggested is true", analyses.contains("analysis2"));
+  }
+
+  @Test
   public void testConfigureAnalysis() {
     String containerName = "myContainer";
     _manager.initContainer(containerName, null);


### PR DESCRIPTION
`listAnalyses` now has an optional Boolean parameter `suggested`. If `suggested` is:
- `true`: only suggested analyses will be returned
- `false`: only user analyses will be returned
- `null`: all analyses will be returned

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/904)
<!-- Reviewable:end -->
