### PR TITLE
Avoid null pointer in Interface.equals

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -660,7 +660,7 @@ public final class Interface extends ComparableStructure<String> {
     if (this._autoState != other._autoState) {
       return false;
     }
-    if (this._bandwidth.compareTo(other._bandwidth) != 0) {
+    if (!Objects.equals(_bandwidth, other._bandwidth)) {
       return false;
     }
     // we check ACLs for name match only -- full ACL diff can be done

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -16,6 +16,7 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
+import javax.annotation.Nullable;
 import org.batfish.common.BatfishException;
 import org.batfish.common.util.ComparableStructure;
 import org.batfish.datamodel.NetworkFactory.NetworkFactoryBuilder;
@@ -31,7 +32,7 @@ public final class Interface extends ComparableStructure<String> {
 
     private InterfaceAddress _address;
 
-    private Double _bandwidth;
+    @Nullable private Double _bandwidth;
 
     private boolean _blacklisted;
 
@@ -164,7 +165,7 @@ public final class Interface extends ComparableStructure<String> {
       return this;
     }
 
-    public Builder setBandwidth(Double bandwidth) {
+    public Builder setBandwidth(@Nullable Double bandwidth) {
       _bandwidth = bandwidth;
       return this;
     }
@@ -510,7 +511,7 @@ public final class Interface extends ComparableStructure<String> {
 
   private boolean _autoState;
 
-  private Double _bandwidth;
+  @Nullable private Double _bandwidth;
 
   private transient boolean _blacklisted;
 
@@ -744,6 +745,7 @@ public final class Interface extends ComparableStructure<String> {
   @JsonProperty(PROP_BANDWIDTH)
   @JsonPropertyDescription(
       "The nominal bandwidth of this interface in bits/sec for use in protocol cost calculations")
+  @Nullable
   public Double getBandwidth() {
     return _bandwidth;
   }
@@ -1081,7 +1083,7 @@ public final class Interface extends ComparableStructure<String> {
   }
 
   @JsonProperty(PROP_BANDWIDTH)
-  public void setBandwidth(Double bandwidth) {
+  public void setBandwidth(@Nullable Double bandwidth) {
     _bandwidth = bandwidth;
   }
 


### PR DESCRIPTION
It was possible for `Interface.equals` to throw a nullpointer when bandwidth was unset. Fixed.