### PR TITLE
WorkMgr: validate questions before accepting and saving them

### DIFF
--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -1534,7 +1534,14 @@ public class WorkMgr extends AbstractCoordinator {
     CommonUtil.deleteIfExists(zipFile);
   }
 
-  public void uploadQuestion(String containerName, String qName, InputStream fileStream) {
+  public void uploadQuestion(String containerName, String qName, String questionJson) {
+    // Validate the question before saving it to disk.
+    try {
+      Question.parseQuestion(questionJson);
+    } catch (Exception e) {
+      throw new BatfishException(String.format("Invalid question %s/%s", containerName, qName), e);
+    }
+
     Path containerDir = getdirContainer(containerName);
     Path qDir = containerDir.resolve(Paths.get(BfConsts.RELPATH_QUESTIONS_DIR, qName));
     if (Files.exists(qDir)) {
@@ -1545,7 +1552,7 @@ public class WorkMgr extends AbstractCoordinator {
       throw new BatfishException("Failed to create directory: '" + qDir + "'");
     }
     Path file = qDir.resolve(BfConsts.RELPATH_QUESTION_FILE);
-    CommonUtil.writeStreamToFile(fileStream, file);
+    CommonUtil.writeFile(file, questionJson);
   }
 
   public void uploadTestrig(

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
@@ -1629,7 +1629,7 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
       @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String testrigName,
       @FormDataParam(CoordConsts.SVC_KEY_QUESTION_NAME) String qName,
-      @FormDataParam(CoordConsts.SVC_KEY_FILE) InputStream fileStream) {
+      @FormDataParam(CoordConsts.SVC_KEY_FILE) String questionJson) {
     try {
       _logger.infof("WMS:uploadQuestion %s %s %s/%s\n", apiKey, containerName, testrigName, qName);
 
@@ -1642,7 +1642,7 @@ public class WorkMgrService {
       checkClientVersion(clientVersion);
       checkContainerAccessibility(apiKey, containerName);
 
-      Main.getWorkMgr().uploadQuestion(containerName, qName, fileStream);
+      Main.getWorkMgr().uploadQuestion(containerName, qName, questionJson);
 
       return successResponse(new JSONObject().put("result", "successfully uploaded question"));
 


### PR DESCRIPTION
Right now, we don't find out questions have bad parameters until we run them. This PR changes this by having the coordinator validate the question before saving it to disk.

@ratulm opinion?