### PR TITLE
List only user analyses by default

### DIFF
--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
@@ -1076,7 +1076,7 @@ public class WorkMgrService {
 
       JSONObject retObject = new JSONObject();
 
-      analysisType = firstNonNull(analysisType, AnalysisType.ALL);
+      analysisType = firstNonNull(analysisType, AnalysisType.USER);
       for (String analysisName : Main.getWorkMgr().listAnalyses(containerName, analysisType)) {
 
         JSONObject analysisJson = new JSONObject();


### PR DESCRIPTION
If client doesn't supply an analysis type, it should list only user analyses by default.