### PR TITLE
Add finer-grained neighborUnreachable predicate by interface

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/z3/Synthesizer.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/Synthesizer.java
@@ -24,6 +24,7 @@ import org.batfish.z3.state.NodeDropAclIn;
 import org.batfish.z3.state.NodeDropAclOut;
 import org.batfish.z3.state.NodeDropNoRoute;
 import org.batfish.z3.state.NodeDropNullRoute;
+import org.batfish.z3.state.NodeInterfaceNeighborUnreachable;
 import org.batfish.z3.state.NodeNeighborUnreachable;
 import org.batfish.z3.state.Originate;
 import org.batfish.z3.state.OriginateVrf;
@@ -93,6 +94,7 @@ public class Synthesizer {
                     NodeDropAclOut.State.INSTANCE,
                     NodeDropNoRoute.State.INSTANCE,
                     NodeDropNullRoute.State.INSTANCE,
+                    NodeInterfaceNeighborUnreachable.State.INSTANCE,
                     NodeNeighborUnreachable.State.INSTANCE,
                     Originate.State.INSTANCE,
                     OriginateVrf.State.INSTANCE,

--- a/projects/batfish/src/main/java/org/batfish/z3/state/NodeInterfaceNeighborUnreachable.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/state/NodeInterfaceNeighborUnreachable.java
@@ -1,0 +1,47 @@
+package org.batfish.z3.state;
+
+import org.batfish.z3.expr.StateExpr;
+import org.batfish.z3.state.visitors.GenericStateExprVisitor;
+import org.batfish.z3.state.visitors.StateVisitor;
+
+public class NodeInterfaceNeighborUnreachable extends StateExpr {
+
+  public static class State extends StateExpr.State {
+
+    public static final State INSTANCE = new State();
+
+    private State() {}
+
+    @Override
+    public void accept(StateVisitor visitor) {
+      visitor.visitNodeInterfaceNeighborUnreachable(this);
+    }
+  }
+
+  private final String _hostname;
+
+  private final String _iface;
+
+  public NodeInterfaceNeighborUnreachable(String hostname, String iface) {
+    _hostname = hostname;
+    _iface = iface;
+  }
+
+  @Override
+  public <R> R accept(GenericStateExprVisitor<R> visitor) {
+    return visitor.visitNodeInterfaceNeighborUnreachable(this);
+  }
+
+  public String getHostname() {
+    return _hostname;
+  }
+
+  public String getIface() {
+    return _iface;
+  }
+
+  @Override
+  public State getState() {
+    return State.INSTANCE;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/z3/state/visitors/GenericStateExprVisitor.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/state/visitors/GenericStateExprVisitor.java
@@ -20,6 +20,7 @@ import org.batfish.z3.state.NodeDropAclIn;
 import org.batfish.z3.state.NodeDropAclOut;
 import org.batfish.z3.state.NodeDropNoRoute;
 import org.batfish.z3.state.NodeDropNullRoute;
+import org.batfish.z3.state.NodeInterfaceNeighborUnreachable;
 import org.batfish.z3.state.NodeNeighborUnreachable;
 import org.batfish.z3.state.NumberedQuery;
 import org.batfish.z3.state.Originate;
@@ -77,6 +78,8 @@ public interface GenericStateExprVisitor<R> {
   R visitNodeDropNoRoute(NodeDropNoRoute nodeDropNoRoute);
 
   R visitNodeDropNullRoute(NodeDropNullRoute nodeDropNullRoute);
+
+  R visitNodeInterfaceNeighborUnreachable(NodeInterfaceNeighborUnreachable nodeNeighborUnreachable);
 
   R visitNodeNeighborUnreachable(NodeNeighborUnreachable nodeNeighborUnreachable);
 

--- a/projects/batfish/src/main/java/org/batfish/z3/state/visitors/Parameterizer.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/state/visitors/Parameterizer.java
@@ -30,6 +30,7 @@ import org.batfish.z3.state.NodeDropAclIn;
 import org.batfish.z3.state.NodeDropAclOut;
 import org.batfish.z3.state.NodeDropNoRoute;
 import org.batfish.z3.state.NodeDropNullRoute;
+import org.batfish.z3.state.NodeInterfaceNeighborUnreachable;
 import org.batfish.z3.state.NodeNeighborUnreachable;
 import org.batfish.z3.state.NumberedQuery;
 import org.batfish.z3.state.Originate;
@@ -169,6 +170,14 @@ public class Parameterizer implements GenericStateExprVisitor<List<StateParamete
   @Override
   public List<StateParameter> visitNodeDropNullRoute(NodeDropNullRoute nodeDropNullRoute) {
     return ImmutableList.of(new StateParameter(nodeDropNullRoute.getHostname(), NODE));
+  }
+
+  @Override
+  public List<StateParameter> visitNodeInterfaceNeighborUnreachable(
+      NodeInterfaceNeighborUnreachable nodeIfaceNeighborUnreachable) {
+    return ImmutableList.of(
+        new StateParameter(nodeIfaceNeighborUnreachable.getHostname(), NODE),
+        new StateParameter(nodeIfaceNeighborUnreachable.getIface(), INTERFACE));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/z3/state/visitors/StateVisitor.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/state/visitors/StateVisitor.java
@@ -20,6 +20,7 @@ import org.batfish.z3.state.NodeDropAclIn;
 import org.batfish.z3.state.NodeDropAclOut;
 import org.batfish.z3.state.NodeDropNoRoute;
 import org.batfish.z3.state.NodeDropNullRoute;
+import org.batfish.z3.state.NodeInterfaceNeighborUnreachable;
 import org.batfish.z3.state.NodeNeighborUnreachable.State;
 import org.batfish.z3.state.NumberedQuery;
 import org.batfish.z3.state.Originate;
@@ -75,6 +76,8 @@ public interface StateVisitor {
   void visitNodeDropNoRoute(NodeDropNoRoute.State nodeDropNoRoute);
 
   void visitNodeDropNullRoute(NodeDropNullRoute.State nodeDropNullRoute);
+
+  void visitNodeInterfaceNeighborUnreachable(NodeInterfaceNeighborUnreachable.State state);
 
   void visitNodeNeighborUnreachable(State state);
 

--- a/projects/batfish/src/test/java/org/batfish/z3/state/visitors/DefaultTransitionGeneratorTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/state/visitors/DefaultTransitionGeneratorTest.java
@@ -54,6 +54,7 @@ import org.batfish.z3.state.NodeDropAclIn;
 import org.batfish.z3.state.NodeDropAclOut;
 import org.batfish.z3.state.NodeDropNoRoute;
 import org.batfish.z3.state.NodeDropNullRoute;
+import org.batfish.z3.state.NodeInterfaceNeighborUnreachable;
 import org.batfish.z3.state.NodeNeighborUnreachable;
 import org.batfish.z3.state.Originate;
 import org.batfish.z3.state.OriginateVrf;
@@ -983,6 +984,56 @@ public class DefaultTransitionGeneratorTest {
   }
 
   @Test
+  public void testVisitNodeInterfaceNeighborUnreachable() {
+    SynthesizerInput input =
+        MockSynthesizerInput.builder()
+            .setNeighborUnreachable(
+                ImmutableMap.of(
+                    NODE1,
+                    ImmutableMap.of(
+                        VRF1,
+                        ImmutableMap.of(INTERFACE1, b(1), INTERFACE2, b(2)),
+                        VRF2,
+                        ImmutableMap.of(INTERFACE3, b(3))),
+                    NODE2,
+                    ImmutableMap.of(VRF1, ImmutableMap.of(INTERFACE1, b(4)))))
+            .build();
+    Set<RuleStatement> rules =
+        ImmutableSet.copyOf(
+            DefaultTransitionGenerator.generateTransitions(
+                input, ImmutableSet.of(NodeInterfaceNeighborUnreachable.State.INSTANCE)));
+
+    assertThat(
+        rules,
+        hasItem(
+            new BasicRuleStatement(
+                b(1),
+                ImmutableSet.of(new PostInVrf(NODE1, VRF1), new PreOut(NODE1)),
+                new NodeInterfaceNeighborUnreachable(NODE1, INTERFACE1))));
+    assertThat(
+        rules,
+        hasItem(
+            new BasicRuleStatement(
+                b(2),
+                ImmutableSet.of(new PostInVrf(NODE1, VRF1), new PreOut(NODE1)),
+                new NodeInterfaceNeighborUnreachable(NODE1, INTERFACE2))));
+    assertThat(
+        rules,
+        hasItem(
+            new BasicRuleStatement(
+                b(3),
+                ImmutableSet.of(new PostInVrf(NODE1, VRF2), new PreOut(NODE1)),
+                new NodeInterfaceNeighborUnreachable(NODE1, INTERFACE3))));
+    assertThat(
+        rules,
+        hasItem(
+            new BasicRuleStatement(
+                b(4),
+                ImmutableSet.of(new PostInVrf(NODE2, VRF1), new PreOut(NODE2)),
+                new NodeInterfaceNeighborUnreachable(NODE2, INTERFACE1))));
+  }
+
+  @Test
   public void testVisitNodeNeighborUnreachable() {
     SynthesizerInput input =
         MockSynthesizerInput.builder()
@@ -1006,29 +1057,25 @@ public class DefaultTransitionGeneratorTest {
         rules,
         hasItem(
             new BasicRuleStatement(
-                b(1),
-                ImmutableSet.of(new PostInVrf(NODE1, VRF1), new PreOut(NODE1)),
+                new NodeInterfaceNeighborUnreachable(NODE1, INTERFACE1),
                 new NodeNeighborUnreachable(NODE1))));
     assertThat(
         rules,
         hasItem(
             new BasicRuleStatement(
-                b(2),
-                ImmutableSet.of(new PostInVrf(NODE1, VRF1), new PreOut(NODE1)),
+                new NodeInterfaceNeighborUnreachable(NODE1, INTERFACE2),
                 new NodeNeighborUnreachable(NODE1))));
     assertThat(
         rules,
         hasItem(
             new BasicRuleStatement(
-                b(3),
-                ImmutableSet.of(new PostInVrf(NODE1, VRF2), new PreOut(NODE1)),
+                new NodeInterfaceNeighborUnreachable(NODE1, INTERFACE3),
                 new NodeNeighborUnreachable(NODE1))));
     assertThat(
         rules,
         hasItem(
             new BasicRuleStatement(
-                b(4),
-                ImmutableSet.of(new PostInVrf(NODE2, VRF1), new PreOut(NODE2)),
+                new NodeInterfaceNeighborUnreachable(NODE2, INTERFACE1),
                 new NodeNeighborUnreachable(NODE2))));
   }
 


### PR DESCRIPTION
 - transition from nodeInterfaceNeighborUnreach to nodeNeighborUnreach
 - allows us to determine if a header injected at some ingress interface, egresses a specific interface
 - add tests
 - passes full regression test