### PR TITLE
Pool manager HttpClient

### DIFF
--- a/projects/coordinator/src/main/java/org/batfish/coordinator/Main.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/Main.java
@@ -323,10 +323,10 @@ public class Main {
   private static void mainRun() {
     try {
       initAuthorizer();
-      initPoolManager();
       if (_settings.getTracingEnable() && !GlobalTracer.isRegistered()) {
         initTracer();
       }
+      initPoolManager();
       initWorkManager();
     } catch (Exception e) {
       System.err.println(


### PR DESCRIPTION
1.)Creating Jersey http client in the constructor and not for every refreshworkerstatus call
2.)Initializing tracer before pool manager to enable registering ClientTracingFeature in createHttpClientBuilder() function

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/913)
<!-- Reviewable:end -->
