### PR TITLE
Fixing AWS refs for elasticsearch and RDS

### DIFF
--- a/test_rigs/example-aws/aws_configs/us-west-2/ElasticsearchDomains.json
+++ b/test_rigs/example-aws/aws_configs/us-west-2/ElasticsearchDomains.json
@@ -38,7 +38,7 @@
      "us-west-2b"
     ],
     "SecurityGroupIds": [
-     "sg-55510831"
+     "sg-3dfb3140"
     ],
     "SubnetIds": [
      "subnet-1641fa70",

--- a/test_rigs/example-aws/aws_configs/us-west-2/SecurityGroups.json
+++ b/test_rigs/example-aws/aws_configs/us-west-2/SecurityGroups.json
@@ -78,7 +78,7 @@
    ], 
    "VpcId": "vpc-b390fad5"
   },
-   {
+  {
    "Description": "RDS VPC security group",
    "GroupId": "sg-55510831",
    "GroupName": "default",
@@ -140,7 +140,7 @@
      "Value": "Default+RDS-sg"
     }
    ],
-   "VpcId": "vpc-f8fad69d"
+   "VpcId": "vpc-b390fad5"
   },
   {
    "Description": "default VPC security group", 
@@ -175,40 +175,7 @@
    ], 
    "OwnerId": "118292266645", 
    "VpcId": "vpc-b390fad5"
-  }, 
-  {
-   "Description": "default VPC security group", 
-   "GroupId": "sg-55510831", 
-   "GroupName": "default", 
-   "IpPermissions": [
-    {
-     "IpProtocol": "-1", 
-     "IpRanges": [
-      {
-       "CidrIp": "0.0.0.0/0"
-      }
-     ], 
-     "Ipv6Ranges": [], 
-     "PrefixListIds": [], 
-     "UserIdGroupPairs": []
-    }
-   ], 
-   "IpPermissionsEgress": [
-    {
-     "IpProtocol": "-1", 
-     "IpRanges": [
-      {
-       "CidrIp": "0.0.0.0/0"
-      }
-     ], 
-     "Ipv6Ranges": [], 
-     "PrefixListIds": [], 
-     "UserIdGroupPairs": []
-    }
-   ], 
-   "OwnerId": "118292266645", 
-   "VpcId": "vpc-f8fad69d"
-  }, 
+  },  
   {
    "Description": "launch-wizard-2 created 2015-11-22T18:20:09.343-08:00", 
    "GroupId": "sg-6c4d1408", 

--- a/tests/aws/nodes-example-aws.ref
+++ b/tests/aws/nodes-example-aws.ref
@@ -85,10 +85,7 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "negate" : false,
-                "srcIps" : [
-                  "0.0.0.0/0"
-                ]
+                "negate" : false
               }
             ]
           }
@@ -3140,9 +3137,19 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
+                "dstPorts" : [
+                  "3306-3306"
+                ],
+                "ipProtocols" : [
+                  "TCP"
+                ],
                 "negate" : false,
                 "srcIps" : [
-                  "0.0.0.0/0"
+                  "10.193.0.0/16",
+                  "67.170.86.87",
+                  "104.236.156.171",
+                  "107.170.243.58",
+                  "162.243.144.192"
                 ]
               }
             ]


### PR DESCRIPTION

- Changed the VPC ID in the RDS security group to match RDS's VPC
- Changed Elasticsearch's security to a security group in the same VPC as Elasticsearch
- Removed a security group with a duplicate SG-ID which was only used by RDS as RDS is not using it now