### PR TITLE
Synthesize all ACLs

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/z3/SynthesizerInputImpl.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/SynthesizerInputImpl.java
@@ -18,7 +18,6 @@ import java.util.Set;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 import org.batfish.common.BatfishException;
-import org.batfish.common.Pair;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Edge;
 import org.batfish.datamodel.EmptyIpSpace;
@@ -347,19 +346,24 @@ public final class SynthesizerInputImpl implements SynthesizerInput {
   }
 
   private Map<String, Map<String, IpAccessList>> computeEnabledAcls() {
-    return _configurations.entrySet()
+    return _configurations
+        .entrySet()
         .stream()
         .filter(e -> !_disabledNodes.contains(e.getKey()))
-        .collect(ImmutableMap.toImmutableMap(Entry::getKey, e -> {
-          String hostname = e.getKey();
-          Set<String> disabledAcls = _disabledAcls.getOrDefault(hostname, ImmutableSet.of());
-          return e.getValue()
-              .getIpAccessLists()
-              .entrySet()
-              .stream()
-              .filter(e2 -> !disabledAcls.contains(e2.getKey()))
-              .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue));
-        }));
+        .collect(
+            ImmutableMap.toImmutableMap(
+                Entry::getKey,
+                e -> {
+                  String hostname = e.getKey();
+                  Set<String> disabledAcls =
+                      _disabledAcls.getOrDefault(hostname, ImmutableSet.of());
+                  return e.getValue()
+                      .getIpAccessLists()
+                      .entrySet()
+                      .stream()
+                      .filter(e2 -> !disabledAcls.contains(e2.getKey()))
+                      .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue));
+                }));
   }
 
   private Set<Edge> computeEnabledEdges() {

--- a/projects/batfish/src/main/java/org/batfish/z3/SynthesizerInputImpl.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/SynthesizerInputImpl.java
@@ -181,7 +181,7 @@ public final class SynthesizerInputImpl implements SynthesizerInput {
 
   private final Map<String, Map<String, String>> _incomingAcls;
 
-  private IpAccessListSpecializer _ipAclListSpecializer;
+  private IpAccessListSpecializer _ipAccessListSpecializer;
 
   private final Map<String, Set<Ip>> _ipsByHostname;
 
@@ -218,7 +218,7 @@ public final class SynthesizerInputImpl implements SynthesizerInput {
     if (configurations == null) {
       throw new BatfishException("Must supply configurations");
     }
-    _ipAclListSpecializer = new IpAccessListSpecializer(headerSpace);
+    _ipAccessListSpecializer = new IpAccessListSpecializer(headerSpace);
     _ipSpaceSpecializer =
         specialize
             ? new IpSpaceSpecializer(headerSpace.getDstIps(), headerSpace.getNotDstIps())
@@ -362,7 +362,10 @@ public final class SynthesizerInputImpl implements SynthesizerInput {
                       .entrySet()
                       .stream()
                       .filter(e2 -> !disabledAcls.contains(e2.getKey()))
-                      .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue));
+                      .collect(
+                          ImmutableMap.toImmutableMap(
+                              Entry::getKey,
+                              entry -> _ipAccessListSpecializer.specialize(entry.getValue())));
                 }));
   }
 

--- a/projects/batfish/src/main/java/org/batfish/z3/SynthesizerInputImpl.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/SynthesizerInputImpl.java
@@ -30,7 +30,6 @@ import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.IpAccessListLine;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.LineAction;
-import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.Topology;
 import org.batfish.z3.expr.BooleanExpr;
 import org.batfish.z3.expr.IpSpaceMatchExpr;
@@ -145,13 +144,6 @@ public final class SynthesizerInputImpl implements SynthesizerInput {
       return this;
     }
   }
-
-  static final IpAccessList DEFAULT_SOURCE_NAT_ACL =
-      new NetworkFactory()
-          .aclBuilder()
-          .setName("~DEFAULT_SOURCE_NAT_ACL~")
-          .setLines(ImmutableList.of(IpAccessListLine.ACCEPT_ALL))
-          .build();
 
   public static Builder builder() {
     return new Builder();
@@ -355,71 +347,19 @@ public final class SynthesizerInputImpl implements SynthesizerInput {
   }
 
   private Map<String, Map<String, IpAccessList>> computeEnabledAcls() {
-    if (_topologyInterfaces != null) {
-      return toImmutableMap(
-          _topologyInterfaces,
-          Entry::getKey, /* node */
-          topologyInterfacesEntry -> {
-            String hostname = topologyInterfacesEntry.getKey();
-            Configuration c = _configurations.get(hostname);
-            return topologyInterfacesEntry
-                .getValue()
-                .stream()
-                .flatMap(
-                    ifaceName -> {
-                      Interface i = c.getInterfaces().get(ifaceName);
-                      ImmutableList.Builder<Pair<String, IpAccessList>> interfaceAcls =
-                          ImmutableList.builder();
-                      IpAccessList aclIn = i.getIncomingFilter();
-                      IpAccessList aclOut = i.getOutgoingFilter();
-                      if (aclIn != null) {
-                        aclIn = _ipAclListSpecializer.specialize(aclIn);
-                        interfaceAcls.add(new Pair<>(aclIn.getName(), aclIn));
-                      }
-                      if (aclOut != null) {
-                        aclOut = _ipAclListSpecializer.specialize(aclOut);
-                        interfaceAcls.add(new Pair<>(aclOut.getName(), aclOut));
-                      }
-                      i.getSourceNats()
-                          .forEach(
-                              sourceNat -> {
-                                IpAccessList sourceNatAcl = sourceNat.getAcl();
-                                if (sourceNatAcl != null) {
-                                  interfaceAcls.add(
-                                      new Pair<>(sourceNatAcl.getName(), sourceNatAcl));
-                                } else {
-                                  interfaceAcls.add(
-                                      new Pair<>(
-                                          DEFAULT_SOURCE_NAT_ACL.getName(),
-                                          DEFAULT_SOURCE_NAT_ACL));
-                                }
-                              });
-
-                      return interfaceAcls.build().stream();
-                    })
-                .collect(ImmutableSet.toImmutableSet())
-                .stream()
-                .collect(ImmutableMap.toImmutableMap(Pair::getFirst, Pair::getSecond));
-          });
-    } else {
-      return _configurations
-          .entrySet()
-          .stream()
-          .filter(e -> !_disabledNodes.contains(e.getKey()))
-          .collect(
-              ImmutableMap.toImmutableMap(
-                  Entry::getKey,
-                  e -> {
-                    String hostname = e.getKey();
-                    Set<String> disabledAcls = _disabledAcls.get(hostname);
-                    return e.getValue()
-                        .getIpAccessLists()
-                        .entrySet()
-                        .stream()
-                        .filter(e2 -> disabledAcls == null || !disabledAcls.contains(e2.getKey()))
-                        .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue));
-                  }));
-    }
+    return _configurations.entrySet()
+        .stream()
+        .filter(e -> !_disabledNodes.contains(e.getKey()))
+        .collect(ImmutableMap.toImmutableMap(Entry::getKey, e -> {
+          String hostname = e.getKey();
+          Set<String> disabledAcls = _disabledAcls.getOrDefault(hostname, ImmutableSet.of());
+          return e.getValue()
+              .getIpAccessLists()
+              .entrySet()
+              .stream()
+              .filter(e2 -> !disabledAcls.contains(e2.getKey()))
+              .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue));
+        }));
   }
 
   private Set<Edge> computeEnabledEdges() {
@@ -634,10 +574,8 @@ public final class SynthesizerInputImpl implements SynthesizerInput {
                       .map(
                           sourceNat -> {
                             IpAccessList acl = sourceNat.getAcl();
-                            String aclName =
-                                acl == null ? DEFAULT_SOURCE_NAT_ACL.getName() : acl.getName();
                             AclPermit preconditionPreTransformationState =
-                                new AclPermit(hostname, aclName);
+                                acl == null ? null : new AclPermit(hostname, acl.getName());
                             BooleanExpr transformationConstraint =
                                 new RangeMatchExpr(
                                     TransformationHeaderField.NEW_SRC_IP,

--- a/projects/batfish/src/main/java/org/batfish/z3/state/visitors/DefaultTransitionGenerator.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/state/visitors/DefaultTransitionGenerator.java
@@ -747,7 +747,10 @@ public class DefaultTransitionGenerator implements StateVisitor {
           .forEach(preStates::add);
 
       // does match the current source NAT.
-      preStates.add(sourceNats.get(natNumber).getKey());
+      AclPermit aclPermit = sourceNats.get(natNumber).getKey();
+      if(aclPermit != null) {
+        preStates.add(sourceNats.get(natNumber).getKey());
+      }
 
       BooleanExpr transformationExpr = sourceNats.get(natNumber).getValue();
 
@@ -757,6 +760,11 @@ public class DefaultTransitionGenerator implements StateVisitor {
               preStates.build(),
               ImmutableSet.of(),
               new PreOutEdgePostNat(node1, iface1, node2, iface2)));
+
+      if(aclPermit == null) {
+        // null means accept everything, so no need to consider subsequent NATs.
+        break;
+      }
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/z3/state/visitors/DefaultTransitionGenerator.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/state/visitors/DefaultTransitionGenerator.java
@@ -748,7 +748,7 @@ public class DefaultTransitionGenerator implements StateVisitor {
 
       // does match the current source NAT.
       AclPermit aclPermit = sourceNats.get(natNumber).getKey();
-      if(aclPermit != null) {
+      if (aclPermit != null) {
         preStates.add(sourceNats.get(natNumber).getKey());
       }
 
@@ -761,7 +761,7 @@ public class DefaultTransitionGenerator implements StateVisitor {
               ImmutableSet.of(),
               new PreOutEdgePostNat(node1, iface1, node2, iface2)));
 
-      if(aclPermit == null) {
+      if (aclPermit == null) {
         // null means accept everything, so no need to consider subsequent NATs.
         break;
       }


### PR DESCRIPTION
Include all ACLs in the synthesizer, not just ACLs attached to edge
interfaces. Also removed the default source NAT ACL that permitted
everything. It's simpler and more efficient to simply remove the
ACL prestate for source NATs with no ACL.