### PR TITLE
Settings changes

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
@@ -45,7 +45,6 @@ public class BfConsts {
   public static final String ARG_BDP_PRINT_ALL_ITERATIONS = "bdpprintalliterations";
   public static final String ARG_BDP_PRINT_OSCILLATING_ITERATIONS = "bdpprintoscillatingiterations";
   public static final String ARG_BDP_RECORD_ALL_ITERATIONS = "bdprecordalliterations";
-  public static final String ARG_BLOCK_NAMES = "blocknames";
   public static final String ARG_CONTAINER_DIR = "containerdir";
   public static final String ARG_DELTA_ENVIRONMENT_NAME = "deltaenv";
   public static final String ARG_DELTA_TESTRIG = "deltatestrig";

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
@@ -143,6 +143,15 @@ public interface IBatfish extends IPluginConsumer {
 
   void registerBgpTablePlugin(BgpTableFormat format, BgpTablePlugin bgpTablePlugin);
 
+  /**
+   * Register a new dataplane plugin
+   *
+   * @param plugin a {@link DataPlanePlugin} capable of computing a dataplane
+   * @param name name of the plugin, will be used to register the plugin and prefixed to all
+   *     plugin-specific settings (and hence command line arguments)
+   */
+  void registerDataPlanePlugin(DataPlanePlugin plugin, String name);
+
   void registerExternalBgpAdvertisementPlugin(
       ExternalBgpAdvertisementPlugin externalBgpAdvertisementPlugin);
 
@@ -179,6 +188,4 @@ public interface IBatfish extends IPluginConsumer {
       Set<String> notTransitNodes);
 
   void writeDataPlane(DataPlane dp, DataPlaneAnswerElement ae);
-
-  void registerDataPlanePlugin(DataPlanePlugin plugin, String name);
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/GrammarSettings.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/GrammarSettings.java
@@ -70,7 +70,7 @@ public interface GrammarSettings {
   /**
    * See {@link GrammarSettings#getPrintParseTree()}
    *
-   * @param disableUnrecognized The new value to be returned by subsequent calls to {@link
+   * @param printParseTree The new value to be returned by subsequent calls to {@link
    *     GrammarSettings#getPrintParseTree()}
    */
   void setPrintParseTree(boolean printParseTree);
@@ -78,7 +78,7 @@ public interface GrammarSettings {
   /**
    * See {@link GrammarSettings#getThrowOnLexerError()}
    *
-   * @param disableUnrecognized The new value to be returned by subsequent calls to {@link
+   * @param throwOnLexerError The new value to be returned by subsequent calls to {@link
    *     GrammarSettings#getThrowOnLexerError()}
    */
   void setThrowOnLexerError(boolean throwOnLexerError);
@@ -86,7 +86,7 @@ public interface GrammarSettings {
   /**
    * See {@link GrammarSettings#getThrowOnParserError()}
    *
-   * @param disableUnrecognized The new value to be returned by subsequent calls to {@link
+   * @param throwOnParserError The new value to be returned by subsequent calls to {@link
    *     GrammarSettings#getThrowOnParserError()}
    */
   void setThrowOnParserError(boolean throwOnParserError);

--- a/projects/batfish/pom.xml
+++ b/projects/batfish/pom.xml
@@ -222,6 +222,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-configuration2</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.codehaus.jettison</groupId>
       <artifactId>jettison</artifactId>
     </dependency>

--- a/projects/batfish/src/main/java/org/batfish/config/Settings.java
+++ b/projects/batfish/src/main/java/org/batfish/config/Settings.java
@@ -822,8 +822,9 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
     return _config.getString(BfConsts.ARG_QUESTION_NAME);
   }
 
+  @Nullable
   public Path getQuestionPath() {
-    return Paths.get(_config.getString(QUESTION_PATH));
+    return nullablePath(_config.getString(QUESTION_PATH));
   }
 
   public boolean getRedFlagAsError() {
@@ -1584,6 +1585,8 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
   public void setQuestionPath(@Nullable Path questionPath) {
     if (questionPath != null) {
       _config.setProperty(QUESTION_PATH, questionPath.toString());
+    } else {
+      _config.clearProperty(QUESTION_PATH);
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/config/Settings.java
+++ b/projects/batfish/src/main/java/org/batfish/config/Settings.java
@@ -1,7 +1,10 @@
 package org.batfish.config;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -413,6 +416,8 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
 
   private static final String ARG_COORDINATOR_WORK_PORT = "coordinatorworkport";
 
+  private static final String ARG_DATAPLANE_ENGINE_NAME = "dataplaneengine";
+
   private static final String ARG_DISABLE_Z3_SIMPLIFICATION = "nosimplify";
 
   private static final String ARG_EXIT_ON_FIRST_ERROR = "ee";
@@ -509,209 +514,21 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
 
   private static final String EXECUTABLE_NAME = "batfish";
 
-  private static final String ARG_DATAPLANE_ENGINE_NAME = "dataplaneengine";
+  private static final String CAN_EXECUTE = "canexecute";
+
+  private static final String DIFFERENTIAL_QUESTION = "diffquestion";
+
+  public static final String TASK_ID = "taskid";
+
+  private static final String QUESTION_PATH = "questionpath";
 
   private TestrigSettings _activeTestrigSettings;
 
-  private String _analysisName;
-
-  private boolean _analyze;
-
-  private boolean _answer;
-
-  private Path _answerJsonPath;
-
   private TestrigSettings _baseTestrigSettings;
 
-  private boolean _bdpDetail;
-
-  private int _bdpMaxOscillationRecoveryAttempts;
-
-  private int _bdpMaxRecordedIterations;
-
-  private boolean _bdpPrintAllIterations;
-
-  private boolean _bdpPrintOscillatingIterations;
-
-  private boolean _bdpRecordAllIterations;
-
-  private List<String> _blockNames;
-
-  private boolean _canExecute;
-
-  private boolean _compileDiffEnvironment;
-
-  private Path _containerDir;
-
-  private String _coordinatorHost;
-
-  private int _coordinatorPoolPort;
-
-  private boolean _coordinatorRegister;
-
-  private int _coordinatorWorkPort;
-
-  private boolean _dataPlane;
-
-  private String _deltaEnvironmentName;
-
-  private String _deltaTestrig;
-
-  private TestrigSettings _deltaTestrigSettings;
-
-  private boolean _diffActive;
-
-  private boolean _differential;
-
-  private boolean _diffQuestion;
-
-  private boolean _disableUnrecognized;
-
-  private String _environmentName;
-
-  private boolean _exitOnFirstError;
-
-  private boolean _flatten;
-
-  private Path _flattenDestination;
-
-  private boolean _flattenOnTheFly;
-
-  private boolean _generateStubs;
-
-  private String _generateStubsInputRole;
-
-  private String _generateStubsInterfaceDescriptionRegex;
-
-  private Integer _generateStubsRemoteAs;
-
-  private Path _genOspfTopologyPath;
-
-  private boolean _haltOnConvertError;
-
-  private boolean _haltOnParseError;
-
-  private List<String> _helpPredicates;
-
-  private boolean _histogram;
-
-  private List<String> _ignoreFilesWithStrings;
-
-  private boolean _ignoreUnknown;
-
-  private boolean _ignoreUnsupported;
-
-  private boolean _initInfo;
-
-  private int _jobs;
-
-  private String _logFile;
+  private final TestrigSettings _deltaTestrigSettings;
 
   private BatfishLogger _logger;
-
-  private String _logLevel;
-
-  private boolean _logTee;
-
-  private int _maxParserContextLines;
-
-  private int _maxParserContextTokens;
-
-  private int _maxParseTreePrintLength;
-
-  private int _maxRuntimeMs;
-
-  private String _outputEnvironmentName;
-
-  private int _parentPid;
-
-  private boolean _pedanticAsError;
-
-  private boolean _pedanticRecord;
-
-  private List<String> _predicates;
-
-  private boolean _prettyPrintAnswer;
-
-  private boolean _printParseTree;
-
-  private boolean _printSymmetricEdges;
-
-  private String _questionName;
-
-  private Path _questionPath;
-
-  private boolean _redFlagAsError;
-
-  private boolean _redFlagRecord;
-
-  private boolean _report;
-
-  private RunMode _runMode;
-
-  private boolean _sequential;
-
-  private boolean _serializeIndependent;
-
-  private boolean _serializeToText;
-
-  private boolean _serializeVendor;
-
-  private String _serviceBindHost;
-
-  private String _serviceHost;
-
-  private int _servicePort;
-
-  private boolean _shuffleJobs;
-
-  private boolean _simplify;
-
-  private boolean _sslDisable;
-
-  private Path _sslKeystoreFile;
-
-  private String _sslKeystorePassword;
-
-  private boolean _sslTrustAllCerts;
-
-  private Path _sslTruststoreFile;
-
-  private String _sslTruststorePassword;
-
-  private boolean _synthesizeJsonTopology;
-
-  private String _taskId;
-
-  private String _taskPlugin;
-
-  private String _testrig;
-
-  private boolean _throwOnLexerError;
-
-  private boolean _throwOnParserError;
-
-  private boolean _timestamp;
-
-  private String _tracingAgentHost;
-
-  private Integer _tracingAgentPort;
-
-  private boolean _tracingEnable;
-
-  private boolean _unimplementedAsError;
-
-  private boolean _unimplementedRecord;
-
-  private boolean _unrecognizedAsRedFlag;
-
-  private boolean _validateEnvironment;
-
-  private boolean _verboseParse;
-
-  private int _z3timeout;
-
-  private String _dataPlaneEngineName;
 
   public Settings() {
     this(new String[] {});
@@ -730,12 +547,37 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
     parseCommandLine(args);
   }
 
+  /**
+   * Create a copy of some existing settings.
+   *
+   * @param other the {@link Settings to copy}
+   */
+  public Settings(Settings other) {
+    super(other._config);
+    initOptions();
+    _activeTestrigSettings = other._activeTestrigSettings;
+    _deltaTestrigSettings = other._deltaTestrigSettings;
+    _baseTestrigSettings = other._baseTestrigSettings;
+    _logger = other._logger;
+  }
+
+  /**
+   * Remove certain setting values
+   *
+   * @param keys a list of keys to clear
+   */
+  public void clearValues(String... keys) {
+    for (String s : keys) {
+      _config.clearProperty(s);
+    }
+  }
+
   public boolean canExecute() {
-    return _canExecute;
+    return _config.getBoolean(CAN_EXECUTE, true);
   }
 
   public boolean flattenOnTheFly() {
-    return _flattenOnTheFly;
+    return _config.getBoolean(ARG_FLATTEN_ON_THE_FLY);
   }
 
   public TestrigSettings getActiveTestrigSettings() {
@@ -743,87 +585,94 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
   }
 
   public String getAnalysisName() {
-    return _analysisName;
+    return _config.getString(BfConsts.ARG_ANALYSIS_NAME);
   }
 
   public boolean getAnalyze() {
-    return _analyze;
+    return _config.getBoolean(BfConsts.COMMAND_ANALYZE);
   }
 
   public boolean getAnswer() {
-    return _answer;
+    return _config.getBoolean(BfConsts.COMMAND_ANSWER);
   }
 
+  @Nullable
   public Path getAnswerJsonPath() {
-    return _answerJsonPath;
+    return nullablePath(_config.getString(BfConsts.ARG_ANSWER_JSON_PATH));
   }
 
   public TestrigSettings getBaseTestrigSettings() {
     return _baseTestrigSettings;
   }
 
+  @Override
   public boolean getBdpDetail() {
-    return _bdpDetail;
+    return _config.getBoolean(BfConsts.ARG_BDP_DETAIL);
   }
 
+  @Override
   public int getBdpMaxOscillationRecoveryAttempts() {
-    return _bdpMaxOscillationRecoveryAttempts;
+    return _config.getInt(BfConsts.ARG_BDP_MAX_OSCILLATION_RECOVERY_ATTEMPTS);
   }
 
+  @Override
   public int getBdpMaxRecordedIterations() {
-    return _bdpMaxRecordedIterations;
+    return _config.getInt(BfConsts.ARG_BDP_MAX_RECORDED_ITERATIONS);
   }
 
+  @Override
   public boolean getBdpPrintAllIterations() {
-    return _bdpPrintAllIterations;
+    return _config.getBoolean(BfConsts.ARG_BDP_PRINT_ALL_ITERATIONS);
   }
 
+  @Override
   public boolean getBdpPrintOscillatingIterations() {
-    return _bdpPrintOscillatingIterations;
+    return _config.getBoolean(BfConsts.ARG_BDP_PRINT_OSCILLATING_ITERATIONS);
   }
 
+  @Override
   public boolean getBdpRecordAllIterations() {
-    return _bdpRecordAllIterations;
+    return _config.getBoolean(BfConsts.ARG_BDP_RECORD_ALL_ITERATIONS);
   }
 
   public List<String> getBlockNames() {
-    return _blockNames;
+    return _config.getList(String.class, BfConsts.ARG_BLOCK_NAMES, Collections.emptyList());
   }
 
   public boolean getCompileEnvironment() {
-    return _compileDiffEnvironment;
+    return _config.getBoolean(BfConsts.COMMAND_COMPILE_DIFF_ENVIRONMENT);
   }
 
   public Path getContainerDir() {
-    return _containerDir;
+    return Paths.get(_config.getString(BfConsts.ARG_CONTAINER_DIR));
   }
 
   public String getCoordinatorHost() {
-    return _coordinatorHost;
+    return _config.getString(ARG_COORDINATOR_HOST);
   }
 
   public int getCoordinatorPoolPort() {
-    return _coordinatorPoolPort;
+    return _config.getInt(ARG_COORDINATOR_POOL_PORT);
   }
 
   public boolean getCoordinatorRegister() {
-    return _coordinatorRegister;
+    return _config.getBoolean(ARG_COORDINATOR_REGISTER);
   }
 
   public int getCoordinatorWorkPort() {
-    return _coordinatorWorkPort;
+    return _config.getInt(ARG_COORDINATOR_WORK_PORT);
   }
 
   public boolean getDataPlane() {
-    return _dataPlane;
+    return _config.getBoolean(BfConsts.COMMAND_DUMP_DP);
   }
 
   public String getDeltaEnvironmentName() {
-    return _deltaEnvironmentName;
+    return _config.getString(BfConsts.ARG_DELTA_ENVIRONMENT_NAME);
   }
 
   public String getDeltaTestrig() {
-    return _deltaTestrig;
+    return _config.getString(BfConsts.ARG_DELTA_TESTRIG);
   }
 
   public TestrigSettings getDeltaTestrigSettings() {
@@ -831,84 +680,81 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
   }
 
   public boolean getDiffActive() {
-    return _diffActive;
+    return _config.getBoolean(BfConsts.ARG_DIFF_ACTIVE);
   }
 
   public boolean getDifferential() {
-    return _differential;
+    return _config.getBoolean(BfConsts.ARG_DIFFERENTIAL);
   }
 
   public boolean getDiffQuestion() {
-    return _diffQuestion;
+    return _config.getBoolean(DIFFERENTIAL_QUESTION);
   }
 
   @Override
   public boolean getDisableUnrecognized() {
-    return _disableUnrecognized;
+    return _config.getBoolean(BfConsts.ARG_DISABLE_UNRECOGNIZED);
   }
 
   public String getEnvironmentName() {
-    return _environmentName;
+    return _config.getString(BfConsts.ARG_ENVIRONMENT_NAME);
   }
 
   public boolean getExitOnFirstError() {
-    return _exitOnFirstError;
+    return _config.getBoolean(ARG_EXIT_ON_FIRST_ERROR);
   }
 
   public boolean getFlatten() {
-    return _flatten;
+    return _config.getBoolean(ARG_FLATTEN);
   }
 
   public Path getFlattenDestination() {
-    return _flattenDestination;
+    return Paths.get(_config.getString(ARG_FLATTEN_DESTINATION));
   }
 
+  @Nullable
   public Path getGenerateOspfTopologyPath() {
-    return _genOspfTopologyPath;
+    return nullablePath(_config.getString(ARG_GEN_OSPF_TOPLOGY_PATH));
   }
 
   public boolean getGenerateStubs() {
-    return _generateStubs;
+    return _config.getBoolean(ARG_GENERATE_STUBS);
   }
 
   public String getGenerateStubsInputRole() {
-    return _generateStubsInputRole;
+    return _config.getString(ARG_GENERATE_STUBS_INPUT_ROLE);
   }
 
   public String getGenerateStubsInterfaceDescriptionRegex() {
-    return _generateStubsInterfaceDescriptionRegex;
+    return _config.getString(ARG_GENERATE_STUBS_INTERFACE_DESCRIPTION_REGEX);
   }
 
   public int getGenerateStubsRemoteAs() {
-    return _generateStubsRemoteAs;
+    return _config.getInt(ARG_GENERATE_STUBS_REMOTE_AS);
   }
 
   public boolean getHaltOnConvertError() {
-    return _haltOnConvertError;
+    return _config.getBoolean(BfConsts.ARG_HALT_ON_CONVERT_ERROR);
   }
 
   public boolean getHaltOnParseError() {
-    return _haltOnParseError;
-  }
-
-  public List<String> getHelpPredicates() {
-    return _helpPredicates;
+    return _config.getBoolean(BfConsts.ARG_HALT_ON_PARSE_ERROR);
   }
 
   public boolean getHistogram() {
-    return _histogram;
+    return _config.getBoolean(ARG_HISTOGRAM);
   }
 
   public boolean getInitInfo() {
-    return _initInfo;
+    return _config.getBoolean(BfConsts.COMMAND_INIT_INFO);
   }
 
   public int getJobs() {
-    return _jobs;
+    return _config.getInt(ARG_JOBS);
   }
 
   public String getLogFile() {
-    return _logFile;
+    return _config.getString(BfConsts.ARG_LOG_FILE);
   }
 
   public BatfishLogger getLogger() {
@@ -916,225 +762,227 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
   }
 
   public String getLogLevel() {
-    return _logLevel;
+    return _config.getString(BfConsts.ARG_LOG_LEVEL);
   }
 
   public boolean getLogTee() {
-    return _logTee;
+    return _config.getBoolean(ARG_LOG_TEE);
   }
 
   public int getParentPid() {
-    return _parentPid;
+    return _config.getInt(ARG_PARENT_PID);
   }
 
   @Override
   public int getMaxParserContextLines() {
-    return _maxParserContextLines;
+    return _config.getInt(ARG_MAX_PARSER_CONTEXT_LINES);
   }
 
   @Override
   public int getMaxParserContextTokens() {
-    return _maxParserContextTokens;
+    return _config.getInt(ARG_MAX_PARSER_CONTEXT_TOKENS);
   }
 
   @Override
   public int getMaxParseTreePrintLength() {
-    return _maxParseTreePrintLength;
+    return _config.getInt(ARG_MAX_PARSE_TREE_PRINT_LENGTH);
   }
 
   public int getMaxRuntimeMs() {
-    return _maxRuntimeMs;
+    return _config.getInt(ARG_MAX_RUNTIME_MS);
   }
 
   public String getOutputEnvironmentName() {
-    return _outputEnvironmentName;
+    return _config.getString(BfConsts.ARG_OUTPUT_ENV);
   }
 
   public boolean getPedanticAsError() {
-    return _pedanticAsError;
+    return _config.getBoolean(BfConsts.ARG_PEDANTIC_AS_ERROR);
   }
 
   public boolean getPedanticRecord() {
-    return _pedanticRecord;
+    return !_config.getBoolean(BfConsts.ARG_PEDANTIC_SUPPRESS);
   }
 
-  public List<String> getPredicates() {
-    return _predicates;
+  public boolean getPrettyPrintAnswer() {
+    return _config.getBoolean(BfConsts.ARG_PRETTY_PRINT_ANSWER);
   }
 
   @Override
   public boolean getPrintParseTree() {
-    return _printParseTree;
+    return _config.getBoolean(ARG_PRINT_PARSE_TREES);
   }
 
   public boolean getPrintSymmetricEdgePairs() {
-    return _printSymmetricEdges;
+    return _config.getBoolean(ARG_PRINT_SYMMETRIC_EDGES);
   }
 
   public String getQuestionName() {
-    return _questionName;
+    return _config.getString(BfConsts.ARG_QUESTION_NAME);
   }
 
   public Path getQuestionPath() {
-    return _questionPath;
+    return Paths.get(_config.getString(QUESTION_PATH));
   }
 
   public boolean getRedFlagAsError() {
-    return _redFlagAsError;
+    return _config.getBoolean(BfConsts.ARG_RED_FLAG_AS_ERROR);
   }
 
   public boolean getRedFlagRecord() {
-    return _redFlagRecord;
+    return !_config.getBoolean(BfConsts.ARG_RED_FLAG_SUPPRESS);
   }
 
   public boolean getReport() {
-    return _report;
+    return _config.getBoolean(BfConsts.COMMAND_REPORT);
   }
 
   public RunMode getRunMode() {
-    return _runMode;
+    return RunMode.valueOf(_config.getString(ARG_RUN_MODE).toUpperCase());
   }
 
   public boolean getSequential() {
-    return _sequential;
+    return _config.getBoolean(ARG_SEQUENTIAL);
   }
 
   public boolean getSerializeIndependent() {
-    return _serializeIndependent;
+    return _config.getBoolean(BfConsts.COMMAND_PARSE_VENDOR_INDEPENDENT);
   }
 
   public boolean getSerializeToText() {
-    return _serializeToText;
+    return _config.getBoolean(ARG_SERIALIZE_TO_TEXT);
   }
 
   public boolean getSerializeVendor() {
-    return _serializeVendor;
+    return _config.getBoolean(BfConsts.COMMAND_PARSE_VENDOR_SPECIFIC);
   }
 
   public String getServiceBindHost() {
-    return _serviceBindHost;
+    return _config.getString(ARG_SERVICE_BIND_HOST);
   }
 
   public String getServiceHost() {
-    return _serviceHost;
+    return _config.getString(ARG_SERVICE_HOST);
   }
 
   public int getServicePort() {
-    return _servicePort;
+    return _config.getInt(ARG_SERVICE_PORT);
   }
 
   public boolean getShuffleJobs() {
-    return _shuffleJobs;
+    return !_config.getBoolean(ARG_NO_SHUFFLE);
   }
 
   public boolean getSimplify() {
-    return _simplify;
+    return !_config.getBoolean(ARG_DISABLE_Z3_SIMPLIFICATION);
   }
 
   public boolean getSslDisable() {
-    return _sslDisable;
+    return _config.getBoolean(BfConsts.ARG_SSL_DISABLE);
   }
 
+  @Nullable
   public Path getSslKeystoreFile() {
-    return _sslKeystoreFile;
+    return nullablePath(_config.getString(BfConsts.ARG_SSL_KEYSTORE_FILE));
   }
 
   public String getSslKeystorePassword() {
-    return _sslKeystorePassword;
+    return _config.getString(BfConsts.ARG_SSL_KEYSTORE_PASSWORD);
   }
 
   public boolean getSslTrustAllCerts() {
-    return _sslTrustAllCerts;
+    return _config.getBoolean(BfConsts.ARG_SSL_TRUST_ALL_CERTS);
   }
 
   public Path getSslTruststoreFile() {
-    return _sslTruststoreFile;
+    return _config.get(Path.class, BfConsts.ARG_SSL_TRUSTSTORE_FILE);
   }
 
   public String getSslTruststorePassword() {
-    return _sslTruststorePassword;
+    return _config.getString(BfConsts.ARG_SSL_TRUSTSTORE_PASSWORD);
   }
 
   public boolean getSynthesizeJsonTopology() {
-    return _synthesizeJsonTopology;
+    return _config.getBoolean(BfConsts.ARG_SYNTHESIZE_JSON_TOPOLOGY);
   }
 
   public String getTaskId() {
-    return _taskId;
+    return _config.getString(TASK_ID);
   }
 
   public String getTaskPlugin() {
-    return _taskPlugin;
+    return _config.getString(BfConsts.ARG_TASK_PLUGIN);
   }
 
   public String getTestrig() {
-    return _testrig;
+    return _config.getString(BfConsts.ARG_TESTRIG);
   }
 
   @Override
   public boolean getThrowOnLexerError() {
-    return _throwOnLexerError;
+    return _config.getBoolean(ARG_THROW_ON_LEXER_ERROR);
   }
 
   @Override
   public boolean getThrowOnParserError() {
-    return _throwOnParserError;
+    return _config.getBoolean(ARG_THROW_ON_PARSER_ERROR);
   }
 
   public boolean getTimestamp() {
-    return _timestamp;
-  }
-
-  public Integer getTracingAgentPort() {
-    return _tracingAgentPort;
+    return _config.getBoolean(ARG_TIMESTAMP);
   }
 
   public String getTracingAgentHost() {
-    return _tracingAgentHost;
+    return _config.getString(ARG_TRACING_AGENT_HOST);
+  }
+
+  public Integer getTracingAgentPort() {
+    return _config.getInt(ARG_TRACING_AGENT_PORT);
   }
 
   public boolean getTracingEnable() {
-    return _tracingEnable;
+    return _config.getBoolean(ARG_TRACING_ENABLE);
   }
 
   public boolean getUnimplementedAsError() {
-    return _unimplementedAsError;
+    return _config.getBoolean(BfConsts.ARG_UNIMPLEMENTED_AS_ERROR);
   }
 
   public boolean getUnimplementedRecord() {
-    return _unimplementedRecord;
+    return !_config.getBoolean(BfConsts.ARG_UNIMPLEMENTED_SUPPRESS);
   }
 
   public boolean getUnrecognizedAsRedFlag() {
-    return _unrecognizedAsRedFlag;
+    return _config.getBoolean(BfConsts.ARG_UNRECOGNIZED_AS_RED_FLAG);
   }
 
   public boolean getValidateEnvironment() {
-    return _validateEnvironment;
+    return _config.getBoolean(BfConsts.COMMAND_VALIDATE_ENVIRONMENT);
   }
 
   public boolean getVerboseParse() {
-    return _verboseParse;
+    return _config.getBoolean(BfConsts.ARG_VERBOSE_PARSE);
   }
 
   public List<String> ignoreFilesWithStrings() {
-    return _ignoreFilesWithStrings;
+    return _config.getList(
+        String.class, BfConsts.ARG_IGNORE_FILES_WITH_STRINGS, Collections.emptyList());
   }
 
   public boolean ignoreUnknown() {
-    return _ignoreUnknown;
+    return _config.getBoolean(ARG_IGNORE_UNKNOWN);
   }
 
   public boolean ignoreUnsupported() {
-    return _ignoreUnsupported;
+    return _config.getBoolean(ARG_IGNORE_UNSUPPORTED);
   }
 
   public int getZ3timeout() {
-    return _z3timeout;
+    return _config.getInt(ARG_Z3_TIMEOUT);
   }
 
   public String getDataPlaneEngineName() {
-    return _dataPlaneEngineName;
+    return _config.getString(ARG_DATAPLANE_ENGINE_NAME);
   }
 
   private void initConfigDefaults() {
@@ -1153,6 +1001,7 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
     setDefaultProperty(ARG_COORDINATOR_POOL_PORT, CoordConsts.SVC_CFG_POOL_PORT);
     setDefaultProperty(ARG_COORDINATOR_WORK_PORT, CoordConsts.SVC_CFG_WORK_PORT);
     setDefaultProperty(BfConsts.ARG_DIFF_ACTIVE, false);
+    setDefaultProperty(DIFFERENTIAL_QUESTION, false);
     setDefaultProperty(BfConsts.ARG_DELTA_ENVIRONMENT_NAME, null);
     setDefaultProperty(BfConsts.ARG_DIFFERENTIAL, false);
     setDefaultProperty(BfConsts.ARG_DISABLE_UNRECOGNIZED, false);
@@ -1519,185 +1368,191 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
         "dataplane engine name");
   }
 
-  private void parseCommandLine(String[] args) {
+  @VisibleForTesting
+  public void parseCommandLine(String[] args) {
     initCommandLine(args);
-    _canExecute = true;
+    _config.setProperty(CAN_EXECUTE, true);
 
     // SPECIAL OPTIONS
-    _logFile = getStringOptionValue(BfConsts.ARG_LOG_FILE);
-    _logLevel = getStringOptionValue(BfConsts.ARG_LOG_LEVEL);
+    getStringOptionValue(BfConsts.ARG_LOG_FILE);
+    getStringOptionValue(BfConsts.ARG_LOG_LEVEL);
     if (getBooleanOptionValue(ARG_HELP)) {
-      _canExecute = false;
+      _config.setProperty(CAN_EXECUTE, false);
       printHelp(EXECUTABLE_NAME);
       return;
     }
 
     // REGULAR OPTIONS
-    _analysisName = getStringOptionValue(BfConsts.ARG_ANALYSIS_NAME);
-    _analyze = getBooleanOptionValue(BfConsts.COMMAND_ANALYZE);
-    _answer = getBooleanOptionValue(BfConsts.COMMAND_ANSWER);
-    _answerJsonPath = getPathOptionValue(BfConsts.ARG_ANSWER_JSON_PATH);
-    _bdpRecordAllIterations = getBooleanOptionValue(BfConsts.ARG_BDP_RECORD_ALL_ITERATIONS);
-    _bdpDetail = getBooleanOptionValue(BfConsts.ARG_BDP_DETAIL);
-    _bdpMaxOscillationRecoveryAttempts =
-        getIntOptionValue(BfConsts.ARG_BDP_MAX_OSCILLATION_RECOVERY_ATTEMPTS);
-    _bdpMaxRecordedIterations = getIntOptionValue(BfConsts.ARG_BDP_MAX_RECORDED_ITERATIONS);
-    _bdpPrintAllIterations = getBooleanOptionValue(BfConsts.ARG_BDP_PRINT_ALL_ITERATIONS);
-    _bdpPrintOscillatingIterations =
-        getBooleanOptionValue(BfConsts.ARG_BDP_PRINT_OSCILLATING_ITERATIONS);
-    _blockNames = getStringListOptionValue(BfConsts.ARG_BLOCK_NAMES);
-    _compileDiffEnvironment = getBooleanOptionValue(BfConsts.COMMAND_COMPILE_DIFF_ENVIRONMENT);
-    _containerDir = getPathOptionValue(BfConsts.ARG_CONTAINER_DIR);
-    _coordinatorHost = getStringOptionValue(ARG_COORDINATOR_HOST);
-    _coordinatorPoolPort = getIntOptionValue(ARG_COORDINATOR_POOL_PORT);
-    _coordinatorRegister = getBooleanOptionValue(ARG_COORDINATOR_REGISTER);
-    _coordinatorWorkPort = getIntOptionValue(ARG_COORDINATOR_WORK_PORT);
-    _dataPlane = getBooleanOptionValue(BfConsts.COMMAND_DUMP_DP);
-    _deltaEnvironmentName = getStringOptionValue(BfConsts.ARG_DELTA_ENVIRONMENT_NAME);
-    _deltaTestrig = getStringOptionValue(BfConsts.ARG_DELTA_TESTRIG);
-    _diffActive = getBooleanOptionValue(BfConsts.ARG_DIFF_ACTIVE);
-    _differential = getBooleanOptionValue(BfConsts.ARG_DIFFERENTIAL);
-    _disableUnrecognized = getBooleanOptionValue(BfConsts.ARG_DISABLE_UNRECOGNIZED);
-    _environmentName = getStringOptionValue(BfConsts.ARG_ENVIRONMENT_NAME);
-    _exitOnFirstError = getBooleanOptionValue(ARG_EXIT_ON_FIRST_ERROR);
-    _flatten = getBooleanOptionValue(ARG_FLATTEN);
-    _flattenDestination = getPathOptionValue(ARG_FLATTEN_DESTINATION);
-    _flattenOnTheFly = getBooleanOptionValue(ARG_FLATTEN_ON_THE_FLY);
-    _generateStubs = getBooleanOptionValue(ARG_GENERATE_STUBS);
-    _generateStubsInputRole = getStringOptionValue(ARG_GENERATE_STUBS_INPUT_ROLE);
-    _generateStubsInterfaceDescriptionRegex =
-        getStringOptionValue(ARG_GENERATE_STUBS_INTERFACE_DESCRIPTION_REGEX);
-    _generateStubsRemoteAs = getIntegerOptionValue(ARG_GENERATE_STUBS_REMOTE_AS);
-    _genOspfTopologyPath = getPathOptionValue(ARG_GEN_OSPF_TOPLOGY_PATH);
-    _haltOnConvertError = getBooleanOptionValue(BfConsts.ARG_HALT_ON_CONVERT_ERROR);
-    _haltOnParseError = getBooleanOptionValue(BfConsts.ARG_HALT_ON_PARSE_ERROR);
-    _histogram = getBooleanOptionValue(ARG_HISTOGRAM);
-    _ignoreFilesWithStrings = getStringListOptionValue(BfConsts.ARG_IGNORE_FILES_WITH_STRINGS);
-    _ignoreUnknown = getBooleanOptionValue(ARG_IGNORE_UNKNOWN);
-    _ignoreUnsupported = getBooleanOptionValue(ARG_IGNORE_UNSUPPORTED);
-    _initInfo = getBooleanOptionValue(BfConsts.COMMAND_INIT_INFO);
-    _jobs = getIntOptionValue(ARG_JOBS);
-    _logTee = getBooleanOptionValue(ARG_LOG_TEE);
-    _maxParserContextLines = getIntOptionValue(ARG_MAX_PARSER_CONTEXT_LINES);
-    _maxParserContextTokens = getIntOptionValue(ARG_MAX_PARSER_CONTEXT_TOKENS);
-    _maxParseTreePrintLength = getIntOptionValue(ARG_MAX_PARSE_TREE_PRINT_LENGTH);
-    _maxRuntimeMs = getIntOptionValue(ARG_MAX_RUNTIME_MS);
-    _outputEnvironmentName = getStringOptionValue(BfConsts.ARG_OUTPUT_ENV);
-    _parentPid = getIntOptionValue(ARG_PARENT_PID);
-    _pedanticAsError = getBooleanOptionValue(BfConsts.ARG_PEDANTIC_AS_ERROR);
-    _pedanticRecord = !getBooleanOptionValue(BfConsts.ARG_PEDANTIC_SUPPRESS);
-    _prettyPrintAnswer = getBooleanOptionValue(BfConsts.ARG_PRETTY_PRINT_ANSWER);
-    _printParseTree = getBooleanOptionValue(ARG_PRINT_PARSE_TREES);
-    _printSymmetricEdges = getBooleanOptionValue(ARG_PRINT_SYMMETRIC_EDGES);
-    _questionName = getStringOptionValue(BfConsts.ARG_QUESTION_NAME);
-    _redFlagAsError = getBooleanOptionValue(BfConsts.ARG_RED_FLAG_AS_ERROR);
-    _redFlagRecord = !getBooleanOptionValue(BfConsts.ARG_RED_FLAG_SUPPRESS);
-    _report = getBooleanOptionValue(BfConsts.COMMAND_REPORT);
-    _runMode = RunMode.valueOf(getStringOptionValue(ARG_RUN_MODE).toUpperCase());
-    _sequential = getBooleanOptionValue(ARG_SEQUENTIAL);
-    _serializeIndependent = getBooleanOptionValue(BfConsts.COMMAND_PARSE_VENDOR_INDEPENDENT);
-    _serializeToText = getBooleanOptionValue(ARG_SERIALIZE_TO_TEXT);
-    _serializeVendor = getBooleanOptionValue(BfConsts.COMMAND_PARSE_VENDOR_SPECIFIC);
-    _serviceBindHost = getStringOptionValue(ARG_SERVICE_BIND_HOST);
-    _serviceHost = getStringOptionValue(ARG_SERVICE_HOST);
-    _servicePort = getIntOptionValue(ARG_SERVICE_PORT);
-    _shuffleJobs = !getBooleanOptionValue(ARG_NO_SHUFFLE);
-    _simplify = !getBooleanOptionValue(ARG_DISABLE_Z3_SIMPLIFICATION);
-    _sslDisable = getBooleanOptionValue(BfConsts.ARG_SSL_DISABLE);
-    _sslKeystoreFile = getPathOptionValue(BfConsts.ARG_SSL_KEYSTORE_FILE);
-    _sslKeystorePassword = getStringOptionValue(BfConsts.ARG_SSL_KEYSTORE_PASSWORD);
-    _sslTrustAllCerts = getBooleanOptionValue(BfConsts.ARG_SSL_TRUST_ALL_CERTS);
-    _sslTruststoreFile = getPathOptionValue(BfConsts.ARG_SSL_TRUSTSTORE_FILE);
-    _sslTruststorePassword = getStringOptionValue(BfConsts.ARG_SSL_TRUSTSTORE_PASSWORD);
-    _synthesizeJsonTopology = getBooleanOptionValue(BfConsts.ARG_SYNTHESIZE_JSON_TOPOLOGY);
-    _taskPlugin = getStringOptionValue(BfConsts.ARG_TASK_PLUGIN);
-    _testrig = getStringOptionValue(BfConsts.ARG_TESTRIG);
-    _throwOnLexerError = getBooleanOptionValue(ARG_THROW_ON_LEXER_ERROR);
-    _throwOnParserError = getBooleanOptionValue(ARG_THROW_ON_PARSER_ERROR);
-    _timestamp = getBooleanOptionValue(ARG_TIMESTAMP);
-    _tracingAgentHost = getStringOptionValue(ARG_TRACING_AGENT_HOST);
-    _tracingAgentPort = getIntegerOptionValue(ARG_TRACING_AGENT_PORT);
-    _tracingEnable = getBooleanOptionValue(ARG_TRACING_ENABLE);
-    _unimplementedAsError = getBooleanOptionValue(BfConsts.ARG_UNIMPLEMENTED_AS_ERROR);
-    _unimplementedRecord = !getBooleanOptionValue(BfConsts.ARG_UNIMPLEMENTED_SUPPRESS);
-    _unrecognizedAsRedFlag = getBooleanOptionValue(BfConsts.ARG_UNRECOGNIZED_AS_RED_FLAG);
-    _validateEnvironment = getBooleanOptionValue(BfConsts.COMMAND_VALIDATE_ENVIRONMENT);
-    _verboseParse = getBooleanOptionValue(BfConsts.ARG_VERBOSE_PARSE);
-    _z3timeout = getIntegerOptionValue(ARG_Z3_TIMEOUT);
-    _dataPlaneEngineName = getStringOptionValue(ARG_DATAPLANE_ENGINE_NAME);
-  }
-
-  public boolean prettyPrintAnswer() {
-    return _prettyPrintAnswer;
+    getStringOptionValue(BfConsts.ARG_ANALYSIS_NAME);
+    getBooleanOptionValue(BfConsts.COMMAND_ANALYZE);
+    getBooleanOptionValue(BfConsts.COMMAND_ANSWER);
+    getPathOptionValue(BfConsts.ARG_ANSWER_JSON_PATH);
+    getBooleanOptionValue(BfConsts.ARG_BDP_RECORD_ALL_ITERATIONS);
+    getBooleanOptionValue(BfConsts.ARG_BDP_DETAIL);
+    getIntOptionValue(BfConsts.ARG_BDP_MAX_OSCILLATION_RECOVERY_ATTEMPTS);
+    getIntOptionValue(BfConsts.ARG_BDP_MAX_RECORDED_ITERATIONS);
+    getBooleanOptionValue(BfConsts.ARG_BDP_PRINT_ALL_ITERATIONS);
+    getBooleanOptionValue(BfConsts.ARG_BDP_PRINT_OSCILLATING_ITERATIONS);
+    getStringListOptionValue(BfConsts.ARG_BLOCK_NAMES);
+    getBooleanOptionValue(BfConsts.COMMAND_COMPILE_DIFF_ENVIRONMENT);
+    getPathOptionValue(BfConsts.ARG_CONTAINER_DIR);
+    getStringOptionValue(ARG_COORDINATOR_HOST);
+    getIntOptionValue(ARG_COORDINATOR_POOL_PORT);
+    getBooleanOptionValue(ARG_COORDINATOR_REGISTER);
+    getIntOptionValue(ARG_COORDINATOR_WORK_PORT);
+    getBooleanOptionValue(BfConsts.COMMAND_DUMP_DP);
+    getStringOptionValue(BfConsts.ARG_DELTA_ENVIRONMENT_NAME);
+    getStringOptionValue(BfConsts.ARG_DELTA_TESTRIG);
+    getBooleanOptionValue(BfConsts.ARG_DIFF_ACTIVE);
+    getBooleanOptionValue(BfConsts.ARG_DIFFERENTIAL);
+    getBooleanOptionValue(BfConsts.ARG_DISABLE_UNRECOGNIZED);
+    getStringOptionValue(BfConsts.ARG_ENVIRONMENT_NAME);
+    getBooleanOptionValue(ARG_EXIT_ON_FIRST_ERROR);
+    getBooleanOptionValue(ARG_FLATTEN);
+    getPathOptionValue(ARG_FLATTEN_DESTINATION);
+    getBooleanOptionValue(ARG_FLATTEN_ON_THE_FLY);
+    getBooleanOptionValue(ARG_GENERATE_STUBS);
+    getStringOptionValue(ARG_GENERATE_STUBS_INPUT_ROLE);
+    getStringOptionValue(ARG_GENERATE_STUBS_INTERFACE_DESCRIPTION_REGEX);
+    getIntegerOptionValue(ARG_GENERATE_STUBS_REMOTE_AS);
+    getPathOptionValue(ARG_GEN_OSPF_TOPLOGY_PATH);
+    getBooleanOptionValue(BfConsts.ARG_HALT_ON_CONVERT_ERROR);
+    getBooleanOptionValue(BfConsts.ARG_HALT_ON_PARSE_ERROR);
+    getBooleanOptionValue(ARG_HISTOGRAM);
+    getStringListOptionValue(BfConsts.ARG_IGNORE_FILES_WITH_STRINGS);
+    getBooleanOptionValue(ARG_IGNORE_UNKNOWN);
+    getBooleanOptionValue(ARG_IGNORE_UNSUPPORTED);
+    getBooleanOptionValue(BfConsts.COMMAND_INIT_INFO);
+    getIntOptionValue(ARG_JOBS);
+    getBooleanOptionValue(ARG_LOG_TEE);
+    getIntOptionValue(ARG_MAX_PARSER_CONTEXT_LINES);
+    getIntOptionValue(ARG_MAX_PARSER_CONTEXT_TOKENS);
+    getIntOptionValue(ARG_MAX_PARSE_TREE_PRINT_LENGTH);
+    getIntOptionValue(ARG_MAX_RUNTIME_MS);
+    getStringOptionValue(BfConsts.ARG_OUTPUT_ENV);
+    getIntOptionValue(ARG_PARENT_PID);
+    getBooleanOptionValue(BfConsts.ARG_PEDANTIC_AS_ERROR);
+    getBooleanOptionValue(BfConsts.ARG_PEDANTIC_SUPPRESS);
+    getBooleanOptionValue(BfConsts.ARG_PRETTY_PRINT_ANSWER);
+    getBooleanOptionValue(ARG_PRINT_PARSE_TREES);
+    getBooleanOptionValue(ARG_PRINT_SYMMETRIC_EDGES);
+    getStringOptionValue(BfConsts.ARG_QUESTION_NAME);
+    getBooleanOptionValue(BfConsts.ARG_RED_FLAG_AS_ERROR);
+    getBooleanOptionValue(BfConsts.ARG_RED_FLAG_SUPPRESS);
+    getBooleanOptionValue(BfConsts.COMMAND_REPORT);
+    getStringOptionValue(ARG_RUN_MODE);
+    getBooleanOptionValue(ARG_SEQUENTIAL);
+    getBooleanOptionValue(BfConsts.COMMAND_PARSE_VENDOR_INDEPENDENT);
+    getBooleanOptionValue(ARG_SERIALIZE_TO_TEXT);
+    getBooleanOptionValue(BfConsts.COMMAND_PARSE_VENDOR_SPECIFIC);
+    getStringOptionValue(ARG_SERVICE_BIND_HOST);
+    getStringOptionValue(ARG_SERVICE_HOST);
+    getIntOptionValue(ARG_SERVICE_PORT);
+    getBooleanOptionValue(ARG_NO_SHUFFLE);
+    getBooleanOptionValue(ARG_DISABLE_Z3_SIMPLIFICATION);
+    getBooleanOptionValue(BfConsts.ARG_SSL_DISABLE);
+    getPathOptionValue(BfConsts.ARG_SSL_KEYSTORE_FILE);
+    getStringOptionValue(BfConsts.ARG_SSL_KEYSTORE_PASSWORD);
+    getBooleanOptionValue(BfConsts.ARG_SSL_TRUST_ALL_CERTS);
+    getPathOptionValue(BfConsts.ARG_SSL_TRUSTSTORE_FILE);
+    getStringOptionValue(BfConsts.ARG_SSL_TRUSTSTORE_PASSWORD);
+    getBooleanOptionValue(BfConsts.ARG_SYNTHESIZE_JSON_TOPOLOGY);
+    getStringOptionValue(BfConsts.ARG_TASK_PLUGIN);
+    getStringOptionValue(BfConsts.ARG_TESTRIG);
+    getBooleanOptionValue(ARG_THROW_ON_LEXER_ERROR);
+    getBooleanOptionValue(ARG_THROW_ON_PARSER_ERROR);
+    getBooleanOptionValue(ARG_TIMESTAMP);
+    getStringOptionValue(ARG_TRACING_AGENT_HOST);
+    getIntegerOptionValue(ARG_TRACING_AGENT_PORT);
+    getBooleanOptionValue(ARG_TRACING_ENABLE);
+    getBooleanOptionValue(BfConsts.ARG_UNIMPLEMENTED_AS_ERROR);
+    getBooleanOptionValue(BfConsts.ARG_UNIMPLEMENTED_SUPPRESS);
+    getBooleanOptionValue(BfConsts.ARG_UNRECOGNIZED_AS_RED_FLAG);
+    getBooleanOptionValue(BfConsts.COMMAND_VALIDATE_ENVIRONMENT);
+    getBooleanOptionValue(BfConsts.ARG_VERBOSE_PARSE);
+    getIntegerOptionValue(ARG_Z3_TIMEOUT);
+    getStringOptionValue(ARG_DATAPLANE_ENGINE_NAME);
   }
 
   public void setActiveTestrigSettings(TestrigSettings activeTestrigSettings) {
     _activeTestrigSettings = activeTestrigSettings;
   }
 
+  @Override
   public void setBdpDetail(boolean bdpDetail) {
-    _bdpDetail = bdpDetail;
+    _config.setProperty(BfConsts.ARG_BDP_DETAIL, bdpDetail);
   }
 
+  @Override
   public void setBdpMaxOscillationRecoveryAttempts(int bdpMaxOscillationRecoveryAttempts) {
-    _bdpMaxOscillationRecoveryAttempts = bdpMaxOscillationRecoveryAttempts;
+    _config.setProperty(
+        BfConsts.ARG_BDP_MAX_OSCILLATION_RECOVERY_ATTEMPTS, bdpMaxOscillationRecoveryAttempts);
   }
 
+  @Override
   public void setBdpMaxRecordedIterations(int bdpMaxRecordedIterations) {
-    _bdpMaxRecordedIterations = bdpMaxRecordedIterations;
+    _config.setProperty(BfConsts.ARG_BDP_MAX_RECORDED_ITERATIONS, bdpMaxRecordedIterations);
   }
 
+  @Override
   public void setBdpPrintAllIterations(boolean bdpPrintAllIterations) {
-    _bdpPrintAllIterations = bdpPrintAllIterations;
+    _config.setProperty(BfConsts.ARG_BDP_PRINT_ALL_ITERATIONS, bdpPrintAllIterations);
   }
 
+  @Override
   public void setBdpPrintOscillatingIterations(boolean bdpPrintOscillatingIterations) {
-    _bdpPrintOscillatingIterations = bdpPrintOscillatingIterations;
+    _config.setProperty(
+        BfConsts.ARG_BDP_PRINT_OSCILLATING_ITERATIONS, bdpPrintOscillatingIterations);
   }
 
+  @Override
   public void setBdpRecordAllIterations(boolean bdpRecordAllIterations) {
-    _bdpRecordAllIterations = bdpRecordAllIterations;
+    _config.setProperty(BfConsts.ARG_BDP_RECORD_ALL_ITERATIONS, bdpRecordAllIterations);
+  }
+
+  public void setCanExecute(boolean canExecute) {
+    _config.setProperty(CAN_EXECUTE, canExecute);
   }
 
   public void setContainerDir(Path containerDir) {
-    _containerDir = containerDir;
+    _config.setProperty(BfConsts.ARG_CONTAINER_DIR, containerDir.toString());
   }
 
   public void setDeltaEnvironmentName(String diffEnvironmentName) {
-    _deltaEnvironmentName = diffEnvironmentName;
+    _config.setProperty(BfConsts.ARG_DELTA_ENVIRONMENT_NAME, diffEnvironmentName);
   }
 
   public void setDeltaTestrig(String deltaTestrig) {
-    _deltaTestrig = deltaTestrig;
+    _config.setProperty(BfConsts.ARG_DELTA_TESTRIG, deltaTestrig);
   }
 
   public void setDiffActive(boolean diffActive) {
-    _diffActive = diffActive;
+    _config.setProperty(BfConsts.ARG_DIFF_ACTIVE, diffActive);
   }
 
   public void setDiffQuestion(boolean diffQuestion) {
-    _diffQuestion = diffQuestion;
+    _config.setProperty(DIFFERENTIAL_QUESTION, diffQuestion);
   }
 
   @Override
   public void setDisableUnrecognized(boolean b) {
-    _disableUnrecognized = b;
+    _config.setProperty(BfConsts.ARG_DISABLE_UNRECOGNIZED, b);
   }
 
   public void setEnvironmentName(String envName) {
-    _environmentName = envName;
+    _config.setProperty(BfConsts.ARG_ENVIRONMENT_NAME, envName);
   }
 
   public void setHaltOnConvertError(boolean haltOnConvertError) {
-    _haltOnConvertError = haltOnConvertError;
+    _config.setProperty(BfConsts.ARG_HALT_ON_CONVERT_ERROR, haltOnConvertError);
   }
 
   public void setHaltOnParseError(boolean haltOnParseError) {
-    _haltOnParseError = haltOnParseError;
+    _config.setProperty(BfConsts.ARG_HALT_ON_PARSE_ERROR, haltOnParseError);
   }
 
   public void setInitInfo(boolean initInfo) {
-    _initInfo = initInfo;
+    _config.setProperty(BfConsts.COMMAND_INIT_INFO, initInfo);
   }
 
   public void setLogger(BatfishLogger logger) {
@@ -1705,97 +1560,103 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
   }
 
   public void setMaxParserContextLines(int maxParserContextLines) {
-    _maxParserContextLines = maxParserContextLines;
+    _config.setProperty(ARG_MAX_PARSER_CONTEXT_LINES, maxParserContextLines);
   }
 
   public void setMaxParserContextTokens(int maxParserContextTokens) {
-    _maxParserContextTokens = maxParserContextTokens;
+    _config.setProperty(ARG_MAX_PARSER_CONTEXT_TOKENS, maxParserContextTokens);
   }
 
   public void setMaxParseTreePrintLength(int maxParseTreePrintLength) {
-    _maxParseTreePrintLength = maxParseTreePrintLength;
+    _config.setProperty(ARG_MAX_PARSE_TREE_PRINT_LENGTH, maxParseTreePrintLength);
   }
 
   public void setMaxRuntimeMs(int runtimeMs) {
-    _maxRuntimeMs = runtimeMs;
+    _config.setProperty(ARG_MAX_RUNTIME_MS, runtimeMs);
   }
 
   @Override
   public void setPrintParseTree(boolean printParseTree) {
-    _printParseTree = printParseTree;
+    _config.setProperty(ARG_PRINT_PARSE_TREES, printParseTree);
   }
 
   public void setQuestionPath(@Nullable Path questionPath) {
-    _questionPath = questionPath;
+    if (questionPath != null) {
+      _config.setProperty(QUESTION_PATH, questionPath.toString());
+    }
   }
 
   public void setReport(boolean report) {
-    _report = report;
+    _config.setProperty(BfConsts.COMMAND_REPORT, report);
+  }
+
+  public void setRunMode(RunMode runMode) {
+    _config.setProperty(ARG_RUN_MODE, runMode.toString());
   }
 
   public void setSequential(boolean sequential) {
-    _sequential = true;
+    _config.setProperty(ARG_SEQUENTIAL, sequential);
   }
 
   public void setSslDisable(boolean sslDisable) {
-    _sslDisable = sslDisable;
+    _config.setProperty(BfConsts.ARG_SSL_DISABLE, sslDisable);
   }
 
   public void setSslKeystoreFile(Path sslKeystoreFile) {
-    _sslKeystoreFile = sslKeystoreFile;
+    _config.setProperty(BfConsts.ARG_SSL_KEYSTORE_FILE, sslKeystoreFile.toString());
   }
 
   public void setSslKeystorePassword(String sslKeystorePassword) {
-    _sslKeystorePassword = sslKeystorePassword;
+    _config.setProperty(BfConsts.ARG_SSL_KEYSTORE_PASSWORD, sslKeystorePassword);
   }
 
   public void setSslTrustAllCerts(boolean sslTrustAllCerts) {
-    _sslTrustAllCerts = sslTrustAllCerts;
+    _config.setProperty(BfConsts.ARG_SSL_TRUST_ALL_CERTS, sslTrustAllCerts);
   }
 
   public void setSslTruststoreFile(Path sslTruststoreFile) {
-    _sslTruststoreFile = sslTruststoreFile;
+    _config.setProperty(BfConsts.ARG_SSL_TRUSTSTORE_FILE, sslTruststoreFile.toString());
   }
 
   public void setSslTruststorePassword(String sslTruststorePassword) {
-    _sslTruststorePassword = sslTruststorePassword;
+    _config.setProperty(BfConsts.ARG_SSL_TRUSTSTORE_PASSWORD, sslTruststorePassword);
   }
 
   public void setTaskId(String taskId) {
-    _taskId = taskId;
+    _config.setProperty(TASK_ID, taskId);
   }
 
   public void setTestrig(String testrig) {
-    _testrig = testrig;
+    _config.setProperty(BfConsts.ARG_TESTRIG, testrig);
   }
 
   @Override
   public void setThrowOnLexerError(boolean throwOnLexerError) {
-    _throwOnLexerError = throwOnLexerError;
+    _config.setProperty(ARG_THROW_ON_LEXER_ERROR, throwOnLexerError);
   }
 
   @Override
   public void setThrowOnParserError(boolean throwOnParserError) {
-    _throwOnParserError = throwOnParserError;
+    _config.setProperty(ARG_THROW_ON_PARSER_ERROR, throwOnParserError);
   }
 
   public void setUnrecognizedAsRedFlag(boolean unrecognizedAsRedFlag) {
-    _unrecognizedAsRedFlag = unrecognizedAsRedFlag;
+    _config.setProperty(BfConsts.ARG_UNRECOGNIZED_AS_RED_FLAG, unrecognizedAsRedFlag);
   }
 
   public void setValidateEnvironment(boolean validateEnvironment) {
-    _validateEnvironment = validateEnvironment;
+    _config.setProperty(BfConsts.COMMAND_VALIDATE_ENVIRONMENT, validateEnvironment);
   }
 
   public void setVerboseParse(boolean verboseParse) {
-    _verboseParse = verboseParse;
+    _config.setProperty(BfConsts.ARG_VERBOSE_PARSE, verboseParse);
   }
 
   public void setZ3Timeout(int z3Timeout) {
-    _z3timeout = z3Timeout;
+    _config.setProperty(ARG_Z3_TIMEOUT, z3Timeout);
   }
 
   public void setDataplaneEngineName(String name) {
-    _dataPlaneEngineName = name;
+    _config.setProperty(ARG_DATAPLANE_ENGINE_NAME, name);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/config/Settings.java
+++ b/projects/batfish/src/main/java/org/batfish/config/Settings.java
@@ -552,13 +552,14 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
    *
    * @param other the {@link Settings to copy}
    */
+  @SuppressWarnings("IncompleteCopyConstructor")
   public Settings(Settings other) {
     super(other._config);
-    initOptions();
-    _activeTestrigSettings = other._activeTestrigSettings;
-    _deltaTestrigSettings = other._deltaTestrigSettings;
-    _baseTestrigSettings = other._baseTestrigSettings;
+    _baseTestrigSettings = new TestrigSettings();
+    _deltaTestrigSettings = new TestrigSettings();
+    _activeTestrigSettings = new TestrigSettings();
     _logger = other._logger;
+    initOptions();
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/config/Settings.java
+++ b/projects/batfish/src/main/java/org/batfish/config/Settings.java
@@ -1,10 +1,9 @@
 package org.batfish.config;
 
-import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -552,7 +551,6 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
    *
    * @param other the {@link Settings to copy}
    */
-  @SuppressWarnings("IncompleteCopyConstructor")
   public Settings(Settings other) {
     super(other._config);
     _baseTestrigSettings = new TestrigSettings();
@@ -574,7 +572,7 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
   }
 
   public boolean canExecute() {
-    return _config.getBoolean(CAN_EXECUTE, true);
+    return _config.getBoolean(CAN_EXECUTE);
   }
 
   public boolean flattenOnTheFly() {
@@ -634,10 +632,6 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
   @Override
   public boolean getBdpRecordAllIterations() {
     return _config.getBoolean(BfConsts.ARG_BDP_RECORD_ALL_ITERATIONS);
-  }
-
-  public List<String> getBlockNames() {
-    return _config.getList(String.class, BfConsts.ARG_BLOCK_NAMES, Collections.emptyList());
   }
 
   public boolean getCompileEnvironment() {
@@ -967,8 +961,8 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
   }
 
   public List<String> ignoreFilesWithStrings() {
-    return _config.getList(
-        String.class, BfConsts.ARG_IGNORE_FILES_WITH_STRINGS, Collections.emptyList());
+    List<String> l = _config.getList(String.class, BfConsts.ARG_IGNORE_FILES_WITH_STRINGS);
+    return l == null ? ImmutableList.of() : l;
   }
 
   public boolean ignoreUnknown() {
@@ -996,7 +990,7 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
     setDefaultProperty(BfConsts.ARG_BDP_PRINT_ALL_ITERATIONS, false);
     setDefaultProperty(BfConsts.ARG_BDP_PRINT_OSCILLATING_ITERATIONS, false);
     setDefaultProperty(BfConsts.ARG_BDP_RECORD_ALL_ITERATIONS, false);
-    setDefaultProperty(BfConsts.ARG_BLOCK_NAMES, new String[] {});
+    setDefaultProperty(CAN_EXECUTE, true);
     setDefaultProperty(BfConsts.ARG_CONTAINER_DIR, null);
     setDefaultProperty(ARG_COORDINATOR_REGISTER, false);
     setDefaultProperty(ARG_COORDINATOR_HOST, "localhost");
@@ -1022,6 +1016,7 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
     setDefaultProperty(BfConsts.ARG_HALT_ON_PARSE_ERROR, false);
     setDefaultProperty(ARG_HELP, false);
     setDefaultProperty(ARG_HISTOGRAM, false);
+    setDefaultProperty(BfConsts.ARG_IGNORE_FILES_WITH_STRINGS, ImmutableList.of());
     setDefaultProperty(ARG_IGNORE_UNSUPPORTED, true);
     setDefaultProperty(ARG_IGNORE_UNKNOWN, true);
     setDefaultProperty(ARG_JOBS, Integer.MAX_VALUE);
@@ -1118,9 +1113,6 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
         BfConsts.ARG_BDP_RECORD_ALL_ITERATIONS,
         "Set to true to record all iterations, including during oscillation. Ignores max recorded "
             + "iterations value.");
-
-    addListOption(
-        BfConsts.ARG_BLOCK_NAMES, "list of blocks of logic rules to add or remove", "blocknames");
 
     addOption(BfConsts.ARG_CONTAINER_DIR, "path to container directory", ARGNAME_PATH);
 
@@ -1370,7 +1362,6 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
         "dataplane engine name");
   }
 
-  @VisibleForTesting
   public void parseCommandLine(String[] args) {
     initCommandLine(args);
     _config.setProperty(CAN_EXECUTE, true);
@@ -1395,7 +1386,6 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
     getIntOptionValue(BfConsts.ARG_BDP_MAX_RECORDED_ITERATIONS);
     getBooleanOptionValue(BfConsts.ARG_BDP_PRINT_ALL_ITERATIONS);
     getBooleanOptionValue(BfConsts.ARG_BDP_PRINT_OSCILLATING_ITERATIONS);
-    getStringListOptionValue(BfConsts.ARG_BLOCK_NAMES);
     getBooleanOptionValue(BfConsts.COMMAND_COMPILE_DIFF_ENVIRONMENT);
     getPathOptionValue(BfConsts.ARG_CONTAINER_DIR);
     getStringOptionValue(ARG_COORDINATOR_HOST);

--- a/projects/batfish/src/main/java/org/batfish/main/Driver.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Driver.java
@@ -632,7 +632,9 @@ public class Driver {
   public static List<String> runBatfishThroughService(final String taskId, String[] args) {
     final Settings settings;
     try {
-      settings = new Settings(args);
+      settings = new Settings(_mainSettings);
+      settings.parseCommandLine(args);
+      settings.setCanExecute(true);
       // assign taskId for status updates, termination requests
       settings.setTaskId(taskId);
     } catch (Exception e) {
@@ -664,8 +666,6 @@ public class Driver {
                   settings.getLogTee(),
                   false);
           settings.setLogger(jobLogger);
-
-          settings.setMaxRuntimeMs(_mainSettings.getMaxRuntimeMs());
 
           final Task task = new Task(args);
 

--- a/projects/batfish/src/main/java/org/batfish/main/Driver.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Driver.java
@@ -633,8 +633,8 @@ public class Driver {
     final Settings settings;
     try {
       settings = new Settings(_mainSettings);
+      settings.setRunMode(RunMode.WORKER);
       settings.parseCommandLine(args);
-      settings.setCanExecute(true);
       // assign taskId for status updates, termination requests
       settings.setTaskId(taskId);
     } catch (Exception e) {

--- a/projects/batfish/src/test/java/org/batfish/config/SettingsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/config/SettingsTest.java
@@ -1,0 +1,59 @@
+package org.batfish.config;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.batfish.common.CleanBatfishException;
+import org.batfish.main.Driver.RunMode;
+import org.junit.Test;
+
+/** Test for {@link org.batfish.config.Settings} */
+public class SettingsTest {
+
+  @Test
+  public void testDefaultDPEngine() {
+    Settings settings = new Settings(new String[] {});
+    assertThat(settings.getDataPlaneEngineName(), equalTo("bdp"));
+  }
+
+  @Test
+  public void testCopy() {
+    Settings origSettings = new Settings(new String[] {});
+    origSettings.setDataplaneEngineName("NewValue");
+
+    // Check that settings are preserved on copy
+    Settings settings = new Settings(origSettings);
+    assertThat(settings.getDataPlaneEngineName(), equalTo("NewValue"));
+
+    // But reparsing the command line updates the value
+    settings.parseCommandLine(new String[] {"-dataplaneengine=CmdValue"});
+    assertThat(settings.getDataPlaneEngineName(), equalTo("CmdValue"));
+
+    // Ensure re-parsing does not modify original config
+    assertThat(
+        origSettings.getDataPlaneEngineName(), not(equalTo(settings.getDataPlaneEngineName())));
+  }
+
+  @Test
+  public void testBooleanParsing() {
+    Settings settings = new Settings(new String[] {"-register=true"});
+    assertThat(settings.getCoordinatorRegister(), is(true));
+
+    settings = new Settings(new String[] {"-register=false"});
+    assertThat(settings.getCoordinatorRegister(), is(false));
+  }
+
+  @Test(expected = CleanBatfishException.class)
+  public void testBoolenParsingBogusValue() {
+    Settings settings = new Settings(new String[] {"-register=blah"});
+    assertThat(settings.getCoordinatorRegister(), is(false));
+  }
+
+  @Test
+  public void testRunModeCaseInsensitive() {
+    Settings settings = new Settings(new String[] {"-runmode=workservice"});
+    assertThat(settings.getRunMode(), equalTo(RunMode.WORKSERVICE));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/config/SettingsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/config/SettingsTest.java
@@ -3,8 +3,10 @@ package org.batfish.config;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import java.nio.file.Paths;
 import org.batfish.common.CleanBatfishException;
 import org.batfish.main.Driver.RunMode;
 import org.junit.Test;
@@ -13,11 +15,13 @@ import org.junit.Test;
 public class SettingsTest {
 
   @Test
+  /** Test default dataplane engine is bdp */
   public void testDefaultDPEngine() {
     Settings settings = new Settings(new String[] {});
     assertThat(settings.getDataPlaneEngineName(), equalTo("bdp"));
   }
 
+  /** Test that settings copy is deep */
   @Test
   public void testCopy() {
     Settings origSettings = new Settings(new String[] {});
@@ -36,6 +40,7 @@ public class SettingsTest {
         origSettings.getDataPlaneEngineName(), not(equalTo(settings.getDataPlaneEngineName())));
   }
 
+  /** Test that boolean parsing recognizes "true" or "false" */
   @Test
   public void testBooleanParsing() {
     Settings settings = new Settings(new String[] {"-register=true"});
@@ -45,15 +50,32 @@ public class SettingsTest {
     assertThat(settings.getCoordinatorRegister(), is(false));
   }
 
+  /** Test that boolean parsing fails on garbage values and not defaults to just false. */
   @Test(expected = CleanBatfishException.class)
   public void testBoolenParsingBogusValue() {
     Settings settings = new Settings(new String[] {"-register=blah"});
     assertThat(settings.getCoordinatorRegister(), is(false));
   }
 
+  /** Test that parsing of runmode is case insensitive */
   @Test
   public void testRunModeCaseInsensitive() {
     Settings settings = new Settings(new String[] {"-runmode=workservice"});
     assertThat(settings.getRunMode(), equalTo(RunMode.WORKSERVICE));
+  }
+
+  /**
+   * Value of question path is allowed to have null and acts as a special value, ensure that's
+   * supported.
+   */
+  @Test
+  public void testQuestionPathAllowNull() {
+    Settings settings = new Settings(new String[] {});
+    settings.setQuestionPath(Paths.get("test"));
+
+    assertThat(settings.getQuestionPath(), equalTo(Paths.get("test")));
+    // Update to null
+    settings.setQuestionPath(null);
+    assertThat(settings.getQuestionPath(), is(nullValue()));
   }
 }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/config/Settings.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/config/Settings.java
@@ -121,7 +121,6 @@ public class Settings extends BaseSettings {
             Settings.class));
 
     initConfigDefaults();
-
     initOptions();
     parseCommandLine(args);
   }
@@ -309,7 +308,7 @@ public class Settings extends BaseSettings {
     setDefaultProperty(ARG_PERIOD_ASSIGN_WORK_MS, 1000);
     setDefaultProperty(ARG_PERIOD_CHECK_WORK_MS, 1000);
     setDefaultProperty(ARG_PERIOD_WORKER_STATUS_REFRESH_MS, 10000);
-    setDefaultProperty(ARG_QUESTION_TEMPLATE_DIRS, Collections.<String>emptyList());
+    setDefaultProperty(ARG_QUESTION_TEMPLATE_DIRS, Collections.emptyList());
     setDefaultProperty(ARG_QUEUE_COMPLETED_WORK, "batfishcompletedwork");
     setDefaultProperty(ARG_QUEUE_INCOMPLETE_WORK, "batfishincompletework");
     setDefaultProperty(ARG_QUEUE_TYPE, WorkQueue.Type.memory.toString());

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/config/SettingsTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/config/SettingsTest.java
@@ -2,24 +2,48 @@ package org.batfish.coordinator.config;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.junit.Test;
 
 /** Tests for {@link Settings}. */
 public class SettingsTest {
 
   @Test
-  public void testDefaultValue() throws Exception {
+  public void testDefaultValue() {
     Settings settings = new Settings(new String[] {});
     assertThat(settings.getPoolBindHost(), equalTo("0.0.0.0"));
     assertThat(settings.getWorkBindHost(), equalTo("0.0.0.0"));
   }
 
   @Test
-  public void testGetBothValues() throws Exception {
+  public void testGetBothValues() {
     String[] args = new String[] {"-poolbindhost=10.10.10.10", "-workbindhost=20.20.20.20"};
     Settings settings = new Settings(args);
     assertThat(settings.getPoolBindHost(), equalTo("10.10.10.10"));
     assertThat(settings.getWorkBindHost(), equalTo("20.20.20.20"));
+  }
+
+  /** Ensure {@link Path} objects are stored/returned properly (with default values) */
+  @Test
+  public void testGetPathDefault() {
+    Settings settings = new Settings(new String[] {});
+    assertThat(settings.getSslPoolKeystoreFile(), is(nullValue()));
+    Path keyfile = Paths.get("keyfile");
+    settings.setSslPoolKeystoreFile(keyfile);
+    assertThat(settings.getSslPoolKeystoreFile(), equalTo(keyfile));
+  }
+
+  /** Ensure lists of {@link Path} objects are stored/returned properly */
+  @Test
+  public void testGetPathList() {
+    String[] args = new String[] {"-templatedirs=path1,path2"};
+    Settings settings = new Settings(args);
+    assertThat(
+        settings.getQuestionTemplateDirs(), contains(Paths.get("path1"), Paths.get("path2")));
   }
 }


### PR DESCRIPTION
*Purpose*:
Partially addressing #894 
Allow settings to be copyable, which in turn allows task arguments to be layered on top of arguments passed to the worker at the start (as opposed to overriding them completely, which is what is happening currently and is not the desired behavior).

*Implementation*:
- Use the underlying configuration object for storing settings as opposed to local fields
- Keeping the existing getters/setter for compatibility
- Additional tests for settings
- Changes to `runBatfishThoughService`: task settings are copied over from `_mainSettings`

*Not in this PR*:
Settings hooks, i.e., allowing different plugins to register custom settings. Deferring to a different PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/956)
<!-- Reviewable:end -->
