### PR TITLE
Switch default compression to lz4 when (de-)serializing objects

### DIFF
--- a/projects/batfish-common-protocol/pom.xml
+++ b/projects/batfish-common-protocol/pom.xml
@@ -217,6 +217,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.lz4</groupId>
+      <artifactId>lz4-java</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.antlr</groupId>
       <artifactId>antlr4-runtime</artifactId>
     </dependency>

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/PluginConsumer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/PluginConsumer.java
@@ -72,12 +72,13 @@ public abstract class PluginConsumer implements IPluginConsumer {
   /**
    * Deserialize object from given bytes into and instance of {@link S}
    *
-   * @deprecated in favor of {@link #deserializeObject(Path, Class)}
+   * @deprecated in favor of {@link #deserializeObject(Path, Class)} or {@link
+   *     #deserializeObject(InputStream, Class, Format)}
    */
   @Deprecated
   protected <S extends Serializable> S deserializeObject(byte[] data, Class<S> outputClass) {
     try (ByteArrayInputStream stream = new ByteArrayInputStream(data)) {
-      return deserializeObject(stream, outputClass, Format.UNKNOWN);
+      return deserializeObject(stream, outputClass, detectFormat(new PushbackInputStream(stream)));
     } catch (IOException e) {
       throw new BatfishException(
           "Failed to deserialize object of type '" + outputClass.getCanonicalName() + "' from data",

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/PluginConsumer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/PluginConsumer.java
@@ -35,7 +35,7 @@ import org.batfish.common.util.BatfishObjectInputStream;
 public abstract class PluginConsumer implements IPluginConsumer {
 
   /** Supported formats we can deserialize from */
-  private enum Format {
+  public enum Format {
     JAVA_SERIALIZED,
     LZ4,
     GZIP,
@@ -151,7 +151,7 @@ public abstract class PluginConsumer implements IPluginConsumer {
    *
    * @return a {@link Format} value.
    */
-  private static Format detectFormat(PushbackInputStream stream) throws IOException {
+  public static Format detectFormat(PushbackInputStream stream) throws IOException {
     byte[] header = new byte[DEFAULT_HEADER_LENGTH_BYTES];
     ByteStreams.readFully(stream, header);
     Format format;
@@ -199,7 +199,7 @@ public abstract class PluginConsumer implements IPluginConsumer {
     }
   }
 
-  /** Serializes the given object to a file with the given output name, using LZ4 compression. */
+  /** Serializes the given object to a file with the given output name. */
   public void serializeObject(Serializable object, Path outputFile) {
     try {
       try (Closer closer = Closer.create()) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/PluginConsumer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/PluginConsumer.java
@@ -26,13 +26,26 @@ import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 import java.util.SortedSet;
 import java.util.TreeSet;
-import net.jpountz.lz4.LZ4BlockInputStream;
-import net.jpountz.lz4.LZ4BlockOutputStream;
-import org.apache.commons.io.IOUtils;
+import java.util.zip.GZIPInputStream;
+import net.jpountz.lz4.LZ4FrameInputStream;
+import net.jpountz.lz4.LZ4FrameOutputStream;
 import org.batfish.common.BatfishException;
 import org.batfish.common.util.BatfishObjectInputStream;
 
 public abstract class PluginConsumer implements IPluginConsumer {
+
+  /** Supported formats we can deserialize from */
+  private enum Format {
+    JAVA_SERIALIZED,
+    LZ4,
+    GZIP,
+    UNKNOWN
+  }
+
+  private static final int DEFAULT_HEADER_LENGTH_BYTES = 4;
+
+  private static final int GZIP_HEADER_LENGTH_BYTES = 2;
+
   /**
    * A byte-array containing the first 4 bytes of the header for a file that is the output of java
    * serialization
@@ -40,6 +53,12 @@ public abstract class PluginConsumer implements IPluginConsumer {
   private static final byte[] JAVA_SERIALIZED_OBJECT_HEADER = {
     (byte) 0xac, (byte) 0xed, (byte) 0x00, (byte) 0x05
   };
+
+  private static final byte[] LZ4_MAGIC_BYTES = {
+    (byte) 0x04, (byte) 0x22, (byte) 0x4D, (byte) 0x18
+  };
+
+  private static final byte[] GZIP_MAGIC_BYTES = {(byte) 0x1f, (byte) 0x8b};
 
   private ClassLoader _currentClassLoader;
 
@@ -50,43 +69,71 @@ public abstract class PluginConsumer implements IPluginConsumer {
     _serializeToText = serializeToText;
   }
 
+  /**
+   * Deserialize object from given bytes into and instance of {@link S}
+   *
+   * @deprecated in favor of {@link #deserializeObject(Path, Class)}
+   */
+  @Deprecated
   protected <S extends Serializable> S deserializeObject(byte[] data, Class<S> outputClass) {
-    ByteArrayInputStream stream = new ByteArrayInputStream(data);
-    return deserializeObject(stream, outputClass);
-  }
-
-  protected <S extends Serializable> S deserializeObject(InputStream stream, Class<S> outputClass) {
-    try {
-      // Allows us to peek at the beginning of the stream and then push the bytes back in for
-      // downstream consumers to read.
-      PushbackInputStream pbstream =
-          new PushbackInputStream(stream, JAVA_SERIALIZED_OBJECT_HEADER.length);
-      boolean isJavaSerializationData = isJavaSerializationData(pbstream);
-      ObjectInputStream ois;
-      if (!isJavaSerializationData) {
-        XStream xstream = new XStream(new DomDriver("UTF-8"));
-        xstream.setClassLoader(_currentClassLoader);
-        ois = xstream.createObjectInputStream(pbstream);
-      } else {
-        ois = new BatfishObjectInputStream(pbstream, _currentClassLoader);
-      }
-      Object o = ois.readObject();
-      return outputClass.cast(o);
-    } catch (IOException | ClassNotFoundException | ClassCastException e) {
+    try (ByteArrayInputStream stream = new ByteArrayInputStream(data)) {
+      return deserializeObject(stream, outputClass, Format.UNKNOWN);
+    } catch (IOException e) {
       throw new BatfishException(
           "Failed to deserialize object of type '" + outputClass.getCanonicalName() + "' from data",
           e);
     }
   }
 
+  private <S extends Serializable> S deserializeObject(
+      InputStream stream, Class<S> outputClass, Format format) throws IOException {
+    try {
+      ObjectInputStream ois;
+      if (format != Format.JAVA_SERIALIZED) {
+        XStream xstream = new XStream(new DomDriver("UTF-8"));
+        xstream.setClassLoader(_currentClassLoader);
+        ois = xstream.createObjectInputStream(stream);
+      } else {
+        ois = new BatfishObjectInputStream(stream, _currentClassLoader);
+      }
+      Object o = ois.readObject();
+      return outputClass.cast(o);
+    } catch (ClassNotFoundException | ClassCastException e) {
+      throw new BatfishException(
+          "Failed to deserialize object of type '" + outputClass.getCanonicalName() + "' from data",
+          e);
+    }
+  }
+
+  /** Deserialize object from file, with support for different compression methods. */
   protected <S extends Serializable> S deserializeObject(Path inputFile, Class<S> outputClass) {
     try {
       // Awkward nested try blocks required because we refuse to throw IOExceptions.
       try (Closer closer = Closer.create()) {
         FileInputStream fis = closer.register(new FileInputStream(inputFile.toFile()));
         BufferedInputStream bis = closer.register(new BufferedInputStream(fis));
-        InputStream lis = closer.register(new LZ4BlockInputStream(bis));
-        return deserializeObject(lis, outputClass);
+        // Allows us to peek at the beginning of the stream and then push the bytes back in for
+        // downstream consumers to read.
+        PushbackInputStream pbCompressed =
+            new PushbackInputStream(bis, DEFAULT_HEADER_LENGTH_BYTES);
+        Format f = detectFormat(pbCompressed);
+        if (f == Format.GZIP) {
+          InputStream gis = closer.register(new GZIPInputStream(pbCompressed));
+          // Update format after decompression
+          PushbackInputStream pbUncompressed =
+              new PushbackInputStream(gis, DEFAULT_HEADER_LENGTH_BYTES);
+          f = detectFormat(pbUncompressed);
+          return deserializeObject(pbUncompressed, outputClass, f);
+        } else if (f == Format.LZ4) {
+          InputStream lis = closer.register(new LZ4FrameInputStream(pbCompressed));
+          // Update format after decompression
+          PushbackInputStream pbUncompressed =
+              new PushbackInputStream(lis, DEFAULT_HEADER_LENGTH_BYTES);
+          f = detectFormat(pbUncompressed);
+          return deserializeObject(pbUncompressed, outputClass, f);
+        } else {
+          return deserializeObject(pbCompressed, outputClass, f);
+        }
       }
     } catch (IOException e) {
       throw new BatfishException(
@@ -97,17 +144,27 @@ public abstract class PluginConsumer implements IPluginConsumer {
     }
   }
 
-  protected static byte[] fromLz4File(Path inputFile) {
-    try {
-      // Awkward nested try blocks required because we refuse to throw IOExceptions.
-      try (Closer closer = Closer.create()) {
-        FileInputStream fis = closer.register(new FileInputStream(inputFile.toFile()));
-        InputStream lis = closer.register(new LZ4BlockInputStream(fis));
-        return IOUtils.toByteArray(lis);
-      }
-    } catch (IOException e) {
-      throw new BatfishException("Failed to unzip file: " + inputFile, e);
+  /**
+   * Determines the format of stream data. Requires a {@link PushbackInputStream} so that the
+   * inspected bytes can be put back into the stream after reading.
+   *
+   * @return a {@link Format} value.
+   */
+  private static Format detectFormat(PushbackInputStream stream) throws IOException {
+    byte[] header = new byte[DEFAULT_HEADER_LENGTH_BYTES];
+    ByteStreams.readFully(stream, header);
+    Format format;
+    if (Arrays.equals(header, JAVA_SERIALIZED_OBJECT_HEADER)) {
+      format = Format.JAVA_SERIALIZED;
+    } else if (Arrays.equals(header, LZ4_MAGIC_BYTES)) {
+      format = Format.LZ4;
+    } else if (Arrays.equals(Arrays.copyOf(header, GZIP_HEADER_LENGTH_BYTES), GZIP_MAGIC_BYTES)) {
+      format = Format.GZIP;
+    } else {
+      format = Format.UNKNOWN;
     }
+    stream.unread(header);
+    return format;
   }
 
   public ClassLoader getCurrentClassLoader() {
@@ -115,18 +172,6 @@ public abstract class PluginConsumer implements IPluginConsumer {
   }
 
   public abstract PluginClientType getType();
-
-  /**
-   * Determines whether the data in the stream is Java serialized bytes. Requires a {@link
-   * PushbackInputStream} so that the inspected bytes can be put back into the stream after reading.
-   */
-  private boolean isJavaSerializationData(PushbackInputStream stream) throws IOException {
-    byte[] header = new byte[JAVA_SERIALIZED_OBJECT_HEADER.length];
-    ByteStreams.readFully(stream, header);
-    boolean ret = Arrays.equals(header, JAVA_SERIALIZED_OBJECT_HEADER);
-    stream.unread(header);
-    return ret;
-  }
 
   protected final void loadPlugins() {
     SortedSet<Plugin> plugins;
@@ -185,7 +230,7 @@ public abstract class PluginConsumer implements IPluginConsumer {
     out = new CloseIgnoringOutputStream(out);
 
     try (Closer closer = Closer.create()) {
-      OutputStream los = closer.register(new LZ4BlockOutputStream(out));
+      OutputStream los = closer.register(new LZ4FrameOutputStream(out));
       ObjectOutputStream oos;
       if (_serializeToText) {
         XStream xstream = new XStream(new DomDriver("UTF-8"));

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/PluginConsumer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/PluginConsumer.java
@@ -42,7 +42,7 @@ public abstract class PluginConsumer implements IPluginConsumer {
     UNKNOWN
   }
 
-  private static final int DEFAULT_HEADER_LENGTH_BYTES = 4;
+  public static final int DEFAULT_HEADER_LENGTH_BYTES = 4;
 
   private static final int GZIP_HEADER_LENGTH_BYTES = 2;
 

--- a/projects/batfish/pom.xml
+++ b/projects/batfish/pom.xml
@@ -1,5 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -25,8 +26,10 @@
               </goals>
               <configuration>
                 <ignoredUnusedDeclaredDependencies>
-                  <ignoredUnusedDeclaredDependency>org.slf4j:slf4j-jdk14</ignoredUnusedDeclaredDependency>
-                  <ignoredUnusedDeclaredDependency>com.google.auto.service:auto-service</ignoredUnusedDeclaredDependency>
+                  <ignoredUnusedDeclaredDependency>org.slf4j:slf4j-jdk14
+                  </ignoredUnusedDeclaredDependency>
+                  <ignoredUnusedDeclaredDependency>com.google.auto.service:auto-service
+                  </ignoredUnusedDeclaredDependency>
                 </ignoredUnusedDeclaredDependencies>
               </configuration>
             </execution>
@@ -61,7 +64,8 @@
             <configuration>
               <includes>**/CiscoLexer.g4,**/CiscoParser.g4</includes>
               <libDirectory>${basedir}/src/main/antlr4/org/batfish/grammar/cisco</libDirectory>
-              <statusDirectory>${project.build.directory}/maven-status/antlr4-cisco</statusDirectory>
+              <statusDirectory>${project.build.directory}/maven-status/antlr4-cisco
+              </statusDirectory>
             </configuration>
           </execution>
           <execution>
@@ -70,9 +74,11 @@
               <goal>antlr4</goal>
             </goals>
             <configuration>
-               <includes>**/FlatJuniperLexer.g4,**/FlatJuniperParser.g4</includes>
-              <libDirectory>${basedir}/src/main/antlr4/org/batfish/grammar/flatjuniper</libDirectory>
-              <statusDirectory>${project.build.directory}/maven-status/antlr4-flatjuniper</statusDirectory>
+              <includes>**/FlatJuniperLexer.g4,**/FlatJuniperParser.g4</includes>
+              <libDirectory>${basedir}/src/main/antlr4/org/batfish/grammar/flatjuniper
+              </libDirectory>
+              <statusDirectory>${project.build.directory}/maven-status/antlr4-flatjuniper
+              </statusDirectory>
             </configuration>
           </execution>
           <execution>
@@ -83,7 +89,8 @@
             <configuration>
               <includes>**/FlatVyosLexer.g4,**/FlatVyosParser.g4</includes>
               <libDirectory>${basedir}/src/main/antlr4/org/batfish/grammar/flatvyos</libDirectory>
-              <statusDirectory>${project.build.directory}/maven-status/antlr4-flatvyos</statusDirectory>
+              <statusDirectory>${project.build.directory}/maven-status/antlr4-flatvyos
+              </statusDirectory>
             </configuration>
           </execution>
           <execution>
@@ -118,7 +125,9 @@
         <executions>
           <execution>
             <id>check</id>
-            <goals><goal>check</goal></goals>
+            <goals>
+              <goal>check</goal>
+            </goals>
             <configuration>
               <failOnViolation>true</failOnViolation>
             </configuration>
@@ -126,7 +135,9 @@
 
           <execution>
             <id>cpd-check</id>
-            <goals><goal>cpd-check</goal></goals>
+            <goals>
+              <goal>cpd-check</goal>
+            </goals>
             <configuration>
               <failOnViolation>false</failOnViolation>
             </configuration>
@@ -251,6 +262,11 @@
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jettison</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.lz4</groupId>
+      <artifactId>lz4-java</artifactId>
     </dependency>
 
     <!-- Runtime dependencies to add logging. -->

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -1204,9 +1204,15 @@ public class Batfish extends PluginConsumer implements IBatfish {
             namesByPath.size());
     namesByPath.forEach(
         (inputPath, name) -> {
-          logger.debugf(
-              "Reading and gunzipping: {} '{}' from '{}'", outputClassName, name, inputPath);
-          byte[] data = fromGzipFile(inputPath);
+          logger.debug(
+              "Reading and unzipping: "
+                  + outputClassName
+                  + " '"
+                  + name
+                  + "' from '"
+                  + inputPath.toString()
+                  + "'");
+          byte[] data = fromLz4File(inputPath);
           logger.debug(" ...OK\n");
           dataByName.put(name, data);
           readCompleted.incrementAndGet();

--- a/projects/pom.xml
+++ b/projects/pom.xml
@@ -69,6 +69,7 @@
     <jsr305.version>3.0.2</jsr305.version>
     <junit.version>4.12</junit.version>
     <jackson-jsonschema.version>1.0.11-batfish-internal</jackson-jsonschema.version>
+    <lz4.version>1.4.1</lz4.version>
     <opentracing-jaxrs2.version>0.0.9</opentracing-jaxrs2.version>
     <opentracing.version>0.30.0</opentracing.version>
     <puppycrawl.version>8.0</puppycrawl.version>
@@ -671,6 +672,12 @@
         <groupId>org.jline</groupId>
         <artifactId>jline</artifactId>
         <version>${jline.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.lz4</groupId>
+        <artifactId>lz4-java</artifactId>
+        <version>${lz4.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
*Purpose*:
Switch from gzip to lz4 for faster (de-)serialization times.

*Implementation*:
- Replace gzip with lz4
- Keep backwards compatibility with gzip by allowing de-serialization of gzip-compressed files
- Which led to slightly more involved (but seemingly more versatile) format detection.

*Additional changes*:
- Perform deserialization without intermediate byte arrays, using streams directly and in one batch in `deserializeObjects`.

*Notes*:
@dhalperi Switched from lz4 block streams to frame streams. This way files have magic numbers (for format detection), and also the internet claims it more interoperable with other tools (e.g., cli tools)


Co-authored-by: dhalperi <dhalperi@users.noreply.github.com>