### PR TITLE
Adding support to use Security Groups IDs as source or dest in Inbound/Outbound rules

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/aws/AwsVpcEntity.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/AwsVpcEntity.java
@@ -90,6 +90,7 @@ public interface AwsVpcEntity {
   String JSON_KEY_TO = "To";
   String JSON_KEY_TO_PORT = "ToPort";
   String JSON_KEY_TYPE = "Type";
+  String JSON_KEY_USER_ID_PAIRS = "UserIdGroupPairs";
   String JSON_KEY_VGW_TELEMETRY = "VgwTelemetry";
   String JSON_KEY_VPC_ATTACHMENTS = "VpcAttachments";
   String JSON_KEY_VPC_ID = "VpcId";

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/ElasticsearchDomain.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/ElasticsearchDomain.java
@@ -1,16 +1,17 @@
 package org.batfish.representation.aws;
 
+import com.google.common.collect.ImmutableSet;
 import java.io.Serializable;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
-import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
-import org.batfish.datamodel.IpAccessList;
-import org.batfish.datamodel.IpAccessListLine;
+import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.StaticRoute;
 import org.codehaus.jettison.json.JSONArray;
@@ -80,30 +81,6 @@ public class ElasticsearchDomain implements AwsVpcEntity, Serializable {
       AwsConfiguration awsVpcConfig, Region region, Warnings warnings) {
     Configuration cfgNode = Utils.newAwsConfiguration(_domainName, "aws");
 
-    String sgIngressAclName = "~SECURITY_GROUP_INGRESS_ACL~";
-    String sgEgressAclName = "~SECURITY_GROUP_EGRESS_ACL~";
-
-    List<IpAccessListLine> inboundRules = new LinkedList<>();
-    List<IpAccessListLine> outboundRules = new LinkedList<>();
-    for (String sGroupId : _securityGroups) {
-      SecurityGroup sGroup = region.getSecurityGroups().get(sGroupId);
-      if (sGroup == null) {
-        warnings.pedantic(
-            String.format(
-                "Security group \"%s\" for Elasticsearch domain \"%s\" not found",
-                sGroupId, _domainName));
-        continue;
-      }
-
-      sGroup.addInOutAccessLines(inboundRules, outboundRules);
-    }
-
-    // create ACLs from inboundRules and outboundRules
-    IpAccessList inAcl = new IpAccessList(sgIngressAclName, inboundRules);
-    IpAccessList outAcl = new IpAccessList(sgEgressAclName, outboundRules);
-    cfgNode.getIpAccessLists().put(sgIngressAclName, inAcl);
-    cfgNode.getIpAccessLists().put(sgEgressAclName, outAcl);
-
     cfgNode.getVendorFamily().getAws().setVpcId(_vpcId);
     cfgNode.getVendorFamily().getAws().setRegion(region.getName());
 
@@ -120,11 +97,7 @@ public class ElasticsearchDomain implements AwsVpcEntity, Serializable {
       Ip instancesIfaceIp = subnet.getNextIp();
       InterfaceAddress instancesIfaceAddress =
           new InterfaceAddress(instancesIfaceIp, subnet.getCidrBlock().getPrefixLength());
-      Interface iface = Utils.newInterface(instancesIfaceName, cfgNode, instancesIfaceAddress);
-
-      // apply ACLs to interface
-      iface.setIncomingFilter(inAcl);
-      iface.setOutgoingFilter(outAcl);
+      Utils.newInterface(instancesIfaceName, cfgNode, instancesIfaceAddress);
 
       Ip defaultGatewayAddress = subnet.computeInstancesIfaceIp();
       StaticRoute defaultRoute =
@@ -135,6 +108,34 @@ public class ElasticsearchDomain implements AwsVpcEntity, Serializable {
               .setNetwork(Prefix.ZERO)
               .build();
       cfgNode.getDefaultVrf().getStaticRoutes().add(defaultRoute);
+    }
+    for (String sGroupId : _securityGroups) {
+      SecurityGroup sGroup = region.getSecurityGroups().get(sGroupId);
+      if (sGroup == null) {
+        warnings.pedantic(
+            String.format(
+                "Security group \"%s\" for Elasticsearch domain \"%s\" not found",
+                sGroupId, _domainName));
+        continue;
+      }
+
+      Set<SecurityGroup> securityGroups =
+          region
+              .getConfigurationSecurityGroups()
+              .computeIfAbsent(cfgNode.getName(), k -> new HashSet<>());
+      securityGroups.add(sGroup);
+
+      sGroup
+          .getUsersIpSpace()
+          .addAll(
+              cfgNode
+                  .getInterfaces()
+                  .values()
+                  .stream()
+                  .flatMap(iface -> iface.getAllAddresses().stream())
+                  .map(InterfaceAddress::getIp)
+                  .map(IpWildcard::new)
+                  .collect(ImmutableSet.toImmutableSet()));
     }
     return cfgNode;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Instance.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Instance.java
@@ -3,13 +3,16 @@ package org.batfish.representation.aws;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import java.io.Serializable;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.SortedSet;
 import org.batfish.common.BatfishException;
 import org.batfish.common.BatfishLogger;
@@ -18,8 +21,7 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
-import org.batfish.datamodel.IpAccessList;
-import org.batfish.datamodel.IpAccessListLine;
+import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.StaticRoute;
 import org.codehaus.jettison.json.JSONArray;
@@ -71,13 +73,9 @@ public class Instance implements AwsVpcEntity, Serializable {
 
   private static final long serialVersionUID = 1L;
 
-  private transient IpAccessList _inAcl;
-
   private final String _instanceId;
 
   private final List<String> _networkInterfaces;
-
-  private transient IpAccessList _outAcl;
 
   private final List<String> _securityGroups;
 
@@ -123,20 +121,12 @@ public class Instance implements AwsVpcEntity, Serializable {
     return _instanceId;
   }
 
-  public IpAccessList getInAcl() {
-    return _inAcl;
-  }
-
   public String getInstanceId() {
     return _instanceId;
   }
 
   public List<String> getNetworkInterfaces() {
     return _networkInterfaces;
-  }
-
-  public IpAccessList getOutAcl() {
-    return _outAcl;
   }
 
   public List<String> getSecurityGroups() {
@@ -174,31 +164,8 @@ public class Instance implements AwsVpcEntity, Serializable {
 
   public Configuration toConfigurationNode(
       AwsConfiguration awsVpcConfig, Region region, Warnings warnings) {
-    String sgIngressAclName = "~SECURITY_GROUP_INGRESS_ACL~";
-    String sgEgressAclName = "~SECURITY_GROUP_EGRESS_ACL~";
     String name = _tags.getOrDefault("Name", _instanceId);
     Configuration cfgNode = Utils.newAwsConfiguration(name, "aws");
-
-    List<IpAccessListLine> inboundRules = new LinkedList<>();
-    List<IpAccessListLine> outboundRules = new LinkedList<>();
-    for (String sGroupId : _securityGroups) {
-      SecurityGroup sGroup = region.getSecurityGroups().get(sGroupId);
-
-      if (sGroup == null) {
-        warnings.pedantic(
-            String.format(
-                "Security group \"%s\" for instance \"%s\" not found", sGroupId, _instanceId));
-        continue;
-      }
-
-      sGroup.addInOutAccessLines(inboundRules, outboundRules);
-    }
-
-    // create ACLs from inboundRules and outboundRules
-    _inAcl = new IpAccessList(sgIngressAclName, inboundRules);
-    _outAcl = new IpAccessList(sgEgressAclName, outboundRules);
-    cfgNode.getIpAccessLists().put(sgIngressAclName, _inAcl);
-    cfgNode.getIpAccessLists().put(sgEgressAclName, _outAcl);
 
     for (String interfaceId : _networkInterfaces) {
 
@@ -247,13 +214,36 @@ public class Instance implements AwsVpcEntity, Serializable {
       Interface iface = Utils.newInterface(interfaceId, cfgNode, ifaceAddresses.first());
       iface.setAllAddresses(ifaceAddresses);
 
-      // apply ACLs to interface
-      iface.setIncomingFilter(_inAcl);
-      iface.setOutgoingFilter(_outAcl);
-
       cfgNode.getVendorFamily().getAws().setVpcId(_vpcId);
       cfgNode.getVendorFamily().getAws().setSubnetId(_subnetId);
       cfgNode.getVendorFamily().getAws().setRegion(region.getName());
+    }
+    for (String sGroupId : _securityGroups) {
+      SecurityGroup sGroup = region.getSecurityGroups().get(sGroupId);
+      if (sGroup == null) {
+        warnings.pedantic(
+            String.format(
+                "Security group \"%s\" for instance \"%s\" not found", sGroupId, _instanceId));
+        continue;
+      }
+
+      Set<SecurityGroup> securityGroups =
+          region
+              .getConfigurationSecurityGroups()
+              .computeIfAbsent(cfgNode.getName(), k -> new HashSet<>());
+      securityGroups.add(sGroup);
+
+      sGroup
+          .getUsersIpSpace()
+          .addAll(
+              cfgNode
+                  .getInterfaces()
+                  .values()
+                  .stream()
+                  .flatMap(iface -> iface.getAllAddresses().stream())
+                  .map(InterfaceAddress::getIp)
+                  .map(IpWildcard::new)
+                  .collect(ImmutableSet.toImmutableSet()));
     }
 
     return cfgNode;

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/IpPermissions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/IpPermissions.java
@@ -88,13 +88,19 @@ public class IpPermissions implements Serializable {
     IpAccessListLine line = toIpAccessListLine();
     ImmutableSortedSet.Builder<IpWildcard> ipWildcardBuilder =
         new ImmutableSortedSet.Builder<>(Comparator.naturalOrder());
-    ipWildcardBuilder.addAll(_ipRanges.stream().map(IpWildcard::new).collect(Collectors.toSet()));
-    ipWildcardBuilder.addAll(
-        _securityGroups
-            .stream()
-            .filter(sg -> region.getSecurityGroups().containsKey(sg))
-            .flatMap(sg -> region.getSecurityGroups().get(sg).getUsersIpSpace().stream())
-            .collect(Collectors.toSet()));
+
+    _ipRanges
+        .stream()
+        .map(IpWildcard::new)
+        .forEach(ipWildcard -> ipWildcardBuilder.add(ipWildcard));
+
+    _securityGroups
+        .stream()
+        .map(sgID -> region.getSecurityGroups().get(sgID))
+        .filter(sg -> sg != null)
+        .flatMap(sg -> sg.getUsersIpSpace().stream())
+        .forEach(ipWildCard -> ipWildcardBuilder.add(ipWildCard));
+
     line.setDstIps(ipWildcardBuilder.build());
     return line;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/RdsInstance.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/RdsInstance.java
@@ -1,20 +1,16 @@
 package org.batfish.representation.aws;
 
 import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimap;
 import java.io.Serializable;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Set;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
-import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.StaticRoute;
 import org.codehaus.jettison.json.JSONArray;
@@ -151,34 +147,8 @@ public class RdsInstance implements AwsVpcEntity, Serializable {
       cfgNode.getDefaultVrf().getStaticRoutes().add(defaultRoute);
     }
 
-    for (String sGroupId : _securityGroups) {
-      SecurityGroup sGroup = region.getSecurityGroups().get(sGroupId);
-      if (sGroup == null) {
-        warnings.pedantic(
-            String.format(
-                "Security group \"%s\" for RDS instance \"%s\" not found",
-                sGroupId, _dbInstanceIdentifier));
-        continue;
-      }
+    Utils.processSecurityGroups(region, cfgNode, _securityGroups, warnings);
 
-      Set<SecurityGroup> securityGroups =
-          region
-              .getConfigurationSecurityGroups()
-              .computeIfAbsent(cfgNode.getName(), k -> new HashSet<>());
-      securityGroups.add(sGroup);
-
-      sGroup
-          .getUsersIpSpace()
-          .addAll(
-              cfgNode
-                  .getInterfaces()
-                  .values()
-                  .stream()
-                  .flatMap(iface -> iface.getAllAddresses().stream())
-                  .map(InterfaceAddress::getIp)
-                  .map(IpWildcard::new)
-                  .collect(ImmutableSet.toImmutableSet()));
-    }
     return cfgNode;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/RdsInstance.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/RdsInstance.java
@@ -1,19 +1,20 @@
 package org.batfish.representation.aws;
 
 import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimap;
 import java.io.Serializable;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
-import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
-import org.batfish.datamodel.IpAccessList;
-import org.batfish.datamodel.IpAccessListLine;
+import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.StaticRoute;
 import org.codehaus.jettison.json.JSONArray;
@@ -116,30 +117,6 @@ public class RdsInstance implements AwsVpcEntity, Serializable {
       AwsConfiguration awsVpcConfig, Region region, Warnings warnings) {
     Configuration cfgNode = Utils.newAwsConfiguration(_dbInstanceIdentifier, "aws");
 
-    String sgIngressAclName = "~SECURITY_GROUP_INGRESS_ACL~";
-    String sgEgressAclName = "~SECURITY_GROUP_EGRESS_ACL~";
-
-    List<IpAccessListLine> inboundRules = new LinkedList<>();
-    List<IpAccessListLine> outboundRules = new LinkedList<>();
-    for (String sGroupId : _securityGroups) {
-      SecurityGroup sGroup = region.getSecurityGroups().get(sGroupId);
-      if (sGroup == null) {
-        warnings.pedantic(
-            String.format(
-                "Security group \"%s\" for RDS instance \"%s\" not found",
-                sGroupId, _dbInstanceIdentifier));
-        continue;
-      }
-
-      sGroup.addInOutAccessLines(inboundRules, outboundRules);
-    }
-
-    // create ACLs from inboundRules and outboundRules
-    IpAccessList inAcl = new IpAccessList(sgIngressAclName, inboundRules);
-    IpAccessList outAcl = new IpAccessList(sgEgressAclName, outboundRules);
-    cfgNode.getIpAccessLists().put(sgIngressAclName, inAcl);
-    cfgNode.getIpAccessLists().put(sgEgressAclName, outAcl);
-
     cfgNode.getVendorFamily().getAws().setVpcId(_vpcId);
     cfgNode.getVendorFamily().getAws().setRegion(region.getName());
 
@@ -161,11 +138,7 @@ public class RdsInstance implements AwsVpcEntity, Serializable {
       Ip instancesIfaceIp = subnet.getNextIp();
       InterfaceAddress instancesIfaceAddress =
           new InterfaceAddress(instancesIfaceIp, subnet.getCidrBlock().getPrefixLength());
-      Interface iface = Utils.newInterface(instancesIfaceName, cfgNode, instancesIfaceAddress);
-
-      // apply ACLs to interface
-      iface.setIncomingFilter(inAcl);
-      iface.setOutgoingFilter(outAcl);
+      Utils.newInterface(instancesIfaceName, cfgNode, instancesIfaceAddress);
 
       Ip defaultGatewayAddress = subnet.computeInstancesIfaceIp();
       StaticRoute defaultRoute =
@@ -176,6 +149,35 @@ public class RdsInstance implements AwsVpcEntity, Serializable {
               .setNetwork(Prefix.ZERO)
               .build();
       cfgNode.getDefaultVrf().getStaticRoutes().add(defaultRoute);
+    }
+
+    for (String sGroupId : _securityGroups) {
+      SecurityGroup sGroup = region.getSecurityGroups().get(sGroupId);
+      if (sGroup == null) {
+        warnings.pedantic(
+            String.format(
+                "Security group \"%s\" for RDS instance \"%s\" not found",
+                sGroupId, _dbInstanceIdentifier));
+        continue;
+      }
+
+      Set<SecurityGroup> securityGroups =
+          region
+              .getConfigurationSecurityGroups()
+              .computeIfAbsent(cfgNode.getName(), k -> new HashSet<>());
+      securityGroups.add(sGroup);
+
+      sGroup
+          .getUsersIpSpace()
+          .addAll(
+              cfgNode
+                  .getInterfaces()
+                  .values()
+                  .stream()
+                  .flatMap(iface -> iface.getAllAddresses().stream())
+                  .map(InterfaceAddress::getIp)
+                  .map(IpWildcard::new)
+                  .collect(ImmutableSet.toImmutableSet()));
     }
     return cfgNode;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Region.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Region.java
@@ -3,7 +3,11 @@ package org.batfish.representation.aws;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.Warnings;
@@ -11,6 +15,8 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DeviceType;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpAccessList;
+import org.batfish.datamodel.IpAccessListLine;
 import org.batfish.datamodel.Vrf;
 import org.batfish.main.Batfish;
 import org.batfish.representation.aws.Instance.Status;
@@ -23,6 +29,8 @@ public class Region implements Serializable {
   private static final long serialVersionUID = 1L;
 
   private Map<String, Address> _addresses = new HashMap<>();
+
+  private Map<String, Set<SecurityGroup>> _configurationSecurityGroups = new HashMap<>();
 
   private Map<String, CustomerGateway> _customerGateways = new HashMap<>();
 
@@ -55,6 +63,9 @@ public class Region implements Serializable {
   private Map<String, VpnConnection> _vpnConnections = new HashMap<>();
 
   private Map<String, VpnGateway> _vpnGateways = new HashMap<>();
+
+  public static String SG_INGRESS_ACL_NAME = "~SECURITY_GROUP_INGRESS_ACL~";
+  public static String SG_EGRESS_ACL_NAME = "~SECURITY_GROUP_EGRESS_ACL~";
 
   public Region(String name) {
     _name = name;
@@ -176,6 +187,10 @@ public class Region implements Serializable {
 
   public Map<String, Address> getAddresses() {
     return _addresses;
+  }
+
+  public Map<String, Set<SecurityGroup>> getConfigurationSecurityGroups() {
+    return _configurationSecurityGroups;
   }
 
   public Map<String, CustomerGateway> getCustomerGateways() {
@@ -329,6 +344,8 @@ public class Region implements Serializable {
       awsConfiguration.getWarningsByHost().put(vpnConnection.getId(), warnings);
     }
 
+    applySecurityGroupsAcls(configurationNodes);
+
     // TODO: for now, set all interfaces to have the same bandwidth
     for (Configuration cfgNode : configurationNodes.values()) {
       for (Vrf vrf : cfgNode.getVrfs().values()) {
@@ -336,6 +353,34 @@ public class Region implements Serializable {
           iface.setBandwidth(1E12d);
         }
       }
+    }
+  }
+
+  private void applySecurityGroupsAcls(Map<String, Configuration> cfgNodes) {
+    for (Entry<String, Set<SecurityGroup>> entry : _configurationSecurityGroups.entrySet()) {
+      Configuration cfgNode = cfgNodes.get(entry.getKey());
+      List<IpAccessListLine> inboundRules = new LinkedList<>();
+      List<IpAccessListLine> outboundRules = new LinkedList<>();
+      entry
+          .getValue()
+          .forEach(securityGroup -> securityGroup.addInOutAccessLines(inboundRules, outboundRules));
+
+      // create ACLs from inboundRules and outboundRules
+      IpAccessList inAcl = new IpAccessList(SG_INGRESS_ACL_NAME, inboundRules);
+      IpAccessList outAcl = new IpAccessList(SG_EGRESS_ACL_NAME, outboundRules);
+
+      cfgNode.getIpAccessLists().put(SG_INGRESS_ACL_NAME, inAcl);
+      cfgNode.getIpAccessLists().put(SG_EGRESS_ACL_NAME, outAcl);
+
+      // applying the filters to all interfaces in the node
+      cfgNode
+          .getInterfaces()
+          .values()
+          .forEach(
+              iface -> {
+                iface.setIncomingFilter(inAcl);
+                iface.setOutgoingFilter(outAcl);
+              });
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Region.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Region.java
@@ -2,6 +2,7 @@ package org.batfish.representation.aws;
 
 import java.io.Serializable;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -401,5 +402,11 @@ public class Region implements Serializable {
                             .stream()
                             .map(Ip::asLong)
                             .collect(Collectors.toSet())));
+  }
+
+  public void updateConfigurationSecurityGroups(String configName, SecurityGroup securityGroup) {
+    Set<SecurityGroup> securityGroups =
+        getConfigurationSecurityGroups().computeIfAbsent(configName, k -> new HashSet<>());
+    securityGroups.add(securityGroup);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Region.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Region.java
@@ -363,7 +363,9 @@ public class Region implements Serializable {
       List<IpAccessListLine> outboundRules = new LinkedList<>();
       entry
           .getValue()
-          .forEach(securityGroup -> securityGroup.addInOutAccessLines(inboundRules, outboundRules));
+          .forEach(
+              securityGroup ->
+                  securityGroup.addInOutAccessLines(inboundRules, outboundRules, this));
 
       // create ACLs from inboundRules and outboundRules
       IpAccessList inAcl = new IpAccessList(SG_INGRESS_ACL_NAME, inboundRules);

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Region.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Region.java
@@ -65,8 +65,8 @@ public class Region implements Serializable {
 
   private Map<String, VpnGateway> _vpnGateways = new HashMap<>();
 
-  public static String SG_INGRESS_ACL_NAME = "~SECURITY_GROUP_INGRESS_ACL~";
-  public static String SG_EGRESS_ACL_NAME = "~SECURITY_GROUP_EGRESS_ACL~";
+  public static final String SG_INGRESS_ACL_NAME = "~SECURITY_GROUP_INGRESS_ACL~";
+  public static final String SG_EGRESS_ACL_NAME = "~SECURITY_GROUP_EGRESS_ACL~";
 
   public Region(String name) {
     _name = name;

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Route.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Route.java
@@ -1,6 +1,7 @@
 package org.batfish.representation.aws;
 
 import java.io.Serializable;
+import java.util.LinkedList;
 import java.util.Set;
 import java.util.TreeSet;
 import javax.annotation.Nullable;
@@ -12,6 +13,7 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.StaticRoute;
 import org.codehaus.jettison.json.JSONException;
@@ -159,9 +161,18 @@ public class Route implements Serializable {
             InterfaceAddress instanceIfaceAddress = instanceLink.getSecond();
             Interface instanceIface =
                 Utils.newInterface(instanceIfaceName, instanceCfgNode, instanceIfaceAddress);
-            Instance instance = region.getInstances().get(instanceId);
-            instanceIface.setIncomingFilter(instance.getInAcl());
-            instanceIface.setOutgoingFilter(instance.getOutAcl());
+            instanceIface.setIncomingFilter(
+                instanceCfgNode
+                    .getIpAccessLists()
+                    .getOrDefault(
+                        Region.SG_INGRESS_ACL_NAME,
+                        new IpAccessList(Region.SG_INGRESS_ACL_NAME, new LinkedList<>())));
+            instanceIface.setOutgoingFilter(
+                instanceCfgNode
+                    .getIpAccessLists()
+                    .getOrDefault(
+                        Region.SG_EGRESS_ACL_NAME,
+                        new IpAccessList(Region.SG_EGRESS_ACL_NAME, new LinkedList<>())));
             Ip nextHopIp = instanceIfaceAddress.getIp();
             srBuilder.setNextHopIp(nextHopIp);
           }

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/SecurityGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/SecurityGroup.java
@@ -8,6 +8,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import org.batfish.common.BatfishLogger;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.IpAccessListLine;
 import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.LineAction;
@@ -142,6 +144,17 @@ public class SecurityGroup implements AwsVpcEntity, Serializable {
 
   public Set<IpWildcard> getUsersIpSpace() {
     return _usersIpSpace;
+  }
+
+  public void updateConfigIps(Configuration configuration) {
+    configuration
+        .getInterfaces()
+        .values()
+        .stream()
+        .flatMap(iface -> iface.getAllAddresses().stream())
+        .map(InterfaceAddress::getIp)
+        .map(IpWildcard::new)
+        .forEach(ipWildcard -> getUsersIpSpace().add(ipWildcard));
   }
 
   private void initIpPerms(

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/SecurityGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/SecurityGroup.java
@@ -3,10 +3,13 @@ package org.batfish.representation.aws;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.io.Serializable;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 import org.batfish.common.BatfishLogger;
 import org.batfish.datamodel.IpAccessListLine;
+import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.TcpFlags;
 import org.codehaus.jettison.json.JSONArray;
@@ -24,6 +27,8 @@ public class SecurityGroup implements AwsVpcEntity, Serializable {
   private final List<IpPermissions> _ipPermsEgress;
 
   private final List<IpPermissions> _ipPermsIngress;
+
+  private final Set<IpWildcard> _usersIpSpace = new HashSet<>();
 
   public SecurityGroup(JSONObject jObj, BatfishLogger logger) throws JSONException {
     _ipPermsEgress = new LinkedList<>();
@@ -123,6 +128,10 @@ public class SecurityGroup implements AwsVpcEntity, Serializable {
 
   public List<IpPermissions> getIpPermsIngress() {
     return _ipPermsIngress;
+  }
+
+  public Set<IpWildcard> getUsersIpSpace() {
+    return _usersIpSpace;
   }
 
   private void initIpPerms(

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/SecurityGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/SecurityGroup.java
@@ -46,16 +46,26 @@ public class SecurityGroup implements AwsVpcEntity, Serializable {
   }
 
   private void addEgressAccessLines(
-      List<IpPermissions> permsList, List<IpAccessListLine> accessList) {
+      List<IpPermissions> permsList, List<IpAccessListLine> accessList, Region region) {
     for (IpPermissions ipPerms : permsList) {
-      accessList.add(ipPerms.toEgressIpAccessListLine());
+      IpAccessListLine ipAccessListLine = ipPerms.toEgressIpAccessListLine(region);
+      // Destination IPs should have been populated using either SG or IP ranges,  if not then this
+      // Ip perm is incomplete
+      if (!ipAccessListLine.getDstIps().isEmpty()) {
+        accessList.add(ipAccessListLine);
+      }
     }
   }
 
   private void addIngressAccessLines(
-      List<IpPermissions> permsList, List<IpAccessListLine> accessList) {
+      List<IpPermissions> permsList, List<IpAccessListLine> accessList, Region region) {
     for (IpPermissions ipPerms : permsList) {
-      accessList.add(ipPerms.toIngressIpAccessListLine());
+      IpAccessListLine ipAccessListLine = ipPerms.toIngressIpAccessListLine(region);
+      // Source IPs should have been populated using either SG or IP ranges, if not then this Ip
+      // perm is incomplete
+      if (!ipAccessListLine.getSrcIps().isEmpty()) {
+        accessList.add(ipAccessListLine);
+      }
     }
   }
 
@@ -103,9 +113,9 @@ public class SecurityGroup implements AwsVpcEntity, Serializable {
   }
 
   public void addInOutAccessLines(
-      List<IpAccessListLine> inboundRules, List<IpAccessListLine> outboundRules) {
-    addIngressAccessLines(_ipPermsIngress, inboundRules);
-    addEgressAccessLines(_ipPermsEgress, outboundRules);
+      List<IpAccessListLine> inboundRules, List<IpAccessListLine> outboundRules, Region region) {
+    addIngressAccessLines(_ipPermsIngress, inboundRules, region);
+    addEgressAccessLines(_ipPermsEgress, outboundRules, region);
     addReverseAcls(inboundRules, outboundRules);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
@@ -44,6 +44,16 @@ public class Utils {
         .build();
   }
 
+  /**
+   * Updates {@link Region}'s mapping between {@link Configuration} names and {@link SecurityGroup}
+   * for a given configuration. Also updates {@link org.batfish.datamodel.Ip} of instances in {@link
+   * SecurityGroup}
+   *
+   * @param region {@link Region} in which the configuration is in
+   * @param configuration {@link Configuration} for which security groups are to be processed
+   * @param securityGroupsIds {@link List} of security group IDs
+   * @param warnings {@link Warnings} for the configuration
+   */
   public static void processSecurityGroups(
       Region region,
       Configuration configuration,
@@ -86,4 +96,6 @@ public class Utils {
     }
     return null;
   }
+
+  private Utils() {}
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
@@ -1,6 +1,8 @@
 package org.batfish.representation.aws;
 
+import java.util.List;
 import javax.annotation.Nullable;
+import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Interface;
@@ -40,6 +42,25 @@ public class Utils {
         .setActive(true)
         .setAddress(primaryAddress)
         .build();
+  }
+
+  public static void processSecurityGroups(
+      Region region,
+      Configuration configuration,
+      List<String> securityGroupsIds,
+      Warnings warnings) {
+    for (String sGroupId : securityGroupsIds) {
+      SecurityGroup securityGroup = region.getSecurityGroups().get(sGroupId);
+      if (securityGroup == null) {
+        warnings.pedantic(
+            String.format(
+                "Security group \"%s\" for \"%s\" not found", sGroupId, configuration.getName()));
+        continue;
+      }
+      region.updateConfigurationSecurityGroups(configuration.getName(), securityGroup);
+
+      securityGroup.updateConfigIps(configuration);
+    }
   }
 
   public static boolean tryGetBoolean(JSONObject jsonObject, String key, boolean defaultValue)

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
@@ -65,6 +65,4 @@ public class Utils {
     }
     return null;
   }
-
-  private Utils() {}
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/ElasticsearchDomainTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/ElasticsearchDomainTest.java
@@ -181,7 +181,9 @@ public class ElasticsearchDomainTest {
                 IpAccessListLine.builder()
                     .setAction(LineAction.ACCEPT)
                     .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
-                    .setSrcIps(Sets.newHashSet(new IpWildcard("1.2.3.4/32")))
+                    .setSrcIps(
+                        Sets.newHashSet(
+                            new IpWildcard("1.2.3.4/32"), new IpWildcard("10.193.16.105/32")))
                     .setDstPorts(Sets.newHashSet(new SubRange(45, 50)))
                     .build(),
                 rejectSynOnly,
@@ -201,7 +203,9 @@ public class ElasticsearchDomainTest {
                 IpAccessListLine.builder()
                     .setAction(LineAction.ACCEPT)
                     .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
-                    .setDstIps(Sets.newHashSet(new IpWildcard("1.2.3.4/32")))
+                    .setDstIps(
+                        Sets.newHashSet(
+                            new IpWildcard("1.2.3.4/32"), new IpWildcard("10.193.16.105/32")))
                     .setSrcPorts(Sets.newHashSet(new SubRange(45, 50)))
                     .build()));
 

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/RdsInstanceTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/RdsInstanceTest.java
@@ -162,7 +162,9 @@ public class RdsInstanceTest {
                 IpAccessListLine.builder()
                     .setAction(LineAction.ACCEPT)
                     .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
-                    .setSrcIps(Sets.newHashSet(new IpWildcard("1.2.3.4/32")))
+                    .setSrcIps(
+                        Sets.newHashSet(
+                            new IpWildcard("1.2.3.4/32"), new IpWildcard("10.193.16.105/32")))
                     .setDstPorts(Sets.newHashSet(new SubRange(45, 50)))
                     .build(),
                 rejectSynOnly,
@@ -182,7 +184,9 @@ public class RdsInstanceTest {
                 IpAccessListLine.builder()
                     .setAction(LineAction.ACCEPT)
                     .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
-                    .setDstIps(Sets.newHashSet(new IpWildcard("1.2.3.4/32")))
+                    .setDstIps(
+                        Sets.newHashSet(
+                            new IpWildcard("1.2.3.4/32"), new IpWildcard("10.193.16.105/32")))
                     .setSrcPorts(Sets.newHashSet(new SubRange(45, 50)))
                     .build()));
 

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/SecurityGroupsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/SecurityGroupsTest.java
@@ -33,6 +33,7 @@ public class SecurityGroupsTest {
   private IpAccessListLine _rejectSynOnly;
   private IpAccessListLine _allowAllReverseOutboundRule;
   private Flow.Builder _flowBuilder;
+  private Region _region;
 
   public static String TEST_ACL = "test_acl";
 
@@ -52,6 +53,7 @@ public class SecurityGroupsTest {
             .setAction(LineAction.ACCEPT)
             .setSrcIps(Sets.newHashSet(new IpWildcard("0.0.0.0/0")))
             .build();
+    _region = new Region("test");
     _flowBuilder = new Builder();
     _flowBuilder.setIngressNode("foo");
     _flowBuilder.setTag("TEST");
@@ -65,7 +67,7 @@ public class SecurityGroupsTest {
     List<IpAccessListLine> inboundRules = new LinkedList<>();
     List<IpAccessListLine> outboundRules = new LinkedList<>();
 
-    sg.addInOutAccessLines(inboundRules, outboundRules);
+    sg.addInOutAccessLines(inboundRules, outboundRules, _region);
 
     assertThat(
         inboundRules,
@@ -88,7 +90,7 @@ public class SecurityGroupsTest {
     List<IpAccessListLine> inboundRules = new LinkedList<>();
     List<IpAccessListLine> outboundRules = new LinkedList<>();
 
-    sg.addInOutAccessLines(inboundRules, outboundRules);
+    sg.addInOutAccessLines(inboundRules, outboundRules, _region);
 
     assertThat(
         inboundRules,
@@ -111,7 +113,7 @@ public class SecurityGroupsTest {
     List<IpAccessListLine> inboundRules = new LinkedList<>();
     List<IpAccessListLine> outboundRules = new LinkedList<>();
 
-    sg.addInOutAccessLines(inboundRules, outboundRules);
+    sg.addInOutAccessLines(inboundRules, outboundRules, _region);
 
     assertThat(
         inboundRules,
@@ -134,7 +136,7 @@ public class SecurityGroupsTest {
     List<IpAccessListLine> inboundRules = new LinkedList<>();
     List<IpAccessListLine> outboundRules = new LinkedList<>();
 
-    sg.addInOutAccessLines(inboundRules, outboundRules);
+    sg.addInOutAccessLines(inboundRules, outboundRules, _region);
 
     assertThat(
         inboundRules,
@@ -156,7 +158,7 @@ public class SecurityGroupsTest {
     List<IpAccessListLine> inboundRules = new LinkedList<>();
     List<IpAccessListLine> outboundRules = new LinkedList<>();
 
-    sg.addInOutAccessLines(inboundRules, outboundRules);
+    sg.addInOutAccessLines(inboundRules, outboundRules, _region);
 
     assertThat(
         inboundRules,
@@ -178,7 +180,7 @@ public class SecurityGroupsTest {
     List<IpAccessListLine> inboundRules = new LinkedList<>();
     List<IpAccessListLine> outboundRules = new LinkedList<>();
 
-    sg.addInOutAccessLines(inboundRules, outboundRules);
+    sg.addInOutAccessLines(inboundRules, outboundRules, _region);
 
     assertThat(
         inboundRules,
@@ -201,7 +203,7 @@ public class SecurityGroupsTest {
     List<IpAccessListLine> inboundRules = new LinkedList<>();
     List<IpAccessListLine> outboundRules = new LinkedList<>();
 
-    sg.addInOutAccessLines(inboundRules, outboundRules);
+    sg.addInOutAccessLines(inboundRules, outboundRules, _region);
 
     assertThat(
         inboundRules,
@@ -224,7 +226,7 @@ public class SecurityGroupsTest {
     List<IpAccessListLine> inboundRules = new LinkedList<>();
     List<IpAccessListLine> outboundRules = new LinkedList<>();
 
-    sg.addInOutAccessLines(inboundRules, outboundRules);
+    sg.addInOutAccessLines(inboundRules, outboundRules, _region);
 
     assertThat(
         inboundRules,
@@ -247,7 +249,7 @@ public class SecurityGroupsTest {
     List<IpAccessListLine> inboundRules = new LinkedList<>();
     List<IpAccessListLine> outboundRules = new LinkedList<>();
 
-    sg.addInOutAccessLines(inboundRules, outboundRules);
+    sg.addInOutAccessLines(inboundRules, outboundRules, _region);
 
     assertThat(
         inboundRules,
@@ -294,7 +296,7 @@ public class SecurityGroupsTest {
     List<IpAccessListLine> inboundRules = new LinkedList<>();
     List<IpAccessListLine> outboundRules = new LinkedList<>();
 
-    sg.addInOutAccessLines(inboundRules, outboundRules);
+    sg.addInOutAccessLines(inboundRules, outboundRules, _region);
 
     IpAccessList outFilter = new IpAccessList(TEST_ACL, outboundRules);
 
@@ -314,7 +316,7 @@ public class SecurityGroupsTest {
     List<IpAccessListLine> inboundRules = new LinkedList<>();
     List<IpAccessListLine> outboundRules = new LinkedList<>();
 
-    sg.addInOutAccessLines(inboundRules, outboundRules);
+    sg.addInOutAccessLines(inboundRules, outboundRules, _region);
 
     IpAccessList outFilter = new IpAccessList(TEST_ACL, outboundRules);
 
@@ -334,7 +336,7 @@ public class SecurityGroupsTest {
     List<IpAccessListLine> inboundRules = new LinkedList<>();
     List<IpAccessListLine> outboundRules = new LinkedList<>();
 
-    sg.addInOutAccessLines(inboundRules, outboundRules);
+    sg.addInOutAccessLines(inboundRules, outboundRules, _region);
 
     IpAccessList outFilter = new IpAccessList(TEST_ACL, outboundRules);
 

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test/aws_configs/NetworkAcls.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test/aws_configs/NetworkAcls.json
@@ -51,6 +51,54 @@
       "NetworkAclId": "acl-4db39c28",
       "Tags": [],
       "VpcId": "vpc-b390fad5"
+    },
+    {
+      "Associations": [
+        {
+          "NetworkAclAssociationId": "aclassoc-4ab7b734",
+          "NetworkAclId": "acl-008d1f79",
+          "SubnetId": "subnet-b26c24fa"
+        },
+        {
+          "NetworkAclAssociationId": "aclassoc-17b6b669",
+          "NetworkAclId": "acl-008d1f79",
+          "SubnetId": "subnet-9c240cfa"
+        }
+      ],
+      "Entries": [
+        {
+          "CidrBlock": "0.0.0.0/0",
+          "Egress": true,
+          "Protocol": "-1",
+          "RuleAction": "allow",
+          "RuleNumber": 100
+        },
+        {
+          "CidrBlock": "0.0.0.0/0",
+          "Egress": true,
+          "Protocol": "-1",
+          "RuleAction": "deny",
+          "RuleNumber": 32767
+        },
+        {
+          "CidrBlock": "0.0.0.0/0",
+          "Egress": false,
+          "Protocol": "-1",
+          "RuleAction": "allow",
+          "RuleNumber": 100
+        },
+        {
+          "CidrBlock": "0.0.0.0/0",
+          "Egress": false,
+          "Protocol": "-1",
+          "RuleAction": "deny",
+          "RuleNumber": 32767
+        }
+      ],
+      "IsDefault": true,
+      "NetworkAclId": "acl-008d1f79",
+      "Tags": [],
+      "VpcId": "vpc-6f6f8316"
     }
   ]
 }

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test/aws_configs/NetworkInterfaces.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test/aws_configs/NetworkInterfaces.json
@@ -38,6 +38,55 @@
       "SubnetId": "subnet-073b8061",
       "TagSet": [],
       "VpcId": "vpc-b390fad5"
+    },
+    {
+      "Association": {
+        "IpOwnerId": "amazon",
+        "PublicDnsName": "ec2-54-191-107-22.us-west-2.compute.amazonaws.com",
+        "PublicIp": "54.191.107.22"
+      },
+      "Attachment": {
+        "AttachTime": "2018-03-26 21:56:17+00:00",
+        "AttachmentId": "eni-attach-0f612575552cfed9b",
+        "DeleteOnTermination": true,
+        "DeviceIndex": 0,
+        "InstanceId": "i-066b1b9957b9200e7",
+        "InstanceOwnerId": "118292266645",
+        "Status": "attached"
+      },
+      "AvailabilityZone": "us-west-2b",
+      "Description": "",
+      "Groups": [
+        {
+          "GroupId": "sg-08893f1a4413ccfc1",
+          "GroupName": "CM-SecurityGroups-1367ZK9SYUAGQ-ECSHostSecurityGroup-1MRE4Z74YJ9KA"
+        }
+      ],
+      "InterfaceType": "interface",
+      "Ipv6Addresses": [],
+      "MacAddress": "06:c1:67:bb:bf:28",
+      "NetworkInterfaceId": "eni-05e8949c37b78cf4d",
+      "OwnerId": "118292266645",
+      "PrivateDnsName": "ip-10-193-16-105.us-west-2.compute.internal",
+      "PrivateIpAddress": "10.193.16.105",
+      "PrivateIpAddresses": [
+        {
+          "Association": {
+            "IpOwnerId": "amazon",
+            "PublicDnsName": "ec2-54-191-107-22.us-west-2.compute.amazonaws.com",
+            "PublicIp": "54.191.107.22"
+          },
+          "Primary": true,
+          "PrivateDnsName": "ip-10-193-16-105.us-west-2.compute.internal",
+          "PrivateIpAddress": "10.193.16.105"
+        }
+      ],
+      "RequesterManaged": false,
+      "SourceDestCheck": true,
+      "Status": "in-use",
+      "SubnetId": "subnet-b26c24fa",
+      "TagSet": [],
+      "VpcId": "vpc-6f6f8316"
     }
   ]
 }

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test/aws_configs/Reservations.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test/aws_configs/Reservations.json
@@ -116,6 +116,131 @@
       ],
       "OwnerId": "118292266645",
       "ReservationId": "r-0cd5ffefa8ca8eabc"
+    },
+    {
+      "Groups": [],
+      "Instances": [
+        {
+          "AmiLaunchIndex": 0,
+          "Architecture": "x86_64",
+          "BlockDeviceMappings": [
+            {
+              "DeviceName": "/dev/xvda",
+              "Ebs": {
+                "AttachTime": "2018-03-26 21:56:18+00:00",
+                "DeleteOnTermination": true,
+                "Status": "attached",
+                "VolumeId": "vol-09c8b6900a39cf921"
+              }
+            },
+            {
+              "DeviceName": "/dev/xvdcz",
+              "Ebs": {
+                "AttachTime": "2018-03-26 21:56:18+00:00",
+                "DeleteOnTermination": true,
+                "Status": "attached",
+                "VolumeId": "vol-03113cc4a103a061f"
+              }
+            }
+          ],
+          "ClientToken": "40b58991-3f49-10f9-af0e-bc52e784c143_subnet-b26c24fa_1",
+          "EbsOptimized": false,
+          "EnaSupport": true,
+          "Hypervisor": "xen",
+          "IamInstanceProfile": {
+            "Arn": "arn:aws:iam::118292266645:instance-profile/CM-ECS-UZCDCF32A729-ECSInstanceProfile-JDC82IKUI7UM",
+            "Id": "AIPAJ73SPIEKTVQUGXG22"
+          },
+          "ImageId": "ami-a64d9ade",
+          "InstanceId": "i-066b1b9957b9200e7",
+          "InstanceType": "t2.small",
+          "LaunchTime": "2018-03-26 21:56:17+00:00",
+          "Monitoring": {
+            "State": "disabled"
+          },
+          "NetworkInterfaces": [
+            {
+              "Association": {
+                "IpOwnerId": "amazon",
+                "PublicDnsName": "ec2-54-191-107-22.us-west-2.compute.amazonaws.com",
+                "PublicIp": "54.191.107.22"
+              },
+              "Attachment": {
+                "AttachTime": "2018-03-26 21:56:17+00:00",
+                "AttachmentId": "eni-attach-0f612575552cfed9b",
+                "DeleteOnTermination": true,
+                "DeviceIndex": 0,
+                "Status": "attached"
+              },
+              "Description": "",
+              "Groups": [
+                {
+                  "GroupId": "sg-08893f1a4413ccfc1",
+                  "GroupName": "Test-Instance-SG"
+                }
+              ],
+              "Ipv6Addresses": [],
+              "MacAddress": "06:c1:67:bb:bf:28",
+              "NetworkInterfaceId": "eni-05e8949c37b78cf4d",
+              "OwnerId": "118292266645",
+              "PrivateDnsName": "ip-10-193-16-105.us-west-2.compute.internal",
+              "PrivateIpAddress": "10.193.16.105",
+              "PrivateIpAddresses": [
+                {
+                  "Association": {
+                    "IpOwnerId": "amazon",
+                    "PublicDnsName": "ec2-54-191-107-22.us-west-2.compute.amazonaws.com",
+                    "PublicIp": "54.191.107.22"
+                  },
+                  "Primary": true,
+                  "PrivateDnsName": "ip-10-193-16-105.us-west-2.compute.internal",
+                  "PrivateIpAddress": "10.193.16.105"
+                }
+              ],
+              "SourceDestCheck": true,
+              "Status": "in-use",
+              "SubnetId": "subnet-b26c24fa",
+              "VpcId": "vpc-6f6f8316"
+            }
+          ],
+          "Placement": {
+            "AvailabilityZone": "us-west-2b",
+            "GroupName": "",
+            "Tenancy": "default"
+          },
+          "PrivateDnsName": "ip-10-193-16-105.us-west-2.compute.internal",
+          "PrivateIpAddress": "10.193.16.105",
+          "ProductCodes": [],
+          "PublicDnsName": "ec2-54-191-107-22.us-west-2.compute.amazonaws.com",
+          "PublicIpAddress": "54.191.107.22",
+          "RootDeviceName": "/dev/xvda",
+          "RootDeviceType": "ebs",
+          "SecurityGroups": [
+            {
+              "GroupId": "sg-08893f1a4413ccfc1",
+              "GroupName": "Test-Instance-SG"
+            }
+          ],
+          "SourceDestCheck": true,
+          "State": {
+            "Code": 16,
+            "Name": "running"
+          },
+          "StateTransitionReason": "",
+          "SubnetId": "subnet-b26c24fa",
+          "Tags": [
+            {
+              "Key": "Name",
+              "Value": "Test host"
+            }
+          ],
+          "VirtualizationType": "hvm",
+          "VpcId": "vpc-6f6f8316"
+        }
+      ],
+      "OwnerId": "118292266645",
+      "RequesterId": "903220451833",
+      "ReservationId": "r-038ad1d6ad1680145"
     }
   ]
 }

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test/aws_configs/SecurityGroups.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test/aws_configs/SecurityGroups.json
@@ -1,40 +1,84 @@
 {
- "SecurityGroups": [
-  {
-   "Description": "Test Security Group",
-   "GroupId": "sg-0de0ddfa8a5a45810",
-   "GroupName": "Test Security Group",
-   "IpPermissions": [
+  "SecurityGroups": [
     {
-     "FromPort": 45,
-     "IpProtocol": "tcp",
-     "IpRanges": [
-      {
-       "CidrIp": "1.2.3.4/32",
-       "Description": "Closed interval"
-      }
-     ],
-     "Ipv6Ranges": [],
-     "PrefixListIds": [],
-     "ToPort": 50,
-     "UserIdGroupPairs": []
-    }
-   ],
-   "IpPermissionsEgress": [
+      "Description": "Test Security Group for ES/RDS",
+      "GroupId": "sg-0de0ddfa8a5a45810",
+      "GroupName": "Test Security Group",
+      "IpPermissions": [
+        {
+          "FromPort": 45,
+          "IpProtocol": "tcp",
+          "IpRanges": [
+            {
+              "CidrIp": "1.2.3.4/32",
+              "Description": "Closed interval"
+            }
+          ],
+          "Ipv6Ranges": [],
+          "PrefixListIds": [],
+          "ToPort": 50,
+          "UserIdGroupPairs": [
+            {
+              "GroupId": "sg-08893f1a4413ccfc1",
+              "UserId": "118292266645"
+            }
+          ]
+        }
+      ],
+      "IpPermissionsEgress": [
+        {
+          "IpProtocol": "-1",
+          "IpRanges": [
+            {
+              "CidrIp": "0.0.0.0/0"
+            }
+          ],
+          "Ipv6Ranges": [],
+          "PrefixListIds": [],
+          "UserIdGroupPairs": []
+        }
+      ],
+      "OwnerId": "118292266645",
+      "VpcId": "vpc-b390fad5"
+    },
     {
-     "IpProtocol": "-1",
-     "IpRanges": [
-      {
-       "CidrIp": "0.0.0.0/0"
-      }
-     ],
-     "Ipv6Ranges": [],
-     "PrefixListIds": [],
-     "UserIdGroupPairs": []
+      "Description": "Security Group for test instance",
+      "GroupId": "sg-08893f1a4413ccfc1",
+      "GroupName": "Test-Instance-SG",
+      "IpPermissions": [
+        {
+          "IpProtocol": "-1",
+          "IpRanges": [
+            {
+              "CidrIp": "0.0.0.0/0"
+            }
+          ],
+          "Ipv6Ranges": [],
+          "PrefixListIds": [],
+          "UserIdGroupPairs": []
+        }
+      ],
+      "IpPermissionsEgress": [
+        {
+          "IpProtocol": "-1",
+          "IpRanges": [
+            {
+              "CidrIp": "0.0.0.0/0"
+            }
+          ],
+          "Ipv6Ranges": [],
+          "PrefixListIds": [],
+          "UserIdGroupPairs": []
+        }
+      ],
+      "OwnerId": "118292266645",
+      "Tags": [
+        {
+          "Key": "Name",
+          "Value": "Test-Instance-SG"
+        }
+      ],
+      "VpcId": "vpc-6f6f8316"
     }
-   ],
-   "OwnerId": "118292266645",
-   "VpcId": "vpc-b390fad5"
-  }
- ]
+  ]
 }

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test/aws_configs/Subnets.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test/aws_configs/Subnets.json
@@ -23,6 +23,18 @@
    "State": "available", 
    "SubnetId": "subnet-1f315846", 
    "VpcId": "vpc-b390fad5"
+  },
+  {
+   "AssignIpv6AddressOnCreation": false,
+   "AvailabilityZone": "us-west-2b",
+   "AvailableIpAddressCount": 2013,
+   "CidrBlock": "10.193.16.0/21",
+   "DefaultForAz": false,
+   "Ipv6CidrBlockAssociationSet": [],
+   "MapPublicIpOnLaunch": true,
+   "State": "available",
+   "SubnetId": "subnet-b26c24fa",
+   "VpcId": "vpc-6f6f8316"
   }
  ]
 }

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test/aws_configs/Vpcs.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test/aws_configs/Vpcs.json
@@ -22,6 +22,29 @@
     }
    ], 
    "VpcId": "vpc-b390fad5"
+  },
+  {
+   "CidrBlock": "10.193.0.0/16",
+   "CidrBlockAssociationSet": [
+    {
+     "AssociationId": "vpc-cidr-assoc-78b81613",
+     "CidrBlock": "10.193.0.0/16",
+     "CidrBlockState": {
+      "State": "associated"
+     }
+    }
+   ],
+   "DhcpOptionsId": "dopt-5870b93d",
+   "InstanceTenancy": "default",
+   "IsDefault": false,
+   "State": "available",
+   "Tags": [
+    {
+     "Key": "Name",
+     "Value": "Test VPC"
+    }
+   ],
+   "VpcId": "vpc-6f6f8316"
   }
  ]
 }

--- a/test_rigs/example-aws/aws_configs/us-west-2/SecurityGroups.json
+++ b/test_rigs/example-aws/aws_configs/us-west-2/SecurityGroups.json
@@ -154,7 +154,7 @@
      "PrefixListIds": [], 
      "UserIdGroupPairs": [
       {
-       "GroupId": "sg-3dfb3140", 
+       "GroupId": "sg-55510831",
        "UserId": "118292266645"
       }
      ]

--- a/tests/aws/nodes-example-aws.ref
+++ b/tests/aws/nodes-example-aws.ref
@@ -108,6 +108,9 @@
               },
               {
                 "action" : "ACCEPT",
+                "dstIps" : [
+                  "192.168.1.3"
+                ],
                 "negate" : false
               }
             ]
@@ -117,7 +120,10 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "negate" : false
+                "negate" : false,
+                "srcIps" : [
+                  "192.168.1.3"
+                ]
               },
               {
                 "action" : "REJECT",


### PR DESCRIPTION
- Moved out conversion of SG to ACLs from the individual `toConfigurationNode` methods as we will need all associations of SGs -> IPs to populate ACLs, and for some AWS constructs(Database instances) we generate IPs on the fly. 

- Use SG->IP mapping to populate Dest/Src for IP Permissions

- Testing this in RDS and ES as that will cover the changed code