### PR TITLE
Batfish: cleanup caching and loading testrigs

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/Snapshot.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/Snapshot.java
@@ -1,0 +1,49 @@
+package org.batfish.common;
+
+import com.google.common.base.MoreObjects;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+
+/** A {@link Snapshot} represents a combination of a testrig and an environment. */
+public class Snapshot {
+  /** Returns a new {@link Snapshot} corresponding to the given {@code testrig} and {@code env}. */
+  public Snapshot(@Nonnull String testrig, @Nonnull String env) {
+    _testrig = testrig;
+    _env = env;
+  }
+
+  public String getTestrig() {
+    return _testrig;
+  }
+
+  public String getEnvironment() {
+    return _env;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    } else if (!(o instanceof Snapshot)) {
+      return false;
+    }
+    Snapshot other = (Snapshot) o;
+    return _testrig.equals(other._testrig) && _env.equals(other._env);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_testrig, _env);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(Snapshot.class)
+        .add("testrig", _testrig)
+        .add("env", _env)
+        .toString();
+  }
+
+  private final String _testrig;
+  private final String _env;
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/Version.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/Version.java
@@ -17,6 +17,10 @@ public final class Version {
   private static final String PROPERTIES_PATH = "org/batfish/common/common.properties";
 
   static final String UNKNOWN_VERSION = "0.0.0";
+  /**
+   * A special version string that is incompatible with all other version. Mainly used for testing.
+   */
+  public static final String INCOMPATIBLE_VERSION = "x.x.x";
 
   /**
    * Checks whether the supplied version for another endpoint is compatible with the Batfish version
@@ -75,6 +79,10 @@ public final class Version {
   static boolean isCompatibleVersion(
       String myName, String myVersion, String otherName, @Nullable String otherVersion) {
     otherVersion = firstNonNull(otherVersion, UNKNOWN_VERSION);
+
+    if (otherVersion.equals(INCOMPATIBLE_VERSION) || myVersion.equals(INCOMPATIBLE_VERSION)) {
+      return false;
+    }
 
     if (otherVersion.equals(UNKNOWN_VERSION) || myVersion.equals(UNKNOWN_VERSION)) {
       // Either version is unknown, assume compatible.

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
@@ -101,7 +101,7 @@ public interface IBatfish extends IPluginConsumer {
 
   SortedMap<String, Configuration> loadConfigurations();
 
-  ConvertConfigurationAnswerElement loadConvertConfigurationAnswerElement();
+  ConvertConfigurationAnswerElement loadConvertConfigurationAnswerElementOrReparse();
 
   DataPlane loadDataPlane();
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/PluginConsumer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/PluginConsumer.java
@@ -8,7 +8,6 @@ import com.thoughtworks.xstream.io.xml.DomDriver;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.FileInputStream;
 import java.io.FilterOutputStream;
 import java.io.IOException;
@@ -167,13 +166,6 @@ public abstract class PluginConsumer implements IPluginConsumer {
       throw new BatfishException(
           "Failed to serialize object to gzip output file: " + outputFile, e);
     }
-  }
-
-  /** Serializes the given object to a GZIP-compressed byte[]. */
-  protected byte[] toGzipData(Serializable object) {
-    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    serializeToGzipData(object, baos);
-    return baos.toByteArray();
   }
 
   private static class CloseIgnoringOutputStream extends FilterOutputStream {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/ConvertConfigurationAnswerElement.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/ConvertConfigurationAnswerElement.java
@@ -7,6 +7,7 @@ import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import org.batfish.common.BatfishException;
+import org.batfish.common.Version;
 import org.batfish.common.Warning;
 import org.batfish.common.Warnings;
 
@@ -36,8 +37,10 @@ public class ConvertConfigurationAnswerElement implements InitStepAnswerElement,
     _undefinedReferences = new TreeMap<>();
     _unusedStructures = new TreeMap<>();
     _errors = new TreeMap<>();
+    _version = Version.getVersion();
   }
 
+  @Override
   public SortedMap<String, BatfishException.BatfishStackTrace> getErrors() {
     return _errors;
   }
@@ -61,6 +64,7 @@ public class ConvertConfigurationAnswerElement implements InitStepAnswerElement,
     return _version;
   }
 
+  @Override
   public SortedMap<String, Warnings> getWarnings() {
     return _warnings;
   }
@@ -118,6 +122,7 @@ public class ConvertConfigurationAnswerElement implements InitStepAnswerElement,
     return sb.toString();
   }
 
+  @Override
   public void setErrors(SortedMap<String, BatfishException.BatfishStackTrace> errors) {
     _errors = errors;
   }
@@ -142,6 +147,7 @@ public class ConvertConfigurationAnswerElement implements InitStepAnswerElement,
     _version = version;
   }
 
+  @Override
   public void setWarnings(SortedMap<String, Warnings> warnings) {
     _warnings = warnings;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/ValidateEnvironmentAnswerElement.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/ValidateEnvironmentAnswerElement.java
@@ -6,6 +6,7 @@ import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import org.batfish.common.Version;
 
 public class ValidateEnvironmentAnswerElement implements AnswerElement, Serializable {
 
@@ -44,6 +45,8 @@ public class ValidateEnvironmentAnswerElement implements AnswerElement, Serializ
     _undefinedInterfaceBlacklistNodes = new TreeSet<>();
     _undefinedNodeBlacklistNodes = new TreeSet<>();
     _undefinedNodeRoleSpecifierNodes = new TreeSet<>();
+    _valid = true;
+    _version = Version.getVersion();
   }
 
   @JsonProperty(PROP_UNDEFINED_INTERFACE_BLACKLIST_INTERFACES)

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/pojo/EnvironmentTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/pojo/EnvironmentTest.java
@@ -3,6 +3,7 @@ package org.batfish.datamodel.pojo;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
+import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -53,8 +54,8 @@ public class EnvironmentTest {
             20,
             new Ip("0.0.0.0"),
             new AsPath(Lists.newArrayList()),
-            null,
-            null,
+            ImmutableSortedSet.of(),
+            ImmutableSortedSet.of(),
             10));
     Environment e =
         new Environment(

--- a/projects/batfish/src/main/java/org/batfish/config/Settings.java
+++ b/projects/batfish/src/main/java/org/batfish/config/Settings.java
@@ -261,8 +261,6 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
 
     private Path _basePath;
 
-    private Path _convertAnswerPath;
-
     private EnvironmentSettings _environmentSettings;
 
     private Path _inferredNodeRolesPath;
@@ -278,8 +276,6 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
     private Path _protocolDependencyGraphPath;
 
     private Path _protocolDependencyGraphZipPath;
-
-    private Path _serializeIndependentPath;
 
     private Path _serializeVendorPath;
 
@@ -305,10 +301,6 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
 
     public Path getBasePath() {
       return _basePath;
-    }
-
-    public Path getConvertAnswerPath() {
-      return _convertAnswerPath;
     }
 
     public EnvironmentSettings getEnvironmentSettings() {
@@ -343,10 +335,6 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
       return _protocolDependencyGraphZipPath;
     }
 
-    public Path getSerializeIndependentPath() {
-      return _serializeIndependentPath;
-    }
-
     public Path getSerializeVendorPath() {
       return _serializeVendorPath;
     }
@@ -372,10 +360,6 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
 
     public void setBasePath(Path basePath) {
       _basePath = basePath;
-    }
-
-    public void setConvertAnswerPath(Path convertAnswerPath) {
-      _convertAnswerPath = convertAnswerPath;
     }
 
     public void setEnvironmentSettings(EnvironmentSettings environmentSettings) {
@@ -410,10 +394,6 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
       _protocolDependencyGraphZipPath = protocolDependencyGraphZipPath;
     }
 
-    public void setSerializeIndependentPath(Path path) {
-      _serializeIndependentPath = path;
-    }
-
     public void setSerializeVendorPath(Path path) {
       _serializeVendorPath = path;
     }
@@ -446,8 +426,6 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
   private static final String ARG_FLATTEN_DESTINATION = "flattendst";
 
   private static final String ARG_FLATTEN_ON_THE_FLY = "flattenonthefly";
-
-  private static final String ARG_GEN_OSPF_TOPLOGY_PATH = "genospf";
 
   private static final String ARG_GENERATE_STUBS = "gs";
 
@@ -725,11 +703,6 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
 
   public Path getFlattenDestination() {
     return Paths.get(_config.getString(ARG_FLATTEN_DESTINATION));
-  }
-
-  @Nullable
-  public Path getGenerateOspfTopologyPath() {
-    return nullablePath(_config.getString(ARG_GEN_OSPF_TOPLOGY_PATH));
   }
 
   public boolean getGenerateStubs() {
@@ -1027,7 +1000,6 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
     setDefaultProperty(ARG_FLATTEN, false);
     setDefaultProperty(ARG_FLATTEN_DESTINATION, null);
     setDefaultProperty(ARG_FLATTEN_ON_THE_FLY, true);
-    setDefaultProperty(ARG_GEN_OSPF_TOPLOGY_PATH, null);
     setDefaultProperty(ARG_GENERATE_STUBS, false);
     setDefaultProperty(ARG_GENERATE_STUBS_INPUT_ROLE, null);
     setDefaultProperty(ARG_GENERATE_STUBS_INTERFACE_DESCRIPTION_REGEX, null);
@@ -1185,9 +1157,6 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
 
     addBooleanOption(
         BfConsts.COMMAND_INIT_INFO, "include parse/convert initialization info in answer");
-
-    addOption(
-        ARG_GEN_OSPF_TOPLOGY_PATH, "generate ospf configs from specified topology", ARGNAME_PATH);
 
     addBooleanOption(ARG_GENERATE_STUBS, "generate stubs");
 
@@ -1427,7 +1396,6 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
     getStringOptionValue(ARG_GENERATE_STUBS_INPUT_ROLE);
     getStringOptionValue(ARG_GENERATE_STUBS_INTERFACE_DESCRIPTION_REGEX);
     getIntegerOptionValue(ARG_GENERATE_STUBS_REMOTE_AS);
-    getPathOptionValue(ARG_GEN_OSPF_TOPLOGY_PATH);
     getBooleanOptionValue(BfConsts.ARG_HALT_ON_CONVERT_ERROR);
     getBooleanOptionValue(BfConsts.ARG_HALT_ON_PARSE_ERROR);
     getBooleanOptionValue(ARG_HISTOGRAM);

--- a/projects/batfish/src/main/java/org/batfish/main/BatfishStorage.java
+++ b/projects/batfish/src/main/java/org/batfish/main/BatfishStorage.java
@@ -1,0 +1,216 @@
+package org.batfish.main;
+
+import com.google.common.base.Throwables;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.OutputStream;
+import java.io.Serializable;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+import javax.annotation.Nullable;
+import org.batfish.common.BatfishException;
+import org.batfish.common.BatfishLogger;
+import org.batfish.common.BfConsts;
+import org.batfish.common.Version;
+import org.batfish.common.util.CommonUtil;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
+
+/** A utility class that abstracts the underlying file system storage used by {@link Batfish}. */
+final class BatfishStorage {
+  private final BatfishLogger _logger;
+  private final Path _containerDir;
+  private final BiFunction<String, Integer, AtomicInteger> _newBatch;
+
+  /** Create a new {@link BatfishStorage} instance that uses the given root path as a container. */
+  public BatfishStorage(
+      Path containerDir,
+      BatfishLogger logger,
+      BiFunction<String, Integer, AtomicInteger> newBatch) {
+    _containerDir = containerDir;
+    _logger = logger;
+    _newBatch = newBatch;
+  }
+
+  /**
+   * Returns the configuration files for the given testrig. If a serialized copy of these
+   * configurations is not already present, then this function returns {@code null}.
+   */
+  @Nullable
+  public SortedMap<String, Configuration> loadConfigurations(String testrig) {
+    Path testrigDir = getTestrigDir(testrig);
+    Path indepDir = testrigDir.resolve(BfConsts.RELPATH_VENDOR_INDEPENDENT_CONFIG_DIR);
+
+    // If the directory that would contain these configs does not even exist, no cache exists.
+    if (!Files.exists(indepDir)) {
+      _logger.debugf("Unable to load configs for %s from disk: no cache directory", testrig);
+      return null;
+    }
+
+    // If the directory exists, then likely the configs exist and are useful. Still, we need to
+    // confirm that they were serialized with a compatible version of Batfish first.
+    if (!cachedConfigsAreCompatible(testrig)) {
+      _logger.debugf(
+          "Unable to load configs for %s from disk: error or incompatible version", testrig);
+      return null;
+    }
+
+    _logger.info("\n*** DESERIALIZING VENDOR-INDEPENDENT CONFIGURATION STRUCTURES ***\n");
+    Map<Path, String> namesByPath = new TreeMap<>();
+    try (DirectoryStream<Path> stream = Files.newDirectoryStream(indepDir)) {
+      for (Path serializedConfig : stream) {
+        String name = serializedConfig.getFileName().toString();
+        namesByPath.put(serializedConfig, name);
+      }
+    } catch (IOException e) {
+      throw new BatfishException(
+          "Error reading vendor-independent configs directory: '" + indepDir + "'", e);
+    }
+    SortedMap<String, Configuration> configurations =
+        deserializeObjects(namesByPath, Configuration.class);
+    return configurations;
+  }
+
+  @Nullable
+  public ConvertConfigurationAnswerElement loadConvertConfigurationAnswerElement(String testrig) {
+    Path ccaePath = getTestrigDir(testrig).resolve(BfConsts.RELPATH_CONVERT_ANSWER_PATH);
+    if (!Files.exists(ccaePath)) {
+      return null;
+    }
+    return deserializeObject(ccaePath, ConvertConfigurationAnswerElement.class);
+  }
+
+  /**
+   * Stores the configuration information into the given testrig. Will replace any previously-stored
+   * configurations.
+   */
+  public void storeConfigurations(
+      Map<String, Configuration> configurations,
+      ConvertConfigurationAnswerElement convertAnswerElement,
+      String testrig) {
+    String batchName =
+        String.format(
+            "Serializing %s vendor-independent configuration structures for testrig %s",
+            configurations.size(), testrig);
+    _logger.infof("\n*** %s***\n", batchName.toUpperCase());
+    AtomicInteger progressCount = _newBatch.apply(batchName, configurations.size());
+
+    Path testrigDir = getTestrigDir(testrig);
+    if (!testrigDir.toFile().exists() && !testrigDir.toFile().mkdirs()) {
+      throw new BatfishException(
+          String.format("Unable to create testrig directory '%s'", testrigDir));
+    }
+
+    // Save the convert configuration answer element.
+    Path ccaePath = testrigDir.resolve(BfConsts.RELPATH_CONVERT_ANSWER_PATH);
+    CommonUtil.deleteIfExists(ccaePath);
+    serializeObject(convertAnswerElement, ccaePath);
+
+    Path outputDir = testrigDir.resolve(BfConsts.RELPATH_VENDOR_INDEPENDENT_CONFIG_DIR);
+
+    // Delete any existing output, then recreate.
+    CommonUtil.deleteDirectory(outputDir);
+    if (!outputDir.toFile().exists() && !outputDir.toFile().mkdirs()) {
+      throw new BatfishException(
+          String.format("Unable to create output directory '%s'", outputDir));
+    }
+
+    configurations.forEach(
+        (name, c) -> {
+          Path currentOutputPath = outputDir.resolve(name);
+          serializeObject(c, currentOutputPath);
+          progressCount.incrementAndGet();
+        });
+  }
+
+  /**
+   * Returns a single object of the given class deserialized from the given file. Uses the {@link
+   * BatfishStorage} default file encoding including serialization format and compression.
+   */
+  private static <S extends Serializable> S deserializeObject(Path inputFile, Class<S> outputClass)
+      throws BatfishException {
+    try (FileInputStream fis = new FileInputStream(inputFile.toFile());
+        GZIPInputStream gis = new GZIPInputStream(fis, 8192 /* enlarge buffer */);
+        ObjectInputStream ois = new ObjectInputStream(gis)) {
+      return outputClass.cast(ois.readObject());
+    } catch (IOException | ClassNotFoundException e) {
+      throw new BatfishException(
+          String.format(
+              "Failed to deserialize object of type %s from file %s",
+              outputClass.getCanonicalName(), inputFile),
+          e);
+    }
+  }
+
+  private <S extends Serializable> SortedMap<String, S> deserializeObjects(
+      Map<Path, String> namesByPath, Class<S> outputClass) {
+    String outputClassName = outputClass.getName();
+    AtomicInteger completed =
+        _newBatch.apply(
+            String.format("Deserializing objects of type '%s' from files", outputClassName),
+            namesByPath.size());
+    return new TreeMap<>(
+        namesByPath
+            .entrySet()
+            .parallelStream()
+            .collect(
+                Collectors.toMap(
+                    Entry::getValue,
+                    entry -> {
+                      Path inputPath = entry.getKey();
+                      String name = entry.getValue();
+                      _logger.debugf("Reading {} '{}' from '{}'", outputClassName, name, inputPath);
+                      S output = deserializeObject(inputPath, outputClass);
+                      completed.incrementAndGet();
+                      return output;
+                    })));
+  }
+
+  /**
+   * Writes a single object of the given class to the given file. Uses the {@link BatfishStorage}
+   * default file encoding including serialization format and compression.
+   */
+  private static void serializeObject(Serializable object, Path outputFile) {
+    try {
+      try (OutputStream out = Files.newOutputStream(outputFile);
+          GZIPOutputStream gos = new GZIPOutputStream(out, 8192 /* enlarged buffer size */);
+          ObjectOutputStream oos = new ObjectOutputStream(gos)) {
+        oos.writeObject(object);
+      }
+    } catch (IOException e) {
+      throw new BatfishException("Failed to serialize object to output file: " + outputFile, e);
+    }
+  }
+
+  private boolean cachedConfigsAreCompatible(String testrig) {
+    try {
+      ConvertConfigurationAnswerElement ccae = loadConvertConfigurationAnswerElement(testrig);
+      return ccae != null
+          && Version.isCompatibleVersion(
+              BatfishStorage.class.getCanonicalName(),
+              "Old processed configurations",
+              ccae.getVersion());
+    } catch (BatfishException e) {
+      _logger.warnf(
+          "Unexpected exception caught while deserializing configs for testrig %s: %s",
+          testrig, Throwables.getStackTraceAsString(e));
+      return false;
+    }
+  }
+
+  private Path getTestrigDir(String testrig) {
+    return _containerDir.resolve(BfConsts.RELPATH_TESTRIGS_DIR).resolve(testrig);
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/main/Driver.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Driver.java
@@ -51,6 +51,7 @@ import org.batfish.common.BfConsts.TaskStatus;
 import org.batfish.common.CleanBatfishException;
 import org.batfish.common.CoordConsts;
 import org.batfish.common.QuestionException;
+import org.batfish.common.Snapshot;
 import org.batfish.common.Task;
 import org.batfish.common.Task.Batch;
 import org.batfish.common.Version;
@@ -125,7 +126,7 @@ public class Driver {
   private static final Map<EnvironmentSettings, SortedMap<String, RoutesByVrf>>
       CACHED_ENVIRONMENT_ROUTING_TABLES = buildEnvironmentRoutingTablesCache();
 
-  private static final Cache<TestrigSettings, SortedMap<String, Configuration>> CACHED_TESTRIGS =
+  private static final Cache<Snapshot, SortedMap<String, Configuration>> CACHED_TESTRIGS =
       buildTestrigCache();
 
   private static final int COORDINATOR_CHECK_INTERVAL_MS = 1 * 60 * 1000; // 1 min
@@ -168,7 +169,7 @@ public class Driver {
             MAX_CACHED_ENVIRONMENT_ROUTING_TABLES));
   }
 
-  private static Cache<TestrigSettings, SortedMap<String, Configuration>> buildTestrigCache() {
+  private static Cache<Snapshot, SortedMap<String, Configuration>> buildTestrigCache() {
     return CacheBuilder.newBuilder().maximumSize(MAX_CACHED_TESTRIGS).build();
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -177,7 +177,7 @@ public class CiscoGrammarTest {
                 .setConfigurationText(TESTRIGS_PREFIX + testrigName, configurationNames)
                 .build(),
             _folder);
-    SortedMap<String, Configuration> configurations = batfish.loadConfigurations();
+    Map<String, Configuration> configurations = batfish.loadConfigurations();
     Map<Ip, Set<String>> ipOwners = CommonUtil.computeIpOwners(configurations, true);
     CommonUtil.initRemoteBgpNeighbors(configurations, ipOwners);
     Configuration r1 = configurations.get("r1");
@@ -210,7 +210,7 @@ public class CiscoGrammarTest {
                 .setConfigurationText(TESTRIGS_PREFIX + testrigName, configurationNames)
                 .build(),
             _folder);
-    SortedMap<String, Configuration> configurations = batfish.loadConfigurations();
+    Map<String, Configuration> configurations = batfish.loadConfigurations();
     Map<Ip, Set<String>> ipOwners = CommonUtil.computeIpOwners(configurations, true);
     CommonUtil.initRemoteBgpNeighbors(configurations, ipOwners);
     MultipathEquivalentAsPathMatchMode aristaDisabled =
@@ -255,7 +255,7 @@ public class CiscoGrammarTest {
                 .setConfigurationText(TESTRIGS_PREFIX + testrigName, configurationNames)
                 .build(),
             _folder);
-    SortedMap<String, Configuration> configurations = batfish.loadConfigurations();
+    Map<String, Configuration> configurations = batfish.loadConfigurations();
     Map<Ip, Set<String>> ipOwners = CommonUtil.computeIpOwners(configurations, true);
     CommonUtil.initRemoteBgpNeighbors(configurations, ipOwners);
     BdpDataPlanePlugin dataPlanePlugin = new BdpDataPlanePlugin();
@@ -315,8 +315,7 @@ public class CiscoGrammarTest {
                 .setConfigurationText(TESTRIGS_PREFIX + testrigName, configurationNames)
                 .build(),
             _folder);
-    SortedMap<String, Configuration> configurations;
-    configurations = batfish.loadConfigurations();
+    Map<String, Configuration> configurations = batfish.loadConfigurations();
 
     Configuration iosCommunityListConfig = configurations.get(iosName);
     SortedMap<String, CommunityList> iosCommunityLists = iosCommunityListConfig.getCommunityLists();
@@ -424,8 +423,7 @@ public class CiscoGrammarTest {
                 .setConfigurationText(TESTRIGS_PREFIX + testrigName, configurationNames)
                 .build(),
             _folder);
-    SortedMap<String, Configuration> configurations;
-    configurations = batfish.loadConfigurations();
+    Map<String, Configuration> configurations = batfish.loadConfigurations();
 
     Interface i1 = configurations.get(iosHostname).getInterfaces().get(i1Name);
     assertThat(i1, hasDeclaredNames("Ethernet0/0", "e0/0", "Eth0/0", "ether0/0-1"));
@@ -442,8 +440,7 @@ public class CiscoGrammarTest {
                 .setConfigurationText(TESTRIGS_PREFIX + testrigName, configurationNames)
                 .build(),
             _folder);
-    SortedMap<String, Configuration> configurations;
-    configurations = batfish.loadConfigurations();
+    Map<String, Configuration> configurations = batfish.loadConfigurations();
 
     assertThat(
         configurations.values().stream().mapToLong(c -> c.getIpsecVpns().values().size()).sum(),
@@ -478,8 +475,7 @@ public class CiscoGrammarTest {
                 .setConfigurationText(TESTRIGS_PREFIX + testrigName, configurationNames)
                 .build(),
             _folder);
-    SortedMap<String, Configuration> configurations;
-    configurations = batfish.loadConfigurations();
+    Map<String, Configuration> configurations = batfish.loadConfigurations();
 
     /* Ensure bidirectional references between OSPF area and interface */
     assertThat(configurations, hasKey(hostname));
@@ -508,8 +504,7 @@ public class CiscoGrammarTest {
                 .setConfigurationText(TESTRIGS_PREFIX + testrigName, configurationNames)
                 .build(),
             _folder);
-    SortedMap<String, Configuration> configurations;
-    configurations = batfish.loadConfigurations();
+    Map<String, Configuration> configurations = batfish.loadConfigurations();
 
     /* Ensure bidirectional references between OSPF area and interface */
     assertThat(configurations, hasKey(hostname));
@@ -541,8 +536,7 @@ public class CiscoGrammarTest {
                 .setConfigurationText(TESTRIGS_PREFIX + testrigName, configurationNames)
                 .build(),
             _folder);
-    SortedMap<String, Configuration> configurations;
-    configurations = batfish.loadConfigurations();
+    Map<String, Configuration> configurations = batfish.loadConfigurations();
 
     Configuration iosMaxMetric = configurations.get(iosMaxMetricName);
     Configuration iosMaxMetricCustom = configurations.get(iosMaxMetricCustomName);
@@ -586,8 +580,7 @@ public class CiscoGrammarTest {
                 .setConfigurationText(TESTRIGS_PREFIX + testrigName, configurationNames)
                 .build(),
             _folder);
-    SortedMap<String, Configuration> configurations;
-    configurations = batfish.loadConfigurations();
+    Map<String, Configuration> configurations = batfish.loadConfigurations();
 
     Configuration iosMaxMetric = configurations.get(iosOspfPointToPoint);
     Interface e0Sub0 = iosMaxMetric.getInterfaces().get("Ethernet0/0");
@@ -610,10 +603,10 @@ public class CiscoGrammarTest {
                 .build(),
             _folder);
     batfish.getSettings().setDisableUnrecognized(false);
-    SortedMap<String, Configuration> configurations = batfish.loadConfigurations();
+    Map<String, Configuration> configurations = batfish.loadConfigurations();
 
     Configuration iosRecovery = configurations.get(hostname);
-    SortedMap<String, Interface> iosRecoveryInterfaces = iosRecovery.getInterfaces();
+    Map<String, Interface> iosRecoveryInterfaces = iosRecovery.getInterfaces();
     Set<String> iosRecoveryInterfaceNames = iosRecoveryInterfaces.keySet();
     Set<InterfaceAddress> l3Prefixes = iosRecoveryInterfaces.get("Loopback3").getAllAddresses();
     Set<InterfaceAddress> l4Prefixes = iosRecoveryInterfaces.get("Loopback4").getAllAddresses();
@@ -642,7 +635,7 @@ public class CiscoGrammarTest {
                 .build(),
             _folder);
     batfish.getSettings().setDisableUnrecognized(false);
-    SortedMap<String, Configuration> configurations = batfish.loadConfigurations();
+    Map<String, Configuration> configurations = batfish.loadConfigurations();
 
     /* Hostname is unknown, but a file should be generated nonetheless */
     assertThat(configurations.entrySet(), hasSize(1));
@@ -660,7 +653,7 @@ public class CiscoGrammarTest {
                 .setConfigurationText(TESTRIGS_PREFIX + testrigName, configurationNames)
                 .build(),
             _folder);
-    SortedMap<String, Configuration> configurations = batfish.loadConfigurations();
+    Map<String, Configuration> configurations = batfish.loadConfigurations();
 
     /* Parser should not crash, and configuration with hostname from file should be generated */
     assertThat(configurations, hasKey(hostname));

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -10,7 +10,7 @@ import static org.junit.Assert.assertThat;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.util.List;
-import java.util.SortedMap;
+import java.util.Map;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
 import org.batfish.common.util.CommonUtil;
 import org.batfish.config.Settings;
@@ -73,8 +73,7 @@ public class FlatJuniperGrammarTest {
                 .setConfigurationText(TESTRIGS_PREFIX + testrigName, configurationNames)
                 .build(),
             _folder);
-    SortedMap<String, Configuration> configurations;
-    configurations = batfish.loadConfigurations();
+    Map<String, Configuration> configurations = batfish.loadConfigurations();
 
     Configuration rr = configurations.get(configName);
     BgpProcess proc = rr.getDefaultVrf().getBgpProcess();
@@ -99,7 +98,7 @@ public class FlatJuniperGrammarTest {
                 .setConfigurationText(TESTRIGS_PREFIX + testrigName, configurationNames)
                 .build(),
             _folder);
-    SortedMap<String, Configuration> configurations = batfish.loadConfigurations();
+    Map<String, Configuration> configurations = batfish.loadConfigurations();
     MultipathEquivalentAsPathMatchMode multipleAsDisabled =
         configurations
             .get("multiple_as_disabled")

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishStorageTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishStorageTest.java
@@ -1,0 +1,74 @@
+package org.batfish.main;
+
+import static org.batfish.common.Version.INCOMPATIBLE_VERSION;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.Sets;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.batfish.common.BatfishLogger;
+import org.batfish.common.Version;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class BatfishStorageTest {
+  @Rule public TemporaryFolder _folder = new TemporaryFolder();
+
+  private Path _containerDir;
+  private BatfishLogger _logger;
+  private BatfishStorage _storage;
+
+  @Before
+  public void before() throws IOException {
+    _containerDir = _folder.newFolder("container").toPath();
+    _logger = new BatfishLogger(BatfishLogger.LEVELSTR_DEBUG, false);
+    _storage = new BatfishStorage(_containerDir, _logger, (m, n) -> new AtomicInteger());
+  }
+
+  @Test
+  public void roundTripConfigurationsSucceeds() {
+    Map<String, Configuration> configs = new HashMap<>();
+    configs.put("node1", new Configuration("node1", ConfigurationFormat.CISCO_IOS));
+
+    _storage.storeConfigurations(configs, new ConvertConfigurationAnswerElement(), "sometr");
+    Map<String, Configuration> deserialized = _storage.loadConfigurations("sometr");
+    assertThat(deserialized, not(nullValue()));
+    assertThat(deserialized.keySet(), equalTo(Sets.newHashSet("node1")));
+  }
+
+  @Test
+  public void loadMissingConfigurationsReturnsNull() {
+    assertThat(_storage.loadConfigurations("nonexistent"), nullValue());
+  }
+
+  @Test
+  public void loadOldConfigurationsReturnsNull() {
+    ConvertConfigurationAnswerElement oldConvertAnswer = new ConvertConfigurationAnswerElement();
+    oldConvertAnswer.setVersion(INCOMPATIBLE_VERSION);
+    assertThat(
+        "should not be compatible with current code",
+        Version.isCompatibleVersion("current", "old test", oldConvertAnswer.getVersion()),
+        equalTo(false));
+
+    String trname = "sometr";
+    Map<String, Configuration> configs = new HashMap<>();
+    configs.put("node1", new Configuration("node1", ConfigurationFormat.CISCO_IOS));
+    _storage.storeConfigurations(configs, oldConvertAnswer, trname);
+
+    assertThat(_storage.loadConfigurations(trname), nullValue());
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
@@ -123,7 +123,7 @@ public class BatfishTest {
                 .setIptablesFilesText(iptablesFilesText)
                 .build(),
             _folder);
-    SortedMap<String, Configuration> configurations = batfish.loadConfigurations();
+    Map<String, Configuration> configurations = batfish.loadConfigurations();
     assertThat(
         configurations.get("host1").getInterfaces().get("Ethernet0").getIncomingFilterName(),
         is(notNullValue()));
@@ -141,7 +141,7 @@ public class BatfishTest {
                 .setConfigurationText(testrigResourcePrefix, configurationNames)
                 .build(),
             _folder);
-    SortedMap<String, Configuration> configurations = batfish.loadConfigurations();
+    Map<String, Configuration> configurations = batfish.loadConfigurations();
     Map<Ip, Set<String>> ipOwners = CommonUtil.computeIpOwners(configurations, true);
     assertThat(ipOwners.get(vrrpAddress), equalTo(Collections.singleton("r1")));
   }
@@ -355,7 +355,7 @@ public class BatfishTest {
     Batfish batfish =
         BatfishTestUtils.getBatfishFromTestrigText(
             TestrigText.builder().setConfigurationText(configMap).build(), _folder);
-    SortedMap<String, Configuration> configs = batfish.loadConfigurations();
+    Map<String, Configuration> configs = batfish.loadConfigurations();
 
     // Assert that the config parsed successfully
     assertThat(configs, hasKey("host1"));

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
@@ -78,7 +78,7 @@ public class BatfishTest {
 
     Path questionPath = _folder.newFile("testAnswerBadQuestion").toPath();
     Files.write(questionPath, badQuestionStr.getBytes(StandardCharsets.UTF_8));
-    Batfish batfish = BatfishTestUtils.getBatfish(new TreeMap<>(), null);
+    Batfish batfish = BatfishTestUtils.getBatfish(new TreeMap<>(), _folder);
     batfish.getSettings().setQuestionPath(questionPath);
     Answer answer = batfish.answer();
     assertThat(answer.getQuestion(), is(nullValue()));
@@ -167,7 +167,7 @@ public class BatfishTest {
 
     Path topologyFilePath = _folder.newFile("testParseTopologyJson").toPath();
     Files.write(topologyFilePath, topologyBadJson.getBytes(StandardCharsets.UTF_8));
-    Batfish batfish = BatfishTestUtils.getBatfish(new TreeMap<>(), null);
+    Batfish batfish = BatfishTestUtils.getBatfish(new TreeMap<>(), _folder);
     String errorMessage = "Topology format error";
     _thrown.expect(BatfishException.class);
     _thrown.expectMessage(errorMessage);
@@ -178,7 +178,7 @@ public class BatfishTest {
   public void testParseTopologyEmpty() throws IOException {
     Path topologyFilePath = _folder.newFile("testParseTopologyJson").toPath();
     Files.write(topologyFilePath, new byte[0]);
-    Batfish batfish = BatfishTestUtils.getBatfish(new TreeMap<>(), null);
+    Batfish batfish = BatfishTestUtils.getBatfish(new TreeMap<>(), _folder);
     String errorMessage = "ERROR: empty topology\n";
     _thrown.expect(BatfishException.class);
     _thrown.expectMessage(errorMessage);
@@ -205,7 +205,7 @@ public class BatfishTest {
 
     Path topologyFilePath = _folder.newFile("testParseTopologyJson").toPath();
     Files.write(topologyFilePath, topologyJson.getBytes(StandardCharsets.UTF_8));
-    Batfish batfish = BatfishTestUtils.getBatfish(new TreeMap<>(), null);
+    Batfish batfish = BatfishTestUtils.getBatfish(new TreeMap<>(), _folder);
     Topology topology = batfish.parseTopology(topologyFilePath);
     assertEquals(topology.getEdges().size(), 2);
   }
@@ -267,7 +267,7 @@ public class BatfishTest {
     ParseVendorConfigurationAnswerElement answerElement =
         new ParseVendorConfigurationAnswerElement();
     answerElement.getParseStatus().put("host1", ParseStatus.PASSED);
-    Batfish batfish = BatfishTestUtils.getBatfish(new TreeMap<>(), null);
+    Batfish batfish = BatfishTestUtils.getBatfish(new TreeMap<>(), _folder);
     String failureMessage =
         "Iptables file iptables/host1.iptables for host host1 "
             + "is not contained within the testrig";
@@ -383,7 +383,7 @@ public class BatfishTest {
     ParseVendorConfigurationAnswerElement answerElement =
         new ParseVendorConfigurationAnswerElement();
     answerElement.getParseStatus().put("host1", ParseStatus.PASSED);
-    Batfish batfish = BatfishTestUtils.getBatfish(new TreeMap<>(), null);
+    Batfish batfish = BatfishTestUtils.getBatfish(new TreeMap<>(), _folder);
     batfish.readIptableFiles(testRigPath, hostConfigurations, iptablesData, answerElement);
     assertThat(answerElement.getParseStatus().get("host1"), equalTo(ParseStatus.PASSED));
     assertThat(answerElement.getErrors().size(), is(0));

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
@@ -9,10 +9,10 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.collections4.map.LRUMap;
 import org.batfish.bdp.BdpDataPlanePlugin;
-import org.batfish.common.BatfishException;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.BfConsts;
 import org.batfish.common.util.CommonUtil;
@@ -47,15 +47,15 @@ public class BatfishTestUtils {
   }
 
   private static Batfish initBatfish(
-      SortedMap<String, Configuration> configurations, @Nullable TemporaryFolder tempFolder)
+      SortedMap<String, Configuration> configurations, @Nonnull TemporaryFolder tempFolder)
       throws IOException {
     Settings settings = new Settings(new String[] {});
     settings.setLogger(new BatfishLogger("debug", false));
     final Cache<TestrigSettings, SortedMap<String, Configuration>> testrigs = makeTestrigCache();
 
+    Path containerDir = tempFolder.newFolder().toPath();
+    settings.setContainerDir(containerDir);
     if (!configurations.isEmpty()) {
-      Path containerDir = tempFolder.newFolder().toPath();
-      settings.setContainerDir(containerDir);
       settings.setTestrig("tempTestrig");
       settings.setEnvironmentName("tempEnvironment");
       Batfish.initTestrigSettings(settings);
@@ -161,11 +161,8 @@ public class BatfishTestUtils {
    * @return New Batfish instance
    */
   public static Batfish getBatfish(
-      SortedMap<String, Configuration> configurations, @Nullable TemporaryFolder tempFolder)
+      SortedMap<String, Configuration> configurations, @Nonnull TemporaryFolder tempFolder)
       throws IOException {
-    if (!configurations.isEmpty() && tempFolder == null) {
-      throw new BatfishException("tempFolder must be set for non-empty configurations");
-    }
     return initBatfish(configurations, tempFolder);
   }
 

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
@@ -15,6 +15,7 @@ import org.apache.commons.collections4.map.LRUMap;
 import org.batfish.bdp.BdpDataPlanePlugin;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.BfConsts;
+import org.batfish.common.Snapshot;
 import org.batfish.common.util.CommonUtil;
 import org.batfish.config.Settings;
 import org.batfish.config.Settings.EnvironmentSettings;
@@ -29,7 +30,7 @@ import org.junit.rules.TemporaryFolder;
 
 public class BatfishTestUtils {
 
-  private static Cache<TestrigSettings, SortedMap<String, Configuration>> makeTestrigCache() {
+  private static Cache<Snapshot, SortedMap<String, Configuration>> makeTestrigCache() {
     return CacheBuilder.newBuilder().maximumSize(5).weakValues().build();
   }
 
@@ -51,7 +52,7 @@ public class BatfishTestUtils {
       throws IOException {
     Settings settings = new Settings(new String[] {});
     settings.setLogger(new BatfishLogger("debug", false));
-    final Cache<TestrigSettings, SortedMap<String, Configuration>> testrigs = makeTestrigCache();
+    final Cache<Snapshot, SortedMap<String, Configuration>> testrigs = makeTestrigCache();
 
     Path containerDir = tempFolder.newFolder().toPath();
     settings.setContainerDir(containerDir);
@@ -59,9 +60,8 @@ public class BatfishTestUtils {
       settings.setTestrig("tempTestrig");
       settings.setEnvironmentName("tempEnvironment");
       Batfish.initTestrigSettings(settings);
-      settings.getBaseTestrigSettings().getSerializeIndependentPath().toFile().mkdirs();
       settings.getBaseTestrigSettings().getEnvironmentSettings().getEnvPath().toFile().mkdirs();
-      testrigs.put(settings.getBaseTestrigSettings(), configurations);
+      testrigs.put(new Snapshot("tempTestrig", "tempEnvironment"), configurations);
       settings.setActiveTestrigSettings(settings.getBaseTestrigSettings());
     }
     Batfish batfish =

--- a/projects/question/src/main/java/org/batfish/question/PerRoleQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/PerRoleQuestionPlugin.java
@@ -77,7 +77,7 @@ public class PerRoleQuestionPlugin extends QuestionPlugin {
             "The question " + innerQuestion.getName() + " does not implement INodeRegexQuestion");
       }
 
-      SortedMap<String, Configuration> configurations = _batfish.loadConfigurations();
+      Map<String, Configuration> configurations = _batfish.loadConfigurations();
       // collect the desired nodes in a list
       Set<String> includeNodes = question.getNodeRegex().getMatchingNodes(configurations);
 

--- a/projects/question/src/main/java/org/batfish/question/UndefinedReferencesQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/UndefinedReferencesQuestionPlugin.java
@@ -99,7 +99,8 @@ public class UndefinedReferencesQuestionPlugin extends QuestionPlugin {
     public UndefinedReferencesAnswerElement answer() {
       UndefinedReferencesQuestion question = (UndefinedReferencesQuestion) _question;
       UndefinedReferencesAnswerElement answerElement = new UndefinedReferencesAnswerElement();
-      ConvertConfigurationAnswerElement ccae = _batfish.loadConvertConfigurationAnswerElement();
+      ConvertConfigurationAnswerElement ccae =
+          _batfish.loadConvertConfigurationAnswerElementOrReparse();
       Set<String> includeNodes =
           question.getNodeRegex().getMatchingNodes(_batfish.loadConfigurations());
 

--- a/projects/question/src/main/java/org/batfish/question/UnusedStructuresQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/UnusedStructuresQuestionPlugin.java
@@ -92,7 +92,8 @@ public class UnusedStructuresQuestionPlugin extends QuestionPlugin {
     public UnusedStructuresAnswerElement answer() {
       UnusedStructuresQuestion question = (UnusedStructuresQuestion) _question;
       UnusedStructuresAnswerElement answerElement = new UnusedStructuresAnswerElement();
-      ConvertConfigurationAnswerElement ccae = _batfish.loadConvertConfigurationAnswerElement();
+      ConvertConfigurationAnswerElement ccae =
+          _batfish.loadConvertConfigurationAnswerElementOrReparse();
       Set<String> includeNodes =
           question.getNodeRegex().getMatchingNodes(_batfish.loadConfigurations());
 


### PR DESCRIPTION
A hodge-podge of restructuring in an attempt to make it more obvious where and how configurations are cached. Now all loading and cache management is in a single place.

* Added `BatfishStorage`, to which we can start moving the code in Batfish that deals with file serialization. Started by moving the code that loads configurations off of disk.

* Added `Snapshot` as a concise way to specifically represent which the testrig+environment under use. Made `Snapshot` the key for the testrig cache, as it contains the only two fields that were actually used in hashcode/equals.
    This change and the above are steps towards getting rid of `TestrigSettings`. For example, I was able to delete both two paths for vendor-independent configs and convert answer element.

* Rewrote `loadConfigurations` in terms of `Snapshot`, with more comments and hopefully clearer code flow.
    * All interaction with the cache is in `loadConfigurations`.
    * It should be self-evident from that function that the return value will always include any environmental effects.

A variety of miscellaneous other changes to things that cropped up during the work: adding comments, naming functions to other things, deleting code I didn't think was used for anything (`processDeltaX`, `generateOspfTopology`) to see if tests would identify the gap, loosening some type requirements in tests, cleaning up a log message, simplifying some iterators.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/959)
<!-- Reviewable:end -->
