### PR TITLE
Pull out traceroute engine into a separate class

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/ITracerouteEngine.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/ITracerouteEngine.java
@@ -1,8 +1,10 @@
 package org.batfish.common.plugin;
 
+import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import org.batfish.datamodel.DataPlane;
+import org.batfish.datamodel.Fib;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowTrace;
 
@@ -10,7 +12,7 @@ import org.batfish.datamodel.FlowTrace;
  * Indicates ability to process a set of {@link Flow} objects and return a set of {@link FlowTrace},
  * performing a traceroute.
  */
-public interface FlowProcessor {
+public interface ITracerouteEngine {
   SortedMap<Flow, Set<FlowTrace>> processFlows(
-      DataPlane dataPlane, Set<Flow> flows, boolean ignoreAcls);
+      DataPlane dataPlane, Set<Flow> flows, Map<String, Map<String, Fib>> fibs, boolean ignoreAcls);
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
@@ -80,7 +80,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.batfish.common.BatfishException;
 import org.batfish.common.BfConsts;
 import org.batfish.common.Pair;
-import org.batfish.common.plugin.FlowProcessor;
+import org.batfish.common.plugin.ITracerouteEngine;
 import org.batfish.datamodel.BgpNeighbor;
 import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.BgpSession;
@@ -686,7 +686,7 @@ public class CommonUtil {
   private static boolean isReachableBgpNeighbor(
       BgpNeighbor src,
       BgpNeighbor dst,
-      @Nullable FlowProcessor flowProcessor,
+      @Nullable ITracerouteEngine tracerouteEngine,
       @Nullable DataPlane dp) {
     Ip srcAddress = src.getLocalIp();
     Ip dstAddress = src.getAddress();
@@ -694,7 +694,7 @@ public class CommonUtil {
       return false;
     }
     boolean isEbgp = !src.getLocalAs().equals(src.getRemoteAs());
-    if (flowProcessor == null || dp == null) {
+    if (tracerouteEngine == null || dp == null) {
       throw new BatfishException("Cannot compute neighbor reachability without a dataplane");
     }
 
@@ -715,7 +715,7 @@ public class CommonUtil {
 
     // Execute the "initiate connection" traceroute
     SortedMap<Flow, Set<FlowTrace>> traces =
-        flowProcessor.processFlows(dp, ImmutableSet.of(forwardFlow), false);
+        tracerouteEngine.processFlows(dp, ImmutableSet.of(forwardFlow), dp.getFibs(), false);
 
     SortedSet<FlowTrace> acceptedFlows =
         traces
@@ -752,7 +752,7 @@ public class CommonUtil {
     fb.setSrcPort(forwardFlow.getDstPort());
     fb.setDstPort(forwardFlow.getSrcPort());
     Flow backwardFlow = fb.build();
-    traces = flowProcessor.processFlows(dp, ImmutableSet.of(backwardFlow), false);
+    traces = tracerouteEngine.processFlows(dp, ImmutableSet.of(backwardFlow), dp.getFibs(), false);
 
     /*
      * If backward traceroutes fail, do not consider the neighbor reachable
@@ -771,7 +771,7 @@ public class CommonUtil {
 
   /**
    * Compute the BGP topology -- a network of {@link BgpNeighbor}s connected by {@link BgpSession}s.
-   * See {@link #initBgpTopology(Map, Map, boolean, boolean, FlowProcessor, DataPlane)} for more
+   * See {@link #initBgpTopology(Map, Map, boolean, boolean, ITracerouteEngine, DataPlane)} for more
    * details.
    *
    * @param configurations configuration keyed by hostname
@@ -800,7 +800,7 @@ public class CommonUtil {
    *     reachable and sessions can be established correctly. <b>Note:</b> this is different from
    *     {@code keepInvalid=false}, which only does filters invalid neighbors at the control-plane
    *     level
-   * @param flowProcessor an instance of {@link FlowProcessor} for doing reachability checks.
+   * @param tracerouteEngine an instance of {@link ITracerouteEngine} for doing reachability checks.
    * @param dp (partially) computed dataplane.
    * @return A graph ({@link Network}) representing all BGP peerings.
    */
@@ -809,7 +809,7 @@ public class CommonUtil {
       Map<Ip, Set<String>> ipOwners,
       boolean keepInvalid,
       boolean checkReachability,
-      @Nullable FlowProcessor flowProcessor,
+      @Nullable ITracerouteEngine tracerouteEngine,
       @Nullable DataPlane dp) {
 
     // TODO: handle duplicate ips on different vrfs
@@ -895,7 +895,7 @@ public class CommonUtil {
          * Perform reachability checks.
          */
         if (checkReachability) {
-          if (isReachableBgpNeighbor(neighbor, candidateNeighbor, flowProcessor, dp)) {
+          if (isReachableBgpNeighbor(neighbor, candidateNeighbor, tracerouteEngine, dp)) {
             graph.addEdge(neighbor, candidateNeighbor, new BgpSession(neighbor, candidateNeighbor));
           }
         } else {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/DataPlane.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/DataPlane.java
@@ -3,16 +3,28 @@ package org.batfish.datamodel;
 import com.google.common.graph.Network;
 import java.io.Serializable;
 import java.util.Map;
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
 
 public interface DataPlane extends Serializable {
 
+  Network<BgpNeighbor, BgpSession> getBgpTopology();
+
+  Map<String, Configuration> getConfigurations();
+
   Map<String, Map<String, Fib>> getFibs();
 
+  /**
+   * Return the map of Ip owners (as computed during dataplane computation). Map structure: Ip ->
+   * Set of hostnames
+   */
+  Map<Ip, Set<String>> getIpOwners();
+
+  /** Return the set of all (main) RIBs. Map structure: hostname -> VRF name -> GenericRib */
   SortedMap<String, SortedMap<String, GenericRib<AbstractRoute>>> getRibs();
 
-  SortedSet<Edge> getTopologyEdges();
+  Topology getTopology();
 
-  Network<BgpNeighbor, BgpSession> getBgpTopology();
+  SortedSet<Edge> getTopologyEdges();
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockDataPlane.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockDataPlane.java
@@ -6,30 +6,51 @@ import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.graph.Network;
 import com.google.common.graph.NetworkBuilder;
 import java.util.Map;
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
+import javax.annotation.Nullable;
 
 public class MockDataPlane implements DataPlane {
 
   public static class Builder {
 
+    private Network<BgpNeighbor, BgpSession> _bgpTopology;
+
+    private Map<String, Configuration> _configurations;
+
     private Map<String, Map<String, Fib>> _fibs;
 
     private SortedMap<String, SortedMap<String, GenericRib<AbstractRoute>>> _ribs;
 
+    @Nullable private Topology _topology;
+
     private SortedSet<Edge> _topologyEdges;
 
-    private Network<BgpNeighbor, BgpSession> _bgpTopology;
+    Map<Ip, Set<String>> _ipOwners;
 
     private Builder() {
+      _bgpTopology = NetworkBuilder.directed().build();
+      _configurations = ImmutableMap.of();
       _fibs = ImmutableMap.of();
       _ribs = ImmutableSortedMap.of();
       _topologyEdges = ImmutableSortedSet.of();
-      _bgpTopology = NetworkBuilder.directed().build();
+      _ipOwners = ImmutableMap.of();
     }
 
     public MockDataPlane build() {
-      return new MockDataPlane(_fibs, _ribs, _topologyEdges, _bgpTopology);
+      return new MockDataPlane(
+          _bgpTopology, _configurations, _fibs, _ipOwners, _ribs, _topology, _topologyEdges);
+    }
+
+    public Builder setBgpTopology(Network<BgpNeighbor, BgpSession> bgpTopology) {
+      _bgpTopology = bgpTopology;
+      return this;
+    }
+
+    public Builder setIpOwners(Map<Ip, Set<String>> owners) {
+      _ipOwners = owners;
+      return this;
     }
 
     public Builder setRibs(SortedMap<String, SortedMap<String, GenericRib<AbstractRoute>>> ribs) {
@@ -37,18 +58,17 @@ public class MockDataPlane implements DataPlane {
       return this;
     }
 
+    public Builder setTopology(Topology topology) {
+      _topology = topology;
+      return this;
+    }
+
     public Builder setTopologyEdges(SortedSet<Edge> topologyEdges) {
       _topologyEdges = topologyEdges;
       return this;
     }
-
-    public Builder setBgpTopology(Network<BgpNeighbor, BgpSession> bgpTopology) {
-      _bgpTopology = bgpTopology;
-      return this;
-    }
   }
 
-  /** */
   private static final long serialVersionUID = 1L;
 
   public static Builder builder() {
@@ -57,21 +77,33 @@ public class MockDataPlane implements DataPlane {
 
   private final Network<BgpNeighbor, BgpSession> _bgpTopology;
 
+  private final Map<String, Configuration> _configurations;
+
   private final Map<String, Map<String, Fib>> _fibs;
 
+  private final Map<Ip, Set<String>> _ipOwners;
+
   private final SortedMap<String, SortedMap<String, GenericRib<AbstractRoute>>> _ribs;
+
+  @Nullable private final Topology _topology;
 
   private final SortedSet<Edge> _topologyEdges;
 
   private MockDataPlane(
+      Network<BgpNeighbor, BgpSession> bgpTopology,
+      Map<String, Configuration> configurations,
       Map<String, Map<String, Fib>> fibs,
+      Map<Ip, Set<String>> ipOwners,
       SortedMap<String, SortedMap<String, GenericRib<AbstractRoute>>> ribs,
-      SortedSet<Edge> topologyEdges,
-      Network<BgpNeighbor, BgpSession> bgpTopology) {
+      @Nullable Topology topology,
+      SortedSet<Edge> topologyEdges) {
+    _bgpTopology = bgpTopology;
+    _configurations = configurations;
     _fibs = fibs;
     _ribs = ImmutableSortedMap.copyOf(ribs);
+    _topology = topology;
     _topologyEdges = ImmutableSortedSet.copyOf(topologyEdges);
-    _bgpTopology = bgpTopology;
+    _ipOwners = ipOwners;
   }
 
   @Override
@@ -80,8 +112,19 @@ public class MockDataPlane implements DataPlane {
   }
 
   @Override
+  public Map<Ip, Set<String>> getIpOwners() {
+    return _ipOwners;
+  }
+
+  @Override
   public SortedMap<String, SortedMap<String, GenericRib<AbstractRoute>>> getRibs() {
     return _ribs;
+  }
+
+  @Override
+  @Nullable
+  public Topology getTopology() {
+    return _topology;
   }
 
   @Override
@@ -92,5 +135,10 @@ public class MockDataPlane implements DataPlane {
   @Override
   public Network<BgpNeighbor, BgpSession> getBgpTopology() {
     return _bgpTopology;
+  }
+
+  @Override
+  public Map<String, Configuration> getConfigurations() {
+    return _configurations;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/TracerouteEngineImpl.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/TracerouteEngineImpl.java
@@ -1,0 +1,633 @@
+package org.batfish.dataplane;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.NavigableMap;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.annotation.Nullable;
+import org.batfish.common.BatfishException;
+import org.batfish.common.plugin.ITracerouteEngine;
+import org.batfish.common.util.CommonUtil;
+import org.batfish.datamodel.AbstractRoute;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.DataPlane;
+import org.batfish.datamodel.Edge;
+import org.batfish.datamodel.Fib;
+import org.batfish.datamodel.FilterResult;
+import org.batfish.datamodel.Flow;
+import org.batfish.datamodel.FlowDisposition;
+import org.batfish.datamodel.FlowTrace;
+import org.batfish.datamodel.FlowTraceHop;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.InterfaceAddress;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpAccessList;
+import org.batfish.datamodel.IpSpace;
+import org.batfish.datamodel.LineAction;
+import org.batfish.datamodel.Route;
+import org.batfish.datamodel.SourceNat;
+import org.batfish.datamodel.collections.NodeInterfacePair;
+
+public class TracerouteEngineImpl implements ITracerouteEngine {
+  private static ITracerouteEngine _instance = new TracerouteEngineImpl();
+
+  private static final String TRACEROUTE_INGRESS_NODE_INTERFACE_NAME =
+      "traceroute_source_interface";
+
+  private static final String TRACEROUTE_INGRESS_NODE_NAME = "traceroute_source_node";
+
+  public static ITracerouteEngine getInstance() {
+    return _instance;
+  }
+
+  private TracerouteEngineImpl() {}
+
+  @Override
+  public SortedMap<Flow, Set<FlowTrace>> processFlows(
+      DataPlane dataPlane,
+      Set<Flow> flows,
+      Map<String, Map<String, Fib>> fibs,
+      boolean ignoreAcls) {
+    Map<Flow, Set<FlowTrace>> flowTraces = new ConcurrentHashMap<>();
+    Map<String, Configuration> configurations = dataPlane.getConfigurations();
+    flows
+        .parallelStream()
+        .forEach(
+            flow -> {
+              Set<FlowTrace> currentFlowTraces = new TreeSet<>();
+              flowTraces.put(flow, currentFlowTraces);
+              String ingressNodeName = flow.getIngressNode();
+              if (ingressNodeName == null) {
+                throw new BatfishException(
+                    "Cannot construct flow trace since ingressNode is not specified");
+              }
+              Ip dstIp = flow.getDstIp();
+              if (dstIp == null) {
+                throw new BatfishException(
+                    "Cannot construct flow trace since dstIp is not specified");
+              }
+              Set<Edge> visitedEdges = Collections.emptySet();
+              List<FlowTraceHop> hops = new ArrayList<>();
+              Set<String> dstIpOwners = dataPlane.getIpOwners().get(dstIp);
+              SortedSet<Edge> edges = new TreeSet<>();
+              String ingressInterfaceName = flow.getIngressInterface();
+              if (ingressInterfaceName != null) {
+                edges.add(
+                    new Edge(
+                        TRACEROUTE_INGRESS_NODE_NAME,
+                        TRACEROUTE_INGRESS_NODE_INTERFACE_NAME,
+                        ingressNodeName,
+                        ingressInterfaceName));
+                processCurrentNextHopInterfaceEdges(
+                    dataPlane,
+                    configurations,
+                    fibs,
+                    TRACEROUTE_INGRESS_NODE_NAME,
+                    visitedEdges,
+                    hops,
+                    currentFlowTraces,
+                    flow,
+                    flow,
+                    ingressInterfaceName,
+                    configurations.get(ingressNodeName).getIpAccessLists(),
+                    configurations.get(ingressNodeName).getIpSpaces(),
+                    dstIp,
+                    dstIpOwners,
+                    null,
+                    new TreeSet<>(),
+                    null,
+                    null,
+                    edges,
+                    false,
+                    ignoreAcls);
+              } else {
+                collectFlowTraces(
+                    dataPlane,
+                    configurations,
+                    dataPlane.getFibs(),
+                    ingressNodeName,
+                    visitedEdges,
+                    hops,
+                    currentFlowTraces,
+                    flow,
+                    flow,
+                    ignoreAcls);
+              }
+            });
+    return new TreeMap<>(flowTraces);
+  }
+
+  private boolean processCurrentNextHopInterfaceEdges(
+      DataPlane dp,
+      Map<String, Configuration> configurations,
+      Map<String, Map<String, Fib>> fibs,
+      String currentNodeName,
+      Set<Edge> visitedEdges,
+      List<FlowTraceHop> hopsSoFar,
+      Set<FlowTrace> flowTraces,
+      Flow originalFlow,
+      Flow transformedFlow,
+      String srcInterface,
+      Map<String, IpAccessList> aclDefinitions,
+      Map<String, IpSpace> namedIpSpaces,
+      Ip dstIp,
+      Set<String> dstIpOwners,
+      @Nullable String nextHopInterfaceName,
+      SortedSet<String> routesForThisNextHopInterface,
+      @Nullable Ip finalNextHopIp,
+      @Nullable NodeInterfacePair nextHopInterface,
+      SortedSet<Edge> edges,
+      boolean arp,
+      boolean ignoreAcls) {
+    boolean continueToNextNextHopInterface = false;
+    int unreachableNeighbors = 0;
+    int potentialNeighbors = 0;
+    for (Edge edge : edges) {
+      if (!edge.getNode1().equals(currentNodeName)) {
+        continue;
+      }
+      potentialNeighbors++;
+      List<FlowTraceHop> newHops = new ArrayList<>(hopsSoFar);
+      Set<Edge> newVisitedEdges = new LinkedHashSet<>(visitedEdges);
+      FlowTraceHop newHop =
+          new FlowTraceHop(
+              edge,
+              routesForThisNextHopInterface,
+              null,
+              null,
+              hopFlow(originalFlow, transformedFlow));
+      newVisitedEdges.add(edge);
+      newHops.add(newHop);
+      /*
+       * Check to see whether neighbor would refrain from sending ARP reply
+       * (NEIGHBOR_UNREACHABLE)
+       *
+       * This occurs if:
+       *
+       * - Using interface-only route
+       *
+       * AND
+       *
+       * - Neighbor does not own arpIp
+       *
+       * AND EITHER
+       *
+       * -- Neighbor not using proxy-arp
+       *
+       * - OR
+       *
+       * -- Subnet of neighbor's receiving-interface contains arpIp
+       */
+      if (arp) {
+        Ip arpIp;
+        Set<String> arpIpOwners;
+        if (finalNextHopIp == null) {
+          arpIp = dstIp;
+          arpIpOwners = dstIpOwners;
+        } else {
+          arpIp = finalNextHopIp;
+          arpIpOwners = dp.getIpOwners().get(arpIp);
+        }
+        // using interface-only route
+        String node2 = edge.getNode2();
+        if (arpIpOwners == null || !arpIpOwners.contains(node2)) {
+          // neighbor does not own arpIp
+          String int2Name = edge.getInt2();
+          Interface int2 = configurations.get(node2).getInterfaces().get(int2Name);
+          boolean neighborUnreachable = false;
+          Boolean proxyArp = int2.getProxyArp();
+          if (proxyArp == null || !proxyArp) {
+            // TODO: proxyArp probably shouldn't be null
+            neighborUnreachable = true;
+          } else {
+            for (InterfaceAddress address : int2.getAllAddresses()) {
+              if (address.getPrefix().containsIp(arpIp)) {
+                neighborUnreachable = true;
+                break;
+              }
+            }
+          }
+          if (neighborUnreachable) {
+            unreachableNeighbors++;
+            continue;
+          }
+        }
+      }
+      if (visitedEdges.contains(edge)) {
+        FlowTrace trace =
+            new FlowTrace(FlowDisposition.LOOP, newHops, FlowDisposition.LOOP.toString());
+        flowTraces.add(trace);
+        potentialNeighbors--;
+        continue;
+      }
+      String nextNodeName = edge.getNode2();
+      // now check output filter and input filter
+      if (nextHopInterfaceName != null) {
+        IpAccessList outFilter =
+            configurations
+                .get(currentNodeName)
+                .getInterfaces()
+                .get(nextHopInterfaceName)
+                .getOutgoingFilter();
+        if (!ignoreAcls && outFilter != null) {
+          FlowDisposition disposition = FlowDisposition.DENIED_OUT;
+          boolean denied =
+              flowTraceFilterHelper(
+                  flowTraces,
+                  originalFlow,
+                  transformedFlow,
+                  srcInterface,
+                  aclDefinitions,
+                  namedIpSpaces,
+                  newHops,
+                  outFilter,
+                  disposition);
+          if (denied) {
+            potentialNeighbors--;
+            continue;
+          }
+        }
+      }
+      IpAccessList inFilter =
+          configurations.get(nextNodeName).getInterfaces().get(edge.getInt2()).getIncomingFilter();
+      if (!ignoreAcls && inFilter != null) {
+        FlowDisposition disposition = FlowDisposition.DENIED_IN;
+        boolean denied =
+            flowTraceFilterHelper(
+                flowTraces,
+                originalFlow,
+                transformedFlow,
+                srcInterface,
+                aclDefinitions,
+                namedIpSpaces,
+                newHops,
+                inFilter,
+                disposition);
+        if (denied) {
+          potentialNeighbors--;
+          continue;
+        }
+      }
+      // recurse
+      collectFlowTraces(
+          dp,
+          configurations,
+          fibs,
+          nextNodeName,
+          newVisitedEdges,
+          newHops,
+          flowTraces,
+          originalFlow,
+          transformedFlow,
+          ignoreAcls);
+    }
+    if (arp && unreachableNeighbors > 0 && unreachableNeighbors == potentialNeighbors) {
+      FlowTrace trace =
+          neighborUnreachableTrace(
+              hopsSoFar,
+              nextHopInterface,
+              routesForThisNextHopInterface,
+              originalFlow,
+              transformedFlow);
+      flowTraces.add(trace);
+      continueToNextNextHopInterface = true;
+    }
+    return continueToNextNextHopInterface;
+  }
+
+  /**
+   * Applies the given list of source NAT rules to the given flow and returns the new transformed
+   * flow. If {@code sourceNats} is null, empty, or does not contain any ACL rules matching the
+   * {@link Flow}, the original flow is returned.
+   *
+   * <p>Each {@link SourceNat} is expected to be valid: it must have a NAT IP or pool.
+   */
+  @VisibleForTesting
+  static Flow applySourceNat(
+      Flow flow,
+      @Nullable String srcInterface,
+      Map<String, IpAccessList> aclDefinitions,
+      Map<String, IpSpace> namedIpSpaces,
+      @Nullable List<SourceNat> sourceNats) {
+    if (CommonUtil.isNullOrEmpty(sourceNats)) {
+      return flow;
+    }
+    Optional<SourceNat> matchingSourceNat =
+        sourceNats
+            .stream()
+            .filter(
+                sourceNat ->
+                    sourceNat.getAcl() != null
+                        && sourceNat
+                                .getAcl()
+                                .filter(flow, srcInterface, aclDefinitions, namedIpSpaces)
+                                .getAction()
+                            != LineAction.REJECT)
+            .findFirst();
+    if (!matchingSourceNat.isPresent()) {
+      // No NAT rule matched.
+      return flow;
+    }
+    SourceNat sourceNat = matchingSourceNat.get();
+    Ip natPoolStartIp = sourceNat.getPoolIpFirst();
+    if (natPoolStartIp == null) {
+      throw new BatfishException(
+          String.format(
+              "Error processing Source NAT rule %s: missing NAT address or pool", sourceNat));
+    }
+    Flow.Builder transformedFlowBuilder = new Flow.Builder(flow);
+    transformedFlowBuilder.setSrcIp(natPoolStartIp);
+    return transformedFlowBuilder.build();
+  }
+
+  private void collectFlowTraces(
+      DataPlane dp,
+      Map<String, Configuration> configurations,
+      Map<String, Map<String, Fib>> fibs,
+      String currentNodeName,
+      Set<Edge> visitedEdges,
+      List<FlowTraceHop> hopsSoFar,
+      Set<FlowTrace> flowTraces,
+      Flow originalFlow,
+      Flow transformedFlow,
+      boolean ignoreAcls) {
+    Ip dstIp = transformedFlow.getDstIp();
+    Set<String> dstIpOwners = dp.getIpOwners().get(dstIp);
+    Configuration currentConfiguration = configurations.get(currentNodeName);
+    if (dstIpOwners != null && dstIpOwners.contains(currentNodeName)) {
+      FlowTrace trace =
+          new FlowTrace(FlowDisposition.ACCEPTED, hopsSoFar, FlowDisposition.ACCEPTED.toString());
+      flowTraces.add(trace);
+    } else {
+      Map<String, IpAccessList> aclDefinitions = currentConfiguration.getIpAccessLists();
+      NavigableMap<String, IpSpace> namedIpSpaces = currentConfiguration.getIpSpaces();
+      String vrfName;
+      String srcInterface;
+      if (hopsSoFar.isEmpty()) {
+        vrfName = transformedFlow.getIngressVrf();
+        srcInterface = null;
+      } else {
+        FlowTraceHop lastHop = hopsSoFar.get(hopsSoFar.size() - 1);
+        srcInterface = lastHop.getEdge().getInt2();
+        vrfName = currentConfiguration.getInterfaces().get(srcInterface).getVrf().getName();
+      }
+      Map<AbstractRoute, Map<String, Map<Ip, Set<AbstractRoute>>>> nextHopInterfacesByRoute =
+          fibs.get(currentNodeName).get(vrfName).getNextHopInterfacesByRoute(dstIp);
+      Map<String, Map<Ip, Set<AbstractRoute>>> nextHopInterfacesWithRoutes =
+          fibs.get(currentNodeName).get(vrfName).getNextHopInterfaces(dstIp);
+      if (!nextHopInterfacesWithRoutes.isEmpty()) {
+        for (String nextHopInterfaceName : nextHopInterfacesWithRoutes.keySet()) {
+          // SortedSet<String> routesForThisNextHopInterface = new
+          // TreeSet<>(
+          // nextHopInterfacesWithRoutes.get(nextHopInterfaceName)
+          // .stream().map(ar -> ar.toString())
+          // .collect(Collectors.toSet()));
+          SortedSet<String> routesForThisNextHopInterface = new TreeSet<>();
+          Ip finalNextHopIp = null;
+          for (Entry<AbstractRoute, Map<String, Map<Ip, Set<AbstractRoute>>>> e :
+              nextHopInterfacesByRoute.entrySet()) {
+            AbstractRoute routeCandidate = e.getKey();
+            Map<String, Map<Ip, Set<AbstractRoute>>> routeCandidateNextHopInterfaces = e.getValue();
+            if (routeCandidateNextHopInterfaces.containsKey(nextHopInterfaceName)) {
+              Ip nextHopIp = routeCandidate.getNextHopIp();
+              if (!nextHopIp.equals(Route.UNSET_ROUTE_NEXT_HOP_IP)) {
+                Set<Ip> finalNextHopIps =
+                    routeCandidateNextHopInterfaces.get(nextHopInterfaceName).keySet();
+                if (finalNextHopIps.size() > 1) {
+                  throw new BatfishException(
+                      "Can not currently handle multiple final next hop ips across multiple "
+                          + "routes leading to one next hop interface");
+                }
+                Ip newFinalNextHopIp = finalNextHopIps.iterator().next();
+                if (finalNextHopIp != null && !newFinalNextHopIp.equals(finalNextHopIp)) {
+                  throw new BatfishException(
+                      "Can not currently handle multiple final next hop ips for same next hop "
+                          + "interface");
+                }
+                finalNextHopIp = newFinalNextHopIp;
+              }
+              routesForThisNextHopInterface.add(routeCandidate + "_fnhip:" + finalNextHopIp);
+            }
+          }
+          NodeInterfacePair nextHopInterface =
+              new NodeInterfacePair(currentNodeName, nextHopInterfaceName);
+          if (nextHopInterfaceName.equals(Interface.NULL_INTERFACE_NAME)) {
+            List<FlowTraceHop> newHops = new ArrayList<>(hopsSoFar);
+            Edge newEdge =
+                new Edge(
+                    nextHopInterface,
+                    new NodeInterfacePair(
+                        Configuration.NODE_NONE_NAME, Interface.NULL_INTERFACE_NAME));
+            FlowTraceHop newHop =
+                new FlowTraceHop(
+                    newEdge,
+                    routesForThisNextHopInterface,
+                    null,
+                    null,
+                    hopFlow(originalFlow, transformedFlow));
+            newHops.add(newHop);
+            FlowTrace nullRouteTrace =
+                new FlowTrace(
+                    FlowDisposition.NULL_ROUTED, newHops, FlowDisposition.NULL_ROUTED.toString());
+            flowTraces.add(nullRouteTrace);
+          } else {
+            Interface outgoingInterface =
+                configurations
+                    .get(nextHopInterface.getHostname())
+                    .getInterfaces()
+                    .get(nextHopInterface.getInterface());
+
+            // Apply any relevant source NAT rules.
+            transformedFlow =
+                applySourceNat(
+                    transformedFlow,
+                    srcInterface,
+                    aclDefinitions,
+                    namedIpSpaces,
+                    outgoingInterface.getSourceNats());
+
+            SortedSet<Edge> edges = dp.getTopology().getInterfaceEdges().get(nextHopInterface);
+            if (edges != null) {
+              boolean continueToNextNextHopInterface = false;
+              continueToNextNextHopInterface =
+                  processCurrentNextHopInterfaceEdges(
+                      dp,
+                      configurations,
+                      fibs,
+                      currentNodeName,
+                      visitedEdges,
+                      hopsSoFar,
+                      flowTraces,
+                      originalFlow,
+                      transformedFlow,
+                      srcInterface,
+                      aclDefinitions,
+                      namedIpSpaces,
+                      dstIp,
+                      dstIpOwners,
+                      nextHopInterfaceName,
+                      routesForThisNextHopInterface,
+                      finalNextHopIp,
+                      nextHopInterface,
+                      edges,
+                      true,
+                      ignoreAcls);
+              if (continueToNextNextHopInterface) {
+                continue;
+              }
+            } else {
+              /*
+               * Should only get here for delta environment where
+               * non-flow-sink interface from base has no edges in delta
+               */
+              Edge neighborUnreachbleEdge =
+                  new Edge(
+                      nextHopInterface,
+                      new NodeInterfacePair(
+                          Configuration.NODE_NONE_NAME, Interface.NULL_INTERFACE_NAME));
+              FlowTraceHop neighborUnreachableHop =
+                  new FlowTraceHop(
+                      neighborUnreachbleEdge,
+                      routesForThisNextHopInterface,
+                      null,
+                      null,
+                      hopFlow(originalFlow, transformedFlow));
+              List<FlowTraceHop> newHops = new ArrayList<>(hopsSoFar);
+              newHops.add(neighborUnreachableHop);
+              /** Check if denied out. If not, make standard neighbor-unreachable trace. */
+              IpAccessList outFilter = outgoingInterface.getOutgoingFilter();
+              boolean denied = false;
+              if (!ignoreAcls && outFilter != null) {
+                FlowDisposition disposition = FlowDisposition.DENIED_OUT;
+                denied =
+                    flowTraceFilterHelper(
+                        flowTraces,
+                        originalFlow,
+                        transformedFlow,
+                        srcInterface,
+                        aclDefinitions,
+                        namedIpSpaces,
+                        newHops,
+                        outFilter,
+                        disposition);
+              }
+              if (!denied) {
+                FlowTrace trace =
+                    new FlowTrace(
+                        FlowDisposition.NEIGHBOR_UNREACHABLE_OR_EXITS_NETWORK,
+                        newHops,
+                        FlowDisposition.NEIGHBOR_UNREACHABLE_OR_EXITS_NETWORK.toString());
+                flowTraces.add(trace);
+              }
+            }
+          }
+        }
+      } else {
+        FlowTrace trace =
+            new FlowTrace(FlowDisposition.NO_ROUTE, hopsSoFar, FlowDisposition.NO_ROUTE.toString());
+        flowTraces.add(trace);
+      }
+    }
+  }
+
+  private boolean flowTraceFilterHelper(
+      Set<FlowTrace> flowTraces,
+      Flow originalFlow,
+      Flow transformedFlow,
+      String srcInterface,
+      Map<String, IpAccessList> aclDefinitions,
+      Map<String, IpSpace> namedIpSpaces,
+      List<FlowTraceHop> newHops,
+      IpAccessList filter,
+      FlowDisposition disposition) {
+    boolean out = disposition == FlowDisposition.DENIED_OUT;
+    FilterResult outResult =
+        filter.filter(transformedFlow, srcInterface, aclDefinitions, namedIpSpaces);
+    String outFilterName = filter.getName();
+    Integer matchLine = outResult.getMatchLine();
+    String lineDesc;
+    if (matchLine != null) {
+      lineDesc = filter.getLines().get(matchLine).getName();
+      if (lineDesc == null) {
+        lineDesc = "line:" + matchLine;
+      }
+    } else {
+      lineDesc = "no-match";
+    }
+    boolean denied = outResult.getAction() == LineAction.REJECT;
+    if (denied) {
+      String notes = disposition + "{" + outFilterName + "}{" + lineDesc + "}";
+      if (out) {
+        FlowTraceHop lastHop = newHops.get(newHops.size() - 1);
+        newHops.remove(newHops.size() - 1);
+        Edge lastEdge = lastHop.getEdge();
+        Edge deniedOutEdge =
+            new Edge(
+                lastEdge.getFirst(),
+                new NodeInterfacePair(Configuration.NODE_NONE_NAME, Interface.NULL_INTERFACE_NAME));
+        FlowTraceHop deniedOutHop =
+            new FlowTraceHop(
+                deniedOutEdge,
+                lastHop.getRoutes(),
+                null,
+                null,
+                hopFlow(originalFlow, transformedFlow));
+        newHops.add(deniedOutHop);
+      }
+      FlowTrace trace = new FlowTrace(disposition, newHops, notes);
+      flowTraces.add(trace);
+    } else {
+      FlowTraceHop hop = newHops.get(newHops.size() - 1);
+      String filterNotes = "{" + outFilterName + "}{" + lineDesc + "}";
+      if (out) {
+        hop.setFilterOut(filterNotes);
+      } else {
+        hop.setFilterIn(filterNotes);
+      }
+    }
+    return denied;
+  }
+
+  @Nullable
+  private Flow hopFlow(Flow originalFlow, Flow transformedFlow) {
+    if (originalFlow == transformedFlow) {
+      return null;
+    } else {
+      return transformedFlow;
+    }
+  }
+
+  private FlowTrace neighborUnreachableTrace(
+      List<FlowTraceHop> completedHops,
+      NodeInterfacePair srcInterface,
+      SortedSet<String> routes,
+      Flow originalFlow,
+      Flow transformedFlow) {
+    Edge neighborUnreachbleEdge =
+        new Edge(
+            srcInterface,
+            new NodeInterfacePair(Configuration.NODE_NONE_NAME, Interface.NULL_INTERFACE_NAME));
+    FlowTraceHop neighborUnreachableHop =
+        new FlowTraceHop(
+            neighborUnreachbleEdge, routes, null, null, hopFlow(originalFlow, transformedFlow));
+    List<FlowTraceHop> newHops = new ArrayList<>(completedHops);
+    newHops.add(neighborUnreachableHop);
+    FlowTrace trace =
+        new FlowTrace(
+            FlowDisposition.NEIGHBOR_UNREACHABLE_OR_EXITS_NETWORK,
+            newHops,
+            FlowDisposition.NEIGHBOR_UNREACHABLE_OR_EXITS_NETWORK.toString());
+    return trace;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/dataplane/bdp/BdpDataPlane.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/bdp/BdpDataPlane.java
@@ -37,6 +37,15 @@ public class BdpDataPlane implements Serializable, DataPlane {
 
   Topology _topology;
 
+  @Override
+  public Map<String, Configuration> getConfigurations() {
+    return _nodes
+        .entrySet()
+        .stream()
+        .collect(ImmutableMap.toImmutableMap(Entry::getKey, e -> e.getValue().getConfiguration()));
+  }
+
+  @Override
   public Map<Ip, Set<String>> getIpOwners() {
     return _ipOwners;
   }
@@ -65,6 +74,11 @@ public class BdpDataPlane implements Serializable, DataPlane {
           ribs.put(hostname, byVrf.build());
         });
     return ribs.build();
+  }
+
+  @Override
+  public Topology getTopology() {
+    return _topology;
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/dataplane/bdp/BdpDataPlanePlugin.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/bdp/BdpDataPlanePlugin.java
@@ -20,6 +20,7 @@ import org.batfish.datamodel.FlowTrace;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.answers.BdpAnswerElement;
 import org.batfish.datamodel.collections.IbgpTopology;
+import org.batfish.dataplane.TracerouteEngineImpl;
 
 @AutoService(Plugin.class)
 public class BdpDataPlanePlugin extends DataPlanePlugin {
@@ -139,7 +140,8 @@ public class BdpDataPlanePlugin extends DataPlanePlugin {
   @Override
   public void processFlows(Set<Flow> flows, DataPlane dataPlane, boolean ignoreAcls) {
     BdpDataPlane dp = (BdpDataPlane) dataPlane;
-    _flowTraces.put(dp, _engine.processFlows(dp, flows, ignoreAcls));
+    _flowTraces.put(
+        dp, TracerouteEngineImpl.getInstance().processFlows(dp, flows, dp.getFibs(), ignoreAcls));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/dataplane/bdp/BdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/bdp/BdpEngine.java
@@ -7,30 +7,23 @@ import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.graph.Network;
 import io.opentracing.ActiveSpan;
 import io.opentracing.util.GlobalTracer;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
-import javax.annotation.Nullable;
 import org.apache.commons.collections4.map.LRUMap;
-import org.batfish.common.BatfishException;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.BdpOscillationException;
 import org.batfish.common.Version;
-import org.batfish.common.plugin.FlowProcessor;
 import org.batfish.common.util.CommonUtil;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.BgpAdvertisement;
@@ -38,78 +31,17 @@ import org.batfish.datamodel.BgpNeighbor;
 import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.BgpSession;
 import org.batfish.datamodel.Configuration;
-import org.batfish.datamodel.DataPlane;
-import org.batfish.datamodel.Edge;
-import org.batfish.datamodel.FilterResult;
-import org.batfish.datamodel.Flow;
-import org.batfish.datamodel.FlowDisposition;
-import org.batfish.datamodel.FlowTrace;
-import org.batfish.datamodel.FlowTraceHop;
 import org.batfish.datamodel.Interface;
-import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
-import org.batfish.datamodel.IpAccessList;
-import org.batfish.datamodel.IpSpace;
-import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Route;
 import org.batfish.datamodel.RouteBuilder;
 import org.batfish.datamodel.RoutingProtocol;
-import org.batfish.datamodel.SourceNat;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.answers.BdpAnswerElement;
-import org.batfish.datamodel.collections.NodeInterfacePair;
+import org.batfish.dataplane.TracerouteEngineImpl;
 
-public class BdpEngine implements FlowProcessor {
-
-  private static final String TRACEROUTE_INGRESS_NODE_INTERFACE_NAME =
-      "traceroute_source_interface";
-
-  private static final String TRACEROUTE_INGRESS_NODE_NAME = "traceroute_source_node";
-
-  /**
-   * Applies the given list of source NAT rules to the given flow and returns the new transformed
-   * flow. If {@code sourceNats} is null, empty, or does not contain any ACL rules matching the
-   * {@link Flow}, the original flow is returned.
-   *
-   * <p>Each {@link SourceNat} is expected to be valid: it must have a NAT IP or pool.
-   */
-  static Flow applySourceNat(
-      Flow flow,
-      @Nullable String srcInterface,
-      Map<String, IpAccessList> aclDefinitions,
-      Map<String, IpSpace> namedIpSpaces,
-      @Nullable List<SourceNat> sourceNats) {
-    if (CommonUtil.isNullOrEmpty(sourceNats)) {
-      return flow;
-    }
-    Optional<SourceNat> matchingSourceNat =
-        sourceNats
-            .stream()
-            .filter(
-                sourceNat ->
-                    sourceNat.getAcl() != null
-                        && sourceNat
-                                .getAcl()
-                                .filter(flow, srcInterface, aclDefinitions, namedIpSpaces)
-                                .getAction()
-                            != LineAction.REJECT)
-            .findFirst();
-    if (!matchingSourceNat.isPresent()) {
-      // No NAT rule matched.
-      return flow;
-    }
-    SourceNat sourceNat = matchingSourceNat.get();
-    Ip natPoolStartIp = sourceNat.getPoolIpFirst();
-    if (natPoolStartIp == null) {
-      throw new BatfishException(
-          String.format(
-              "Error processing Source NAT rule %s: missing NAT address or pool", sourceNat));
-    }
-    Flow.Builder transformedFlowBuilder = new Flow.Builder(flow);
-    transformedFlowBuilder.setSrcIp(natPoolStartIp);
-    return transformedFlowBuilder.build();
-  }
+public class BdpEngine {
 
   private final BatfishLogger _logger;
 
@@ -141,194 +73,6 @@ public class BdpEngine implements FlowProcessor {
       return true;
     } else {
       return evenDependentRoutesChanged.get() || oddDependentRoutesChanged.get();
-    }
-  }
-
-  private void collectFlowTraces(
-      BdpDataPlane dp,
-      String currentNodeName,
-      Set<Edge> visitedEdges,
-      List<FlowTraceHop> hopsSoFar,
-      Set<FlowTrace> flowTraces,
-      Flow originalFlow,
-      Flow transformedFlow,
-      boolean ignoreAcls) {
-    Ip dstIp = transformedFlow.getDstIp();
-    Set<String> dstIpOwners = dp._ipOwners.get(dstIp);
-    if (dstIpOwners != null && dstIpOwners.contains(currentNodeName)) {
-      FlowTrace trace =
-          new FlowTrace(FlowDisposition.ACCEPTED, hopsSoFar, FlowDisposition.ACCEPTED.toString());
-      flowTraces.add(trace);
-    } else {
-      Node currentNode = dp._nodes.get(currentNodeName);
-      Map<String, IpAccessList> aclDefinitions = currentNode._c.getIpAccessLists();
-      Map<String, IpSpace> namedIpSpaces = currentNode._c.getIpSpaces();
-      String vrfName;
-      String srcInterface;
-      if (hopsSoFar.isEmpty()) {
-        vrfName = transformedFlow.getIngressVrf();
-        srcInterface = null;
-      } else {
-        FlowTraceHop lastHop = hopsSoFar.get(hopsSoFar.size() - 1);
-        srcInterface = lastHop.getEdge().getInt2();
-        vrfName = currentNode._c.getInterfaces().get(srcInterface).getVrf().getName();
-      }
-      VirtualRouter currentVirtualRouter = currentNode._virtualRouters.get(vrfName);
-      Map<AbstractRoute, Map<String, Map<Ip, Set<AbstractRoute>>>> nextHopInterfacesByRoute =
-          currentVirtualRouter._fib.getNextHopInterfacesByRoute(dstIp);
-      Map<String, Map<Ip, Set<AbstractRoute>>> nextHopInterfacesWithRoutes =
-          currentVirtualRouter._fib.getNextHopInterfaces(dstIp);
-      if (!nextHopInterfacesWithRoutes.isEmpty()) {
-        for (String nextHopInterfaceName : nextHopInterfacesWithRoutes.keySet()) {
-          // SortedSet<String> routesForThisNextHopInterface = new
-          // TreeSet<>(
-          // nextHopInterfacesWithRoutes.get(nextHopInterfaceName)
-          // .stream().map(ar -> ar.toString())
-          // .collect(Collectors.toSet()));
-          SortedSet<String> routesForThisNextHopInterface = new TreeSet<>();
-          Ip finalNextHopIp = null;
-          for (Entry<AbstractRoute, Map<String, Map<Ip, Set<AbstractRoute>>>> e :
-              nextHopInterfacesByRoute.entrySet()) {
-            AbstractRoute routeCandidate = e.getKey();
-            Map<String, Map<Ip, Set<AbstractRoute>>> routeCandidateNextHopInterfaces = e.getValue();
-            if (routeCandidateNextHopInterfaces.containsKey(nextHopInterfaceName)) {
-              Ip nextHopIp = routeCandidate.getNextHopIp();
-              if (!nextHopIp.equals(Route.UNSET_ROUTE_NEXT_HOP_IP)) {
-                Set<Ip> finalNextHopIps =
-                    routeCandidateNextHopInterfaces.get(nextHopInterfaceName).keySet();
-                if (finalNextHopIps.size() > 1) {
-                  throw new BatfishException(
-                      "Can not currently handle multiple final next hop ips across multiple "
-                          + "routes leading to one next hop interface");
-                }
-                Ip newFinalNextHopIp = finalNextHopIps.iterator().next();
-                if (finalNextHopIp != null && !newFinalNextHopIp.equals(finalNextHopIp)) {
-                  throw new BatfishException(
-                      "Can not currently handle multiple final next hop ips for same next hop "
-                          + "interface");
-                }
-                finalNextHopIp = newFinalNextHopIp;
-              }
-              routesForThisNextHopInterface.add(routeCandidate + "_fnhip:" + finalNextHopIp);
-            }
-          }
-          NodeInterfacePair nextHopInterface =
-              new NodeInterfacePair(currentNodeName, nextHopInterfaceName);
-          if (nextHopInterfaceName.equals(Interface.NULL_INTERFACE_NAME)) {
-            List<FlowTraceHop> newHops = new ArrayList<>(hopsSoFar);
-            Edge newEdge =
-                new Edge(
-                    nextHopInterface,
-                    new NodeInterfacePair(
-                        Configuration.NODE_NONE_NAME, Interface.NULL_INTERFACE_NAME));
-            FlowTraceHop newHop =
-                new FlowTraceHop(
-                    newEdge,
-                    routesForThisNextHopInterface,
-                    null,
-                    null,
-                    hopFlow(originalFlow, transformedFlow));
-            newHops.add(newHop);
-            FlowTrace nullRouteTrace =
-                new FlowTrace(
-                    FlowDisposition.NULL_ROUTED, newHops, FlowDisposition.NULL_ROUTED.toString());
-            flowTraces.add(nullRouteTrace);
-          } else {
-            Interface outgoingInterface =
-                dp._nodes
-                    .get(nextHopInterface.getHostname())
-                    ._c
-                    .getInterfaces()
-                    .get(nextHopInterface.getInterface());
-
-            // Apply any relevant source NAT rules.
-            transformedFlow =
-                applySourceNat(
-                    transformedFlow,
-                    srcInterface,
-                    aclDefinitions,
-                    namedIpSpaces,
-                    outgoingInterface.getSourceNats());
-
-            SortedSet<Edge> edges = dp._topology.getInterfaceEdges().get(nextHopInterface);
-            if (edges != null) {
-              boolean continueToNextNextHopInterface = false;
-              continueToNextNextHopInterface =
-                  processCurrentNextHopInterfaceEdges(
-                      dp,
-                      currentNodeName,
-                      visitedEdges,
-                      hopsSoFar,
-                      flowTraces,
-                      originalFlow,
-                      transformedFlow,
-                      srcInterface,
-                      aclDefinitions,
-                      namedIpSpaces,
-                      dstIp,
-                      dstIpOwners,
-                      nextHopInterfaceName,
-                      routesForThisNextHopInterface,
-                      finalNextHopIp,
-                      nextHopInterface,
-                      edges,
-                      true,
-                      ignoreAcls);
-              if (continueToNextNextHopInterface) {
-                continue;
-              }
-            } else {
-              /*
-               * Should only get here for delta environment where
-               * non-flow-sink interface from base has no edges in delta
-               */
-              Edge neighborUnreachbleEdge =
-                  new Edge(
-                      nextHopInterface,
-                      new NodeInterfacePair(
-                          Configuration.NODE_NONE_NAME, Interface.NULL_INTERFACE_NAME));
-              FlowTraceHop neighborUnreachableHop =
-                  new FlowTraceHop(
-                      neighborUnreachbleEdge,
-                      routesForThisNextHopInterface,
-                      null,
-                      null,
-                      hopFlow(originalFlow, transformedFlow));
-              List<FlowTraceHop> newHops = new ArrayList<>(hopsSoFar);
-              newHops.add(neighborUnreachableHop);
-              /** Check if denied out. If not, make standard neighbor-unreachable trace. */
-              IpAccessList outFilter = outgoingInterface.getOutgoingFilter();
-              boolean denied = false;
-              if (!ignoreAcls && outFilter != null) {
-                FlowDisposition disposition = FlowDisposition.DENIED_OUT;
-                denied =
-                    flowTraceFilterHelper(
-                        flowTraces,
-                        originalFlow,
-                        transformedFlow,
-                        srcInterface,
-                        aclDefinitions,
-                        namedIpSpaces,
-                        newHops,
-                        outFilter,
-                        disposition);
-              }
-              if (!denied) {
-                FlowTrace trace =
-                    new FlowTrace(
-                        FlowDisposition.NEIGHBOR_UNREACHABLE_OR_EXITS_NETWORK,
-                        newHops,
-                        FlowDisposition.NEIGHBOR_UNREACHABLE_OR_EXITS_NETWORK.toString());
-                flowTraces.add(trace);
-              }
-            }
-          }
-        }
-      } else {
-        FlowTrace trace =
-            new FlowTrace(FlowDisposition.NO_ROUTE, hopsSoFar, FlowDisposition.NO_ROUTE.toString());
-        flowTraces.add(trace);
-      }
     }
   }
 
@@ -829,7 +573,8 @@ public class BdpEngine implements FlowProcessor {
       computeFibs(nodes);
       dp.setTopology(topology);
       Network<BgpNeighbor, BgpSession> bgpTopology =
-          initBgpTopology(configuations, dp.getIpOwners(), false, true, this, dp);
+          initBgpTopology(
+              configuations, dp.getIpOwners(), false, true, TracerouteEngineImpl.getInstance(), dp);
       dp.setBgpTopology(bgpTopology);
       // END DONE ONCE
 
@@ -933,7 +678,14 @@ public class BdpEngine implements FlowProcessor {
          */
         if (numDependentRoutesIterations < 2) {
           computeFibs(nodes);
-          bgpTopology = initBgpTopology(configuations, dp.getIpOwners(), false, true, this, dp);
+          bgpTopology =
+              initBgpTopology(
+                  configuations,
+                  dp.getIpOwners(),
+                  false,
+                  true,
+                  TracerouteEngineImpl.getInstance(),
+                  dp);
         }
         dp.setBgpTopology(bgpTopology);
       } while (checkDependentRoutesChanged(
@@ -1231,64 +983,6 @@ public class BdpEngine implements FlowProcessor {
     return errorMessage;
   }
 
-  private boolean flowTraceFilterHelper(
-      Set<FlowTrace> flowTraces,
-      Flow originalFlow,
-      Flow transformedFlow,
-      String srcInterface,
-      Map<String, IpAccessList> aclDefinitions,
-      Map<String, IpSpace> namedIpSpaces,
-      List<FlowTraceHop> newHops,
-      IpAccessList filter,
-      FlowDisposition disposition) {
-    boolean out = disposition == FlowDisposition.DENIED_OUT;
-    FilterResult outResult =
-        filter.filter(transformedFlow, srcInterface, aclDefinitions, namedIpSpaces);
-    String outFilterName = filter.getName();
-    Integer matchLine = outResult.getMatchLine();
-    String lineDesc;
-    if (matchLine != null) {
-      lineDesc = filter.getLines().get(matchLine).getName();
-      if (lineDesc == null) {
-        lineDesc = "line:" + matchLine;
-      }
-    } else {
-      lineDesc = "no-match";
-    }
-    boolean denied = outResult.getAction() == LineAction.REJECT;
-    if (denied) {
-      String notes = disposition + "{" + outFilterName + "}{" + lineDesc + "}";
-      if (out) {
-        FlowTraceHop lastHop = newHops.get(newHops.size() - 1);
-        newHops.remove(newHops.size() - 1);
-        Edge lastEdge = lastHop.getEdge();
-        Edge deniedOutEdge =
-            new Edge(
-                lastEdge.getFirst(),
-                new NodeInterfacePair(Configuration.NODE_NONE_NAME, Interface.NULL_INTERFACE_NAME));
-        FlowTraceHop deniedOutHop =
-            new FlowTraceHop(
-                deniedOutEdge,
-                lastHop.getRoutes(),
-                null,
-                null,
-                hopFlow(originalFlow, transformedFlow));
-        newHops.add(deniedOutHop);
-      }
-      FlowTrace trace = new FlowTrace(disposition, newHops, notes);
-      flowTraces.add(trace);
-    } else {
-      FlowTraceHop hop = newHops.get(newHops.size() - 1);
-      String filterNotes = "{" + outFilterName + "}{" + lineDesc + "}";
-      if (out) {
-        hop.setFilterOut(filterNotes);
-      } else {
-        hop.setFilterIn(filterNotes);
-      }
-    }
-    return denied;
-  }
-
   SortedMap<String, SortedMap<String, SortedSet<AbstractRoute>>> getRoutes(BdpDataPlane dp) {
     SortedMap<String, SortedMap<String, SortedSet<AbstractRoute>>> routesByHostname =
         new TreeMap<>();
@@ -1394,15 +1088,6 @@ public class BdpEngine implements FlowProcessor {
                 : debugIterations(msgWithPrefixes, iterationRoutes, 1, end);
         throw new BdpOscillationException(errorMessage);
       }
-    }
-  }
-
-  @Nullable
-  private Flow hopFlow(Flow originalFlow, Flow transformedFlow) {
-    if (originalFlow == transformedFlow) {
-      return null;
-    } else {
-      return transformedFlow;
     }
   }
 
@@ -1523,272 +1208,6 @@ public class BdpEngine implements FlowProcessor {
               ripInternalImportCompleted.incrementAndGet();
             });
     return ripInternalIterations;
-  }
-
-  private FlowTrace neighborUnreachableTrace(
-      List<FlowTraceHop> completedHops,
-      NodeInterfacePair srcInterface,
-      SortedSet<String> routes,
-      Flow originalFlow,
-      Flow transformedFlow) {
-    Edge neighborUnreachbleEdge =
-        new Edge(
-            srcInterface,
-            new NodeInterfacePair(Configuration.NODE_NONE_NAME, Interface.NULL_INTERFACE_NAME));
-    FlowTraceHop neighborUnreachableHop =
-        new FlowTraceHop(
-            neighborUnreachbleEdge, routes, null, null, hopFlow(originalFlow, transformedFlow));
-    List<FlowTraceHop> newHops = new ArrayList<>(completedHops);
-    newHops.add(neighborUnreachableHop);
-    FlowTrace trace =
-        new FlowTrace(
-            FlowDisposition.NEIGHBOR_UNREACHABLE_OR_EXITS_NETWORK,
-            newHops,
-            FlowDisposition.NEIGHBOR_UNREACHABLE_OR_EXITS_NETWORK.toString());
-    return trace;
-  }
-
-  private boolean processCurrentNextHopInterfaceEdges(
-      BdpDataPlane dp,
-      String currentNodeName,
-      Set<Edge> visitedEdges,
-      List<FlowTraceHop> hopsSoFar,
-      Set<FlowTrace> flowTraces,
-      Flow originalFlow,
-      Flow transformedFlow,
-      String srcInterface,
-      Map<String, IpAccessList> aclDefinitions,
-      Map<String, IpSpace> namedIpSpaces,
-      Ip dstIp,
-      Set<String> dstIpOwners,
-      @Nullable String nextHopInterfaceName,
-      SortedSet<String> routesForThisNextHopInterface,
-      @Nullable Ip finalNextHopIp,
-      @Nullable NodeInterfacePair nextHopInterface,
-      SortedSet<Edge> edges,
-      boolean arp,
-      boolean ignoreAcls) {
-    boolean continueToNextNextHopInterface = false;
-    int unreachableNeighbors = 0;
-    int potentialNeighbors = 0;
-    for (Edge edge : edges) {
-      if (!edge.getNode1().equals(currentNodeName)) {
-        continue;
-      }
-      potentialNeighbors++;
-      List<FlowTraceHop> newHops = new ArrayList<>(hopsSoFar);
-      Set<Edge> newVisitedEdges = new LinkedHashSet<>(visitedEdges);
-      FlowTraceHop newHop =
-          new FlowTraceHop(
-              edge,
-              routesForThisNextHopInterface,
-              null,
-              null,
-              hopFlow(originalFlow, transformedFlow));
-      newVisitedEdges.add(edge);
-      newHops.add(newHop);
-      /*
-       * Check to see whether neighbor would refrain from sending ARP reply
-       * (NEIGHBOR_UNREACHABLE)
-       *
-       * This occurs if:
-       *
-       * - Using interface-only route
-       *
-       * AND
-       *
-       * - Neighbor does not own arpIp
-       *
-       * AND EITHER
-       *
-       * -- Neighbor not using proxy-arp
-       *
-       * - OR
-       *
-       * -- Subnet of neighbor's receiving-interface contains arpIp
-       */
-      if (arp) {
-        Ip arpIp;
-        Set<String> arpIpOwners;
-        if (finalNextHopIp == null) {
-          arpIp = dstIp;
-          arpIpOwners = dstIpOwners;
-        } else {
-          arpIp = finalNextHopIp;
-          arpIpOwners = dp._ipOwners.get(arpIp);
-        }
-        // using interface-only route
-        String node2 = edge.getNode2();
-        if (arpIpOwners == null || !arpIpOwners.contains(node2)) {
-          // neighbor does not own arpIp
-          String int2Name = edge.getInt2();
-          Interface int2 = dp._nodes.get(node2)._c.getInterfaces().get(int2Name);
-          boolean neighborUnreachable = false;
-          Boolean proxyArp = int2.getProxyArp();
-          if (proxyArp == null || !proxyArp) {
-            // TODO: proxyArp probably shouldn't be null
-            neighborUnreachable = true;
-          } else {
-            for (InterfaceAddress address : int2.getAllAddresses()) {
-              if (address.getPrefix().containsIp(arpIp)) {
-                neighborUnreachable = true;
-                break;
-              }
-            }
-          }
-          if (neighborUnreachable) {
-            unreachableNeighbors++;
-            continue;
-          }
-        }
-      }
-      if (visitedEdges.contains(edge)) {
-        FlowTrace trace =
-            new FlowTrace(FlowDisposition.LOOP, newHops, FlowDisposition.LOOP.toString());
-        flowTraces.add(trace);
-        potentialNeighbors--;
-        continue;
-      }
-      String nextNodeName = edge.getNode2();
-      // now check output filter and input filter
-      if (nextHopInterfaceName != null) {
-        IpAccessList outFilter =
-            dp._nodes
-                .get(currentNodeName)
-                ._c
-                .getInterfaces()
-                .get(nextHopInterfaceName)
-                .getOutgoingFilter();
-        if (!ignoreAcls && outFilter != null) {
-          FlowDisposition disposition = FlowDisposition.DENIED_OUT;
-          boolean denied =
-              flowTraceFilterHelper(
-                  flowTraces,
-                  originalFlow,
-                  transformedFlow,
-                  srcInterface,
-                  aclDefinitions,
-                  namedIpSpaces,
-                  newHops,
-                  outFilter,
-                  disposition);
-          if (denied) {
-            potentialNeighbors--;
-            continue;
-          }
-        }
-      }
-      IpAccessList inFilter =
-          dp._nodes.get(nextNodeName)._c.getInterfaces().get(edge.getInt2()).getIncomingFilter();
-      if (!ignoreAcls && inFilter != null) {
-        FlowDisposition disposition = FlowDisposition.DENIED_IN;
-        boolean denied =
-            flowTraceFilterHelper(
-                flowTraces,
-                originalFlow,
-                transformedFlow,
-                srcInterface,
-                aclDefinitions,
-                namedIpSpaces,
-                newHops,
-                inFilter,
-                disposition);
-        if (denied) {
-          potentialNeighbors--;
-          continue;
-        }
-      }
-      // recurse
-      collectFlowTraces(
-          dp,
-          nextNodeName,
-          newVisitedEdges,
-          newHops,
-          flowTraces,
-          originalFlow,
-          transformedFlow,
-          ignoreAcls);
-    }
-    if (arp && unreachableNeighbors > 0 && unreachableNeighbors == potentialNeighbors) {
-      FlowTrace trace =
-          neighborUnreachableTrace(
-              hopsSoFar,
-              nextHopInterface,
-              routesForThisNextHopInterface,
-              originalFlow,
-              transformedFlow);
-      flowTraces.add(trace);
-      continueToNextNextHopInterface = true;
-    }
-    return continueToNextNextHopInterface;
-  }
-
-  @Override
-  public SortedMap<Flow, Set<FlowTrace>> processFlows(
-      DataPlane dataPlane, Set<Flow> flows, boolean ignoreAcls) {
-    Map<Flow, Set<FlowTrace>> flowTraces = new ConcurrentHashMap<>();
-    BdpDataPlane dp = (BdpDataPlane) dataPlane;
-    flows
-        .parallelStream()
-        .forEach(
-            flow -> {
-              Set<FlowTrace> currentFlowTraces = new TreeSet<>();
-              flowTraces.put(flow, currentFlowTraces);
-              String ingressNodeName = flow.getIngressNode();
-              if (ingressNodeName == null) {
-                throw new BatfishException(
-                    "Cannot construct flow trace since ingressNode is not specified");
-              }
-              Ip dstIp = flow.getDstIp();
-              if (dstIp == null) {
-                throw new BatfishException(
-                    "Cannot construct flow trace since dstIp is not specified");
-              }
-              Set<Edge> visitedEdges = Collections.emptySet();
-              List<FlowTraceHop> hops = new ArrayList<>();
-              Set<String> dstIpOwners = dp._ipOwners.get(dstIp);
-              SortedSet<Edge> edges = new TreeSet<>();
-              String ingressInterfaceName = flow.getIngressInterface();
-              if (ingressInterfaceName != null) {
-                edges.add(
-                    new Edge(
-                        TRACEROUTE_INGRESS_NODE_NAME,
-                        TRACEROUTE_INGRESS_NODE_INTERFACE_NAME,
-                        ingressNodeName,
-                        ingressInterfaceName));
-                processCurrentNextHopInterfaceEdges(
-                    dp,
-                    TRACEROUTE_INGRESS_NODE_NAME,
-                    visitedEdges,
-                    hops,
-                    currentFlowTraces,
-                    flow,
-                    flow,
-                    ingressInterfaceName,
-                    dp._nodes.get(ingressNodeName)._c.getIpAccessLists(),
-                    dp._nodes.get(ingressNodeName)._c.getIpSpaces(),
-                    dstIp,
-                    dstIpOwners,
-                    null,
-                    new TreeSet<>(),
-                    null,
-                    null,
-                    edges,
-                    false,
-                    ignoreAcls);
-              } else {
-                collectFlowTraces(
-                    dp,
-                    ingressNodeName,
-                    visitedEdges,
-                    hops,
-                    currentFlowTraces,
-                    flow,
-                    flow,
-                    ignoreAcls);
-              }
-            });
-    return new TreeMap<>(flowTraces);
   }
 
   private void recordIterationDebugInfo(

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlane.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlane.java
@@ -21,7 +21,6 @@ import org.batfish.datamodel.Fib;
 import org.batfish.datamodel.GenericRib;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Topology;
-import org.batfish.datamodel.collections.NodeInterfacePair;
 
 public class IncrementalDataPlane implements Serializable, DataPlane {
 
@@ -29,15 +28,13 @@ public class IncrementalDataPlane implements Serializable, DataPlane {
 
   private transient Network<BgpNeighbor, BgpSession> _bgpTopology;
 
-  Set<NodeInterfacePair> _flowSinks;
-
-  Map<Ip, Set<String>> _ipOwners;
+  private Map<Ip, Set<String>> _ipOwners;
 
   private Map<Ip, String> _ipOwnersSimple;
 
   Map<String, Node> _nodes;
 
-  Topology _topology;
+  private Topology _topology;
 
   @Override
   public Map<String, Map<String, Fib>> getFibs() {
@@ -58,6 +55,7 @@ public class IncrementalDataPlane implements Serializable, DataPlane {
                                 Entry::getKey, eVr -> eVr.getValue()._fib))));
   }
 
+  @Override
   public Map<Ip, Set<String>> getIpOwners() {
     return _ipOwners;
   }
@@ -89,6 +87,11 @@ public class IncrementalDataPlane implements Serializable, DataPlane {
   }
 
   @Override
+  public Topology getTopology() {
+    return _topology;
+  }
+
+  @Override
   public SortedSet<Edge> getTopologyEdges() {
     return _topology.getEdges();
   }
@@ -99,10 +102,6 @@ public class IncrementalDataPlane implements Serializable, DataPlane {
       Map<Ip, String> ipOwnersSimple) {
     setIpOwners(ipOwners);
     setIpOwnersSimple(ipOwnersSimple);
-  }
-
-  public void setFlowSinks(Set<NodeInterfacePair> flowSinks) {
-    _flowSinks = flowSinks;
   }
 
   public void setIpOwners(Map<Ip, Set<String>> ipOwners) {
@@ -124,6 +123,14 @@ public class IncrementalDataPlane implements Serializable, DataPlane {
   @Override
   public Network<BgpNeighbor, BgpSession> getBgpTopology() {
     return _bgpTopology;
+  }
+
+  @Override
+  public Map<String, Configuration> getConfigurations() {
+    return _nodes
+        .entrySet()
+        .stream()
+        .collect(ImmutableMap.toImmutableMap(Entry::getKey, e -> e.getValue().getConfiguration()));
   }
 
   void setBgpTopology(Network<BgpNeighbor, BgpSession> bgpTopology) {

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePlugin.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePlugin.java
@@ -22,6 +22,7 @@ import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.answers.Answer;
 import org.batfish.datamodel.answers.BdpAnswerElement;
 import org.batfish.datamodel.collections.IbgpTopology;
+import org.batfish.dataplane.TracerouteEngineImpl;
 
 @AutoService(Plugin.class)
 public class IncrementalDataPlanePlugin extends DataPlanePlugin {
@@ -128,7 +129,8 @@ public class IncrementalDataPlanePlugin extends DataPlanePlugin {
   public void processFlows(Set<Flow> flows, DataPlane dataPlane, boolean ignoreAcls) {
     _flowTraces.put(
         (IncrementalDataPlane) dataPlane,
-        _engine.processFlows((IncrementalDataPlane) dataPlane, flows, ignoreAcls));
+        TracerouteEngineImpl.getInstance()
+            .processFlows(dataPlane, flows, dataPlane.getFibs(), ignoreAcls));
   }
 
   private IncrementalDataPlane loadDataPlane() {

--- a/projects/batfish/src/test/java/org/batfish/dataplane/TracerouteEngineTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/TracerouteEngineTest.java
@@ -1,0 +1,116 @@
+package org.batfish.dataplane;
+
+import static java.util.Collections.singletonList;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import org.batfish.common.BatfishException;
+import org.batfish.datamodel.Flow;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpAccessList;
+import org.batfish.datamodel.IpAccessListLine;
+import org.batfish.datamodel.LineAction;
+import org.batfish.datamodel.SourceNat;
+import org.batfish.datamodel.acl.TrueExpr;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/** Tests for {@link TracerouteEngineImpl} */
+public class TracerouteEngineTest {
+  @Rule public ExpectedException _thrown = ExpectedException.none();
+
+  private static Flow makeFlow() {
+    Flow.Builder builder = new Flow.Builder();
+    builder.setSrcIp(new Ip("1.2.3.4"));
+    builder.setIngressNode("foo");
+    builder.setTag("TEST");
+    return builder.build();
+  }
+
+  private static IpAccessList makeAcl(String name, LineAction action) {
+    IpAccessListLine aclLine =
+        IpAccessListLine.builder().setAction(action).setMatchCondition(TrueExpr.INSTANCE).build();
+    return new IpAccessList(name, singletonList(aclLine));
+  }
+
+  @Test
+  public void testApplySourceNatSingleAclMatch() {
+    Flow flow = makeFlow();
+
+    SourceNat nat = new SourceNat();
+    nat.setAcl(makeAcl("accept", LineAction.ACCEPT));
+    nat.setPoolIpFirst(new Ip("4.5.6.7"));
+
+    Flow transformed =
+        TracerouteEngineImpl.applySourceNat(
+            flow, null, ImmutableMap.of(), ImmutableMap.of(), singletonList(nat));
+    assertThat(transformed.getSrcIp(), equalTo(new Ip("4.5.6.7")));
+  }
+
+  @Test
+  public void testApplySourceNatSingleAclNoMatch() {
+    Flow flow = makeFlow();
+
+    SourceNat nat = new SourceNat();
+    nat.setAcl(makeAcl("reject", LineAction.REJECT));
+    nat.setPoolIpFirst(new Ip("4.5.6.7"));
+
+    Flow transformed =
+        TracerouteEngineImpl.applySourceNat(
+            flow, null, ImmutableMap.of(), ImmutableMap.of(), singletonList(nat));
+    assertThat(transformed, is(flow));
+  }
+
+  @Test
+  public void testApplySourceNatFirstMatchWins() {
+    Flow flow = makeFlow();
+
+    SourceNat nat = new SourceNat();
+    nat.setAcl(makeAcl("firstAccept", LineAction.ACCEPT));
+    nat.setPoolIpFirst(new Ip("4.5.6.7"));
+
+    SourceNat secondNat = new SourceNat();
+    secondNat.setAcl(makeAcl("secondAccept", LineAction.ACCEPT));
+    secondNat.setPoolIpFirst(new Ip("4.5.6.8"));
+
+    Flow transformed =
+        TracerouteEngineImpl.applySourceNat(
+            flow, null, ImmutableMap.of(), ImmutableMap.of(), Lists.newArrayList(nat, secondNat));
+    assertThat(transformed.getSrcIp(), equalTo(new Ip("4.5.6.7")));
+  }
+
+  @Test
+  public void testApplySourceNatLateMatchWins() {
+    Flow flow = makeFlow();
+
+    SourceNat nat = new SourceNat();
+    nat.setAcl(makeAcl("rejectAll", LineAction.REJECT));
+    nat.setPoolIpFirst(new Ip("4.5.6.7"));
+
+    SourceNat secondNat = new SourceNat();
+    secondNat.setAcl(makeAcl("acceptAnyway", LineAction.ACCEPT));
+    secondNat.setPoolIpFirst(new Ip("4.5.6.8"));
+
+    Flow transformed =
+        TracerouteEngineImpl.applySourceNat(
+            flow, null, ImmutableMap.of(), ImmutableMap.of(), Lists.newArrayList(nat, secondNat));
+    assertThat(transformed.getSrcIp(), equalTo(new Ip("4.5.6.8")));
+  }
+
+  @Test
+  public void testApplySourceNatInvalidAclThrows() {
+    Flow flow = makeFlow();
+
+    SourceNat nat = new SourceNat();
+    nat.setAcl(makeAcl("matchAll", LineAction.ACCEPT));
+
+    _thrown.expect(BatfishException.class);
+    _thrown.expectMessage("missing NAT address or pool");
+    TracerouteEngineImpl.applySourceNat(
+        flow, null, ImmutableMap.of(), ImmutableMap.of(), singletonList(nat));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/dataplane/bdp/BdpDataPlanePluginTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/bdp/BdpDataPlanePluginTest.java
@@ -1,6 +1,5 @@
 package org.batfish.dataplane.bdp;
 
-import static java.util.Collections.singletonList;
 import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
@@ -19,7 +18,6 @@ import static org.junit.Assert.assertTrue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
-import com.google.common.collect.Lists;
 import com.google.common.graph.Network;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -36,7 +34,6 @@ import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.batfish.common.BatfishException;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.BdpOscillationException;
 import org.batfish.common.plugin.DataPlanePlugin;
@@ -50,24 +47,18 @@ import org.batfish.datamodel.BgpSession;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.DataPlane;
-import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
-import org.batfish.datamodel.IpAccessList;
-import org.batfish.datamodel.IpAccessListLine;
-import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.MultipathEquivalentAsPathMatchMode;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.OriginType;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Route;
 import org.batfish.datamodel.RoutingProtocol;
-import org.batfish.datamodel.SourceNat;
 import org.batfish.datamodel.StaticRoute;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.Vrf;
-import org.batfish.datamodel.acl.TrueExpr;
 import org.batfish.datamodel.answers.BdpAnswerElement;
 import org.batfish.datamodel.collections.RoutesByVrf;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
@@ -209,96 +200,6 @@ public class BdpDataPlanePluginTest {
 
     // Test that compute Data Plane finishes in a finite time
     dataPlanePlugin.computeDataPlane(false);
-  }
-
-  private static Flow makeFlow() {
-    Flow.Builder builder = new Flow.Builder();
-    builder.setSrcIp(new Ip("1.2.3.4"));
-    builder.setIngressNode("foo");
-    builder.setTag("TEST");
-    return builder.build();
-  }
-
-  private static IpAccessList makeAcl(String name, LineAction action) {
-    IpAccessListLine aclLine =
-        IpAccessListLine.builder().setAction(action).setMatchCondition(TrueExpr.INSTANCE).build();
-    return new IpAccessList(name, singletonList(aclLine));
-  }
-
-  @Test
-  public void testApplySourceNatSingleAclMatch() {
-    Flow flow = makeFlow();
-
-    SourceNat nat = new SourceNat();
-    nat.setAcl(makeAcl("accept", LineAction.ACCEPT));
-    nat.setPoolIpFirst(new Ip("4.5.6.7"));
-
-    Flow transformed =
-        BdpEngine.applySourceNat(
-            flow, null, ImmutableMap.of(), ImmutableMap.of(), singletonList(nat));
-    assertThat(transformed.getSrcIp(), equalTo(new Ip("4.5.6.7")));
-  }
-
-  @Test
-  public void testApplySourceNatSingleAclNoMatch() {
-    Flow flow = makeFlow();
-
-    SourceNat nat = new SourceNat();
-    nat.setAcl(makeAcl("reject", LineAction.REJECT));
-    nat.setPoolIpFirst(new Ip("4.5.6.7"));
-
-    Flow transformed =
-        BdpEngine.applySourceNat(
-            flow, null, ImmutableMap.of(), ImmutableMap.of(), singletonList(nat));
-    assertThat(transformed, is(flow));
-  }
-
-  @Test
-  public void testApplySourceNatFirstMatchWins() {
-    Flow flow = makeFlow();
-
-    SourceNat nat = new SourceNat();
-    nat.setAcl(makeAcl("firstAccept", LineAction.ACCEPT));
-    nat.setPoolIpFirst(new Ip("4.5.6.7"));
-
-    SourceNat secondNat = new SourceNat();
-    secondNat.setAcl(makeAcl("secondAccept", LineAction.ACCEPT));
-    secondNat.setPoolIpFirst(new Ip("4.5.6.8"));
-
-    Flow transformed =
-        BdpEngine.applySourceNat(
-            flow, null, ImmutableMap.of(), ImmutableMap.of(), Lists.newArrayList(nat, secondNat));
-    assertThat(transformed.getSrcIp(), equalTo(new Ip("4.5.6.7")));
-  }
-
-  @Test
-  public void testApplySourceNatLateMatchWins() {
-    Flow flow = makeFlow();
-
-    SourceNat nat = new SourceNat();
-    nat.setAcl(makeAcl("rejectAll", LineAction.REJECT));
-    nat.setPoolIpFirst(new Ip("4.5.6.7"));
-
-    SourceNat secondNat = new SourceNat();
-    secondNat.setAcl(makeAcl("acceptAnyway", LineAction.ACCEPT));
-    secondNat.setPoolIpFirst(new Ip("4.5.6.8"));
-
-    Flow transformed =
-        BdpEngine.applySourceNat(
-            flow, null, ImmutableMap.of(), ImmutableMap.of(), Lists.newArrayList(nat, secondNat));
-    assertThat(transformed.getSrcIp(), equalTo(new Ip("4.5.6.8")));
-  }
-
-  @Test
-  public void testApplySourceNatInvalidAclThrows() {
-    Flow flow = makeFlow();
-
-    SourceNat nat = new SourceNat();
-    nat.setAcl(makeAcl("matchAll", LineAction.ACCEPT));
-
-    _thrown.expect(BatfishException.class);
-    _thrown.expectMessage("missing NAT address or pool");
-    BdpEngine.applySourceNat(flow, null, ImmutableMap.of(), ImmutableMap.of(), singletonList(nat));
   }
 
   private void testBgpAsPathMultipathHelper(


### PR DESCRIPTION
Incremental progress towards cleaner dataplane code

*Changes*:
- No functionality changes
- Pull out a traceroute engine
   - Single traceroute engine interface (`TracerouteEngine`, formerly `FlowProcessor`)
   - Single traceroute implementation (`TracerouteEngineImpl`), as a singleton.
   - De-duplicate tests.
   - Decouple traceroute engine from dataplane internals. No need for traceroute to know about `Node` and `VirtualRouter`, it operates on datamodel classes and info extracted from `Dataplane` interface, namely `Configuration` and `Fib`