### PR TITLE
BatfishANTLRErrorStrategy: preserve error nodes if deleting current node.

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/BatfishANTLRErrorStrategy.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/BatfishANTLRErrorStrategy.java
@@ -203,6 +203,13 @@ public class BatfishANTLRErrorStrategy extends DefaultErrorStrategy {
       // Second base case
       List<ParseTree> parentChildren = parent.children;
       parentChildren.remove(parentChildren.size() - 1);
+      // Copy error nodes to parent so we don't lose unrecognized lines.
+      if (ctx.children != null) {
+        ctx.children
+            .stream()
+            .filter(c -> c instanceof ErrorNode)
+            .forEach(c -> parent.addErrorNode((ErrorNode) c));
+      }
       parser.consume();
       Token errorNode = createErrorNode(parser, parent, separatorToken);
       endErrorCondition(parser);


### PR DESCRIPTION
This may be triggerable in some cases that came up in debugging. Not sure if it is triggered with #1155 also merged.