### PR TITLE
Using enum instead of boolean to filter analyses in list-analysis

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/CoordConsts.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/CoordConsts.java
@@ -65,6 +65,7 @@ public class CoordConsts {
 
   public static final String SVC_KEY_ANALYSIS_LIST = "analysislist";
   public static final String SVC_KEY_ANALYSIS_NAME = "analysisname";
+  public static final String SVC_KEY_ANALYSIS_TYPE = "analysistype";
   public static final String SVC_KEY_ANSWER = "answer";
   public static final String SVC_KEY_ANSWERS = "answers";
   public static final String SVC_KEY_API_KEY = "apikey";

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/AnalysisMetadataMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/AnalysisMetadataMgr.java
@@ -11,6 +11,17 @@ import org.batfish.common.util.CommonUtil;
 import org.batfish.datamodel.AnalysisMetadata;
 
 public class AnalysisMetadataMgr {
+  /** Analyses that can be requested for listing */
+  public enum AnalysisType {
+    /** Selects the suggested analyses */
+    SUGGESTED,
+
+    /** Selects the user analyses */
+    USER,
+
+    /** Selects both suggested and user analyses */
+    ALL
+  }
 
   public static Instant getAnalysisCreationTimeOrMin(String container, String analysis) {
     try {

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
@@ -1,5 +1,7 @@
 package org.batfish.coordinator;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
@@ -1074,6 +1076,7 @@ public class WorkMgrService {
 
       JSONObject retObject = new JSONObject();
 
+      analysisType = firstNonNull(analysisType, AnalysisType.ALL);
       for (String analysisName : Main.getWorkMgr().listAnalyses(containerName, analysisType)) {
 
         JSONObject analysisJson = new JSONObject();

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
@@ -35,6 +35,7 @@ import org.batfish.common.CoordConsts;
 import org.batfish.common.Version;
 import org.batfish.common.WorkItem;
 import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.coordinator.AnalysisMetadataMgr.AnalysisType;
 import org.batfish.coordinator.WorkDetails.WorkType;
 import org.batfish.coordinator.WorkQueueMgr.QueueType;
 import org.batfish.coordinator.config.Settings;
@@ -1048,8 +1049,8 @@ public class WorkMgrService {
    * @param apiKey The API key of the client
    * @param clientVersion The version of the client
    * @param containerName The name of the container whose analyses are to be listed
-   * @param suggested Optional Boolean indicating which analyses to list: true = only suggested
-   *     analyses, false = only user's analyses, null = all analyses
+   * @param analysisType Optional enum {@link AnalysisType} indicating which analyses to list,
+   *     keeping null equivalent to {@link AnalysisType#ALL} for backward compatibility
    * @return TODO: document JSON response
    */
   @POST
@@ -1059,7 +1060,7 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
       @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
-      @Nullable @FormDataParam(CoordConsts.SVC_KEY_SUGGESTED) Boolean suggested) {
+      @Nullable @FormDataParam(CoordConsts.SVC_KEY_ANALYSIS_TYPE) AnalysisType analysisType) {
     try {
       _logger.infof("WMS:listAnalyses %s %s\n", apiKey, containerName);
 
@@ -1073,7 +1074,7 @@ public class WorkMgrService {
 
       JSONObject retObject = new JSONObject();
 
-      for (String analysisName : Main.getWorkMgr().listAnalyses(containerName, suggested)) {
+      for (String analysisName : Main.getWorkMgr().listAnalyses(containerName, analysisType)) {
 
         JSONObject analysisJson = new JSONObject();
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -24,6 +25,7 @@ import org.batfish.common.BatfishLogger;
 import org.batfish.common.BfConsts;
 import org.batfish.common.Container;
 import org.batfish.common.util.CommonUtil;
+import org.batfish.coordinator.AnalysisMetadataMgr.AnalysisType;
 import org.batfish.coordinator.config.Settings;
 import org.junit.Before;
 import org.junit.Rule;
@@ -208,17 +210,24 @@ public class WorkMgrTest {
         containerName, true, "analysis2", Maps.newHashMap(), Lists.newArrayList(), true);
 
     SortedSet<String> analyses = _manager.listAnalyses(containerName, null);
-    assertTrue("User analyses listed if suggested is null", analyses.contains("analysis1"));
-    assertTrue("Suggested analyses listed if suggested is null", analyses.contains("analysis2"));
 
-    analyses = _manager.listAnalyses(containerName, false);
-    assertTrue("User analyses listed if suggested is false", analyses.contains("analysis1"));
-    assertFalse(
-        "Suggested analyses not listed if suggested is false", analyses.contains("analysis2"));
+    // checking that both analyses are returned for AnalysisType as null
+    assertThat(analyses, equalTo(ImmutableSortedSet.of("analysis1", "analysis2")));
 
-    analyses = _manager.listAnalyses(containerName, true);
-    assertFalse("User analyses not listed if suggested is true", analyses.contains("analysis1"));
-    assertTrue("Suggested analyses listed if suggested is true", analyses.contains("analysis2"));
+    analyses = _manager.listAnalyses(containerName, AnalysisType.ALL);
+
+    // checking that both analyses are returned for AnalysisType as ALL
+    assertThat(analyses, equalTo(ImmutableSortedSet.of("analysis1", "analysis2")));
+
+    analyses = _manager.listAnalyses(containerName, AnalysisType.USER);
+
+    // checking that user analysis is returned for AnalysisType as USER
+    assertThat(analyses, equalTo(ImmutableSortedSet.of("analysis1")));
+
+    analyses = _manager.listAnalyses(containerName, AnalysisType.SUGGESTED);
+
+    // checking that suggested analysis is returned for AnalysisType as SUGGESTED
+    assertThat(analyses, equalTo(ImmutableSortedSet.of("analysis2")));
   }
 
   @Test

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
@@ -7,7 +7,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -209,25 +208,16 @@ public class WorkMgrTest {
     _manager.configureAnalysis(
         containerName, true, "analysis2", Maps.newHashMap(), Lists.newArrayList(), true);
 
-    SortedSet<String> analyses = _manager.listAnalyses(containerName, null);
-
-    // checking that both analyses are returned for AnalysisType as null
-    assertThat(analyses, equalTo(ImmutableSortedSet.of("analysis1", "analysis2")));
-
-    analyses = _manager.listAnalyses(containerName, AnalysisType.ALL);
-
-    // checking that both analyses are returned for AnalysisType as ALL
-    assertThat(analyses, equalTo(ImmutableSortedSet.of("analysis1", "analysis2")));
-
-    analyses = _manager.listAnalyses(containerName, AnalysisType.USER);
-
-    // checking that user analysis is returned for AnalysisType as USER
-    assertThat(analyses, equalTo(ImmutableSortedSet.of("analysis1")));
-
-    analyses = _manager.listAnalyses(containerName, AnalysisType.SUGGESTED);
-
-    // checking that suggested analysis is returned for AnalysisType as SUGGESTED
-    assertThat(analyses, equalTo(ImmutableSortedSet.of("analysis2")));
+    // checking that we get analyses according to AnalysisType
+    assertThat(
+        _manager.listAnalyses(containerName, AnalysisType.ALL),
+        equalTo(Sets.newHashSet("analysis1", "analysis2")));
+    assertThat(
+        _manager.listAnalyses(containerName, AnalysisType.USER),
+        equalTo(Sets.newHashSet("analysis1")));
+    assertThat(
+        _manager.listAnalyses(containerName, AnalysisType.SUGGESTED),
+        equalTo(Sets.newHashSet("analysis2")));
   }
 
   @Test


### PR DESCRIPTION
 - Using boolean caused the client to always get only the user policies even when it passed `null` for `suggested` parameter, as  `null` was converted to `false` when received by `WorkMgrService`

- Enum will prevent `nulls` being exchanged between the client and service when providing a valid value of `AnalysisType` is made mandatory for client in the future