### PR TITLE
Combine multiple reachability queries into chunks

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
@@ -188,7 +188,8 @@ public interface IBatfish extends IPluginConsumer {
       NodesSpecifier notFinalNodeRegex,
       Set<String> transitNodes,
       Set<String> notTransitNodes,
-      boolean useCompression);
+      boolean useCompression,
+      int maxChunkSize);
 
   void writeDataPlane(DataPlane dp, DataPlaneAnswerElement ae);
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
@@ -46,6 +46,7 @@ import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
@@ -482,6 +483,14 @@ public class CommonUtil {
       s.append((bit != 0) ? '1' : '0');
     }
     return s.toString();
+  }
+
+  public static <T> void forEachWithIndex(Iterable<T> ts, BiConsumer<Integer, T> biConsumer) {
+    int i = 0;
+    for (T t : ts) {
+      biConsumer.accept(i, t);
+      i++;
+    }
   }
 
   public static Path getCanonicalPath(Path path) {

--- a/projects/batfish/src/main/java/org/batfish/config/Settings.java
+++ b/projects/batfish/src/main/java/org/batfish/config/Settings.java
@@ -600,6 +600,10 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
     return nullablePath(_config.getString(BfConsts.ARG_ANSWER_JSON_PATH));
   }
 
+  public int getAvailableThreads() {
+    return Math.min(Runtime.getRuntime().availableProcessors(), getJobs());
+  }
+
   public TestrigSettings getBaseTestrigSettings() {
     return _baseTestrigSettings;
   }

--- a/projects/batfish/src/main/java/org/batfish/job/BatfishJobExecutor.java
+++ b/projects/batfish/src/main/java/org/batfish/job/BatfishJobExecutor.java
@@ -151,9 +151,7 @@ public class BatfishJobExecutor {
       return Executors.newSingleThreadExecutor();
     }
     // if parallel processing is allowed
-    int maxConcurrentThreads = Runtime.getRuntime().availableProcessors();
-    int numConcurrentThreads = Math.min(maxConcurrentThreads, _settings.getJobs());
-    return Executors.newFixedThreadPool(numConcurrentThreads);
+    return Executors.newFixedThreadPool(_settings.getAvailableThreads());
   }
 
   <

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -12,6 +12,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import io.opentracing.ActiveSpan;
 import io.opentracing.util.GlobalTracer;
@@ -4156,17 +4157,8 @@ public class Batfish extends PluginConsumer implements IBatfish {
                 originateNodeVrfs.size() / Runtime.getRuntime().availableProcessors()));
 
     // partition originateNodeVrfs into chunks
-    List<List<Pair<String, String>>> originateNodeVrfChunks = new LinkedList<>();
-    CommonUtil.forEachWithIndex(
-        originateNodeVrfs,
-        (index, originateNodeVrf) -> {
-          // Invariant: current chunk is the first in the list.
-          if (index % chunkSize == 0) {
-            // create a new chunk
-            originateNodeVrfChunks.add(0, new ArrayList<>());
-          }
-          originateNodeVrfChunks.get(0).add(originateNodeVrf);
-        });
+    List<List<Pair<String, String>>> originateNodeVrfChunks =
+        Lists.partition(originateNodeVrfs, chunkSize);
 
     // build query jobs
     List<NodJob> jobs =

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -4155,10 +4156,11 @@ public class Batfish extends PluginConsumer implements IBatfish {
                 originateNodeVrfs.size() / Runtime.getRuntime().availableProcessors()));
 
     // partition originateNodeVrfs into chunks
-    List<List<Pair<String, String>>> originateNodeVrfChunks = new ArrayList<>();
+    List<List<Pair<String, String>>> originateNodeVrfChunks = new LinkedList<>();
     CommonUtil.forEachWithIndex(
         originateNodeVrfs,
         (index, originateNodeVrf) -> {
+          // Invariant: current chunk is the first in the list.
           if (index % chunkSize == 0) {
             // create a new chunk
             originateNodeVrfChunks.add(0, new ArrayList<>());

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -31,7 +31,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -4087,8 +4087,6 @@ public class Batfish extends PluginConsumer implements IBatfish {
         useCompression ? compressionResult._compressedConfigs : loadConfigurations();
     DataPlane dataPlane = useCompression ? compressionResult._compressedDataPlane : loadDataPlane();
 
-    Synthesizer dataPlaneSynthesizer = synthesizeDataPlane(configurations, dataPlane);
-
     // collect ingress nodes
     Set<String> ingressNodes = ingressNodeRegex.getMatchingNodes(configurations);
     Set<String> notIngressNodes = notIngressNodeRegex.getMatchingNodes(configurations);
@@ -4147,17 +4145,15 @@ public class Batfish extends PluginConsumer implements IBatfish {
                         .map(ingressVrf -> new Pair<>(ingressNode, ingressVrf)))
             .collect(Collectors.toList());
 
-    int minChunkSize = 1;
     int chunkSize =
         Math.max(
-            minChunkSize,
-            Math.min(
-                maxChunkSize,
-                originateNodeVrfs.size() / Runtime.getRuntime().availableProcessors()));
+            1, Math.min(maxChunkSize, originateNodeVrfs.size() / _settings.getAvailableThreads()));
 
     // partition originateNodeVrfs into chunks
     List<List<Pair<String, String>>> originateNodeVrfChunks =
         Lists.partition(originateNodeVrfs, chunkSize);
+
+    Synthesizer dataPlaneSynthesizer = synthesizeDataPlane(configurations, dataPlane);
 
     // build query jobs
     List<NodJob> jobs =

--- a/projects/batfish/src/main/java/org/batfish/z3/AbstractNodJob.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/AbstractNodJob.java
@@ -162,6 +162,6 @@ public abstract class AbstractNodJob extends Z3ContextJob<NodJobResult> {
   }
 
   private static class QueryUnsatException extends Throwable {
-    static final long serialVersionUID = 0L;
+    static final long serialVersionUID = 1L;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/z3/AbstractNodJob.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/AbstractNodJob.java
@@ -50,9 +50,9 @@ public abstract class AbstractNodJob extends Z3ContextJob<NodJobResult> {
     Solver solver = ctx.mkSolver();
     solver.add(smtInput._expr);
 
-    int originateVrfBVSize = _originateVrfInstrumentation.getFieldBits();
+    int originateVrfBvSize = _originateVrfInstrumentation.getFieldBits();
     BitVecExpr originateVrfFieldConst =
-        ctx.mkBVConst(OriginateVrfInstrumentation.ORIGINATE_VRF_FIELD_NAME, originateVrfBVSize);
+        ctx.mkBVConst(OriginateVrfInstrumentation.ORIGINATE_VRF_FIELD_NAME, originateVrfBvSize);
 
     ImmutableMap.Builder<OriginateVrf, Map<String, Long>> models = ImmutableMap.builder();
     // keep refining until no new models
@@ -68,7 +68,7 @@ public abstract class AbstractNodJob extends Z3ContextJob<NodJobResult> {
         // refine: different OriginateVrf
         solver.add(
             ctx.mkNot(
-                ctx.mkEq(originateVrfFieldConst, ctx.mkBV(originateVrfId, originateVrfBVSize))));
+                ctx.mkEq(originateVrfFieldConst, ctx.mkBV(originateVrfId, originateVrfBvSize))));
       } catch (QueryUnsatException e) {
         break;
       }
@@ -141,18 +141,16 @@ public abstract class AbstractNodJob extends Z3ContextJob<NodJobResult> {
         .map(
             entry ->
                 createFlow(
-                    // hostname
+                    /* hostname */
                     entry.getKey().getHostname(),
-                    // VRF name
+                    /* VRF name */
                     entry.getKey().getVrf(),
-                    // field constraints map
+                    /* field constraints map */
                     entry.getValue()))
         .collect(Collectors.toSet());
   }
 
   Map<String, Long> getFieldConstraints(Model model, Map<String, BitVecExpr> variablesAsConsts) {
-    FuncDecl[] decls = model.getConstDecls();
-
     return Arrays.stream(model.getConstDecls())
         .map(FuncDecl::getName)
         .map(Object::toString)
@@ -163,6 +161,7 @@ public abstract class AbstractNodJob extends Z3ContextJob<NodJobResult> {
                     ((BitVecNum) model.getConstInterp(variablesAsConsts.get(field))).getLong()));
   }
 
-  @SuppressWarnings("serial")
-  private static class QueryUnsatException extends Throwable {}
+  private static class QueryUnsatException extends Throwable {
+    static final long serialVersionUID = 0L;
+  }
 }

--- a/projects/batfish/src/main/java/org/batfish/z3/CompositeNodJob.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/CompositeNodJob.java
@@ -41,9 +41,12 @@ public class CompositeNodJob extends AbstractNodJob {
     for (int i = 0; i < _numPrograms; i++) {
       Synthesizer dataPlaneSynthesizer = _dataPlaneSynthesizers.get(i);
       QuerySynthesizer querySynthesizer = _querySynthesizers.get(i);
-      ReachabilityProgram baseProgram = dataPlaneSynthesizer.synthesizeNodDataPlaneProgram();
+      ReachabilityProgram baseProgram =
+          instrumentReachabilityProgram(dataPlaneSynthesizer.synthesizeNodDataPlaneProgram());
       ReachabilityProgram queryProgram =
-          querySynthesizer.getReachabilityProgram(dataPlaneSynthesizer.getInput());
+          instrumentReachabilityProgram(
+              querySynthesizer.getReachabilityProgram(dataPlaneSynthesizer.getInput()));
+
       NodProgram program = new NodProgram(ctx, baseProgram, queryProgram);
       variablesAsConsts.putAll(program.getNodContext().getVariablesAsConsts());
       answers[i] = computeSmtConstraintsViaNod(program, _querySynthesizers.get(i).getNegate());

--- a/projects/batfish/src/main/java/org/batfish/z3/Field.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/Field.java
@@ -21,6 +21,9 @@ public class Field {
 
   @Override
   public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
     if (!(other instanceof Field)) {
       return false;
     }

--- a/projects/batfish/src/main/java/org/batfish/z3/Field.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/Field.java
@@ -1,0 +1,35 @@
+package org.batfish.z3;
+
+import java.util.Objects;
+
+public class Field {
+  private final String _name;
+  private final int _size;
+
+  public Field(String name, int size) {
+    _name = name;
+    _size = size;
+  }
+
+  public String getName() {
+    return _name;
+  }
+
+  public int getSize() {
+    return _size;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (!(other instanceof Field)) {
+      return false;
+    }
+    Field field = (Field) other;
+    return _name.equals(field._name) && _size == field._size;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_name, _size);
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/z3/NodContext.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/NodContext.java
@@ -1,21 +1,39 @@
 package org.batfish.z3;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Streams;
 import com.microsoft.z3.BitVecExpr;
+import com.microsoft.z3.BitVecSort;
 import com.microsoft.z3.Context;
 import com.microsoft.z3.FuncDecl;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.batfish.z3.expr.VarIntExpr;
 import org.batfish.z3.expr.visitors.RelationCollector;
 import org.batfish.z3.expr.visitors.VariableSizeCollector;
 import org.batfish.z3.state.visitors.FuncDeclTransformer;
 
 public class NodContext {
+
+  private final List<BitVecSort> _basicStateVariableSorts;
+
+  private final List<BitVecSort> _transformationStateVariableSorts;
+
+  private final VarIntExpr[] _basicStateVarIntExprs;
+
+  private final VarIntExpr[] _tranformationStateVarIntExprs;
+
+  private final ImmutableList<String> _variableNames;
 
   private Context _context;
 
@@ -33,28 +51,33 @@ public class NodContext {
             .flatMap(
                 program ->
                     Streams.concat(program.getRules().stream(), program.getQueries().stream())
-                        .map(
-                            statement ->
-                                VariableSizeCollector.collectVariableSizes(
-                                    program.getInput(), statement))
+                        .map(VariableSizeCollector::collectVariableSizes)
                         .map(Map::entrySet)
                         .flatMap(Collection::stream))
             .collect(ImmutableSet.toImmutableSet())
             .stream()
             .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue));
 
-    _variables =
+    _variableNames = computeVariableNames(variableSizes);
+
+    Map<String, BitVecSort> variableSorts =
         variableSizes
             .entrySet()
             .stream()
             .collect(
                 ImmutableMap.toImmutableMap(
                     Entry::getKey,
-                    variableSizeEntry ->
+                    variableSizeEntry -> ctx.mkBitVecSort(variableSizeEntry.getValue())));
+    _variables =
+        _variableNames
+            .stream()
+            .collect(
+                ImmutableMap.toImmutableMap(
+                    Function.identity(),
+                    variableName ->
                         (BitVecExpr)
                             ctx.mkBound(
-                                deBruijnIndex.getAndIncrement(),
-                                ctx.mkBitVecSort(variableSizeEntry.getValue()))));
+                                deBruijnIndex.getAndIncrement(), variableSorts.get(variableName))));
     _variablesAsConsts =
         variableSizes
             .entrySet()
@@ -64,7 +87,36 @@ public class NodContext {
                     Entry::getKey,
                     variableSizeEntry ->
                         ctx.mkBVConst(variableSizeEntry.getKey(), variableSizeEntry.getValue())));
-    FuncDeclTransformer funcDeclTransformer = new FuncDeclTransformer(ctx);
+
+    ImmutableMap<String, VarIntExpr> varIntExprs =
+        variableSizes
+            .entrySet()
+            .stream()
+            .collect(
+                ImmutableMap.toImmutableMap(
+                    Entry::getKey,
+                    variableSizeEntry ->
+                        new VarIntExpr(variableSizeEntry.getKey(), variableSizeEntry.getValue())));
+    _basicStateVarIntExprs =
+        _variableNames
+            .stream()
+            .filter(nm -> !TransformationHeaderField.transformationHeaderFieldNames.contains(nm))
+            .map(varIntExprs::get)
+            .toArray(VarIntExpr[]::new);
+    _tranformationStateVarIntExprs =
+        _variableNames.stream().map(varIntExprs::get).toArray(VarIntExpr[]::new);
+
+    _basicStateVariableSorts =
+        _variableNames
+            .stream()
+            .filter(nm -> !TransformationHeaderField.transformationHeaderFieldNames.contains(nm))
+            .map(variableSorts::get)
+            .collect(Collectors.toList());
+
+    _transformationStateVariableSorts =
+        _variableNames.stream().map(variableSorts::get).collect(Collectors.toList());
+    FuncDeclTransformer funcDeclTransformer =
+        new FuncDeclTransformer(ctx, _basicStateVariableSorts, _transformationStateVariableSorts);
     _relationDeclarations =
         Arrays.stream(programs)
             .flatMap(
@@ -85,6 +137,37 @@ public class NodContext {
                             relationsEntry.getKey(), relationsEntry.getValue())));
   }
 
+  private static ImmutableList<String> computeVariableNames(Map<String, Integer> variableSizes) {
+    // Order the variables. Instrumentation variables first (in sorted order).
+    List<String> variableNames = new ArrayList<>(variableSizes.keySet());
+    Arrays.stream(BasicHeaderField.values())
+        .map(BasicHeaderField::getName)
+        .forEach(variableNames::remove);
+    Arrays.stream(TransformationHeaderField.values())
+        .map(TransformationHeaderField::getName)
+        .forEach(variableNames::remove);
+    Collections.sort(variableNames);
+    Arrays.stream(BasicHeaderField.values())
+        .map(BasicHeaderField::getName)
+        .forEach(variableNames::add);
+    Arrays.stream(TransformationHeaderField.values())
+        .map(TransformationHeaderField::getName)
+        .forEach(variableNames::add);
+    // restrict to the variables that occur in the program
+    return variableNames
+        .stream()
+        .filter(variableSizes::containsKey)
+        .collect(ImmutableList.toImmutableList());
+  }
+
+  public List<BitVecSort> getBasicStateVariableSorts() {
+    return _basicStateVariableSorts;
+  }
+
+  public List<BitVecSort> getTransformationStateVariableSorts() {
+    return _transformationStateVariableSorts;
+  }
+
   public Context getContext() {
     return _context;
   }
@@ -99,5 +182,17 @@ public class NodContext {
 
   public Map<String, BitVecExpr> getVariablesAsConsts() {
     return _variablesAsConsts;
+  }
+
+  public VarIntExpr[] getBasicStateVarIntExprs() {
+    return _basicStateVarIntExprs;
+  }
+
+  public VarIntExpr[] getTranformationStateVarIntExprs() {
+    return _tranformationStateVarIntExprs;
+  }
+
+  public ImmutableList<String> getVariableNames() {
+    return _variableNames;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/z3/NodJob.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/NodJob.java
@@ -36,9 +36,11 @@ public final class NodJob extends AbstractNodJob {
 
   @Nonnull
   protected NodProgram getNodProgram(Context ctx) {
-    ReachabilityProgram baseProgram = _dataPlaneSynthesizer.synthesizeNodDataPlaneProgram();
+    ReachabilityProgram baseProgram =
+        instrumentReachabilityProgram(_dataPlaneSynthesizer.synthesizeNodDataPlaneProgram());
     ReachabilityProgram queryProgram =
-        _querySynthesizer.getReachabilityProgram(_dataPlaneSynthesizer.getInput());
+        instrumentReachabilityProgram(
+            _querySynthesizer.getReachabilityProgram(_dataPlaneSynthesizer.getInput()));
     return new NodProgram(ctx, baseProgram, queryProgram);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/z3/NodProgram.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/NodProgram.java
@@ -86,12 +86,8 @@ public class NodProgram {
     _queries.forEach(
         query -> sb.append(String.format("(query %s)\n", query.getFuncDecl().getName())));
 
-    String[] variablesAsNames =
-        Streams.<HeaderField>concat(
-                Arrays.stream(BasicHeaderField.values()),
-                Arrays.stream(TransformationHeaderField.values()))
-            .map(HeaderField::getName)
-            .toArray(String[]::new);
+    String[] variablesAsNames = _context.getVariableNames().stream().toArray(String[]::new);
+
     String[] variablesAsDebruijnIndices =
         IntStream.range(0, variablesAsNames.length)
             .mapToObj(index -> String.format("(:var %d)", index))

--- a/projects/batfish/src/main/java/org/batfish/z3/OriginateVrfInstrumentation.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/OriginateVrfInstrumentation.java
@@ -1,0 +1,92 @@
+package org.batfish.z3;
+
+import static java.lang.Math.max;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.math.LongMath;
+import java.math.RoundingMode;
+import java.util.List;
+import org.batfish.z3.expr.AndExpr;
+import org.batfish.z3.expr.BasicRuleStatement;
+import org.batfish.z3.expr.Comment;
+import org.batfish.z3.expr.EqExpr;
+import org.batfish.z3.expr.GenericStatementVisitor;
+import org.batfish.z3.expr.LitIntExpr;
+import org.batfish.z3.expr.QueryStatement;
+import org.batfish.z3.expr.Statement;
+import org.batfish.z3.expr.TransformationRuleStatement;
+import org.batfish.z3.expr.TransformedBasicRuleStatement;
+import org.batfish.z3.expr.VarIntExpr;
+import org.batfish.z3.state.OriginateVrf;
+
+/**
+ * A NodInstrumentation that tracks which of several possible OriginateVrf states was used to derive
+ * each solution.
+ */
+public class OriginateVrfInstrumentation implements GenericStatementVisitor<Statement> {
+
+  private final int _fieldBits;
+
+  private final ImmutableList<OriginateVrf> _originateVrfs;
+
+  private final Field _originateVrfField;
+
+  public static final String ORIGINATE_VRF_FIELD_NAME = "ORIGINATE_VRF";
+
+  public OriginateVrfInstrumentation(ImmutableList<OriginateVrf> originateVrfs) {
+    _originateVrfs = originateVrfs;
+    _fieldBits = max(LongMath.log2(_originateVrfs.size(), RoundingMode.CEILING), 1);
+    _originateVrfField = new Field(ORIGINATE_VRF_FIELD_NAME, _fieldBits);
+  }
+
+  public int getFieldBits() {
+    return _fieldBits;
+  }
+
+  public List<OriginateVrf> getOriginateVrfs() {
+    return _originateVrfs;
+  }
+
+  public Statement instrumentStatement(Statement statement) {
+    return statement.accept(this);
+  }
+
+  @Override
+  public Statement visitBasicRuleStatement(BasicRuleStatement basicRuleStatement) {
+    if (basicRuleStatement.getPostconditionState() instanceof OriginateVrf) {
+      int index = _originateVrfs.indexOf(basicRuleStatement.getPostconditionState());
+      return new BasicRuleStatement(
+          new AndExpr(
+              ImmutableList.of(
+                  basicRuleStatement.getPreconditionStateIndependentConstraints(),
+                  new EqExpr(
+                      new VarIntExpr(_originateVrfField), new LitIntExpr(index, _fieldBits)))),
+          basicRuleStatement.getPreconditionStates(),
+          basicRuleStatement.getPostconditionState());
+    } else {
+      return basicRuleStatement;
+    }
+  }
+
+  @Override
+  public Statement visitComment(Comment comment) {
+    return comment;
+  }
+
+  @Override
+  public Statement visitQueryStatement(QueryStatement queryStatement) {
+    return queryStatement;
+  }
+
+  @Override
+  public Statement visitTransformationRuleStatement(
+      TransformationRuleStatement transformationRuleStatement) {
+    return transformationRuleStatement;
+  }
+
+  @Override
+  public Statement visitTransformedBasicRuleStatement(
+      TransformedBasicRuleStatement transformedBasicRuleStatement) {
+    return transformedBasicRuleStatement;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/z3/OriginateVrfInstrumentation.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/OriginateVrfInstrumentation.java
@@ -20,8 +20,8 @@ import org.batfish.z3.expr.VarIntExpr;
 import org.batfish.z3.state.OriginateVrf;
 
 /**
- * A NodInstrumentation that tracks which of several possible OriginateVrf states was used to derive
- * each solution.
+ * A NOD instrumentation that tracks which of several possible OriginateVrf states was used to
+ * derive each solution.
  */
 public class OriginateVrfInstrumentation implements GenericStatementVisitor<Statement> {
 

--- a/projects/batfish/src/main/java/org/batfish/z3/TransformationHeaderField.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/TransformationHeaderField.java
@@ -1,5 +1,9 @@
 package org.batfish.z3;
 
+import com.google.common.collect.ImmutableSet;
+import java.util.Arrays;
+import java.util.Set;
+
 public enum TransformationHeaderField implements HeaderField {
   NEW_SRC_IP(32, BasicHeaderField.ORIG_SRC_IP, BasicHeaderField.SRC_IP);
 
@@ -8,6 +12,11 @@ public enum TransformationHeaderField implements HeaderField {
   private final BasicHeaderField _original;
 
   private final int _size;
+
+  public static final Set<String> transformationHeaderFieldNames =
+      Arrays.stream(TransformationHeaderField.values())
+          .map(TransformationHeaderField::getName)
+          .collect(ImmutableSet.toImmutableSet());
 
   private TransformationHeaderField(int size, BasicHeaderField original, BasicHeaderField current) {
     _size = size;

--- a/projects/batfish/src/main/java/org/batfish/z3/Z3ContextJob.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/Z3ContextJob.java
@@ -1,6 +1,8 @@
 package org.batfish.z3;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Streams;
 import com.microsoft.z3.BitVecExpr;
 import com.microsoft.z3.BoolExpr;
 import com.microsoft.z3.Context;
@@ -9,9 +11,10 @@ import com.microsoft.z3.Fixedpoint;
 import com.microsoft.z3.FuncDecl;
 import com.microsoft.z3.Params;
 import com.microsoft.z3.Status;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.batfish.common.BatfishException;
 import org.batfish.config.Settings;
@@ -24,14 +27,28 @@ import org.batfish.job.BatfishJobResult;
 
 public abstract class Z3ContextJob<R extends BatfishJobResult<?, ?>> extends BatfishJob<R> {
 
+  private static Map<String, HeaderField> HEADER_FIELDS_BY_NAME =
+      Streams.concat(
+              Arrays.stream(BasicHeaderField.values()),
+              Arrays.stream(TransformationHeaderField.values()))
+          .collect(
+              ImmutableMap.toImmutableMap(
+                  // Can't use a method reference here (Enums)
+                  fld -> fld.getName(),
+                  Function.identity()));
+
   protected static Flow createFlow(
-      String node, String vrf, Map<HeaderField, Long> constraints, String tag) {
+      String node, String vrf, Map<String, Long> constraints, String tag) {
     Flow.Builder flowBuilder = new Flow.Builder();
     flowBuilder.setIngressNode(node);
     flowBuilder.setIngressVrf(vrf);
     flowBuilder.setTag(tag);
     constraints.forEach(
-        (headerField, value) -> {
+        (name, value) -> {
+          if (!HEADER_FIELDS_BY_NAME.containsKey(name)) {
+            return;
+          }
+          HeaderField headerField = HEADER_FIELDS_BY_NAME.get(name);
           if (headerField instanceof BasicHeaderField) {
             switch ((BasicHeaderField) headerField) {
               case DST_IP:
@@ -166,15 +183,17 @@ public abstract class Z3ContextJob<R extends BatfishJobResult<?, ?>> extends Bat
     BoolExpr solverInput;
     if (answer.getArgs().length > 0) {
 
+      Map<String, BitVecExpr> variablesAsConsts = program.getNodContext().getVariablesAsConsts();
       List<BitVecExpr> reversedVars =
           Lists.reverse(
               program
                   .getNodContext()
-                  .getVariablesAsConsts()
-                  .entrySet()
+                  .getVariableNames()
                   .stream()
-                  .filter(entry -> BasicHeaderField.basicHeaderFieldNames.contains(entry.getKey()))
-                  .map(Entry::getValue)
+                  .filter(
+                      name ->
+                          !TransformationHeaderField.transformationHeaderFieldNames.contains(name))
+                  .map(variablesAsConsts::get)
                   .collect(Collectors.toList()));
 
       Expr substitutedAnswer = answer.substituteVars(reversedVars.toArray(new Expr[] {}));

--- a/projects/batfish/src/main/java/org/batfish/z3/Z3ContextJob.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/Z3ContextJob.java
@@ -28,14 +28,10 @@ import org.batfish.job.BatfishJobResult;
 public abstract class Z3ContextJob<R extends BatfishJobResult<?, ?>> extends BatfishJob<R> {
 
   private static Map<String, HeaderField> HEADER_FIELDS_BY_NAME =
-      Streams.concat(
+      Streams.<HeaderField>concat(
               Arrays.stream(BasicHeaderField.values()),
               Arrays.stream(TransformationHeaderField.values()))
-          .collect(
-              ImmutableMap.toImmutableMap(
-                  // Can't use a method reference here (Enums)
-                  fld -> fld.getName(),
-                  Function.identity()));
+          .collect(ImmutableMap.toImmutableMap(HeaderField::getName, Function.identity()));
 
   protected static Flow createFlow(
       String node, String vrf, Map<String, Long> constraints, String tag) {

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/VarIntExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/VarIntExpr.java
@@ -1,6 +1,7 @@
 package org.batfish.z3.expr;
 
 import java.util.Objects;
+import org.batfish.z3.Field;
 import org.batfish.z3.HeaderField;
 import org.batfish.z3.expr.visitors.ExprVisitor;
 import org.batfish.z3.expr.visitors.GenericIntExprVisitor;
@@ -8,10 +9,18 @@ import org.batfish.z3.expr.visitors.IntExprVisitor;
 
 public class VarIntExpr extends IntExpr {
 
-  private HeaderField _headerField;
+  private final Field _field;
 
   public VarIntExpr(HeaderField headerField) {
-    _headerField = headerField;
+    _field = new Field(headerField.getName(), headerField.getSize());
+  }
+
+  public VarIntExpr(Field field) {
+    _field = field;
+  }
+
+  public VarIntExpr(String name, Integer size) {
+    _field = new Field(name, size);
   }
 
   @Override
@@ -31,20 +40,20 @@ public class VarIntExpr extends IntExpr {
 
   @Override
   public boolean exprEquals(Expr e) {
-    return Objects.equals(_headerField, ((VarIntExpr) e)._headerField);
+    return Objects.equals(_field, ((VarIntExpr) e)._field);
   }
 
-  public HeaderField getHeaderField() {
-    return _headerField;
+  public Field getField() {
+    return _field;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_headerField);
+    return Objects.hash(_field);
   }
 
   @Override
   public int numBits() {
-    return _headerField.getSize();
+    return _field.getSize();
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/visitors/BitVecExprTransformer.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/visitors/BitVecExprTransformer.java
@@ -43,7 +43,7 @@ public class BitVecExprTransformer implements GenericIntExprVisitor<BitVecExpr> 
 
   @Override
   public BitVecExpr visitVarIntExpr(VarIntExpr varIntExpr) {
-    String headerField = varIntExpr.getHeaderField().getName();
+    String headerField = varIntExpr.getField().getName();
     BitVecExpr ret = _nodContext.getVariables().get(headerField);
     if (ret == null) {
       throw new BatfishException("nodContext missing mapping for variable: '" + headerField + "'");

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/visitors/ExprPrinter.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/visitors/ExprPrinter.java
@@ -309,6 +309,6 @@ public class ExprPrinter implements ExprVisitor, VoidStatementVisitor {
 
   @Override
   public void visitVarIntExpr(VarIntExpr varIntExpr) {
-    _sb.append(varIntExpr.getHeaderField().getName());
+    _sb.append(varIntExpr.getField().getName());
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/visitors/VariableSizeCollector.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/visitors/VariableSizeCollector.java
@@ -10,8 +10,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import org.batfish.z3.BasicHeaderField;
-import org.batfish.z3.HeaderField;
-import org.batfish.z3.SynthesizerInput;
+import org.batfish.z3.Field;
 import org.batfish.z3.TransformationHeaderField;
 import org.batfish.z3.expr.AndExpr;
 import org.batfish.z3.expr.BasicRuleStatement;
@@ -57,8 +56,8 @@ public class VariableSizeCollector implements ExprVisitor, VoidStatementVisitor 
               .map(hf -> Maps.immutableEntry(hf.getName(), hf.getSize()))
               .collect(ImmutableSet.toImmutableSet());
 
-  public static Map<String, Integer> collectVariableSizes(SynthesizerInput input, Statement s) {
-    VariableSizeCollector variableSizeCollector = new VariableSizeCollector(input);
+  public static Map<String, Integer> collectVariableSizes(Statement s) {
+    VariableSizeCollector variableSizeCollector = new VariableSizeCollector();
     s.accept(variableSizeCollector);
     return variableSizeCollector
         ._variableSizes
@@ -67,13 +66,9 @@ public class VariableSizeCollector implements ExprVisitor, VoidStatementVisitor 
         .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue));
   }
 
-  @SuppressWarnings("unused")
-  private final SynthesizerInput _input;
-
   private final ImmutableSet.Builder<Entry<String, Integer>> _variableSizes;
 
-  private VariableSizeCollector(SynthesizerInput input) {
-    _input = input;
+  private VariableSizeCollector() {
     _variableSizes = ImmutableSet.builder();
   }
 
@@ -218,7 +213,7 @@ public class VariableSizeCollector implements ExprVisitor, VoidStatementVisitor 
 
   @Override
   public void visitVarIntExpr(VarIntExpr varIntExpr) {
-    HeaderField headerField = varIntExpr.getHeaderField();
-    _variableSizes.add(Maps.immutableEntry(headerField.getName(), headerField.getSize()));
+    Field field = varIntExpr.getField();
+    _variableSizes.add(Maps.immutableEntry(field.getName(), field.getSize()));
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/z3/state/visitors/FuncDeclTransformer.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/state/visitors/FuncDeclTransformer.java
@@ -1,21 +1,16 @@
 package org.batfish.z3.state.visitors;
 
-import com.google.common.base.Supplier;
-import com.google.common.collect.Streams;
 import com.microsoft.z3.BitVecSort;
 import com.microsoft.z3.Context;
 import com.microsoft.z3.FuncDecl;
-import java.util.Arrays;
-import org.batfish.z3.BasicHeaderField;
-import org.batfish.z3.HeaderField;
-import org.batfish.z3.TransformationHeaderField;
+import java.util.List;
 import org.batfish.z3.expr.BasicStateExpr;
 import org.batfish.z3.expr.StateExpr.State;
 import org.batfish.z3.expr.TransformationStateExpr;
 
 public class FuncDeclTransformer implements GeneralStateVisitor {
 
-  private final Supplier<BitVecSort[]> _basicParameterTypes;
+  private final BitVecSort[] _basicStateVariableSorts;
 
   private final Context _ctx;
 
@@ -23,24 +18,16 @@ public class FuncDeclTransformer implements GeneralStateVisitor {
 
   private String _name;
 
-  private final Supplier<BitVecSort[]> _transformationParameterTypes;
+  private final BitVecSort[] _transformationStateVariableSorts;
 
-  public FuncDeclTransformer(Context ctx) {
+  public FuncDeclTransformer(
+      Context ctx,
+      List<BitVecSort> basicStateVariableSorts,
+      List<BitVecSort> transformationStateVariableSorts) {
     _ctx = ctx;
-    _basicParameterTypes =
-        () ->
-            Arrays.stream(BasicHeaderField.values())
-                .map(HeaderField::getSize)
-                .map(_ctx::mkBitVecSort)
-                .toArray(BitVecSort[]::new);
-    _transformationParameterTypes =
-        () ->
-            Streams.concat(
-                    Arrays.stream(_basicParameterTypes.get()),
-                    Arrays.stream(TransformationHeaderField.values())
-                        .map(HeaderField::getSize)
-                        .map(_ctx::mkBitVecSort))
-                .toArray(BitVecSort[]::new);
+    _basicStateVariableSorts = basicStateVariableSorts.stream().toArray(BitVecSort[]::new);
+    _transformationStateVariableSorts =
+        transformationStateVariableSorts.stream().toArray(BitVecSort[]::new);
   }
 
   public FuncDecl toFuncDecl(String name, State state) {
@@ -51,11 +38,11 @@ public class FuncDeclTransformer implements GeneralStateVisitor {
 
   @Override
   public void visitBasicStateExpr(BasicStateExpr.State basicState) {
-    _funcDecl = _ctx.mkFuncDecl(_name, _basicParameterTypes.get(), _ctx.mkBoolSort());
+    _funcDecl = _ctx.mkFuncDecl(_name, _basicStateVariableSorts, _ctx.mkBoolSort());
   }
 
   @Override
   public void visitTransformationStateExpr(TransformationStateExpr.State transformationState) {
-    _funcDecl = _ctx.mkFuncDecl(_name, _transformationParameterTypes.get(), _ctx.mkBoolSort());
+    _funcDecl = _ctx.mkFuncDecl(_name, _transformationStateVariableSorts, _ctx.mkBoolSort());
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/z3/NodJobChunkingTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/NodJobChunkingTest.java
@@ -1,0 +1,205 @@
+package org.batfish.z3;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.hasSize;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.ImmutableSortedSet;
+import com.microsoft.z3.Context;
+import java.io.IOException;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import org.batfish.bdp.BdpDataPlanePlugin;
+import org.batfish.common.Pair;
+import org.batfish.config.Settings;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.DataPlane;
+import org.batfish.datamodel.ForwardingAction;
+import org.batfish.datamodel.HeaderSpace;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.InterfaceAddress;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpAccessList;
+import org.batfish.datamodel.IpAccessListLine;
+import org.batfish.datamodel.IpWildcard;
+import org.batfish.datamodel.LineAction;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.StaticRoute;
+import org.batfish.datamodel.Vrf;
+import org.batfish.main.Batfish;
+import org.batfish.main.BatfishTestUtils;
+import org.batfish.z3.state.OriginateVrf;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Run a reachability query on a simple network with two possible origination VRFs. Test that we get
+ * one flow for each origination VRF.
+ */
+public class NodJobChunkingTest {
+  private NetworkFactory _nf;
+  private SortedMap<String, Configuration> _configs;
+  private DataPlane _dataPlane;
+  private Configuration _dstNode;
+  private Configuration _srcNode1;
+  private Configuration _srcNode2;
+  private Vrf _srcVrf1;
+  private Vrf _srcVrf2;
+  private Synthesizer _synthesizer;
+  private OriginateVrf _originateVrf1;
+  private OriginateVrf _originateVrf2;
+
+  @Before
+  public void setup() throws IOException {
+    setupConfigs();
+    setupDataPlane();
+    setupSynthesizer();
+  }
+
+  private IpAccessList mkOutgoingFilter(Configuration owner, Ip srcIp) {
+    return _nf.aclBuilder()
+        .setOwner(owner)
+        .setLines(
+            ImmutableList.of(
+                IpAccessListLine.builder()
+                    .setAction(LineAction.ACCEPT)
+                    .setSrcIps(ImmutableList.of(new IpWildcard(srcIp)))
+                    .build()))
+        .build();
+  }
+
+  private void setupConfigs() {
+    _nf = new NetworkFactory();
+    Configuration.Builder cb =
+        _nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+    Interface.Builder ib = _nf.interfaceBuilder().setActive(true).setBandwidth(1E9d);
+    Vrf.Builder vb = _nf.vrfBuilder();
+
+    _srcNode1 = cb.build();
+    _srcNode2 = cb.build();
+    _srcVrf1 = vb.setOwner(_srcNode1).build();
+    _srcVrf2 = vb.setOwner(_srcNode2).build();
+    _originateVrf1 = new OriginateVrf(_srcNode1.getHostname(), _srcVrf1.getName());
+    _originateVrf2 = new OriginateVrf(_srcNode2.getHostname(), _srcVrf2.getName());
+    _dstNode = cb.build();
+    Vrf dstVrf = vb.setOwner(_dstNode).build();
+
+    Prefix p1 = Prefix.parse("1.0.0.0/31");
+    ib.setOwner(_srcNode1)
+        .setVrf(_srcVrf1)
+        .setAddress(new InterfaceAddress(p1.getStartIp(), p1.getPrefixLength()))
+        // require traffic srcNode1 -> dstNode to have srcIp == p1.getStartIp
+        .setOutgoingFilter(mkOutgoingFilter(_srcNode1, p1.getStartIp()))
+        .build();
+    ib.setOwner(_dstNode)
+        .setVrf(dstVrf)
+        .setAddress(new InterfaceAddress(p1.getEndIp(), p1.getPrefixLength()))
+        .setSourceNats(ImmutableList.of())
+        .build();
+
+    Prefix p2 = Prefix.parse("2.0.0.0/31");
+    ib.setOwner(_srcNode2)
+        .setVrf(_srcVrf2)
+        .setAddress(new InterfaceAddress(p2.getStartIp(), p2.getPrefixLength()))
+        // require traffic srcNode2 -> dstNode to have srcIp == p2.getStartIp
+        .setOutgoingFilter(mkOutgoingFilter(_srcNode2, p2.getStartIp()))
+        .build();
+    ib.setOwner(_dstNode)
+        .setVrf(dstVrf)
+        .setAddress(new InterfaceAddress(p2.getEndIp(), p2.getPrefixLength()))
+        .setSourceNats(ImmutableList.of())
+        .build();
+
+    // For the destination
+    Prefix pDest = Prefix.parse("3.0.0.0/32");
+    ib.setOwner(_dstNode)
+        .setVrf(dstVrf)
+        .setAddress(new InterfaceAddress(pDest.getEndIp(), pDest.getPrefixLength()))
+        .build();
+
+    StaticRoute.Builder bld = StaticRoute.builder().setNetwork(pDest);
+    _srcVrf1.getStaticRoutes().add(bld.setNextHopIp(p1.getEndIp()).build());
+    _srcVrf2.getStaticRoutes().add(bld.setNextHopIp(p2.getEndIp()).build());
+
+    _configs =
+        ImmutableSortedMap.of(
+            _srcNode1.getName(), _srcNode1,
+            _srcNode2.getName(), _srcNode2,
+            _dstNode.getName(), _dstNode);
+  }
+
+  private void setupDataPlane() throws IOException {
+    TemporaryFolder tmp = new TemporaryFolder();
+    tmp.create();
+    Batfish batfish = BatfishTestUtils.getBatfish(_configs, tmp);
+    BdpDataPlanePlugin bdpDataPlanePlugin = new BdpDataPlanePlugin();
+    bdpDataPlanePlugin.initialize(batfish);
+    batfish.registerDataPlanePlugin(bdpDataPlanePlugin, "bdp");
+    batfish.computeDataPlane(false);
+    _dataPlane = batfish.loadDataPlane();
+  }
+
+  private void setupSynthesizer() {
+    SynthesizerInput input =
+        SynthesizerInputImpl.builder().setConfigurations(_configs).setDataPlane(_dataPlane).build();
+    _synthesizer = new Synthesizer(input);
+  }
+
+  private NodJob getNodJob() {
+    ReachabilityQuerySynthesizer querySynthesizer =
+        new ReachabilityQuerySynthesizer(
+            ImmutableSet.of(ForwardingAction.ACCEPT),
+            new HeaderSpace(),
+            // finalNodes
+            ImmutableSet.of(_dstNode.getHostname()),
+            // ingressNodeVrfs
+            ImmutableMap.of(
+                _srcNode1.getHostname(), ImmutableSet.of(_srcVrf1.getName()),
+                _srcNode2.getHostname(), ImmutableSet.of(_srcVrf2.getName())),
+            // transitNodes
+            ImmutableSet.of(),
+            // notTransitNodes
+            ImmutableSet.of());
+    SortedSet<Pair<String, String>> ingressNodes =
+        ImmutableSortedSet.of(
+            new Pair<>(_srcNode1.getHostname(), _srcVrf1.getName()),
+            new Pair<>(_srcNode2.getHostname(), _srcVrf2.getName()));
+    return new NodJob(new Settings(), _synthesizer, querySynthesizer, ingressNodes, "tag");
+  }
+
+  @Test
+  public void testChunking() {
+    NodJob nodJob = getNodJob();
+
+    Context z3Context = new Context();
+    SmtInput smtInput = nodJob.computeSmtInput(System.currentTimeMillis(), z3Context);
+
+    Map<OriginateVrf, Map<String, Long>> fieldConstraintsByOriginateVrf =
+        nodJob.getOriginateVrfConstraints(z3Context, smtInput);
+    assertThat(fieldConstraintsByOriginateVrf.entrySet(), hasSize(2));
+    assertThat(fieldConstraintsByOriginateVrf, hasKey(_originateVrf1));
+    assertThat(fieldConstraintsByOriginateVrf, hasKey(_originateVrf2));
+    Map<String, Long> fieldConstraints1 = fieldConstraintsByOriginateVrf.get(_originateVrf1);
+    Map<String, Long> fieldConstraints2 = fieldConstraintsByOriginateVrf.get(_originateVrf2);
+
+    assertThat(
+        fieldConstraints1,
+        hasEntry(OriginateVrfInstrumentation.ORIGINATE_VRF_FIELD_NAME, new Long(0)));
+    assertThat(
+        fieldConstraints1, hasEntry(BasicHeaderField.SRC_IP.getName(), new Ip("1.0.0.0").asLong()));
+    assertThat(
+        fieldConstraints2,
+        hasEntry(OriginateVrfInstrumentation.ORIGINATE_VRF_FIELD_NAME, new Long(1)));
+    assertThat(
+        fieldConstraints2, hasEntry(BasicHeaderField.SRC_IP.getName(), new Ip("2.0.0.0").asLong()));
+  }
+}

--- a/projects/question/src/main/java/org/batfish/question/ReachabilityQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/ReachabilityQuestionPlugin.java
@@ -92,7 +92,8 @@ public class ReachabilityQuestionPlugin extends QuestionPlugin {
           question.getNotFinalNodeRegex(),
           question.getTransitNodes(),
           question.getNotTransitNodes(),
-          question.getUseCompression());
+          question.getUseCompression(),
+          question.getMaxChunkSize());
     }
   }
 
@@ -121,6 +122,8 @@ public class ReachabilityQuestionPlugin extends QuestionPlugin {
     private static final NodesSpecifier DEFAULT_FINAL_NODE_REGEX = NodesSpecifier.ALL;
 
     private static final NodesSpecifier DEFAULT_INGRESS_NODE_REGEX = NodesSpecifier.ALL;
+
+    private static final int DEFAULT_MAX_CHUNK_SIZE = 1;
 
     private static final NodesSpecifier DEFAULT_NOT_FINAL_NODE_REGEX = NodesSpecifier.NONE;
 
@@ -202,7 +205,11 @@ public class ReachabilityQuestionPlugin extends QuestionPlugin {
 
     private static final String PROP_USE_COMPRESSION = "useCompression";
 
+    private static final String PROP_MAX_CHUNK_SIZE = "maxChunkSize";
+
     private SortedSet<ForwardingAction> _actions;
+
+    private int _maxChunkSize;
 
     private NodesSpecifier _finalNodeRegex;
 
@@ -227,11 +234,12 @@ public class ReachabilityQuestionPlugin extends QuestionPlugin {
       _finalNodeRegex = DEFAULT_FINAL_NODE_REGEX;
       _headerSpace = new HeaderSpace();
       _ingressNodeRegex = DEFAULT_INGRESS_NODE_REGEX;
-      _reachabilityType = ReachabilityType.STANDARD;
+      _maxChunkSize = DEFAULT_MAX_CHUNK_SIZE;
       _notFinalNodeRegex = DEFAULT_NOT_FINAL_NODE_REGEX;
-      _notIngressNodeRegex = DEFAULT_NOT_INGRESS_NODE_REGEX;
-      _transitNodes = DEFAULT_TRANSIT_NODES;
       _notTransitNodes = DEFAULT_NOT_TRANSIT_NODES;
+      _notIngressNodeRegex = DEFAULT_NOT_INGRESS_NODE_REGEX;
+      _reachabilityType = ReachabilityType.STANDARD;
+      _transitNodes = DEFAULT_TRANSIT_NODES;
       _useCompression = DEFAULT_USE_COMPRESSION;
     }
 
@@ -293,6 +301,11 @@ public class ReachabilityQuestionPlugin extends QuestionPlugin {
     @JsonProperty(PROP_IP_PROTOCOLS)
     public SortedSet<IpProtocol> getIpProtocols() {
       return _headerSpace.getIpProtocols();
+    }
+
+    @JsonProperty(PROP_MAX_CHUNK_SIZE)
+    public int getMaxChunkSize() {
+      return _maxChunkSize;
     }
 
     @Override
@@ -596,6 +609,11 @@ public class ReachabilityQuestionPlugin extends QuestionPlugin {
     @JsonProperty(PROP_IP_PROTOCOLS)
     public void setIpProtocols(SortedSet<IpProtocol> ipProtocols) {
       _headerSpace.setIpProtocols(ipProtocols);
+    }
+
+    @JsonProperty(PROP_MAX_CHUNK_SIZE)
+    public void setMaxChunkSize(int maxChunkSize) {
+      _maxChunkSize = maxChunkSize;
     }
 
     @JsonProperty(PROP_NEGATE_HEADER)


### PR DESCRIPTION
For queries with the same destination node and header constraints but
with different origination node/vrf, we can combine them into a single
query and use model refinement to find solutions to each original query.

Use a Field class for NoD variables, rather than only the enums in
BasicHeaderField and TransformationHeaderField. Using Field makes it easier to
do instrumention. The enums are still there though, at least for now.
We can consider moving away from them later.

Instrument ReachabilityProgram to solve for OriginateVrf.
The instrumentation adds a field of variable width. The instrumentation
is a post-processing step that runs after Synthesizer. This is for three
reasons: 1st, I wanted to avoid adding complexity to Synthesizer; 2nd,
synthesizer doesn't know what OriginateVrfs to solver for; 3rd, there
are multiple synthesizers involved, and we'd have to modify each of them
to do the instrumentation. This approach is simpler and cleaner, though
I don't like how/where instrumentReachabilityProgram is being called.
The Z3ContextJob class hierarchy should be refactored to make this
cleaner, but I'm not sure how yet. Leaving as-is for now.

AbstractNodJob does the refinement of the model to get one model for
each OriginateVrf. Factored out the call to solver.check and status checking
in AbstractNodJob.

Added maxChunkSize parameter to ReachabilityQuestion