### PR TITLE
Don't try to serialize property _exception of BatfishException

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/BatfishException.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/BatfishException.java
@@ -24,7 +24,7 @@ public class BatfishException extends RuntimeException {
     /** */
     private static final long serialVersionUID = 1L;
 
-    private final BatfishException _exception;
+    private final transient BatfishException _exception;
 
     private final List<String> _lines;
 


### PR DESCRIPTION
Parsing could fail in a certain case due to Java trying to serialize a BatfishException.