### PR TITLE
Hotfixing the bdp computation

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/SelfNextHop.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/SelfNextHop.java
@@ -1,5 +1,6 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import javax.annotation.Nullable;
 import org.batfish.datamodel.BgpNeighbor;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
@@ -25,12 +26,15 @@ public class SelfNextHop extends NextHopExpr {
   }
 
   @Override
+  @Nullable
   public Ip getNextHopIp(Environment environment) {
     // TODO: make work for dynamic sessions
     Prefix prefix = new Prefix(environment.getPeerAddress(), Prefix.MAX_PREFIX_LENGTH);
     BgpNeighbor neighbor = environment.getVrf().getBgpProcess().getNeighbors().get(prefix);
-    Ip localIp = neighbor.getLocalIp();
-    return localIp;
+    if (neighbor == null) {
+      return null;
+    }
+    return neighbor.getLocalIp();
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/SetNextHop.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/SetNextHop.java
@@ -1,6 +1,7 @@
 package org.batfish.datamodel.routing_policy.statement;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 import org.batfish.datamodel.routing_policy.expr.NextHopExpr;
@@ -50,7 +51,11 @@ public class SetNextHop extends Statement {
   @Override
   public Result execute(Environment environment) {
     Result result = new Result();
-    environment.getOutputRoute().setNextHopIp(_expr.getNextHopIp(environment));
+    Ip nextHop = _expr.getNextHopIp(environment);
+    if (nextHop == null) {
+      return result;
+    }
+    environment.getOutputRoute().setNextHopIp(nextHop);
     return result;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/bdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/bdp/VirtualRouter.java
@@ -870,6 +870,9 @@ public class VirtualRouter extends ComparableStructure<String> {
         continue;
       }
       Prefix remotePrefix = neighbor.getPrefix();
+      if (remotePrefix.getPrefixLength() < Prefix.MAX_PREFIX_LENGTH) {
+        continue;
+      }
       Ip remoteIp = remotePrefix.getStartIp();
       if (ipOwners.get(remoteIp) != null) {
         // Skip if neighbor is not outside the network


### PR DESCRIPTION
compute advertisements to outside can fail sometimes when applying routing policy; hotfixing for now, better solution in the works.