### PR TITLE
Enable recording warnings per AWS config node

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/Warnings.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/Warnings.java
@@ -165,6 +165,17 @@ public class Warnings implements Serializable {
     _unimplementedRecord = unimplementedRecord;
   }
 
+  public Warnings(Warnings other) {
+    this();
+    _pedanticAsError = other._pedanticAsError;
+    _pedanticRecord = other._pedanticRecord;
+    _printParseTree = other._printParseTree;
+    _redFlagAsError = other._redFlagAsError;
+    _redFlagRecord = other._redFlagRecord;
+    _unimplementedAsError = other._unimplementedAsError;
+    _unimplementedRecord = other._unimplementedRecord;
+  }
+
   public boolean getPedanticAsError() {
     return _pedanticAsError;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/Warnings.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/Warnings.java
@@ -165,17 +165,6 @@ public class Warnings implements Serializable {
     _unimplementedRecord = unimplementedRecord;
   }
 
-  public Warnings(Warnings other) {
-    this();
-    _pedanticAsError = other._pedanticAsError;
-    _pedanticRecord = other._pedanticRecord;
-    _printParseTree = other._printParseTree;
-    _redFlagAsError = other._redFlagAsError;
-    _redFlagRecord = other._redFlagRecord;
-    _unimplementedAsError = other._unimplementedAsError;
-    _unimplementedRecord = other._unimplementedRecord;
-  }
-
   public boolean getPedanticAsError() {
     return _pedanticAsError;
   }

--- a/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
@@ -35,6 +35,7 @@ public class ConvertConfigurationJob extends BatfishJob<ConvertConfigurationResu
     long elapsedTime;
     _logger.infof("Processing: \"%s\"", _name);
     Map<String, Configuration> configurations = new HashMap<>();
+    Map<String, Warnings> warningsByHost = new HashMap<>();
     ConvertConfigurationAnswerElement answerElement = new ConvertConfigurationAnswerElement();
     try {
       // We have only two options: AWS VPCs or router configs
@@ -74,8 +75,10 @@ public class ConvertConfigurationJob extends BatfishJob<ConvertConfigurationResu
         }
 
         configurations.put(_name, configuration);
+        warningsByHost.put(_name, _warnings);
       } else {
-        configurations = ((AwsConfiguration) _configObject).toConfigurations(_warnings);
+        configurations =
+            ((AwsConfiguration) _configObject).toConfigurations(_warnings, warningsByHost);
       }
       _logger.info(" ...OK\n");
     } catch (Exception e) {
@@ -88,6 +91,6 @@ public class ConvertConfigurationJob extends BatfishJob<ConvertConfigurationResu
     }
     elapsedTime = System.currentTimeMillis() - startTime;
     return new ConvertConfigurationResult(
-        elapsedTime, _logger.getHistory(), _warnings, _name, configurations, answerElement);
+        elapsedTime, _logger.getHistory(), warningsByHost, _name, configurations, answerElement);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationResult.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationResult.java
@@ -18,7 +18,7 @@ public class ConvertConfigurationResult
 
   private String _name;
 
-  private Warnings _warnings;
+  private Map<String, Warnings> _warningsByHost;
 
   public ConvertConfigurationResult(
       long elapsedTime, BatfishLoggerHistory history, String name, Throwable failureCause) {
@@ -29,13 +29,13 @@ public class ConvertConfigurationResult
   public ConvertConfigurationResult(
       long elapsedTime,
       BatfishLoggerHistory history,
-      Warnings warnings,
+      Map<String, Warnings> warningsByHost,
       String name,
       Map<String, Configuration> configurations,
       ConvertConfigurationAnswerElement answerElement) {
     super(elapsedTime, history);
     _name = name;
-    _warnings = warnings;
+    _warningsByHost = warningsByHost;
     _configurations = configurations;
     _answerElement = answerElement;
   }
@@ -65,8 +65,8 @@ public class ConvertConfigurationResult
           throw new BatfishException("Duplicate hostname: " + hostname);
         } else {
           configurations.put(hostname, config);
-          if (!_warnings.isEmpty()) {
-            answerElement.getWarnings().put(hostname, _warnings);
+          if (_warningsByHost.containsKey(hostname) && !_warningsByHost.get(hostname).isEmpty()) {
+            answerElement.getWarnings().put(hostname, _warningsByHost.get(hostname));
           }
           if (!_answerElement.getUnusedStructures().isEmpty()) {
             answerElement.getUnusedStructures().putAll(_answerElement.getUnusedStructures());

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/AwsConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/AwsConfiguration.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.Pair;
 import org.batfish.common.Warnings;
+import org.batfish.config.Settings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.GenericConfigObject;
 import org.batfish.datamodel.InterfaceAddress;
@@ -26,7 +27,7 @@ public class AwsConfiguration implements Serializable, GenericConfigObject {
 
   private Map<String, Region> _regions = new HashMap<>();
 
-  private transient Warnings _warnings;
+  private Settings _settings;
 
   private transient Map<String, Warnings> _warningsByHost;
 
@@ -58,8 +59,8 @@ public class AwsConfiguration implements Serializable, GenericConfigObject {
     return new Pair<>(val, val2);
   }
 
-  public Warnings getWarnings() {
-    return _warnings;
+  public Settings getSettings() {
+    return _settings;
   }
 
   public Map<String, Warnings> getWarningsByHost() {
@@ -67,9 +68,9 @@ public class AwsConfiguration implements Serializable, GenericConfigObject {
   }
 
   public Map<String, Configuration> toConfigurations(
-      Warnings warnings, Map<String, Warnings> warningsByHost) {
-    _warnings = warnings;
+      Settings settings, Map<String, Warnings> warningsByHost) {
     _warningsByHost = warningsByHost;
+    _settings = settings;
 
     for (Region region : _regions.values()) {
       region.toConfigurationNodes(this, _configurationNodes);

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/AwsConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/AwsConfiguration.java
@@ -28,6 +28,8 @@ public class AwsConfiguration implements Serializable, GenericConfigObject {
 
   private transient Warnings _warnings;
 
+  private transient Map<String, Warnings> _warningsByHost;
+
   public AwsConfiguration() {
     _currentGeneratedIpAsLong = INITIAL_GENERATED_IP;
   }
@@ -60,8 +62,14 @@ public class AwsConfiguration implements Serializable, GenericConfigObject {
     return _warnings;
   }
 
-  public Map<String, Configuration> toConfigurations(Warnings warnings) {
+  public Map<String, Warnings> getWarningsByHost() {
+    return _warningsByHost;
+  }
+
+  public Map<String, Configuration> toConfigurations(
+      Warnings warnings, Map<String, Warnings> warningsByHost) {
     _warnings = warnings;
+    _warningsByHost = warningsByHost;
 
     for (Region region : _regions.values()) {
       region.toConfigurationNodes(this, _configurationNodes);

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/ElasticsearchDomain.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/ElasticsearchDomain.java
@@ -5,6 +5,7 @@ import java.util.LinkedList;
 import java.util.List;
 import org.batfish.common.BatfishException;
 import org.batfish.common.BatfishLogger;
+import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
@@ -75,7 +76,8 @@ public class ElasticsearchDomain implements AwsVpcEntity, Serializable {
     }
   }
 
-  public Configuration toConfigurationNode(AwsConfiguration awsVpcConfig, Region region) {
+  public Configuration toConfigurationNode(
+      AwsConfiguration awsVpcConfig, Region region, Warnings warnings) {
     Configuration cfgNode = Utils.newAwsConfiguration(_domainName, "aws");
 
     String sgIngressAclName = "~SECURITY_GROUP_INGRESS_ACL~";

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Instance.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Instance.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.SortedSet;
 import org.batfish.common.BatfishException;
 import org.batfish.common.BatfishLogger;
+import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.InterfaceAddress;
@@ -171,7 +172,8 @@ public class Instance implements AwsVpcEntity, Serializable {
     }
   }
 
-  public Configuration toConfigurationNode(AwsConfiguration awsVpcConfig, Region region) {
+  public Configuration toConfigurationNode(
+      AwsConfiguration awsVpcConfig, Region region, Warnings warnings) {
     String sgIngressAclName = "~SECURITY_GROUP_INGRESS_ACL~";
     String sgEgressAclName = "~SECURITY_GROUP_EGRESS_ACL~";
     String name = _tags.getOrDefault("Name", _instanceId);

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/InternetGateway.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/InternetGateway.java
@@ -5,6 +5,7 @@ import java.util.LinkedList;
 import java.util.List;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.Pair;
+import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.StaticRoute;
@@ -35,7 +36,8 @@ public class InternetGateway implements AwsVpcEntity, Serializable {
     return _internetGatewayId;
   }
 
-  public Configuration toConfigurationNode(AwsConfiguration awsConfiguration, Region region) {
+  public Configuration toConfigurationNode(
+      AwsConfiguration awsConfiguration, Region region, Warnings warnings) {
     Configuration cfgNode = Utils.newAwsConfiguration(_internetGatewayId, "aws");
     cfgNode.getVendorFamily().getAws().setRegion(region.getName());
 

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/NatGateway.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/NatGateway.java
@@ -4,6 +4,7 @@ import java.io.Serializable;
 import java.util.LinkedList;
 import java.util.List;
 import org.batfish.common.BatfishLogger;
+import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Ip;
 import org.codehaus.jettison.json.JSONArray;
@@ -58,7 +59,8 @@ public class NatGateway implements AwsVpcEntity, Serializable {
     return _vpcId;
   }
 
-  public Configuration toConfigurationNode(AwsConfiguration awsConfiguration, Region region) {
+  public Configuration toConfigurationNode(
+      AwsConfiguration awsConfiguration, Region region, Warnings warnings) {
     Configuration cfgNode = Utils.newAwsConfiguration(_natGatewayId, "aws");
     cfgNode.getVendorFamily().getAws().setRegion(region.getName());
 

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/RdsInstance.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/RdsInstance.java
@@ -8,6 +8,7 @@ import java.util.LinkedList;
 import java.util.List;
 import org.batfish.common.BatfishException;
 import org.batfish.common.BatfishLogger;
+import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
@@ -111,7 +112,8 @@ public class RdsInstance implements AwsVpcEntity, Serializable {
     }
   }
 
-  public Configuration toConfigurationNode(AwsConfiguration awsVpcConfig, Region region) {
+  public Configuration toConfigurationNode(
+      AwsConfiguration awsVpcConfig, Region region, Warnings warning) {
     Configuration cfgNode = Utils.newAwsConfiguration(_dbInstanceIdentifier, "aws");
 
     String sgIngressAclName = "~SECURITY_GROUP_INGRESS_ACL~";

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Region.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Region.java
@@ -12,6 +12,7 @@ import org.batfish.datamodel.DeviceType;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Vrf;
+import org.batfish.main.Batfish;
 import org.batfish.representation.aws.Instance.Status;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
@@ -262,14 +263,14 @@ public class Region implements Serializable {
     // updates the Ips which have been allocated already in subnets of all interfaces
     updateAllocatedIps();
     for (Vpc vpc : getVpcs().values()) {
-      Warnings warnings = new Warnings(awsConfiguration.getWarnings());
+      Warnings warnings = Batfish.buildWarnings(awsConfiguration.getSettings());
       Configuration cfgNode = vpc.toConfigurationNode(awsConfiguration, this, warnings);
       configurationNodes.put(cfgNode.getName(), cfgNode);
       awsConfiguration.getWarningsByHost().put(cfgNode.getName(), warnings);
     }
 
     for (ElasticsearchDomain elasticsearchDomain : getElasticSearchDomains().values()) {
-      Warnings warnings = new Warnings(awsConfiguration.getWarnings());
+      Warnings warnings = Batfish.buildWarnings(awsConfiguration.getSettings());
       Configuration cfgNode =
           elasticsearchDomain.toConfigurationNode(awsConfiguration, this, warnings);
       configurationNodes.put(cfgNode.getName(), cfgNode);
@@ -277,14 +278,14 @@ public class Region implements Serializable {
     }
 
     for (InternetGateway igw : getInternetGateways().values()) {
-      Warnings warnings = new Warnings(awsConfiguration.getWarnings());
+      Warnings warnings = Batfish.buildWarnings(awsConfiguration.getSettings());
       Configuration cfgNode = igw.toConfigurationNode(awsConfiguration, this, warnings);
       configurationNodes.put(cfgNode.getName(), cfgNode);
       awsConfiguration.getWarningsByHost().put(cfgNode.getName(), warnings);
     }
 
     for (NatGateway ngw : getNatGateways().values()) {
-      Warnings warnings = new Warnings(awsConfiguration.getWarnings());
+      Warnings warnings = Batfish.buildWarnings(awsConfiguration.getSettings());
       warnings.redFlag("NAT functionality not yet implemented for " + ngw.getId());
       Configuration cfgNode = ngw.toConfigurationNode(awsConfiguration, this, warnings);
       configurationNodes.put(cfgNode.getName(), cfgNode);
@@ -292,14 +293,14 @@ public class Region implements Serializable {
     }
 
     for (VpnGateway vgw : getVpnGateways().values()) {
-      Warnings warnings = new Warnings(awsConfiguration.getWarnings());
+      Warnings warnings = Batfish.buildWarnings(awsConfiguration.getSettings());
       Configuration cfgNode = vgw.toConfigurationNode(awsConfiguration, this, warnings);
       configurationNodes.put(cfgNode.getName(), cfgNode);
       awsConfiguration.getWarningsByHost().put(cfgNode.getName(), warnings);
     }
 
     for (Instance instance : getInstances().values()) {
-      Warnings warnings = new Warnings(awsConfiguration.getWarnings());
+      Warnings warnings = Batfish.buildWarnings(awsConfiguration.getSettings());
       Configuration cfgNode = instance.toConfigurationNode(awsConfiguration, this, warnings);
       cfgNode.setDeviceType(DeviceType.HOST);
       configurationNodes.put(cfgNode.getName(), cfgNode);
@@ -307,21 +308,21 @@ public class Region implements Serializable {
     }
 
     for (RdsInstance rdsInstance : getRdsInstances().values()) {
-      Warnings warnings = new Warnings(awsConfiguration.getWarnings());
+      Warnings warnings = Batfish.buildWarnings(awsConfiguration.getSettings());
       Configuration cfgNode = rdsInstance.toConfigurationNode(awsConfiguration, this, warnings);
       configurationNodes.put(cfgNode.getName(), cfgNode);
       awsConfiguration.getWarningsByHost().put(cfgNode.getName(), warnings);
     }
 
     for (Subnet subnet : getSubnets().values()) {
-      Warnings warnings = new Warnings(awsConfiguration.getWarnings());
+      Warnings warnings = Batfish.buildWarnings(awsConfiguration.getSettings());
       Configuration cfgNode = subnet.toConfigurationNode(awsConfiguration, this, warnings);
       configurationNodes.put(cfgNode.getName(), cfgNode);
       awsConfiguration.getWarningsByHost().put(cfgNode.getName(), warnings);
     }
 
     for (VpnConnection vpnConnection : getVpnConnections().values()) {
-      Warnings warnings = new Warnings(awsConfiguration.getWarnings());
+      Warnings warnings = Batfish.buildWarnings(awsConfiguration.getSettings());
       vpnConnection.applyToVpnGateway(awsConfiguration, this, warnings);
       awsConfiguration.getWarningsByHost().put(vpnConnection.getId(), warnings);
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Region.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Region.java
@@ -6,6 +6,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.batfish.common.BatfishLogger;
+import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DeviceType;
 import org.batfish.datamodel.Interface;
@@ -260,53 +261,69 @@ public class Region implements Serializable {
 
     // updates the Ips which have been allocated already in subnets of all interfaces
     updateAllocatedIps();
-
     for (Vpc vpc : getVpcs().values()) {
-      Configuration cfgNode = vpc.toConfigurationNode(awsConfiguration, this);
+      Warnings warnings = new Warnings(awsConfiguration.getWarnings());
+      Configuration cfgNode = vpc.toConfigurationNode(awsConfiguration, this, warnings);
       configurationNodes.put(cfgNode.getName(), cfgNode);
+      awsConfiguration.getWarningsByHost().put(cfgNode.getName(), warnings);
     }
 
     for (ElasticsearchDomain elasticsearchDomain : getElasticSearchDomains().values()) {
-      Configuration cfgNode = elasticsearchDomain.toConfigurationNode(awsConfiguration, this);
+      Warnings warnings = new Warnings(awsConfiguration.getWarnings());
+      Configuration cfgNode =
+          elasticsearchDomain.toConfigurationNode(awsConfiguration, this, warnings);
       configurationNodes.put(cfgNode.getName(), cfgNode);
+      awsConfiguration.getWarningsByHost().put(cfgNode.getName(), warnings);
     }
 
     for (InternetGateway igw : getInternetGateways().values()) {
-      Configuration cfgNode = igw.toConfigurationNode(awsConfiguration, this);
+      Warnings warnings = new Warnings(awsConfiguration.getWarnings());
+      Configuration cfgNode = igw.toConfigurationNode(awsConfiguration, this, warnings);
       configurationNodes.put(cfgNode.getName(), cfgNode);
+      awsConfiguration.getWarningsByHost().put(cfgNode.getName(), warnings);
     }
 
     for (NatGateway ngw : getNatGateways().values()) {
-      awsConfiguration
-          .getWarnings()
-          .redFlag("NAT functionality not yet implemented for " + ngw.getId());
-      Configuration cfgNode = ngw.toConfigurationNode(awsConfiguration, this);
+      Warnings warnings = new Warnings(awsConfiguration.getWarnings());
+      warnings.redFlag("NAT functionality not yet implemented for " + ngw.getId());
+      Configuration cfgNode = ngw.toConfigurationNode(awsConfiguration, this, warnings);
       configurationNodes.put(cfgNode.getName(), cfgNode);
+      awsConfiguration.getWarningsByHost().put(cfgNode.getName(), warnings);
     }
 
     for (VpnGateway vgw : getVpnGateways().values()) {
-      Configuration cfgNode = vgw.toConfigurationNode(awsConfiguration, this);
+      Warnings warnings = new Warnings(awsConfiguration.getWarnings());
+      Configuration cfgNode = vgw.toConfigurationNode(awsConfiguration, this, warnings);
       configurationNodes.put(cfgNode.getName(), cfgNode);
+      awsConfiguration.getWarningsByHost().put(cfgNode.getName(), warnings);
     }
 
     for (Instance instance : getInstances().values()) {
-      Configuration cfgNode = instance.toConfigurationNode(awsConfiguration, this);
+      Warnings warnings = new Warnings(awsConfiguration.getWarnings());
+      Configuration cfgNode = instance.toConfigurationNode(awsConfiguration, this, warnings);
       cfgNode.setDeviceType(DeviceType.HOST);
       configurationNodes.put(cfgNode.getName(), cfgNode);
+      awsConfiguration.getWarningsByHost().put(cfgNode.getName(), warnings);
     }
 
     for (RdsInstance rdsInstance : getRdsInstances().values()) {
-      Configuration cfgNode = rdsInstance.toConfigurationNode(awsConfiguration, this);
+      Warnings warnings = new Warnings(awsConfiguration.getWarnings());
+      Configuration cfgNode = rdsInstance.toConfigurationNode(awsConfiguration, this, warnings);
       configurationNodes.put(cfgNode.getName(), cfgNode);
+      awsConfiguration.getWarningsByHost().put(cfgNode.getName(), warnings);
     }
 
     for (Subnet subnet : getSubnets().values()) {
-      Configuration cfgNode = subnet.toConfigurationNode(awsConfiguration, this);
+      Warnings warnings = new Warnings(awsConfiguration.getWarnings());
+      Configuration cfgNode = subnet.toConfigurationNode(awsConfiguration, this, warnings);
       configurationNodes.put(cfgNode.getName(), cfgNode);
+      awsConfiguration.getWarningsByHost().put(cfgNode.getName(), warnings);
     }
 
     for (VpnConnection vpnConnection : getVpnConnections().values()) {
-      vpnConnection.applyToVpnGateway(awsConfiguration, this);
+      Warnings warnings = new Warnings(awsConfiguration.getWarnings());
+      vpnConnection.applyToVpnGateway(awsConfiguration, this, warnings);
+      awsConfiguration.getWarningsByHost().put(vpnConnection.getId(), warnings);
     }
 
     // TODO: for now, set all interfaces to have the same bandwidth

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Route.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Route.java
@@ -7,6 +7,7 @@ import javax.annotation.Nullable;
 import org.batfish.common.BatfishException;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.Pair;
+import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.InterfaceAddress;
@@ -81,7 +82,8 @@ public class Route implements Serializable {
       @Nullable Ip igwAddress,
       @Nullable Ip vgwAddress,
       Subnet subnet,
-      Configuration subnetCfgNode) {
+      Configuration subnetCfgNode,
+      Warnings warnings) {
     // setting the common properties
     StaticRoute.Builder srBuilder =
         StaticRoute.builder()
@@ -177,14 +179,12 @@ public class Route implements Serializable {
           Configuration remoteVpcCfgNode =
               awsConfiguration.getConfigurationNodes().get(remoteVpcId);
           if (remoteVpcCfgNode == null) {
-            awsConfiguration
-                .getWarnings()
-                .redFlag(
-                    "VPC \""
-                        + localVpcId
-                        + "\" cannot peer with non-existent VPC: \""
-                        + remoteVpcId
-                        + "\"");
+            warnings.redFlag(
+                "VPC \""
+                    + localVpcId
+                    + "\" cannot peer with non-existent VPC: \""
+                    + remoteVpcId
+                    + "\"");
             return null;
           }
 
@@ -226,14 +226,12 @@ public class Route implements Serializable {
 
         case Instance:
           // TODO: create route for instance
-          awsConfiguration
-              .getWarnings()
-              .redFlag(
-                  "Skipping creating route to "
-                      + _destinationCidrBlock
-                      + " for instance: \""
-                      + _target
-                      + "\"");
+          warnings.redFlag(
+              "Skipping creating route to "
+                  + _destinationCidrBlock
+                  + " for instance: \""
+                  + _target
+                  + "\"");
           return null;
 
         default:

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Subnet.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Subnet.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 import org.batfish.common.BatfishException;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.Pair;
+import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.InterfaceAddress;
@@ -171,7 +172,8 @@ public class Subnet implements AwsVpcEntity, Serializable {
     return _vpnGatewayId;
   }
 
-  public Configuration toConfigurationNode(AwsConfiguration awsConfiguration, Region region) {
+  public Configuration toConfigurationNode(
+      AwsConfiguration awsConfiguration, Region region, Warnings warnings) {
     Configuration cfgNode = Utils.newAwsConfiguration(_subnetId, "aws");
 
     // add one interface that faces the instances

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Vpc.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Vpc.java
@@ -4,6 +4,7 @@ import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
 import org.batfish.common.BatfishLogger;
+import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Prefix;
@@ -66,7 +67,8 @@ public class Vpc implements AwsVpcEntity, Serializable {
     _vpnGatewayId = vpnGatewayId;
   }
 
-  public Configuration toConfigurationNode(AwsConfiguration awsConfiguration, Region region) {
+  public Configuration toConfigurationNode(
+      AwsConfiguration awsConfiguration, Region region, Warnings warnings) {
     Configuration cfgNode = Utils.newAwsConfiguration(_vpcId, "aws");
     cfgNode.getVendorFamily().getAws().setRegion(region.getName());
     cfgNode.getVendorFamily().getAws().setVpcId(_vpcId);

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/VpnConnection.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/VpnConnection.java
@@ -11,6 +11,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import org.batfish.common.BatfishException;
 import org.batfish.common.BatfishLogger;
+import org.batfish.common.Warnings;
 import org.batfish.datamodel.BgpNeighbor;
 import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.Configuration;
@@ -192,7 +193,8 @@ public class VpnConnection implements AwsVpcEntity, Serializable {
     }
   }
 
-  public void applyToVpnGateway(AwsConfiguration awsConfiguration, Region region) {
+  public void applyToVpnGateway(
+      AwsConfiguration awsConfiguration, Region region, Warnings warnings) {
     Configuration vpnGatewayCfgNode = awsConfiguration.getConfigurationNodes().get(_vpnGatewayId);
     for (int i = 0; i < _ipsecTunnels.size(); i++) {
       int idNum = i + 1;

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/VpnGateway.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/VpnGateway.java
@@ -5,6 +5,7 @@ import java.util.LinkedList;
 import java.util.List;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.Pair;
+import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.InterfaceAddress;
@@ -40,7 +41,8 @@ public class VpnGateway implements AwsVpcEntity, Serializable {
     return _vpnGatewayId;
   }
 
-  public Configuration toConfigurationNode(AwsConfiguration awsConfiguration, Region region) {
+  public Configuration toConfigurationNode(
+      AwsConfiguration awsConfiguration, Region region, Warnings warnings) {
     Configuration cfgNode = Utils.newAwsConfiguration(_vpnGatewayId, "aws");
     cfgNode.getVendorFamily().getAws().setRegion(region.getName());
 

--- a/test_rigs/parsing-tests/unit-tests.ref
+++ b/test_rigs/parsing-tests/unit-tests.ref
@@ -49592,14 +49592,12 @@
         },
         "nat-08c21704416f06046" : {
           "Red flags" : {
-            "1" : "MISCELLANEOUS: NAT functionality not yet implemented for nat-08c21704416f06046",
-            "2" : "MISCELLANEOUS: NAT functionality not yet implemented for nat-09fd8f73171d2d9a3"
+            "1" : "MISCELLANEOUS: NAT functionality not yet implemented for nat-08c21704416f06046"
           }
         },
         "nat-09fd8f73171d2d9a3" : {
           "Red flags" : {
-            "1" : "MISCELLANEOUS: NAT functionality not yet implemented for nat-08c21704416f06046",
-            "2" : "MISCELLANEOUS: NAT functionality not yet implemented for nat-09fd8f73171d2d9a3"
+            "1" : "MISCELLANEOUS: NAT functionality not yet implemented for nat-09fd8f73171d2d9a3"
           }
         },
         "neighbor" : {

--- a/tests/basic/init-unit-tests.ref
+++ b/tests/basic/init-unit-tests.ref
@@ -2013,14 +2013,12 @@
         },
         "nat-08c21704416f06046" : {
           "Red flags" : {
-            "1" : "MISCELLANEOUS: NAT functionality not yet implemented for nat-08c21704416f06046",
-            "2" : "MISCELLANEOUS: NAT functionality not yet implemented for nat-09fd8f73171d2d9a3"
+            "1" : "MISCELLANEOUS: NAT functionality not yet implemented for nat-08c21704416f06046"
           }
         },
         "nat-09fd8f73171d2d9a3" : {
           "Red flags" : {
-            "1" : "MISCELLANEOUS: NAT functionality not yet implemented for nat-08c21704416f06046",
-            "2" : "MISCELLANEOUS: NAT functionality not yet implemented for nat-09fd8f73171d2d9a3"
+            "1" : "MISCELLANEOUS: NAT functionality not yet implemented for nat-09fd8f73171d2d9a3"
           }
         },
         "neighbor" : {


### PR DESCRIPTION
`ConvertConfigurationResult` class supported a map of `Configurations` but accepted only a single `Warnings` object, changed that to a `Map` of `<Hostname, Warnings>` so that we can store a separate `Warnings` object for each configuration. It worked for physical `Configuration` nodes as in that case the `configurations` map contains just a single node at a time, whereas for AWS configs it contains all AWS nodes parsed.