### PR TITLE
Small log message tweaks

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -939,6 +939,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
   private CompressDataPlaneResult computeCompressedDataPlane(HeaderSpace headerSpace) {
     // Since compression mutates the configurations, we must clone them before that happens.
     // A simple way to do this is to create a deep clone of each entry using Java serialization.
+    _logger.info("Computing compressed dataplane");
     Map<String, Configuration> clonedConfigs =
         loadConfigurations()
             .entrySet()

--- a/projects/batfish/src/main/java/org/batfish/main/BatfishStorage.java
+++ b/projects/batfish/src/main/java/org/batfish/main/BatfishStorage.java
@@ -171,7 +171,8 @@ final class BatfishStorage {
                     entry -> {
                       Path inputPath = entry.getKey();
                       String name = entry.getValue();
-                      _logger.debugf("Reading {} '{}' from '{}'", outputClassName, name, inputPath);
+                      _logger.debugf(
+                          "Reading %s '%s' from '%s'\n", outputClassName, name, inputPath);
                       S output = deserializeObject(inputPath, outputClass);
                       completed.incrementAndGet();
                       return output;


### PR DESCRIPTION
Couple of logging tweaks:
- Add logging message when compressed dataplane is being computed
- In `BatfishStorage` one of the log strings wasn't producing the right output. It's not python nor were we using `MessageFormat`