### PR TITLE
Comment: fix equals/hashCode

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/z3/expr/Comment.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/Comment.java
@@ -1,6 +1,6 @@
 package org.batfish.z3.expr;
 
-import java.util.Objects;
+import java.util.Arrays;
 
 public class Comment extends Statement {
 
@@ -26,11 +26,11 @@ public class Comment extends Statement {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(_lines);
+    return Arrays.hashCode(_lines);
   }
 
   @Override
   public boolean statementEquals(Statement e) {
-    return Objects.equals(_lines, ((Comment) e)._lines);
+    return Arrays.equals(_lines, ((Comment) e)._lines);
   }
 }


### PR DESCRIPTION
The `Arrays` functions do handle `null`.

* IntelliJ warned about one of these.
* Bazel warned about both.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/batfish/batfish/967)
<!-- Reviewable:end -->
