### PR TITLE
BatfishObjectMapper: cleanup APIs and usage

### DIFF
--- a/projects/batfish-client/src/main/java/org/batfish/client/BfCoordWorkHelper.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/BfCoordWorkHelper.java
@@ -506,8 +506,7 @@ public class BfCoordWorkHelper {
       }
 
       String containerStr = response.readEntity(String.class);
-      BatfishObjectMapper mapper = new BatfishObjectMapper();
-      Container container = mapper.readValue(containerStr, Container.class);
+      Container container = BatfishObjectMapper.mapper().readValue(containerStr, Container.class);
       return container;
     } catch (Exception e) {
       _logger.errorf("Exception in getContainer from %s for %s\n", _coordWorkMgrV2, containerName);
@@ -940,11 +939,10 @@ public class BfCoordWorkHelper {
         return null;
       }
 
-      BatfishObjectMapper mapper = new BatfishObjectMapper();
       String result = jObj.getString(CoordConsts.SVC_KEY_WORK_LIST);
 
       List<WorkStatus> workList =
-          mapper.readValue(result, new TypeReference<List<WorkStatus>>() {});
+          BatfishObjectMapper.mapper().readValue(result, new TypeReference<List<WorkStatus>>() {});
 
       return workList;
     } catch (Exception e) {
@@ -1075,8 +1073,8 @@ public class BfCoordWorkHelper {
       MultiPart multiPart = new MultiPart();
       multiPart.setMediaType(MediaType.MULTIPART_FORM_DATA_TYPE);
 
-      BatfishObjectMapper mapper = new BatfishObjectMapper();
-      addTextMultiPart(multiPart, CoordConsts.SVC_KEY_WORKITEM, mapper.writeValueAsString(wItem));
+      addTextMultiPart(
+          multiPart, CoordConsts.SVC_KEY_WORKITEM, BatfishObjectMapper.writeString(wItem));
       addTextMultiPart(multiPart, CoordConsts.SVC_KEY_API_KEY, _settings.getApiKey());
 
       JSONObject jObj = postData(webTarget, multiPart);
@@ -1088,7 +1086,6 @@ public class BfCoordWorkHelper {
     }
   }
 
-  @Nullable
   public boolean syncTestrigsSyncNow(String pluginId, String containerName, boolean force) {
     try {
       WebTarget webTarget = getTarget(CoordConsts.SVC_RSC_SYNC_TESTRIGS_SYNC_NOW);
@@ -1111,12 +1108,10 @@ public class BfCoordWorkHelper {
     }
   }
 
-  @Nullable
   public boolean syncTestrigsUpdateSettings(
       String pluginId, String containerName, Map<String, String> settings) {
     try {
-      BatfishObjectMapper mapper = new BatfishObjectMapper();
-      String settingsStr = mapper.writeValueAsString(settings);
+      String settingsStr = BatfishObjectMapper.writePrettyString(settings);
 
       WebTarget webTarget = getTarget(CoordConsts.SVC_RSC_SYNC_TESTRIGS_UPDATE_SETTINGS);
 

--- a/projects/batfish-client/src/main/java/org/batfish/client/Client.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/Client.java
@@ -574,11 +574,11 @@ public class Client extends AbstractClient implements IClient {
       throw new BatfishException("Question is missing instance data", e);
     }
     String instanceDataStr = instanceJson.toString();
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
     InstanceData instanceData;
     try {
       instanceData =
-          mapper.<InstanceData>readValue(instanceDataStr, new TypeReference<InstanceData>() {});
+          BatfishObjectMapper.mapper()
+              .readValue(instanceDataStr, new TypeReference<InstanceData>() {});
     } catch (IOException e) {
       throw new BatfishException("Invalid instance data (JSON)", e);
     }
@@ -588,7 +588,7 @@ public class Client extends AbstractClient implements IClient {
 
     String modifiedInstanceDataStr;
     try {
-      modifiedInstanceDataStr = mapper.writeValueAsString(instanceData);
+      modifiedInstanceDataStr = BatfishObjectMapper.writePrettyString(instanceData);
       JSONObject modifiedInstanceData = new JSONObject(modifiedInstanceDataStr);
       questionJson.put(BfConsts.PROP_INSTANCE, modifiedInstanceData);
     } catch (JSONException | JsonProcessingException e) {
@@ -729,10 +729,10 @@ public class Client extends AbstractClient implements IClient {
     }
 
     String modifiedQuestionJson = questionJson.toString();
-    BatfishObjectMapper mapper = new BatfishObjectMapper(getCurrentClassLoader());
     Question modifiedQuestion = null;
     try {
-      modifiedQuestion = mapper.readValue(modifiedQuestionJson, Question.class);
+      modifiedQuestion =
+          BatfishObjectMapper.mapper().readValue(modifiedQuestionJson, Question.class);
     } catch (IOException e) {
       throw new BatfishException(
           "Modified question is no longer valid, likely due to invalid parameters", e);
@@ -1017,10 +1017,9 @@ public class Client extends AbstractClient implements IClient {
 
   private void generateDatamodel() {
     try {
-      ObjectMapper mapper = new BatfishObjectMapper();
-      JsonSchemaGenerator schemaGenNew = new JsonSchemaGenerator(mapper);
+      JsonSchemaGenerator schemaGenNew = new JsonSchemaGenerator(BatfishObjectMapper.mapper());
       JsonNode schemaNew = schemaGenNew.generateJsonSchema(Configuration.class);
-      _logger.output(mapper.writeValueAsString(schemaNew));
+      _logger.output(BatfishObjectMapper.writePrettyString(schemaNew));
 
       // Reflections reflections = new Reflections("org.batfish.datamodel");
       // Set<Class<? extends AnswerElement>> classes =
@@ -1252,10 +1251,9 @@ public class Client extends AbstractClient implements IClient {
 
     String answerStringToPrint = answerString;
     if (outWriter == null && _settings.getPrettyPrintAnswers()) {
-      ObjectMapper mapper = new BatfishObjectMapper(getCurrentClassLoader());
       Answer answer;
       try {
-        answer = mapper.readValue(answerString, Answer.class);
+        answer = BatfishObjectMapper.mapper().readValue(answerString, Answer.class);
       } catch (IOException e) {
         throw new BatfishException(
             "Response does not appear to be valid JSON representation of "
@@ -1553,7 +1551,7 @@ public class Client extends AbstractClient implements IClient {
         if (!paramsNodeBlacklist.isEmpty()) {
           String nodeBlacklistText;
           try {
-            nodeBlacklistText = new BatfishObjectMapper().writeValueAsString(paramsNodeBlacklist);
+            nodeBlacklistText = BatfishObjectMapper.writePrettyString(paramsNodeBlacklist);
           } catch (JsonProcessingException e) {
             throw new BatfishException("Failed to write node blacklist to string", e);
           }
@@ -1564,7 +1562,7 @@ public class Client extends AbstractClient implements IClient {
           String interfaceBlacklistText;
           try {
             interfaceBlacklistText =
-                new BatfishObjectMapper().writeValueAsString(paramsInterfaceBlacklist);
+                BatfishObjectMapper.writePrettyString(paramsInterfaceBlacklist);
           } catch (JsonProcessingException e) {
             throw new BatfishException("Failed to write interface blacklist to string", e);
           }
@@ -1575,7 +1573,7 @@ public class Client extends AbstractClient implements IClient {
         if (!paramsEdgeBlacklist.isEmpty()) {
           String edgeBlacklistText;
           try {
-            edgeBlacklistText = new BatfishObjectMapper().writeValueAsString(paramsEdgeBlacklist);
+            edgeBlacklistText = BatfishObjectMapper.writePrettyString(paramsEdgeBlacklist);
           } catch (JsonProcessingException e) {
             throw new BatfishException("Failed to write edge blacklist to string", e);
           }
@@ -1692,14 +1690,13 @@ public class Client extends AbstractClient implements IClient {
       Answer answer = new Answer();
       answer.addAnswerElement(ae);
       mergeQuestions(analysisQuestions, questionMap, ae);
-      ObjectMapper mapper = new BatfishObjectMapper(getCurrentClassLoader());
 
       String answerStringToPrint;
       if (_settings.getPrettyPrintAnswers()) {
         answerStringToPrint = answer.prettyPrint();
       } else {
         try {
-          answerStringToPrint = mapper.writeValueAsString(answer);
+          answerStringToPrint = BatfishObjectMapper.writePrettyString(answer);
         } catch (JsonProcessingException e) {
           throw new BatfishException("Could not write answer element as string", e);
         }
@@ -2050,9 +2047,9 @@ public class Client extends AbstractClient implements IClient {
       if (questionObj.has(BfConsts.PROP_INSTANCE) && !questionObj.isNull(BfConsts.PROP_INSTANCE)) {
         JSONObject instanceDataObj = questionObj.getJSONObject(BfConsts.PROP_INSTANCE);
         String instanceDataStr = instanceDataObj.toString();
-        BatfishObjectMapper mapper = new BatfishObjectMapper();
         InstanceData instanceData =
-            mapper.<InstanceData>readValue(instanceDataStr, new TypeReference<InstanceData>() {});
+            BatfishObjectMapper.mapper()
+                .readValue(instanceDataStr, new TypeReference<InstanceData>() {});
         validateInstanceData(instanceData);
         return questionObj;
       } else {
@@ -2106,13 +2103,12 @@ public class Client extends AbstractClient implements IClient {
     }
 
     // outputting the final answer
-    ObjectMapper mapper = new BatfishObjectMapper(getCurrentClassLoader());
     String answerStringToPrint;
     if (outWriter == null && _settings.getPrettyPrintAnswers()) {
       answerStringToPrint = answer.prettyPrint();
     } else {
       try {
-        answerStringToPrint = mapper.writeValueAsString(answer);
+        answerStringToPrint = BatfishObjectMapper.writePrettyString(answer);
       } catch (JsonProcessingException e) {
         throw new BatfishException("Could not write answer element as string", e);
       }
@@ -2137,10 +2133,10 @@ public class Client extends AbstractClient implements IClient {
       if (questionTemplatesJson == null) {
         return loadedQuestions;
       }
-      BatfishObjectMapper mapper = new BatfishObjectMapper();
       Map<String, String> questionsMap =
-          mapper.readValue(
-              questionTemplatesJson.toString(), new TypeReference<Map<String, String>>() {});
+          BatfishObjectMapper.mapper()
+              .readValue(
+                  questionTemplatesJson.toString(), new TypeReference<Map<String, String>>() {});
 
       for (Entry<String, String> question : questionsMap.entrySet()) {
         JSONObject questionJSON = loadQuestionFromText(question.getValue(), question.getKey());
@@ -2252,13 +2248,13 @@ public class Client extends AbstractClient implements IClient {
 
   static InitEnvironmentParams parseInitEnvironmentParams(String paramsLine) {
     String jsonParamsStr = "{ " + paramsLine + " }";
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
     InitEnvironmentParams parameters;
     try {
       parameters =
-          mapper.<InitEnvironmentParams>readValue(
-              new JSONObject(jsonParamsStr).toString(),
-              new TypeReference<InitEnvironmentParams>() {});
+          BatfishObjectMapper.mapper()
+              .readValue(
+                  new JSONObject(jsonParamsStr).toString(),
+                  new TypeReference<InitEnvironmentParams>() {});
       return parameters;
     } catch (JSONException | IOException e) {
       throw new BatfishException(
@@ -2270,13 +2266,13 @@ public class Client extends AbstractClient implements IClient {
 
   private Map<String, JsonNode> parseParams(String paramsLine) {
     String jsonParamsStr = "{ " + paramsLine + " }";
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
     Map<String, JsonNode> parameters;
     try {
       parameters =
-          mapper.<Map<String, JsonNode>>readValue(
-              new JSONObject(jsonParamsStr).toString(),
-              new TypeReference<Map<String, JsonNode>>() {});
+          BatfishObjectMapper.mapper()
+              .readValue(
+                  new JSONObject(jsonParamsStr).toString(),
+                  new TypeReference<Map<String, JsonNode>>() {});
       return parameters;
     } catch (JSONException | IOException e) {
       throw new BatfishException(
@@ -2347,10 +2343,9 @@ public class Client extends AbstractClient implements IClient {
       // that case
       String answerStringToPrint = answerString;
       if (outWriter == null && _settings.getPrettyPrintAnswers()) {
-        ObjectMapper mapper = new BatfishObjectMapper(getCurrentClassLoader());
         Answer answer;
         try {
-          answer = mapper.readValue(answerString, Answer.class);
+          answer = BatfishObjectMapper.mapper().readValue(answerString, Answer.class);
         } catch (IOException e) {
           throw new BatfishException(
               "Response does not appear to be valid JSON representation of "
@@ -2365,12 +2360,12 @@ public class Client extends AbstractClient implements IClient {
       // tests serialization/deserialization when running in debug mode
       if (_logger.getLogLevel() >= BatfishLogger.LEVEL_DEBUG) {
         try {
-          ObjectMapper mapper = new BatfishObjectMapper(getCurrentClassLoader());
-          Answer answer = mapper.readValue(answerString, Answer.class);
+          ObjectMapper reader = BatfishObjectMapper.mapper();
+          Answer answer = reader.readValue(answerString, Answer.class);
 
-          String newAnswerString = mapper.writeValueAsString(answer);
-          JsonNode tree = mapper.readTree(answerString);
-          JsonNode newTree = mapper.readTree(newAnswerString);
+          String newAnswerString = BatfishObjectMapper.writeString(answer);
+          JsonNode tree = reader.readTree(answerString);
+          JsonNode newTree = reader.readTree(newAnswerString);
           if (!CommonUtil.checkJsonEqual(tree, newTree)) {
             // if (!tree.equals(newTree)) {
             _logger.errorf(
@@ -2417,10 +2412,9 @@ public class Client extends AbstractClient implements IClient {
       WorkStatusCode status = response.getFirst();
       _logger.outputf("status: %s\n", status);
 
-      BatfishObjectMapper mapper = new BatfishObjectMapper();
       Task task;
       try {
-        task = mapper.readValue(response.getSecond(), Task.class);
+        task = BatfishObjectMapper.mapper().readValue(response.getSecond(), Task.class);
       } catch (IOException e) {
         _logger.errorf("Could not deserialize task object: %s\n", e);
         return;
@@ -3127,10 +3121,11 @@ public class Client extends AbstractClient implements IClient {
     Map<String, String> settings = null;
 
     try {
-      BatfishObjectMapper mapper = new BatfishObjectMapper();
       settings =
-          mapper.readValue(
-              new JSONObject(settingsStr).toString(), new TypeReference<Map<String, String>>() {});
+          BatfishObjectMapper.mapper()
+              .readValue(
+                  new JSONObject(settingsStr).toString(),
+                  new TypeReference<Map<String, String>>() {});
     } catch (JSONException | IOException e) {
       _logger.errorf(
           "Failed to parse parameters. "
@@ -3180,16 +3175,14 @@ public class Client extends AbstractClient implements IClient {
     if (!failingTest && testCommandSucceeded) {
       try {
 
-        ObjectMapper mapper = new BatfishObjectMapper(getCurrentClassLoader());
-
         // rewrite new answer string using local implementation
         String testOutput = CommonUtil.readFile(Paths.get(testoutFile.getAbsolutePath()));
 
         String testAnswerString = testOutput;
 
         try {
-          Answer testAnswer = mapper.readValue(testOutput, Answer.class);
-          testAnswerString = mapper.writeValueAsString(testAnswer);
+          Answer testAnswer = BatfishObjectMapper.mapper().readValue(testOutput, Answer.class);
+          testAnswerString = BatfishObjectMapper.writePrettyString(testAnswer);
         } catch (JsonProcessingException e) {
           // not all outputs of process command are of Answer.class type
           // in that case, we use the exact string as initialized above for
@@ -3205,8 +3198,8 @@ public class Client extends AbstractClient implements IClient {
           // rewrite reference string using local implementation
           Answer referenceAnswer;
           try {
-            referenceAnswer = mapper.readValue(referenceOutput, Answer.class);
-            referenceAnswerString = mapper.writeValueAsString(referenceAnswer);
+            referenceAnswer = BatfishObjectMapper.mapper().readValue(referenceOutput, Answer.class);
+            referenceAnswerString = BatfishObjectMapper.writePrettyString(referenceAnswer);
           } catch (JsonProcessingException e) {
             // not all outputs of process command are of Answer.class type
             // in that case, we use the exact string as initialized above

--- a/projects/batfish-client/src/test/java/org/batfish/client/ClientTest.java
+++ b/projects/batfish-client/src/test/java/org/batfish/client/ClientTest.java
@@ -90,6 +90,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import java.io.File;
@@ -117,7 +118,6 @@ import org.batfish.datamodel.questions.Question.InstanceData.Variable;
 import org.batfish.datamodel.questions.Question.InstanceData.Variable.Type;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -134,7 +134,7 @@ public class ClientTest {
 
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
   @Rule public ExpectedException _thrown = ExpectedException.none();
-  private BatfishObjectMapper _mapper;
+  private ObjectMapper _mapper = BatfishObjectMapper.mapper();
 
   private void checkProcessCommandErrorMessage(
       Command command, String[] parameters, String expected) throws Exception {
@@ -168,11 +168,6 @@ public class ClientTest {
             "Test: 'get' matches %s: Fail\nCopied output to %s.testout\n",
             tempFilePath.toString(), tempFilePath.toString());
     testProcessCommandWithValidInput(TEST, parameters, expected + additionalMessage);
-  }
-
-  @Before
-  public void initMapper() {
-    _mapper = new BatfishObjectMapper();
   }
 
   @Test
@@ -884,11 +879,10 @@ public class ClientTest {
     client._logger = new BatfishLogger("output", false);
     client.processCommand(
         new String[] {LOAD_QUESTIONS.commandName(), questionJsonPath.getParent().toString()}, null);
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
 
     // Reading the answer written by load-questions
     Answer answerLoadQuestions =
-        mapper.readValue(
+        _mapper.readValue(
             client.getLogger().getHistory().toString(BatfishLogger.LEVEL_OUTPUT), Answer.class);
     LoadQuestionAnswerElement ae =
         (LoadQuestionAnswerElement) answerLoadQuestions.getAnswerElements().get(0);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/Answerer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/Answerer.java
@@ -1,7 +1,6 @@
 package org.batfish.common;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.function.BiFunction;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.common.util.BatfishObjectMapper;
@@ -55,10 +54,9 @@ public abstract class Answerer {
     _batfish.pushDeltaEnvironment();
     AnswerElement after = create(_question, _batfish).answer();
     _batfish.popEnvironment();
-    ObjectMapper mapper = new BatfishObjectMapper();
     try {
-      String beforeJsonStr = mapper.writeValueAsString(before);
-      String afterJsonStr = mapper.writeValueAsString(after);
+      String beforeJsonStr = BatfishObjectMapper.writePrettyString(before);
+      String afterJsonStr = BatfishObjectMapper.writePrettyString(after);
       JSONObject beforeJson = new JSONObject(beforeJsonStr);
       JSONObject afterJson = new JSONObject(afterJsonStr);
       JsonDiff diff = new JsonDiff(beforeJson, afterJson);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/BatfishObjectMapper.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/BatfishObjectMapper.java
@@ -16,11 +16,14 @@ import java.io.IOException;
 
 public final class BatfishObjectMapper {
   private static final ObjectMapper MAPPER = baseMapper();
+
   private static final ObjectWriter WRITER = MAPPER.writer();
+
   private static final PrettyPrinter PRETTY_PRINTER = new PrettyPrinter();
 
   private static final ObjectWriter PRETTY_WRITER =
       baseMapper().enable(SerializationFeature.INDENT_OUTPUT).writer(PRETTY_PRINTER);
+
   private static final ObjectWriter VERBOSE_WRITER =
       baseMapper()
           .enable(SerializationFeature.INDENT_OUTPUT)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
@@ -174,10 +174,9 @@ public class CommonUtil {
   }
 
   public static boolean checkJsonEqual(Object a, Object b) {
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
     try {
-      String aString = mapper.writeValueAsString(a);
-      String bString = mapper.writeValueAsString(b);
+      String aString = BatfishObjectMapper.writePrettyString(a);
+      String bString = BatfishObjectMapper.writePrettyString(b);
       JSONAssert.assertEquals(aString, bString, false);
       return true;
     } catch (Exception e) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/PrettyPrinter.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/PrettyPrinter.java
@@ -1,7 +1,6 @@
 package org.batfish.common.util;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.LinkedList;
 import java.util.TreeMap;
 
@@ -58,11 +57,10 @@ public class PrettyPrinter {
     } else if (value instanceof LinkedList<?>) {
       sb.append(print(prefixStr + "  ", (LinkedList<?>) value));
     } else if (value instanceof String) {
-      sb.append(prefixStr + "  " + (String) value + "\n");
+      sb.append(prefixStr + "  " + value + "\n");
     } else {
-      ObjectMapper mapper = new BatfishObjectMapper();
       try {
-        sb.append(mapper.writeValueAsString(value));
+        sb.append(BatfishObjectMapper.writePrettyString(value));
       } catch (JsonProcessingException e) {
         sb.append("Exception while pretty printing " + value + "\n" + e.getMessage());
       }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AnswerElement.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AnswerElement.java
@@ -3,7 +3,6 @@ package org.batfish.datamodel.answers;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import javax.annotation.Nullable;
 import org.batfish.common.BatfishException;
 import org.batfish.common.util.BatfishObjectMapper;
@@ -20,9 +19,8 @@ public interface AnswerElement {
   }
 
   default String prettyPrint() {
-    ObjectMapper mapper = new BatfishObjectMapper();
     try {
-      return mapper.writeValueAsString(this);
+      return BatfishObjectMapper.writePrettyString(this);
     } catch (JsonProcessingException e) {
       throw new BatfishException("Failed to pretty print answer element", e);
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/NamedStructureEquivalenceSets.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/NamedStructureEquivalenceSets.java
@@ -3,7 +3,6 @@ package org.batfish.datamodel.collections;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import java.util.Collections;
@@ -35,15 +34,12 @@ public class NamedStructureEquivalenceSets<T> {
       }
     }
 
-    private final ObjectMapper _mapper;
-
     private Map<String, Map<Integer, Set<NamedStructureEquivalenceSet<T>>>>
         _sameNamedStructuresByNameAndHash;
 
     private final String _structureClassName;
 
     private Builder(String structureClassName) {
-      _mapper = new BatfishObjectMapper();
       _sameNamedStructuresByNameAndHash = new HashMap<>();
       _structureClassName = structureClassName;
     }
@@ -100,7 +96,7 @@ public class NamedStructureEquivalenceSets<T> {
 
     private String writeObject(T t) {
       try {
-        String structureJson = _mapper.writeValueAsString(t);
+        String structureJson = BatfishObjectMapper.writePrettyString(t);
         return structureJson;
       } catch (JsonProcessingException e) {
         throw new BatfishException("Could not write named structure as JSON", e);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/Question.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/Question.java
@@ -296,9 +296,8 @@ public abstract class Question implements IQuestion {
   // by default, pretty printing is Json
   // override this function in derived classes to do something more meaningful
   public String prettyPrint() {
-    ObjectMapper mapper = new BatfishObjectMapper();
     try {
-      return mapper.writeValueAsString(this);
+      return BatfishObjectMapper.writePrettyString(this);
     } catch (JsonProcessingException e) {
       throw new BatfishException("Failed to pretty-print question", e);
     }
@@ -317,16 +316,14 @@ public abstract class Question implements IQuestion {
     }
   }
 
-  public static Question parseQuestion(Path questionPath, ClassLoader classLoader) {
-    return parseQuestion(CommonUtil.readFile(questionPath), classLoader);
+  public static Question parseQuestion(Path questionPath) {
+    return parseQuestion(CommonUtil.readFile(questionPath));
   }
 
-  public static Question parseQuestion(String rawQuestionText, ClassLoader classLoader) {
+  public static Question parseQuestion(String rawQuestionText) {
     String questionText = Question.preprocessQuestion(rawQuestionText);
     try {
-      ObjectMapper mapper =
-          (classLoader == null) ? new BatfishObjectMapper() : new BatfishObjectMapper(classLoader);
-      Question question = mapper.readValue(questionText, Question.class);
+      Question question = BatfishObjectMapper.mapper().readValue(questionText, Question.class);
       return question;
     } catch (IOException e) {
       throw new BatfishException("Could not parse JSON question", e);
@@ -338,9 +335,9 @@ public abstract class Question implements IQuestion {
       JSONObject jobj = new JSONObject(rawQuestionText);
       if (jobj.has(BfConsts.PROP_INSTANCE) && !jobj.isNull(BfConsts.PROP_INSTANCE)) {
         String instanceDataStr = jobj.getString(BfConsts.PROP_INSTANCE);
-        BatfishObjectMapper mapper = new BatfishObjectMapper();
         InstanceData instanceData =
-            mapper.<InstanceData>readValue(instanceDataStr, new TypeReference<InstanceData>() {});
+            BatfishObjectMapper.mapper()
+                .readValue(instanceDataStr, new TypeReference<InstanceData>() {});
         for (Entry<String, Variable> e : instanceData.getVariables().entrySet()) {
           String varName = e.getKey();
           Variable variable = e.getValue();
@@ -447,10 +444,8 @@ public abstract class Question implements IQuestion {
 
   @Override
   public String toFullJsonString() {
-    ObjectMapper mapper = new BatfishObjectMapper();
-    mapper.setSerializationInclusion(Include.ALWAYS);
     try {
-      return mapper.writeValueAsString(this);
+      return BatfishObjectMapper.verboseWriter().writeValueAsString(this);
     } catch (JsonProcessingException e) {
       throw new BatfishException("Failed to convert question to full JSON string", e);
     }
@@ -458,9 +453,8 @@ public abstract class Question implements IQuestion {
 
   @Override
   public String toJsonString() {
-    ObjectMapper mapper = new BatfishObjectMapper();
     try {
-      return mapper.writeValueAsString(this);
+      return BatfishObjectMapper.writePrettyString(this);
     } catch (JsonProcessingException e) {
       throw new BatfishException("Failed to convert question to JSON string", e);
     }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/BatfishObjectMapperTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/BatfishObjectMapperTest.java
@@ -38,12 +38,12 @@ public class BatfishObjectMapperTest {
 
   private enum SomeEnum {
     ACCEPT,
-    DROP;
+    DROP
   }
 
   @Test
   public void testMapperAcceptsCaseInsensitiveEnums() throws IOException {
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
+    ObjectMapper mapper = BatfishObjectMapper.mapper();
     assertThat(mapper.writeValueAsString(SomeEnum.ACCEPT), equalTo("\"ACCEPT\""));
     assertThat(mapper.writeValueAsString(SomeEnum.DROP), equalTo("\"DROP\""));
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PrefixRangeTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PrefixRangeTest.java
@@ -22,14 +22,14 @@ public class PrefixRangeTest {
   @Test
   public void testSerialization() throws JsonProcessingException {
     PrefixRange pr = PrefixRange.fromString("1.2.3.4/8:17-19");
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
-    assertThat(mapper.writeValueAsString(pr), equalTo("\"1.0.0.0/8:17-19\""));
+    assertThat(BatfishObjectMapper.writeString(pr), equalTo("\"1.0.0.0/8:17-19\""));
   }
 
   @Test
   public void testDeSerialization() throws IOException {
     PrefixRange pr = PrefixRange.fromString("1.2.3.4/8:17-19");
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
-    assertThat(mapper.readValue("\"1.0.0.0/8:17-19\"", PrefixRange.class), equalTo(pr));
+    assertThat(
+        BatfishObjectMapper.mapper().readValue("\"1.0.0.0/8:17-19\"", PrefixRange.class),
+        equalTo(pr));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/StaticRouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/StaticRouteTest.java
@@ -56,8 +56,6 @@ public class StaticRouteTest {
 
   @Test
   public void checkSerialization() {
-    BatfishObjectMapper mapper =
-        new BatfishObjectMapper(Thread.currentThread().getContextClassLoader());
     StaticRoute sr =
         StaticRoute.builder()
             .setNextHopIp(new Ip("192.168.1.1"))
@@ -67,8 +65,7 @@ public class StaticRouteTest {
             .setTag(0)
             .build();
     try {
-      String json = mapper.writeValueAsString(sr);
-      StaticRoute parsedObj = mapper.readValue(json, StaticRoute.class);
+      StaticRoute parsedObj = BatfishObjectMapper.clone(sr, StaticRoute.class);
       assertThat(parsedObj.getNextHopIp(), is(new Ip("192.168.1.1")));
       assertThat(parsedObj.getNetwork(), is(Prefix.ZERO));
       assertThat(parsedObj.getNextHopInterface(), is("192.168.1.2"));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/TestrigMetadataTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/TestrigMetadataTest.java
@@ -19,8 +19,7 @@ public class TestrigMetadataTest {
     TestrigMetadata metadata =
         new TestrigMetadata(
             Instant.ofEpochMilli(758949005001L), BfConsts.RELPATH_DEFAULT_ENVIRONMENT_NAME);
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
-    JsonNode jsonNode = mapper.valueToTree(metadata);
+    JsonNode jsonNode = BatfishObjectMapper.mapper().valueToTree(metadata);
     assertThat(jsonNode.get("creationTimestamp").asText(), equalTo("1994-01-19T03:10:05.001Z"));
     assertThat(
         jsonNode

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/answers/AnswerSummaryTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/answers/AnswerSummaryTest.java
@@ -25,8 +25,7 @@ public class AnswerSummaryTest {
   public void deserializationTest() throws IOException {
     String summaryStr =
         "{\"notes\" : \"notes1\", \"numFailed\" : 21, \"numPassed\" : 23, " + "\"numResults\": 42}";
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
-    AnswerSummary summary = mapper.readValue(summaryStr, AnswerSummary.class);
+    AnswerSummary summary = BatfishObjectMapper.mapper().readValue(summaryStr, AnswerSummary.class);
     assertThat(summary.getNotes(), equalTo("notes1"));
     assertThat(summary.getNumFailed(), equalTo(21));
     assertThat(summary.getNumPassed(), equalTo(23));
@@ -36,12 +35,10 @@ public class AnswerSummaryTest {
   @Test
   public void serializationTest() throws IOException {
     AnswerSummary summary = new AnswerSummary("notes1", 21, 23, 42);
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
-    String summaryStr = mapper.writeValueAsString(summary);
 
-    // we test if serialization happened correctly, by deserializing it
-    // in fact, deserializing might be the problem, but then the test above should fail
-    AnswerSummary summaryAfter = mapper.readValue(summaryStr, AnswerSummary.class);
+    // The summary should survive cloning through JSON.
+    AnswerSummary summaryAfter = BatfishObjectMapper.clone(summary, AnswerSummary.class);
+
     assertThat(summaryAfter.getNotes(), equalTo("notes1"));
     assertThat(summaryAfter.getNumFailed(), equalTo(21));
     assertThat(summaryAfter.getNumPassed(), equalTo(23));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/pojo/AggregateTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/pojo/AggregateTest.java
@@ -20,16 +20,14 @@ public class AggregateTest {
   @Test
   public void constructorFail() throws IOException {
     String aggStr = "{\"nonamefield\" : \"nodeName\"}";
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
     _thrown.expect(com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException.class);
-    mapper.readValue(aggStr, Aggregate.class);
+    BatfishObjectMapper.mapper().readValue(aggStr, Aggregate.class);
   }
 
   @Test
   public void constructorBasic() throws IOException {
     String aggStr = "{\"name\" : \"test\"}";
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
-    Aggregate aggregate = mapper.readValue(aggStr, Aggregate.class);
+    Aggregate aggregate = BatfishObjectMapper.mapper().readValue(aggStr, Aggregate.class);
 
     assertThat(aggregate.getId(), equalTo(Aggregate.getId("test")));
     assertThat(aggregate.getName(), equalTo("test"));
@@ -38,8 +36,7 @@ public class AggregateTest {
   @Test
   public void constructorProperties() throws IOException {
     String aggStr = "{\"name\" : \"aggName\", \"properties\" : { \"key\": \"value\"}}";
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
-    Aggregate node = mapper.readValue(aggStr, Aggregate.class);
+    Aggregate node = BatfishObjectMapper.mapper().readValue(aggStr, Aggregate.class);
 
     assertThat(node.getId(), equalTo(Aggregate.getId("aggName")));
     assertThat(node.getName(), equalTo("aggName"));
@@ -53,8 +50,7 @@ public class AggregateTest {
     Map<String, String> properties = new HashMap<>();
     properties.put("key", "value");
     aggregate.setProperties(properties);
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
-    JsonNode jsonNode = mapper.valueToTree(aggregate);
+    JsonNode jsonNode = BatfishObjectMapper.mapper().valueToTree(aggregate);
 
     assertThat(jsonNode.get("id").asText(), equalTo(Aggregate.getId("test")));
     assertThat(jsonNode.get("name").asText(), equalTo("test"));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/pojo/InterfaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/pojo/InterfaceTest.java
@@ -20,16 +20,14 @@ public class InterfaceTest {
   @Test
   public void constructorFail() throws IOException {
     String ifaceStr = "{\"nofield\" : \"test\"}";
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
     _thrown.expect(com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException.class);
-    mapper.readValue(ifaceStr, Interface.class);
+    BatfishObjectMapper.mapper().readValue(ifaceStr, Interface.class);
   }
 
   @Test
   public void constructorBasic() throws IOException {
     String ifaceStr = "{\"nodeId\" : \"node\", \"name\" : \"iname\"}";
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
-    Interface iface = mapper.readValue(ifaceStr, Interface.class);
+    Interface iface = BatfishObjectMapper.mapper().readValue(ifaceStr, Interface.class);
 
     assertThat(iface.getId(), equalTo(Interface.getId("node", "iname")));
     assertThat(iface.getNodeId(), equalTo("node"));
@@ -40,8 +38,7 @@ public class InterfaceTest {
   public void constructorProperties() throws IOException {
     String ifaceStr =
         "{\"nodeId\" : \"node\", \"name\" : \"name\", \"properties\" : { \"key\": \"value\"}}";
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
-    Interface iface = mapper.readValue(ifaceStr, Interface.class);
+    Interface iface = BatfishObjectMapper.mapper().readValue(ifaceStr, Interface.class);
 
     assertThat(iface.getId(), equalTo(Interface.getId("node", "name")));
     assertThat(iface.getNodeId(), equalTo("node"));
@@ -56,8 +53,7 @@ public class InterfaceTest {
     Map<String, String> properties = new HashMap<>();
     properties.put("key", "value");
     iface.setProperties(properties);
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
-    JsonNode jsonNode = mapper.valueToTree(iface);
+    JsonNode jsonNode = BatfishObjectMapper.mapper().valueToTree(iface);
 
     assertThat(jsonNode.get("id").asText(), equalTo(Interface.getId("node", "name")));
     assertThat(jsonNode.get("nodeId").asText(), equalTo("node"));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/pojo/LinkTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/pojo/LinkTest.java
@@ -20,16 +20,14 @@ public class LinkTest {
   @Test
   public void constructorFail() throws IOException {
     String linkStr = "{\"nofield\" : \"test\"}";
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
     _thrown.expect(com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException.class);
-    mapper.readValue(linkStr, Link.class);
+    BatfishObjectMapper.mapper().readValue(linkStr, Link.class);
   }
 
   @Test
   public void constructorBasic() throws IOException {
     String linkStr = "{\"srcId\" : \"src\", \"dstId\" : \"dst\"}";
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
-    Link link = mapper.readValue(linkStr, Link.class);
+    Link link = BatfishObjectMapper.mapper().readValue(linkStr, Link.class);
 
     assertThat(link.getId(), equalTo(Link.getId("src", "dst")));
     assertThat(link.getDstId(), equalTo("dst"));
@@ -40,8 +38,7 @@ public class LinkTest {
   public void constructorProperties() throws IOException {
     String linkStr =
         "{\"srcId\" : \"src\", \"dstId\" : \"dst\", \"properties\" : { \"key\": \"value\"}}";
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
-    Link link = mapper.readValue(linkStr, Link.class);
+    Link link = BatfishObjectMapper.mapper().readValue(linkStr, Link.class);
 
     assertThat(link.getId(), equalTo(Link.getId("src", "dst")));
     assertThat(link.getDstId(), equalTo("dst"));
@@ -56,8 +53,7 @@ public class LinkTest {
     Map<String, String> properties = new HashMap<>();
     properties.put("key", "value");
     link.setProperties(properties);
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
-    JsonNode jsonNode = mapper.valueToTree(link);
+    JsonNode jsonNode = BatfishObjectMapper.mapper().valueToTree(link);
 
     assertThat(jsonNode.get("id").asText(), equalTo(Link.getId("src", "dst")));
     assertThat(jsonNode.get("srcId").asText(), equalTo("src"));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/pojo/NodeTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/pojo/NodeTest.java
@@ -20,16 +20,14 @@ public class NodeTest {
   @Test
   public void constructorFail() throws IOException {
     String nodeStr = "{\"nonamefield\" : \"nodeName\"}";
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
     _thrown.expect(com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException.class);
-    mapper.readValue(nodeStr, Node.class);
+    BatfishObjectMapper.mapper().readValue(nodeStr, Node.class);
   }
 
   @Test
   public void constructorBasic() throws IOException {
     String nodeStr = "{\"name\" : \"nodeName\"}";
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
-    Node node = mapper.readValue(nodeStr, Node.class);
+    Node node = BatfishObjectMapper.mapper().readValue(nodeStr, Node.class);
 
     assertThat(node.getId(), equalTo(Node.getId("nodeName")));
     assertThat(node.getName(), equalTo("nodeName"));
@@ -38,8 +36,7 @@ public class NodeTest {
   @Test
   public void constructorProperties() throws IOException {
     String nodeStr = "{\"name\" : \"nodeName\", \"properties\" : { \"key\": \"value\"}}";
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
-    Node node = mapper.readValue(nodeStr, Node.class);
+    Node node = BatfishObjectMapper.mapper().readValue(nodeStr, Node.class);
 
     assertThat(node.getId(), equalTo(Node.getId("nodeName")));
     assertThat(node.getName(), equalTo("nodeName"));
@@ -53,8 +50,7 @@ public class NodeTest {
     Map<String, String> properties = new HashMap<>();
     properties.put("key", "value");
     node.setProperties(properties);
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
-    JsonNode jsonNode = mapper.valueToTree(node);
+    JsonNode jsonNode = BatfishObjectMapper.mapper().valueToTree(node);
 
     assertThat(jsonNode.get("id").asText(), equalTo(Node.getId("testnode")));
     assertThat(jsonNode.get("name").asText(), equalTo("testnode"));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/pojo/TopologyTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/pojo/TopologyTest.java
@@ -21,8 +21,7 @@ public class TopologyTest {
             + " \"links\" : [{\"srcId\" : \"src\", \"dstId\" : \"dst\"}],"
             + " \"interfaces\" : [{\"nodeId\": \"node\", \"name\" : \"node\"}],"
             + " \"aggregates\" : [{\"name\": \"cloud\", \"contents\" : [\"id1\"]}]}";
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
-    Topology topo = mapper.readValue(str, Topology.class);
+    Topology topo = BatfishObjectMapper.mapper().readValue(str, Topology.class);
 
     assertThat(topo.getId(), equalTo(Topology.getId("testrig")));
     assertThat(topo.getTestrigName(), equalTo("testrig"));
@@ -44,8 +43,7 @@ public class TopologyTest {
     Map<String, String> properties = new HashMap<>();
     properties.put("key", "value");
     topo.setProperties(properties);
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
-    JsonNode jsonNode = mapper.valueToTree(topo);
+    JsonNode jsonNode = BatfishObjectMapper.mapper().valueToTree(topo);
 
     assertThat(jsonNode.get("id").asText(), equalTo(Topology.getId("testrig")));
     assertThat(jsonNode.get("aggregates").get(0).get("name").asText(), equalTo("cloud"));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/DisplayHintsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/DisplayHintsTest.java
@@ -15,8 +15,7 @@ public class DisplayHintsTest {
   @Test
   public void displayHintsParsingTest() throws IOException {
     String text = CommonUtil.readResource("org/batfish/datamodel/questions/displayHintsTest.json");
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
-    DisplayHints displayHints = mapper.readValue(text, DisplayHints.class);
+    DisplayHints displayHints = BatfishObjectMapper.mapper().readValue(text, DisplayHints.class);
 
     // here, we only test for ExtractionHint level concepts
     // tests that sit with jsonpath question validate if prefix/suffix filters are parsed correctly

--- a/projects/batfish/src/main/java/org/batfish/bgp/JsonExternalBgpAdvertisementPlugin.java
+++ b/projects/batfish/src/main/java/org/batfish/bgp/JsonExternalBgpAdvertisementPlugin.java
@@ -1,6 +1,5 @@
 package org.batfish.bgp;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.auto.service.AutoService;
 import java.io.IOException;
 import java.util.Iterator;
@@ -10,6 +9,7 @@ import org.batfish.common.BatfishException;
 import org.batfish.common.BfConsts;
 import org.batfish.common.plugin.ExternalBgpAdvertisementPlugin;
 import org.batfish.common.plugin.Plugin;
+import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.BgpAdvertisement;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
@@ -36,8 +36,6 @@ public class JsonExternalBgpAdvertisementPlugin extends ExternalBgpAdvertisement
 
         JSONArray announcements = jsonObj.getJSONArray(BfConsts.PROP_BGP_ANNOUNCEMENTS);
 
-        ObjectMapper mapper = new ObjectMapper();
-
         for (int index = 0; index < announcements.length(); index++) {
           JSONObject announcement = new JSONObject();
           JSONObject announcementSrc = announcements.getJSONObject(index);
@@ -46,7 +44,8 @@ public class JsonExternalBgpAdvertisementPlugin extends ExternalBgpAdvertisement
             announcement.put(key, announcementSrc.get(key));
           }
           BgpAdvertisement bgpAdvertisement =
-              mapper.readValue(announcement.toString(), BgpAdvertisement.class);
+              BatfishObjectMapper.mapper()
+                  .readValue(announcement.toString(), BgpAdvertisement.class);
           advertSet.add(bgpAdvertisement);
         }
 

--- a/projects/batfish/src/main/java/org/batfish/main/Service.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Service.java
@@ -62,7 +62,7 @@ public class Service {
       if (task == null) {
         task = new Task(TaskStatus.Unknown);
       }
-      String taskStr = new BatfishObjectMapper().writeValueAsString(task);
+      String taskStr = BatfishObjectMapper.writePrettyString(task);
       return new JSONArray(Arrays.asList(BfConsts.SVC_SUCCESS_KEY, taskStr));
     } catch (Exception e) {
       return new JSONArray(Arrays.asList(BfConsts.SVC_FAILURE_KEY, e.getMessage()));
@@ -79,7 +79,7 @@ public class Service {
         return new JSONArray(Arrays.asList(BfConsts.SVC_FAILURE_KEY, "taskid not supplied"));
       }
       Task task = Driver.killTask(taskId);
-      String taskStr = new BatfishObjectMapper().writeValueAsString(task);
+      String taskStr = BatfishObjectMapper.writePrettyString(task);
       return new JSONArray(Arrays.asList(BfConsts.SVC_SUCCESS_KEY, taskStr));
     } catch (Exception e) {
       return new JSONArray(Arrays.asList(BfConsts.SVC_FAILURE_KEY, e.getMessage()));

--- a/projects/batfish/src/main/java/org/batfish/representation/host/HostConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/host/HostConfiguration.java
@@ -2,9 +2,6 @@ package org.batfish.representation.host;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
@@ -67,10 +64,9 @@ public class HostConfiguration extends VendorConfiguration {
   /** */
   private static final long serialVersionUID = 1L;
 
-  public static HostConfiguration fromJson(String text, Warnings warnings)
-      throws JsonParseException, JsonMappingException, IOException {
-    ObjectMapper mapper = new BatfishObjectMapper();
-    HostConfiguration hostConfiguration = mapper.readValue(text, HostConfiguration.class);
+  public static HostConfiguration fromJson(String text, Warnings warnings) throws IOException {
+    HostConfiguration hostConfiguration =
+        BatfishObjectMapper.mapper().readValue(text, HostConfiguration.class);
     hostConfiguration._w = warnings;
     return hostConfiguration;
   }

--- a/projects/batfish/src/test/java/org/batfish/grammar/host/HostInterfaceTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/host/HostInterfaceTest.java
@@ -10,7 +10,6 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import org.batfish.common.Warnings;
 import org.batfish.common.util.BatfishObjectMapper;
@@ -48,13 +47,10 @@ public class HostInterfaceTest {
 
   private NetworkFactory _factory;
 
-  private ObjectMapper _mapper;
-
   private Warnings _w;
 
   @Before
   public void setup() {
-    _mapper = new BatfishObjectMapper();
     _factory = new NetworkFactory();
     _c =
         _factory
@@ -80,11 +76,12 @@ public class HostInterfaceTest {
     String ifaceNonShared2Text =
         "{\"name\":\"non_shared2_interface\", \"prefix\":\"" + nonShared2Prefix + "\"}";
 
-    HostInterface sharedHostInterface = _mapper.readValue(ifaceSharedText, HostInterface.class);
+    HostInterface sharedHostInterface =
+        BatfishObjectMapper.mapper().readValue(ifaceSharedText, HostInterface.class);
     HostInterface nonShared1HostInterface =
-        _mapper.readValue(ifaceNonShared1Text, HostInterface.class);
+        BatfishObjectMapper.mapper().readValue(ifaceNonShared1Text, HostInterface.class);
     HostInterface nonShared2HostInterface =
-        _mapper.readValue(ifaceNonShared2Text, HostInterface.class);
+        BatfishObjectMapper.mapper().readValue(ifaceNonShared2Text, HostInterface.class);
     Interface sharedInterface = sharedHostInterface.toInterface(_c, _w);
     Interface nonShared1Interface = nonShared1HostInterface.toInterface(_c, _w);
     Interface nonShared2Interface = nonShared2HostInterface.toInterface(_c, _w);

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/AnalysisMetadataMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/AnalysisMetadataMgr.java
@@ -57,7 +57,7 @@ public class AnalysisMetadataMgr {
 
   public static AnalysisMetadata readMetadata(Path metadataPath) throws IOException {
     String jsonStr = CommonUtil.readFile(metadataPath);
-    return new BatfishObjectMapper().readValue(jsonStr, AnalysisMetadata.class);
+    return BatfishObjectMapper.mapper().readValue(jsonStr, AnalysisMetadata.class);
   }
 
   public static void writeMetadata(AnalysisMetadata metadata, String container, String analysis)
@@ -67,6 +67,6 @@ public class AnalysisMetadataMgr {
 
   public static synchronized void writeMetadata(AnalysisMetadata metadata, Path metadataPath)
       throws JsonProcessingException {
-    CommonUtil.writeFile(metadataPath, new BatfishObjectMapper().writeValueAsString(metadata));
+    CommonUtil.writeFile(metadataPath, BatfishObjectMapper.writePrettyString(metadata));
   }
 }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/Main.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/Main.java
@@ -98,9 +98,8 @@ public class Main {
       if (questionObj.has(BfConsts.PROP_INSTANCE) && !questionObj.isNull(BfConsts.PROP_INSTANCE)) {
         JSONObject instanceDataObj = questionObj.getJSONObject(BfConsts.PROP_INSTANCE);
         String instanceDataStr = instanceDataObj.toString();
-        BatfishObjectMapper mapper = new BatfishObjectMapper();
         Question.InstanceData instanceData =
-            mapper.<Question.InstanceData>readValue(instanceDataStr, Question.InstanceData.class);
+            BatfishObjectMapper.mapper().readValue(instanceDataStr, Question.InstanceData.class);
         String name = instanceData.getInstanceName();
 
         if (templates.containsKey(name)) {

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/TestrigMetadataMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/TestrigMetadataMgr.java
@@ -44,7 +44,7 @@ public class TestrigMetadataMgr {
 
   public static TestrigMetadata readMetadata(Path metadataPath) throws IOException {
     String jsonStr = CommonUtil.readFile(metadataPath);
-    return new BatfishObjectMapper().readValue(jsonStr, TestrigMetadata.class);
+    return BatfishObjectMapper.mapper().readValue(jsonStr, TestrigMetadata.class);
   }
 
   public static void writeMetadata(TestrigMetadata metadata, String container, String testrig)
@@ -54,7 +54,7 @@ public class TestrigMetadataMgr {
 
   public static synchronized void writeMetadata(TestrigMetadata metadata, Path metadataPath)
       throws JsonProcessingException {
-    CommonUtil.writeFile(metadataPath, new BatfishObjectMapper().writeValueAsString(metadata));
+    CommonUtil.writeFile(metadataPath, BatfishObjectMapper.writePrettyString(metadata));
   }
 
   public static synchronized void updateEnvironmentStatus(

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/authorizer/FileAuthorizer.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/authorizer/FileAuthorizer.java
@@ -133,8 +133,7 @@ public class FileAuthorizer implements Authorizer {
 
   private Permissions loadPermissions() {
     try {
-      BatfishObjectMapper mapper = new BatfishObjectMapper();
-      return mapper.readerFor(Permissions.class).readValue(_permsFile.toFile());
+      return BatfishObjectMapper.mapper().readValue(_permsFile.toFile(), Permissions.class);
     } catch (IOException e) {
       throw new BatfishException(
           String.format("Error loading permissions from '%s'", _permsFile.toAbsolutePath()), e);
@@ -143,8 +142,7 @@ public class FileAuthorizer implements Authorizer {
 
   private void savePermissions(Permissions p) {
     try {
-      BatfishObjectMapper mapper = new BatfishObjectMapper();
-      mapper.writerFor(Permissions.class).writeValue(_permsFile.toFile(), p);
+      BatfishObjectMapper.prettyWriter().writeValue(_permsFile.toFile(), p);
     } catch (IOException e) {
       throw new BatfishException(
           String.format("Error saving permissions to '%s'", _permsFile.toAbsolutePath()), e);
@@ -153,8 +151,7 @@ public class FileAuthorizer implements Authorizer {
 
   private Users loadUsers() {
     try {
-      BatfishObjectMapper mapper = new BatfishObjectMapper();
-      return mapper.readerFor(Users.class).readValue(_usersFile.toFile());
+      return BatfishObjectMapper.mapper().readValue(_usersFile.toFile(), Users.class);
     } catch (IOException e) {
       throw new BatfishException(
           String.format("Error loading users from '%s'", _usersFile.toAbsolutePath()), e);

--- a/projects/question/src/main/java/org/batfish/question/assertion/AssertQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/assertion/AssertQuestionPlugin.java
@@ -89,10 +89,9 @@ public class AssertQuestionPlugin extends QuestionPlugin {
       nodesQuestion.setSummary(false);
       NodesAnswerer nodesAnswerer = new NodesAnswerer(nodesQuestion, _batfish);
       AnswerElement nodesAnswer = nodesAnswerer.answer();
-      BatfishObjectMapper mapper = new BatfishObjectMapper();
       String nodesAnswerStr = null;
       try {
-        nodesAnswerStr = mapper.writeValueAsString(nodesAnswer);
+        nodesAnswerStr = BatfishObjectMapper.writePrettyString(nodesAnswer);
       } catch (IOException e) {
         throw new BatfishException("Could not get JSON string from nodes answer", e);
       }

--- a/projects/question/src/main/java/org/batfish/question/assertion/Assertion.java
+++ b/projects/question/src/main/java/org/batfish/question/assertion/Assertion.java
@@ -48,9 +48,8 @@ public class Assertion {
 
   @Override
   public String toString() {
-    BatfishObjectMapper mapper = new BatfishObjectMapper(false);
     try {
-      return mapper.writeValueAsString(this);
+      return BatfishObjectMapper.writePrettyString(this);
     } catch (JsonProcessingException e) {
       throw new BatfishException("Could not map to JSON string", e);
     }

--- a/projects/question/src/main/java/org/batfish/question/jsonpath/JsonPathAssertion.java
+++ b/projects/question/src/main/java/org/batfish/question/jsonpath/JsonPathAssertion.java
@@ -74,9 +74,9 @@ public class JsonPathAssertion {
         Set<JsonPathResultEntry> expectedEntries = new HashSet<>();
         for (final JsonNode nodeEntry : _expect) {
           try {
-            BatfishObjectMapper mapper = new BatfishObjectMapper();
             JsonPathResultEntry expectedEntry =
-                mapper.readValue(nodeEntry.toString(), JsonPathResultEntry.class);
+                BatfishObjectMapper.mapper()
+                    .readValue(nodeEntry.toString(), JsonPathResultEntry.class);
             expectedEntries.add(expectedEntry);
           } catch (IOException e) {
             throw new BatfishException(
@@ -109,7 +109,7 @@ public class JsonPathAssertion {
   @Override
   public String toString() {
     try {
-      return new BatfishObjectMapper().writeValueAsString(this);
+      return BatfishObjectMapper.writePrettyString(this);
     } catch (JsonProcessingException e) {
       throw new BatfishException("Cannot serialize to Json", e);
     }

--- a/projects/question/src/main/java/org/batfish/question/jsonpath/JsonPathExtractionHint.java
+++ b/projects/question/src/main/java/org/batfish/question/jsonpath/JsonPathExtractionHint.java
@@ -30,10 +30,8 @@ public class JsonPathExtractionHint {
 
   public static JsonPathExtractionHint fromExtractionHint(Extraction extraction)
       throws IOException {
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
-    String extractionMethodStr = mapper.writeValueAsString(extraction.getMethod());
     JsonPathExtractionHint jpExtractionHint =
-        mapper.readValue(extractionMethodStr, JsonPathExtractionHint.class);
+        BatfishObjectMapper.clone(extraction.getMethod(), JsonPathExtractionHint.class);
 
     // sanity check what we got
     if (jpExtractionHint.getUse() == null) {

--- a/projects/question/src/main/java/org/batfish/question/jsonpath/JsonPathQuery.java
+++ b/projects/question/src/main/java/org/batfish/question/jsonpath/JsonPathQuery.java
@@ -101,7 +101,7 @@ public class JsonPathQuery {
   @Override
   public String toString() {
     try {
-      return new BatfishObjectMapper().writeValueAsString(this);
+      return BatfishObjectMapper.writePrettyString(this);
     } catch (JsonProcessingException e) {
       throw new BatfishException("Cannot serialize to Json", e);
     }

--- a/projects/question/src/main/java/org/batfish/question/jsonpath/JsonPathQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/jsonpath/JsonPathQuestionPlugin.java
@@ -172,10 +172,9 @@ public class JsonPathQuestionPlugin extends QuestionPlugin {
       AnswerElement innerAnswer =
           (innerQuestion.getDifferential()) ? innerAnswerer.answerDiff() : innerAnswerer.answer();
 
-      BatfishObjectMapper mapper = new BatfishObjectMapper(false /* save bytes: don't prettify */);
       String innerAnswerStr = null;
       try {
-        innerAnswerStr = mapper.writeValueAsString(innerAnswer);
+        innerAnswerStr = BatfishObjectMapper.writeString(innerAnswer);
       } catch (IOException e) {
         throw new BatfishException("Could not get JSON string from inner answer", e);
       }
@@ -424,13 +423,12 @@ public class JsonPathQuestionPlugin extends QuestionPlugin {
     @Override
     public Question configureTemplate(@Nullable String exceptions, @Nullable String assertion) {
       try {
-        BatfishObjectMapper mapper = new BatfishObjectMapper();
-        JsonPathQuestion question =
-            mapper.readValue(mapper.writeValueAsString(this), JsonPathQuestion.class); // deep copy
+        JsonPathQuestion question = BatfishObjectMapper.clone(this, JsonPathQuestion.class);
 
         if (exceptions != null) {
           Set<JsonPathException> jpExceptions =
-              mapper.readValue(exceptions, new TypeReference<Set<JsonPathException>>() {});
+              BatfishObjectMapper.mapper()
+                  .readValue(exceptions, new TypeReference<Set<JsonPathException>>() {});
           for (JsonPathQuery query : question.getPaths()) {
             query.setExceptions(jpExceptions);
           }
@@ -440,7 +438,7 @@ public class JsonPathQuestionPlugin extends QuestionPlugin {
               // indicates a desire to remove the assertion
               (assertion.equals("") || assertion.equals("{}"))
                   ? null
-                  : mapper.readValue(assertion, JsonPathAssertion.class);
+                  : BatfishObjectMapper.mapper().readValue(assertion, JsonPathAssertion.class);
 
           for (JsonPathQuery query : question.getPaths()) {
             query.setAssertion(jpAssertion);

--- a/projects/question/src/main/java/org/batfish/question/jsonpath/JsonPathResult.java
+++ b/projects/question/src/main/java/org/batfish/question/jsonpath/JsonPathResult.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.IntNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -206,7 +207,7 @@ public class JsonPathResult {
     if (listLen == 0) {
       throw new BatfishException("None of the extraction values is a list for " + compositionName);
     }
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
+    ObjectMapper mapper = BatfishObjectMapper.mapper();
     ArrayNode arrayNode = mapper.createArrayNode();
     for (int index = 0; index < listLen; index++) {
       ObjectNode object = mapper.createObjectNode();
@@ -228,7 +229,7 @@ public class JsonPathResult {
 
   private void doCompositionSingleton(
       String resultKey, String compositionName, Composition composition) {
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
+    ObjectMapper mapper = BatfishObjectMapper.mapper();
     ObjectNode object = mapper.createObjectNode();
     for (Entry<String, String> pEntry : composition.getDictionary().entrySet()) {
       String propertyName = pEntry.getKey();
@@ -331,8 +332,7 @@ public class JsonPathResult {
       }
 
       if (extraction.getSchemaAsObject().isList()) {
-        BatfishObjectMapper mapper = new BatfishObjectMapper();
-        ArrayNode arrayNode = mapper.valueToTree(extractedList);
+        ArrayNode arrayNode = BatfishObjectMapper.mapper().valueToTree(extractedList);
         _displayValues.get(entry.getKey()).put(displayVar, arrayNode);
       } else {
         if (extractedList.size() > 1) {
@@ -346,9 +346,8 @@ public class JsonPathResult {
   }
 
   private static void confirmValueType(JsonNode value, Class<?> baseClass) {
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
     try {
-      mapper.readValue(value.toString(), baseClass);
+      BatfishObjectMapper.mapper().readValue(value.toString(), baseClass);
     } catch (IOException e) {
       throw new BatfishException(
           "Could not map extracted value to expected type " + baseClass + "\nValue: " + value, e);

--- a/projects/question/src/test/java/org/batfish/question/jsonpath/JsonPathAssertionTest.java
+++ b/projects/question/src/test/java/org/batfish/question/jsonpath/JsonPathAssertionTest.java
@@ -45,10 +45,10 @@ public class JsonPathAssertionTest {
             "org/batfish/question/jsonpath/jsonPathAssertionTest.json",
             "$.nodes..interface1.mtu",
             true);
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
     JsonPathAssertion jpAssertion =
         new JsonPathAssertion(
-            JsonPathAssertionType.countequals, mapper.readValue("2", JsonNode.class));
+            JsonPathAssertionType.countequals,
+            BatfishObjectMapper.mapper().readValue("2", JsonNode.class));
     boolean result = jpAssertion.evaluate(results);
     assertThat(result, equalTo(false));
   }
@@ -58,10 +58,10 @@ public class JsonPathAssertionTest {
     Set<JsonPathResultEntry> results =
         computeResults(
             "org/batfish/question/jsonpath/jsonPathAssertionTest.json", "$.nodes..mtu", true);
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
     JsonPathAssertion jpAssertion =
         new JsonPathAssertion(
-            JsonPathAssertionType.countequals, mapper.readValue("2", JsonNode.class));
+            JsonPathAssertionType.countequals,
+            BatfishObjectMapper.mapper().readValue("2", JsonNode.class));
     boolean result = jpAssertion.evaluate(results);
     assertThat(result, equalTo(true));
   }
@@ -73,11 +73,11 @@ public class JsonPathAssertionTest {
             "org/batfish/question/jsonpath/jsonPathAssertionTest.json",
             "$.nodes..interface1.mtu",
             false);
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
     JsonPathAssertion jpAssertion =
         new JsonPathAssertion(
             JsonPathAssertionType.equals,
-            mapper.readValue("[{\"concretePath\": [\"'kkl'\"]}]", JsonNode.class));
+            BatfishObjectMapper.mapper()
+                .readValue("[{\"concretePath\": [\"'kkl'\"]}]", JsonNode.class));
     boolean result = jpAssertion.evaluate(results);
     assertThat(result, equalTo(false));
   }
@@ -87,14 +87,14 @@ public class JsonPathAssertionTest {
     Set<JsonPathResultEntry> results =
         computeResults(
             "org/batfish/question/jsonpath/jsonPathAssertionTest.json", "$..ntpServers", true);
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
     JsonNode expect =
-        mapper.readValue(
-            "[{"
-                + "\"concretePath\": [\"'nodes'\", \"'node1'\", \"'ntpServers'\"], "
-                + "\"suffix\" : [\"1.2.3.4\", \"5.6.7.8\"]"
-                + "}]",
-            JsonNode.class);
+        BatfishObjectMapper.mapper()
+            .readValue(
+                "[{"
+                    + "\"concretePath\": [\"'nodes'\", \"'node1'\", \"'ntpServers'\"], "
+                    + "\"suffix\" : [\"1.2.3.4\", \"5.6.7.8\"]"
+                    + "}]",
+                JsonNode.class);
     JsonPathAssertion jpAssertion = new JsonPathAssertion(JsonPathAssertionType.equals, expect);
     boolean result = jpAssertion.evaluate(results);
     assertThat(result, equalTo(true));
@@ -105,9 +105,9 @@ public class JsonPathAssertionTest {
     Set<JsonPathResultEntry> results =
         computeResults(
             "org/batfish/question/jsonpath/jsonPathAssertionTest.json", "$..node1", false);
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
     JsonNode expect =
-        mapper.readValue("[{\"concretePath\": [\"'nodes'\", \"'node1'\"]}]", JsonNode.class);
+        BatfishObjectMapper.mapper()
+            .readValue("[{\"concretePath\": [\"'nodes'\", \"'node1'\"]}]", JsonNode.class);
     JsonPathAssertion jpAssertion = new JsonPathAssertion(JsonPathAssertionType.equals, expect);
     boolean result = jpAssertion.evaluate(results);
     assertThat(result, equalTo(true));

--- a/projects/question/src/test/java/org/batfish/question/jsonpath/JsonPathDisplayHintsTest.java
+++ b/projects/question/src/test/java/org/batfish/question/jsonpath/JsonPathDisplayHintsTest.java
@@ -33,8 +33,7 @@ public class JsonPathDisplayHintsTest {
   public void readDisplayHints() throws IOException {
     String text =
         CommonUtil.readResource("org/batfish/question/jsonpath/jsonPathDisplayHintsTestHints.json");
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
-    _displayHints = mapper.readValue(text, DisplayHints.class);
+    _displayHints = BatfishObjectMapper.mapper().readValue(text, DisplayHints.class);
   }
 
   private static JsonPathResult computeJsonPathResult(

--- a/projects/question/src/test/java/org/batfish/question/jsonpath/JsonPathQuestionPluginTest.java
+++ b/projects/question/src/test/java/org/batfish/question/jsonpath/JsonPathQuestionPluginTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Set;
@@ -17,7 +18,7 @@ public class JsonPathQuestionPluginTest {
 
   @Test
   public void configureTemplateTest() throws IOException {
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
+    ObjectMapper mapper = BatfishObjectMapper.mapper();
 
     Set<JsonPathException> oldExceptions =
         Collections.singleton(new JsonPathException(Collections.singletonList("old"), null));
@@ -46,7 +47,7 @@ public class JsonPathQuestionPluginTest {
 
   @Test
   public void configureTemplateTestNullValues() throws IOException {
-    BatfishObjectMapper mapper = new BatfishObjectMapper();
+    ObjectMapper mapper = BatfishObjectMapper.mapper();
 
     Set<JsonPathException> oldExceptions =
         Collections.singleton(new JsonPathException(Collections.singletonList("old"), null));


### PR DESCRIPTION
ObjectMapper/ObjectWriter is threadsafe and should not be mutated after configuration, so why not make it a singleton?