### PR TITLE
Put timestamp into names of folders in /original

### DIFF
--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -1460,7 +1460,10 @@ public class WorkMgr extends AbstractCoordinator {
 
     // Persist the user's upload to a directory inside the container, named for the testrig,
     // where we save the original upload for later analysis.
-    Path originalDir = containerDir.resolve(BfConsts.RELPATH_ORIGINAL_DIR).resolve(testrigName);
+    Path originalDir =
+        containerDir
+            .resolve(BfConsts.RELPATH_ORIGINAL_DIR)
+            .resolve(testrigName + "_" + Instant.now());
     if (!originalDir.toFile().mkdirs()) {
       throw new BatfishException("Failed to create directory: '" + originalDir + "'");
     }


### PR DESCRIPTION
Renames folders in /containerName/original to include timestamp. Example for testrig named Dakota: `LHR/original/Dakota_2018-02-15T18:41:47.341Z/testrig.zip`

Fixes #944.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/950)
<!-- Reviewable:end -->
