### PR TITLE
Stop using BitSet in favor of bit operations

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Ip.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Ip.java
@@ -1,7 +1,5 @@
 package org.batfish.datamodel;
 
-import static org.batfish.datamodel.Prefix.MAX_PREFIX_LENGTH;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.io.Serializable;
@@ -121,7 +119,7 @@ public class Ip implements Comparable<Ip>, Serializable {
    * @return a boolean representation of the bit value
    */
   public static boolean getBitAtPosition(long bits, int position) {
-    return (bits & (1 << (MAX_PREFIX_LENGTH - 1 - position))) != 0;
+    return (bits & (1 << (Prefix.MAX_PREFIX_LENGTH - 1 - position))) != 0;
   }
 
   /**

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Ip.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Ip.java
@@ -133,6 +133,7 @@ public class Ip implements Comparable<Ip>, Serializable {
   }
 
   /** @deprecated In favor of much simpler {@link #getBitAtPosition(Ip, int)} */
+  @Deprecated
   public BitSet getAddressBits() {
     BitSet bits = _addressBitsCache.get(this);
     if (bits == null) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Ip.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Ip.java
@@ -1,5 +1,7 @@
 package org.batfish.datamodel;
 
+import static org.batfish.datamodel.Prefix.MAX_PREFIX_LENGTH;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.io.Serializable;
@@ -111,6 +113,26 @@ public class Ip implements Comparable<Ip>, Serializable {
     return _ip == rhs._ip;
   }
 
+  /**
+   * Return the boolean value of a bit at the given position.
+   *
+   * @param bits the representation of an IP address as a long
+   * @param position bit position (0 means most significant, 31 least significant)
+   * @return a boolean representation of the bit value
+   */
+  public static boolean getBitAtPosition(long bits, int position) {
+    return (bits & (1 << (MAX_PREFIX_LENGTH - 1 - position))) != 0;
+  }
+
+  /**
+   * See {@link #getBitAtPosition(long, int)}. Equivalent to {@code getBitAtPosition(ip.asLong(),
+   * position)}
+   */
+  public static boolean getBitAtPosition(Ip ip, int position) {
+    return getBitAtPosition(ip.asLong(), position);
+  }
+
+  /** @deprecated In favor of much simpler {@link #getBitAtPosition(Ip, int)} */
   public BitSet getAddressBits() {
     BitSet bits = _addressBitsCache.get(this);
     if (bits == null) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixTrie.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixTrie.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.collect.ImmutableSortedSet;
 import java.io.Serializable;
-import java.util.BitSet;
 import java.util.Collections;
 import java.util.SortedSet;
 import javax.annotation.Nullable;
@@ -24,18 +23,18 @@ public class PrefixTrie implements Serializable {
 
     public void addPrefix(Prefix prefix) {
       int prefixLength = prefix.getPrefixLength();
-      BitSet bits = prefix.getStartIp().getAddressBits();
+      long bits = prefix.getStartIp().asLong();
       _root.addPrefix(prefix, bits, prefixLength, 0);
     }
 
     public boolean containsPathFromPrefix(Prefix prefix) {
       int prefixLength = prefix.getPrefixLength();
-      BitSet bits = prefix.getStartIp().getAddressBits();
+      long bits = prefix.getStartIp().asLong();
       return _root.containsPathFromPrefix(bits, prefixLength, 0);
     }
 
     public Prefix getLongestPrefixMatch(Ip address) {
-      BitSet addressBits = address.getAddressBits();
+      long addressBits = address.asLong();
       return _root.getLongestPrefixMatch(address, addressBits, 0);
     }
   }
@@ -51,12 +50,12 @@ public class PrefixTrie implements Serializable {
 
     private ByteTrieNode _right;
 
-    public void addPrefix(Prefix prefix, BitSet bits, int prefixLength, int depth) {
+    public void addPrefix(Prefix prefix, long bits, int prefixLength, int depth) {
       if (prefixLength == depth) {
         _prefix = prefix;
         return;
       } else {
-        boolean currentBit = bits.get(depth);
+        boolean currentBit = Ip.getBitAtPosition(bits, depth);
         if (currentBit) {
           if (_right == null) {
             _right = new ByteTrieNode();
@@ -71,7 +70,7 @@ public class PrefixTrie implements Serializable {
       }
     }
 
-    public boolean containsPathFromPrefix(BitSet bits, int prefixLength, int depth) {
+    public boolean containsPathFromPrefix(long bits, int prefixLength, int depth) {
       if (prefixLength == depth) {
         if (depth == 0 && _prefix == null) {
           return false;
@@ -79,7 +78,7 @@ public class PrefixTrie implements Serializable {
           return true;
         }
       } else {
-        boolean currentBit = bits.get(depth);
+        boolean currentBit = Ip.getBitAtPosition(bits, depth);
         if (currentBit) {
           if (_right == null) {
             return false;
@@ -105,12 +104,12 @@ public class PrefixTrie implements Serializable {
       }
     }
 
-    public Prefix getLongestPrefixMatch(Ip address, BitSet bits, int index) {
+    public Prefix getLongestPrefixMatch(Ip address, long bits, int index) {
       Prefix longestPrefixMatch = getLongestPrefixMatch(address);
       if (index == Prefix.MAX_PREFIX_LENGTH) {
         return longestPrefixMatch;
       }
-      boolean currentBit = bits.get(index);
+      boolean currentBit = Ip.getBitAtPosition(bits, index);
       Prefix longerMatch = null;
       if (currentBit) {
         if (_right != null) {

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/IpTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/IpTest.java
@@ -1,8 +1,12 @@
 package org.batfish.datamodel;
 
+import static org.batfish.datamodel.Ip.getBitAtPosition;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -18,5 +22,17 @@ public class IpTest {
     assertThat(Ip.numSubnetBitsToSubnetLong(17), equalTo(0xFFFF8000L));
     assertThat(Ip.numSubnetBitsToSubnetLong(31), equalTo(0xFFFFFFFEL));
     assertThat(Ip.numSubnetBitsToSubnetLong(32), equalTo(0xFFFFFFFFL));
+  }
+
+  @Test
+  public void testGetBitAtPosition() {
+    assertThat(getBitAtPosition(0L, 0), is(false));
+    assertThat(getBitAtPosition(0L, 31), is(false));
+    assertThat(getBitAtPosition(1L, 31), is(true));
+    assertThat(getBitAtPosition(0xFF000000L, 7), is(true));
+    assertThat(getBitAtPosition(0xFF000000L, 8), is(false));
+    for (int i = 0; i < 32; i++) {
+      MatcherAssert.assertThat(getBitAtPosition(Ip.MAX.asLong(), i), IsEqual.equalTo(true));
+    }
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/symbolic/abstraction/PrefixTrieMap.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/abstraction/PrefixTrieMap.java
@@ -2,7 +2,6 @@ package org.batfish.symbolic.abstraction;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.BitSet;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -29,7 +28,7 @@ public class PrefixTrieMap implements Serializable {
 
     void addPrefix(Prefix prefix, String device) {
       int prefixLength = prefix.getPrefixLength();
-      BitSet bits = prefix.getStartIp().getAddressBits();
+      long bits = prefix.getStartIp().asLong();
       Set<String> devices = new HashSet<>();
       devices.add(device);
       _root.addPrefix(prefix, devices, bits, prefixLength, 0);
@@ -50,7 +49,7 @@ public class PrefixTrieMap implements Serializable {
     private ByteTrieNode _right;
 
     private void addPrefix(
-        Prefix prefix, Set<String> devices, BitSet bits, int prefixLength, int depth) {
+        Prefix prefix, Set<String> devices, long bits, int prefixLength, int depth) {
       if (prefixLength == depth) {
         _prefix = prefix;
         if (_devices == null) {
@@ -59,7 +58,7 @@ public class PrefixTrieMap implements Serializable {
           _devices.addAll(devices);
         }
       } else {
-        boolean currentBit = bits.get(depth);
+        boolean currentBit = Ip.getBitAtPosition(bits, depth);
         if (_devices != null) {
           devices.addAll(_devices);
         }

--- a/projects/batfish/src/main/java/org/batfish/symbolic/bdd/BDDAcl.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/bdd/BDDAcl.java
@@ -1,7 +1,6 @@
 package org.batfish.symbolic.bdd;
 
 import java.util.ArrayList;
-import java.util.BitSet;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -11,6 +10,7 @@ import net.sf.javabdd.BDD;
 import net.sf.javabdd.BDDFactory;
 import org.batfish.common.BatfishException;
 import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.IpAccessListLine;
 import org.batfish.datamodel.IpProtocol;
@@ -313,10 +313,10 @@ public class BDDAcl {
    * [var(0), ..., var(n)]
    */
   private BDD firstBitsEqual(BDD[] bits, Prefix p, int length) {
-    BitSet b = p.getStartIp().getAddressBits();
+    long b = p.getStartIp().asLong();
     BDD acc = _factory.one();
     for (int i = 0; i < length; i++) {
-      boolean res = b.get(i);
+      boolean res = Ip.getBitAtPosition(b, i);
       if (res) {
         acc = acc.and(bits[i]);
       } else {

--- a/projects/batfish/src/main/java/org/batfish/symbolic/bdd/BDDPacket.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/bdd/BDDPacket.java
@@ -1,6 +1,5 @@
 package org.batfish.symbolic.bdd;
 
-import java.util.BitSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -12,6 +11,7 @@ import net.sf.javabdd.BDDFactory;
 import net.sf.javabdd.BDDPairing;
 import net.sf.javabdd.JFactory;
 import org.batfish.common.BatfishException;
+import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
 
 /**
@@ -395,13 +395,13 @@ public class BDDPacket {
 
   public BDD restrict(BDD bdd, Prefix pfx) {
     int len = pfx.getPrefixLength();
-    BitSet bits = pfx.getStartIp().getAddressBits();
+    long bits = pfx.getStartIp().asLong();
     int[] vars = new int[len];
     BDD[] vals = new BDD[len];
     pairing.reset();
     for (int i = 0; i < len; i++) {
       int var = _dstIp.getBitvec()[i].var(); // dstIpIndex + i;
-      BDD subst = bits.get(i) ? factory.one() : factory.zero();
+      BDD subst = Ip.getBitAtPosition(bits, i) ? factory.one() : factory.zero();
       vars[i] = var;
       vals[i] = subst;
     }

--- a/projects/batfish/src/main/java/org/batfish/symbolic/bdd/BDDRoute.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/bdd/BDDRoute.java
@@ -1,7 +1,6 @@
 package org.batfish.symbolic.bdd;
 
 import java.util.ArrayList;
-import java.util.BitSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -15,6 +14,7 @@ import net.sf.javabdd.BDDFactory;
 import net.sf.javabdd.BDDPairing;
 import net.sf.javabdd.JFactory;
 import org.batfish.common.BatfishException;
+import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
 import org.batfish.symbolic.CommunityVar;
 import org.batfish.symbolic.CommunityVar.Type;
@@ -351,7 +351,7 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
 
   public BDDRoute restrict(Prefix pfx) {
     int len = pfx.getPrefixLength();
-    BitSet bits = pfx.getStartIp().getAddressBits();
+    long bits = pfx.getStartIp().asLong();
     int[] vars = new int[len];
     BDD[] vals = new BDD[len];
     // NOTE: do not create a new pairing each time
@@ -359,7 +359,7 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
     pairing.reset();
     for (int i = 0; i < len; i++) {
       int var = _prefix.getBitvec()[i].var(); // prefixIndex + i;
-      BDD subst = bits.get(i) ? factory.one() : factory.zero();
+      BDD subst = Ip.getBitAtPosition(bits, i) ? factory.one() : factory.zero();
       vars[i] = var;
       vals[i] = subst;
     }

--- a/projects/batfish/src/main/java/org/batfish/symbolic/bdd/TransferBDD.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/bdd/TransferBDD.java
@@ -1,7 +1,6 @@
 package org.batfish.symbolic.bdd;
 
 import java.util.ArrayList;
-import java.util.BitSet;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -14,6 +13,7 @@ import org.batfish.common.BatfishException;
 import org.batfish.datamodel.CommunityList;
 import org.batfish.datamodel.CommunityListLine;
 import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.OspfMetricType;
 import org.batfish.datamodel.Prefix;
@@ -116,10 +116,10 @@ class TransferBDD {
    * [var(0), ..., var(n)]
    */
   public static BDD firstBitsEqual(BDD[] bits, Prefix p, int length) {
-    BitSet b = p.getStartIp().getAddressBits();
+    long b = p.getStartIp().asLong();
     BDD acc = factory.one();
     for (int i = 0; i < length; i++) {
-      boolean res = b.get(i);
+      boolean res = Ip.getBitAtPosition(b, i);
       if (res) {
         acc = acc.and(bits[i]);
       } else {


### PR DESCRIPTION
Avoid unnecessary caching & loops for something that can be accomplished with bit arithmetic.
Marked `getAddressBits` as deprecated.