### PR TITLE
ProxyArp: update getter & setter to primitive boolean

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -944,7 +944,7 @@ public final class Interface extends ComparableStructure<String> {
   }
 
   @JsonPropertyDescription("Whether or not proxy-ARP is enabled on this interface.")
-  public Boolean getProxyArp() {
+  public boolean getProxyArp() {
     return _proxyArp;
   }
 
@@ -1240,7 +1240,7 @@ public final class Interface extends ComparableStructure<String> {
     _address = address;
   }
 
-  public void setProxyArp(Boolean proxyArp) {
+  public void setProxyArp(boolean proxyArp) {
     _proxyArp = proxyArp;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/TracerouteEngineImpl.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/TracerouteEngineImpl.java
@@ -206,9 +206,7 @@ public class TracerouteEngineImpl implements ITracerouteEngine {
           String int2Name = edge.getInt2();
           Interface int2 = configurations.get(node2).getInterfaces().get(int2Name);
           boolean neighborUnreachable = false;
-          Boolean proxyArp = int2.getProxyArp();
-          if (proxyArp == null || !proxyArp) {
-            // TODO: proxyArp probably shouldn't be null
+          if (!int2.getProxyArp()) {
             neighborUnreachable = true;
           } else {
             for (InterfaceAddress address : int2.getAllAddresses()) {


### PR DESCRIPTION
Followup on #1262:
Boxing/unboxing won't work for null values, so updated getters and setter to primitives as well.
There was only one place where we expected a `Boolean` and we weren't handling that in any sophisticated way, so this change should not be a problem.