### PR TITLE
Adding a default deny-all rule for SG ACLs

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/aws/SecurityGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/SecurityGroup.java
@@ -5,6 +5,7 @@ import java.util.LinkedList;
 import java.util.List;
 import org.batfish.common.BatfishLogger;
 import org.batfish.datamodel.IpAccessListLine;
+import org.batfish.datamodel.LineAction;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
@@ -41,6 +42,7 @@ public class SecurityGroup implements AwsVpcEntity, Serializable {
     for (IpPermissions ipPerms : permsList) {
       accessList.add(ipPerms.toEgressIpAccessListLine());
     }
+    accessList.add(IpAccessListLine.builder().setAction(LineAction.REJECT).build());
   }
 
   private void addIngressAccessLines(
@@ -48,6 +50,7 @@ public class SecurityGroup implements AwsVpcEntity, Serializable {
     for (IpPermissions ipPerms : permsList) {
       accessList.add(ipPerms.toIngressIpAccessListLine());
     }
+    accessList.add(IpAccessListLine.builder().setAction(LineAction.REJECT).build());
   }
 
   public void addInOutAccessLines(

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/ElasticsearchDomainTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/ElasticsearchDomainTest.java
@@ -177,7 +177,8 @@ public class ElasticsearchDomainTest {
                     .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
                     .setSrcIps(Sets.newHashSet(new IpWildcard("1.2.3.4/32")))
                     .setDstPorts(Sets.newHashSet(new SubRange(45, 50)))
-                    .build()));
+                    .build(),
+                IpAccessListLine.builder().setAction(LineAction.REJECT).build()));
     IpAccessList expectedOutgoingFilter =
         new IpAccessList(
             "~SECURITY_GROUP_EGRESS_ACL~",
@@ -185,7 +186,8 @@ public class ElasticsearchDomainTest {
                 IpAccessListLine.builder()
                     .setAction(LineAction.ACCEPT)
                     .setDstIps(Sets.newHashSet(new IpWildcard("0.0.0.0/0")))
-                    .build()));
+                    .build(),
+                IpAccessListLine.builder().setAction(LineAction.REJECT).build()));
 
     for (Interface iface : configurations.get("es-domain").getInterfaces().values()) {
       assertThat(iface.getIncomingFilter(), equalTo(expectedIncomingFilter));

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/RdsInstanceTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/RdsInstanceTest.java
@@ -157,7 +157,8 @@ public class RdsInstanceTest {
                     .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
                     .setSrcIps(Sets.newHashSet(new IpWildcard("1.2.3.4/32")))
                     .setDstPorts(Sets.newHashSet(new SubRange(45, 50)))
-                    .build()));
+                    .build(),
+                IpAccessListLine.builder().setAction(LineAction.REJECT).build()));
     IpAccessList expectedOutgoingFilter =
         new IpAccessList(
             "~SECURITY_GROUP_EGRESS_ACL~",
@@ -165,7 +166,8 @@ public class RdsInstanceTest {
                 IpAccessListLine.builder()
                     .setAction(LineAction.ACCEPT)
                     .setDstIps(Sets.newHashSet(new IpWildcard("0.0.0.0/0")))
-                    .build()));
+                    .build(),
+                IpAccessListLine.builder().setAction(LineAction.REJECT).build()));
 
     for (Interface iface : configurations.get("test-rds").getInterfaces().values()) {
       assertThat(iface.getIncomingFilter(), equalTo(expectedIncomingFilter));

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/SecurityGroupsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/SecurityGroupsTest.java
@@ -51,7 +51,8 @@ public class SecurityGroupsTest {
                     .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
                     .setSrcIps(Sets.newHashSet(new IpWildcard("1.2.3.4/32")))
                     .setDstPorts(Sets.newHashSet(new SubRange(22, 22)))
-                    .build())));
+                    .build(),
+                IpAccessListLine.builder().setAction(LineAction.REJECT).build())));
   }
 
   @Test
@@ -72,7 +73,8 @@ public class SecurityGroupsTest {
                     .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
                     .setSrcIps(Sets.newHashSet(new IpWildcard("1.2.3.4/32")))
                     .setDstPorts(Sets.newHashSet(new SubRange(0, 22)))
-                    .build())));
+                    .build(),
+                IpAccessListLine.builder().setAction(LineAction.REJECT).build())));
   }
 
   @Test
@@ -93,7 +95,8 @@ public class SecurityGroupsTest {
                     .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
                     .setSrcIps(Sets.newHashSet(new IpWildcard("1.2.3.4/32")))
                     .setDstPorts(Sets.newHashSet(new SubRange(65530, 65535)))
-                    .build())));
+                    .build(),
+                IpAccessListLine.builder().setAction(LineAction.REJECT).build())));
   }
 
   @Test
@@ -113,7 +116,8 @@ public class SecurityGroupsTest {
                     .setAction(LineAction.ACCEPT)
                     .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
                     .setSrcIps(Sets.newHashSet(new IpWildcard("1.2.3.4/32")))
-                    .build())));
+                    .build(),
+                IpAccessListLine.builder().setAction(LineAction.REJECT).build())));
   }
 
   @Test
@@ -133,7 +137,8 @@ public class SecurityGroupsTest {
                     .setAction(LineAction.ACCEPT)
                     .setSrcIps(Sets.newHashSet(new IpWildcard("0.0.0.0/0")))
                     .setDstPorts(Sets.newHashSet())
-                    .build())));
+                    .build(),
+                IpAccessListLine.builder().setAction(LineAction.REJECT).build())));
   }
 
   @Test
@@ -154,7 +159,8 @@ public class SecurityGroupsTest {
                     .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
                     .setSrcIps(Sets.newHashSet(new IpWildcard("1.2.3.4/32")))
                     .setDstPorts(Sets.newHashSet(new SubRange(45, 50)))
-                    .build())));
+                    .build(),
+                IpAccessListLine.builder().setAction(LineAction.REJECT).build())));
   }
 
   @Test
@@ -175,7 +181,8 @@ public class SecurityGroupsTest {
                     .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
                     .setSrcIps(Sets.newHashSet(new IpWildcard("1.2.3.4/32")))
                     .setDstPorts(Sets.newHashSet(new SubRange(0, 50)))
-                    .build())));
+                    .build(),
+                IpAccessListLine.builder().setAction(LineAction.REJECT).build())));
   }
 
   @Test
@@ -196,6 +203,7 @@ public class SecurityGroupsTest {
                     .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
                     .setSrcIps(Sets.newHashSet(new IpWildcard("1.2.3.4/32")))
                     .setDstPorts(Sets.newHashSet(new SubRange(30, 65535)))
-                    .build())));
+                    .build(),
+                IpAccessListLine.builder().setAction(LineAction.REJECT).build())));
   }
 }

--- a/tests/aws/nodes-example-aws.ref
+++ b/tests/aws/nodes-example-aws.ref
@@ -81,6 +81,10 @@
                   "0.0.0.0/0"
                 ],
                 "negate" : false
+              },
+              {
+                "action" : "REJECT",
+                "negate" : false
               }
             ]
           },
@@ -89,6 +93,10 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
+                "negate" : false
+              },
+              {
+                "action" : "REJECT",
                 "negate" : false
               }
             ]
@@ -3135,6 +3143,10 @@
                   "0.0.0.0/0"
                 ],
                 "negate" : false
+              },
+              {
+                "action" : "REJECT",
+                "negate" : false
               }
             ]
           },
@@ -3157,6 +3169,10 @@
                   "107.170.243.58",
                   "162.243.144.192"
                 ]
+              },
+              {
+                "action" : "REJECT",
+                "negate" : false
               }
             ]
           }


### PR DESCRIPTION
- Security Groups are permissive and only traffic specified in the rules are allowed.
- Rest of the traffic should be denied by a default deny all rule.