### PR TITLE
FlatJuniper: more rigorous about interface name

### DIFF
--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchers.java
@@ -11,6 +11,7 @@ import org.batfish.datamodel.OspfArea;
 import org.batfish.datamodel.SourceNat;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasDeclaredNames;
+import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasMtu;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasOspfArea;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasOspfCost;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasSourceNats;
@@ -48,6 +49,18 @@ public final class InterfaceMatchers {
   public static HasDeclaredNames hasDeclaredNames(@Nonnull String... expectedDeclaredNames) {
     return new HasDeclaredNames(
         containsInAnyOrder(ImmutableSet.copyOf(expectedDeclaredNames).toArray()));
+  }
+
+  /** Provides a matcher that matches if the provided value matches the interface's MTU. */
+  public static HasMtu hasMtu(int value) {
+    return hasMtu(equalTo(value));
+  }
+
+  /**
+   * Provides a matcher that matches if the provided {@code subMatcher} matches the interface's MTU.
+   */
+  public static HasMtu hasMtu(Matcher<? super Integer> subMatcher) {
+    return new HasMtu(subMatcher);
   }
 
   /**

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchersImpl.java
@@ -23,6 +23,17 @@ final class InterfaceMatchersImpl {
     }
   }
 
+  static final class HasMtu extends FeatureMatcher<Interface, Integer> {
+    HasMtu(@Nonnull Matcher<? super Integer> subMatcher) {
+      super(subMatcher, "an interface with MTU:", "MTU");
+    }
+
+    @Override
+    protected Integer featureValueOf(Interface actual) {
+      return actual.getMtu();
+    }
+  }
+
   static final class HasOspfArea extends FeatureMatcher<Interface, OspfArea> {
     HasOspfArea(@Nonnull Matcher<? super OspfArea> subMatcher) {
       super(subMatcher, "ospfArea", "ospfArea");

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -1703,7 +1703,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   public void enterIs_interface(Is_interfaceContext ctx) {
     Map<String, Interface> interfaces = _configuration.getInterfaces();
     String unitFullName = null;
-    String name = ctx.id.name.getText();
+    String name = getInterfaceName(ctx.id);
     int definitionLine = ctx.id.name.getLine();
     String unit = null;
     if (ctx.id.unit != null) {
@@ -3125,7 +3125,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
 
   @Override
   public void exitPopsf_interface(Popsf_interfaceContext ctx) {
-    String name = ctx.id.name.getText();
+    String name = getInterfaceName(ctx.id);
     int definitionLine = ctx.id.name.getLine();
     String unit = null;
     if (ctx.id.unit != null) {
@@ -3940,7 +3940,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
     } else {
       interfaces = _configuration.getInterfaces();
     }
-    String name = id.name.getText();
+    String name = getInterfaceName(id);
     int definitionLine = id.name.getLine();
     String unit = null;
     if (id.unit != null) {

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -2,6 +2,7 @@ package org.batfish.grammar.flatjuniper;
 
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasDefaultVrf;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasInterface;
+import static org.batfish.datamodel.matchers.InterfaceMatchers.hasMtu;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasOspfCost;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.isOspfPassive;
 import static org.batfish.datamodel.matchers.OspfAreaSummaryMatchers.hasMetric;
@@ -17,6 +18,7 @@ import static org.junit.Assert.assertThat;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
@@ -176,6 +178,15 @@ public class FlatJuniperGrammarTest {
 
     // Interface override
     assertThat(config, hasInterface("fe-1/0/1.0", hasOspfCost(equalTo(17))));
+  }
+
+  @Test
+  public void testInterfaceMtu() throws IOException {
+    Configuration c = parseConfig("interfaceMtu");
+
+    /* Properly configured interfaces should be present in respective areas. */
+    assertThat(c.getInterfaces().keySet(), equalTo(Collections.singleton("xe-0/0/0:0.0")));
+    assertThat(c, hasInterface("xe-0/0/0:0.0", hasMtu(9000)));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interfaceMtu
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interfaceMtu
@@ -1,0 +1,10 @@
+#
+set system host-name interfaceMtu
+#
+set groups MTU_GROUP interfaces "<[xe][et]-*>" mtu 9300
+set groups MTU_GROUP interfaces "<[xe][et]-*>" unit <*> family inet mtu 9000
+#
+set interfaces xe-0/0/0:0 apply-groups MTU_GROUP
+set interfaces xe-0/0/0:0 unit 0 family inet address 10.1.2.3/31
+#
+set protocols ospf area 0.0.0.0 interface xe-0/0/0:0.0

--- a/test_rigs/parsing-tests/unit-tests.ref
+++ b/test_rigs/parsing-tests/unit-tests.ref
@@ -49612,8 +49612,8 @@
         "juniper-ospf" : {
           "Red flags" : {
             "1" : "MISCELLANEOUS: Cannot assign interface xe-0/0/1.0 to be active in area 0.1.2.3 because it has no IP address.",
-            "2" : "MISCELLANEOUS: Cannot assign interface xe-0/0/20.0 to be active in area 0.1.2.3 because it has no IP address.",
-            "3" : "MISCELLANEOUS: Cannot assign interface xe-0/0/21.0 to be passive in area 0.1.2.3 because it has no IP address."
+            "2" : "MISCELLANEOUS: Cannot assign interface xe-0/0/20:0.0 to be active in area 0.1.2.3 because it has no IP address.",
+            "3" : "MISCELLANEOUS: Cannot assign interface xe-0/0/21:0.0 to be passive in area 0.1.2.3 because it has no IP address."
           }
         },
         "juniper-tcpflags" : {

--- a/tests/basic/init-unit-tests.ref
+++ b/tests/basic/init-unit-tests.ref
@@ -1983,8 +1983,8 @@
         "juniper-ospf" : {
           "Red flags" : {
             "1" : "MISCELLANEOUS: Cannot assign interface xe-0/0/1.0 to be active in area 0.1.2.3 because it has no IP address.",
-            "2" : "MISCELLANEOUS: Cannot assign interface xe-0/0/20.0 to be active in area 0.1.2.3 because it has no IP address.",
-            "3" : "MISCELLANEOUS: Cannot assign interface xe-0/0/21.0 to be passive in area 0.1.2.3 because it has no IP address."
+            "2" : "MISCELLANEOUS: Cannot assign interface xe-0/0/20:0.0 to be active in area 0.1.2.3 because it has no IP address.",
+            "3" : "MISCELLANEOUS: Cannot assign interface xe-0/0/21:0.0 to be passive in area 0.1.2.3 because it has no IP address."
           }
         },
         "juniper-tcpflags" : {

--- a/tests/basic/nodes-unit-tests.ref
+++ b/tests/basic/nodes-unit-tests.ref
@@ -11364,14 +11364,14 @@
               "type" : "PHYSICAL",
               "vrf" : "default"
             },
-            "xe-0/0/20.0" : {
-              "name" : "xe-0/0/20.0",
+            "xe-0/0/20:0.0" : {
+              "name" : "xe-0/0/20:0.0",
               "accessVlan" : 0,
               "active" : true,
               "autostate" : true,
               "bandwidth" : 1.0E10,
               "declaredNames" : [
-                "xe-0/0/20.0"
+                "xe-0/0/20:0.0"
               ],
               "isisL1InterfaceMode" : "unset",
               "isisL2InterfaceMode" : "unset",
@@ -11390,14 +11390,14 @@
               "type" : "PHYSICAL",
               "vrf" : "default"
             },
-            "xe-0/0/21.0" : {
-              "name" : "xe-0/0/21.0",
+            "xe-0/0/21:0.0" : {
+              "name" : "xe-0/0/21:0.0",
               "accessVlan" : 0,
               "active" : true,
               "autostate" : true,
               "bandwidth" : 1.0E10,
               "declaredNames" : [
-                "xe-0/0/21.0"
+                "xe-0/0/21:0.0"
               ],
               "isisL1InterfaceMode" : "unset",
               "isisL2InterfaceMode" : "unset",
@@ -11454,8 +11454,8 @@
               "name" : "default",
               "interfaces" : [
                 "xe-0/0/1.0",
-                "xe-0/0/20.0",
-                "xe-0/0/21.0"
+                "xe-0/0/20:0.0",
+                "xe-0/0/21:0.0"
               ],
               "ospfProcess" : {
                 "areas" : {


### PR DESCRIPTION
We have a helper to get the interface name out, but we were not using it in all places.
Now all references to Interface_idContext.name go through the helper, and we no longer
drop suffix in various places.