### PR TITLE
ignoring ctrl+c when run through watchdog

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/main/Driver.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Driver.java
@@ -248,7 +248,9 @@ public class Driver {
   @Nullable
   public static synchronized Task killTask(String taskId) {
     Task task = _taskLog.get(taskId);
-    if (task == null) {
+    if (_mainSettings.getParentPid() <= 0) {
+      throw new BatfishException("Cannot kill tasks when started in non-watchdog mode");
+    } else if (task == null) {
       throw new BatfishException("Task with provided id not found: " + taskId);
     } else if (task.getStatus().isTerminated()) {
       throw new BatfishException("Task with provided id already terminated " + taskId);

--- a/projects/batfish/src/main/java/org/batfish/main/Driver.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Driver.java
@@ -70,6 +70,8 @@ import org.codehaus.jettison.json.JSONArray;
 import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory;
 import org.glassfish.jersey.jettison.JettisonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
+import sun.misc.Signal;
+import sun.misc.SignalHandler;
 
 public class Driver {
 
@@ -458,6 +460,8 @@ public class Driver {
                   0,
                   PARENT_CHECK_INTERVAL_MS,
                   TimeUnit.MILLISECONDS);
+          SignalHandler handler = signal -> _mainLogger.infof("BFS: Ignoring signal %s\n", signal);
+          Signal.handle(new Signal("INT"), handler);
         }
       }
 


### PR DESCRIPTION
(this gap was created when we moved the signal handler to client.)