### PR TITLE
equals() bug fix in AbstractOutliersSet

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/AbstractOutlierSet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/AbstractOutlierSet.java
@@ -68,7 +68,7 @@ public abstract class AbstractOutlierSet implements RoleBasedOutlierSet {
     AbstractOutlierSet rhs = (AbstractOutlierSet) other;
     return _conformers.equals(rhs.getConformers())
         && _outliers.equals(rhs.getOutliers())
-        && Objects.equals(_role, rhs.getRole());
+        && Objects.equals(this.getRole(), rhs.getRole());
   }
 
   @JsonProperty(PROP_CONFORMERS)


### PR DESCRIPTION
Was comparing a String to an Optional<String> -- now comparing two Optional<String> objects.