### PR TITLE
Fix Vrrp handling in computeIpOwners

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
@@ -227,6 +227,14 @@ public class CommonUtil {
                 ImmutableMap.toImmutableMap(Entry::getKey, e -> e.getValue().getInterfaces())));
   }
 
+  /**
+   * Compute the owners of IP addresses
+   *
+   * @param excludeInactive whether to ignore inactive interfaces
+   * @param enabledInterfaces A mapping of enabled interfaces hostname -> interface name -> {@link
+   *     Interface}
+   * @return A map of {@link Ip}s to a set of hostnames that own this IP
+   */
   public static Map<Ip, Set<String>> computeIpOwners(
       boolean excludeInactive, Map<String, Map<String, Interface>> enabledInterfaces) {
     // TODO: confirm VRFs are handled correctly
@@ -271,23 +279,26 @@ public class CommonUtil {
           int groupNum = p.getSecond();
           InterfaceAddress address = p.getFirst();
           Ip ip = address.getIp();
-          int lowestPriority = Integer.MAX_VALUE;
+          int highestPriority = Integer.MIN_VALUE;
           String bestCandidate = null;
-          SortedSet<String> bestCandidates = new TreeSet<>();
+          // In case of multiple candidates with same priority, keep track of Interface IP as well
+          SortedSet<Pair<Ip, String>> bestCandidates = new TreeSet<>();
           for (Interface candidate : candidates) {
             VrrpGroup group = candidate.getVrrpGroups().get(groupNum);
             int currentPriority = group.getPriority();
-            if (currentPriority < lowestPriority) {
-              lowestPriority = currentPriority;
+            if (currentPriority > highestPriority) {
+              highestPriority = currentPriority;
               bestCandidates.clear();
               bestCandidate = candidate.getOwner().getHostname();
             }
-            if (currentPriority == lowestPriority) {
-              bestCandidates.add(candidate.getOwner().getHostname());
+            if (currentPriority == highestPriority) {
+              bestCandidates.add(
+                  new Pair<>(candidate.getAddress().getIp(), candidate.getOwner().getHostname()));
             }
           }
           if (bestCandidates.size() != 1) {
-            String deterministicBestCandidate = bestCandidates.first();
+            // last() because highest IP should win
+            String deterministicBestCandidate = bestCandidates.last().getSecond();
             bestCandidate = deterministicBestCandidate;
             //            _logger.redflag(
             //                "Arbitrarily choosing best vrrp candidate: '"

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
@@ -281,8 +281,8 @@ public class CommonUtil {
           Ip ip = address.getIp();
           int highestPriority = Integer.MIN_VALUE;
           String bestCandidate = null;
-          // In case of multiple candidates with same priority, keep track of Interface IP as well
-          SortedSet<Pair<Ip, String>> bestCandidates = new TreeSet<>();
+          // In case multiple candidates have the same priority, keep track of Interface IP
+          SortedMap<Ip, String> bestCandidates = new TreeMap<>();
           for (Interface candidate : candidates) {
             VrrpGroup group = candidate.getVrrpGroups().get(groupNum);
             int currentPriority = group.getPriority();
@@ -292,21 +292,13 @@ public class CommonUtil {
               bestCandidate = candidate.getOwner().getHostname();
             }
             if (currentPriority == highestPriority) {
-              bestCandidates.add(
-                  new Pair<>(candidate.getAddress().getIp(), candidate.getOwner().getHostname()));
+              bestCandidates.put(
+                  candidate.getAddress().getIp(), candidate.getOwner().getHostname());
             }
           }
           if (bestCandidates.size() != 1) {
             // last() because highest IP should win
-            String deterministicBestCandidate = bestCandidates.last().getSecond();
-            bestCandidate = deterministicBestCandidate;
-            //            _logger.redflag(
-            //                "Arbitrarily choosing best vrrp candidate: '"
-            //                    + deterministicBestCandidate
-            //                    + " for prefix/groupNumber: '"
-            //                    + p.toString()
-            //                    + "' among multiple best candidates: "
-            //                    + bestCandidates);
+            bestCandidate = bestCandidates.get(bestCandidates.lastKey());
           }
           Set<String> owners = ipOwners.computeIfAbsent(ip, k -> new HashSet<>());
           owners.add(bestCandidate);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/CommonUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/CommonUtilTest.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 
 public class CommonUtilTest {
 
-  public NetworkFactory _nf;
+  private NetworkFactory _nf;
   private InterfaceAddress _virtInterfaceAddr =
       new InterfaceAddress(new Ip("1.1.1.1"), Prefix.MAX_PREFIX_LENGTH);
 
@@ -29,6 +29,12 @@ public class CommonUtilTest {
     _nf = new NetworkFactory();
   }
 
+  /**
+   * Setup up two nodes with two vrrp groups that own the same virtual IP.
+   *
+   * @param equalPriority whether vrrp group priority between two groups should be equal (will force
+   *     IP-based tie breaking)
+   */
   private Map<String, Configuration> setupVrrpTestCase(boolean equalPriority) {
     // Setup nodes and interface configs
     Configuration.Builder cb = _nf.configurationBuilder();
@@ -73,11 +79,13 @@ public class CommonUtilTest {
 
     Map<Ip, Set<String>> owners = computeIpOwners(configs, false);
 
-    // Ensure higher priority node wins
     assertThat(owners.get(_virtInterfaceAddr.getIp()), contains("n2"));
   }
 
-  /** Test that VRRP tie brekaing in case of equal priority */
+  /**
+   * Test that VRRP tie breaking works correctly by picking higher IP in case of equal vrrp group
+   * priority
+   */
   @Test
   public void testVrrpPriorityTieBreaking() {
     Map<String, Configuration> configs = setupVrrpTestCase(true);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/CommonUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/CommonUtilTest.java
@@ -1,0 +1,90 @@
+package org.batfish.common.util;
+
+import static org.batfish.common.util.CommonUtil.computeIpOwners;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+
+import com.google.common.collect.ImmutableSortedMap;
+import java.util.Map;
+import java.util.Set;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.InterfaceAddress;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.VrrpGroup;
+import org.junit.Before;
+import org.junit.Test;
+
+public class CommonUtilTest {
+
+  public NetworkFactory _nf;
+  private InterfaceAddress _virtInterfaceAddr =
+      new InterfaceAddress(new Ip("1.1.1.1"), Prefix.MAX_PREFIX_LENGTH);
+
+  @Before
+  public void setup() {
+    _nf = new NetworkFactory();
+  }
+
+  private Map<String, Configuration> setupVrrpTestCase(boolean equalPriority) {
+    // Setup nodes and interface configs
+    Configuration.Builder cb = _nf.configurationBuilder();
+    cb.setConfigurationFormat(ConfigurationFormat.JUNIPER);
+
+    int vrrpGroupId = 1;
+    int priority = 100;
+    VrrpGroup vg1 = new VrrpGroup(vrrpGroupId);
+    vg1.setPriority(priority);
+    vg1.setVirtualAddress(_virtInterfaceAddr);
+    VrrpGroup vg2 = new VrrpGroup(vrrpGroupId);
+    if (equalPriority) {
+      vg2.setPriority(priority);
+    } else {
+      vg2.setPriority(priority + 1);
+    }
+    vg2.setVirtualAddress(_virtInterfaceAddr);
+
+    Configuration c1 = cb.setHostname("n1").build();
+    Configuration c2 = cb.setHostname("n2").build();
+
+    Interface.Builder ib = _nf.interfaceBuilder();
+    ib.setActive(true);
+
+    ib.setOwner(c1);
+    ib.setAddress(new InterfaceAddress("1.1.1.22/32"));
+    Interface i1 = ib.build();
+    i1.setVrrpGroups(ImmutableSortedMap.of(vrrpGroupId, vg1));
+
+    ib.setOwner(c2);
+    ib.setAddress(new InterfaceAddress("1.1.1.33/32"));
+    Interface i2 = ib.build();
+    i2.setVrrpGroups(ImmutableSortedMap.of(vrrpGroupId, vg2));
+
+    return ImmutableSortedMap.of("n1", c1, "n2", c2);
+  }
+
+  /** Test that higher priority router wins */
+  @Test
+  public void testVrrpPriority() {
+    Map<String, Configuration> configs = setupVrrpTestCase(false);
+
+    Map<Ip, Set<String>> owners = computeIpOwners(configs, false);
+
+    // Ensure higher priority node wins
+    assertThat(owners.get(_virtInterfaceAddr.getIp()), contains("n2"));
+  }
+
+  /** Test that VRRP tie brekaing in case of equal priority */
+  @Test
+  public void testVrrpPriorityTieBreaking() {
+    Map<String, Configuration> configs = setupVrrpTestCase(true);
+
+    Map<Ip, Set<String>> owners = computeIpOwners(configs, false);
+
+    // Ensure node that has higher interface IP wins
+    assertThat(owners.get(_virtInterfaceAddr.getIp()), contains("n2"));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
@@ -143,7 +143,7 @@ public class BatfishTest {
             _folder);
     Map<String, Configuration> configurations = batfish.loadConfigurations();
     Map<Ip, Set<String>> ipOwners = CommonUtil.computeIpOwners(configurations, true);
-    assertThat(ipOwners.get(vrrpAddress), equalTo(Collections.singleton("r1")));
+    assertThat(ipOwners.get(vrrpAddress), equalTo(Collections.singleton("r2")));
   }
 
   @Test


### PR DESCRIPTION
1. The vrrp group with highest priority should take precedence, we were using lowest.
2. Added the tie breaker (highest IP) in case group priorities are equal
(Following https://www.juniper.net/documentation/en_US/junos/topics/reference/configuration-statement/priority-edit-interfaces-vrrp.html)
3. (2) required a change to an existing test: `testMultipleBestVrrpCandidates`