### PR TITLE
Reorder commands and fix OspfNeighbor and yak shaving.

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
@@ -85,6 +85,7 @@ import org.batfish.datamodel.FlowTrace;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpLink;
 import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.IpWildcard;
@@ -892,7 +893,7 @@ public class CommonUtil {
                       if (remoteArea != null
                           && remoteArea.getInterfaces().contains(remoteIfaceName)) {
                         Ip remoteIp = remoteIface.getAddress().getIp();
-                        Pair<Ip, Ip> localKey = new Pair<>(localIp, remoteIp);
+                        IpLink localKey = new IpLink(localIp, remoteIp);
                         OspfNeighbor neighbor = proc.getOspfNeighbors().get(localKey);
                         if (neighbor == null) {
                           hasNeighbor = true;
@@ -906,7 +907,7 @@ public class CommonUtil {
                           proc.getOspfNeighbors().put(localKey, neighbor);
 
                           // initialize remote neighbor
-                          Pair<Ip, Ip> remoteKey = new Pair<>(remoteIp, localIp);
+                          IpLink remoteKey = new IpLink(remoteIp, localIp);
                           OspfNeighbor remoteNeighbor = new OspfNeighbor(remoteKey);
                           remoteNeighbor.setArea(areaNum);
                           remoteNeighbor.setVrf(remoteVrfName);
@@ -924,7 +925,7 @@ public class CommonUtil {
                 }
               }
               if (!hasNeighbor) {
-                Pair<Ip, Ip> key = new Pair<>(localIp, Ip.ZERO);
+                IpLink key = new IpLink(localIp, Ip.ZERO);
                 OspfNeighbor neighbor = new OspfNeighbor(key);
                 neighbor.setArea(areaNum);
                 neighbor.setVrf(vrfName);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpLink.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpLink.java
@@ -1,0 +1,57 @@
+package org.batfish.datamodel;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+
+/** Represents a link by a pair of IP addresses. */
+public final class IpLink implements Comparable<IpLink> {
+
+  private final Ip _ip1;
+  private final Ip _ip2;
+
+  @JsonCreator
+  public IpLink(@JsonProperty("ip1") Ip ip1, @JsonProperty("ip2") Ip ip2) {
+    this._ip1 = ip1;
+    this._ip2 = ip2;
+  }
+
+  public Ip getIp1() {
+    return _ip1;
+  }
+
+  public Ip getIp2() {
+    return _ip2;
+  }
+
+  @Override
+  public int compareTo(@Nonnull IpLink o) {
+    int cmp = _ip1.compareTo(o._ip1);
+    if (cmp != 0) {
+      return cmp;
+    }
+    return _ip2.compareTo(o._ip2);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    } else if (!(o instanceof IpLink)) {
+      return false;
+    }
+    IpLink other = (IpLink) o;
+    return _ip1.equals(other._ip1) && _ip2.equals(other._ip2);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_ip1, _ip2);
+  }
+
+  @Override
+  public String toString() {
+    return String.format("<%s:%s>", _ip1, _ip2);
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpLink.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpLink.java
@@ -7,20 +7,24 @@ import javax.annotation.Nonnull;
 
 /** Represents a link by a pair of IP addresses. */
 public final class IpLink implements Comparable<IpLink> {
+  private static final String PROP_IP1 = "ip1";
+  private static final String PROP_IP2 = "ip2";
 
   private final Ip _ip1;
   private final Ip _ip2;
 
   @JsonCreator
-  public IpLink(@JsonProperty("ip1") Ip ip1, @JsonProperty("ip2") Ip ip2) {
+  public IpLink(@JsonProperty(PROP_IP1) Ip ip1, @JsonProperty(PROP_IP2) Ip ip2) {
     this._ip1 = ip1;
     this._ip2 = ip2;
   }
 
+  @JsonProperty(PROP_IP1)
   public Ip getIp1() {
     return _ip1;
   }
 
+  @JsonProperty(PROP_IP2)
   public Ip getIp2() {
     return _ip2;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfNeighbor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfNeighbor.java
@@ -3,10 +3,9 @@ package org.batfish.datamodel;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.batfish.common.Pair;
 import org.batfish.common.util.ComparableStructure;
 
-public class OspfNeighbor extends ComparableStructure<Pair<Ip, Ip>> {
+public class OspfNeighbor extends ComparableStructure<IpLink> {
 
   public static final class OspfNeighborSummary extends ComparableStructure<String> {
 
@@ -27,8 +26,8 @@ public class OspfNeighbor extends ComparableStructure<Pair<Ip, Ip>> {
 
     public OspfNeighborSummary(OspfNeighbor ospfNeighbor) {
       super(ospfNeighbor.getOwner().getName() + ":" + ospfNeighbor._key);
-      _localIp = ospfNeighbor._key.getFirst();
-      _remoteIp = ospfNeighbor._key.getSecond();
+      _localIp = ospfNeighbor._key.getIp1();
+      _remoteIp = ospfNeighbor._key.getIp2();
       _vrf = ospfNeighbor._vrf;
     }
 
@@ -73,7 +72,8 @@ public class OspfNeighbor extends ComparableStructure<Pair<Ip, Ip>> {
 
   private String _vrf;
 
-  public OspfNeighbor(Pair<Ip, Ip> ipEdge) {
+  @JsonCreator
+  public OspfNeighbor(@JsonProperty(PROP_NAME) IpLink ipEdge) {
     super(ipEdge);
   }
 
@@ -87,7 +87,7 @@ public class OspfNeighbor extends ComparableStructure<Pair<Ip, Ip>> {
 
   @JsonIgnore
   public Ip getLocalIp() {
-    return _key.getFirst();
+    return _key.getIp1();
   }
 
   @JsonIgnore
@@ -97,7 +97,7 @@ public class OspfNeighbor extends ComparableStructure<Pair<Ip, Ip>> {
 
   @JsonIgnore
   public Ip getRemoteIp() {
-    return _key.getSecond();
+    return _key.getIp2();
   }
 
   @JsonIgnore

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfProcess.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfProcess.java
@@ -12,7 +12,6 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import javax.annotation.Nullable;
 import org.batfish.common.BatfishException;
-import org.batfish.common.Pair;
 import org.batfish.datamodel.NetworkFactory.NetworkFactoryBuilder;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
 
@@ -126,7 +125,7 @@ public class OspfProcess implements Serializable {
 
   private Long _maxMetricTransitLinks;
 
-  private transient Map<Pair<Ip, Ip>, OspfNeighbor> _ospfNeighbors;
+  private transient Map<IpLink, OspfNeighbor> _ospfNeighbors;
 
   private String _processId;
 
@@ -213,7 +212,7 @@ public class OspfProcess implements Serializable {
   }
 
   @JsonIgnore
-  public Map<Pair<Ip, Ip>, OspfNeighbor> getOspfNeighbors() {
+  public Map<IpLink, OspfNeighbor> getOspfNeighbors() {
     return _ospfNeighbors;
   }
 
@@ -290,7 +289,7 @@ public class OspfProcess implements Serializable {
   }
 
   @JsonIgnore
-  public void setOspfNeighbors(Map<Pair<Ip, Ip>, OspfNeighbor> ospfNeighbors) {
+  public void setOspfNeighbors(Map<IpLink, OspfNeighbor> ospfNeighbors) {
     _ospfNeighbors = ospfNeighbors;
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/OspfNeighborTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/OspfNeighborTest.java
@@ -1,7 +1,7 @@
 package org.batfish.datamodel;
 
+import static org.batfish.datamodel.matchers.LinkMatchers.hasIp1;
 import static org.batfish.datamodel.matchers.OspfProcessMatchers.hasOspfNeighbors;
-import static org.batfish.datamodel.matchers.PairMatchers.hasFirst;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
@@ -10,7 +10,6 @@ import static org.hamcrest.Matchers.not;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import java.util.Set;
-import org.batfish.common.Pair;
 import org.batfish.common.util.CommonUtil;
 import org.junit.Before;
 import org.junit.Test;
@@ -70,7 +69,7 @@ public class OspfNeighborTest {
     Topology topology = CommonUtil.synthesizeTopology(configurations);
     CommonUtil.initRemoteOspfNeighbors(configurations, ipOwners, topology);
 
-    assertThat(op1, hasOspfNeighbors(hasKey(new Pair<>(ip1, Ip.ZERO))));
-    assertThat(op1, hasOspfNeighbors(not(hasKey(hasFirst(equalTo(ip2))))));
+    assertThat(op1, hasOspfNeighbors(hasKey(new IpLink(ip1, Ip.ZERO))));
+    assertThat(op1, hasOspfNeighbors(not(hasKey(hasIp1(equalTo(ip2))))));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/LinkMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/LinkMatchers.java
@@ -1,0 +1,31 @@
+package org.batfish.datamodel.matchers;
+
+import javax.annotation.Nonnull;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpLink;
+import org.hamcrest.FeatureMatcher;
+import org.hamcrest.Matcher;
+
+public class LinkMatchers {
+
+  /**
+   * Provides a matcher that matches if the provided {@code subMatcher} matches {@link
+   * IpLink#getIp1}.
+   */
+  public static HasIp1 hasIp1(Matcher<? super Ip> subMatcher) {
+    return new HasIp1(subMatcher);
+  }
+
+  private static final class HasIp1 extends FeatureMatcher<IpLink, Ip> {
+    HasIp1(@Nonnull Matcher<? super Ip> subMatcher) {
+      super(subMatcher, "An IpLink with ip1:", "ip1");
+    }
+
+    @Override
+    protected Ip featureValueOf(IpLink actual) {
+      return actual.getIp1();
+    }
+  }
+
+  private LinkMatchers() {}
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/OspfProcessMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/OspfProcessMatchers.java
@@ -2,8 +2,7 @@ package org.batfish.datamodel.matchers;
 
 import java.util.Map;
 import javax.annotation.Nonnull;
-import org.batfish.common.Pair;
-import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpLink;
 import org.batfish.datamodel.OspfArea;
 import org.batfish.datamodel.OspfNeighbor;
 import org.batfish.datamodel.matchers.OspfProcessMatchersImpl.HasArea;
@@ -34,7 +33,7 @@ public class OspfProcessMatchers {
    * OSPF neighbors.
    */
   public static HasOspfNeighbors hasOspfNeighbors(
-      Matcher<? super Map<Pair<Ip, Ip>, OspfNeighbor>> subMatcher) {
+      Matcher<? super Map<IpLink, OspfNeighbor>> subMatcher) {
     return new HasOspfNeighbors(subMatcher);
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/OspfProcessMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/OspfProcessMatchersImpl.java
@@ -2,8 +2,7 @@ package org.batfish.datamodel.matchers;
 
 import java.util.Map;
 import javax.annotation.Nonnull;
-import org.batfish.common.Pair;
-import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpLink;
 import org.batfish.datamodel.OspfArea;
 import org.batfish.datamodel.OspfNeighbor;
 import org.batfish.datamodel.OspfProcess;
@@ -38,13 +37,13 @@ final class OspfProcessMatchersImpl {
   }
 
   static final class HasOspfNeighbors
-      extends FeatureMatcher<OspfProcess, Map<Pair<Ip, Ip>, OspfNeighbor>> {
-    HasOspfNeighbors(@Nonnull Matcher<? super Map<Pair<Ip, Ip>, OspfNeighbor>> subMatcher) {
+      extends FeatureMatcher<OspfProcess, Map<IpLink, OspfNeighbor>> {
+    HasOspfNeighbors(@Nonnull Matcher<? super Map<IpLink, OspfNeighbor>> subMatcher) {
       super(subMatcher, "An OSPF process with ospfNeighbors:", "ospfNeighbors");
     }
 
     @Override
-    protected Map<Pair<Ip, Ip>, OspfNeighbor> featureValueOf(OspfProcess actual) {
+    protected Map<IpLink, OspfNeighbor> featureValueOf(OspfProcess actual) {
       return actual.getOspfNeighbors();
     }
   }

--- a/projects/batfish/src/main/java/org/batfish/symbolic/abstraction/AbstractionBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/abstraction/AbstractionBuilder.java
@@ -14,7 +14,6 @@ import java.util.SortedSet;
 import java.util.Stack;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import org.batfish.common.Pair;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.datamodel.BgpNeighbor;
 import org.batfish.datamodel.BgpProcess;
@@ -22,6 +21,7 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpLink;
 import org.batfish.datamodel.OspfNeighbor;
 import org.batfish.datamodel.OspfProcess;
 import org.batfish.datamodel.Prefix;
@@ -470,7 +470,7 @@ class AbstractionBuilder {
     abstractConf.setRoute6FilterLists(conf.getRoute6FilterLists());
 
     SortedSet<Interface> toRetain = new TreeSet<>();
-    SortedSet<Pair<Ip, Ip>> ipNeighbors = new TreeSet<>();
+    SortedSet<IpLink> ipNeighbors = new TreeSet<>();
     SortedSet<BgpNeighbor> bgpNeighbors = new TreeSet<>();
 
     List<GraphEdge> edges = _graph.getEdgeMap().get(conf.getName());
@@ -482,7 +482,7 @@ class AbstractionBuilder {
         Ip start = ge.getStart().getAddress().getIp();
         if (!leavesNetwork) {
           Ip end = ge.getEnd().getAddress().getIp();
-          ipNeighbors.add(new Pair<>(start, end));
+          ipNeighbors.add(new IpLink(start, end));
         }
         BgpNeighbor n = _graph.getEbgpNeighbors().get(ge);
         if (n != null) {
@@ -532,13 +532,13 @@ class AbstractionBuilder {
         abstractOspf.setReferenceBandwidth(ospf.getReferenceBandwidth());
         abstractOspf.setRouterId(ospf.getRouterId());
         // Copy over neighbors
-        Map<Pair<Ip, Ip>, OspfNeighbor> abstractNeighbors = new HashMap<>();
+        Map<IpLink, OspfNeighbor> abstractNeighbors = new HashMap<>();
         if (ospf.getOspfNeighbors() != null) {
-          for (Entry<Pair<Ip, Ip>, OspfNeighbor> entry2 : ospf.getOspfNeighbors().entrySet()) {
-            Pair<Ip, Ip> pair = entry2.getKey();
+          for (Entry<IpLink, OspfNeighbor> entry2 : ospf.getOspfNeighbors().entrySet()) {
+            IpLink link = entry2.getKey();
             OspfNeighbor neighbor = entry2.getValue();
-            if (ipNeighbors.contains(pair)) {
-              abstractNeighbors.put(pair, neighbor);
+            if (ipNeighbors.contains(link)) {
+              abstractNeighbors.put(link, neighbor);
             }
           }
         }

--- a/projects/batfish/src/test/java/org/batfish/bdp/OspfTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bdp/OspfTest.java
@@ -26,7 +26,6 @@ import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.batfish.common.BatfishLogger;
-import org.batfish.common.Pair;
 import org.batfish.common.util.CommonUtil;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.Configuration;
@@ -34,6 +33,7 @@ import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpLink;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.OspfArea;
 import org.batfish.datamodel.OspfMetricType;
@@ -634,8 +634,8 @@ public class OspfTest {
     Topology topology = CommonUtil.synthesizeTopology(configurations);
     CommonUtil.initRemoteOspfNeighbors(configurations, ipOwners, topology);
 
-    Pair<Ip, Ip> expectedIpEdge1 = new Pair<>(i1Address.getIp(), i2Address.getIp());
-    Pair<Ip, Ip> expectedIpEdge2 = new Pair<>(i2Address.getIp(), i1Address.getIp());
+    IpLink expectedIpEdge1 = new IpLink(i1Address.getIp(), i2Address.getIp());
+    IpLink expectedIpEdge2 = new IpLink(i2Address.getIp(), i1Address.getIp());
 
     assertThat(o1, hasOspfNeighbors(hasKey(expectedIpEdge1)));
     OspfNeighbor on1 = o1.getOspfNeighbors().get(expectedIpEdge1);

--- a/tests/basic/commands
+++ b/tests/basic/commands
@@ -4,28 +4,33 @@ add-batfish-option haltonconverterror
 add-batfish-option haltonparseerror
 add-batfish-option verboseparse
 
-# example testrig
+# some ref tests using example testrig
 test -compareall tests/basic/init.ref init-testrig test_rigs/example basic-example
-test -compareall tests/basic/init-delta.ref init-delta-testrig test_rigs/example-with-delta basic-example-delta
 test -compareall tests/basic/genDp.ref generate-dataplane
-test -compareall tests/basic/genDp-delta.ref generate-delta-dataplane
 test -raw tests/basic/topology.ref get-object testrig_pojo_topology
+test tests/basic/nodes-summary.ref get nodes summary=true
+test tests/basic/nodes.ref get nodes summary=false
+test tests/basic/neighbors-summary.ref get neighbors neighborTypes=["ebgp","ibgp","ospf","lan"]
+test tests/basic/neighbors.ref get neighbors style=verbose, neighborTypes=["ebgp","ibgp","ospf","lan"]
+test tests/basic/routes.ref get routes
+
+# some ref tests using delta testrig
+test -compareall tests/basic/init-delta.ref init-delta-testrig test_rigs/example-with-delta basic-example-delta
+test -compareall tests/basic/genDp-delta.ref generate-delta-dataplane
+test tests/basic/nodes-diff.ref get nodes summary=false, differential=true
+
+# Everything below here is to be converted into regular unit tests in some form.
 test tests/basic/aclReachability.ref get aclReachability
 test tests/basic/assert.ref get assert assertions=[{"assertion":"(eq 15 (pathsize '$.nodes[*]'))"},{"assertion":"(eq 0 (pathsize '$.nodes[\"as1border\"]'))"},{"assertion":"(not (eq 0 (pathsize '$.nodes[\"as1border1\"]')))"}, {"assertion":"(eq (pathsize '$.nodes[*].aaaSettings.newModel') (pathsize '$.nodes[*].aaaSettings[?(@.newModel == true)]'))"}]
 test tests/basic/bgpSessionStatus.ref get bgpsessionstatus type="ebgp.*", status="missing.*"
 test tests/basic/compareSameName.ref get compareSameName
 test tests/basic/error.ref -error get error
 test tests/basic/isisLoopbacks.ref get isisLoopbacks
-test tests/basic/neighbors.ref get neighbors neighborTypes=["ebgp","ibgp","ospf","lan"]
 test tests/basic/roleNeighbors.ref get neighbors neighborTypes=["ebgp","ibgp","ospf","lan"], style="role"
-test tests/basic/nodes-summary.ref get nodes summary=true
-test tests/basic/nodes.ref get nodes summary=false
-test tests/basic/nodes-diff.ref get nodes summary=false, differential=true
 test tests/basic/ospfSessionCheck.ref get ospfsessioncheck
 test tests/basic/ospfStatus.ref get ospfstatus interfacesSpecifier="Loopback.*", status=".*passive"
 test tests/basic/roles.ref get roles
 test tests/basic/roles2.ref get roles inferred=true
-test tests/basic/routes.ref get routes
 test tests/basic/routes-diff.ref get routes differential=true
 test tests/basic/selfAdjacencies.ref get selfAdjacencies
 test tests/basic/traceroute-1-2.ref get traceroute ingressNode="as1core1", dst="host1"

--- a/tests/basic/neighbors-summary.ref
+++ b/tests/basic/neighbors-summary.ref
@@ -1,0 +1,601 @@
+[
+  {
+    "class" : "org.batfish.question.NeighborsQuestionPlugin$NeighborsAnswerElement",
+    "ebgpNeighbors" : [
+      {
+        "ip1" : "10.12.11.1",
+        "ip2" : "10.12.11.2",
+        "node1" : "as1border1",
+        "node2" : "as2border1"
+      },
+      {
+        "ip1" : "10.13.22.1",
+        "ip2" : "10.13.22.3",
+        "node1" : "as1border2",
+        "node2" : "as3border2"
+      },
+      {
+        "ip1" : "10.12.11.2",
+        "ip2" : "10.12.11.1",
+        "node1" : "as2border1",
+        "node2" : "as1border1"
+      },
+      {
+        "ip1" : "10.23.21.2",
+        "ip2" : "10.23.21.3",
+        "node1" : "as2border2",
+        "node2" : "as3border1"
+      },
+      {
+        "ip1" : "2.34.101.4",
+        "ip2" : "2.34.101.3",
+        "node1" : "as2dept1",
+        "node2" : "as2dist1"
+      },
+      {
+        "ip1" : "2.34.201.4",
+        "ip2" : "2.34.201.3",
+        "node1" : "as2dept1",
+        "node2" : "as2dist2"
+      },
+      {
+        "ip1" : "2.34.101.3",
+        "ip2" : "2.34.101.4",
+        "node1" : "as2dist1",
+        "node2" : "as2dept1"
+      },
+      {
+        "ip1" : "2.34.201.3",
+        "ip2" : "2.34.201.4",
+        "node1" : "as2dist2",
+        "node2" : "as2dept1"
+      },
+      {
+        "ip1" : "10.23.21.3",
+        "ip2" : "10.23.21.2",
+        "node1" : "as3border1",
+        "node2" : "as2border2"
+      },
+      {
+        "ip1" : "10.13.22.3",
+        "ip2" : "10.13.22.1",
+        "node1" : "as3border2",
+        "node2" : "as1border2"
+      }
+    ],
+    "ibgpNeighbors" : [
+      {
+        "ip1" : "1.1.1.1",
+        "ip2" : "1.10.1.1",
+        "node1" : "as1border1",
+        "node2" : "as1core1"
+      },
+      {
+        "ip1" : "1.2.2.2",
+        "ip2" : "1.10.1.1",
+        "node1" : "as1border2",
+        "node2" : "as1core1"
+      },
+      {
+        "ip1" : "1.10.1.1",
+        "ip2" : "1.1.1.1",
+        "node1" : "as1core1",
+        "node2" : "as1border1"
+      },
+      {
+        "ip1" : "1.10.1.1",
+        "ip2" : "1.2.2.2",
+        "node1" : "as1core1",
+        "node2" : "as1border2"
+      },
+      {
+        "ip1" : "2.1.1.1",
+        "ip2" : "2.1.2.1",
+        "node1" : "as2border1",
+        "node2" : "as2core1"
+      },
+      {
+        "ip1" : "2.1.1.1",
+        "ip2" : "2.1.2.2",
+        "node1" : "as2border1",
+        "node2" : "as2core2"
+      },
+      {
+        "ip1" : "2.1.1.2",
+        "ip2" : "2.1.2.1",
+        "node1" : "as2border2",
+        "node2" : "as2core1"
+      },
+      {
+        "ip1" : "2.1.1.2",
+        "ip2" : "2.1.2.2",
+        "node1" : "as2border2",
+        "node2" : "as2core2"
+      },
+      {
+        "ip1" : "2.1.2.1",
+        "ip2" : "2.1.1.1",
+        "node1" : "as2core1",
+        "node2" : "as2border1"
+      },
+      {
+        "ip1" : "2.1.2.1",
+        "ip2" : "2.1.1.2",
+        "node1" : "as2core1",
+        "node2" : "as2border2"
+      },
+      {
+        "ip1" : "2.1.2.1",
+        "ip2" : "2.1.3.1",
+        "node1" : "as2core1",
+        "node2" : "as2dist1"
+      },
+      {
+        "ip1" : "2.1.2.1",
+        "ip2" : "2.1.3.2",
+        "node1" : "as2core1",
+        "node2" : "as2dist2"
+      },
+      {
+        "ip1" : "2.1.2.2",
+        "ip2" : "2.1.1.1",
+        "node1" : "as2core2",
+        "node2" : "as2border1"
+      },
+      {
+        "ip1" : "2.1.2.2",
+        "ip2" : "2.1.1.2",
+        "node1" : "as2core2",
+        "node2" : "as2border2"
+      },
+      {
+        "ip1" : "2.1.2.2",
+        "ip2" : "2.1.3.1",
+        "node1" : "as2core2",
+        "node2" : "as2dist1"
+      },
+      {
+        "ip1" : "2.1.2.2",
+        "ip2" : "2.1.3.2",
+        "node1" : "as2core2",
+        "node2" : "as2dist2"
+      },
+      {
+        "ip1" : "2.1.3.1",
+        "ip2" : "2.1.2.1",
+        "node1" : "as2dist1",
+        "node2" : "as2core1"
+      },
+      {
+        "ip1" : "2.1.3.1",
+        "ip2" : "2.1.2.2",
+        "node1" : "as2dist1",
+        "node2" : "as2core2"
+      },
+      {
+        "ip1" : "2.1.3.2",
+        "ip2" : "2.1.2.1",
+        "node1" : "as2dist2",
+        "node2" : "as2core1"
+      },
+      {
+        "ip1" : "2.1.3.2",
+        "ip2" : "2.1.2.2",
+        "node1" : "as2dist2",
+        "node2" : "as2core2"
+      },
+      {
+        "ip1" : "3.1.1.1",
+        "ip2" : "3.10.1.1",
+        "node1" : "as3border1",
+        "node2" : "as3core1"
+      },
+      {
+        "ip1" : "3.2.2.2",
+        "ip2" : "3.10.1.1",
+        "node1" : "as3border2",
+        "node2" : "as3core1"
+      },
+      {
+        "ip1" : "3.10.1.1",
+        "ip2" : "3.1.1.1",
+        "node1" : "as3core1",
+        "node2" : "as3border1"
+      },
+      {
+        "ip1" : "3.10.1.1",
+        "ip2" : "3.2.2.2",
+        "node1" : "as3core1",
+        "node2" : "as3border2"
+      }
+    ],
+    "lanNeighbors" : [
+      {
+        "node1" : "as1border1",
+        "node1interface" : "GigabitEthernet0/0",
+        "node2" : "as1core1",
+        "node2interface" : "GigabitEthernet1/0"
+      },
+      {
+        "node1" : "as1border1",
+        "node1interface" : "GigabitEthernet1/0",
+        "node2" : "as2border1",
+        "node2interface" : "GigabitEthernet0/0"
+      },
+      {
+        "node1" : "as1border2",
+        "node1interface" : "GigabitEthernet0/0",
+        "node2" : "as3border2",
+        "node2interface" : "GigabitEthernet0/0"
+      },
+      {
+        "node1" : "as1border2",
+        "node1interface" : "GigabitEthernet1/0",
+        "node2" : "as1core1",
+        "node2interface" : "GigabitEthernet0/0"
+      },
+      {
+        "node1" : "as1core1",
+        "node1interface" : "GigabitEthernet0/0",
+        "node2" : "as1border2",
+        "node2interface" : "GigabitEthernet1/0"
+      },
+      {
+        "node1" : "as1core1",
+        "node1interface" : "GigabitEthernet1/0",
+        "node2" : "as1border1",
+        "node2interface" : "GigabitEthernet0/0"
+      },
+      {
+        "node1" : "as2border1",
+        "node1interface" : "GigabitEthernet0/0",
+        "node2" : "as1border1",
+        "node2interface" : "GigabitEthernet1/0"
+      },
+      {
+        "node1" : "as2border1",
+        "node1interface" : "GigabitEthernet1/0",
+        "node2" : "as2core1",
+        "node2interface" : "GigabitEthernet0/0"
+      },
+      {
+        "node1" : "as2border1",
+        "node1interface" : "GigabitEthernet2/0",
+        "node2" : "as2core2",
+        "node2interface" : "GigabitEthernet1/0"
+      },
+      {
+        "node1" : "as2border2",
+        "node1interface" : "GigabitEthernet0/0",
+        "node2" : "as3border1",
+        "node2interface" : "GigabitEthernet1/0"
+      },
+      {
+        "node1" : "as2border2",
+        "node1interface" : "GigabitEthernet1/0",
+        "node2" : "as2core2",
+        "node2interface" : "GigabitEthernet0/0"
+      },
+      {
+        "node1" : "as2border2",
+        "node1interface" : "GigabitEthernet2/0",
+        "node2" : "as2core1",
+        "node2interface" : "GigabitEthernet1/0"
+      },
+      {
+        "node1" : "as2core1",
+        "node1interface" : "GigabitEthernet0/0",
+        "node2" : "as2border1",
+        "node2interface" : "GigabitEthernet1/0"
+      },
+      {
+        "node1" : "as2core1",
+        "node1interface" : "GigabitEthernet1/0",
+        "node2" : "as2border2",
+        "node2interface" : "GigabitEthernet2/0"
+      },
+      {
+        "node1" : "as2core1",
+        "node1interface" : "GigabitEthernet2/0",
+        "node2" : "as2dist1",
+        "node2interface" : "GigabitEthernet0/0"
+      },
+      {
+        "node1" : "as2core1",
+        "node1interface" : "GigabitEthernet3/0",
+        "node2" : "as2dist2",
+        "node2interface" : "GigabitEthernet1/0"
+      },
+      {
+        "node1" : "as2core2",
+        "node1interface" : "GigabitEthernet0/0",
+        "node2" : "as2border2",
+        "node2interface" : "GigabitEthernet1/0"
+      },
+      {
+        "node1" : "as2core2",
+        "node1interface" : "GigabitEthernet1/0",
+        "node2" : "as2border1",
+        "node2interface" : "GigabitEthernet2/0"
+      },
+      {
+        "node1" : "as2core2",
+        "node1interface" : "GigabitEthernet2/0",
+        "node2" : "as2dist2",
+        "node2interface" : "GigabitEthernet0/0"
+      },
+      {
+        "node1" : "as2core2",
+        "node1interface" : "GigabitEthernet3/0",
+        "node2" : "as2dist1",
+        "node2interface" : "GigabitEthernet1/0"
+      },
+      {
+        "node1" : "as2dept1",
+        "node1interface" : "GigabitEthernet0/0",
+        "node2" : "as2dist1",
+        "node2interface" : "GigabitEthernet2/0"
+      },
+      {
+        "node1" : "as2dept1",
+        "node1interface" : "GigabitEthernet1/0",
+        "node2" : "as2dist2",
+        "node2interface" : "GigabitEthernet2/0"
+      },
+      {
+        "node1" : "as2dept1",
+        "node1interface" : "GigabitEthernet2/0",
+        "node2" : "host1",
+        "node2interface" : "eth0"
+      },
+      {
+        "node1" : "as2dept1",
+        "node1interface" : "GigabitEthernet3/0",
+        "node2" : "host2",
+        "node2interface" : "eth0"
+      },
+      {
+        "node1" : "as2dist1",
+        "node1interface" : "GigabitEthernet0/0",
+        "node2" : "as2core1",
+        "node2interface" : "GigabitEthernet2/0"
+      },
+      {
+        "node1" : "as2dist1",
+        "node1interface" : "GigabitEthernet1/0",
+        "node2" : "as2core2",
+        "node2interface" : "GigabitEthernet3/0"
+      },
+      {
+        "node1" : "as2dist1",
+        "node1interface" : "GigabitEthernet2/0",
+        "node2" : "as2dept1",
+        "node2interface" : "GigabitEthernet0/0"
+      },
+      {
+        "node1" : "as2dist2",
+        "node1interface" : "GigabitEthernet0/0",
+        "node2" : "as2core2",
+        "node2interface" : "GigabitEthernet2/0"
+      },
+      {
+        "node1" : "as2dist2",
+        "node1interface" : "GigabitEthernet1/0",
+        "node2" : "as2core1",
+        "node2interface" : "GigabitEthernet3/0"
+      },
+      {
+        "node1" : "as2dist2",
+        "node1interface" : "GigabitEthernet2/0",
+        "node2" : "as2dept1",
+        "node2interface" : "GigabitEthernet1/0"
+      },
+      {
+        "node1" : "as3border1",
+        "node1interface" : "GigabitEthernet0/0",
+        "node2" : "as3core1",
+        "node2interface" : "GigabitEthernet1/0"
+      },
+      {
+        "node1" : "as3border1",
+        "node1interface" : "GigabitEthernet1/0",
+        "node2" : "as2border2",
+        "node2interface" : "GigabitEthernet0/0"
+      },
+      {
+        "node1" : "as3border2",
+        "node1interface" : "GigabitEthernet0/0",
+        "node2" : "as1border2",
+        "node2interface" : "GigabitEthernet0/0"
+      },
+      {
+        "node1" : "as3border2",
+        "node1interface" : "GigabitEthernet1/0",
+        "node2" : "as3core1",
+        "node2interface" : "GigabitEthernet0/0"
+      },
+      {
+        "node1" : "as3core1",
+        "node1interface" : "GigabitEthernet0/0",
+        "node2" : "as3border2",
+        "node2interface" : "GigabitEthernet1/0"
+      },
+      {
+        "node1" : "as3core1",
+        "node1interface" : "GigabitEthernet1/0",
+        "node2" : "as3border1",
+        "node2interface" : "GigabitEthernet0/0"
+      },
+      {
+        "node1" : "as3core1",
+        "node1interface" : "GigabitEthernet2/0",
+        "node2" : "as3core1",
+        "node2interface" : "GigabitEthernet3/0"
+      },
+      {
+        "node1" : "as3core1",
+        "node1interface" : "GigabitEthernet3/0",
+        "node2" : "as3core1",
+        "node2interface" : "GigabitEthernet2/0"
+      },
+      {
+        "node1" : "host1",
+        "node1interface" : "eth0",
+        "node2" : "as2dept1",
+        "node2interface" : "GigabitEthernet2/0"
+      },
+      {
+        "node1" : "host2",
+        "node1interface" : "eth0",
+        "node2" : "as2dept1",
+        "node2interface" : "GigabitEthernet3/0"
+      }
+    ],
+    "ospfNeighbors" : [
+      {
+        "ip1" : "1.0.1.1",
+        "ip2" : "1.0.1.2",
+        "node1" : "as1border1",
+        "node2" : "as1core1"
+      },
+      {
+        "ip1" : "1.0.2.1",
+        "ip2" : "1.0.2.2",
+        "node1" : "as1border2",
+        "node2" : "as1core1"
+      },
+      {
+        "ip1" : "1.0.1.2",
+        "ip2" : "1.0.1.1",
+        "node1" : "as1core1",
+        "node2" : "as1border1"
+      },
+      {
+        "ip1" : "1.0.2.2",
+        "ip2" : "1.0.2.1",
+        "node1" : "as1core1",
+        "node2" : "as1border2"
+      },
+      {
+        "ip1" : "2.12.11.1",
+        "ip2" : "2.12.11.2",
+        "node1" : "as2border1",
+        "node2" : "as2core1"
+      },
+      {
+        "ip1" : "2.12.12.1",
+        "ip2" : "2.12.12.2",
+        "node1" : "as2border1",
+        "node2" : "as2core2"
+      },
+      {
+        "ip1" : "2.12.21.1",
+        "ip2" : "2.12.21.2",
+        "node1" : "as2border2",
+        "node2" : "as2core1"
+      },
+      {
+        "ip1" : "2.12.22.1",
+        "ip2" : "2.12.22.2",
+        "node1" : "as2border2",
+        "node2" : "as2core2"
+      },
+      {
+        "ip1" : "2.12.11.2",
+        "ip2" : "2.12.11.1",
+        "node1" : "as2core1",
+        "node2" : "as2border1"
+      },
+      {
+        "ip1" : "2.12.21.2",
+        "ip2" : "2.12.21.1",
+        "node1" : "as2core1",
+        "node2" : "as2border2"
+      },
+      {
+        "ip1" : "2.23.11.2",
+        "ip2" : "2.23.11.3",
+        "node1" : "as2core1",
+        "node2" : "as2dist1"
+      },
+      {
+        "ip1" : "2.23.12.2",
+        "ip2" : "2.23.12.3",
+        "node1" : "as2core1",
+        "node2" : "as2dist2"
+      },
+      {
+        "ip1" : "2.12.12.2",
+        "ip2" : "2.12.12.1",
+        "node1" : "as2core2",
+        "node2" : "as2border1"
+      },
+      {
+        "ip1" : "2.12.22.2",
+        "ip2" : "2.12.22.1",
+        "node1" : "as2core2",
+        "node2" : "as2border2"
+      },
+      {
+        "ip1" : "2.23.21.2",
+        "ip2" : "2.23.21.3",
+        "node1" : "as2core2",
+        "node2" : "as2dist1"
+      },
+      {
+        "ip1" : "2.23.22.2",
+        "ip2" : "2.23.22.3",
+        "node1" : "as2core2",
+        "node2" : "as2dist2"
+      },
+      {
+        "ip1" : "2.23.11.3",
+        "ip2" : "2.23.11.2",
+        "node1" : "as2dist1",
+        "node2" : "as2core1"
+      },
+      {
+        "ip1" : "2.23.21.3",
+        "ip2" : "2.23.21.2",
+        "node1" : "as2dist1",
+        "node2" : "as2core2"
+      },
+      {
+        "ip1" : "2.23.12.3",
+        "ip2" : "2.23.12.2",
+        "node1" : "as2dist2",
+        "node2" : "as2core1"
+      },
+      {
+        "ip1" : "2.23.22.3",
+        "ip2" : "2.23.22.2",
+        "node1" : "as2dist2",
+        "node2" : "as2core2"
+      },
+      {
+        "ip1" : "3.0.1.1",
+        "ip2" : "3.0.1.2",
+        "node1" : "as3border1",
+        "node2" : "as3core1"
+      },
+      {
+        "ip1" : "3.0.2.1",
+        "ip2" : "3.0.2.2",
+        "node1" : "as3border2",
+        "node2" : "as3core1"
+      },
+      {
+        "ip1" : "3.0.1.2",
+        "ip2" : "3.0.1.1",
+        "node1" : "as3core1",
+        "node2" : "as3border1"
+      },
+      {
+        "ip1" : "3.0.2.2",
+        "ip2" : "3.0.2.1",
+        "node1" : "as3core1",
+        "node2" : "as3border2"
+      }
+    ]
+  }
+]

--- a/tests/basic/neighbors.ref
+++ b/tests/basic/neighbors.ref
@@ -1,600 +1,7136 @@
 [
   {
     "class" : "org.batfish.question.NeighborsQuestionPlugin$NeighborsAnswerElement",
-    "ebgpNeighbors" : [
+    "verboseEbgpNeighbors" : [
       {
-        "ip1" : "10.12.11.1",
-        "ip2" : "10.12.11.2",
-        "node1" : "as1border1",
-        "node2" : "as2border1"
+        "edgeSummary" : {
+          "ip1" : "10.12.11.1",
+          "ip2" : "10.12.11.2",
+          "node1" : "as1border1",
+          "node2" : "as2border1"
+        },
+        "node1Session" : {
+          "name" : "10.12.11.2/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "10.12.11.2",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 16843009,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.12.11.2~",
+          "exportPolicySources" : [
+            "as1_to_as2"
+          ],
+          "group" : "as2",
+          "importPolicy" : "as2_to_as1",
+          "importPolicySources" : [
+            "as2_to_as1"
+          ],
+          "localAs" : 1,
+          "localIp" : "10.12.11.1",
+          "remoteAs" : 2,
+          "remotePrefix" : "10.12.11.2/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : "10.12.11.1/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "10.12.11.1",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620225,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.12.11.1~",
+          "exportPolicySources" : [
+            "as2_to_as1"
+          ],
+          "group" : "as1",
+          "importPolicy" : "as1_to_as2",
+          "importPolicySources" : [
+            "as1_to_as2"
+          ],
+          "localAs" : 2,
+          "localIp" : "10.12.11.2",
+          "remoteAs" : 1,
+          "remotePrefix" : "10.12.11.1/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "10.13.22.1",
-        "ip2" : "10.13.22.3",
-        "node1" : "as1border2",
-        "node2" : "as3border2"
+        "edgeSummary" : {
+          "ip1" : "10.13.22.1",
+          "ip2" : "10.13.22.3",
+          "node1" : "as1border2",
+          "node2" : "as3border2"
+        },
+        "node1Session" : {
+          "name" : "10.13.22.3/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "10.13.22.3",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 16908802,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.13.22.3~",
+          "exportPolicySources" : [
+            "as1_to_as3"
+          ],
+          "group" : "as3",
+          "importPolicy" : "as3_to_as1",
+          "importPolicySources" : [
+            "as3_to_as1"
+          ],
+          "localAs" : 1,
+          "localIp" : "10.13.22.1",
+          "remoteAs" : 3,
+          "remotePrefix" : "10.13.22.3/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : "10.13.22.1/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "10.13.22.1",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 50463234,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.13.22.1~",
+          "exportPolicySources" : [
+            "as3_to_as1"
+          ],
+          "group" : "as1",
+          "importPolicy" : "as1_to_as3",
+          "importPolicySources" : [
+            "as1_to_as3"
+          ],
+          "localAs" : 3,
+          "localIp" : "10.13.22.3",
+          "remoteAs" : 1,
+          "remotePrefix" : "10.13.22.1/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "10.12.11.2",
-        "ip2" : "10.12.11.1",
-        "node1" : "as2border1",
-        "node2" : "as1border1"
+        "edgeSummary" : {
+          "ip1" : "10.12.11.2",
+          "ip2" : "10.12.11.1",
+          "node1" : "as2border1",
+          "node2" : "as1border1"
+        },
+        "node1Session" : {
+          "name" : "10.12.11.1/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "10.12.11.1",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620225,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.12.11.1~",
+          "exportPolicySources" : [
+            "as2_to_as1"
+          ],
+          "group" : "as1",
+          "importPolicy" : "as1_to_as2",
+          "importPolicySources" : [
+            "as1_to_as2"
+          ],
+          "localAs" : 2,
+          "localIp" : "10.12.11.2",
+          "remoteAs" : 1,
+          "remotePrefix" : "10.12.11.1/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : "10.12.11.2/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "10.12.11.2",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 16843009,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.12.11.2~",
+          "exportPolicySources" : [
+            "as1_to_as2"
+          ],
+          "group" : "as2",
+          "importPolicy" : "as2_to_as1",
+          "importPolicySources" : [
+            "as2_to_as1"
+          ],
+          "localAs" : 1,
+          "localIp" : "10.12.11.1",
+          "remoteAs" : 2,
+          "remotePrefix" : "10.12.11.2/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "10.23.21.2",
-        "ip2" : "10.23.21.3",
-        "node1" : "as2border2",
-        "node2" : "as3border1"
+        "edgeSummary" : {
+          "ip1" : "10.23.21.2",
+          "ip2" : "10.23.21.3",
+          "node1" : "as2border2",
+          "node2" : "as3border1"
+        },
+        "node1Session" : {
+          "name" : "10.23.21.3/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "10.23.21.3",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620226,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.23.21.3~",
+          "exportPolicySources" : [
+            "as2_to_as3"
+          ],
+          "group" : "as3",
+          "importPolicy" : "as3_to_as2",
+          "importPolicySources" : [
+            "as3_to_as2"
+          ],
+          "localAs" : 2,
+          "localIp" : "10.23.21.2",
+          "remoteAs" : 3,
+          "remotePrefix" : "10.23.21.3/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : "10.23.21.2/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "10.23.21.2",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 50397441,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.23.21.2~",
+          "exportPolicySources" : [
+            "as3_to_as2"
+          ],
+          "group" : "as2",
+          "importPolicy" : "as2_to_as3",
+          "importPolicySources" : [
+            "as2_to_as3"
+          ],
+          "localAs" : 3,
+          "localIp" : "10.23.21.3",
+          "remoteAs" : 2,
+          "remotePrefix" : "10.23.21.2/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "2.34.101.4",
-        "ip2" : "2.34.101.3",
-        "node1" : "as2dept1",
-        "node2" : "as2dist1"
+        "edgeSummary" : {
+          "ip1" : "2.34.101.4",
+          "ip2" : "2.34.101.3",
+          "node1" : "as2dept1",
+          "node2" : "as2dist1"
+        },
+        "node1Session" : {
+          "name" : "2.34.101.3/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "2.34.101.3",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620993,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.34.101.3~",
+          "exportPolicySources" : [
+            "dept_to_as2"
+          ],
+          "group" : "as2",
+          "importPolicy" : "as2_to_dept",
+          "importPolicySources" : [
+            "as2_to_dept"
+          ],
+          "localAs" : 65001,
+          "localIp" : "2.34.101.4",
+          "remoteAs" : 2,
+          "remotePrefix" : "2.34.101.3/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : "2.34.101.4/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "2.34.101.4",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620737,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.34.101.4~",
+          "exportPolicySources" : [
+            "as2dist_to_dept"
+          ],
+          "group" : "dept",
+          "importPolicy" : "dept_to_as2dist",
+          "importPolicySources" : [
+            "dept_to_as2dist"
+          ],
+          "localAs" : 2,
+          "localIp" : "2.34.101.3",
+          "remoteAs" : 65001,
+          "remotePrefix" : "2.34.101.4/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "2.34.201.4",
-        "ip2" : "2.34.201.3",
-        "node1" : "as2dept1",
-        "node2" : "as2dist2"
+        "edgeSummary" : {
+          "ip1" : "2.34.201.4",
+          "ip2" : "2.34.201.3",
+          "node1" : "as2dept1",
+          "node2" : "as2dist2"
+        },
+        "node1Session" : {
+          "name" : "2.34.201.3/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "2.34.201.3",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620993,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.34.201.3~",
+          "exportPolicySources" : [
+            "dept_to_as2"
+          ],
+          "group" : "as2",
+          "importPolicy" : "as2_to_dept",
+          "importPolicySources" : [
+            "as2_to_dept"
+          ],
+          "localAs" : 65001,
+          "localIp" : "2.34.201.4",
+          "remoteAs" : 2,
+          "remotePrefix" : "2.34.201.3/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : "2.34.201.4/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "2.34.201.4",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620738,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.34.201.4~",
+          "exportPolicySources" : [
+            "as2dist_to_dept"
+          ],
+          "group" : "dept",
+          "importPolicy" : "dept_to_as2dist",
+          "importPolicySources" : [
+            "dept_to_as2dist"
+          ],
+          "localAs" : 2,
+          "localIp" : "2.34.201.3",
+          "remoteAs" : 65001,
+          "remotePrefix" : "2.34.201.4/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "2.34.101.3",
-        "ip2" : "2.34.101.4",
-        "node1" : "as2dist1",
-        "node2" : "as2dept1"
+        "edgeSummary" : {
+          "ip1" : "2.34.101.3",
+          "ip2" : "2.34.101.4",
+          "node1" : "as2dist1",
+          "node2" : "as2dept1"
+        },
+        "node1Session" : {
+          "name" : "2.34.101.4/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "2.34.101.4",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620737,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.34.101.4~",
+          "exportPolicySources" : [
+            "as2dist_to_dept"
+          ],
+          "group" : "dept",
+          "importPolicy" : "dept_to_as2dist",
+          "importPolicySources" : [
+            "dept_to_as2dist"
+          ],
+          "localAs" : 2,
+          "localIp" : "2.34.101.3",
+          "remoteAs" : 65001,
+          "remotePrefix" : "2.34.101.4/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : "2.34.101.3/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "2.34.101.3",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620993,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.34.101.3~",
+          "exportPolicySources" : [
+            "dept_to_as2"
+          ],
+          "group" : "as2",
+          "importPolicy" : "as2_to_dept",
+          "importPolicySources" : [
+            "as2_to_dept"
+          ],
+          "localAs" : 65001,
+          "localIp" : "2.34.101.4",
+          "remoteAs" : 2,
+          "remotePrefix" : "2.34.101.3/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "2.34.201.3",
-        "ip2" : "2.34.201.4",
-        "node1" : "as2dist2",
-        "node2" : "as2dept1"
+        "edgeSummary" : {
+          "ip1" : "2.34.201.3",
+          "ip2" : "2.34.201.4",
+          "node1" : "as2dist2",
+          "node2" : "as2dept1"
+        },
+        "node1Session" : {
+          "name" : "2.34.201.4/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "2.34.201.4",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620738,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.34.201.4~",
+          "exportPolicySources" : [
+            "as2dist_to_dept"
+          ],
+          "group" : "dept",
+          "importPolicy" : "dept_to_as2dist",
+          "importPolicySources" : [
+            "dept_to_as2dist"
+          ],
+          "localAs" : 2,
+          "localIp" : "2.34.201.3",
+          "remoteAs" : 65001,
+          "remotePrefix" : "2.34.201.4/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : "2.34.201.3/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "2.34.201.3",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620993,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.34.201.3~",
+          "exportPolicySources" : [
+            "dept_to_as2"
+          ],
+          "group" : "as2",
+          "importPolicy" : "as2_to_dept",
+          "importPolicySources" : [
+            "as2_to_dept"
+          ],
+          "localAs" : 65001,
+          "localIp" : "2.34.201.4",
+          "remoteAs" : 2,
+          "remotePrefix" : "2.34.201.3/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "10.23.21.3",
-        "ip2" : "10.23.21.2",
-        "node1" : "as3border1",
-        "node2" : "as2border2"
+        "edgeSummary" : {
+          "ip1" : "10.23.21.3",
+          "ip2" : "10.23.21.2",
+          "node1" : "as3border1",
+          "node2" : "as2border2"
+        },
+        "node1Session" : {
+          "name" : "10.23.21.2/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "10.23.21.2",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 50397441,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.23.21.2~",
+          "exportPolicySources" : [
+            "as3_to_as2"
+          ],
+          "group" : "as2",
+          "importPolicy" : "as2_to_as3",
+          "importPolicySources" : [
+            "as2_to_as3"
+          ],
+          "localAs" : 3,
+          "localIp" : "10.23.21.3",
+          "remoteAs" : 2,
+          "remotePrefix" : "10.23.21.2/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : "10.23.21.3/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "10.23.21.3",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620226,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.23.21.3~",
+          "exportPolicySources" : [
+            "as2_to_as3"
+          ],
+          "group" : "as3",
+          "importPolicy" : "as3_to_as2",
+          "importPolicySources" : [
+            "as3_to_as2"
+          ],
+          "localAs" : 2,
+          "localIp" : "10.23.21.2",
+          "remoteAs" : 3,
+          "remotePrefix" : "10.23.21.3/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "10.13.22.3",
-        "ip2" : "10.13.22.1",
-        "node1" : "as3border2",
-        "node2" : "as1border2"
+        "edgeSummary" : {
+          "ip1" : "10.13.22.3",
+          "ip2" : "10.13.22.1",
+          "node1" : "as3border2",
+          "node2" : "as1border2"
+        },
+        "node1Session" : {
+          "name" : "10.13.22.1/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "10.13.22.1",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 50463234,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.13.22.1~",
+          "exportPolicySources" : [
+            "as3_to_as1"
+          ],
+          "group" : "as1",
+          "importPolicy" : "as1_to_as3",
+          "importPolicySources" : [
+            "as1_to_as3"
+          ],
+          "localAs" : 3,
+          "localIp" : "10.13.22.3",
+          "remoteAs" : 1,
+          "remotePrefix" : "10.13.22.1/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : "10.13.22.3/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "10.13.22.3",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 16908802,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.13.22.3~",
+          "exportPolicySources" : [
+            "as1_to_as3"
+          ],
+          "group" : "as3",
+          "importPolicy" : "as3_to_as1",
+          "importPolicySources" : [
+            "as3_to_as1"
+          ],
+          "localAs" : 1,
+          "localIp" : "10.13.22.1",
+          "remoteAs" : 3,
+          "remotePrefix" : "10.13.22.3/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        }
       }
     ],
-    "ibgpNeighbors" : [
+    "verboseIbgpNeighbors" : [
       {
-        "ip1" : "1.1.1.1",
-        "ip2" : "1.10.1.1",
-        "node1" : "as1border1",
-        "node2" : "as1core1"
+        "edgeSummary" : {
+          "ip1" : "1.1.1.1",
+          "ip2" : "1.10.1.1",
+          "node1" : "as1border1",
+          "node2" : "as1core1"
+        },
+        "node1Session" : {
+          "name" : "1.10.1.1/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "1.10.1.1",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 16843009,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:1.10.1.1~",
+          "group" : "as1",
+          "localAs" : 1,
+          "localIp" : "1.1.1.1",
+          "remoteAs" : 1,
+          "remotePrefix" : "1.10.1.1/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : "1.1.1.1/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "1.1.1.1",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 17432833,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:1.1.1.1~",
+          "group" : "as1",
+          "localAs" : 1,
+          "localIp" : "1.10.1.1",
+          "remoteAs" : 1,
+          "remotePrefix" : "1.1.1.1/32",
+          "routeReflectorClient" : true,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "1.2.2.2",
-        "ip2" : "1.10.1.1",
-        "node1" : "as1border2",
-        "node2" : "as1core1"
+        "edgeSummary" : {
+          "ip1" : "1.2.2.2",
+          "ip2" : "1.10.1.1",
+          "node1" : "as1border2",
+          "node2" : "as1core1"
+        },
+        "node1Session" : {
+          "name" : "1.10.1.1/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "1.10.1.1",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 16908802,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:1.10.1.1~",
+          "group" : "as1",
+          "localAs" : 1,
+          "localIp" : "1.2.2.2",
+          "remoteAs" : 1,
+          "remotePrefix" : "1.10.1.1/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : "1.2.2.2/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "1.2.2.2",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 17432833,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:1.2.2.2~",
+          "group" : "as1",
+          "localAs" : 1,
+          "localIp" : "1.10.1.1",
+          "remoteAs" : 1,
+          "remotePrefix" : "1.2.2.2/32",
+          "routeReflectorClient" : true,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "1.10.1.1",
-        "ip2" : "1.1.1.1",
-        "node1" : "as1core1",
-        "node2" : "as1border1"
+        "edgeSummary" : {
+          "ip1" : "1.10.1.1",
+          "ip2" : "1.1.1.1",
+          "node1" : "as1core1",
+          "node2" : "as1border1"
+        },
+        "node1Session" : {
+          "name" : "1.1.1.1/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "1.1.1.1",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 17432833,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:1.1.1.1~",
+          "group" : "as1",
+          "localAs" : 1,
+          "localIp" : "1.10.1.1",
+          "remoteAs" : 1,
+          "remotePrefix" : "1.1.1.1/32",
+          "routeReflectorClient" : true,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : "1.10.1.1/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "1.10.1.1",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 16843009,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:1.10.1.1~",
+          "group" : "as1",
+          "localAs" : 1,
+          "localIp" : "1.1.1.1",
+          "remoteAs" : 1,
+          "remotePrefix" : "1.10.1.1/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "1.10.1.1",
-        "ip2" : "1.2.2.2",
-        "node1" : "as1core1",
-        "node2" : "as1border2"
+        "edgeSummary" : {
+          "ip1" : "1.10.1.1",
+          "ip2" : "1.2.2.2",
+          "node1" : "as1core1",
+          "node2" : "as1border2"
+        },
+        "node1Session" : {
+          "name" : "1.2.2.2/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "1.2.2.2",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 17432833,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:1.2.2.2~",
+          "group" : "as1",
+          "localAs" : 1,
+          "localIp" : "1.10.1.1",
+          "remoteAs" : 1,
+          "remotePrefix" : "1.2.2.2/32",
+          "routeReflectorClient" : true,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : "1.10.1.1/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "1.10.1.1",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 16908802,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:1.10.1.1~",
+          "group" : "as1",
+          "localAs" : 1,
+          "localIp" : "1.2.2.2",
+          "remoteAs" : 1,
+          "remotePrefix" : "1.10.1.1/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "2.1.1.1",
-        "ip2" : "2.1.2.1",
-        "node1" : "as2border1",
-        "node2" : "as2core1"
+        "edgeSummary" : {
+          "ip1" : "2.1.1.1",
+          "ip2" : "2.1.2.1",
+          "node1" : "as2border1",
+          "node2" : "as2core1"
+        },
+        "node1Session" : {
+          "name" : "2.1.2.1/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "2.1.2.1",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620225,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.1.1",
+          "remoteAs" : 2,
+          "remotePrefix" : "2.1.2.1/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : "2.1.1.1/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "2.1.1.1",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620481,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.1.1~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.2.1",
+          "remoteAs" : 2,
+          "remotePrefix" : "2.1.1.1/32",
+          "routeReflectorClient" : true,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "2.1.1.1",
-        "ip2" : "2.1.2.2",
-        "node1" : "as2border1",
-        "node2" : "as2core2"
+        "edgeSummary" : {
+          "ip1" : "2.1.1.1",
+          "ip2" : "2.1.2.2",
+          "node1" : "as2border1",
+          "node2" : "as2core2"
+        },
+        "node1Session" : {
+          "name" : "2.1.2.2/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "2.1.2.2",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620225,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.1.1",
+          "remoteAs" : 2,
+          "remotePrefix" : "2.1.2.2/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : "2.1.1.1/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "2.1.1.1",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620482,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.1.1~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.2.2",
+          "remoteAs" : 2,
+          "remotePrefix" : "2.1.1.1/32",
+          "routeReflectorClient" : true,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "2.1.1.2",
-        "ip2" : "2.1.2.1",
-        "node1" : "as2border2",
-        "node2" : "as2core1"
+        "edgeSummary" : {
+          "ip1" : "2.1.1.2",
+          "ip2" : "2.1.2.1",
+          "node1" : "as2border2",
+          "node2" : "as2core1"
+        },
+        "node1Session" : {
+          "name" : "2.1.2.1/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "2.1.2.1",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620226,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.1.2",
+          "remoteAs" : 2,
+          "remotePrefix" : "2.1.2.1/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : "2.1.1.2/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "2.1.1.2",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620481,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.1.2~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.2.1",
+          "remoteAs" : 2,
+          "remotePrefix" : "2.1.1.2/32",
+          "routeReflectorClient" : true,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "2.1.1.2",
-        "ip2" : "2.1.2.2",
-        "node1" : "as2border2",
-        "node2" : "as2core2"
+        "edgeSummary" : {
+          "ip1" : "2.1.1.2",
+          "ip2" : "2.1.2.2",
+          "node1" : "as2border2",
+          "node2" : "as2core2"
+        },
+        "node1Session" : {
+          "name" : "2.1.2.2/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "2.1.2.2",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620226,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.1.2",
+          "remoteAs" : 2,
+          "remotePrefix" : "2.1.2.2/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : "2.1.1.2/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "2.1.1.2",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620482,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.1.2~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.2.2",
+          "remoteAs" : 2,
+          "remotePrefix" : "2.1.1.2/32",
+          "routeReflectorClient" : true,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "2.1.2.1",
-        "ip2" : "2.1.1.1",
-        "node1" : "as2core1",
-        "node2" : "as2border1"
+        "edgeSummary" : {
+          "ip1" : "2.1.2.1",
+          "ip2" : "2.1.1.1",
+          "node1" : "as2core1",
+          "node2" : "as2border1"
+        },
+        "node1Session" : {
+          "name" : "2.1.1.1/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "2.1.1.1",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620481,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.1.1~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.2.1",
+          "remoteAs" : 2,
+          "remotePrefix" : "2.1.1.1/32",
+          "routeReflectorClient" : true,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : "2.1.2.1/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "2.1.2.1",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620225,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.1.1",
+          "remoteAs" : 2,
+          "remotePrefix" : "2.1.2.1/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "2.1.2.1",
-        "ip2" : "2.1.1.2",
-        "node1" : "as2core1",
-        "node2" : "as2border2"
+        "edgeSummary" : {
+          "ip1" : "2.1.2.1",
+          "ip2" : "2.1.1.2",
+          "node1" : "as2core1",
+          "node2" : "as2border2"
+        },
+        "node1Session" : {
+          "name" : "2.1.1.2/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "2.1.1.2",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620481,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.1.2~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.2.1",
+          "remoteAs" : 2,
+          "remotePrefix" : "2.1.1.2/32",
+          "routeReflectorClient" : true,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : "2.1.2.1/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "2.1.2.1",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620226,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.1.2",
+          "remoteAs" : 2,
+          "remotePrefix" : "2.1.2.1/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "2.1.2.1",
-        "ip2" : "2.1.3.1",
-        "node1" : "as2core1",
-        "node2" : "as2dist1"
+        "edgeSummary" : {
+          "ip1" : "2.1.2.1",
+          "ip2" : "2.1.3.1",
+          "node1" : "as2core1",
+          "node2" : "as2dist1"
+        },
+        "node1Session" : {
+          "name" : "2.1.3.1/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "2.1.3.1",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620481,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.3.1~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.2.1",
+          "remoteAs" : 2,
+          "remotePrefix" : "2.1.3.1/32",
+          "routeReflectorClient" : true,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : "2.1.2.1/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "2.1.2.1",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620737,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.3.1",
+          "remoteAs" : 2,
+          "remotePrefix" : "2.1.2.1/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "2.1.2.1",
-        "ip2" : "2.1.3.2",
-        "node1" : "as2core1",
-        "node2" : "as2dist2"
+        "edgeSummary" : {
+          "ip1" : "2.1.2.1",
+          "ip2" : "2.1.3.2",
+          "node1" : "as2core1",
+          "node2" : "as2dist2"
+        },
+        "node1Session" : {
+          "name" : "2.1.3.2/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "2.1.3.2",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620481,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.3.2~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.2.1",
+          "remoteAs" : 2,
+          "remotePrefix" : "2.1.3.2/32",
+          "routeReflectorClient" : true,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : "2.1.2.1/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "2.1.2.1",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620738,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.3.2",
+          "remoteAs" : 2,
+          "remotePrefix" : "2.1.2.1/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "2.1.2.2",
-        "ip2" : "2.1.1.1",
-        "node1" : "as2core2",
-        "node2" : "as2border1"
+        "edgeSummary" : {
+          "ip1" : "2.1.2.2",
+          "ip2" : "2.1.1.1",
+          "node1" : "as2core2",
+          "node2" : "as2border1"
+        },
+        "node1Session" : {
+          "name" : "2.1.1.1/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "2.1.1.1",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620482,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.1.1~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.2.2",
+          "remoteAs" : 2,
+          "remotePrefix" : "2.1.1.1/32",
+          "routeReflectorClient" : true,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : "2.1.2.2/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "2.1.2.2",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620225,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.1.1",
+          "remoteAs" : 2,
+          "remotePrefix" : "2.1.2.2/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "2.1.2.2",
-        "ip2" : "2.1.1.2",
-        "node1" : "as2core2",
-        "node2" : "as2border2"
+        "edgeSummary" : {
+          "ip1" : "2.1.2.2",
+          "ip2" : "2.1.1.2",
+          "node1" : "as2core2",
+          "node2" : "as2border2"
+        },
+        "node1Session" : {
+          "name" : "2.1.1.2/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "2.1.1.2",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620482,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.1.2~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.2.2",
+          "remoteAs" : 2,
+          "remotePrefix" : "2.1.1.2/32",
+          "routeReflectorClient" : true,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : "2.1.2.2/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "2.1.2.2",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620226,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.1.2",
+          "remoteAs" : 2,
+          "remotePrefix" : "2.1.2.2/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "2.1.2.2",
-        "ip2" : "2.1.3.1",
-        "node1" : "as2core2",
-        "node2" : "as2dist1"
+        "edgeSummary" : {
+          "ip1" : "2.1.2.2",
+          "ip2" : "2.1.3.1",
+          "node1" : "as2core2",
+          "node2" : "as2dist1"
+        },
+        "node1Session" : {
+          "name" : "2.1.3.1/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "2.1.3.1",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620482,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.3.1~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.2.2",
+          "remoteAs" : 2,
+          "remotePrefix" : "2.1.3.1/32",
+          "routeReflectorClient" : true,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : "2.1.2.2/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "2.1.2.2",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620737,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.3.1",
+          "remoteAs" : 2,
+          "remotePrefix" : "2.1.2.2/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "2.1.2.2",
-        "ip2" : "2.1.3.2",
-        "node1" : "as2core2",
-        "node2" : "as2dist2"
+        "edgeSummary" : {
+          "ip1" : "2.1.2.2",
+          "ip2" : "2.1.3.2",
+          "node1" : "as2core2",
+          "node2" : "as2dist2"
+        },
+        "node1Session" : {
+          "name" : "2.1.3.2/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "2.1.3.2",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620482,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.3.2~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.2.2",
+          "remoteAs" : 2,
+          "remotePrefix" : "2.1.3.2/32",
+          "routeReflectorClient" : true,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : "2.1.2.2/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "2.1.2.2",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620738,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.3.2",
+          "remoteAs" : 2,
+          "remotePrefix" : "2.1.2.2/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "2.1.3.1",
-        "ip2" : "2.1.2.1",
-        "node1" : "as2dist1",
-        "node2" : "as2core1"
+        "edgeSummary" : {
+          "ip1" : "2.1.3.1",
+          "ip2" : "2.1.2.1",
+          "node1" : "as2dist1",
+          "node2" : "as2core1"
+        },
+        "node1Session" : {
+          "name" : "2.1.2.1/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "2.1.2.1",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620737,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.3.1",
+          "remoteAs" : 2,
+          "remotePrefix" : "2.1.2.1/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : "2.1.3.1/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "2.1.3.1",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620481,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.3.1~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.2.1",
+          "remoteAs" : 2,
+          "remotePrefix" : "2.1.3.1/32",
+          "routeReflectorClient" : true,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "2.1.3.1",
-        "ip2" : "2.1.2.2",
-        "node1" : "as2dist1",
-        "node2" : "as2core2"
+        "edgeSummary" : {
+          "ip1" : "2.1.3.1",
+          "ip2" : "2.1.2.2",
+          "node1" : "as2dist1",
+          "node2" : "as2core2"
+        },
+        "node1Session" : {
+          "name" : "2.1.2.2/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "2.1.2.2",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620737,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.3.1",
+          "remoteAs" : 2,
+          "remotePrefix" : "2.1.2.2/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : "2.1.3.1/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "2.1.3.1",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620482,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.3.1~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.2.2",
+          "remoteAs" : 2,
+          "remotePrefix" : "2.1.3.1/32",
+          "routeReflectorClient" : true,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "2.1.3.2",
-        "ip2" : "2.1.2.1",
-        "node1" : "as2dist2",
-        "node2" : "as2core1"
+        "edgeSummary" : {
+          "ip1" : "2.1.3.2",
+          "ip2" : "2.1.2.1",
+          "node1" : "as2dist2",
+          "node2" : "as2core1"
+        },
+        "node1Session" : {
+          "name" : "2.1.2.1/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "2.1.2.1",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620738,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.3.2",
+          "remoteAs" : 2,
+          "remotePrefix" : "2.1.2.1/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : "2.1.3.2/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "2.1.3.2",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620481,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.3.2~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.2.1",
+          "remoteAs" : 2,
+          "remotePrefix" : "2.1.3.2/32",
+          "routeReflectorClient" : true,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "2.1.3.2",
-        "ip2" : "2.1.2.2",
-        "node1" : "as2dist2",
-        "node2" : "as2core2"
+        "edgeSummary" : {
+          "ip1" : "2.1.3.2",
+          "ip2" : "2.1.2.2",
+          "node1" : "as2dist2",
+          "node2" : "as2core2"
+        },
+        "node1Session" : {
+          "name" : "2.1.2.2/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "2.1.2.2",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620738,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.3.2",
+          "remoteAs" : 2,
+          "remotePrefix" : "2.1.2.2/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : "2.1.3.2/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "2.1.3.2",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 33620482,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.3.2~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.2.2",
+          "remoteAs" : 2,
+          "remotePrefix" : "2.1.3.2/32",
+          "routeReflectorClient" : true,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "3.1.1.1",
-        "ip2" : "3.10.1.1",
-        "node1" : "as3border1",
-        "node2" : "as3core1"
+        "edgeSummary" : {
+          "ip1" : "3.1.1.1",
+          "ip2" : "3.10.1.1",
+          "node1" : "as3border1",
+          "node2" : "as3core1"
+        },
+        "node1Session" : {
+          "name" : "3.10.1.1/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "3.10.1.1",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 50397441,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:3.10.1.1~",
+          "group" : "as3",
+          "localAs" : 3,
+          "localIp" : "3.1.1.1",
+          "remoteAs" : 3,
+          "remotePrefix" : "3.10.1.1/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : "3.1.1.1/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "3.1.1.1",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 50987265,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:3.1.1.1~",
+          "group" : "as3",
+          "localAs" : 3,
+          "localIp" : "3.10.1.1",
+          "remoteAs" : 3,
+          "remotePrefix" : "3.1.1.1/32",
+          "routeReflectorClient" : true,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "3.2.2.2",
-        "ip2" : "3.10.1.1",
-        "node1" : "as3border2",
-        "node2" : "as3core1"
+        "edgeSummary" : {
+          "ip1" : "3.2.2.2",
+          "ip2" : "3.10.1.1",
+          "node1" : "as3border2",
+          "node2" : "as3core1"
+        },
+        "node1Session" : {
+          "name" : "3.10.1.1/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "3.10.1.1",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 50463234,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:3.10.1.1~",
+          "group" : "as3",
+          "localAs" : 3,
+          "localIp" : "3.2.2.2",
+          "remoteAs" : 3,
+          "remotePrefix" : "3.10.1.1/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : "3.2.2.2/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "3.2.2.2",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 50987265,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:3.2.2.2~",
+          "group" : "as3",
+          "localAs" : 3,
+          "localIp" : "3.10.1.1",
+          "remoteAs" : 3,
+          "remotePrefix" : "3.2.2.2/32",
+          "routeReflectorClient" : true,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "3.10.1.1",
-        "ip2" : "3.1.1.1",
-        "node1" : "as3core1",
-        "node2" : "as3border1"
+        "edgeSummary" : {
+          "ip1" : "3.10.1.1",
+          "ip2" : "3.1.1.1",
+          "node1" : "as3core1",
+          "node2" : "as3border1"
+        },
+        "node1Session" : {
+          "name" : "3.1.1.1/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "3.1.1.1",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 50987265,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:3.1.1.1~",
+          "group" : "as3",
+          "localAs" : 3,
+          "localIp" : "3.10.1.1",
+          "remoteAs" : 3,
+          "remotePrefix" : "3.1.1.1/32",
+          "routeReflectorClient" : true,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : "3.10.1.1/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "3.10.1.1",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 50397441,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:3.10.1.1~",
+          "group" : "as3",
+          "localAs" : 3,
+          "localIp" : "3.1.1.1",
+          "remoteAs" : 3,
+          "remotePrefix" : "3.10.1.1/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "3.10.1.1",
-        "ip2" : "3.2.2.2",
-        "node1" : "as3core1",
-        "node2" : "as3border2"
+        "edgeSummary" : {
+          "ip1" : "3.10.1.1",
+          "ip2" : "3.2.2.2",
+          "node1" : "as3core1",
+          "node2" : "as3border2"
+        },
+        "node1Session" : {
+          "name" : "3.2.2.2/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "3.2.2.2",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 50987265,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:3.2.2.2~",
+          "group" : "as3",
+          "localAs" : 3,
+          "localIp" : "3.10.1.1",
+          "remoteAs" : 3,
+          "remotePrefix" : "3.2.2.2/32",
+          "routeReflectorClient" : true,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : "3.10.1.1/32",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "address" : "3.10.1.1",
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : false,
+          "clusterId" : 50463234,
+          "defaultMetric" : 0,
+          "dynamic" : false,
+          "ebgpMultihop" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:3.10.1.1~",
+          "group" : "as3",
+          "localAs" : 3,
+          "localIp" : "3.2.2.2",
+          "remoteAs" : 3,
+          "remotePrefix" : "3.10.1.1/32",
+          "routeReflectorClient" : false,
+          "sendCommunity" : true,
+          "vrf" : "default"
+        }
       }
     ],
-    "lanNeighbors" : [
+    "verboseLanNeighbors" : [
       {
-        "node1" : "as1border1",
-        "node1interface" : "GigabitEthernet0/0",
-        "node2" : "as1core1",
-        "node2interface" : "GigabitEthernet1/0"
+        "edgeSummary" : {
+          "node1" : "as1border1",
+          "node1interface" : "GigabitEthernet0/0",
+          "node2" : "as1core1",
+          "node2interface" : "GigabitEthernet1/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "1.0.1.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "1.0.1.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "1.0.1.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "1.0.1.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
       },
       {
-        "node1" : "as1border1",
-        "node1interface" : "GigabitEthernet1/0",
-        "node2" : "as2border1",
-        "node2interface" : "GigabitEthernet0/0"
+        "edgeSummary" : {
+          "node1" : "as1border1",
+          "node1interface" : "GigabitEthernet1/0",
+          "node2" : "as2border1",
+          "node2interface" : "GigabitEthernet0/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "10.12.11.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "10.12.11.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "10.12.11.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "incomingFilter" : "OUTSIDE_TO_INSIDE",
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "outgoingFilter" : "INSIDE_TO_AS1",
+          "prefix" : "10.12.11.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
       },
       {
-        "node1" : "as1border2",
-        "node1interface" : "GigabitEthernet0/0",
-        "node2" : "as3border2",
-        "node2interface" : "GigabitEthernet0/0"
+        "edgeSummary" : {
+          "node1" : "as1border2",
+          "node1interface" : "GigabitEthernet0/0",
+          "node2" : "as3border2",
+          "node2interface" : "GigabitEthernet0/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "10.13.22.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "10.13.22.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "10.13.22.3/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "10.13.22.3/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
       },
       {
-        "node1" : "as1border2",
-        "node1interface" : "GigabitEthernet1/0",
-        "node2" : "as1core1",
-        "node2interface" : "GigabitEthernet0/0"
+        "edgeSummary" : {
+          "node1" : "as1border2",
+          "node1interface" : "GigabitEthernet1/0",
+          "node2" : "as1core1",
+          "node2interface" : "GigabitEthernet0/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "1.0.2.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "1.0.2.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "1.0.2.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "1.0.2.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
       },
       {
-        "node1" : "as1core1",
-        "node1interface" : "GigabitEthernet0/0",
-        "node2" : "as1border2",
-        "node2interface" : "GigabitEthernet1/0"
+        "edgeSummary" : {
+          "node1" : "as1core1",
+          "node1interface" : "GigabitEthernet0/0",
+          "node2" : "as1border2",
+          "node2interface" : "GigabitEthernet1/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "1.0.2.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "1.0.2.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "1.0.2.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "1.0.2.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
       },
       {
-        "node1" : "as1core1",
-        "node1interface" : "GigabitEthernet1/0",
-        "node2" : "as1border1",
-        "node2interface" : "GigabitEthernet0/0"
+        "edgeSummary" : {
+          "node1" : "as1core1",
+          "node1interface" : "GigabitEthernet1/0",
+          "node2" : "as1border1",
+          "node2interface" : "GigabitEthernet0/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "1.0.1.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "1.0.1.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "1.0.1.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "1.0.1.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
       },
       {
-        "node1" : "as2border1",
-        "node1interface" : "GigabitEthernet0/0",
-        "node2" : "as1border1",
-        "node2interface" : "GigabitEthernet1/0"
+        "edgeSummary" : {
+          "node1" : "as2border1",
+          "node1interface" : "GigabitEthernet0/0",
+          "node2" : "as1border1",
+          "node2interface" : "GigabitEthernet1/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "10.12.11.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "incomingFilter" : "OUTSIDE_TO_INSIDE",
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "outgoingFilter" : "INSIDE_TO_AS1",
+          "prefix" : "10.12.11.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "10.12.11.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "10.12.11.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
       },
       {
-        "node1" : "as2border1",
-        "node1interface" : "GigabitEthernet1/0",
-        "node2" : "as2core1",
-        "node2interface" : "GigabitEthernet0/0"
+        "edgeSummary" : {
+          "node1" : "as2border1",
+          "node1interface" : "GigabitEthernet1/0",
+          "node2" : "as2core1",
+          "node2interface" : "GigabitEthernet0/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.12.11.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.12.11.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.12.11.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.12.11.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
       },
       {
-        "node1" : "as2border1",
-        "node1interface" : "GigabitEthernet2/0",
-        "node2" : "as2core2",
-        "node2interface" : "GigabitEthernet1/0"
+        "edgeSummary" : {
+          "node1" : "as2border1",
+          "node1interface" : "GigabitEthernet2/0",
+          "node2" : "as2core2",
+          "node2interface" : "GigabitEthernet1/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet2/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.12.12.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet2/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.12.12.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.12.12.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1600,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.12.12.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
       },
       {
-        "node1" : "as2border2",
-        "node1interface" : "GigabitEthernet0/0",
-        "node2" : "as3border1",
-        "node2interface" : "GigabitEthernet1/0"
+        "edgeSummary" : {
+          "node1" : "as2border2",
+          "node1interface" : "GigabitEthernet0/0",
+          "node2" : "as3border1",
+          "node2interface" : "GigabitEthernet1/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "10.23.21.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "incomingFilter" : "OUTSIDE_TO_INSIDE",
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "outgoingFilter" : "INSIDE_TO_AS3",
+          "prefix" : "10.23.21.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "10.23.21.3/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "10.23.21.3/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
       },
       {
-        "node1" : "as2border2",
-        "node1interface" : "GigabitEthernet1/0",
-        "node2" : "as2core2",
-        "node2interface" : "GigabitEthernet0/0"
+        "edgeSummary" : {
+          "node1" : "as2border2",
+          "node1interface" : "GigabitEthernet1/0",
+          "node2" : "as2core2",
+          "node2interface" : "GigabitEthernet0/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.12.22.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.12.22.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.12.22.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1800,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.12.22.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
       },
       {
-        "node1" : "as2border2",
-        "node1interface" : "GigabitEthernet2/0",
-        "node2" : "as2core1",
-        "node2interface" : "GigabitEthernet1/0"
+        "edgeSummary" : {
+          "node1" : "as2border2",
+          "node1interface" : "GigabitEthernet2/0",
+          "node2" : "as2core1",
+          "node2interface" : "GigabitEthernet1/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet2/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.12.21.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet2/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.12.21.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.12.21.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.12.21.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
       },
       {
-        "node1" : "as2core1",
-        "node1interface" : "GigabitEthernet0/0",
-        "node2" : "as2border1",
-        "node2interface" : "GigabitEthernet1/0"
+        "edgeSummary" : {
+          "node1" : "as2core1",
+          "node1interface" : "GigabitEthernet0/0",
+          "node2" : "as2border1",
+          "node2interface" : "GigabitEthernet1/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.12.11.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.12.11.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.12.11.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.12.11.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
       },
       {
-        "node1" : "as2core1",
-        "node1interface" : "GigabitEthernet1/0",
-        "node2" : "as2border2",
-        "node2interface" : "GigabitEthernet2/0"
+        "edgeSummary" : {
+          "node1" : "as2core1",
+          "node1interface" : "GigabitEthernet1/0",
+          "node2" : "as2border2",
+          "node2interface" : "GigabitEthernet2/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.12.21.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.12.21.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet2/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.12.21.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet2/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.12.21.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
       },
       {
-        "node1" : "as2core1",
-        "node1interface" : "GigabitEthernet2/0",
-        "node2" : "as2dist1",
-        "node2interface" : "GigabitEthernet0/0"
+        "edgeSummary" : {
+          "node1" : "as2core1",
+          "node1interface" : "GigabitEthernet2/0",
+          "node2" : "as2dist1",
+          "node2interface" : "GigabitEthernet0/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet2/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.23.11.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet2/0"
+          ],
+          "incomingFilter" : "blocktelnet",
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.23.11.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.23.11.3/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.23.11.3/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
       },
       {
-        "node1" : "as2core1",
-        "node1interface" : "GigabitEthernet3/0",
-        "node2" : "as2dist2",
-        "node2interface" : "GigabitEthernet1/0"
+        "edgeSummary" : {
+          "node1" : "as2core1",
+          "node1interface" : "GigabitEthernet3/0",
+          "node2" : "as2dist2",
+          "node2interface" : "GigabitEthernet1/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet3/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.23.12.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet3/0"
+          ],
+          "incomingFilter" : "blocktelnet",
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.23.12.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.23.12.3/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.23.12.3/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
       },
       {
-        "node1" : "as2core2",
-        "node1interface" : "GigabitEthernet0/0",
-        "node2" : "as2border2",
-        "node2interface" : "GigabitEthernet1/0"
+        "edgeSummary" : {
+          "node1" : "as2core2",
+          "node1interface" : "GigabitEthernet0/0",
+          "node2" : "as2border2",
+          "node2interface" : "GigabitEthernet1/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.12.22.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1800,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.12.22.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.12.22.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.12.22.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
       },
       {
-        "node1" : "as2core2",
-        "node1interface" : "GigabitEthernet1/0",
-        "node2" : "as2border1",
-        "node2interface" : "GigabitEthernet2/0"
+        "edgeSummary" : {
+          "node1" : "as2core2",
+          "node1interface" : "GigabitEthernet1/0",
+          "node2" : "as2border1",
+          "node2interface" : "GigabitEthernet2/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.12.12.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1600,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.12.12.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet2/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.12.12.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet2/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.12.12.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
       },
       {
-        "node1" : "as2core2",
-        "node1interface" : "GigabitEthernet2/0",
-        "node2" : "as2dist2",
-        "node2interface" : "GigabitEthernet0/0"
+        "edgeSummary" : {
+          "node1" : "as2core2",
+          "node1interface" : "GigabitEthernet2/0",
+          "node2" : "as2dist2",
+          "node2interface" : "GigabitEthernet0/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet2/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.23.22.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet2/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1700,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.23.22.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.23.22.3/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.23.22.3/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
       },
       {
-        "node1" : "as2core2",
-        "node1interface" : "GigabitEthernet3/0",
-        "node2" : "as2dist1",
-        "node2interface" : "GigabitEthernet1/0"
+        "edgeSummary" : {
+          "node1" : "as2core2",
+          "node1interface" : "GigabitEthernet3/0",
+          "node2" : "as2dist1",
+          "node2interface" : "GigabitEthernet1/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet3/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.23.21.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet3/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.23.21.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.23.21.3/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.23.21.3/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
       },
       {
-        "node1" : "as2dept1",
-        "node1interface" : "GigabitEthernet0/0",
-        "node2" : "as2dist1",
-        "node2interface" : "GigabitEthernet2/0"
+        "edgeSummary" : {
+          "node1" : "as2dept1",
+          "node1interface" : "GigabitEthernet0/0",
+          "node2" : "as2dist1",
+          "node2interface" : "GigabitEthernet2/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.34.101.4/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.34.101.4/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet2/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.34.101.3/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet2/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.34.101.3/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
       },
       {
-        "node1" : "as2dept1",
-        "node1interface" : "GigabitEthernet1/0",
-        "node2" : "as2dist2",
-        "node2interface" : "GigabitEthernet2/0"
+        "edgeSummary" : {
+          "node1" : "as2dept1",
+          "node1interface" : "GigabitEthernet1/0",
+          "node2" : "as2dist2",
+          "node2interface" : "GigabitEthernet2/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.34.201.4/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.34.201.4/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet2/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.34.201.3/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet2/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.34.201.3/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
       },
       {
-        "node1" : "as2dept1",
-        "node1interface" : "GigabitEthernet2/0",
-        "node2" : "host1",
-        "node2interface" : "eth0"
+        "edgeSummary" : {
+          "node1" : "as2dept1",
+          "node1interface" : "GigabitEthernet2/0",
+          "node2" : "host1",
+          "node2interface" : "eth0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet2/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.128.0.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet2/0"
+          ],
+          "incomingFilter" : "RESTRICT_HOST_TRAFFIC_IN",
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.128.0.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "eth0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.128.0.101/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "eth0"
+          ],
+          "incomingFilter" : "filter::INPUT",
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "outgoingFilter" : "filter::OUTPUT",
+          "prefix" : "2.128.0.101/24",
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
       },
       {
-        "node1" : "as2dept1",
-        "node1interface" : "GigabitEthernet3/0",
-        "node2" : "host2",
-        "node2interface" : "eth0"
+        "edgeSummary" : {
+          "node1" : "as2dept1",
+          "node1interface" : "GigabitEthernet3/0",
+          "node2" : "host2",
+          "node2interface" : "eth0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet3/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.128.1.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet3/0"
+          ],
+          "incomingFilter" : "RESTRICT_HOST_TRAFFIC_IN",
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.128.1.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "eth0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.128.1.101/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "eth0"
+          ],
+          "incomingFilter" : "filter::INPUT",
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "outgoingFilter" : "filter::OUTPUT",
+          "prefix" : "2.128.1.101/24",
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
       },
       {
-        "node1" : "as2dist1",
-        "node1interface" : "GigabitEthernet0/0",
-        "node2" : "as2core1",
-        "node2interface" : "GigabitEthernet2/0"
+        "edgeSummary" : {
+          "node1" : "as2dist1",
+          "node1interface" : "GigabitEthernet0/0",
+          "node2" : "as2core1",
+          "node2interface" : "GigabitEthernet2/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.23.11.3/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.23.11.3/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet2/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.23.11.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet2/0"
+          ],
+          "incomingFilter" : "blocktelnet",
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.23.11.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
       },
       {
-        "node1" : "as2dist1",
-        "node1interface" : "GigabitEthernet1/0",
-        "node2" : "as2core2",
-        "node2interface" : "GigabitEthernet3/0"
+        "edgeSummary" : {
+          "node1" : "as2dist1",
+          "node1interface" : "GigabitEthernet1/0",
+          "node2" : "as2core2",
+          "node2interface" : "GigabitEthernet3/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.23.21.3/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.23.21.3/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet3/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.23.21.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet3/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.23.21.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
       },
       {
-        "node1" : "as2dist1",
-        "node1interface" : "GigabitEthernet2/0",
-        "node2" : "as2dept1",
-        "node2interface" : "GigabitEthernet0/0"
+        "edgeSummary" : {
+          "node1" : "as2dist1",
+          "node1interface" : "GigabitEthernet2/0",
+          "node2" : "as2dept1",
+          "node2interface" : "GigabitEthernet0/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet2/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.34.101.3/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet2/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.34.101.3/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.34.101.4/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.34.101.4/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
       },
       {
-        "node1" : "as2dist2",
-        "node1interface" : "GigabitEthernet0/0",
-        "node2" : "as2core2",
-        "node2interface" : "GigabitEthernet2/0"
+        "edgeSummary" : {
+          "node1" : "as2dist2",
+          "node1interface" : "GigabitEthernet0/0",
+          "node2" : "as2core2",
+          "node2interface" : "GigabitEthernet2/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.23.22.3/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.23.22.3/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet2/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.23.22.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet2/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1700,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.23.22.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
       },
       {
-        "node1" : "as2dist2",
-        "node1interface" : "GigabitEthernet1/0",
-        "node2" : "as2core1",
-        "node2interface" : "GigabitEthernet3/0"
+        "edgeSummary" : {
+          "node1" : "as2dist2",
+          "node1interface" : "GigabitEthernet1/0",
+          "node2" : "as2core1",
+          "node2interface" : "GigabitEthernet3/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.23.12.3/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.23.12.3/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet3/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.23.12.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet3/0"
+          ],
+          "incomingFilter" : "blocktelnet",
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.23.12.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
       },
       {
-        "node1" : "as2dist2",
-        "node1interface" : "GigabitEthernet2/0",
-        "node2" : "as2dept1",
-        "node2interface" : "GigabitEthernet1/0"
+        "edgeSummary" : {
+          "node1" : "as2dist2",
+          "node1interface" : "GigabitEthernet2/0",
+          "node2" : "as2dept1",
+          "node2interface" : "GigabitEthernet1/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet2/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.34.201.3/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet2/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.34.201.3/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.34.201.4/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.34.201.4/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
       },
       {
-        "node1" : "as3border1",
-        "node1interface" : "GigabitEthernet0/0",
-        "node2" : "as3core1",
-        "node2interface" : "GigabitEthernet1/0"
+        "edgeSummary" : {
+          "node1" : "as3border1",
+          "node1interface" : "GigabitEthernet0/0",
+          "node2" : "as3core1",
+          "node2interface" : "GigabitEthernet1/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "3.0.1.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "3.0.1.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "3.0.1.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "3.0.1.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
       },
       {
-        "node1" : "as3border1",
-        "node1interface" : "GigabitEthernet1/0",
-        "node2" : "as2border2",
-        "node2interface" : "GigabitEthernet0/0"
+        "edgeSummary" : {
+          "node1" : "as3border1",
+          "node1interface" : "GigabitEthernet1/0",
+          "node2" : "as2border2",
+          "node2interface" : "GigabitEthernet0/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "10.23.21.3/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "10.23.21.3/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "10.23.21.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "incomingFilter" : "OUTSIDE_TO_INSIDE",
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "outgoingFilter" : "INSIDE_TO_AS3",
+          "prefix" : "10.23.21.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
       },
       {
-        "node1" : "as3border2",
-        "node1interface" : "GigabitEthernet0/0",
-        "node2" : "as1border2",
-        "node2interface" : "GigabitEthernet0/0"
+        "edgeSummary" : {
+          "node1" : "as3border2",
+          "node1interface" : "GigabitEthernet0/0",
+          "node2" : "as1border2",
+          "node2interface" : "GigabitEthernet0/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "10.13.22.3/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "10.13.22.3/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "10.13.22.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "10.13.22.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
       },
       {
-        "node1" : "as3border2",
-        "node1interface" : "GigabitEthernet1/0",
-        "node2" : "as3core1",
-        "node2interface" : "GigabitEthernet0/0"
+        "edgeSummary" : {
+          "node1" : "as3border2",
+          "node1interface" : "GigabitEthernet1/0",
+          "node2" : "as3core1",
+          "node2interface" : "GigabitEthernet0/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "3.0.2.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "3.0.2.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "3.0.2.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "3.0.2.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
       },
       {
-        "node1" : "as3core1",
-        "node1interface" : "GigabitEthernet0/0",
-        "node2" : "as3border2",
-        "node2interface" : "GigabitEthernet1/0"
+        "edgeSummary" : {
+          "node1" : "as3core1",
+          "node1interface" : "GigabitEthernet0/0",
+          "node2" : "as3border2",
+          "node2interface" : "GigabitEthernet1/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "3.0.2.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "3.0.2.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "3.0.2.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "3.0.2.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
       },
       {
-        "node1" : "as3core1",
-        "node1interface" : "GigabitEthernet1/0",
-        "node2" : "as3border1",
-        "node2interface" : "GigabitEthernet0/0"
+        "edgeSummary" : {
+          "node1" : "as3core1",
+          "node1interface" : "GigabitEthernet1/0",
+          "node2" : "as3border1",
+          "node2interface" : "GigabitEthernet0/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "3.0.1.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "3.0.1.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "3.0.1.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "3.0.1.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
       },
       {
-        "node1" : "as3core1",
-        "node1interface" : "GigabitEthernet2/0",
-        "node2" : "as3core1",
-        "node2interface" : "GigabitEthernet3/0"
+        "edgeSummary" : {
+          "node1" : "as3core1",
+          "node1interface" : "GigabitEthernet2/0",
+          "node2" : "as3core1",
+          "node2interface" : "GigabitEthernet3/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet2/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "90.90.90.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet2/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "90.90.90.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet3/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "90.90.90.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet3/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "90.90.90.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
       },
       {
-        "node1" : "as3core1",
-        "node1interface" : "GigabitEthernet3/0",
-        "node2" : "as3core1",
-        "node2interface" : "GigabitEthernet2/0"
+        "edgeSummary" : {
+          "node1" : "as3core1",
+          "node1interface" : "GigabitEthernet3/0",
+          "node2" : "as3core1",
+          "node2interface" : "GigabitEthernet2/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet3/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "90.90.90.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet3/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "90.90.90.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet2/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "90.90.90.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet2/0"
+          ],
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "90.90.90.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
       },
       {
-        "node1" : "host1",
-        "node1interface" : "eth0",
-        "node2" : "as2dept1",
-        "node2interface" : "GigabitEthernet2/0"
+        "edgeSummary" : {
+          "node1" : "host1",
+          "node1interface" : "eth0",
+          "node2" : "as2dept1",
+          "node2interface" : "GigabitEthernet2/0"
+        },
+        "node1Interface" : {
+          "name" : "eth0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.128.0.101/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "eth0"
+          ],
+          "incomingFilter" : "filter::INPUT",
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "outgoingFilter" : "filter::OUTPUT",
+          "prefix" : "2.128.0.101/24",
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet2/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.128.0.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet2/0"
+          ],
+          "incomingFilter" : "RESTRICT_HOST_TRAFFIC_IN",
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.128.0.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
       },
       {
-        "node1" : "host2",
-        "node1interface" : "eth0",
-        "node2" : "as2dept1",
-        "node2interface" : "GigabitEthernet3/0"
+        "edgeSummary" : {
+          "node1" : "host2",
+          "node1interface" : "eth0",
+          "node2" : "as2dept1",
+          "node2interface" : "GigabitEthernet3/0"
+        },
+        "node1Interface" : {
+          "name" : "eth0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.128.1.101/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "eth0"
+          ],
+          "incomingFilter" : "filter::INPUT",
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "outgoingFilter" : "filter::OUTPUT",
+          "prefix" : "2.128.1.101/24",
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet3/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.128.1.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet3/0"
+          ],
+          "incomingFilter" : "RESTRICT_HOST_TRAFFIC_IN",
+          "isisL1InterfaceMode" : "unset",
+          "isisL2InterfaceMode" : "unset",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.128.1.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
       }
     ],
-    "ospfNeighbors" : [
+    "verboseOspfNeighbors" : [
       {
-        "ip1" : "1.0.1.1",
-        "ip2" : "1.0.1.2",
-        "node1" : "as1border1",
-        "node2" : "as1core1"
+        "edgeSummary" : {
+          "ip1" : "1.0.1.1",
+          "ip2" : "1.0.1.2",
+          "node1" : "as1border1",
+          "node2" : "as1core1"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "1.0.1.1",
+            "ip2" : "1.0.1.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "1.0.1.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "1.0.1.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "1.0.1.2",
+            "ip2" : "1.0.1.1"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "1.0.1.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "1.0.1.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "1.0.2.1",
-        "ip2" : "1.0.2.2",
-        "node1" : "as1border2",
-        "node2" : "as1core1"
+        "edgeSummary" : {
+          "ip1" : "1.0.2.1",
+          "ip2" : "1.0.2.2",
+          "node1" : "as1border2",
+          "node2" : "as1core1"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "1.0.2.1",
+            "ip2" : "1.0.2.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "1.0.2.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "1.0.2.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "1.0.2.2",
+            "ip2" : "1.0.2.1"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "1.0.2.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "1.0.2.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "1.0.1.2",
-        "ip2" : "1.0.1.1",
-        "node1" : "as1core1",
-        "node2" : "as1border1"
+        "edgeSummary" : {
+          "ip1" : "1.0.1.2",
+          "ip2" : "1.0.1.1",
+          "node1" : "as1core1",
+          "node2" : "as1border1"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "1.0.1.2",
+            "ip2" : "1.0.1.1"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "1.0.1.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "1.0.1.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "1.0.1.1",
+            "ip2" : "1.0.1.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "1.0.1.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "1.0.1.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "1.0.2.2",
-        "ip2" : "1.0.2.1",
-        "node1" : "as1core1",
-        "node2" : "as1border2"
+        "edgeSummary" : {
+          "ip1" : "1.0.2.2",
+          "ip2" : "1.0.2.1",
+          "node1" : "as1core1",
+          "node2" : "as1border2"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "1.0.2.2",
+            "ip2" : "1.0.2.1"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "1.0.2.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "1.0.2.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "1.0.2.1",
+            "ip2" : "1.0.2.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "1.0.2.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "1.0.2.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "2.12.11.1",
-        "ip2" : "2.12.11.2",
-        "node1" : "as2border1",
-        "node2" : "as2core1"
+        "edgeSummary" : {
+          "ip1" : "2.12.11.1",
+          "ip2" : "2.12.11.2",
+          "node1" : "as2border1",
+          "node2" : "as2core1"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "2.12.11.1",
+            "ip2" : "2.12.11.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.11.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.11.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "2.12.11.2",
+            "ip2" : "2.12.11.1"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.11.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.11.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "2.12.12.1",
-        "ip2" : "2.12.12.2",
-        "node1" : "as2border1",
-        "node2" : "as2core2"
+        "edgeSummary" : {
+          "ip1" : "2.12.12.1",
+          "ip2" : "2.12.12.2",
+          "node1" : "as2border1",
+          "node2" : "as2core2"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "2.12.12.1",
+            "ip2" : "2.12.12.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.12.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.12.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "2.12.12.2",
+            "ip2" : "2.12.12.1"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.12.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1600,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.12.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "2.12.21.1",
-        "ip2" : "2.12.21.2",
-        "node1" : "as2border2",
-        "node2" : "as2core1"
+        "edgeSummary" : {
+          "ip1" : "2.12.21.1",
+          "ip2" : "2.12.21.2",
+          "node1" : "as2border2",
+          "node2" : "as2core1"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "2.12.21.1",
+            "ip2" : "2.12.21.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.21.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.21.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "2.12.21.2",
+            "ip2" : "2.12.21.1"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.21.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.21.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "2.12.22.1",
-        "ip2" : "2.12.22.2",
-        "node1" : "as2border2",
-        "node2" : "as2core2"
+        "edgeSummary" : {
+          "ip1" : "2.12.22.1",
+          "ip2" : "2.12.22.2",
+          "node1" : "as2border2",
+          "node2" : "as2core2"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "2.12.22.1",
+            "ip2" : "2.12.22.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.22.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.22.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "2.12.22.2",
+            "ip2" : "2.12.22.1"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.22.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1800,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.22.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "2.12.11.2",
-        "ip2" : "2.12.11.1",
-        "node1" : "as2core1",
-        "node2" : "as2border1"
+        "edgeSummary" : {
+          "ip1" : "2.12.11.2",
+          "ip2" : "2.12.11.1",
+          "node1" : "as2core1",
+          "node2" : "as2border1"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "2.12.11.2",
+            "ip2" : "2.12.11.1"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.11.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.11.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "2.12.11.1",
+            "ip2" : "2.12.11.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.11.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.11.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "2.12.21.2",
-        "ip2" : "2.12.21.1",
-        "node1" : "as2core1",
-        "node2" : "as2border2"
+        "edgeSummary" : {
+          "ip1" : "2.12.21.2",
+          "ip2" : "2.12.21.1",
+          "node1" : "as2core1",
+          "node2" : "as2border2"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "2.12.21.2",
+            "ip2" : "2.12.21.1"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.21.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.21.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "2.12.21.1",
+            "ip2" : "2.12.21.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.21.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.21.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "2.23.11.2",
-        "ip2" : "2.23.11.3",
-        "node1" : "as2core1",
-        "node2" : "as2dist1"
+        "edgeSummary" : {
+          "ip1" : "2.23.11.2",
+          "ip2" : "2.23.11.3",
+          "node1" : "as2core1",
+          "node2" : "as2dist1"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "2.23.11.2",
+            "ip2" : "2.23.11.3"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.11.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "incomingFilter" : "blocktelnet",
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.11.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "2.23.11.3",
+            "ip2" : "2.23.11.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.11.3/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.11.3/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "2.23.12.2",
-        "ip2" : "2.23.12.3",
-        "node1" : "as2core1",
-        "node2" : "as2dist2"
+        "edgeSummary" : {
+          "ip1" : "2.23.12.2",
+          "ip2" : "2.23.12.3",
+          "node1" : "as2core1",
+          "node2" : "as2dist2"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "2.23.12.2",
+            "ip2" : "2.23.12.3"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet3/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.12.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet3/0"
+            ],
+            "incomingFilter" : "blocktelnet",
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.12.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "2.23.12.3",
+            "ip2" : "2.23.12.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.12.3/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.12.3/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "2.12.12.2",
-        "ip2" : "2.12.12.1",
-        "node1" : "as2core2",
-        "node2" : "as2border1"
+        "edgeSummary" : {
+          "ip1" : "2.12.12.2",
+          "ip2" : "2.12.12.1",
+          "node1" : "as2core2",
+          "node2" : "as2border1"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "2.12.12.2",
+            "ip2" : "2.12.12.1"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.12.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1600,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.12.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "2.12.12.1",
+            "ip2" : "2.12.12.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.12.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.12.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "2.12.22.2",
-        "ip2" : "2.12.22.1",
-        "node1" : "as2core2",
-        "node2" : "as2border2"
+        "edgeSummary" : {
+          "ip1" : "2.12.22.2",
+          "ip2" : "2.12.22.1",
+          "node1" : "as2core2",
+          "node2" : "as2border2"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "2.12.22.2",
+            "ip2" : "2.12.22.1"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.22.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1800,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.22.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "2.12.22.1",
+            "ip2" : "2.12.22.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.22.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.22.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "2.23.21.2",
-        "ip2" : "2.23.21.3",
-        "node1" : "as2core2",
-        "node2" : "as2dist1"
+        "edgeSummary" : {
+          "ip1" : "2.23.21.2",
+          "ip2" : "2.23.21.3",
+          "node1" : "as2core2",
+          "node2" : "as2dist1"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "2.23.21.2",
+            "ip2" : "2.23.21.3"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet3/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.21.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet3/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.21.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "2.23.21.3",
+            "ip2" : "2.23.21.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.21.3/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.21.3/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "2.23.22.2",
-        "ip2" : "2.23.22.3",
-        "node1" : "as2core2",
-        "node2" : "as2dist2"
+        "edgeSummary" : {
+          "ip1" : "2.23.22.2",
+          "ip2" : "2.23.22.3",
+          "node1" : "as2core2",
+          "node2" : "as2dist2"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "2.23.22.2",
+            "ip2" : "2.23.22.3"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.22.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1700,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.22.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "2.23.22.3",
+            "ip2" : "2.23.22.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.22.3/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.22.3/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "2.23.11.3",
-        "ip2" : "2.23.11.2",
-        "node1" : "as2dist1",
-        "node2" : "as2core1"
+        "edgeSummary" : {
+          "ip1" : "2.23.11.3",
+          "ip2" : "2.23.11.2",
+          "node1" : "as2dist1",
+          "node2" : "as2core1"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "2.23.11.3",
+            "ip2" : "2.23.11.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.11.3/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.11.3/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "2.23.11.2",
+            "ip2" : "2.23.11.3"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.11.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "incomingFilter" : "blocktelnet",
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.11.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "2.23.21.3",
-        "ip2" : "2.23.21.2",
-        "node1" : "as2dist1",
-        "node2" : "as2core2"
+        "edgeSummary" : {
+          "ip1" : "2.23.21.3",
+          "ip2" : "2.23.21.2",
+          "node1" : "as2dist1",
+          "node2" : "as2core2"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "2.23.21.3",
+            "ip2" : "2.23.21.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.21.3/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.21.3/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "2.23.21.2",
+            "ip2" : "2.23.21.3"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet3/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.21.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet3/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.21.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "2.23.12.3",
-        "ip2" : "2.23.12.2",
-        "node1" : "as2dist2",
-        "node2" : "as2core1"
+        "edgeSummary" : {
+          "ip1" : "2.23.12.3",
+          "ip2" : "2.23.12.2",
+          "node1" : "as2dist2",
+          "node2" : "as2core1"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "2.23.12.3",
+            "ip2" : "2.23.12.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.12.3/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.12.3/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "2.23.12.2",
+            "ip2" : "2.23.12.3"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet3/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.12.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet3/0"
+            ],
+            "incomingFilter" : "blocktelnet",
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.12.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "2.23.22.3",
-        "ip2" : "2.23.22.2",
-        "node1" : "as2dist2",
-        "node2" : "as2core2"
+        "edgeSummary" : {
+          "ip1" : "2.23.22.3",
+          "ip2" : "2.23.22.2",
+          "node1" : "as2dist2",
+          "node2" : "as2core2"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "2.23.22.3",
+            "ip2" : "2.23.22.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.22.3/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.22.3/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "2.23.22.2",
+            "ip2" : "2.23.22.3"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.22.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1700,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.22.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "3.0.1.1",
-        "ip2" : "3.0.1.2",
-        "node1" : "as3border1",
-        "node2" : "as3core1"
+        "edgeSummary" : {
+          "ip1" : "3.0.1.1",
+          "ip2" : "3.0.1.2",
+          "node1" : "as3border1",
+          "node2" : "as3core1"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "3.0.1.1",
+            "ip2" : "3.0.1.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "3.0.1.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "3.0.1.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "3.0.1.2",
+            "ip2" : "3.0.1.1"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "3.0.1.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "3.0.1.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "3.0.2.1",
-        "ip2" : "3.0.2.2",
-        "node1" : "as3border2",
-        "node2" : "as3core1"
+        "edgeSummary" : {
+          "ip1" : "3.0.2.1",
+          "ip2" : "3.0.2.2",
+          "node1" : "as3border2",
+          "node2" : "as3core1"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "3.0.2.1",
+            "ip2" : "3.0.2.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "3.0.2.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "3.0.2.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "3.0.2.2",
+            "ip2" : "3.0.2.1"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "3.0.2.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "3.0.2.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "3.0.1.2",
-        "ip2" : "3.0.1.1",
-        "node1" : "as3core1",
-        "node2" : "as3border1"
+        "edgeSummary" : {
+          "ip1" : "3.0.1.2",
+          "ip2" : "3.0.1.1",
+          "node1" : "as3core1",
+          "node2" : "as3border1"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "3.0.1.2",
+            "ip2" : "3.0.1.1"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "3.0.1.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "3.0.1.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "3.0.1.1",
+            "ip2" : "3.0.1.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "3.0.1.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "3.0.1.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
       },
       {
-        "ip1" : "3.0.2.2",
-        "ip2" : "3.0.2.1",
-        "node1" : "as3core1",
-        "node2" : "as3border2"
+        "edgeSummary" : {
+          "ip1" : "3.0.2.2",
+          "ip2" : "3.0.2.1",
+          "node1" : "as3core1",
+          "node2" : "as3border2"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "3.0.2.2",
+            "ip2" : "3.0.2.1"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "3.0.2.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "3.0.2.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "3.0.2.1",
+            "ip2" : "3.0.2.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "3.0.2.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "isisL1InterfaceMode" : "unset",
+            "isisL2InterfaceMode" : "unset",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "3.0.2.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
       }
     ]
   }


### PR DESCRIPTION
1) Reorder the basic commands file to make it clear which refs we'll keep.
2) Fix a bug in OspfNeighbors serializability -- it had no creator.
3) Replace Pair<Ip,Ip> with IpLink throughout OspfNeighbor. Pair is not
   JSON-serializable by choice.

This is for #1084 