### PR TITLE
Juniper: support ospf area interface metric

### DIFF
--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchers.java
@@ -12,6 +12,7 @@ import org.batfish.datamodel.SourceNat;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasDeclaredNames;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasOspfArea;
+import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasOspfCost;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasSourceNats;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasVrf;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.IsActive;
@@ -55,6 +56,14 @@ public final class InterfaceMatchers {
    */
   public static HasOspfArea hasOspfArea(Matcher<OspfArea> subMatcher) {
     return new HasOspfArea(subMatcher);
+  }
+
+  /**
+   * Provides a matcher that matches if the provided {@code subMatcher} matches the interface's OSPF
+   * cost.
+   */
+  public static HasOspfCost hasOspfCost(Matcher<Integer> subMatcher) {
+    return new HasOspfCost(subMatcher);
   }
 
   /**

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchersImpl.java
@@ -36,7 +36,7 @@ final class InterfaceMatchersImpl {
 
   static final class HasOspfCost extends FeatureMatcher<Interface, Integer> {
     HasOspfCost(@Nonnull Matcher<? super Integer> subMatcher) {
-      super(subMatcher, "an interface with ospfCost", "ospfCost");
+      super(subMatcher, "an interface with ospfCost:", "ospfCost");
     }
 
     @Override

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchersImpl.java
@@ -34,6 +34,17 @@ final class InterfaceMatchersImpl {
     }
   }
 
+  static final class HasOspfCost extends FeatureMatcher<Interface, Integer> {
+    HasOspfCost(@Nonnull Matcher<? super Integer> subMatcher) {
+      super(subMatcher, "an interface with ospfCost", "ospfCost");
+    }
+
+    @Override
+    protected Integer featureValueOf(Interface actual) {
+      return actual.getOspfCost();
+    }
+  }
+
   static final class HasSourceNats extends FeatureMatcher<Interface, List<SourceNat>> {
     HasSourceNats(@Nonnull Matcher<? super List<SourceNat>> subMatcher) {
       super(subMatcher, "sourceNats", "sourceNats");

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -2313,6 +2313,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
     _currentBgpGroup.setAdvertisePeerAs(true);
   }
 
+  @Override
   public void exitB_authentication_algorithm(B_authentication_algorithmContext ctx) {
     if (ctx.AES_128_CMAC_96() != null) {
       _currentBgpGroup.setAuthenticationAlgorithm(BgpAuthenticationAlgorithm.AES_128_CMAC_96);
@@ -2323,10 +2324,12 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
     }
   }
 
+  @Override
   public void exitB_authentication_key(B_authentication_keyContext ctx) {
     _currentBgpGroup.setAuthenticationKey(ctx.key.getText());
   }
 
+  @Override
   public void exitB_authentication_key_chain(B_authentication_key_chainContext ctx) {
     _currentBgpGroup.setAuthenticationKeyChainName(ctx.name.getText());
     int line = ctx.getStart().getLine();
@@ -2995,6 +2998,12 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   @Override
   public void exitOaa_restrict(FlatJuniperParser.Oaa_restrictContext ctx) {
     _currentAreaRangeRestrict = true;
+  }
+
+  @Override
+  public void exitOai_metric(FlatJuniperParser.Oai_metricContext ctx) {
+    int ospfCost = toInt(ctx.DEC());
+    _currentOspfInterface.setOspfCost(ospfCost);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
@@ -231,13 +231,19 @@ public class Interface extends ComparableStructure<String> {
   }
 
   public void inheritUnsetFields() {
-    if (_parent == null || !_inherited) {
+    if (_parent == null || _inherited) {
       return;
     }
     _inherited = true;
     _parent.inheritUnsetFields();
     if (_mtu == null) {
       _mtu = _parent._mtu;
+    }
+    if (_ospfCost == null) {
+      _ospfCost = _parent._ospfCost;
+    }
+    if (_ospfActiveArea == null) {
+      _ospfActiveArea = _parent._ospfActiveArea;
     }
   }
 
@@ -277,8 +283,8 @@ public class Interface extends ComparableStructure<String> {
     _ospfActiveArea = ospfActiveArea;
   }
 
-  public void setOspfCost(int defaultOspfCost) {
-    _ospfCost = defaultOspfCost;
+  public void setOspfCost(int ospfCost) {
+    _ospfCost = ospfCost;
   }
 
   public void setOspfDeadInterval(int seconds) {

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -175,7 +175,7 @@ public class FlatJuniperGrammarTest {
     assertThat(summary, hasMetric(nullValue()));
 
     // Interface override
-    assertThat(config.getInterfaces().get("fe-1/0/1.0"), hasOspfCost(equalTo(17)));
+    assertThat(config, hasInterface("fe-1/0/1.0", hasOspfCost(equalTo(17))));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -2,6 +2,7 @@ package org.batfish.grammar.flatjuniper;
 
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasDefaultVrf;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasInterface;
+import static org.batfish.datamodel.matchers.InterfaceMatchers.hasOspfCost;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.isOspfPassive;
 import static org.batfish.datamodel.matchers.OspfAreaSummaryMatchers.hasMetric;
 import static org.batfish.datamodel.matchers.OspfAreaSummaryMatchers.isAdvertised;
@@ -145,10 +146,11 @@ public class FlatJuniperGrammarTest {
   }
 
   @Test
-  public void testOspf() throws IOException {
+  public void testOspfMetric() throws IOException {
     Configuration config =
-        BatfishTestUtils.parseTextConfigs(_folder, "org/batfish/grammar/juniper/testconfigs/ospf")
-            .get("ospf");
+        BatfishTestUtils.parseTextConfigs(
+                _folder, "org/batfish/grammar/juniper/testconfigs/ospfmetric")
+            .get("ospfmetric");
     OspfAreaSummary summary =
         config
             .getDefaultVrf()
@@ -171,6 +173,9 @@ public class FlatJuniperGrammarTest {
             .get(Prefix.parse("10.0.0.0/16"));
     assertThat(summary, isAdvertised());
     assertThat(summary, hasMetric(nullValue()));
+
+    // Interface override
+    assertThat(config.getInterfaces().get("fe-1/0/1.0"), hasOspfCost(equalTo(17)));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/ospf
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/ospf
@@ -1,5 +1,0 @@
-#
-set system host-name ospf
-#
-set protocols ospf area 0.0.0.1 area-range 10.0.0.0/16 override-metric 123 restrict
-set protocols ospf area 0.0.0.2 area-range 10.0.0.0/16

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/ospfmetric
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/ospfmetric
@@ -1,0 +1,8 @@
+#
+set system host-name ospfmetric
+#
+set protocols ospf area 0.0.0.1 area-range 10.0.0.0/16 override-metric 123 restrict
+set protocols ospf area 0.0.0.2 area-range 10.0.0.0/16
+#
+set interfaces fe-1/0/1 unit 0 family inet address 1.0.0.0/31
+set protocols ospf area 0.0.0.3 interface fe-1/0/1 metric 17


### PR DESCRIPTION
* Fix inheritance (inverted condition on whether inheritance had been performed)
* Add parsing for metric configuration for an ospf area interface
* Add inheritance of ospf cost and ospf area
* Rename parameter in setOspfCost
* and test with new matchers and everthing.