### PR TITLE
Use Z3's if-then-else operator to optimize encoding of AclIpSpaces

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/z3/expr/AndExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/AndExpr.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 import org.batfish.z3.expr.visitors.ExprVisitor;
 import org.batfish.z3.expr.visitors.GenericBooleanExprVisitor;
 
-public class AndExpr extends BooleanExpr {
+public final class AndExpr extends BooleanExpr {
 
   private List<BooleanExpr> _conjuncts;
 
@@ -26,7 +26,7 @@ public class AndExpr extends BooleanExpr {
   }
 
   @Override
-  public boolean exprEquals(Expr e) {
+  protected boolean exprEquals(Expr e) {
     return Objects.equals(_conjuncts, ((AndExpr) e)._conjuncts);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/BitVecExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/BitVecExpr.java
@@ -3,7 +3,7 @@ package org.batfish.z3.expr;
 import java.util.Objects;
 import org.batfish.z3.expr.visitors.ExprVisitor;
 
-public class BitVecExpr extends TypeExpr {
+public final class BitVecExpr extends TypeExpr {
 
   private final int _size;
 
@@ -17,7 +17,7 @@ public class BitVecExpr extends TypeExpr {
   }
 
   @Override
-  public boolean exprEquals(Expr e) {
+  protected boolean exprEquals(Expr e) {
     return Objects.equals(_size, ((BitVecExpr) e)._size);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/CurrentIsOriginalExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/CurrentIsOriginalExpr.java
@@ -7,7 +7,7 @@ import org.batfish.z3.TransformationHeaderField;
 import org.batfish.z3.expr.visitors.ExprVisitor;
 import org.batfish.z3.expr.visitors.GenericBooleanExprVisitor;
 
-public class CurrentIsOriginalExpr extends BooleanExpr {
+public final class CurrentIsOriginalExpr extends BooleanExpr {
 
   public static final CurrentIsOriginalExpr INSTANCE = new CurrentIsOriginalExpr();
 
@@ -35,7 +35,7 @@ public class CurrentIsOriginalExpr extends BooleanExpr {
   }
 
   @Override
-  public boolean exprEquals(Expr e) {
+  protected boolean exprEquals(Expr e) {
     return Objects.equals(_expr, ((CurrentIsOriginalExpr) e)._expr);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/EqExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/EqExpr.java
@@ -5,7 +5,7 @@ import org.batfish.common.BatfishException;
 import org.batfish.z3.expr.visitors.ExprVisitor;
 import org.batfish.z3.expr.visitors.GenericBooleanExprVisitor;
 
-public class EqExpr extends BooleanExpr {
+public final class EqExpr extends BooleanExpr {
 
   private final IntExpr _lhs;
 
@@ -35,7 +35,7 @@ public class EqExpr extends BooleanExpr {
   }
 
   @Override
-  public boolean exprEquals(Expr e) {
+  protected boolean exprEquals(Expr e) {
     EqExpr other = (EqExpr) e;
     return Objects.equals(_lhs, other._lhs) && Objects.equals(_rhs, other._rhs);
   }

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/Expr.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/Expr.java
@@ -18,7 +18,7 @@ public abstract class Expr {
     return exprEquals((Expr) o);
   }
 
-  public abstract boolean exprEquals(Expr e);
+  protected abstract boolean exprEquals(Expr e);
 
   @Override
   public abstract int hashCode();

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/ExtractExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/ExtractExpr.java
@@ -10,7 +10,7 @@ import org.batfish.z3.expr.visitors.IntExprVisitor;
  * Represents a projection of a bitvector to a bitvector of a lower dimension. The output consists
  * of a contiguous subvector of the original.
  */
-public class ExtractExpr extends IntExpr {
+public final class ExtractExpr extends IntExpr {
 
   public static IntExpr newExtractExpr(HeaderField var, int low, int high) {
     int varSize = var.getSize();
@@ -53,7 +53,7 @@ public class ExtractExpr extends IntExpr {
   }
 
   @Override
-  public boolean exprEquals(Expr e) {
+  protected boolean exprEquals(Expr e) {
     ExtractExpr other = (ExtractExpr) e;
     return Objects.equals(_high, other._high)
         && Objects.equals(_low, other._low)

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/FalseExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/FalseExpr.java
@@ -3,7 +3,7 @@ package org.batfish.z3.expr;
 import org.batfish.z3.expr.visitors.ExprVisitor;
 import org.batfish.z3.expr.visitors.GenericBooleanExprVisitor;
 
-public class FalseExpr extends BooleanExpr {
+public final class FalseExpr extends BooleanExpr {
 
   public static final FalseExpr INSTANCE = new FalseExpr();
 
@@ -20,8 +20,8 @@ public class FalseExpr extends BooleanExpr {
   }
 
   @Override
-  public boolean exprEquals(Expr e) {
-    return true;
+  protected boolean exprEquals(Expr e) {
+    return this == e;
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/HeaderSpaceMatchExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/HeaderSpaceMatchExpr.java
@@ -20,7 +20,7 @@ import org.batfish.z3.BasicHeaderField;
 import org.batfish.z3.expr.visitors.ExprVisitor;
 import org.batfish.z3.expr.visitors.GenericBooleanExprVisitor;
 
-public class HeaderSpaceMatchExpr extends BooleanExpr {
+public final class HeaderSpaceMatchExpr extends BooleanExpr {
 
   public static BooleanExpr matchDscp(Set<Integer> dscps) {
     return new OrExpr(
@@ -427,7 +427,7 @@ public class HeaderSpaceMatchExpr extends BooleanExpr {
   }
 
   @Override
-  public boolean exprEquals(Expr e) {
+  protected boolean exprEquals(Expr e) {
     return Objects.equals(_expr, ((HeaderSpaceMatchExpr) e)._expr);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/IdExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/IdExpr.java
@@ -3,7 +3,7 @@ package org.batfish.z3.expr;
 import java.util.Objects;
 import org.batfish.z3.expr.visitors.ExprVisitor;
 
-public class IdExpr extends Expr {
+public final class IdExpr extends Expr {
 
   private String _id;
 
@@ -17,7 +17,7 @@ public class IdExpr extends Expr {
   }
 
   @Override
-  public boolean exprEquals(Expr e) {
+  protected boolean exprEquals(Expr e) {
     return Objects.equals(_id, ((IdExpr) e)._id);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/IfExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/IfExpr.java
@@ -4,7 +4,7 @@ import java.util.Objects;
 import org.batfish.z3.expr.visitors.ExprVisitor;
 import org.batfish.z3.expr.visitors.GenericBooleanExprVisitor;
 
-public class IfExpr extends BooleanExpr {
+public final class IfExpr extends BooleanExpr {
 
   private final BooleanExpr _antecedent;
 
@@ -26,7 +26,7 @@ public class IfExpr extends BooleanExpr {
   }
 
   @Override
-  public boolean exprEquals(Expr e) {
+  protected boolean exprEquals(Expr e) {
     IfExpr other = (IfExpr) e;
     return Objects.equals(_antecedent, other._antecedent)
         && Objects.equals(_consequent, other._consequent);

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/IfThenElse.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/IfThenElse.java
@@ -1,0 +1,68 @@
+package org.batfish.z3.expr;
+
+import java.util.Objects;
+import org.batfish.z3.expr.visitors.ExprVisitor;
+import org.batfish.z3.expr.visitors.GenericBooleanExprVisitor;
+
+public class IfThenElse extends BooleanExpr {
+
+  private final BooleanExpr _condition;
+
+  private final BooleanExpr _then;
+
+  private final BooleanExpr _else;
+
+  public IfThenElse(BooleanExpr condition, BooleanExpr then, BooleanExpr els) {
+    _condition = condition;
+    _then = then;
+    _else = els;
+  }
+
+  @Override
+  public <R> R accept(GenericBooleanExprVisitor<R> visitor) {
+    return visitor.visitIfThenElse(this);
+  }
+
+  @Override
+  public void accept(ExprVisitor visitor) {
+    visitor.visitIfThenElse(this);
+  }
+
+  @Override
+  public boolean exprEquals(Expr e) {
+    if (this == e) {
+      return true;
+    }
+
+    if (e == null) {
+      return false;
+    }
+
+    if (!(e instanceof IfThenElse)) {
+      return false;
+    }
+
+    IfThenElse other = (IfThenElse) e;
+
+    return Objects.equals(_condition, other._condition)
+        && Objects.equals(_then, other._then)
+        && Objects.equals(_else, other._else);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_condition, _then, _else);
+  }
+
+  public BooleanExpr getCondition() {
+    return _condition;
+  }
+
+  public BooleanExpr getThen() {
+    return _then;
+  }
+
+  public BooleanExpr getElse() {
+    return _else;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/IfThenElse.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/IfThenElse.java
@@ -4,7 +4,7 @@ import java.util.Objects;
 import org.batfish.z3.expr.visitors.ExprVisitor;
 import org.batfish.z3.expr.visitors.GenericBooleanExprVisitor;
 
-public class IfThenElse extends BooleanExpr {
+public final class IfThenElse extends BooleanExpr {
 
   private final BooleanExpr _condition;
 
@@ -29,21 +29,8 @@ public class IfThenElse extends BooleanExpr {
   }
 
   @Override
-  public boolean exprEquals(Expr e) {
-    if (this == e) {
-      return true;
-    }
-
-    if (e == null) {
-      return false;
-    }
-
-    if (!(e instanceof IfThenElse)) {
-      return false;
-    }
-
+  protected boolean exprEquals(Expr e) {
     IfThenElse other = (IfThenElse) e;
-
     return Objects.equals(_condition, other._condition)
         && Objects.equals(_then, other._then)
         && Objects.equals(_else, other._else);

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/IpSpaceMatchExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/IpSpaceMatchExpr.java
@@ -6,7 +6,7 @@ import org.batfish.z3.expr.visitors.ExprVisitor;
 import org.batfish.z3.expr.visitors.GenericBooleanExprVisitor;
 import org.batfish.z3.expr.visitors.IpSpaceBooleanExprTransformer;
 
-public class IpSpaceMatchExpr extends BooleanExpr {
+public final class IpSpaceMatchExpr extends BooleanExpr {
 
   private final BooleanExpr _expr;
 
@@ -25,7 +25,7 @@ public class IpSpaceMatchExpr extends BooleanExpr {
   }
 
   @Override
-  public boolean exprEquals(Expr e) {
+  protected boolean exprEquals(Expr e) {
     return Objects.equals(_expr, ((IpSpaceMatchExpr) e)._expr);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/ListExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/ListExpr.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.Objects;
 import org.batfish.z3.expr.visitors.ExprVisitor;
 
-public class ListExpr extends Expr {
+public final class ListExpr extends Expr {
 
   private final List<Expr> _subExpressions;
 
@@ -18,7 +18,7 @@ public class ListExpr extends Expr {
   }
 
   @Override
-  public final boolean exprEquals(Expr e) {
+  protected boolean exprEquals(Expr e) {
     return Objects.equals(_subExpressions, ((ListExpr) e)._subExpressions);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/ListExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/ListExpr.java
@@ -27,7 +27,7 @@ public final class ListExpr extends Expr {
   }
 
   @Override
-  public final int hashCode() {
+  public int hashCode() {
     return Objects.hash(_subExpressions);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/LitIntExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/LitIntExpr.java
@@ -6,7 +6,7 @@ import org.batfish.z3.expr.visitors.ExprVisitor;
 import org.batfish.z3.expr.visitors.GenericIntExprVisitor;
 import org.batfish.z3.expr.visitors.IntExprVisitor;
 
-public class LitIntExpr extends IntExpr {
+public final class LitIntExpr extends IntExpr {
 
   private final int _bits;
 
@@ -43,7 +43,7 @@ public class LitIntExpr extends IntExpr {
   }
 
   @Override
-  public boolean exprEquals(Expr e) {
+  protected boolean exprEquals(Expr e) {
     LitIntExpr other = (LitIntExpr) e;
     return Objects.equals(_bits, other._bits) && Objects.equals(_num, other._num);
   }

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/NotExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/NotExpr.java
@@ -4,7 +4,7 @@ import java.util.Objects;
 import org.batfish.z3.expr.visitors.ExprVisitor;
 import org.batfish.z3.expr.visitors.GenericBooleanExprVisitor;
 
-public class NotExpr extends BooleanExpr {
+public final class NotExpr extends BooleanExpr {
 
   private final BooleanExpr _arg;
 
@@ -23,7 +23,7 @@ public class NotExpr extends BooleanExpr {
   }
 
   @Override
-  public boolean exprEquals(Expr e) {
+  protected boolean exprEquals(Expr e) {
     return Objects.equals(_arg, ((NotExpr) e)._arg);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/OrExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/OrExpr.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 import org.batfish.z3.expr.visitors.ExprVisitor;
 import org.batfish.z3.expr.visitors.GenericBooleanExprVisitor;
 
-public class OrExpr extends BooleanExpr {
+public final class OrExpr extends BooleanExpr {
 
   private List<BooleanExpr> _disjuncts;
 
@@ -28,7 +28,7 @@ public class OrExpr extends BooleanExpr {
   }
 
   @Override
-  public boolean exprEquals(Expr e) {
+  protected boolean exprEquals(Expr e) {
     return Objects.equals(_disjuncts, ((OrExpr) e)._disjuncts);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/PrefixMatchExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/PrefixMatchExpr.java
@@ -6,7 +6,7 @@ import org.batfish.z3.HeaderField;
 import org.batfish.z3.expr.visitors.ExprVisitor;
 import org.batfish.z3.expr.visitors.GenericBooleanExprVisitor;
 
-public class PrefixMatchExpr extends BooleanExpr {
+public final class PrefixMatchExpr extends BooleanExpr {
 
   private BooleanExpr _expr;
 
@@ -37,7 +37,7 @@ public class PrefixMatchExpr extends BooleanExpr {
   }
 
   @Override
-  public boolean exprEquals(Expr e) {
+  protected boolean exprEquals(Expr e) {
     return Objects.equals(_expr, ((PrefixMatchExpr) e)._expr);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/RangeMatchExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/RangeMatchExpr.java
@@ -10,7 +10,7 @@ import org.batfish.z3.HeaderField;
 import org.batfish.z3.expr.visitors.ExprVisitor;
 import org.batfish.z3.expr.visitors.GenericBooleanExprVisitor;
 
-public class RangeMatchExpr extends BooleanExpr {
+public final class RangeMatchExpr extends BooleanExpr {
 
   public static RangeMatchExpr fromSubRanges(HeaderField var, int bits, Set<SubRange> range) {
     return new RangeMatchExpr(
@@ -126,7 +126,7 @@ public class RangeMatchExpr extends BooleanExpr {
   }
 
   @Override
-  public boolean exprEquals(Expr e) {
+  protected boolean exprEquals(Expr e) {
     return Objects.equals(_expr, ((RangeMatchExpr) e)._expr);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/SaneExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/SaneExpr.java
@@ -9,7 +9,7 @@ import org.batfish.z3.BasicHeaderField;
 import org.batfish.z3.expr.visitors.ExprVisitor;
 import org.batfish.z3.expr.visitors.GenericBooleanExprVisitor;
 
-public class SaneExpr extends BooleanExpr {
+public final class SaneExpr extends BooleanExpr {
 
   public static final SaneExpr INSTANCE = new SaneExpr();
 
@@ -76,7 +76,7 @@ public class SaneExpr extends BooleanExpr {
   }
 
   @Override
-  public boolean exprEquals(Expr e) {
+  protected boolean exprEquals(Expr e) {
     return Objects.equals(_expr, ((SaneExpr) e)._expr);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/StateExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/StateExpr.java
@@ -21,7 +21,7 @@ public abstract class StateExpr extends Expr {
   public abstract <R> R accept(GenericStateExprVisitor<R> visitor);
 
   @Override
-  public boolean exprEquals(Expr e) {
+  protected final boolean exprEquals(Expr e) {
     return Parameterizer.getParameters(this).equals(Parameterizer.getParameters((StateExpr) e));
   }
 

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/TrueExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/TrueExpr.java
@@ -3,7 +3,7 @@ package org.batfish.z3.expr;
 import org.batfish.z3.expr.visitors.ExprVisitor;
 import org.batfish.z3.expr.visitors.GenericBooleanExprVisitor;
 
-public class TrueExpr extends BooleanExpr {
+public final class TrueExpr extends BooleanExpr {
 
   public static final TrueExpr INSTANCE = new TrueExpr();
 

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/TrueExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/TrueExpr.java
@@ -20,7 +20,7 @@ public final class TrueExpr extends BooleanExpr {
   }
 
   @Override
-  public boolean exprEquals(Expr e) {
+  protected boolean exprEquals(Expr e) {
     return this == e;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/TrueExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/TrueExpr.java
@@ -21,7 +21,7 @@ public class TrueExpr extends BooleanExpr {
 
   @Override
   public boolean exprEquals(Expr e) {
-    return true;
+    return this == e;
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/VarIntExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/VarIntExpr.java
@@ -7,7 +7,7 @@ import org.batfish.z3.expr.visitors.ExprVisitor;
 import org.batfish.z3.expr.visitors.GenericIntExprVisitor;
 import org.batfish.z3.expr.visitors.IntExprVisitor;
 
-public class VarIntExpr extends IntExpr {
+public final class VarIntExpr extends IntExpr {
 
   private final Field _field;
 
@@ -39,7 +39,7 @@ public class VarIntExpr extends IntExpr {
   }
 
   @Override
-  public boolean exprEquals(Expr e) {
+  protected boolean exprEquals(Expr e) {
     return Objects.equals(_field, ((VarIntExpr) e)._field);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/visitors/BoolExprTransformer.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/visitors/BoolExprTransformer.java
@@ -21,6 +21,7 @@ import org.batfish.z3.expr.FalseExpr;
 import org.batfish.z3.expr.GenericStatementVisitor;
 import org.batfish.z3.expr.HeaderSpaceMatchExpr;
 import org.batfish.z3.expr.IfExpr;
+import org.batfish.z3.expr.IfThenElse;
 import org.batfish.z3.expr.IpSpaceMatchExpr;
 import org.batfish.z3.expr.NotExpr;
 import org.batfish.z3.expr.OrExpr;
@@ -189,6 +190,16 @@ public class BoolExprTransformer
         .mkImplies(
             BoolExprTransformer.toBoolExpr(ifExpr.getAntecedent(), _input, _nodContext),
             BoolExprTransformer.toBoolExpr(ifExpr.getConsequent(), _input, _nodContext));
+  }
+
+  @Override
+  public BoolExpr visitIfThenElse(IfThenElse ifThenElse) {
+    Context ctx = _nodContext.getContext();
+    return (BoolExpr)
+        ctx.mkITE(
+            ifThenElse.getCondition().accept(this),
+            ifThenElse.getThen().accept(this),
+            ifThenElse.getElse().accept(this));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/visitors/ExprPrinter.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/visitors/ExprPrinter.java
@@ -15,6 +15,7 @@ import org.batfish.z3.expr.FalseExpr;
 import org.batfish.z3.expr.HeaderSpaceMatchExpr;
 import org.batfish.z3.expr.IdExpr;
 import org.batfish.z3.expr.IfExpr;
+import org.batfish.z3.expr.IfThenElse;
 import org.batfish.z3.expr.IpSpaceMatchExpr;
 import org.batfish.z3.expr.ListExpr;
 import org.batfish.z3.expr.LitIntExpr;
@@ -181,6 +182,16 @@ public class ExprPrinter implements ExprVisitor, VoidStatementVisitor {
   public void visitIfExpr(IfExpr ifExpr) {
     printExpandedComplexExpr(
         ImmutableList.of(new IdExpr("=>"), ifExpr.getAntecedent(), ifExpr.getConsequent()));
+  }
+
+  @Override
+  public void visitIfThenElse(IfThenElse ifThenElse) {
+    printCollapsedComplexExpr(
+        ImmutableList.of(
+            new IdExpr("ite"),
+            ifThenElse.getCondition(),
+            ifThenElse.getThen(),
+            ifThenElse.getElse()));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/visitors/ExprVisitor.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/visitors/ExprVisitor.java
@@ -9,6 +9,7 @@ import org.batfish.z3.expr.FalseExpr;
 import org.batfish.z3.expr.HeaderSpaceMatchExpr;
 import org.batfish.z3.expr.IdExpr;
 import org.batfish.z3.expr.IfExpr;
+import org.batfish.z3.expr.IfThenElse;
 import org.batfish.z3.expr.IpSpaceMatchExpr;
 import org.batfish.z3.expr.ListExpr;
 import org.batfish.z3.expr.LitIntExpr;
@@ -39,6 +40,8 @@ public interface ExprVisitor {
   void visitIdExpr(IdExpr idExpr);
 
   void visitIfExpr(IfExpr ifExpr);
+
+  void visitIfThenElse(IfThenElse ifThenElse);
 
   void visitListExpr(ListExpr listExpr);
 

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/visitors/GenericBooleanExprVisitor.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/visitors/GenericBooleanExprVisitor.java
@@ -6,6 +6,7 @@ import org.batfish.z3.expr.EqExpr;
 import org.batfish.z3.expr.FalseExpr;
 import org.batfish.z3.expr.HeaderSpaceMatchExpr;
 import org.batfish.z3.expr.IfExpr;
+import org.batfish.z3.expr.IfThenElse;
 import org.batfish.z3.expr.IpSpaceMatchExpr;
 import org.batfish.z3.expr.NotExpr;
 import org.batfish.z3.expr.OrExpr;
@@ -29,6 +30,8 @@ public interface GenericBooleanExprVisitor<R> {
   R visitHeaderSpaceMatchExpr(HeaderSpaceMatchExpr headerSpaceMatchExpr);
 
   R visitIfExpr(IfExpr ifExpr);
+
+  R visitIfThenElse(IfThenElse ifThenElse);
 
   R visitMatchIpSpaceExpr(IpSpaceMatchExpr matchIpSpaceExpr);
 

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/visitors/IpSpaceBooleanExprTransformer.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/visitors/IpSpaceBooleanExprTransformer.java
@@ -3,6 +3,7 @@ package org.batfish.z3.expr.visitors;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.batfish.datamodel.AclIpSpace;
+import org.batfish.datamodel.AclIpSpaceLine;
 import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpWildcard;
@@ -15,8 +16,8 @@ import org.batfish.z3.expr.AndExpr;
 import org.batfish.z3.expr.BooleanExpr;
 import org.batfish.z3.expr.FalseExpr;
 import org.batfish.z3.expr.HeaderSpaceMatchExpr;
+import org.batfish.z3.expr.IfThenElse;
 import org.batfish.z3.expr.NotExpr;
-import org.batfish.z3.expr.OrExpr;
 import org.batfish.z3.expr.TrueExpr;
 
 /**
@@ -41,24 +42,17 @@ public class IpSpaceBooleanExprTransformer implements GenericIpSpaceVisitor<Bool
 
   @Override
   public BooleanExpr visitAclIpSpace(AclIpSpace aclIpSpace) {
-    ImmutableList.Builder<BooleanExpr> lineSpaceMatchConditions = ImmutableList.builder();
-    ImmutableList.Builder<BooleanExpr> dontMatchPrevious = ImmutableList.builder();
-    aclIpSpace
-        .getLines()
-        .forEach(
-            line -> {
-              BooleanExpr matchCurrentInIsolation = line.getIpSpace().accept(this);
-              if (line.getAction() == LineAction.ACCEPT) {
-                lineSpaceMatchConditions.add(
-                    new AndExpr(
-                        ImmutableList.<BooleanExpr>builder()
-                            .addAll(dontMatchPrevious.build())
-                            .add(matchCurrentInIsolation)
-                            .build()));
-              }
-              dontMatchPrevious.add(new NotExpr(matchCurrentInIsolation));
-            });
-    return new OrExpr(lineSpaceMatchConditions.build());
+    // right fold
+    BooleanExpr expr = FalseExpr.INSTANCE;
+    for (int i = aclIpSpace.getLines().size() - 1; i >= 0; i--) {
+      AclIpSpaceLine line = aclIpSpace.getLines().get(i);
+      expr =
+          new IfThenElse(
+              line.getIpSpace().accept(this),
+              line.getAction() == LineAction.ACCEPT ? TrueExpr.INSTANCE : FalseExpr.INSTANCE,
+              expr);
+    }
+    return expr;
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/visitors/IsComplexVisitor.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/visitors/IsComplexVisitor.java
@@ -10,6 +10,7 @@ import org.batfish.z3.expr.FalseExpr;
 import org.batfish.z3.expr.HeaderSpaceMatchExpr;
 import org.batfish.z3.expr.IdExpr;
 import org.batfish.z3.expr.IfExpr;
+import org.batfish.z3.expr.IfThenElse;
 import org.batfish.z3.expr.IpSpaceMatchExpr;
 import org.batfish.z3.expr.ListExpr;
 import org.batfish.z3.expr.LitIntExpr;
@@ -74,6 +75,11 @@ public class IsComplexVisitor implements ExprVisitor {
 
   @Override
   public void visitIfExpr(IfExpr ifExpr) {
+    _isComplex = true;
+  }
+
+  @Override
+  public void visitIfThenElse(IfThenElse ifThenElse) {
     _isComplex = true;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/visitors/Simplifier.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/visitors/Simplifier.java
@@ -204,13 +204,19 @@ public class Simplifier
   public BooleanExpr visitIfThenElse(IfThenElse ifThenElse) {
     BooleanExpr condition = ifThenElse.getCondition().accept(this);
 
-    if (condition.equals(TrueExpr.INSTANCE)) {
+    if (condition == TrueExpr.INSTANCE) {
       return ifThenElse.getThen().accept(this);
-    } else if (condition.equals(FalseExpr.INSTANCE)) {
+    } else if (condition == FalseExpr.INSTANCE) {
       return ifThenElse.getElse().accept(this);
     } else {
       BooleanExpr then = ifThenElse.getThen().accept(this);
       BooleanExpr els = ifThenElse.getElse().accept(this);
+      if(then == TrueExpr.INSTANCE && els == TrueExpr.INSTANCE) {
+        return TrueExpr.INSTANCE;
+      }
+      if(then == FalseExpr.INSTANCE && els == FalseExpr.INSTANCE) {
+        return FalseExpr.INSTANCE;
+      }
       if (condition != ifThenElse.getCondition()
           || then != ifThenElse.getThen()
           || els != ifThenElse.getElse()) {

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/visitors/Simplifier.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/visitors/Simplifier.java
@@ -18,6 +18,7 @@ import org.batfish.z3.expr.GenericStatementVisitor;
 import org.batfish.z3.expr.HeaderSpaceMatchExpr;
 import org.batfish.z3.expr.IdExpr;
 import org.batfish.z3.expr.IfExpr;
+import org.batfish.z3.expr.IfThenElse;
 import org.batfish.z3.expr.IntExpr;
 import org.batfish.z3.expr.IpSpaceMatchExpr;
 import org.batfish.z3.expr.ListExpr;
@@ -196,6 +197,27 @@ public class Simplifier
       return new IfExpr(newAntecedent, newConsequent);
     } else {
       return ifExpr;
+    }
+  }
+
+  @Override
+  public BooleanExpr visitIfThenElse(IfThenElse ifThenElse) {
+    BooleanExpr condition = ifThenElse.getCondition().accept(this);
+
+    if (condition.equals(TrueExpr.INSTANCE)) {
+      return ifThenElse.getThen().accept(this);
+    } else if (condition.equals(FalseExpr.INSTANCE)) {
+      return ifThenElse.getElse().accept(this);
+    } else {
+      BooleanExpr then = ifThenElse.getThen().accept(this);
+      BooleanExpr els = ifThenElse.getElse().accept(this);
+      if (condition != ifThenElse.getCondition()
+          || then != ifThenElse.getThen()
+          || els != ifThenElse.getElse()) {
+        return new IfThenElse(condition, then, els);
+      } else {
+        return ifThenElse;
+      }
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/visitors/Simplifier.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/visitors/Simplifier.java
@@ -211,11 +211,8 @@ public class Simplifier
     } else {
       BooleanExpr then = ifThenElse.getThen().accept(this);
       BooleanExpr els = ifThenElse.getElse().accept(this);
-      if (then == TrueExpr.INSTANCE && els == TrueExpr.INSTANCE) {
-        return TrueExpr.INSTANCE;
-      }
-      if (then == FalseExpr.INSTANCE && els == FalseExpr.INSTANCE) {
-        return FalseExpr.INSTANCE;
+      if (then == els) {
+        return then;
       }
       if (condition != ifThenElse.getCondition()
           || then != ifThenElse.getThen()

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/visitors/Simplifier.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/visitors/Simplifier.java
@@ -211,10 +211,10 @@ public class Simplifier
     } else {
       BooleanExpr then = ifThenElse.getThen().accept(this);
       BooleanExpr els = ifThenElse.getElse().accept(this);
-      if(then == TrueExpr.INSTANCE && els == TrueExpr.INSTANCE) {
+      if (then == TrueExpr.INSTANCE && els == TrueExpr.INSTANCE) {
         return TrueExpr.INSTANCE;
       }
-      if(then == FalseExpr.INSTANCE && els == FalseExpr.INSTANCE) {
+      if (then == FalseExpr.INSTANCE && els == FalseExpr.INSTANCE) {
         return FalseExpr.INSTANCE;
       }
       if (condition != ifThenElse.getCondition()

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/visitors/VariableSizeCollector.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/visitors/VariableSizeCollector.java
@@ -21,6 +21,7 @@ import org.batfish.z3.expr.FalseExpr;
 import org.batfish.z3.expr.HeaderSpaceMatchExpr;
 import org.batfish.z3.expr.IdExpr;
 import org.batfish.z3.expr.IfExpr;
+import org.batfish.z3.expr.IfThenElse;
 import org.batfish.z3.expr.IpSpaceMatchExpr;
 import org.batfish.z3.expr.ListExpr;
 import org.batfish.z3.expr.LitIntExpr;
@@ -116,6 +117,13 @@ public class VariableSizeCollector implements ExprVisitor, VoidStatementVisitor 
   public void visitIfExpr(IfExpr ifExpr) {
     ifExpr.getAntecedent().accept(this);
     ifExpr.getConsequent().accept(this);
+  }
+
+  @Override
+  public void visitIfThenElse(IfThenElse ifThenElse) {
+    ifThenElse.getCondition().accept(this);
+    ifThenElse.getThen().accept(this);
+    ifThenElse.getElse().accept(this);
   }
 
   @Override

--- a/projects/batfish/src/test/java/org/batfish/z3/expr/visitors/IpSpaceBooleanExprTransformerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/expr/visitors/IpSpaceBooleanExprTransformerTest.java
@@ -1,0 +1,117 @@
+package org.batfish.z3.expr.visitors;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.batfish.datamodel.AclIpSpace;
+import org.batfish.datamodel.EmptyIpSpace;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpWildcard;
+import org.batfish.datamodel.IpWildcardSetIpSpace;
+import org.batfish.datamodel.UniverseIpSpace;
+import org.batfish.z3.expr.AndExpr;
+import org.batfish.z3.expr.BooleanExpr;
+import org.batfish.z3.expr.FalseExpr;
+import org.batfish.z3.expr.HeaderSpaceMatchExpr;
+import org.batfish.z3.expr.IfThenElse;
+import org.batfish.z3.expr.NotExpr;
+import org.batfish.z3.expr.TrueExpr;
+import org.junit.Test;
+
+public class IpSpaceBooleanExprTransformerTest {
+
+  private IpSpaceBooleanExprTransformer _srcIpSpaceBooleanExprTransformer =
+      new IpSpaceBooleanExprTransformer(true, false);
+
+  private IpSpaceBooleanExprTransformer _dstIpSpaceBooleanExprTransformer =
+      new IpSpaceBooleanExprTransformer(false, true);
+
+  private IpSpaceBooleanExprTransformer _srcOrDstIpSpaceBooleanExprTransformer =
+      new IpSpaceBooleanExprTransformer(true, true);
+
+  @Test
+  public void testVisitAclIpSpace() {
+    AclIpSpace ipSpace =
+        AclIpSpace.builder()
+            .thenRejecting(UniverseIpSpace.INSTANCE)
+            .thenPermitting(EmptyIpSpace.INSTANCE)
+            .build();
+
+    BooleanExpr expr = ipSpace.accept(_srcIpSpaceBooleanExprTransformer);
+
+    assertThat(
+        expr,
+        equalTo(
+            new IfThenElse(
+                // Matches UniverseIpSpace
+                TrueExpr.INSTANCE,
+                // Reject
+                FalseExpr.INSTANCE,
+                new IfThenElse(
+                    // Matches EmptyIpSpace
+                    FalseExpr.INSTANCE,
+                    // Accept
+                    TrueExpr.INSTANCE,
+                    // Matches nothing so reject
+                    FalseExpr.INSTANCE))));
+  }
+
+  @Test
+  public void testVisitEmptyIpSpace() {
+    BooleanExpr expr = EmptyIpSpace.INSTANCE.accept(_srcIpSpaceBooleanExprTransformer);
+    assertThat(expr, equalTo(FalseExpr.INSTANCE));
+  }
+
+  @Test
+  public void testVisitIp() {
+    Ip ip = new Ip("1.2.3.4");
+
+    BooleanExpr matchSrcExpr = ip.accept(_srcIpSpaceBooleanExprTransformer);
+    assertThat(
+        matchSrcExpr,
+        equalTo(HeaderSpaceMatchExpr.matchSrcIp(ImmutableSet.of(new IpWildcard(ip)))));
+
+    BooleanExpr matchDstExpr = ip.accept(_dstIpSpaceBooleanExprTransformer);
+    assertThat(
+        matchDstExpr,
+        equalTo(HeaderSpaceMatchExpr.matchDstIp(ImmutableSet.of(new IpWildcard(ip)))));
+
+    BooleanExpr matchSrcOrDstExpr = ip.accept(_srcOrDstIpSpaceBooleanExprTransformer);
+    assertThat(
+        matchSrcOrDstExpr,
+        equalTo(HeaderSpaceMatchExpr.matchSrcOrDstIp(ImmutableSet.of(new IpWildcard(ip)))));
+  }
+
+  @Test
+  public void testVisitIpWildcard() {
+    IpWildcard wildcard = new IpWildcard(new Ip("1.2.0.4"), new Ip(0x0000FF00L));
+    BooleanExpr matchExpr = wildcard.accept(_srcIpSpaceBooleanExprTransformer);
+    assertThat(matchExpr, equalTo(HeaderSpaceMatchExpr.matchSrcIp(ImmutableSet.of(wildcard))));
+  }
+
+  @Test
+  public void testVisitIpWildcardSetIpSpace() {
+    IpWildcard includeWildcard = new IpWildcard("1.1.1.1");
+    IpWildcard excludeWildcard = new IpWildcard("2.2.2.2");
+    IpWildcardSetIpSpace ipSpace =
+        IpWildcardSetIpSpace.builder()
+            .including(includeWildcard)
+            .excluding(excludeWildcard)
+            .build();
+
+    BooleanExpr expr = ipSpace.accept(_srcIpSpaceBooleanExprTransformer);
+    BooleanExpr includeExpr = includeWildcard.accept(_srcIpSpaceBooleanExprTransformer);
+    BooleanExpr excludeExpr = excludeWildcard.accept(_srcIpSpaceBooleanExprTransformer);
+
+    assertThat(expr, equalTo(new AndExpr(ImmutableList.of(new NotExpr(excludeExpr), includeExpr))));
+  }
+
+  @Test
+  public void testVisitUniverseIpSpace() {
+    BooleanExpr expr =
+        UniverseIpSpace.INSTANCE.accept(new IpSpaceBooleanExprTransformer(true, false));
+    assertThat(expr, equalTo(TrueExpr.INSTANCE));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/z3/expr/visitors/IpSpaceBooleanExprTransformerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/expr/visitors/IpSpaceBooleanExprTransformerTest.java
@@ -21,14 +21,13 @@ import org.batfish.z3.expr.TrueExpr;
 import org.junit.Test;
 
 public class IpSpaceBooleanExprTransformerTest {
-
-  private IpSpaceBooleanExprTransformer _srcIpSpaceBooleanExprTransformer =
+  private static final IpSpaceBooleanExprTransformer SRC_IP_SPACE_BOOLEAN_EXPR_TRANSFORMER =
       new IpSpaceBooleanExprTransformer(true, false);
 
-  private IpSpaceBooleanExprTransformer _dstIpSpaceBooleanExprTransformer =
+  private static final IpSpaceBooleanExprTransformer DST_IP_SPACE_BOOLEAN_EXPR_TRANSFORMER =
       new IpSpaceBooleanExprTransformer(false, true);
 
-  private IpSpaceBooleanExprTransformer _srcOrDstIpSpaceBooleanExprTransformer =
+  private static final IpSpaceBooleanExprTransformer SRC_OR_DST_IP_SPACE_BOOLEAN_EXPR_TRANSFORMER =
       new IpSpaceBooleanExprTransformer(true, true);
 
   @Test
@@ -39,7 +38,7 @@ public class IpSpaceBooleanExprTransformerTest {
             .thenPermitting(EmptyIpSpace.INSTANCE)
             .build();
 
-    BooleanExpr expr = ipSpace.accept(_srcIpSpaceBooleanExprTransformer);
+    BooleanExpr expr = ipSpace.accept(SRC_IP_SPACE_BOOLEAN_EXPR_TRANSFORMER);
 
     assertThat(
         expr,
@@ -60,7 +59,7 @@ public class IpSpaceBooleanExprTransformerTest {
 
   @Test
   public void testVisitEmptyIpSpace() {
-    BooleanExpr expr = EmptyIpSpace.INSTANCE.accept(_srcIpSpaceBooleanExprTransformer);
+    BooleanExpr expr = EmptyIpSpace.INSTANCE.accept(SRC_IP_SPACE_BOOLEAN_EXPR_TRANSFORMER);
     assertThat(expr, equalTo(FalseExpr.INSTANCE));
   }
 
@@ -68,17 +67,17 @@ public class IpSpaceBooleanExprTransformerTest {
   public void testVisitIp() {
     Ip ip = new Ip("1.2.3.4");
 
-    BooleanExpr matchSrcExpr = ip.accept(_srcIpSpaceBooleanExprTransformer);
+    BooleanExpr matchSrcExpr = ip.accept(SRC_IP_SPACE_BOOLEAN_EXPR_TRANSFORMER);
     assertThat(
         matchSrcExpr,
         equalTo(HeaderSpaceMatchExpr.matchSrcIp(ImmutableSet.of(new IpWildcard(ip)))));
 
-    BooleanExpr matchDstExpr = ip.accept(_dstIpSpaceBooleanExprTransformer);
+    BooleanExpr matchDstExpr = ip.accept(DST_IP_SPACE_BOOLEAN_EXPR_TRANSFORMER);
     assertThat(
         matchDstExpr,
         equalTo(HeaderSpaceMatchExpr.matchDstIp(ImmutableSet.of(new IpWildcard(ip)))));
 
-    BooleanExpr matchSrcOrDstExpr = ip.accept(_srcOrDstIpSpaceBooleanExprTransformer);
+    BooleanExpr matchSrcOrDstExpr = ip.accept(SRC_OR_DST_IP_SPACE_BOOLEAN_EXPR_TRANSFORMER);
     assertThat(
         matchSrcOrDstExpr,
         equalTo(HeaderSpaceMatchExpr.matchSrcOrDstIp(ImmutableSet.of(new IpWildcard(ip)))));
@@ -87,7 +86,7 @@ public class IpSpaceBooleanExprTransformerTest {
   @Test
   public void testVisitIpWildcard() {
     IpWildcard wildcard = new IpWildcard(new Ip("1.2.0.4"), new Ip(0x0000FF00L));
-    BooleanExpr matchExpr = wildcard.accept(_srcIpSpaceBooleanExprTransformer);
+    BooleanExpr matchExpr = wildcard.accept(SRC_IP_SPACE_BOOLEAN_EXPR_TRANSFORMER);
     assertThat(matchExpr, equalTo(HeaderSpaceMatchExpr.matchSrcIp(ImmutableSet.of(wildcard))));
   }
 
@@ -101,17 +100,16 @@ public class IpSpaceBooleanExprTransformerTest {
             .excluding(excludeWildcard)
             .build();
 
-    BooleanExpr expr = ipSpace.accept(_srcIpSpaceBooleanExprTransformer);
-    BooleanExpr includeExpr = includeWildcard.accept(_srcIpSpaceBooleanExprTransformer);
-    BooleanExpr excludeExpr = excludeWildcard.accept(_srcIpSpaceBooleanExprTransformer);
+    BooleanExpr expr = ipSpace.accept(SRC_IP_SPACE_BOOLEAN_EXPR_TRANSFORMER);
+    BooleanExpr includeExpr = includeWildcard.accept(SRC_IP_SPACE_BOOLEAN_EXPR_TRANSFORMER);
+    BooleanExpr excludeExpr = excludeWildcard.accept(SRC_IP_SPACE_BOOLEAN_EXPR_TRANSFORMER);
 
     assertThat(expr, equalTo(new AndExpr(ImmutableList.of(new NotExpr(excludeExpr), includeExpr))));
   }
 
   @Test
   public void testVisitUniverseIpSpace() {
-    BooleanExpr expr =
-        UniverseIpSpace.INSTANCE.accept(new IpSpaceBooleanExprTransformer(true, false));
+    BooleanExpr expr = UniverseIpSpace.INSTANCE.accept(SRC_IP_SPACE_BOOLEAN_EXPR_TRANSFORMER);
     assertThat(expr, equalTo(TrueExpr.INSTANCE));
   }
 }


### PR DESCRIPTION
The previous encoding of AclIpSpace cause the line expressions
of AclIpSpaces to be duplicated many times. Using z3's if-then-else operator
is much more efficient.