### PR TITLE
Implement stricter type checking in equals OSPF external routes

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfExternalType1Route.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfExternalType1Route.java
@@ -35,4 +35,19 @@ public class OspfExternalType1Route extends OspfExternalRoute {
   public int routeCompare(AbstractRoute rhs) {
     return 0;
   }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof OspfExternalType1Route)) {
+      return false;
+    }
+    if (!super.equals(obj)) {
+      return false;
+    }
+    OspfExternalType1Route other = (OspfExternalType1Route) obj;
+    return getCostToAdvertiser() == other.getCostToAdvertiser();
+  }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfExternalType2Route.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfExternalType2Route.java
@@ -26,14 +26,14 @@ public class OspfExternalType2Route extends OspfExternalRoute {
     if (this == obj) {
       return true;
     }
+    if (!(obj instanceof OspfExternalType2Route)) {
+      return false;
+    }
     if (!super.equals(obj)) {
       return false;
     }
     OspfExternalType2Route other = (OspfExternalType2Route) obj;
-    if (getCostToAdvertiser() != other.getCostToAdvertiser()) {
-      return false;
-    }
-    return true;
+    return getCostToAdvertiser() == other.getCostToAdvertiser();
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/OspfExternalType1RouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/OspfExternalType1RouteTest.java
@@ -1,0 +1,35 @@
+package org.batfish.datamodel;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.Test;
+
+/** Test for {@link OspfExternalType1Route} */
+public class OspfExternalType1RouteTest {
+
+  @Test
+  public void testEquals() {
+
+    OspfExternalType1Route r1 =
+        new OspfExternalType1Route(new Prefix(new Ip("1.1.1.1"), 32), Ip.ZERO, 1, 1, 1, 1, 1, "");
+    OspfExternalType1Route r1DiffObj =
+        new OspfExternalType1Route(new Prefix(new Ip("1.1.1.1"), 32), Ip.ZERO, 1, 1, 1, 1, 1, "");
+    OspfExternalType1Route r2 =
+        new OspfExternalType1Route(new Prefix(new Ip("1.1.1.1"), 32), Ip.ZERO, 1, 1, 1, 1, 2, "");
+    OspfExternalType2Route type2Route =
+        new OspfExternalType2Route(new Prefix(new Ip("1.1.1.1"), 32), Ip.ZERO, 1, 1, 1, 1, 2, "");
+
+    // Simple equality checks
+    assertThat(r1, equalTo(r1));
+    assertThat(r1, equalTo(r1DiffObj));
+    assertThat(r1, not(equalTo(nullValue())));
+
+    // Cost to advertiser differs
+    assertThat(r1, not(equalTo(r2)));
+    // Not the same type
+    assertThat(r1, not(equalTo(type2Route)));
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/OspfExternalType2RouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/OspfExternalType2RouteTest.java
@@ -1,0 +1,35 @@
+package org.batfish.datamodel;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.Test;
+
+/** Test for {@link OspfExternalType2Route} */
+public class OspfExternalType2RouteTest {
+
+  @Test
+  public void testEquals() {
+
+    OspfExternalType2Route r1 =
+        new OspfExternalType2Route(new Prefix(new Ip("1.1.1.1"), 32), Ip.ZERO, 1, 1, 1, 1, 1, "");
+    OspfExternalType2Route r1DiffObj =
+        new OspfExternalType2Route(new Prefix(new Ip("1.1.1.1"), 32), Ip.ZERO, 1, 1, 1, 1, 1, "");
+    OspfExternalType2Route r2 =
+        new OspfExternalType2Route(new Prefix(new Ip("1.1.1.1"), 32), Ip.ZERO, 1, 1, 1, 1, 2, "");
+    OspfExternalType1Route type1Route =
+        new OspfExternalType1Route(new Prefix(new Ip("1.1.1.1"), 32), Ip.ZERO, 1, 1, 1, 1, 2, "");
+
+    // Simple equality checks
+    assertThat(r1, equalTo(r1));
+    assertThat(r1, equalTo(r1DiffObj));
+    assertThat(r1, not(equalTo(nullValue())));
+
+    // Cost to advertiser differs
+    assertThat(r1, not(equalTo(r2)));
+    // Not the same type
+    assertThat(r1, not(equalTo(type1Route)));
+  }
+}


### PR DESCRIPTION
OSPF external type routes were not doing and `instanceof` check.
Added the check and tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/948)
<!-- Reviewable:end -->
