### PR TITLE
Fixing routing policy null pointers + support for dynamic sessions

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/Environment.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/Environment.java
@@ -9,6 +9,7 @@ import org.batfish.datamodel.BgpRoute;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Vrf;
 
 public class Environment {
@@ -40,30 +41,34 @@ public class Environment {
 
   private final AbstractRoute _originalRoute;
 
-  private AbstractRoute6 _originalRoute6;
+  @Nullable private AbstractRoute6 _originalRoute6;
 
   private final AbstractRouteBuilder<?, ?> _outputRoute;
 
-  private final Ip _peerAddress;
+  @Nullable private final Ip _peerAddress;
+
+  @Nullable private final Prefix _peerPrefix;
 
   private boolean _readFromIntermediateBgpAttributes;
 
   private final boolean _useOutputAttributes;
 
-  private Vrf _vrf;
+  private final Vrf _vrf;
 
   private boolean _writeToIntermediateBgpAttributes;
 
-  public Environment(
+  private Environment(
       @Nonnull Configuration configuration,
       String vrf,
       AbstractRoute originalRoute,
       @Nullable AbstractRoute6 originalRoute6,
       AbstractRouteBuilder<?, ?> outputRoute,
-      Ip peerAddress,
-      Direction direction) {
+      @Nullable Ip peerAddress,
+      Direction direction,
+      @Nullable Prefix peerPrefix) {
     _configuration = configuration;
     _direction = direction;
+    _peerPrefix = peerPrefix;
     _vrf = configuration.getVrfs().get(vrf);
     _originalRoute = originalRoute;
     _originalRoute6 = originalRoute6;
@@ -120,6 +125,7 @@ public class Environment {
     return _originalRoute;
   }
 
+  @Nullable
   public AbstractRoute6 getOriginalRoute6() {
     return _originalRoute6;
   }
@@ -128,8 +134,14 @@ public class Environment {
     return _outputRoute;
   }
 
+  @Nullable
   public Ip getPeerAddress() {
     return _peerAddress;
+  }
+
+  @Nullable
+  public Prefix getPeerPrefix() {
+    return _peerPrefix;
   }
 
   public boolean getReadFromIntermediateBgpAttributes() {
@@ -186,5 +198,155 @@ public class Environment {
 
   public void setWriteToIntermediateBgpAttributes(boolean writeToIntermediateBgpAttributes) {
     _writeToIntermediateBgpAttributes = writeToIntermediateBgpAttributes;
+  }
+
+  public static final class Builder {
+    private boolean _buffered;
+    private boolean _callExprContext;
+    private boolean _callStatementContext;
+    private Configuration _configuration;
+    private boolean _defaultAction;
+    private String _defaultPolicy;
+    private Direction _direction;
+    private boolean _error;
+    private BgpRoute.Builder _intermediateBgpAttributes;
+    private boolean _localDefaultAction;
+    private AbstractRoute _originalRoute;
+    private AbstractRoute6 _originalRoute6;
+    private AbstractRouteBuilder<?, ?> _outputRoute;
+    @Nullable private Ip _peerAddress;
+    private Prefix _peerPrefix;
+    private boolean _readFromIntermediateBgpAttributes;
+    private boolean _useOutputAttributes;
+    private String _vrf;
+    private boolean _writeToIntermediateBgpAttributes;
+
+    private Builder(Configuration c) {
+      _configuration = c;
+    }
+
+    public static Builder newEnvironment(@Nonnull Configuration c) {
+      return new Builder(c);
+    }
+
+    public Builder setBuffered(boolean buffered) {
+      this._buffered = buffered;
+      return this;
+    }
+
+    public Builder setCallExprContext(boolean callExprContext) {
+      this._callExprContext = callExprContext;
+      return this;
+    }
+
+    public Builder setCallStatementContext(boolean callStatementContext) {
+      this._callStatementContext = callStatementContext;
+      return this;
+    }
+
+    public Builder setConfiguration(Configuration configuration) {
+      this._configuration = configuration;
+      return this;
+    }
+
+    public Builder setDefaultAction(boolean defaultAction) {
+      this._defaultAction = defaultAction;
+      return this;
+    }
+
+    public Builder setDefaultPolicy(String defaultPolicy) {
+      this._defaultPolicy = defaultPolicy;
+      return this;
+    }
+
+    public Builder setDirection(Direction direction) {
+      this._direction = direction;
+      return this;
+    }
+
+    public Builder setError(boolean error) {
+      this._error = error;
+      return this;
+    }
+
+    public Builder setIntermediateBgpAttributes(BgpRoute.Builder intermediateBgpAttributes) {
+      this._intermediateBgpAttributes = intermediateBgpAttributes;
+      return this;
+    }
+
+    public Builder setLocalDefaultAction(boolean localDefaultAction) {
+      this._localDefaultAction = localDefaultAction;
+      return this;
+    }
+
+    public Builder setOriginalRoute(AbstractRoute originalRoute) {
+      this._originalRoute = originalRoute;
+      return this;
+    }
+
+    public Builder setOriginalRoute6(AbstractRoute6 originalRoute6) {
+      this._originalRoute6 = originalRoute6;
+      return this;
+    }
+
+    public Builder setOutputRoute(AbstractRouteBuilder<?, ?> outputRoute) {
+      this._outputRoute = outputRoute;
+      return this;
+    }
+
+    public Builder setPeerAddress(@Nullable Ip peerAddress) {
+      this._peerAddress = peerAddress;
+      return this;
+    }
+
+    public Builder setPeerPrefix(@Nullable Prefix peerPrefix) {
+      this._peerPrefix = peerPrefix;
+      return this;
+    }
+
+    public Builder setReadFromIntermediateBgpAttributes(boolean readFromIntermediateBgpAttributes) {
+      this._readFromIntermediateBgpAttributes = readFromIntermediateBgpAttributes;
+      return this;
+    }
+
+    public Builder setUseOutputAttributes(boolean useOutputAttributes) {
+      this._useOutputAttributes = useOutputAttributes;
+      return this;
+    }
+
+    public Builder setVrf(String vrf) {
+      this._vrf = vrf;
+      return this;
+    }
+
+    public Builder setWriteToIntermediateBgpAttributes(boolean writeToIntermediateBgpAttributes) {
+      this._writeToIntermediateBgpAttributes = writeToIntermediateBgpAttributes;
+      return this;
+    }
+
+    public Environment build() {
+      Environment environment =
+          new Environment(
+              _configuration,
+              _vrf,
+              _originalRoute,
+              _originalRoute6,
+              _outputRoute,
+              _peerAddress,
+              _direction,
+              _peerPrefix);
+      environment._error = this._error;
+      environment._defaultAction = this._defaultAction;
+      environment._localDefaultAction = this._localDefaultAction;
+      environment._intermediateBgpAttributes = this._intermediateBgpAttributes;
+      environment._callStatementContext = this._callStatementContext;
+      environment._readFromIntermediateBgpAttributes = this._readFromIntermediateBgpAttributes;
+      environment._buffered = this._buffered;
+      environment._originalRoute6 = this._originalRoute6;
+      environment._writeToIntermediateBgpAttributes = this._writeToIntermediateBgpAttributes;
+      environment._defaultPolicy = this._defaultPolicy;
+      environment._callExprContext = this._callExprContext;
+      return environment;
+    }
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/Environment.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/Environment.java
@@ -14,6 +14,10 @@ import org.batfish.datamodel.Vrf;
 
 public class Environment {
 
+  public static Builder builder(@Nonnull Configuration c) {
+    return new Builder(c);
+  }
+
   public enum Direction {
     IN,
     OUT
@@ -41,7 +45,7 @@ public class Environment {
 
   private final AbstractRoute _originalRoute;
 
-  @Nullable private AbstractRoute6 _originalRoute6;
+  @Nullable private final AbstractRoute6 _originalRoute6;
 
   private final AbstractRouteBuilder<?, ?> _outputRoute;
 
@@ -57,28 +61,49 @@ public class Environment {
 
   private boolean _writeToIntermediateBgpAttributes;
 
-  private Environment(
+  public Environment(
+      boolean buffered,
+      boolean callExprContext,
+      boolean callStatementContext,
       @Nonnull Configuration configuration,
-      String vrf,
+      boolean defaultAction,
+      String defaultPolicy,
+      Direction direction,
+      boolean error,
+      BgpRoute.Builder intermediateBgpAttributes,
+      boolean localDefaultAction,
       AbstractRoute originalRoute,
       @Nullable AbstractRoute6 originalRoute6,
       AbstractRouteBuilder<?, ?> outputRoute,
       @Nullable Ip peerAddress,
-      Direction direction,
-      @Nullable Prefix peerPrefix) {
-    _configuration = configuration;
-    _direction = direction;
-    _peerPrefix = peerPrefix;
-    _vrf = configuration.getVrfs().get(vrf);
-    _originalRoute = originalRoute;
-    _originalRoute6 = originalRoute6;
-    _outputRoute = outputRoute;
-    _peerAddress = peerAddress;
-    ConfigurationFormat format = _configuration.getConfigurationFormat();
-    _useOutputAttributes =
+      @Nullable Prefix peerPrefix,
+      boolean readFromIntermediateBgpAttributes,
+      boolean useOutputAttributes,
+      Vrf vrf,
+      boolean writeToIntermediateBgpAttributes) {
+    this._buffered = buffered;
+    this._callExprContext = callExprContext;
+    this._callStatementContext = callStatementContext;
+    this._configuration = configuration;
+    this._defaultAction = defaultAction;
+    this._defaultPolicy = defaultPolicy;
+    this._direction = direction;
+    this._error = error;
+    this._intermediateBgpAttributes = intermediateBgpAttributes;
+    this._localDefaultAction = localDefaultAction;
+    this._originalRoute = originalRoute;
+    this._originalRoute6 = originalRoute6;
+    this._outputRoute = outputRoute;
+    this._peerAddress = peerAddress;
+    this._peerPrefix = peerPrefix;
+    this._readFromIntermediateBgpAttributes = readFromIntermediateBgpAttributes;
+    ConfigurationFormat format = configuration.getConfigurationFormat();
+    this._useOutputAttributes =
         format == ConfigurationFormat.JUNIPER
             || format == ConfigurationFormat.JUNIPER_SWITCH
             || format == ConfigurationFormat.FLAT_JUNIPER;
+    this._vrf = vrf;
+    this._writeToIntermediateBgpAttributes = writeToIntermediateBgpAttributes;
   }
 
   public boolean getBuffered() {
@@ -215,7 +240,7 @@ public class Environment {
     private AbstractRoute6 _originalRoute6;
     private AbstractRouteBuilder<?, ?> _outputRoute;
     @Nullable private Ip _peerAddress;
-    private Prefix _peerPrefix;
+    @Nullable private Prefix _peerPrefix;
     private boolean _readFromIntermediateBgpAttributes;
     private boolean _useOutputAttributes;
     private String _vrf;
@@ -223,10 +248,6 @@ public class Environment {
 
     private Builder(Configuration c) {
       _configuration = c;
-    }
-
-    public static Builder newEnvironment(@Nonnull Configuration c) {
-      return new Builder(c);
     }
 
     public Builder setBuffered(boolean buffered) {
@@ -325,28 +346,27 @@ public class Environment {
     }
 
     public Environment build() {
-      Environment environment =
-          new Environment(
-              _configuration,
-              _vrf,
-              _originalRoute,
-              _originalRoute6,
-              _outputRoute,
-              _peerAddress,
-              _direction,
-              _peerPrefix);
-      environment._error = this._error;
-      environment._defaultAction = this._defaultAction;
-      environment._localDefaultAction = this._localDefaultAction;
-      environment._intermediateBgpAttributes = this._intermediateBgpAttributes;
-      environment._callStatementContext = this._callStatementContext;
-      environment._readFromIntermediateBgpAttributes = this._readFromIntermediateBgpAttributes;
-      environment._buffered = this._buffered;
-      environment._originalRoute6 = this._originalRoute6;
-      environment._writeToIntermediateBgpAttributes = this._writeToIntermediateBgpAttributes;
-      environment._defaultPolicy = this._defaultPolicy;
-      environment._callExprContext = this._callExprContext;
-      return environment;
+      Vrf vrf = _configuration.getVrfs().get(_vrf);
+      return new Environment(
+          _buffered,
+          _callExprContext,
+          _callStatementContext,
+          _configuration,
+          _defaultAction,
+          _defaultPolicy,
+          _direction,
+          _error,
+          _intermediateBgpAttributes,
+          _localDefaultAction,
+          _originalRoute,
+          _originalRoute6,
+          _outputRoute,
+          _peerAddress,
+          _peerPrefix,
+          _readFromIntermediateBgpAttributes,
+          _useOutputAttributes,
+          vrf,
+          _writeToIntermediateBgpAttributes);
     }
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/RoutingPolicy.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/RoutingPolicy.java
@@ -171,7 +171,7 @@ public class RoutingPolicy extends ComparableStructure<String> {
       String vrf,
       Direction direction) {
     Environment environment =
-        Environment.Builder.newEnvironment(_owner)
+        Environment.builder(_owner)
             .setVrf(vrf)
             .setOriginalRoute(inputRoute)
             .setOutputRoute(outputRoute)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/RoutingPolicy.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/RoutingPolicy.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.batfish.common.Warnings;
 import org.batfish.common.util.ComparableStructure;
 import org.batfish.datamodel.AbstractRoute;
@@ -21,6 +22,7 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.NetworkFactory.NetworkFactoryBuilder;
+import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.routing_policy.Environment.Direction;
 import org.batfish.datamodel.routing_policy.statement.Statement;
 
@@ -155,11 +157,28 @@ public class RoutingPolicy extends ComparableStructure<String> {
   public boolean process(
       AbstractRoute inputRoute,
       AbstractRouteBuilder<?, ?> outputRoute,
-      Ip peerAddress,
+      @Nullable Ip peerAddress,
+      String vrf,
+      Direction direction) {
+    return process(inputRoute, outputRoute, peerAddress, null, vrf, direction);
+  }
+
+  public boolean process(
+      AbstractRoute inputRoute,
+      AbstractRouteBuilder<?, ?> outputRoute,
+      @Nullable Ip peerAddress,
+      @Nullable Prefix peerPrefix,
       String vrf,
       Direction direction) {
     Environment environment =
-        new Environment(_owner, vrf, inputRoute, null, outputRoute, peerAddress, direction);
+        Environment.Builder.newEnvironment(_owner)
+            .setVrf(vrf)
+            .setOriginalRoute(inputRoute)
+            .setOutputRoute(outputRoute)
+            .setPeerAddress(peerAddress)
+            .setDirection(direction)
+            .setPeerPrefix(peerPrefix)
+            .build();
     Result result = call(environment);
     return result.getBooleanValue();
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/NextHopExpr.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/NextHopExpr.java
@@ -2,6 +2,7 @@ package org.batfish.datamodel.routing_policy.expr;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.io.Serializable;
+import javax.annotation.Nullable;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.routing_policy.Environment;
 
@@ -14,6 +15,7 @@ public abstract class NextHopExpr implements Serializable {
   @Override
   public abstract boolean equals(Object obj);
 
+  @Nullable
   public abstract Ip getNextHopIp(Environment environment);
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/PeerAddressNextHop.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/PeerAddressNextHop.java
@@ -6,17 +6,19 @@ import org.batfish.datamodel.routing_policy.Environment;
 
 public class PeerAddressNextHop extends NextHopExpr {
 
+  private static PeerAddressNextHop _instance = new PeerAddressNextHop();
+
+  public static PeerAddressNextHop getInstance() {
+    return _instance;
+  }
+
   private static final long serialVersionUID = 1L;
+
+  private PeerAddressNextHop() {}
 
   @Override
   public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    return getClass() == obj.getClass();
+    return this == obj || obj instanceof PeerAddressNextHop;
   }
 
   @Nullable

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/PeerAddressNextHop.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/PeerAddressNextHop.java
@@ -1,11 +1,11 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import javax.annotation.Nullable;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.routing_policy.Environment;
 
 public class PeerAddressNextHop extends NextHopExpr {
 
-  /** */
   private static final long serialVersionUID = 1L;
 
   @Override
@@ -16,12 +16,10 @@ public class PeerAddressNextHop extends NextHopExpr {
     if (obj == null) {
       return false;
     }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    return true;
+    return getClass() == obj.getClass();
   }
 
+  @Nullable
   @Override
   public Ip getNextHopIp(Environment environment) {
     return environment.getPeerAddress();

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/SelfNextHop.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/SelfNextHop.java
@@ -1,13 +1,14 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import javax.annotation.Nullable;
 import org.batfish.datamodel.BgpNeighbor;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.routing_policy.Environment;
 
+/** Implements BGP next-hop-self semantics */
 public class SelfNextHop extends NextHopExpr {
 
-  /** */
   private static final long serialVersionUID = 1L;
 
   @Override
@@ -18,19 +19,21 @@ public class SelfNextHop extends NextHopExpr {
     if (obj == null) {
       return false;
     }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    return true;
+    return getClass() == obj.getClass();
   }
 
   @Override
+  @Nullable
   public Ip getNextHopIp(Environment environment) {
-    // TODO: make work for dynamic sessions
-    Prefix prefix = new Prefix(environment.getPeerAddress(), Prefix.MAX_PREFIX_LENGTH);
-    BgpNeighbor neighbor = environment.getVrf().getBgpProcess().getNeighbors().get(prefix);
-    Ip localIp = neighbor.getLocalIp();
-    return localIp;
+    Prefix peerPrefix = environment.getPeerPrefix();
+    if (peerPrefix == null) {
+      return null;
+    }
+    BgpNeighbor neighbor = environment.getVrf().getBgpProcess().getNeighbors().get(peerPrefix);
+    if (neighbor == null) {
+      return null;
+    }
+    return neighbor.getLocalIp();
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/SelfNextHop.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/SelfNextHop.java
@@ -11,15 +11,17 @@ public class SelfNextHop extends NextHopExpr {
 
   private static final long serialVersionUID = 1L;
 
+  private static final SelfNextHop _instance = new SelfNextHop();
+
+  public static SelfNextHop getInstance() {
+    return _instance;
+  }
+
+  private SelfNextHop() {}
+
   @Override
   public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    return getClass() == obj.getClass();
+    return this == obj || obj instanceof NextHopExpr;
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/SetNextHop.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/SetNextHop.java
@@ -1,6 +1,7 @@
 package org.batfish.datamodel.routing_policy.statement;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 import org.batfish.datamodel.routing_policy.expr.NextHopExpr;
@@ -50,7 +51,11 @@ public class SetNextHop extends Statement {
   @Override
   public Result execute(Environment environment) {
     Result result = new Result();
-    environment.getOutputRoute().setNextHopIp(_expr.getNextHopIp(environment));
+    Ip nextHop = _expr.getNextHopIp(environment);
+    if (nextHop == null) {
+      return result;
+    }
+    environment.getOutputRoute().setNextHopIp(nextHop);
     return result;
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/RouteIsClassfulTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/RouteIsClassfulTest.java
@@ -20,8 +20,7 @@ public class RouteIsClassfulTest {
   private static boolean evaluateIsClassful(Prefix network) {
     Configuration c = new Configuration("host", ConfigurationFormat.CISCO_IOS);
     ConnectedRoute route = new ConnectedRoute(network, "Ethernet0");
-    Environment env =
-        Environment.Builder.newEnvironment(c).setVrf("vrf").setOriginalRoute(route).build();
+    Environment env = Environment.builder(c).setVrf("vrf").setOriginalRoute(route).build();
     Result res = RouteIsClassful.instance().evaluate(env);
     return res.getBooleanValue();
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/RouteIsClassfulTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/RouteIsClassfulTest.java
@@ -20,7 +20,8 @@ public class RouteIsClassfulTest {
   private static boolean evaluateIsClassful(Prefix network) {
     Configuration c = new Configuration("host", ConfigurationFormat.CISCO_IOS);
     ConnectedRoute route = new ConnectedRoute(network, "Ethernet0");
-    Environment env = new Environment(c, "vrf", route, null, null, null, null);
+    Environment env =
+        Environment.Builder.newEnvironment(c).setVrf("vrf").setOriginalRoute(route).build();
     Result res = RouteIsClassful.instance().evaluate(env);
     return res.getBooleanValue();
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/statement/PrependAsPathTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/statement/PrependAsPathTest.java
@@ -25,7 +25,7 @@ public class PrependAsPathTest {
 
   private static Environment newTestEnvironment(BgpRoute.Builder outputRoute) {
     Configuration c = new Configuration("host", ConfigurationFormat.CISCO_IOS);
-    return Environment.Builder.newEnvironment(c).setVrf("vrf").setOutputRoute(outputRoute).build();
+    return Environment.builder(c).setVrf("vrf").setOutputRoute(outputRoute).build();
   }
 
   private static List<SortedSet<Integer>> mkAsPath(Integer... explicitAs) {

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/statement/PrependAsPathTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/statement/PrependAsPathTest.java
@@ -25,7 +25,7 @@ public class PrependAsPathTest {
 
   private static Environment newTestEnvironment(BgpRoute.Builder outputRoute) {
     Configuration c = new Configuration("host", ConfigurationFormat.CISCO_IOS);
-    return new Environment(c, "vrf", null, null, outputRoute, null, null);
+    return Environment.Builder.newEnvironment(c).setVrf("vrf").setOutputRoute(outputRoute).build();
   }
 
   private static List<SortedSet<Integer>> mkAsPath(Integer... explicitAs) {

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/VpnConnection.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/VpnConnection.java
@@ -346,7 +346,7 @@ public class VpnConnection implements AwsVpcEntity, Serializable {
             new RoutingPolicy(rpAcceptAllEbgpAndSetNextHopSelfName, vpnGatewayCfgNode);
         vpnGatewayCfgNode.getRoutingPolicies().put(vgwRpAcceptAllBgp.getName(), vgwRpAcceptAllBgp);
         vgwRpAcceptAllBgp.setStatements(
-            ImmutableList.of(new SetNextHop(new SelfNextHop(), false), acceptIffEbgp));
+            ImmutableList.of(new SetNextHop(SelfNextHop.getInstance(), false), acceptIffEbgp));
         vgwToVpcBgpNeighbor.setExportPolicy(rpAcceptAllEbgpAndSetNextHopSelfName);
         RoutingPolicy vgwRpRejectAll = new RoutingPolicy(rpRejectAllName, vpnGatewayCfgNode);
         vpnGatewayCfgNode.getRoutingPolicies().put(rpRejectAllName, vgwRpRejectAll);

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -1781,7 +1781,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
         c.getRoutingPolicies().put(peerExportPolicyName, peerExportPolicy);
       }
       if (lpg.getNextHopSelf() != null && lpg.getNextHopSelf()) {
-        peerExportPolicy.getStatements().add(new SetNextHop(new SelfNextHop(), false));
+        peerExportPolicy.getStatements().add(new SetNextHop(SelfNextHop.getInstance(), false));
       }
       if (lpg.getRemovePrivateAs() != null && lpg.getRemovePrivateAs()) {
         peerExportPolicy.getStatements().add(Statements.RemovePrivateAs.toStaticStatement());

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/RouteMapSetNextHopPeerAddress.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/RouteMapSetNextHopPeerAddress.java
@@ -15,7 +15,7 @@ public class RouteMapSetNextHopPeerAddress extends RouteMapSetLine {
   @Override
   public void applyTo(
       List<Statement> statements, CiscoConfiguration cc, Configuration c, Warnings w) {
-    statements.add(new SetNextHop(new PeerAddressNextHop(), false));
+    statements.add(new SetNextHop(PeerAddressNextHop.getInstance(), false));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/RoutePolicyNextHopPeerAddress.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/RoutePolicyNextHopPeerAddress.java
@@ -11,6 +11,6 @@ public class RoutePolicyNextHopPeerAddress extends RoutePolicyNextHop {
 
   @Override
   public NextHopExpr toNextHopExpr(CiscoConfiguration cc, Configuration c, Warnings w) {
-    return new PeerAddressNextHop();
+    return PeerAddressNextHop.getInstance();
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/RoutePolicyNextHopSelf.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/RoutePolicyNextHopSelf.java
@@ -11,6 +11,6 @@ public class RoutePolicyNextHopSelf extends RoutePolicyNextHop {
 
   @Override
   public NextHopExpr toNextHopExpr(CiscoConfiguration cc, Configuration c, Warnings w) {
-    return new SelfNextHop();
+    return SelfNextHop.getInstance();
   }
 }


### PR DESCRIPTION
Context:
- We were crashing with NPE when executing next-hop-self
- Root cause: Passing in wrong VRF when creating environments in (i)bdp, fixed now.

Additional changes: 
- Support not just peer address but also peer prefix in routing policy/environment.
- Better nullable annotations (RoutingPolicy is used for multiple protocols, where we pass `peerAddress==null`
- Builder for `routingpolicy.Enviroment` to make dealing with all of this easier.
- Small fixes to ibdp that were part of #1165 for regular bdp