### PR TITLE
Shut eclipse up about unchecked intersection cast

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpProcess.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpProcess.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableSet;
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDescription;
 import java.io.Serializable;
@@ -48,6 +47,19 @@ public class BgpProcess implements Serializable {
     public BgpProcess.Builder setVrf(Vrf vrf) {
       _vrf = vrf;
       return this;
+    }
+  }
+
+  private class ClusterIdsSupplier implements Serializable, Supplier<Set<Long>> {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public Set<Long> get() {
+      return _neighbors
+          .values()
+          .stream()
+          .map(BgpNeighbor::getClusterId)
+          .collect(ImmutableSet.toImmutableSet());
     }
   }
 
@@ -97,19 +109,7 @@ public class BgpProcess implements Serializable {
     _neighbors = new TreeMap<>();
     _generatedRoutes = new TreeSet<>();
     _tieBreaker = BgpTieBreaker.ARRIVAL_ORDER;
-    _clusterIds = initClusterIdsMemoization();
-  }
-
-  @SuppressWarnings("unchecked")
-  private Supplier<Set<Long>> initClusterIdsMemoization() {
-    return Suppliers.memoize(
-        (Serializable & Supplier<Set<Long>>)
-            () ->
-                _neighbors
-                    .values()
-                    .stream()
-                    .map(BgpNeighbor::getClusterId)
-                    .collect(ImmutableSet.toImmutableSet()));
+    _clusterIds = new ClusterIdsSupplier();
   }
 
   /**

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpProcess.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpProcess.java
@@ -97,15 +97,19 @@ public class BgpProcess implements Serializable {
     _neighbors = new TreeMap<>();
     _generatedRoutes = new TreeSet<>();
     _tieBreaker = BgpTieBreaker.ARRIVAL_ORDER;
-    _clusterIds =
-        Suppliers.memoize(
-            (Serializable & Supplier<Set<Long>>)
-                () ->
-                    _neighbors
-                        .values()
-                        .stream()
-                        .map(BgpNeighbor::getClusterId)
-                        .collect(ImmutableSet.toImmutableSet()));
+    _clusterIds = initClusterIdsMemoization();
+  }
+
+  @SuppressWarnings("unchecked")
+  private Supplier<Set<Long>> initClusterIdsMemoization() {
+    return Suppliers.memoize(
+        (Serializable & Supplier<Set<Long>>)
+            () ->
+                _neighbors
+                    .values()
+                    .stream()
+                    .map(BgpNeighbor::getClusterId)
+                    .collect(ImmutableSet.toImmutableSet()));
   }
 
   /**

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/InlineCommunitySet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/InlineCommunitySet.java
@@ -27,10 +27,13 @@ public class InlineCommunitySet extends CommunitySetExpr {
 
   @JsonCreator
   private InlineCommunitySet() {
-    _cachedCommunities =
-        Suppliers.memoize(
-            (Serializable & com.google.common.base.Supplier<SortedSet<Long>>)
-                () -> initCommunities());
+    _cachedCommunities = initCachedCommunitiesMemoization();
+  }
+
+  @SuppressWarnings("unchecked")
+  private Supplier<SortedSet<Long>> initCachedCommunitiesMemoization() {
+    return Suppliers.memoize(
+        (Serializable & com.google.common.base.Supplier<SortedSet<Long>>) () -> initCommunities());
   }
 
   public InlineCommunitySet(Collection<Long> communities) {


### PR DESCRIPTION
Eclipse Oxygen does not like this cast again. Moving to separate function so I can suppress with minimal side effects.