### PR TITLE
Adding rules to allow responses to permitted TCP requests

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/TcpFlags.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/TcpFlags.java
@@ -135,6 +135,9 @@ public final class TcpFlags implements Serializable {
 
   public static final int FIN = 0x01;
 
+  public static final TcpFlags SYN_ONLY =
+      TcpFlags.builder().setSyn(true).setAck(false).setUseSyn(true).setUseAck(true).build();
+
   public static final int PSH = 0x08;
 
   public static final int RST = 0x04;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/TcpFlags.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/TcpFlags.java
@@ -135,9 +135,6 @@ public final class TcpFlags implements Serializable {
 
   public static final int FIN = 0x01;
 
-  public static final TcpFlags SYN_ONLY =
-      TcpFlags.builder().setSyn(true).setAck(false).setUseSyn(true).setUseAck(true).build();
-
   public static final int PSH = 0x08;
 
   public static final int RST = 0x04;
@@ -146,6 +143,9 @@ public final class TcpFlags implements Serializable {
   private static final long serialVersionUID = 1L;
 
   public static final int SYN = 0x02;
+
+  public static final TcpFlags SYN_ONLY =
+      builder().setSyn(true).setAck(false).setUseSyn(true).setUseAck(true).build();
 
   public static final int URG = 0x20;
 

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/SecurityGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/SecurityGroup.java
@@ -1,10 +1,14 @@
 package org.batfish.representation.aws;
 
+import com.google.common.collect.ImmutableSet;
 import java.io.Serializable;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.batfish.common.BatfishLogger;
 import org.batfish.datamodel.IpAccessListLine;
+import org.batfish.datamodel.LineAction;
+import org.batfish.datamodel.TcpFlags;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
@@ -50,10 +54,54 @@ public class SecurityGroup implements AwsVpcEntity, Serializable {
     }
   }
 
+  private void addReverseAcls(
+      List<IpAccessListLine> inboundRules, List<IpAccessListLine> outboundRules) {
+
+    List<IpAccessListLine> reverseInboundRules =
+        inboundRules
+            .stream()
+            .map(
+                ipAccessListLine ->
+                    IpAccessListLine.builder()
+                        .setIpProtocols(ipAccessListLine.getIpProtocols())
+                        .setAction(ipAccessListLine.getAction())
+                        .setDstIps(ipAccessListLine.getSrcIps())
+                        .setSrcPorts(ipAccessListLine.getDstPorts())
+                        .build())
+            .collect(Collectors.toList());
+
+    List<IpAccessListLine> reverseOutboundRules =
+        outboundRules
+            .stream()
+            .map(
+                ipAccessListLine ->
+                    IpAccessListLine.builder()
+                        .setIpProtocols(ipAccessListLine.getIpProtocols())
+                        .setAction(ipAccessListLine.getAction())
+                        .setSrcIps(ipAccessListLine.getDstIps())
+                        .setSrcPorts(ipAccessListLine.getDstPorts())
+                        .build())
+            .collect(Collectors.toList());
+
+    // denying SYN-only packets to prevent new TCP connections
+    IpAccessListLine rejectSynOnly =
+        IpAccessListLine.builder()
+            .setTcpFlags(ImmutableSet.of(TcpFlags.builder().setAck(false).setSyn(true).build()))
+            .setAction(LineAction.REJECT)
+            .build();
+    inboundRules.add(rejectSynOnly);
+    outboundRules.add(rejectSynOnly);
+
+    // adding reverse inbound/outbound rules for stateful allowance of packets
+    outboundRules.addAll(reverseInboundRules);
+    inboundRules.addAll(reverseOutboundRules);
+  }
+
   public void addInOutAccessLines(
       List<IpAccessListLine> inboundRules, List<IpAccessListLine> outboundRules) {
     addIngressAccessLines(_ipPermsIngress, inboundRules);
     addEgressAccessLines(_ipPermsEgress, outboundRules);
+    addReverseAcls(inboundRules, outboundRules);
   }
 
   public String getGroupId() {

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/SecurityGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/SecurityGroup.java
@@ -1,10 +1,10 @@
 package org.batfish.representation.aws;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.io.Serializable;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.batfish.common.BatfishLogger;
 import org.batfish.datamodel.IpAccessListLine;
 import org.batfish.datamodel.LineAction;
@@ -68,7 +68,7 @@ public class SecurityGroup implements AwsVpcEntity, Serializable {
                         .setDstIps(ipAccessListLine.getSrcIps())
                         .setSrcPorts(ipAccessListLine.getDstPorts())
                         .build())
-            .collect(Collectors.toList());
+            .collect(ImmutableList.toImmutableList());
 
     List<IpAccessListLine> reverseOutboundRules =
         outboundRules
@@ -81,20 +81,20 @@ public class SecurityGroup implements AwsVpcEntity, Serializable {
                         .setSrcIps(ipAccessListLine.getDstIps())
                         .setSrcPorts(ipAccessListLine.getDstPorts())
                         .build())
-            .collect(Collectors.toList());
+            .collect(ImmutableList.toImmutableList());
 
     // denying SYN-only packets to prevent new TCP connections
     IpAccessListLine rejectSynOnly =
         IpAccessListLine.builder()
-            .setTcpFlags(ImmutableSet.of(TcpFlags.builder().setAck(false).setSyn(true).build()))
+            .setTcpFlags(ImmutableSet.of(TcpFlags.SYN_ONLY))
             .setAction(LineAction.REJECT)
             .build();
     inboundRules.add(rejectSynOnly);
     outboundRules.add(rejectSynOnly);
 
     // adding reverse inbound/outbound rules for stateful allowance of packets
-    outboundRules.addAll(reverseInboundRules);
     inboundRules.addAll(reverseOutboundRules);
+    outboundRules.addAll(reverseInboundRules);
   }
 
   public void addInOutAccessLines(

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/ElasticsearchDomainTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/ElasticsearchDomainTest.java
@@ -171,7 +171,7 @@ public class ElasticsearchDomainTest {
 
     IpAccessListLine rejectSynOnly =
         IpAccessListLine.builder()
-            .setTcpFlags(ImmutableSet.of(TcpFlags.builder().setAck(false).setSyn(true).build()))
+            .setTcpFlags(ImmutableSet.of(TcpFlags.SYN_ONLY))
             .setAction(LineAction.REJECT)
             .build();
     IpAccessList expectedIncomingFilter =

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/RdsInstanceTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/RdsInstanceTest.java
@@ -151,7 +151,7 @@ public class RdsInstanceTest {
 
     IpAccessListLine rejectSynOnly =
         IpAccessListLine.builder()
-            .setTcpFlags(ImmutableSet.of(TcpFlags.builder().setAck(false).setSyn(true).build()))
+            .setTcpFlags(ImmutableSet.of(TcpFlags.SYN_ONLY))
             .setAction(LineAction.REJECT)
             .build();
 

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/SecurityGroupTest.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/SecurityGroupTest.json
@@ -285,6 +285,45 @@
       ],
       "OwnerId": "118292266645",
       "VpcId": "vpc-6f6f8316"
+    },
+    {
+      "Description": "For test",
+      "GroupId": "sg-0de0ddfa8a5a12347",
+      "GroupName": "Stateful TCP rules",
+      "IpPermissions": [
+        {
+          "FromPort": 22,
+          "IpProtocol": "tcp",
+          "IpRanges": [
+            {
+              "CidrIp": "1.2.3.4/32",
+              "Description": "allowed source"
+            }
+          ],
+          "Ipv6Ranges": [],
+          "PrefixListIds": [],
+          "ToPort": 22,
+          "UserIdGroupPairs": []
+        }
+      ],
+      "IpPermissionsEgress": [
+        {
+          "FromPort": 80,
+          "IpProtocol": "tcp",
+          "IpRanges": [
+            {
+              "CidrIp": "5.6.7.8/32",
+              "Description": "allowed destination"
+            }
+          ],
+          "Ipv6Ranges": [],
+          "PrefixListIds": [],
+          "ToPort": 80,
+          "UserIdGroupPairs": []
+        }
+      ],
+      "OwnerId": "118292266645",
+      "VpcId": "vpc-6f6f8316"
     }
   ]
 }

--- a/tests/aws/nodes-example-aws.ref
+++ b/tests/aws/nodes-example-aws.ref
@@ -95,13 +95,13 @@
                     "rst" : false,
                     "syn" : true,
                     "urg" : false,
-                    "useAck" : false,
+                    "useAck" : true,
                     "useCwr" : false,
                     "useEce" : false,
                     "useFin" : false,
                     "usePsh" : false,
                     "useRst" : false,
-                    "useSyn" : false,
+                    "useSyn" : true,
                     "useUrg" : false
                   }
                 ]
@@ -132,13 +132,13 @@
                     "rst" : false,
                     "syn" : true,
                     "urg" : false,
-                    "useAck" : false,
+                    "useAck" : true,
                     "useCwr" : false,
                     "useEce" : false,
                     "useFin" : false,
                     "usePsh" : false,
                     "useRst" : false,
-                    "useSyn" : false,
+                    "useSyn" : true,
                     "useUrg" : false
                   }
                 ]
@@ -3208,13 +3208,13 @@
                     "rst" : false,
                     "syn" : true,
                     "urg" : false,
-                    "useAck" : false,
+                    "useAck" : true,
                     "useCwr" : false,
                     "useEce" : false,
                     "useFin" : false,
                     "usePsh" : false,
                     "useRst" : false,
-                    "useSyn" : false,
+                    "useSyn" : true,
                     "useUrg" : false
                   }
                 ]
@@ -3271,13 +3271,13 @@
                     "rst" : false,
                     "syn" : true,
                     "urg" : false,
-                    "useAck" : false,
+                    "useAck" : true,
                     "useCwr" : false,
                     "useEce" : false,
                     "useFin" : false,
                     "usePsh" : false,
                     "useRst" : false,
-                    "useSyn" : false,
+                    "useSyn" : true,
                     "useUrg" : false
                   }
                 ]

--- a/tests/aws/nodes-example-aws.ref
+++ b/tests/aws/nodes-example-aws.ref
@@ -81,6 +81,34 @@
                   "0.0.0.0/0"
                 ],
                 "negate" : false
+              },
+              {
+                "action" : "REJECT",
+                "negate" : false,
+                "tcpFlags" : [
+                  {
+                    "ack" : false,
+                    "cwr" : false,
+                    "ece" : false,
+                    "fin" : false,
+                    "psh" : false,
+                    "rst" : false,
+                    "syn" : true,
+                    "urg" : false,
+                    "useAck" : false,
+                    "useCwr" : false,
+                    "useEce" : false,
+                    "useFin" : false,
+                    "usePsh" : false,
+                    "useRst" : false,
+                    "useSyn" : false,
+                    "useUrg" : false
+                  }
+                ]
+              },
+              {
+                "action" : "ACCEPT",
+                "negate" : false
               }
             ]
           },
@@ -90,6 +118,37 @@
               {
                 "action" : "ACCEPT",
                 "negate" : false
+              },
+              {
+                "action" : "REJECT",
+                "negate" : false,
+                "tcpFlags" : [
+                  {
+                    "ack" : false,
+                    "cwr" : false,
+                    "ece" : false,
+                    "fin" : false,
+                    "psh" : false,
+                    "rst" : false,
+                    "syn" : true,
+                    "urg" : false,
+                    "useAck" : false,
+                    "useCwr" : false,
+                    "useEce" : false,
+                    "useFin" : false,
+                    "usePsh" : false,
+                    "useRst" : false,
+                    "useSyn" : false,
+                    "useUrg" : false
+                  }
+                ]
+              },
+              {
+                "action" : "ACCEPT",
+                "negate" : false,
+                "srcIps" : [
+                  "0.0.0.0/0"
+                ]
               }
             ]
           }
@@ -3135,6 +3194,47 @@
                   "0.0.0.0/0"
                 ],
                 "negate" : false
+              },
+              {
+                "action" : "REJECT",
+                "negate" : false,
+                "tcpFlags" : [
+                  {
+                    "ack" : false,
+                    "cwr" : false,
+                    "ece" : false,
+                    "fin" : false,
+                    "psh" : false,
+                    "rst" : false,
+                    "syn" : true,
+                    "urg" : false,
+                    "useAck" : false,
+                    "useCwr" : false,
+                    "useEce" : false,
+                    "useFin" : false,
+                    "usePsh" : false,
+                    "useRst" : false,
+                    "useSyn" : false,
+                    "useUrg" : false
+                  }
+                ]
+              },
+              {
+                "action" : "ACCEPT",
+                "dstIps" : [
+                  "10.193.0.0/16",
+                  "67.170.86.87",
+                  "104.236.156.171",
+                  "107.170.243.58",
+                  "162.243.144.192"
+                ],
+                "ipProtocols" : [
+                  "TCP"
+                ],
+                "negate" : false,
+                "srcPorts" : [
+                  "3306-3306"
+                ]
               }
             ]
           },
@@ -3156,6 +3256,37 @@
                   "104.236.156.171",
                   "107.170.243.58",
                   "162.243.144.192"
+                ]
+              },
+              {
+                "action" : "REJECT",
+                "negate" : false,
+                "tcpFlags" : [
+                  {
+                    "ack" : false,
+                    "cwr" : false,
+                    "ece" : false,
+                    "fin" : false,
+                    "psh" : false,
+                    "rst" : false,
+                    "syn" : true,
+                    "urg" : false,
+                    "useAck" : false,
+                    "useCwr" : false,
+                    "useEce" : false,
+                    "useFin" : false,
+                    "usePsh" : false,
+                    "useRst" : false,
+                    "useSyn" : false,
+                    "useUrg" : false
+                  }
+                ]
+              },
+              {
+                "action" : "ACCEPT",
+                "negate" : false,
+                "srcIps" : [
+                  "0.0.0.0/0"
                 ]
               }
             ]


### PR DESCRIPTION
In addition to allowed inbound/outbound packets, also allow packets containing ACK and packets containing reversed inbound/outbound rules