### PR TITLE
 Enable specifying interfaces by VRF.

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/InterfacesSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/InterfacesSpecifier.java
@@ -24,7 +24,8 @@ public class InterfacesSpecifier {
 
   public enum Type {
     DESC,
-    NAME
+    NAME,
+    VRF
   }
 
   public static InterfacesSpecifier ALL = new InterfacesSpecifier(".*");
@@ -73,12 +74,14 @@ public class InterfacesSpecifier {
 
   public boolean matches(Interface iface) {
     switch (_type) {
-      case DESC:
-        return _regex.matcher(iface.getDescription()).matches();
-      case NAME:
-        return _regex.matcher(iface.getName()).matches();
-      default:
-        throw new BatfishException("Unhandled InterfacesSpecifier type: " + _type);
+    case DESC:
+      return _regex.matcher(iface.getDescription()).matches();
+    case NAME:
+      return _regex.matcher(iface.getName()).matches();
+    case VRF:
+      return _regex.matcher(iface.getVrfName()).matches();
+    default:
+      throw new BatfishException("Unhandled InterfacesSpecifier type: " + _type);
     }
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/InterfacesSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/InterfacesSpecifier.java
@@ -74,14 +74,14 @@ public class InterfacesSpecifier {
 
   public boolean matches(Interface iface) {
     switch (_type) {
-    case DESC:
-      return _regex.matcher(iface.getDescription()).matches();
-    case NAME:
-      return _regex.matcher(iface.getName()).matches();
-    case VRF:
-      return _regex.matcher(iface.getVrfName()).matches();
-    default:
-      throw new BatfishException("Unhandled InterfacesSpecifier type: " + _type);
+      case DESC:
+        return _regex.matcher(iface.getDescription()).matches();
+      case NAME:
+        return _regex.matcher(iface.getName()).matches();
+      case VRF:
+        return _regex.matcher(iface.getVrfName()).matches();
+      default:
+        throw new BatfishException("Unhandled InterfacesSpecifier type: " + _type);
     }
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/InterfacesSpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/InterfacesSpecifierTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertThat;
 
 import java.util.regex.Pattern;
 import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.questions.InterfacesSpecifier.Type;
 import org.junit.Test;
 
@@ -53,5 +54,14 @@ public class InterfacesSpecifierTest {
 
     assertThat(specifier.matches(secretInterface), equalTo(true));
     assertThat(specifier.matches(nonSecretInterface), equalTo(false));
+  }
+
+  @Test
+  public void matchesVrf() {
+    InterfacesSpecifier specifier = new InterfacesSpecifier("vrf:vrf1");
+    Interface vrf1Iface = Interface.builder().setName("iface").setVrf(new Vrf("vrf1")).build();
+    Interface vrf2Iface = Interface.builder().setName("iface").setVrf(new Vrf("vrf2")).build();
+    assertThat(specifier.matches(vrf1Iface), equalTo(true));
+    assertThat(specifier.matches(vrf2Iface), equalTo(false));
   }
 }


### PR DESCRIPTION
Allow specifying interfaces by regexes on VRF name. Example: `vrf:internal.*`.