### PR TITLE
List questions filtering

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/CoordConsts.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/CoordConsts.java
@@ -102,6 +102,7 @@ public class CoordConsts {
   public static final String SVC_KEY_TESTRIG_LIST = "testriglist";
   public static final String SVC_KEY_TESTRIG_METADATA = "testrigmetadata";
   public static final String SVC_KEY_TESTRIG_NAME = "testrigname";
+  public static final String SVC_KEY_VERBOSE = "verbose";
   public static final String SVC_KEY_VERSION = "version";
   public static final String SVC_KEY_WORK_LIST = "worklist";
   public static final String SVC_KEY_WORK_TYPE = "worktype";

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -1223,9 +1223,9 @@ public class WorkMgr extends AbstractCoordinator {
         new TreeSet<>(
             CommonUtil.getSubdirectories(questionsDir)
                 .stream()
-                // Question dirs starting with __ are internal questions, hidden from clients
-                .filter(dir -> !dir.getFileName().toString().startsWith("__"))
                 .map(dir -> dir.getFileName().toString())
+                // Question dirs starting with __ are internal questions, hidden from clients
+                .filter(dir -> !dir.startsWith("__"))
                 .collect(Collectors.toSet()));
     return questions;
   }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -1213,7 +1213,7 @@ public class WorkMgr extends AbstractCoordinator {
     return _workQueueMgr.listIncompleteWork(containerName, testrigName, workType);
   }
 
-  public SortedSet<String> listQuestions(String containerName) {
+  public SortedSet<String> listQuestions(String containerName, boolean verbose) {
     Path containerDir = getdirContainer(containerName);
     Path questionsDir = containerDir.resolve(BfConsts.RELPATH_QUESTIONS_DIR);
     if (!Files.exists(questionsDir)) {
@@ -1224,8 +1224,9 @@ public class WorkMgr extends AbstractCoordinator {
             CommonUtil.getSubdirectories(questionsDir)
                 .stream()
                 .map(dir -> dir.getFileName().toString())
-                // Question dirs starting with __ are internal questions, hidden from clients
-                .filter(dir -> !dir.startsWith("__"))
+                // Question dirs starting with __ are internal questions
+                // and should not show up in listQuestions
+                .filter(dir -> verbose || !dir.startsWith("__"))
                 .collect(Collectors.toSet()));
     return questions;
   }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -1223,6 +1223,8 @@ public class WorkMgr extends AbstractCoordinator {
         new TreeSet<>(
             CommonUtil.getSubdirectories(questionsDir)
                 .stream()
+                // Question dirs starting with __ are internal questions, hidden from clients
+                .filter(dir -> !dir.getFileName().toString().startsWith("__"))
                 .map(dir -> dir.getFileName().toString())
                 .collect(Collectors.toSet()));
     return questions;

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
@@ -1217,6 +1217,7 @@ public class WorkMgrService {
    * @param apiKey The API key of the client
    * @param clientVersion The version of the client
    * @param containerName The name of the container in which the testrig and questions reside
+   * @param verbose The flag to show all questions, including internal ones
    * @return TODO: document JSON response
    */
   @POST
@@ -1225,7 +1226,8 @@ public class WorkMgrService {
   public JSONArray listQuestions(
       @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
-      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName) {
+      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
+      @FormDataParam(CoordConsts.SVC_KEY_VERBOSE) boolean verbose) {
     try {
       _logger.info("WMS:listQuestions " + apiKey + " " + containerName + "\n");
 
@@ -1239,7 +1241,7 @@ public class WorkMgrService {
 
       JSONObject retObject = new JSONObject();
 
-      for (String questionName : Main.getWorkMgr().listQuestions(containerName)) {
+      for (String questionName : Main.getWorkMgr().listQuestions(containerName, verbose)) {
         String questionText = Main.getWorkMgr().getQuestion(containerName, questionName);
 
         retObject.put(questionName, new JSONObject(questionText));

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
@@ -25,6 +25,7 @@ import org.batfish.common.BfConsts;
 import org.batfish.common.Container;
 import org.batfish.common.util.CommonUtil;
 import org.batfish.coordinator.config.Settings;
+import org.hamcrest.collection.IsEmptyCollection;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -85,14 +86,33 @@ public class WorkMgrTest {
 
   @Test
   public void listQuestionNames() {
+    String questionName = "testquestion";
     _manager.initContainer("container", null);
     Path containerDir =
         Main.getSettings().getContainersLocation().resolve("container").toAbsolutePath();
     Path questionsDir = containerDir.resolve(BfConsts.RELPATH_QUESTIONS_DIR);
-    assertThat(questionsDir.resolve("initinfo").toFile().mkdirs(), is(true));
+    assertThat(questionsDir.resolve(questionName).toFile().mkdirs(), is(true));
+
+    // Confirm the question shows up in listQuestions
     SortedSet<String> questions = _manager.listQuestions("container");
     assertThat(questions.size(), is(1));
-    assertThat(questions.first(), equalTo("initinfo"));
+    assertThat(questions.first(), equalTo(questionName));
+  }
+
+  @Test
+  public void listQuestionWithInternalQuestion() {
+    // Leading __ means this question is an internal question
+    // And should be hidden from listQuestions
+    String internalQuestionName = "__internalquestion";
+    _manager.initContainer("container", null);
+    Path containerDir =
+        Main.getSettings().getContainersLocation().resolve("container").toAbsolutePath();
+    Path questionsDir = containerDir.resolve(BfConsts.RELPATH_QUESTIONS_DIR);
+    assertThat(questionsDir.resolve(internalQuestionName).toFile().mkdirs(), is(true));
+
+    // Confirm no questions show up in listQuestions
+    SortedSet<String> questions = _manager.listQuestions("container");
+    assertThat(questions, IsEmptyCollection.empty());
   }
 
   @Test

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
@@ -103,7 +103,7 @@ public class WorkMgrTest {
   @Test
   public void listQuestionVerbose() {
     // Leading __ means this question is an internal question
-    // And should be hidden from listQuestions
+    // And should be hidden from listQuestions when verbose is false
     String internalQuestionName = "__internalquestion";
     _manager.initContainer("container", null);
     Path containerDir =


### PR DESCRIPTION
* Added verbose flag for `listQuestions` API call
* Added filter in `listQuestions` to hide any questions with instance name starting with `__` unless `verbose` flag is set
