### PR TITLE
BatfishJobExecutor: Better error message when inner job fails

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/job/BatfishJobExecutor.java
+++ b/projects/batfish/src/main/java/org/batfish/job/BatfishJobExecutor.java
@@ -125,7 +125,7 @@ public class BatfishJobExecutor {
         } catch (InterruptedException e) {
           throw new BatfishException("Job didn't finish", e);
         } catch (ExecutionException e) {
-          throw new BatfishException("Error executing job", e);
+          throw new BatfishException("Error executing job: " + e.getMessage(), e);
         }
 
         markJobCompleted();


### PR DESCRIPTION
Surface the inner message at the top level.