### PR TITLE
Be more stringent during static route initialization for bdp

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/bdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/bdp/VirtualRouter.java
@@ -879,7 +879,8 @@ public class VirtualRouter extends ComparableStructure<String> {
       String nextHopInt = sr.getNextHopInterface();
       if (!nextHopInt.equals(Route.UNSET_NEXT_HOP_INTERFACE)
           && !Interface.NULL_INTERFACE_NAME.equals(nextHopInt)
-          && !_vrf.getInterfaces().get(nextHopInt).getActive()) {
+          && (_c.getInterfaces().get(nextHopInt) == null
+              || !_c.getInterfaces().get(nextHopInt).getActive())) {
         continue;
       }
       // interface route


### PR DESCRIPTION
Couple of fixes when initializing static RIBs:
- It is possible to have a static route that has a next hop interface not in the current VRF.
- Due to potential network misconfigurations or parser errors it is possible for such next hop interface to be null during BDP computation; we shouldn't crash on a null pointer, just skip route installation instead.