### PR TITLE
Honor vrfs during bgp topology construction

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
@@ -669,6 +669,7 @@ public class CommonUtil {
     fb.setTag("neighbor-resolution");
 
     fb.setIngressNode(src.getOwner().getHostname());
+    fb.setIngressVrf(src.getVrf());
     fb.setSrcIp(srcAddress);
     fb.setDstIp(dstAddress);
     fb.setSrcPort(NamedPort.EPHEMERAL_LOWEST.number());


### PR DESCRIPTION
When performing traceroutes to check BGP neighbor reachability, ingress VRFs matter.