### PR TITLE
 Client: indicate non-answer tests explicitly using raw test mode

### DIFF
--- a/projects/batfish-client/src/main/java/org/batfish/client/Client.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/Client.java
@@ -3166,11 +3166,13 @@ public class Client extends AbstractClient implements IClient {
     if (!isValidArgument(options, parameters, 1, 2, Integer.MAX_VALUE, Command.TEST)) {
       return false;
     }
+
     TestComparisonMode comparisonMode = TestComparisonMode.COMPAREANSWER;
-    if (options.size() > 0) {
-      String opt = options.get(0).toUpperCase();
-      comparisonMode = TestComparisonMode.valueOf(opt.substring(1, opt.length())); // remove '-'
+    if (!options.isEmpty()) {
+      comparisonMode =
+          TestComparisonMode.valueOf(options.get(0).substring(1).toUpperCase()); // remove '-'
     }
+
     if (parameters.get(testCommandIndex).equals(FLAG_FAILING_TEST)) {
       testCommandIndex++;
       failingTest = true;
@@ -3218,11 +3220,9 @@ public class Client extends AbstractClient implements IClient {
       }
     } else if (testCommandSucceeded) {
       try {
-        try {
+        if (TestComparisonMode.RAW != comparisonMode) {
           Answer testAnswer = BatfishObjectMapper.mapper().readValue(testOutput, Answer.class);
           testOutput = getTestComparisonString(testAnswer, comparisonMode);
-        } catch (JsonProcessingException e) {
-          // when the output cannot be converted to Answer, we use the exact string read from file
         }
 
         if (!missingReferenceFile) {

--- a/projects/batfish-client/src/main/java/org/batfish/client/Command.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/Command.java
@@ -95,7 +95,8 @@ public enum Command {
     COMPAREANSWER,
     COMPAREALL,
     COMPAREFAILURES,
-    COMPARESUMMARY
+    COMPARESUMMARY,
+    RAW
   }
 
   private static final Map<String, Command> _nameMap = buildNameMap();

--- a/tests/aws/commands
+++ b/tests/aws/commands
@@ -7,5 +7,5 @@ add-batfish-option verboseparse
 # example-aws testrig
 test tests/aws/init-example-aws.ref init-testrig test_rigs/example-aws basic-example-aws
 test tests/aws/nodes-example-aws.ref get nodes summary=false
-test tests/aws/topology-example-aws.ref get-object testrig_pojo_topology
+test -raw tests/aws/topology-example-aws.ref get-object testrig_pojo_topology
 test tests/aws/ipsecvpnstatus-example-aws.ref get ipsecvpnstatus node1Regex="lhr-border-02", problemRegex="missing.*"

--- a/tests/basic/commands
+++ b/tests/basic/commands
@@ -9,7 +9,7 @@ test -compareall tests/basic/init.ref init-testrig test_rigs/example basic-examp
 test -compareall tests/basic/init-delta.ref init-delta-testrig test_rigs/example-with-delta basic-example-delta
 test -compareall tests/basic/genDp.ref generate-dataplane
 test -compareall tests/basic/genDp-delta.ref generate-delta-dataplane
-test -compareall tests/basic/topology.ref get-object testrig_pojo_topology
+test -raw tests/basic/topology.ref get-object testrig_pojo_topology
 test tests/basic/aclReachability.ref get aclReachability
 test tests/basic/assert.ref get assert assertions=[{"assertion":"(eq 15 (pathsize '$.nodes[*]'))"},{"assertion":"(eq 0 (pathsize '$.nodes[\"as1border\"]'))"},{"assertion":"(not (eq 0 (pathsize '$.nodes[\"as1border1\"]')))"}, {"assertion":"(eq (pathsize '$.nodes[*].aaaSettings.newModel') (pathsize '$.nodes[*].aaaSettings[?(@.newModel == true)]'))"}]
 test tests/basic/bgpSessionStatus.ref get bgpsessionstatus type="ebgp.*", status="missing.*"

--- a/tests/jsonpath-addons/commands
+++ b/tests/jsonpath-addons/commands
@@ -32,7 +32,7 @@ test tests/jsonpath-addons/jsonpath-display-hints-suffixofsuffix.ref get jsonpat
 
 # load templates
 load-questions tests/jsonpath-addons/templates
-test tests/jsonpath-addons/add-exceptions-assertions.ref configure-template new1AaaAccountingCommands aaaAccountingCommands exceptions=[{"concretePath" : ["'nodes'", "'as3border1'", "'interfaces'", "'Ethernet0/0'", "'mtu'"], "suffix": 1500}], assertion={"type" : "countequals", "expect" : 3}
-test tests/jsonpath-addons/remove-assertions.ref configure-template new2AaaAccountingCommands new1AaaAccountingCommands assertion={}
-test tests/jsonpath-addons/remove-exceptions.ref configure-template new3AaaAccountingCommands new2AaaAccountingCommands exceptions=[]
+test -raw tests/jsonpath-addons/add-exceptions-assertions.ref configure-template new1AaaAccountingCommands aaaAccountingCommands exceptions=[{"concretePath" : ["'nodes'", "'as3border1'", "'interfaces'", "'Ethernet0/0'", "'mtu'"], "suffix": 1500}], assertion={"type" : "countequals", "expect" : 3}
+test -raw tests/jsonpath-addons/remove-assertions.ref configure-template new2AaaAccountingCommands new1AaaAccountingCommands assertion={}
+test -raw tests/jsonpath-addons/remove-exceptions.ref configure-template new3AaaAccountingCommands new2AaaAccountingCommands exceptions=[]
 

--- a/tests/ui-focused/commands
+++ b/tests/ui-focused/commands
@@ -7,17 +7,17 @@ add-batfish-option verboseparse
 ### creating, listing, deleting testrigs
 test tests/ui-focused/init0.ref init-testrig test_rigs/example testrig0
 test tests/ui-focused/init1.ref init-testrig test_rigs/example testrig1
-test tests/ui-focused/del-testrig.ref del-testrig testrig0
-test tests/ui-focused/list-testrigs1.ref list-testrigs -nometadata
+test -raw tests/ui-focused/del-testrig.ref del-testrig testrig0
+test -raw tests/ui-focused/list-testrigs1.ref list-testrigs -nometadata
 
 #### creating, listing, and deleting analyses
-test tests/ui-focused/init-analysis0.ref init-analysis analysis0 tests/ui-focused/templates
-test tests/ui-focused/init-analysis1.ref init-analysis analysis1 tests/ui-focused/templates
-test tests/ui-focused/del-analysis.ref del-analysis analysis0
-test tests/ui-focused/del-analysis-questions.ref del-analysis-questions analysis1 undefinedreferences uniqueipassignments
-test tests/ui-focused/list-analyses.ref list-analyses
+test -raw tests/ui-focused/init-analysis0.ref init-analysis analysis0 tests/ui-focused/templates
+test -raw tests/ui-focused/init-analysis1.ref init-analysis analysis1 tests/ui-focused/templates
+test -raw tests/ui-focused/del-analysis.ref del-analysis analysis0
+test -raw tests/ui-focused/del-analysis-questions.ref del-analysis-questions analysis1 undefinedreferences uniqueipassignments
+test -raw tests/ui-focused/list-analyses.ref list-analyses
 
 #### run analysis and getting results
-test tests/ui-focused/analysis-answers-before.ref get-analysis-answers analysis1
+test -raw tests/ui-focused/analysis-answers-before.ref get-analysis-answers analysis1
 test tests/ui-focused/run-analysis.ref run-analysis analysis1
-test tests/ui-focused/analysis-answers-after.ref get-analysis-answers analysis1
+test -raw tests/ui-focused/analysis-answers-after.ref get-analysis-answers analysis1

--- a/tests/watchdog/commands
+++ b/tests/watchdog/commands
@@ -13,6 +13,6 @@ kill-work 00000000-0000-0000-0000-000000000001
 poll-work 00000000-0000-0000-0000-000000000002
 
 # now check what happened with each
-test tests/watchdog/w1.ref get-work-status 00000000-0000-0000-0000-000000000001
-test tests/watchdog/w2.ref get-work-status 00000000-0000-0000-0000-000000000002
+test -raw tests/watchdog/w1.ref get-work-status 00000000-0000-0000-0000-000000000001
+test -raw tests/watchdog/w2.ref get-work-status 00000000-0000-0000-0000-000000000002
 


### PR DESCRIPTION
Always falling-back to comparing raw file content masks deserialization errors in answer elements.