### PR TITLE
travis: reduce the coordinator assign work period to speed up tests

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -8,10 +8,14 @@ fi
 
 trap 'kill -9 $(pgrep -g $$ | grep -v $$) >& /dev/null' EXIT SIGINT SIGTERM
 
-export ALLINONE_JAVA_ARGS="-enableassertions $ALLINONE_JAVA_ARGS"
-
 . tools/batfish_functions.sh
+
+
+# Build batfish and run the Maven unit tests.
 batfish_test_all || exit 1
+
+# Configure arguments for allinone throughout later runs.
+export ALLINONE_JAVA_ARGS="-enableassertions -DbatfishCoordinatorPropertiesPath=${BATFISH_ROOT}/.travis/travis_coordinator.properties"
 
 echo -e "\n  ..... Running parsing tests"
 allinone -cmdfile test_rigs/parsing-tests/commands || exit 1

--- a/.travis/travis_coordinator.properties
+++ b/.travis/travis_coordinator.properties
@@ -1,0 +1,2 @@
+# Only wait 5ms before checking tasks to speed up the build
+periodassignworkms=5


### PR DESCRIPTION
Shaves about 2 minutes off of Travis build time, which suggests that redesigning the coordinator's task completion mechanism would give gains.

cc: @haverma

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/921)
<!-- Reviewable:end -->
