### PR TITLE
Allow listing containers with default api key

### DIFF
--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
@@ -41,7 +41,6 @@ import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.coordinator.AnalysisMetadataMgr.AnalysisType;
 import org.batfish.coordinator.WorkDetails.WorkType;
 import org.batfish.coordinator.WorkQueueMgr.QueueType;
-import org.batfish.coordinator.config.Settings;
 import org.batfish.datamodel.TestrigMetadata;
 import org.batfish.datamodel.pojo.WorkStatus;
 import org.batfish.datamodel.questions.Question;
@@ -54,7 +53,6 @@ import org.glassfish.jersey.media.multipart.FormDataParam;
 public class WorkMgrService {
 
   BatfishLogger _logger = Main.getLogger();
-  Settings _settings = Main.getSettings();
 
   private static JSONArray successResponse(Object entity) {
     return new JSONArray(Arrays.asList(CoordConsts.SVC_KEY_SUCCESS, entity));
@@ -1125,10 +1123,6 @@ public class WorkMgrService {
 
       checkApiKeyValidity(apiKey);
       checkClientVersion(clientVersion);
-
-      if (!_settings.getDefaultKeyListings() && apiKey.equals(CoordConsts.DEFAULT_API_KEY)) {
-        throw new AccessControlException("Listing containers is not allowed with Default API key");
-      }
 
       SortedSet<String> containerList = Main.getWorkMgr().listContainers(apiKey);
 

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/config/Settings.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/config/Settings.java
@@ -76,7 +76,6 @@ public class Settings extends BaseSettings {
   private Path _containersLocation;
   private String _dbAuthorizerConnString;
   private long _dbCacheExpiryMs;
-  private boolean _defaultKeyListings;
   private String _driverClass;
   private Path _fileAuthorizerPermsFile;
   private Path _fileAuthorizerRootDir;
@@ -141,10 +140,6 @@ public class Settings extends BaseSettings {
 
   public String getDbAuthorizerConnString() {
     return _dbAuthorizerConnString;
-  }
-
-  public boolean getDefaultKeyListings() {
-    return _defaultKeyListings;
   }
 
   public String getDriverClass() {
@@ -351,9 +346,6 @@ public class Settings extends BaseSettings {
   private void initOptions() {
     addOption(ARG_AUTHORIZER_TYPE, "type of authorizer to use", "authorizer type");
 
-    addBooleanOption(
-        ARG_ALLOW_DEFAULT_KEY_LISTINGS, "allow default API key to list containers and testrigs");
-
     addOption(ARG_CONTAINERS_LOCATION, "where to store containers", "containers_location");
 
     addOption(
@@ -443,7 +435,6 @@ public class Settings extends BaseSettings {
     _authorizerType = Authorizer.Type.valueOf(getStringOptionValue(ARG_AUTHORIZER_TYPE));
     _dbAuthorizerConnString = getStringOptionValue(ARG_DB_AUTHORIZER_CONN_STRING);
     _dbCacheExpiryMs = getLongOptionValue(ARG_DB_AUTHORIZER_CACHE_EXPIRY_MS);
-    _defaultKeyListings = getBooleanOptionValue(ARG_ALLOW_DEFAULT_KEY_LISTINGS);
     _driverClass = getStringOptionValue(ARG_DRIVER_CLASS);
     _fileAuthorizerRootDir = Paths.get(getStringOptionValue(ARG_FILE_AUTHORIZER_ROOT_DIR));
     _fileAuthorizerPermsFile = Paths.get(getStringOptionValue(ARG_FILE_AUTHORIZER_PERMS_FILE));


### PR DESCRIPTION
It's not like this provides all that much more security, especially if authorizers are not setup; just annoyances when developing.

**Note**: Removing associated coordinator arg/setting as well, since I doubt anyone uses it.