### PR TITLE
If parsing or dataplaning fails, put err msg in metadata

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/Task.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/Task.java
@@ -88,6 +88,8 @@ public class Task {
 
   private static final String PROP_BATCHES = "batches";
 
+  private static final String PROP_ERR_MESSAGE = "errMessage";
+
   private static final String PROP_OBTAINED = "obtained";
 
   private static final String PROP_STATUS = "status";
@@ -97,6 +99,8 @@ public class Task {
   private final String[] _args;
 
   private final List<Batch> _batches;
+
+  private String _errMessage;
 
   private final Date _obtained;
 
@@ -110,20 +114,22 @@ public class Task {
       @JsonProperty(PROP_OBTAINED) Date obtained,
       @JsonProperty(PROP_STATUS) TaskStatus status,
       @JsonProperty(PROP_TERMINATED) Date terminated,
-      @JsonProperty(PROP_BATCHES) List<Batch> batches) {
+      @JsonProperty(PROP_BATCHES) List<Batch> batches,
+      @JsonProperty(PROP_ERR_MESSAGE) String errMessage) {
     _args = args;
     _obtained = obtained;
     _status = status;
     _terminated = terminated;
     _batches = batches;
+    _errMessage = errMessage;
   }
 
   public Task(@Nullable String[] args) {
-    this(args, new Date(), TaskStatus.Unscheduled, null, new ArrayList<>());
+    this(args, new Date(), TaskStatus.Unscheduled, null, new ArrayList<>(), null);
   }
 
   public Task(TaskStatus status) {
-    this(null, new Date(), status, null, new ArrayList<>());
+    this(null, new Date(), status, null, new ArrayList<>(), null);
     if (status == TaskStatus.TerminatedNormally || status == TaskStatus.TerminatedAbnormally) {
       _terminated = new Date();
     }
@@ -141,6 +147,11 @@ public class Task {
 
   public List<Batch> getBatches() {
     return _batches;
+  }
+
+  @JsonProperty(PROP_ERR_MESSAGE)
+  public String getErrMessage() {
+    return _errMessage;
   }
 
   @JsonProperty(PROP_OBTAINED)
@@ -165,6 +176,11 @@ public class Task {
     batch.setStartDate(date);
     _batches.add(batch);
     return batch;
+  }
+
+  @JsonProperty(PROP_ERR_MESSAGE)
+  public void setErrMessage(String msg) {
+    _errMessage = msg;
   }
 
   public void setStatus(TaskStatus status) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EnvironmentMetadata.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EnvironmentMetadata.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.Instant;
 import java.util.LinkedList;
 import java.util.List;
+import javax.annotation.Nullable;
 
 public class EnvironmentMetadata {
 
@@ -20,17 +21,23 @@ public class EnvironmentMetadata {
 
   private static final String PROP_CURRENT_STATUS = "currentStatus";
 
+  private static final String PROP_ERR_MESSAGE = "errMessage";
+
   private static final String PROP_STATUS_HISTORY = "statusHistory";
 
   private ProcessingStatus _currentStatus;
+
+  private String _errMessage;
 
   private List<String> _statusHistory;
 
   @JsonCreator
   public EnvironmentMetadata(
       @JsonProperty(PROP_CURRENT_STATUS) ProcessingStatus status,
+      @Nullable @JsonProperty(PROP_ERR_MESSAGE) String errMessage,
       @JsonProperty(PROP_STATUS_HISTORY) List<String> statusHistory) {
     _currentStatus = status;
+    _errMessage = errMessage;
     _statusHistory = statusHistory;
     if (_statusHistory == null) {
       _statusHistory = new LinkedList<>();
@@ -42,13 +49,21 @@ public class EnvironmentMetadata {
     return _currentStatus;
   }
 
+  @JsonProperty(PROP_ERR_MESSAGE)
+  public String getErrMessage() {
+    return _errMessage;
+  }
+
   @JsonProperty(PROP_STATUS_HISTORY)
   public List<String> getStatusHistory() {
     return _statusHistory;
   }
 
-  public void updateStatus(ProcessingStatus status) {
+  public void updateStatus(ProcessingStatus status, String errMessage) {
     _currentStatus = status;
+    if (errMessage != null) {
+      _errMessage = errMessage;
+    }
     _statusHistory.add("Status changed to " + status + " at " + Instant.now());
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/TestrigMetadata.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/TestrigMetadata.java
@@ -33,7 +33,8 @@ public class TestrigMetadata {
 
   public void initializeEnvironment(String environment) {
     _environments.put(
-        environment, new EnvironmentMetadata(ProcessingStatus.UNINITIALIZED, new LinkedList<>()));
+        environment,
+        new EnvironmentMetadata(ProcessingStatus.UNINITIALIZED, null, new LinkedList<>()));
   }
 
   @JsonProperty(PROP_CREATIONTIMESTAMP)

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -450,8 +450,8 @@ public class Batfish extends PluginConsumer implements IBatfish {
   private Settings _settings;
 
   // this variable is used communicate with parent thread on how the job
-  // finished
-  private boolean _terminatedWithException;
+  // finished (null if job finished successfully)
+  private String _terminatingExceptionMessage;
 
   private TestrigSettings _testrigSettings;
 
@@ -480,7 +480,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
     _baseTestrigSettings = settings.getBaseTestrigSettings();
     _logger = _settings.getLogger();
     _deltaTestrigSettings = settings.getDeltaTestrigSettings();
-    _terminatedWithException = false;
+    _terminatingExceptionMessage = null;
     _answererCreators = new HashMap<>();
     _testrigSettingsStack = new ArrayList<>();
     _dataPlanePlugins = new HashMap<>();
@@ -1881,8 +1881,8 @@ public class Batfish extends PluginConsumer implements IBatfish {
     return _settings.getTaskId();
   }
 
-  public boolean getTerminatedWithException() {
-    return _terminatedWithException;
+  public String getTerminatingExceptionMessage() {
+    return _terminatingExceptionMessage;
   }
 
   @Override
@@ -4011,8 +4011,8 @@ public class Batfish extends PluginConsumer implements IBatfish {
     _monotonicCache = monotonicCache;
   }
 
-  public void setTerminatedWithException(boolean terminatedWithException) {
-    _terminatedWithException = terminatedWithException;
+  public void setTerminatingExceptionMessage(String terminatingExceptionMessage) {
+    _terminatingExceptionMessage = terminatingExceptionMessage;
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/main/Driver.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Driver.java
@@ -253,6 +253,7 @@ public class Driver {
       task.newBatch("Got kill request");
       task.setStatus(TaskStatus.TerminatedByUser);
       task.setTerminated(new Date());
+      task.setErrMessage("Terminated by user");
 
       // we die after a little bit, to allow for the response making it back to the coordinator
       new java.util.Timer()
@@ -401,7 +402,7 @@ public class Driver {
     if (_mainSettings.canExecute()) {
       _mainSettings.setLogger(_mainLogger);
       Batfish.initTestrigSettings(_mainSettings);
-      if (!runBatfish(_mainSettings)) {
+      if (runBatfish(_mainSettings) != null) {
         System.exit(1);
       }
     }
@@ -529,7 +530,7 @@ public class Driver {
   }
 
   @SuppressWarnings("deprecation")
-  private static boolean runBatfish(final Settings settings) {
+  private static String runBatfish(final Settings settings) {
 
     final BatfishLogger logger = settings.getLogger();
 
@@ -561,36 +562,39 @@ public class Driver {
                 Answer answer = null;
                 try {
                   answer = batfish.run();
-                  batfish.setTerminatedWithException(false);
                   if (answer.getStatus() == null) {
                     answer.setStatus(AnswerStatus.SUCCESS);
                   }
                 } catch (CleanBatfishException e) {
-                  batfish.setTerminatedWithException(true);
                   String msg = "FATAL ERROR: " + e.getMessage();
                   logger.error(msg);
+                  batfish.setTerminatingExceptionMessage(
+                      e.getClass().getName() + ": " + e.getMessage());
                   answer = Answer.failureAnswer(msg, null);
                 } catch (QuestionException e) {
                   String stackTrace = ExceptionUtils.getFullStackTrace(e);
                   logger.error(stackTrace);
+                  batfish.setTerminatingExceptionMessage(
+                      e.getClass().getName() + ": " + e.getMessage());
                   answer = e.getAnswer();
                   answer.setStatus(AnswerStatus.FAILURE);
-                  batfish.setTerminatedWithException(true);
                 } catch (BatfishException e) {
                   String stackTrace = ExceptionUtils.getFullStackTrace(e);
                   logger.error(stackTrace);
+                  batfish.setTerminatingExceptionMessage(
+                      e.getClass().getName() + ": " + e.getMessage());
                   answer = new Answer();
                   answer.setStatus(AnswerStatus.FAILURE);
                   answer.addAnswerElement(e.getBatfishStackTrace());
-                  batfish.setTerminatedWithException(true);
                 } catch (Throwable e) {
                   String stackTrace = ExceptionUtils.getFullStackTrace(e);
                   logger.error(stackTrace);
+                  batfish.setTerminatingExceptionMessage(
+                      e.getClass().getName() + ": " + e.getMessage());
                   answer = new Answer();
                   answer.setStatus(AnswerStatus.FAILURE);
                   answer.addAnswerElement(
                       new BatfishException("Batfish job failed", e).getBatfishStackTrace());
-                  batfish.setTerminatedWithException(true);
                 } finally {
                   try (ActiveSpan outputAnswerSpan =
                       GlobalTracer.get().buildSpan("Outputting answer").startActive()) {
@@ -611,17 +615,17 @@ public class Driver {
         // this is deprecated but we should be safe since we don't have
         // locks and such
         // AF: This doesn't do what you think it does, esp. not in Java 8.
-        // It needs to be replaced.
+        // It needs to be replaced. TODO
         thread.stop();
         logger.error("Batfish worker took too long. Terminated.");
-        batfish.setTerminatedWithException(true);
+        batfish.setTerminatingExceptionMessage("Batfish worker took too long. Terminated.");
       }
 
-      return !batfish.getTerminatedWithException();
+      return batfish.getTerminatingExceptionMessage();
     } catch (Exception e) {
       String stackTrace = ExceptionUtils.getFullStackTrace(e);
       logger.error(stackTrace);
-      return false;
+      return stackTrace;
     }
   }
 
@@ -685,10 +689,12 @@ public class Driver {
                           .startActive()) {
                     assert runBatfishSpan != null; // avoid unused warning
                     task.setStatus(TaskStatus.InProgress);
-                    if (runBatfish(settings)) {
+                    String errMsg = runBatfish(settings);
+                    if (errMsg == null) {
                       task.setStatus(TaskStatus.TerminatedNormally);
                     } else {
                       task.setStatus(TaskStatus.TerminatedAbnormally);
+                      task.setErrMessage(errMsg);
                     }
                     task.setTerminated(new Date());
                     jobLogger.close();

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/TestrigMetadataMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/TestrigMetadataMgr.java
@@ -58,12 +58,12 @@ public class TestrigMetadataMgr {
   }
 
   public static synchronized void updateEnvironmentStatus(
-      String container, String testrig, String envName, ProcessingStatus status)
+      String container, String testrig, String envName, ProcessingStatus status, String errMessage)
       throws IOException {
     Path metadataPath = WorkMgr.getpathTestrigMetadata(container, testrig);
     TestrigMetadata trMetadata = readMetadata(metadataPath);
     EnvironmentMetadata environmentMetadata = trMetadata.getEnvironments().get(envName);
-    environmentMetadata.updateStatus(status);
+    environmentMetadata.updateStatus(status, errMessage);
     writeMetadata(trMetadata, metadataPath);
   }
 }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkQueueMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkQueueMgr.java
@@ -80,11 +80,11 @@ public class WorkQueueMgr {
     if (envMetadata.getProcessingStatus() == ProcessingStatus.PARSING
         && getIncompleteWork(container, testrig, environment, WorkType.PARSING) == null) {
       TestrigMetadataMgr.updateEnvironmentStatus(
-          container, testrig, environment, ProcessingStatus.PARSING_FAIL);
+          container, testrig, environment, ProcessingStatus.PARSING_FAIL, null);
     } else if (envMetadata.getProcessingStatus() == ProcessingStatus.DATAPLANING
         && getIncompleteWork(container, testrig, environment, WorkType.DATAPLANING) == null) {
       TestrigMetadataMgr.updateEnvironmentStatus(
-          container, testrig, environment, ProcessingStatus.DATAPLANING_FAIL);
+          container, testrig, environment, ProcessingStatus.DATAPLANING_FAIL, null);
     }
   }
 
@@ -391,13 +391,15 @@ public class WorkQueueMgr {
           wItem.getContainerName(),
           wDetails.baseTestrig,
           wDetails.baseEnv,
-          ProcessingStatus.PARSING);
+          ProcessingStatus.PARSING,
+          null);
     } else if (wDetails.workType == WorkType.DATAPLANING) {
       TestrigMetadataMgr.updateEnvironmentStatus(
           wItem.getContainerName(),
           wDetails.baseTestrig,
           wDetails.baseEnv,
-          ProcessingStatus.DATAPLANING);
+          ProcessingStatus.DATAPLANING,
+          null);
     }
   }
 
@@ -432,7 +434,11 @@ public class WorkQueueMgr {
                     ? ProcessingStatus.PARSED
                     : ProcessingStatus.PARSING_FAIL;
             TestrigMetadataMgr.updateEnvironmentStatus(
-                wItem.getContainerName(), wDetails.baseTestrig, wDetails.baseEnv, status);
+                wItem.getContainerName(),
+                wDetails.baseTestrig,
+                wDetails.baseEnv,
+                status,
+                task.getErrMessage());
           } else if (wDetails.workType == WorkType.DATAPLANING) {
             // no change in status needed if task.getStatus() is RequeueFailure
             if (task.getStatus() == TaskStatus.TerminatedAbnormally
@@ -441,13 +447,15 @@ public class WorkQueueMgr {
                   wItem.getContainerName(),
                   wDetails.baseTestrig,
                   wDetails.baseEnv,
-                  ProcessingStatus.DATAPLANING_FAIL);
+                  ProcessingStatus.DATAPLANING_FAIL,
+                  task.getErrMessage());
             } else if (task.getStatus() == TaskStatus.TerminatedNormally) {
               TestrigMetadataMgr.updateEnvironmentStatus(
                   wItem.getContainerName(),
                   wDetails.baseTestrig,
                   wDetails.baseEnv,
-                  ProcessingStatus.DATAPLANED);
+                  ProcessingStatus.DATAPLANED,
+                  null);
             }
           }
 
@@ -517,7 +525,8 @@ public class WorkQueueMgr {
                       wItem.getContainerName(),
                       wDetails.baseTestrig,
                       wDetails.baseEnv,
-                      ProcessingStatus.UNINITIALIZED);
+                      ProcessingStatus.UNINITIALIZED,
+                      task.getErrMessage());
                 }
               } else { // wDetails.workType == WorkType.DATAPLANING
                 if (envMetadata.getProcessingStatus() != ProcessingStatus.DATAPLANING) {
@@ -529,7 +538,8 @@ public class WorkQueueMgr {
                       wItem.getContainerName(),
                       wDetails.baseTestrig,
                       wDetails.baseEnv,
-                      ProcessingStatus.PARSED);
+                      ProcessingStatus.PARSED,
+                      task.getErrMessage());
                 }
               }
             }

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkQueueMgrTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkQueueMgrTest.java
@@ -143,7 +143,7 @@ public class WorkQueueMgrTest {
     metadataPath.getParent().toFile().mkdirs();
     TestrigMetadata trMetadata = new TestrigMetadata(Instant.now(), environment);
     EnvironmentMetadata envMetadata = trMetadata.getEnvironments().get(environment);
-    envMetadata.updateStatus(status);
+    envMetadata.updateStatus(status, null);
     TestrigMetadataMgr.writeMetadata(trMetadata, metadataPath);
   }
 


### PR DESCRIPTION
The idea is that if a testrig has failed to parse or dataplane, the metadata should contain the error message that caused the failure (e.g., "No valid configurations found"). This is implemented by adding an `errMessage` property to `Task`. Details:
- `Batfish._terminatedWithException`, a boolean, has been replaced with `Batfish._terminatingExceptionMessage`, a String that is null if no error occurs
- In `Driver.runBatfish()`, when an exception occurs in the running thread, the Batfish instance stores the error message as `_terminatingExceptionMessage`
- `runBatfish()` returns the error message (if any, otherwise null) instead of a boolean
- `Driver.runBatfishThroughService` sets its task's error message to the output of `runBatfish()` if any error occurred
- `WorkQueueMgr.processTaskCheckResult()` will put the given task's error message (if any) into the environment metadata
- Metadata classes have been updated to accommodate an `errMessage` property in EnvironmentMetadata

To me it looks like the biggest question about this setup is whether it captures all the exceptions we want it to, because an exception outside of the runBatfish thread will not be recorded in a `Task`. There is also a question of what exactly to include in the error message: in some cases `e.getMessage()` is too verbose.

Also, it won't help with issues that prevent testrig initialization (like having multiple top-level folders) because no folder is created for the testrig, so no metadata exists for it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/946)
<!-- Reviewable:end -->