### PR TITLE
Register dataplane plugins in BatfishTestUtils

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/dataplane/bdp/DynamicBgpTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/bdp/DynamicBgpTest.java
@@ -53,8 +53,6 @@ public class DynamicBgpTest {
                 .build(),
             _folder);
 
-    BdpDataPlanePlugin dataPlanePlugin = new BdpDataPlanePlugin();
-    dataPlanePlugin.initialize(batfish);
     batfish.computeDataPlane(false); // compute and cache the dataPlane
 
     DataPlane dp = batfish.loadDataPlane();
@@ -87,8 +85,6 @@ public class DynamicBgpTest {
                 .build(),
             _folder);
 
-    BdpDataPlanePlugin dataPlanePlugin = new BdpDataPlanePlugin();
-    dataPlanePlugin.initialize(batfish);
     batfish.computeDataPlane(false); // compute and cache the dataPlane
 
     DataPlane dp = batfish.loadDataPlane();
@@ -132,8 +128,6 @@ public class DynamicBgpTest {
                 .build(),
             _folder);
 
-    BdpDataPlanePlugin dataPlanePlugin = new BdpDataPlanePlugin();
-    dataPlanePlugin.initialize(batfish);
     batfish.computeDataPlane(false); // compute and cache the dataPlane
 
     DataPlane dp = batfish.loadDataPlane();

--- a/projects/batfish/src/test/java/org/batfish/dataplane/bdp/RipAndBgpTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/bdp/RipAndBgpTest.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.stream.Collectors;
+import org.batfish.common.plugin.DataPlanePlugin;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Prefix;
@@ -38,9 +39,8 @@ public class RipAndBgpTest {
                 .setConfigurationText(testrigResourcePrefix, configurations)
                 .build(),
             _folder);
-    BdpDataPlanePlugin dataPlanePlugin = new BdpDataPlanePlugin();
-    dataPlanePlugin.initialize(batfish);
     batfish.computeDataPlane(false);
+    DataPlanePlugin dataPlanePlugin = batfish.getDataPlanePlugin();
     SortedMap<String, SortedMap<String, SortedSet<AbstractRoute>>> routes =
         dataPlanePlugin.getRoutes(batfish.loadDataPlane());
     SortedSet<AbstractRoute> r1Routes = routes.get("r1").get(Configuration.DEFAULT_VRF_NAME);

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -78,6 +78,7 @@ import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.stream.Collectors;
 import org.batfish.common.WellKnownCommunity;
+import org.batfish.common.plugin.DataPlanePlugin;
 import org.batfish.common.util.CommonUtil;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.AsPath;
@@ -101,7 +102,6 @@ import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
 import org.batfish.datamodel.matchers.OspfAreaMatchers;
-import org.batfish.dataplane.bdp.BdpDataPlanePlugin;
 import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
 import org.batfish.main.TestrigText;
@@ -720,8 +720,7 @@ public class CiscoGrammarTest {
     Map<String, Configuration> configurations = batfish.loadConfigurations();
     Map<Ip, Set<String>> ipOwners = CommonUtil.computeIpOwners(configurations, true);
     CommonUtil.initBgpTopology(configurations, ipOwners, false);
-    BdpDataPlanePlugin dataPlanePlugin = new BdpDataPlanePlugin();
-    dataPlanePlugin.initialize(batfish);
+    DataPlanePlugin dataPlanePlugin = batfish.getDataPlanePlugin();
     batfish.computeDataPlane(false); // compute and cache the dataPlane
 
     // Check that 1.1.1.1/32 appears on r3

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
@@ -27,6 +27,7 @@ import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.collections.BgpAdvertisementsByVrf;
 import org.batfish.datamodel.collections.RoutesByVrf;
 import org.batfish.dataplane.bdp.BdpDataPlanePlugin;
+import org.batfish.dataplane.ibdp.IncrementalDataPlanePlugin;
 import org.junit.rules.TemporaryFolder;
 
 public class BatfishTestUtils {
@@ -86,7 +87,15 @@ public class BatfishTestUtils {
           batfish.computeEnvironmentTopology(configurations),
           "environment topology");
     }
+    registerDataPlanePlugins(batfish);
     return batfish;
+  }
+
+  private static void registerDataPlanePlugins(Batfish batfish) {
+    BdpDataPlanePlugin bdpPlugin = new BdpDataPlanePlugin();
+    bdpPlugin.initialize(batfish);
+    IncrementalDataPlanePlugin ibdpPlugin = new IncrementalDataPlanePlugin();
+    ibdpPlugin.initialize(batfish);
   }
 
   /**
@@ -118,7 +127,6 @@ public class BatfishTestUtils {
     settings.setContainerDir(containerDir);
     settings.setTestrig("tempTestrig");
     settings.setEnvironmentName("tempEnvironment");
-    settings.setDataplaneEngineName(BdpDataPlanePlugin.PLUGIN_NAME);
     Batfish.initTestrigSettings(settings);
     Path testrigPath = settings.getBaseTestrigSettings().getTestRigPath();
     settings.setActiveTestrigSettings(settings.getBaseTestrigSettings());
@@ -141,6 +149,7 @@ public class BatfishTestUtils {
             makeEnvBgpCache(),
             makeEnvRouteCache(),
             makeForwardingAnalysisCache());
+    registerDataPlanePlugins(batfish);
     return batfish;
   }
 

--- a/projects/batfish/src/test/java/org/batfish/symbolic/abstraction/BatfishCompressionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/symbolic/abstraction/BatfishCompressionTest.java
@@ -40,7 +40,6 @@ import org.batfish.datamodel.StaticRoute;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.routing_policy.statement.If;
-import org.batfish.dataplane.bdp.BdpDataPlanePlugin;
 import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
 import org.junit.Test;
@@ -208,9 +207,6 @@ public class BatfishCompressionTest {
     TemporaryFolder tmp = new TemporaryFolder();
     tmp.create();
     Batfish batfish = BatfishTestUtils.getBatfish(configs, tmp);
-    BdpDataPlanePlugin bdpDataPlanePlugin = new BdpDataPlanePlugin();
-    bdpDataPlanePlugin.initialize(batfish);
-    batfish.registerDataPlanePlugin(bdpDataPlanePlugin, "bdp");
     batfish.computeDataPlane(false);
     return batfish.loadDataPlane();
   }

--- a/projects/batfish/src/test/java/org/batfish/z3/NodJobAclTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/NodJobAclTest.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
 import org.batfish.common.Pair;
+import org.batfish.common.plugin.DataPlanePlugin;
 import org.batfish.config.Settings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
@@ -51,7 +52,6 @@ import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.datamodel.acl.MatchSrcInterface;
 import org.batfish.datamodel.acl.PermittedByAcl;
-import org.batfish.dataplane.bdp.BdpDataPlanePlugin;
 import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
 import org.batfish.z3.state.OriginateVrf;
@@ -135,9 +135,6 @@ public class NodJobAclTest {
     TemporaryFolder tmp = new TemporaryFolder();
     tmp.create();
     Batfish batfish = BatfishTestUtils.getBatfish(configs, tmp);
-    BdpDataPlanePlugin bdpDataPlanePlugin = new BdpDataPlanePlugin();
-    bdpDataPlanePlugin.initialize(batfish);
-    batfish.registerDataPlanePlugin(bdpDataPlanePlugin, "bdp");
     batfish.computeDataPlane(false);
     DataPlane dataPlane = batfish.loadDataPlane();
 
@@ -194,8 +191,9 @@ public class NodJobAclTest {
     assertThat(fieldConstraints, hasEntry(Field.SRC_IP.getName(), new Ip("1.1.1.1").asLong()));
 
     Set<Flow> flows = nodJob.getFlows(fieldConstraintsByOriginateVrf);
-    bdpDataPlanePlugin.processFlows(flows, dataPlane, false);
-    List<FlowTrace> flowTraces = bdpDataPlanePlugin.getHistoryFlowTraces(dataPlane);
+    DataPlanePlugin dpPlugin = batfish.getDataPlanePlugin();
+    dpPlugin.processFlows(flows, dataPlane, false);
+    List<FlowTrace> flowTraces = dpPlugin.getHistoryFlowTraces(dataPlane);
     assertThat(flowTraces, hasSize(2));
     assertThat(
         flowTraces,
@@ -273,9 +271,6 @@ public class NodJobAclTest {
     TemporaryFolder tmp = new TemporaryFolder();
     tmp.create();
     Batfish batfish = BatfishTestUtils.getBatfish(configs, tmp);
-    BdpDataPlanePlugin bdpDataPlanePlugin = new BdpDataPlanePlugin();
-    bdpDataPlanePlugin.initialize(batfish);
-    batfish.registerDataPlanePlugin(bdpDataPlanePlugin, "bdp");
     batfish.computeDataPlane(false);
     DataPlane dataPlane = batfish.loadDataPlane();
 

--- a/projects/batfish/src/test/java/org/batfish/z3/NodJobChunkingTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/NodJobChunkingTest.java
@@ -34,7 +34,6 @@ import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.StaticRoute;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.Vrf;
-import org.batfish.dataplane.bdp.BdpDataPlanePlugin;
 import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
 import org.batfish.z3.state.OriginateVrf;
@@ -142,9 +141,6 @@ public class NodJobChunkingTest {
     TemporaryFolder tmp = new TemporaryFolder();
     tmp.create();
     Batfish batfish = BatfishTestUtils.getBatfish(_configs, tmp);
-    BdpDataPlanePlugin bdpDataPlanePlugin = new BdpDataPlanePlugin();
-    bdpDataPlanePlugin.initialize(batfish);
-    batfish.registerDataPlanePlugin(bdpDataPlanePlugin, "bdp");
     batfish.computeDataPlane(false);
     _dataPlane = batfish.loadDataPlane();
   }

--- a/projects/batfish/src/test/java/org/batfish/z3/NodJobTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/NodJobTest.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
 import org.batfish.common.Pair;
+import org.batfish.common.plugin.DataPlanePlugin;
 import org.batfish.config.Settings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
@@ -47,7 +48,6 @@ import org.batfish.datamodel.SourceNat;
 import org.batfish.datamodel.StaticRoute;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.Vrf;
-import org.batfish.dataplane.bdp.BdpDataPlanePlugin;
 import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
 import org.batfish.z3.state.OriginateVrf;
@@ -57,7 +57,7 @@ import org.junit.rules.TemporaryFolder;
 
 public class NodJobTest {
 
-  private BdpDataPlanePlugin _bdpDataPlanePlugin;
+  private DataPlanePlugin _dataPlanePlugin;
   private SortedMap<String, Configuration> _configs;
   private DataPlane _dataPlane;
   private Configuration _dstNode;
@@ -166,9 +166,7 @@ public class NodJobTest {
     TemporaryFolder tmp = new TemporaryFolder();
     tmp.create();
     Batfish batfish = BatfishTestUtils.getBatfish(_configs, tmp);
-    _bdpDataPlanePlugin = new BdpDataPlanePlugin();
-    _bdpDataPlanePlugin.initialize(batfish);
-    batfish.registerDataPlanePlugin(_bdpDataPlanePlugin, "bdp");
+    _dataPlanePlugin = batfish.getDataPlanePlugin();
     batfish.computeDataPlane(false);
     _dataPlane = batfish.loadDataPlane();
   }
@@ -215,8 +213,8 @@ public class NodJobTest {
     assertThat(fieldConstraints, hasEntry(Field.SRC_IP.getName(), new Ip("1.0.0.10").asLong()));
 
     Set<Flow> flows = nodJob.getFlows(fieldConstraintsByOriginateVrf);
-    _bdpDataPlanePlugin.processFlows(flows, _dataPlane, false);
-    List<FlowTrace> flowTraces = _bdpDataPlanePlugin.getHistoryFlowTraces(_dataPlane);
+    _dataPlanePlugin.processFlows(flows, _dataPlane, false);
+    List<FlowTrace> flowTraces = _dataPlanePlugin.getHistoryFlowTraces(_dataPlane);
 
     flowTraces.forEach(
         trace -> {
@@ -279,8 +277,8 @@ public class NodJobTest {
     assertThat(fieldConstraints, hasEntry(Field.SRC_IP.getName(), new Ip("3.0.0.1").asLong()));
 
     Set<Flow> flows = nodJob.getFlows(fieldConstraintsByOriginateVrf);
-    _bdpDataPlanePlugin.processFlows(flows, _dataPlane, false);
-    List<FlowTrace> flowTraces = _bdpDataPlanePlugin.getHistoryFlowTraces(_dataPlane);
+    _dataPlanePlugin.processFlows(flows, _dataPlane, false);
+    List<FlowTrace> flowTraces = _dataPlanePlugin.getHistoryFlowTraces(_dataPlane);
 
     flowTraces.forEach(
         trace -> {


### PR DESCRIPTION
Quality of life enchancement:
- Automatically register both dataplane plugins for tests when getting batfish instance through `initBatfish` or `getBatfishFromTestrigText`.
- This simplifies writing tests that are not tied to a particular dataplane engine. No need to explicitly create `BdpDataplanePlugin` and this will also make tests work with ibdp.
- The plugin picked will the the default one specified in `Settings`, which currently is still **bdp** (working towards switching).