### PR TITLE
Add flag to control bgp session reachability check

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/BaseSettings.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/BaseSettings.java
@@ -17,6 +17,7 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.configuration2.ConfigurationUtils;
+import org.apache.commons.configuration2.ImmutableConfiguration;
 import org.apache.commons.configuration2.builder.fluent.Configurations;
 import org.apache.commons.configuration2.ex.ConfigurationException;
 
@@ -210,5 +211,9 @@ public abstract class BaseSettings {
     if (_config.getProperty(key) == null) {
       _config.setProperty(key, value);
     }
+  }
+
+  public ImmutableConfiguration getImmutableConfiguration() {
+    return ConfigurationUtils.unmodifiableConfiguration(_config);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
@@ -81,6 +81,11 @@ public interface IBatfish extends IPluginConsumer {
 
   SortedMap<String, SortedMap<String, SortedSet<AbstractRoute>>> getRoutes(boolean useCompression);
 
+  /**
+   * Get batfish settings
+   *
+   * @return the {@link ImmutableConfiguration} that represents batfish settings.
+   */
   ImmutableConfiguration getSettingsConfiguration();
 
   String getTaskId();

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
@@ -8,6 +8,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
+import org.apache.commons.configuration2.ImmutableConfiguration;
 import org.batfish.common.Answerer;
 import org.batfish.common.Directory;
 import org.batfish.datamodel.AbstractRoute;
@@ -79,6 +80,8 @@ public interface IBatfish extends IPluginConsumer {
   Map<String, String> getQuestionTemplates();
 
   SortedMap<String, SortedMap<String, SortedSet<AbstractRoute>>> getRoutes(boolean useCompression);
+
+  ImmutableConfiguration getSettingsConfiguration();
 
   String getTaskId();
 

--- a/projects/batfish/src/main/java/org/batfish/config/Settings.java
+++ b/projects/batfish/src/main/java/org/batfish/config/Settings.java
@@ -407,6 +407,8 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
     }
   }
 
+  public static final String ARG_CHECK_BGP_REACHABILITY = "checkbgpsessionreachability";
+
   public static final String ARG_COORDINATOR_HOST = "coordinatorhost";
 
   private static final String ARG_COORDINATOR_POOL_PORT = "coordinatorpoolport";
@@ -1029,6 +1031,7 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
     setDefaultProperty(ARG_MAX_PARSER_CONTEXT_TOKENS, 10);
     setDefaultProperty(ARG_MAX_PARSE_TREE_PRINT_LENGTH, 0);
     setDefaultProperty(ARG_MAX_RUNTIME_MS, 0);
+    setDefaultProperty(ARG_CHECK_BGP_REACHABILITY, true);
     setDefaultProperty(ARG_NO_SHUFFLE, false);
     setDefaultProperty(BfConsts.ARG_OUTPUT_ENV, null);
     setDefaultProperty(BfConsts.ARG_PEDANTIC_AS_ERROR, false);
@@ -1116,6 +1119,10 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
         BfConsts.ARG_BDP_RECORD_ALL_ITERATIONS,
         "Set to true to record all iterations, including during oscillation. Ignores max recorded "
             + "iterations value.");
+
+    addBooleanOption(
+        ARG_CHECK_BGP_REACHABILITY,
+        "whether to check BGP session reachability during data plane computation");
 
     addOption(BfConsts.ARG_CONTAINER_DIR, "path to container directory", ARGNAME_PATH);
 
@@ -1389,6 +1396,7 @@ public final class Settings extends BaseSettings implements BdpSettings, Grammar
     getIntOptionValue(BfConsts.ARG_BDP_MAX_RECORDED_ITERATIONS);
     getBooleanOptionValue(BfConsts.ARG_BDP_PRINT_ALL_ITERATIONS);
     getBooleanOptionValue(BfConsts.ARG_BDP_PRINT_OSCILLATING_ITERATIONS);
+    getBooleanOptionValue(ARG_CHECK_BGP_REACHABILITY);
     getBooleanOptionValue(BfConsts.COMMAND_COMPILE_DIFF_ENVIRONMENT);
     getPathOptionValue(BfConsts.ARG_CONTAINER_DIR);
     getStringOptionValue(ARG_COORDINATOR_HOST);

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -52,6 +52,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
+import org.apache.commons.configuration2.ImmutableConfiguration;
 import org.apache.commons.lang3.SerializationUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.batfish.common.Answerer;
@@ -1830,6 +1831,11 @@ public class Batfish extends PluginConsumer implements IBatfish {
 
   public Settings getSettings() {
     return _settings;
+  }
+
+  @Override
+  public ImmutableConfiguration getSettingsConfiguration() {
+    return _settings.getImmutableConfiguration();
   }
 
   private Set<Edge> getSymmetricEdgePairs(SortedSet<Edge> edges) {

--- a/projects/pom.xml
+++ b/projects/pom.xml
@@ -49,7 +49,7 @@
     <build-helper-maven-plugin.version>3.0.0</build-helper-maven-plugin.version>
     <commons-cli.version>1.3.1</commons-cli.version>
     <commons-collections4.version>4.1</commons-collections4.version>
-    <commons-configuration2.version>2.0</commons-configuration2.version>
+    <commons-configuration2.version>2.2</commons-configuration2.version>
     <commons-exec.version>1.3</commons-exec.version>
     <commons-io.version>2.4</commons-io.version>
     <commons-lang3.version>3.6</commons-lang3.version>


### PR DESCRIPTION
Followup on #1038:
Add an argument to control the behavior (i.e., whether the reachability check is performed)

Side effect of this PR: Update commons-configuration to version 2.2, as it has better handling of `ImmutableConfiguration`s