### PR TITLE
Honor vrfs during bgp topology construction, followup

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
@@ -709,6 +709,7 @@ public class CommonUtil {
     String acceptedHostname = acceptPoint.getHostname();
     // The reply traceroute
     fb.setIngressNode(acceptedHostname);
+    fb.setIngressVrf(dst.getVrf());
     fb.setSrcIp(forwardFlow.getDstIp());
     fb.setDstIp(forwardFlow.getSrcIp());
     fb.setSrcPort(forwardFlow.getDstPort());


### PR DESCRIPTION
Follow up on #1208 
Reply packets can originate in a differently-named vrf, need update the flow builder for reply traceroute.