### PR TITLE
Allowing access-groups to also accept mac-acls

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -2645,7 +2645,7 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
       line = ctx.num.getLine();
     }
     _configuration.referenceStructure(
-        CiscoStructureType.IP_ACCESS_LIST, name, CiscoStructureUsage.CLASS_MAP_ACCESS_GROUP, line);
+        CiscoStructureType.ACCESS_LIST, name, CiscoStructureUsage.CLASS_MAP_ACCESS_GROUP, line);
     _configuration.getClassMapAccessGroups().add(name);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -1048,6 +1048,18 @@ public final class CiscoConfiguration extends VendorConfiguration {
         cable != null ? cable.getDocsisPolicyRules() : null);
   }
 
+  private void markIpOrMacAcls(CiscoStructureUsage usage) {
+    markStructure(
+        CiscoStructureType.ACCESS_LIST,
+        usage,
+        Arrays.asList(
+            _extendedAccessLists,
+            _standardAccessLists,
+            _extendedIpv6AccessLists,
+            _macAccessLists,
+            _standardIpv6AccessLists));
+  }
+
   private void markIpsecProfiles(CiscoStructureUsage usage) {
     markStructure(CiscoStructureType.IPSEC_PROFILE, usage, _ipsecProfiles);
   }
@@ -3754,7 +3766,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
     }
 
     // mark references to IPv4/6 ACLs that may not appear in data model
-    markAcls(CiscoStructureUsage.CLASS_MAP_ACCESS_GROUP);
+    markIpOrMacAcls(CiscoStructureUsage.CLASS_MAP_ACCESS_GROUP);
     markIpv4Acls(CiscoStructureUsage.CONTROL_PLANE_ACCESS_GROUP);
     markAcls(CiscoStructureUsage.COPS_LISTENER_ACCESS_LIST);
     markAcls(CiscoStructureUsage.CRYPTO_MAP_IPSEC_ISAKMP_ACL);

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoStructureType.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoStructureType.java
@@ -3,6 +3,7 @@ package org.batfish.representation.cisco;
 import org.batfish.vendor.StructureType;
 
 public enum CiscoStructureType implements StructureType {
+  ACCESS_LIST("acl"),
   AS_PATH_ACCESS_LIST("as-path acl"),
   AS_PATH_SET("as-path-set"),
   BGP_PEER_GROUP("bgp group"),

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -69,6 +69,7 @@ import org.batfish.datamodel.matchers.OspfAreaMatchers;
 import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
 import org.batfish.main.TestrigText;
+import org.batfish.representation.cisco.CiscoStructureType;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -93,6 +94,70 @@ public class CiscoGrammarTest {
     Configuration noNewModelConfiguration = parseConfig("aaaNoNewmodel");
     aaaNewmodel = noNewModelConfiguration.getVendorFamily().getCisco().getAaa().getNewModel();
     assertFalse(aaaNewmodel);
+  }
+
+  @Test
+  public void testAGAclUnused() throws IOException {
+    String hostName = "iosAccessGroupAcl";
+    String testrigName = "access-group-acl";
+    List<String> configurationNames = ImmutableList.of("iosAccessGroupAcl");
+
+    Batfish batfish =
+        BatfishTestUtils.getBatfishFromTestrigText(
+            TestrigText.builder()
+                .setConfigurationText(TESTRIGS_PREFIX + testrigName, configurationNames)
+                .build(),
+            _folder);
+
+    SortedMap<String, SortedMap<String, SortedMap<String, SortedSet<Integer>>>> unusedStructures =
+        batfish.loadConvertConfigurationAnswerElementOrReparse().getUnusedStructures();
+
+    // only mac_acl_unused and ip_acl_unused should exist as unused structures
+    assertThat(unusedStructures, hasKey(hostName));
+    SortedMap<String, SortedMap<String, SortedSet<Integer>>> byType =
+        unusedStructures.get(hostName);
+
+    assertThat(byType, hasKey(CiscoStructureType.MAC_ACCESS_LIST.getDescription()));
+    assertThat(byType, hasKey(CiscoStructureType.IP_ACCESS_LIST_EXTENDED.getDescription()));
+    SortedMap<String, SortedSet<Integer>> byNameMacAcl =
+        byType.get(CiscoStructureType.MAC_ACCESS_LIST.getDescription());
+    SortedMap<String, SortedSet<Integer>> byNameIpAclExt =
+        byType.get(CiscoStructureType.IP_ACCESS_LIST_EXTENDED.getDescription());
+
+    assertThat(byNameMacAcl.keySet(), hasSize(1));
+    assertThat(byNameIpAclExt.keySet(), hasSize(1));
+    assertThat(byNameMacAcl, hasKey("mac_acl_unused"));
+    assertThat(byNameIpAclExt, hasKey("ip_acl_unused"));
+  }
+
+  @Test
+  public void testAGAclUndefined() throws IOException {
+    String hostName = "iosAccessGroupAcl";
+    String testrigName = "access-group-acl";
+    List<String> configurationNames = ImmutableList.of("iosAccessGroupAcl");
+
+    Batfish batfish =
+        BatfishTestUtils.getBatfishFromTestrigText(
+            TestrigText.builder()
+                .setConfigurationText(TESTRIGS_PREFIX + testrigName, configurationNames)
+                .build(),
+            _folder);
+
+    SortedMap<String, SortedMap<String, SortedMap<String, SortedMap<String, SortedSet<Integer>>>>>
+        undefinedReferences =
+            batfish.loadConvertConfigurationAnswerElementOrReparse().getUndefinedReferences();
+
+    // only mac_acl_udef and ip_acl_udef should be undefined references
+    assertThat(undefinedReferences, hasKey(hostName));
+    SortedMap<String, SortedMap<String, SortedMap<String, SortedSet<Integer>>>> byHost =
+        undefinedReferences.get(hostName);
+    assertThat(byHost, hasKey(CiscoStructureType.ACCESS_LIST.getDescription()));
+    SortedMap<String, SortedMap<String, SortedSet<Integer>>> byType =
+        byHost.get(CiscoStructureType.ACCESS_LIST.getDescription());
+
+    assertThat(byType.keySet(), hasSize(2));
+    assertThat(byType, hasKey("ip_acl_udef"));
+    assertThat(byType, hasKey("mac_acl_udef"));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/access-group-acl/configs/iosAccessGroupAcl
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/access-group-acl/configs/iosAccessGroupAcl
@@ -1,0 +1,23 @@
+!!!!!! trick Batfish into recognizing this as an IOS device. !!!!!!
+! exit-address-family
+!!!!!! trick Batfish into recognizing this as an IOS device. !!!!!!
+
+hostname iosAccessGroupAcl
+
+mac access-list extended mac_acl
+ permit any c100.0000.0000 0000.0000.0000
+
+access-list ip_acl extended permit ip 1.2.3.4 0.0.0.255 4.3.2.1 0.0.255.255
+
+mac access-list extended mac_acl_unused
+ permit any c200.0000.0000 0000.0000.0000
+
+access-list ip_acl_unused extended permit ip 2.3.4.5 0.0.0.255 5.4.3.2 0.0.255.255
+
+class-map match-any class_map
+  match access-group name mac_acl
+  match access-group name ip_acl
+  match access-group name mac_acl_udef
+  match access-group name ip_acl_udef
+
+

--- a/test_rigs/parsing-tests/unit-tests-undefined.ref
+++ b/test_rigs/parsing-tests/unit-tests-undefined.ref
@@ -2,6 +2,14 @@
   {
     "class" : "org.batfish.question.UndefinedReferencesQuestionPlugin$UndefinedReferencesAnswerElement",
     "problems" : {
+      "undefined:acl:usage:class-map access-group:boop" : {
+        "description" : "Undefined reference to structure of type: 'acl' with usage: 'class-map access-group' named 'boop'",
+        "files" : {
+          "cisco_qos" : [
+            14
+          ]
+        }
+      },
       "undefined:as-path-set:usage:route-policy as-path in:chill-as-path" : {
         "description" : "Undefined reference to structure of type: 'as-path-set' with usage: 'route-policy as-path in' named 'chill-as-path'",
         "files" : {
@@ -402,14 +410,6 @@
         "files" : {
           "ios_xr_route_policy" : [
             66
-          ]
-        }
-      },
-      "undefined:ipv4/6 acl:usage:class-map access-group:boop" : {
-        "description" : "Undefined reference to structure of type: 'ipv4/6 acl' with usage: 'class-map access-group' named 'boop'",
-        "files" : {
-          "cisco_qos" : [
-            14
           ]
         }
       },
@@ -1284,7 +1284,7 @@
         }
       },
       "cisco_qos" : {
-        "ipv4/6 acl" : {
+        "acl" : {
           "boop" : {
             "class-map access-group" : [
               14

--- a/test_rigs/parsing-tests/unit-tests.ref
+++ b/test_rigs/parsing-tests/unit-tests.ref
@@ -25598,7 +25598,7 @@
             "        BSD_CLIENT:'bsd-client'  <== mode:DEFAULT_MODE",
             "        (null_rest_of_line",
             "          SERVER:'server'  <== mode:DEFAULT_MODE",
-            "          VARIABLE:'url'  <== mode:DEFAULT_MODE",
+            "          URL:'url'  <== mode:DEFAULT_MODE",
             "          HTTPS:'https'  <== mode:DEFAULT_MODE",
             "          COLON:':'  <== mode:DEFAULT_MODE",
             "          VARIABLE:'//cloudsso.cisco.com/as/token.oauth2'  <== mode:DEFAULT_MODE",
@@ -51074,7 +51074,7 @@
           }
         },
         "cisco_qos" : {
-          "ipv4/6 acl" : {
+          "acl" : {
             "boop" : {
               "class-map access-group" : [
                 14

--- a/test_rigs/parsing-tests/unit-tests.ref
+++ b/test_rigs/parsing-tests/unit-tests.ref
@@ -25598,7 +25598,7 @@
             "        BSD_CLIENT:'bsd-client'  <== mode:DEFAULT_MODE",
             "        (null_rest_of_line",
             "          SERVER:'server'  <== mode:DEFAULT_MODE",
-            "          URL:'url'  <== mode:DEFAULT_MODE",
+            "          VARIABLE:'url'  <== mode:DEFAULT_MODE",
             "          HTTPS:'https'  <== mode:DEFAULT_MODE",
             "          COLON:':'  <== mode:DEFAULT_MODE",
             "          VARIABLE:'//cloudsso.cisco.com/as/token.oauth2'  <== mode:DEFAULT_MODE",


### PR DESCRIPTION
Cisco does not mentions anywhere that only IP access lists are allowed with access-groups (https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/qos/command/qos-cr-book/qos-m1.html#wp7738095440),
So we should support mac-acl as well