### PR TITLE
fix ipOwners bug

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/z3/SynthesizerInputImpl.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/SynthesizerInputImpl.java
@@ -570,12 +570,16 @@ public final class SynthesizerInputImpl implements SynthesizerInput {
                     }));
     Map<Ip, Set<String>> ipOwners = CommonUtil.computeIpOwners(true, enabledInterfaces);
     Map<String, Set<Ip>> map = new HashMap<>();
+    // ipOwners may not contain all nodes (i.e. a node may not own any IPs),
+    // so frst initialize to make sure there is an entry for each node.
+    _enabledInterfaces.keySet().forEach(node -> map.put(node,new HashSet<>()));
     ipOwners.forEach(
         (ip, owners) -> {
           for (String owner : owners) {
-            map.computeIfAbsent(owner, o -> new HashSet<>()).add(ip);
+            map.get(owner).add(ip);
           }
         });
+    ipOwners.forEach((ip, owners) -> owners.forEach(owner -> map.get(owner).add(ip)));
     return map.entrySet()
         .stream()
         .collect(

--- a/projects/batfish/src/main/java/org/batfish/z3/SynthesizerInputImpl.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/SynthesizerInputImpl.java
@@ -581,7 +581,6 @@ public final class SynthesizerInputImpl implements SynthesizerInput {
             map.get(owner).add(ip);
           }
         });
-    ipOwners.forEach((ip, owners) -> owners.forEach(owner -> map.get(owner).add(ip)));
     return map.entrySet()
         .stream()
         .collect(

--- a/projects/batfish/src/main/java/org/batfish/z3/SynthesizerInputImpl.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/SynthesizerInputImpl.java
@@ -572,7 +572,7 @@ public final class SynthesizerInputImpl implements SynthesizerInput {
     Map<String, Set<Ip>> map = new HashMap<>();
     // ipOwners may not contain all nodes (i.e. a node may not own any IPs),
     // so frst initialize to make sure there is an entry for each node.
-    _enabledInterfaces.keySet().forEach(node -> map.put(node,new HashSet<>()));
+    _enabledInterfaces.keySet().forEach(node -> map.put(node, new HashSet<>()));
     ipOwners.forEach(
         (ip, owners) -> {
           for (String owner : owners) {

--- a/projects/batfish/src/main/java/org/batfish/z3/SynthesizerInputImpl.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/SynthesizerInputImpl.java
@@ -570,8 +570,10 @@ public final class SynthesizerInputImpl implements SynthesizerInput {
                     }));
     Map<Ip, Set<String>> ipOwners = CommonUtil.computeIpOwners(true, enabledInterfaces);
     Map<String, Set<Ip>> map = new HashMap<>();
-    // ipOwners may not contain all nodes (i.e. a node may not own any IPs),
-    // so frst initialize to make sure there is an entry for each node.
+    /*
+     * ipOwners may not contain all nodes (i.e. a node may not own any IPs),
+     * so first initialize to make sure there is an entry for each node.
+     */
     _enabledInterfaces.keySet().forEach(node -> map.put(node, new HashSet<>()));
     ipOwners.forEach(
         (ip, owners) -> {

--- a/projects/batfish/src/test/java/org/batfish/z3/SynthesizerInputImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/SynthesizerInputImplTest.java
@@ -543,6 +543,27 @@ public class SynthesizerInputImplTest {
             equalTo(ImmutableMap.of(c.getName(), ImmutableSet.of(ipEnabled1, ipEnabled2)))));
   }
 
+  /**
+   * Hosts that own no IPs should be assigned an empty set by computeIpsByHostname
+   */
+  @Test
+  public void testComputeIpsByHostname_noIps() {
+    Configuration c = _cb.build();
+    Vrf v = _vb.setOwner(c).build();
+    _ib.setOwner(c)
+        .setVrf(v)
+        .build();
+
+    SynthesizerInput inputWithDataPlane =
+        _inputBuilder
+            .setConfigurations(ImmutableMap.of(c.getName(), c))
+            .setDataPlane(TestDataPlane.builder().build()).build();
+    assertThat(
+        inputWithDataPlane,
+        hasIpsByHostname(
+            equalTo(ImmutableMap.of(c.getName(), ImmutableSet.of()))));
+  }
+
   @Test
   public void testComputeSourceNats() {
     Configuration srcNode = _cb.build();

--- a/projects/batfish/src/test/java/org/batfish/z3/SynthesizerInputImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/SynthesizerInputImplTest.java
@@ -543,25 +543,21 @@ public class SynthesizerInputImplTest {
             equalTo(ImmutableMap.of(c.getName(), ImmutableSet.of(ipEnabled1, ipEnabled2)))));
   }
 
-  /**
-   * Hosts that own no IPs should be assigned an empty set by computeIpsByHostname
-   */
+  /** Hosts that own no IPs should be assigned an empty set by computeIpsByHostname */
   @Test
   public void testComputeIpsByHostname_noIps() {
     Configuration c = _cb.build();
     Vrf v = _vb.setOwner(c).build();
-    _ib.setOwner(c)
-        .setVrf(v)
-        .build();
+    _ib.setOwner(c).setVrf(v).build();
 
     SynthesizerInput inputWithDataPlane =
         _inputBuilder
             .setConfigurations(ImmutableMap.of(c.getName(), c))
-            .setDataPlane(TestDataPlane.builder().build()).build();
+            .setDataPlane(TestDataPlane.builder().build())
+            .build();
     assertThat(
         inputWithDataPlane,
-        hasIpsByHostname(
-            equalTo(ImmutableMap.of(c.getName(), ImmutableSet.of()))));
+        hasIpsByHostname(equalTo(ImmutableMap.of(c.getName(), ImmutableSet.of()))));
   }
 
   @Test


### PR DESCRIPTION
Fixes a NPE bug that occurs when a network device does not own any IPs. The solution is to initialize the ipOwners map so that each device has an entry.