### PR TITLE
Cache compressed configs

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
@@ -163,6 +163,7 @@ public class BfConsts {
   public static final String RELPATH_TESTRIG_TOPOLOGY_PATH = "testrig_topology";
   public static final String RELPATH_TESTRIGS_DIR = "testrigs";
   public static final String RELPATH_VALIDATE_ENVIRONMENT_ANSWER = "venv_answer";
+  public static final String RELPATH_COMPRESSED_CONFIG_DIR = "compressed_configs";
   public static final String RELPATH_VENDOR_INDEPENDENT_CONFIG_DIR = "indep";
   public static final String RELPATH_VENDOR_SPECIFIC_CONFIG_DIR = "vendor";
 

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -2244,7 +2244,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
     _logger.debugf("Loading configurations for %s, cache miss", snapshot);
 
     // Next, see if we have an up-to-date, environment-specific configurations on disk.
-    configurations = _storage.loadConfigurations(snapshot.getTestrig(), true);
+    configurations = _storage.loadCompressedConfigurations(snapshot.getTestrig());
     if (configurations != null) {
       return configurations;
     } else {
@@ -2270,7 +2270,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
     _logger.debugf("Loading configurations for %s, cache miss", snapshot);
 
     // Next, see if we have an up-to-date, environment-specific configurations on disk.
-    configurations = _storage.loadConfigurations(snapshot.getTestrig(), false);
+    configurations = _storage.loadConfigurations(snapshot.getTestrig());
     if (configurations != null) {
       _logger.debugf("Loaded configurations for %s off disk", snapshot);
       applyEnvironment(configurations);
@@ -2288,7 +2288,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
     _logger.infof("Repairing configurations for testrig %s", _testrigSettings.getName());
     repairConfigurations();
     SortedMap<String, Configuration> configurations =
-        _storage.loadConfigurations(_testrigSettings.getName(), false);
+        _storage.loadConfigurations(_testrigSettings.getName());
     Verify.verify(
         configurations != null,
         "Configurations should not be null when loaded immediately after repair.");
@@ -4125,7 +4125,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
     // general compression
     Snapshot snapshot = getSnapshot();
     Map<String, Configuration> configurations =
-        useCompression ? loadCompressedConfigurations(snapshot) : loadConfigurations();
+        useCompression ? loadCompressedConfigurations(snapshot) : loadConfigurations(snapshot);
     DataPlane dataPlane = loadDataPlane(useCompression);
 
     if (configurations == null) {

--- a/projects/batfish/src/main/java/org/batfish/main/BatfishStorage.java
+++ b/projects/batfish/src/main/java/org/batfish/main/BatfishStorage.java
@@ -66,7 +66,7 @@ final class BatfishStorage {
     return loadConfigurations(testrig, indepDir);
   }
 
-  public SortedMap<String, Configuration> loadConfigurations(String testrig, Path indepDir) {
+  private SortedMap<String, Configuration> loadConfigurations(String testrig, Path indepDir) {
     // If the directory that would contain these configs does not even exist, no cache exists.
     if (!Files.exists(indepDir)) {
       _logger.debugf("Unable to load configs for %s from disk: no cache directory", testrig);

--- a/projects/batfish/src/main/java/org/batfish/main/Driver.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Driver.java
@@ -131,6 +131,9 @@ public class Driver {
   private static final Cache<Snapshot, SortedMap<String, Configuration>> CACHED_TESTRIGS =
       buildTestrigCache();
 
+  private static final Cache<Snapshot, SortedMap<String, Configuration>>
+      CACHED_COMPRESSED_TESTRIGS = buildTestrigCache();
+
   private static final int COORDINATOR_CHECK_INTERVAL_MS = 1 * 60 * 1000; // 1 min
 
   private static final int COORDINATOR_POLL_TIMEOUT_MS = 30 * 1000; // 30 secs
@@ -548,6 +551,7 @@ public class Driver {
       final Batfish batfish =
           new Batfish(
               settings,
+              CACHED_COMPRESSED_TESTRIGS,
               CACHED_TESTRIGS,
               CACHED_COMPRESSED_DATA_PLANES,
               CACHED_DATA_PLANES,

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishStorageTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishStorageTest.java
@@ -45,14 +45,14 @@ public class BatfishStorageTest {
     configs.put("node1", new Configuration("node1", ConfigurationFormat.CISCO_IOS));
 
     _storage.storeConfigurations(configs, new ConvertConfigurationAnswerElement(), "sometr");
-    Map<String, Configuration> deserialized = _storage.loadConfigurations("sometr");
+    Map<String, Configuration> deserialized = _storage.loadConfigurations("sometr", false);
     assertThat(deserialized, not(nullValue()));
     assertThat(deserialized.keySet(), equalTo(Sets.newHashSet("node1")));
   }
 
   @Test
   public void loadMissingConfigurationsReturnsNull() {
-    assertThat(_storage.loadConfigurations("nonexistent"), nullValue());
+    assertThat(_storage.loadConfigurations("nonexistent", false), nullValue());
   }
 
   @Test
@@ -69,6 +69,6 @@ public class BatfishStorageTest {
     configs.put("node1", new Configuration("node1", ConfigurationFormat.CISCO_IOS));
     _storage.storeConfigurations(configs, oldConvertAnswer, trname);
 
-    assertThat(_storage.loadConfigurations(trname), nullValue());
+    assertThat(_storage.loadConfigurations(trname, false), nullValue());
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishStorageTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishStorageTest.java
@@ -45,14 +45,14 @@ public class BatfishStorageTest {
     configs.put("node1", new Configuration("node1", ConfigurationFormat.CISCO_IOS));
 
     _storage.storeConfigurations(configs, new ConvertConfigurationAnswerElement(), "sometr");
-    Map<String, Configuration> deserialized = _storage.loadConfigurations("sometr", false);
+    Map<String, Configuration> deserialized = _storage.loadConfigurations("sometr");
     assertThat(deserialized, not(nullValue()));
     assertThat(deserialized.keySet(), equalTo(Sets.newHashSet("node1")));
   }
 
   @Test
   public void loadMissingConfigurationsReturnsNull() {
-    assertThat(_storage.loadConfigurations("nonexistent", false), nullValue());
+    assertThat(_storage.loadConfigurations("nonexistent"), nullValue());
   }
 
   @Test
@@ -69,6 +69,6 @@ public class BatfishStorageTest {
     configs.put("node1", new Configuration("node1", ConfigurationFormat.CISCO_IOS));
     _storage.storeConfigurations(configs, oldConvertAnswer, trname);
 
-    assertThat(_storage.loadConfigurations(trname, false), nullValue());
+    assertThat(_storage.loadConfigurations(trname), nullValue());
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
@@ -53,6 +53,7 @@ public class BatfishTestUtils {
     Settings settings = new Settings(new String[] {});
     settings.setLogger(new BatfishLogger("debug", false));
     final Cache<Snapshot, SortedMap<String, Configuration>> testrigs = makeTestrigCache();
+    final Cache<Snapshot, SortedMap<String, Configuration>> compressedTestrigs = makeTestrigCache();
 
     Path containerDir = tempFolder.newFolder().toPath();
     settings.setContainerDir(containerDir);
@@ -67,6 +68,7 @@ public class BatfishTestUtils {
     Batfish batfish =
         new Batfish(
             settings,
+            compressedTestrigs,
             testrigs,
             makeDataPlaneCache(),
             makeDataPlaneCache(),
@@ -126,6 +128,7 @@ public class BatfishTestUtils {
     Batfish batfish =
         new Batfish(
             settings,
+            makeTestrigCache(),
             makeTestrigCache(),
             makeDataPlaneCache(),
             makeDataPlaneCache(),


### PR DESCRIPTION
Until we can debug/optimize compression on large networks, start
caching the compressed configs in addition to the compressed dataplane,
and switch reachability to use general compression, rather than
compressing per-query (which yields better NoD performance).