### PR TITLE
cache forwarding analysis

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -43,6 +43,7 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 import java.util.regex.Pattern;
@@ -94,6 +95,7 @@ import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowHistory;
 import org.batfish.datamodel.FlowTrace;
 import org.batfish.datamodel.ForwardingAction;
+import org.batfish.datamodel.ForwardingAnalysis;
 import org.batfish.datamodel.ForwardingAnalysisImpl;
 import org.batfish.datamodel.GenericConfigObject;
 import org.batfish.datamodel.HeaderSpace;
@@ -458,6 +460,8 @@ public class Batfish extends PluginConsumer implements IBatfish {
   private final Map<EnvironmentSettings, SortedMap<String, RoutesByVrf>>
       _cachedEnvironmentRoutingTables;
 
+  private final Cache<TestrigSettings, ForwardingAnalysis> _cachedForwardingAnalyses;
+
   private TestrigSettings _deltaTestrigSettings;
 
   private Set<ExternalBgpAdvertisementPlugin> _externalBgpAdvertisementPlugins;
@@ -486,16 +490,18 @@ public class Batfish extends PluginConsumer implements IBatfish {
       Cache<TestrigSettings, DataPlane> cachedDataPlanes,
       Map<EnvironmentSettings, SortedMap<String, BgpAdvertisementsByVrf>>
           cachedEnvironmentBgpTables,
-      Map<EnvironmentSettings, SortedMap<String, RoutesByVrf>> cachedEnvironmentRoutingTables) {
+      Map<EnvironmentSettings, SortedMap<String, RoutesByVrf>> cachedEnvironmentRoutingTables,
+      Cache<TestrigSettings, ForwardingAnalysis> cachedForwardingAnalyses) {
     super(settings.getSerializeToText());
     _settings = settings;
     _bgpTablePlugins = new TreeMap<>();
     _cachedCompressedConfigurations = cachedCompressedConfigurations;
     _cachedConfigurations = cachedConfigurations;
-    _cachedEnvironmentBgpTables = cachedEnvironmentBgpTables;
-    _cachedEnvironmentRoutingTables = cachedEnvironmentRoutingTables;
     _cachedCompressedDataPlanes = cachedCompressedDataPlanes;
     _cachedDataPlanes = cachedDataPlanes;
+    _cachedEnvironmentBgpTables = cachedEnvironmentBgpTables;
+    _cachedEnvironmentRoutingTables = cachedEnvironmentRoutingTables;
+    _cachedForwardingAnalyses = cachedForwardingAnalyses;
     _externalBgpAdvertisementPlugins = new TreeSet<>();
     _testrigSettings = settings.getActiveTestrigSettings();
     _baseTestrigSettings = settings.getBaseTestrigSettings();
@@ -2369,6 +2375,20 @@ public class Batfish extends PluginConsumer implements IBatfish {
     return environmentRoutingTables;
   }
 
+  private ForwardingAnalysis loadForwardingAnalysis(Map<String, Configuration> configurations, DataPlane dataPlane) {
+    Topology topology = new Topology(dataPlane.getTopologyEdges());
+    try {
+      return _cachedForwardingAnalyses.get(
+          _testrigSettings,
+          () -> new ForwardingAnalysisImpl(configurations,
+              dataPlane.getRibs(),
+              dataPlane.getFibs(),
+              topology));
+    } catch(ExecutionException e) {
+      throw new BatfishException("error loading ForwardingAnalysis", e);
+    }
+  }
+
   @Override
   public ParseEnvironmentBgpTablesAnswerElement loadParseEnvironmentBgpTablesAnswerElement() {
     return loadParseEnvironmentBgpTablesAnswerElement(true);
@@ -4041,7 +4061,10 @@ public class Batfish extends PluginConsumer implements IBatfish {
 
     Synthesizer dataPlaneSynthesizer =
         synthesizeDataPlane(
-            configurations, dataPlane, headerSpace, reachabilitySettings.getSpecialize());
+            configurations, dataPlane,
+            loadForwardingAnalysis(configurations, dataPlane),
+            headerSpace,
+            reachabilitySettings.getSpecialize());
 
     // build query jobs
     List<NodJob> jobs =
@@ -4189,13 +4212,17 @@ public class Batfish extends PluginConsumer implements IBatfish {
   }
 
   public Synthesizer synthesizeDataPlane() {
-    return synthesizeDataPlane(loadConfigurations(), loadDataPlane(), new HeaderSpace(), false);
+    SortedMap<String, Configuration> configurations = loadConfigurations();
+    DataPlane dataPlane = loadDataPlane();
+    ForwardingAnalysis forwardingAnalysis = loadForwardingAnalysis(configurations,dataPlane);
+    return synthesizeDataPlane(configurations, dataPlane, forwardingAnalysis, new HeaderSpace(), false);
   }
 
   @Nonnull
   public Synthesizer synthesizeDataPlane(
       Map<String, Configuration> configurations,
       DataPlane dataPlane,
+      ForwardingAnalysis forwardingAnalysis,
       HeaderSpace headerSpace,
       boolean specialize) {
     _logger.info("\n*** GENERATING Z3 LOGIC ***\n");
@@ -4206,7 +4233,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
     Synthesizer s =
         new Synthesizer(
             computeSynthesizerInput(
-                configurations, dataPlane, headerSpace, _settings.getSimplify(), specialize));
+                configurations, dataPlane, forwardingAnalysis, headerSpace, _settings.getSimplify(), specialize));
 
     List<String> warnings = s.getWarnings();
     int numWarnings = warnings.size();
@@ -4224,6 +4251,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
   public static SynthesizerInputImpl computeSynthesizerInput(
       Map<String, Configuration> configurations,
       DataPlane dataPlane,
+      ForwardingAnalysis forwardingAnalysis,
       HeaderSpace headerSpace,
       boolean simplify,
       boolean specialize) {
@@ -4231,9 +4259,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
     return SynthesizerInputImpl.builder()
         .setConfigurations(configurations)
         .setHeaderSpace(headerSpace)
-        .setForwardingAnalysis(
-            new ForwardingAnalysisImpl(
-                configurations, dataPlane.getRibs(), dataPlane.getFibs(), topology))
+        .setForwardingAnalysis(forwardingAnalysis)
         .setSimplify(simplify)
         .setSpecialize(specialize)
         .setTopology(topology)

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -2375,16 +2375,16 @@ public class Batfish extends PluginConsumer implements IBatfish {
     return environmentRoutingTables;
   }
 
-  private ForwardingAnalysis loadForwardingAnalysis(Map<String, Configuration> configurations, DataPlane dataPlane) {
+  private ForwardingAnalysis loadForwardingAnalysis(
+      Map<String, Configuration> configurations, DataPlane dataPlane) {
     Topology topology = new Topology(dataPlane.getTopologyEdges());
     try {
       return _cachedForwardingAnalyses.get(
           _testrigSettings,
-          () -> new ForwardingAnalysisImpl(configurations,
-              dataPlane.getRibs(),
-              dataPlane.getFibs(),
-              topology));
-    } catch(ExecutionException e) {
+          () ->
+              new ForwardingAnalysisImpl(
+                  configurations, dataPlane.getRibs(), dataPlane.getFibs(), topology));
+    } catch (ExecutionException e) {
       throw new BatfishException("error loading ForwardingAnalysis", e);
     }
   }
@@ -4061,7 +4061,8 @@ public class Batfish extends PluginConsumer implements IBatfish {
 
     Synthesizer dataPlaneSynthesizer =
         synthesizeDataPlane(
-            configurations, dataPlane,
+            configurations,
+            dataPlane,
             loadForwardingAnalysis(configurations, dataPlane),
             headerSpace,
             reachabilitySettings.getSpecialize());
@@ -4214,8 +4215,9 @@ public class Batfish extends PluginConsumer implements IBatfish {
   public Synthesizer synthesizeDataPlane() {
     SortedMap<String, Configuration> configurations = loadConfigurations();
     DataPlane dataPlane = loadDataPlane();
-    ForwardingAnalysis forwardingAnalysis = loadForwardingAnalysis(configurations,dataPlane);
-    return synthesizeDataPlane(configurations, dataPlane, forwardingAnalysis, new HeaderSpace(), false);
+    ForwardingAnalysis forwardingAnalysis = loadForwardingAnalysis(configurations, dataPlane);
+    return synthesizeDataPlane(
+        configurations, dataPlane, forwardingAnalysis, new HeaderSpace(), false);
   }
 
   @Nonnull
@@ -4233,7 +4235,12 @@ public class Batfish extends PluginConsumer implements IBatfish {
     Synthesizer s =
         new Synthesizer(
             computeSynthesizerInput(
-                configurations, dataPlane, forwardingAnalysis, headerSpace, _settings.getSimplify(), specialize));
+                configurations,
+                dataPlane,
+                forwardingAnalysis,
+                headerSpace,
+                _settings.getSimplify(),
+                specialize));
 
     List<String> warnings = s.getWarnings();
     int numWarnings = warnings.size();

--- a/projects/batfish/src/main/java/org/batfish/main/Driver.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Driver.java
@@ -62,6 +62,7 @@ import org.batfish.config.Settings.EnvironmentSettings;
 import org.batfish.config.Settings.TestrigSettings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DataPlane;
+import org.batfish.datamodel.ForwardingAnalysis;
 import org.batfish.datamodel.answers.Answer;
 import org.batfish.datamodel.answers.AnswerStatus;
 import org.batfish.datamodel.collections.BgpAdvertisementsByVrf;
@@ -135,6 +136,9 @@ public class Driver {
   private static final Cache<Snapshot, SortedMap<String, Configuration>>
       CACHED_COMPRESSED_TESTRIGS = buildTestrigCache();
 
+  private static final Cache<TestrigSettings,ForwardingAnalysis>
+      CACHED_FORWARDING_ANALYSES = buildForwardingAnalysisCache();
+
   private static final int COORDINATOR_CHECK_INTERVAL_MS = 1 * 60 * 1000; // 1 min
 
   private static final int COORDINATOR_POLL_TIMEOUT_MS = 30 * 1000; // 30 secs
@@ -151,6 +155,8 @@ public class Driver {
   private static final int MAX_CACHED_ENVIRONMENT_BGP_TABLES = 4;
 
   private static final int MAX_CACHED_ENVIRONMENT_ROUTING_TABLES = 4;
+
+  private static final int MAX_CACHED_FORWARDING_ANALYSES = 5;
 
   private static final int MAX_CACHED_TESTRIGS = 5;
 
@@ -173,6 +179,10 @@ public class Driver {
     return Collections.synchronizedMap(
         new LRUMap<EnvironmentSettings, SortedMap<String, RoutesByVrf>>(
             MAX_CACHED_ENVIRONMENT_ROUTING_TABLES));
+  }
+
+  private static Cache<TestrigSettings, ForwardingAnalysis> buildForwardingAnalysisCache() {
+    return CacheBuilder.newBuilder().maximumSize(MAX_CACHED_FORWARDING_ANALYSES).build();
   }
 
   private static Cache<Snapshot, SortedMap<String, Configuration>> buildTestrigCache() {
@@ -557,7 +567,8 @@ public class Driver {
               CACHED_COMPRESSED_DATA_PLANES,
               CACHED_DATA_PLANES,
               CACHED_ENVIRONMENT_BGP_TABLES,
-              CACHED_ENVIRONMENT_ROUTING_TABLES);
+              CACHED_ENVIRONMENT_ROUTING_TABLES,
+              CACHED_FORWARDING_ANALYSES);
 
       @Nullable
       SpanContext runBatfishSpanContext =

--- a/projects/batfish/src/main/java/org/batfish/main/Driver.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Driver.java
@@ -136,8 +136,8 @@ public class Driver {
   private static final Cache<Snapshot, SortedMap<String, Configuration>>
       CACHED_COMPRESSED_TESTRIGS = buildTestrigCache();
 
-  private static final Cache<TestrigSettings,ForwardingAnalysis>
-      CACHED_FORWARDING_ANALYSES = buildForwardingAnalysisCache();
+  private static final Cache<TestrigSettings, ForwardingAnalysis> CACHED_FORWARDING_ANALYSES =
+      buildForwardingAnalysisCache();
 
   private static final int COORDINATOR_CHECK_INTERVAL_MS = 1 * 60 * 1000; // 1 min
 

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
@@ -23,6 +23,7 @@ import org.batfish.config.Settings.TestrigSettings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.DataPlane;
+import org.batfish.datamodel.ForwardingAnalysis;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.collections.BgpAdvertisementsByVrf;
 import org.batfish.datamodel.collections.RoutesByVrf;
@@ -45,6 +46,10 @@ public class BatfishTestUtils {
 
   private static Cache<TestrigSettings, DataPlane> makeDataPlaneCache() {
     return CacheBuilder.newBuilder().maximumSize(2).weakValues().build();
+  }
+
+  private static Cache<TestrigSettings, ForwardingAnalysis> makeForwardingAnalysisCache() {
+    return CacheBuilder.newBuilder().maximumSize(2).build();
   }
 
   private static Batfish initBatfish(
@@ -73,7 +78,8 @@ public class BatfishTestUtils {
             makeDataPlaneCache(),
             makeDataPlaneCache(),
             makeEnvBgpCache(),
-            makeEnvRouteCache());
+            makeEnvRouteCache(),
+            makeForwardingAnalysisCache());
     if (!configurations.isEmpty()) {
       Batfish.serializeAsJson(
           settings.getBaseTestrigSettings().getEnvironmentSettings().getSerializedTopologyPath(),
@@ -133,7 +139,8 @@ public class BatfishTestUtils {
             makeDataPlaneCache(),
             makeDataPlaneCache(),
             makeEnvBgpCache(),
-            makeEnvRouteCache());
+            makeEnvRouteCache(),
+            makeForwardingAnalysisCache());
     return batfish;
   }
 

--- a/projects/batfish/src/test/java/org/batfish/z3/NodJobChunkingTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/NodJobChunkingTest.java
@@ -153,10 +153,17 @@ public class NodJobChunkingTest {
   private void setupSynthesizer() {
     _synthesizer =
         new Synthesizer(
-            Batfish.computeSynthesizerInput(_configs, _dataPlane,
-                new ForwardingAnalysisImpl(_configs, _dataPlane.getRibs(), _dataPlane.getFibs(),
+            Batfish.computeSynthesizerInput(
+                _configs,
+                _dataPlane,
+                new ForwardingAnalysisImpl(
+                    _configs,
+                    _dataPlane.getRibs(),
+                    _dataPlane.getFibs(),
                     new Topology(_dataPlane.getTopologyEdges())),
-                new HeaderSpace(), true, false));
+                new HeaderSpace(),
+                true,
+                false));
   }
 
   private NodJob getNodJob() {

--- a/projects/batfish/src/test/java/org/batfish/z3/NodJobChunkingTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/NodJobChunkingTest.java
@@ -22,6 +22,7 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.ForwardingAction;
+import org.batfish.datamodel.ForwardingAnalysisImpl;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.InterfaceAddress;
@@ -33,6 +34,7 @@ import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.StaticRoute;
+import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.Vrf;
 import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
@@ -151,7 +153,10 @@ public class NodJobChunkingTest {
   private void setupSynthesizer() {
     _synthesizer =
         new Synthesizer(
-            Batfish.computeSynthesizerInput(_configs, _dataPlane, new HeaderSpace(), true, false));
+            Batfish.computeSynthesizerInput(_configs, _dataPlane,
+                new ForwardingAnalysisImpl(_configs, _dataPlane.getRibs(), _dataPlane.getFibs(),
+                    new Topology(_dataPlane.getTopologyEdges())),
+                new HeaderSpace(), true, false));
   }
 
   private NodJob getNodJob() {


### PR DESCRIPTION
The forwarding analysis can take close to a minute for large networks. Since it is independent of the question, we can compute it once and cache it.