### PR TITLE
Add null checks in Juniper FwFrom conversion

### DIFF
--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/HeaderSpaceMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/HeaderSpaceMatchers.java
@@ -5,6 +5,8 @@ import javax.annotation.Nonnull;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.State;
 import org.batfish.datamodel.matchers.HeaderSpaceMatchersImpl.HasDstIps;
+import org.batfish.datamodel.matchers.HeaderSpaceMatchersImpl.HasNotDstIps;
+import org.batfish.datamodel.matchers.HeaderSpaceMatchersImpl.HasNotSrcIps;
 import org.batfish.datamodel.matchers.HeaderSpaceMatchersImpl.HasSrcIps;
 import org.batfish.datamodel.matchers.HeaderSpaceMatchersImpl.HasStates;
 import org.hamcrest.Matcher;
@@ -17,6 +19,22 @@ public class HeaderSpaceMatchers {
    */
   public static HasDstIps hasDstIps(@Nonnull Matcher<? super IpSpace> subMatcher) {
     return new HasDstIps(subMatcher);
+  }
+
+  /**
+   * Provides a matcher that matches if the provided {@code subMatcher} matches the HeaderSpace's
+   * notDstIps.
+   */
+  public static HasNotDstIps hasNotDstIps(@Nonnull Matcher<? super IpSpace> subMatcher) {
+    return new HasNotDstIps(subMatcher);
+  }
+
+  /**
+   * Provides a matcher that matches if the provided {@code subMatcher} matches the HeaderSpace's
+   * notSrcIps.
+   */
+  public static HasNotSrcIps hasNotSrcIps(@Nonnull Matcher<? super IpSpace> subMatcher) {
+    return new HasNotSrcIps(subMatcher);
   }
 
   /**

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/HeaderSpaceMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/HeaderSpaceMatchersImpl.java
@@ -34,6 +34,28 @@ public class HeaderSpaceMatchersImpl {
     }
   }
 
+  static class HasNotDstIps extends FeatureMatcher<HeaderSpace, IpSpace> {
+    HasNotDstIps(@Nonnull Matcher<? super IpSpace> subMatcher) {
+      super(subMatcher, "A HeaderSpace with notDstIps:", "notDstIps");
+    }
+
+    @Override
+    protected IpSpace featureValueOf(HeaderSpace actual) {
+      return actual.getNotDstIps();
+    }
+  }
+
+  static class HasNotSrcIps extends FeatureMatcher<HeaderSpace, IpSpace> {
+    HasNotSrcIps(@Nonnull Matcher<? super IpSpace> subMatcher) {
+      super(subMatcher, "A HeaderSpace with notSrcIps:", "notSrcIps");
+    }
+
+    @Override
+    protected IpSpace featureValueOf(HeaderSpace actual) {
+      return actual.getNotSrcIps();
+    }
+  }
+
   static class HasSrcIps extends FeatureMatcher<HeaderSpace, IpSpace> {
     HasSrcIps(@Nonnull Matcher<? super IpSpace> subMatcher) {
       super(subMatcher, "A HeaderSpace with srcIps:", "srcIps");

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromDestinationPrefixList.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromDestinationPrefixList.java
@@ -40,12 +40,12 @@ public final class FwFromDestinationPrefixList extends FwFrom {
               .stream()
               .map(IpWildcard::toIpSpace)
               .collect(ImmutableList.toImmutableList());
-      headerSpaceBuilder.setDstIps(
-          AclIpSpace.union(
-              ImmutableList.<IpSpace>builder()
-                  .add(headerSpaceBuilder.getDstIps())
-                  .addAll(wildcards)
-                  .build()));
+
+      ImmutableList.Builder<IpSpace> ipSpaceBuilder = ImmutableList.builder();
+      if (headerSpaceBuilder.getDstIps() != null) {
+        ipSpaceBuilder.add(headerSpaceBuilder.getDstIps());
+      }
+      headerSpaceBuilder.setDstIps(AclIpSpace.union(ipSpaceBuilder.addAll(wildcards).build()));
     } else {
       w.redFlag("Reference to undefined source prefix-list: \"" + _name + "\"");
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromDestinationPrefixListExcept.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromDestinationPrefixListExcept.java
@@ -41,12 +41,12 @@ public final class FwFromDestinationPrefixListExcept extends FwFrom {
               .stream()
               .map(IpWildcard::toIpSpace)
               .collect(ImmutableList.toImmutableList());
-      headerSpaceBuilder.setNotDstIps(
-          AclIpSpace.union(
-              ImmutableList.<IpSpace>builder()
-                  .add(headerSpaceBuilder.getNotDstIps())
-                  .addAll(wildcards)
-                  .build()));
+
+      ImmutableList.Builder<IpSpace> ipSpaceBuilder = ImmutableList.builder();
+      if (headerSpaceBuilder.getNotDstIps() != null) {
+        ipSpaceBuilder.add(headerSpaceBuilder.getNotDstIps());
+      }
+      headerSpaceBuilder.setNotDstIps(AclIpSpace.union(ipSpaceBuilder.addAll(wildcards).build()));
     } else {
       w.redFlag("Reference to undefined source prefix-list: \"" + _name + "\"");
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromSourcePrefixList.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromSourcePrefixList.java
@@ -40,12 +40,12 @@ public final class FwFromSourcePrefixList extends FwFrom {
               .stream()
               .map(IpWildcard::toIpSpace)
               .collect(ImmutableList.toImmutableList());
-      headerSpaceBuilder.setSrcIps(
-          AclIpSpace.union(
-              ImmutableList.<IpSpace>builder()
-                  .add(headerSpaceBuilder.getSrcIps())
-                  .addAll(wildcards)
-                  .build()));
+
+      ImmutableList.Builder<IpSpace> ipSpaceBuilder = ImmutableList.builder();
+      if (headerSpaceBuilder.getSrcIps() != null) {
+        ipSpaceBuilder.add(headerSpaceBuilder.getSrcIps());
+      }
+      headerSpaceBuilder.setSrcIps(AclIpSpace.union(ipSpaceBuilder.addAll(wildcards).build()));
     } else {
       w.redFlag("Reference to undefined source prefix-list: \"" + _name + "\"");
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromSourcePrefixListExcept.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromSourcePrefixListExcept.java
@@ -40,12 +40,12 @@ public class FwFromSourcePrefixListExcept extends FwFrom {
               .stream()
               .map(IpWildcard::toIpSpace)
               .collect(ImmutableList.toImmutableList());
-      headerSpaceBuilder.setNotSrcIps(
-          AclIpSpace.union(
-              ImmutableList.<IpSpace>builder()
-                  .add(headerSpaceBuilder.getNotSrcIps())
-                  .addAll(wildcards)
-                  .build()));
+
+      ImmutableList.Builder<IpSpace> ipSpaceBuilder = ImmutableList.builder();
+      if (headerSpaceBuilder.getNotSrcIps() != null) {
+        ipSpaceBuilder.add(headerSpaceBuilder.getNotSrcIps());
+      }
+      headerSpaceBuilder.setNotSrcIps(AclIpSpace.union(ipSpaceBuilder.addAll(wildcards).build()));
     } else {
       w.redFlag("Reference to undefined source prefix-list: \"" + _name + "\"");
     }

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromDestinationPrefixListExceptTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromDestinationPrefixListExceptTest.java
@@ -14,10 +14,8 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Ip;
-import org.batfish.datamodel.IpIpSpace;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.IpWildcard;
-import org.batfish.datamodel.IpWildcardIpSpace;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.RouteFilterLine;
@@ -58,10 +56,10 @@ public class FwFromDestinationPrefixListExceptTest {
     FwFromDestinationPrefixListExcept fwFrom =
         new FwFromDestinationPrefixListExcept(BASE_PREFIX_LIST_NAME);
 
-    // Combine base IP prefix with null headerSpace IpSpace
+    // Apply base IP prefix to headerSpace with null IpSpace
     fwFrom.applyTo(headerSpaceBuilder, _jc, _w, _c);
 
-    // Combine base IP prefix with non-null headerSpace IpSpace
+    // Apply base IP prefix to headerSpace with non-null IpSpace
     fwFrom.applyTo(headerSpaceBuilderWithIpSpaceFilter, _jc, _w, _c);
 
     // Confirm combining base with null IpSpace results in just base IpSpace

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromDestinationPrefixListExceptTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromDestinationPrefixListExceptTest.java
@@ -47,12 +47,12 @@ public class FwFromDestinationPrefixListExceptTest {
 
   @Test
   public void testApplyTo() {
-    Ip additionalIp = new Ip("2.2.2.2");
+    IpSpace additionalIpSpace = new Ip("2.2.2.2").toIpSpace();
     IpSpace baseIpSpace = new IpWildcard(BASE_IP_PREFIX).toIpSpace();
 
     HeaderSpace.Builder headerSpaceBuilder = HeaderSpace.builder();
     HeaderSpace.Builder headerSpaceBuilderWithIpSpaceFilter =
-        HeaderSpace.builder().setNotDstIps(additionalIp.toIpSpace());
+        HeaderSpace.builder().setNotDstIps(additionalIpSpace);
     FwFromDestinationPrefixListExcept fwFrom =
         new FwFromDestinationPrefixListExcept(BASE_PREFIX_LIST_NAME);
 
@@ -72,7 +72,7 @@ public class FwFromDestinationPrefixListExceptTest {
             isAclIpSpaceThat(
                 hasLines(
                     containsInAnyOrder(
-                        AclIpSpaceLine.permit(additionalIp.toIpSpace()),
+                        AclIpSpaceLine.permit(additionalIpSpace),
                         AclIpSpaceLine.permit(baseIpSpace))))));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromDestinationPrefixListExceptTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromDestinationPrefixListExceptTest.java
@@ -1,0 +1,80 @@
+package org.batfish.representation.juniper;
+
+import static org.batfish.datamodel.matchers.AclIpSpaceMatchers.hasLines;
+import static org.batfish.datamodel.matchers.AclIpSpaceMatchers.isAclIpSpaceThat;
+import static org.batfish.datamodel.matchers.HeaderSpaceMatchers.hasNotDstIps;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+import com.google.common.collect.ImmutableSet;
+import org.batfish.common.Warnings;
+import org.batfish.datamodel.AclIpSpaceLine;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.HeaderSpace;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpIpSpace;
+import org.batfish.datamodel.IpSpace;
+import org.batfish.datamodel.IpWildcard;
+import org.batfish.datamodel.IpWildcardIpSpace;
+import org.batfish.datamodel.LineAction;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.RouteFilterLine;
+import org.batfish.datamodel.RouteFilterList;
+import org.batfish.datamodel.SubRange;
+import org.junit.Before;
+import org.junit.Test;
+
+public class FwFromDestinationPrefixListExceptTest {
+  private JuniperConfiguration _jc;
+  private Warnings _w;
+  private Configuration _c;
+
+  private static final String BASE_PREFIX_LIST_NAME = "prefixList";
+  private static final String BASE_IP_PREFIX = "1.2.3.4/32";
+
+  @Before
+  public void setup() {
+    _jc = new JuniperConfiguration(ImmutableSet.of());
+    _jc.getPrefixLists().put(BASE_PREFIX_LIST_NAME, new PrefixList(BASE_PREFIX_LIST_NAME, -1));
+    _w = new Warnings();
+    _c = new Configuration("test", ConfigurationFormat.FLAT_JUNIPER);
+    RouteFilterList rflist = new RouteFilterList(BASE_PREFIX_LIST_NAME);
+    RouteFilterLine rfline =
+        new RouteFilterLine(LineAction.ACCEPT, Prefix.parse(BASE_IP_PREFIX), new SubRange(0, 0));
+    rflist.addLine(rfline);
+    _c.getRouteFilterLists().put(BASE_PREFIX_LIST_NAME, rflist);
+  }
+
+  @Test
+  public void testApplyTo() {
+    Ip additionalIp = new Ip("2.2.2.2");
+    IpSpace baseIpSpace = new IpWildcard(BASE_IP_PREFIX).toIpSpace();
+
+    HeaderSpace.Builder headerSpaceBuilder = HeaderSpace.builder();
+    HeaderSpace.Builder headerSpaceBuilderWithIpSpaceFilter =
+        HeaderSpace.builder().setNotDstIps(additionalIp.toIpSpace());
+    FwFromDestinationPrefixListExcept fwFrom =
+        new FwFromDestinationPrefixListExcept(BASE_PREFIX_LIST_NAME);
+
+    // Combine base IP prefix with null headerSpace IpSpace
+    fwFrom.applyTo(headerSpaceBuilder, _jc, _w, _c);
+
+    // Combine base IP prefix with non-null headerSpace IpSpace
+    fwFrom.applyTo(headerSpaceBuilderWithIpSpaceFilter, _jc, _w, _c);
+
+    // Confirm combining base with null IpSpace results in just base IpSpace
+    assertThat(headerSpaceBuilder.build(), hasNotDstIps(equalTo(baseIpSpace)));
+
+    // Confirm combining base with additional IpSpace results in an IpSpace combining both
+    assertThat(
+        headerSpaceBuilderWithIpSpaceFilter.build(),
+        hasNotDstIps(
+            isAclIpSpaceThat(
+                hasLines(
+                    containsInAnyOrder(
+                        AclIpSpaceLine.permit(additionalIp.toIpSpace()),
+                        AclIpSpaceLine.permit(baseIpSpace))))));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromDestinationPrefixListTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromDestinationPrefixListTest.java
@@ -47,12 +47,12 @@ public class FwFromDestinationPrefixListTest {
 
   @Test
   public void testApplyTo() {
-    Ip additionalIp = new Ip("2.2.2.2");
+    IpSpace additionalIpSpace = new Ip("2.2.2.2").toIpSpace();
     IpSpace baseIpSpace = new IpWildcard(BASE_IP_PREFIX).toIpSpace();
 
     HeaderSpace.Builder headerSpaceBuilder = HeaderSpace.builder();
     HeaderSpace.Builder headerSpaceBuilderWithIpSpaceFilter =
-        HeaderSpace.builder().setDstIps(additionalIp.toIpSpace());
+        HeaderSpace.builder().setDstIps(additionalIpSpace);
     FwFromDestinationPrefixList fwFrom = new FwFromDestinationPrefixList(BASE_PREFIX_LIST_NAME);
 
     // Apply base IP prefix to headerSpace with null IpSpace
@@ -71,7 +71,7 @@ public class FwFromDestinationPrefixListTest {
             isAclIpSpaceThat(
                 hasLines(
                     containsInAnyOrder(
-                        AclIpSpaceLine.permit(additionalIp.toIpSpace()),
+                        AclIpSpaceLine.permit(additionalIpSpace),
                         AclIpSpaceLine.permit(baseIpSpace))))));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromDestinationPrefixListTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromDestinationPrefixListTest.java
@@ -14,10 +14,8 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Ip;
-import org.batfish.datamodel.IpIpSpace;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.IpWildcard;
-import org.batfish.datamodel.IpWildcardIpSpace;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.RouteFilterLine;
@@ -57,10 +55,10 @@ public class FwFromDestinationPrefixListTest {
         HeaderSpace.builder().setDstIps(additionalIp.toIpSpace());
     FwFromDestinationPrefixList fwFrom = new FwFromDestinationPrefixList(BASE_PREFIX_LIST_NAME);
 
-    // Combine base IP prefix with null headerSpace IpSpace
+    // Apply base IP prefix to headerSpace with null IpSpace
     fwFrom.applyTo(headerSpaceBuilder, _jc, _w, _c);
 
-    // Combine base IP prefix with non-null headerSpace IpSpace
+    // Apply base IP prefix to headerSpace with non-null IpSpace
     fwFrom.applyTo(headerSpaceBuilderWithIpSpaceFilter, _jc, _w, _c);
 
     // Confirm combining base with null IpSpace results in just base IpSpace

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromDestinationPrefixListTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromDestinationPrefixListTest.java
@@ -1,0 +1,79 @@
+package org.batfish.representation.juniper;
+
+import static org.batfish.datamodel.matchers.AclIpSpaceMatchers.hasLines;
+import static org.batfish.datamodel.matchers.AclIpSpaceMatchers.isAclIpSpaceThat;
+import static org.batfish.datamodel.matchers.HeaderSpaceMatchers.hasDstIps;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+import com.google.common.collect.ImmutableSet;
+import org.batfish.common.Warnings;
+import org.batfish.datamodel.AclIpSpaceLine;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.HeaderSpace;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpIpSpace;
+import org.batfish.datamodel.IpSpace;
+import org.batfish.datamodel.IpWildcard;
+import org.batfish.datamodel.IpWildcardIpSpace;
+import org.batfish.datamodel.LineAction;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.RouteFilterLine;
+import org.batfish.datamodel.RouteFilterList;
+import org.batfish.datamodel.SubRange;
+import org.junit.Before;
+import org.junit.Test;
+
+public class FwFromDestinationPrefixListTest {
+  private JuniperConfiguration _jc;
+  private Warnings _w;
+  private Configuration _c;
+
+  private static final String BASE_PREFIX_LIST_NAME = "prefixList";
+  private static final String BASE_IP_PREFIX = "1.2.3.4/32";
+
+  @Before
+  public void setup() {
+    _jc = new JuniperConfiguration(ImmutableSet.of());
+    _jc.getPrefixLists().put(BASE_PREFIX_LIST_NAME, new PrefixList(BASE_PREFIX_LIST_NAME, -1));
+    _w = new Warnings();
+    _c = new Configuration("test", ConfigurationFormat.FLAT_JUNIPER);
+    RouteFilterList rflist = new RouteFilterList(BASE_PREFIX_LIST_NAME);
+    RouteFilterLine rfline =
+        new RouteFilterLine(LineAction.ACCEPT, Prefix.parse(BASE_IP_PREFIX), new SubRange(0, 0));
+    rflist.addLine(rfline);
+    _c.getRouteFilterLists().put(BASE_PREFIX_LIST_NAME, rflist);
+  }
+
+  @Test
+  public void testApplyTo() {
+    Ip additionalIp = new Ip("2.2.2.2");
+    IpSpace baseIpSpace = new IpWildcard(BASE_IP_PREFIX).toIpSpace();
+
+    HeaderSpace.Builder headerSpaceBuilder = HeaderSpace.builder();
+    HeaderSpace.Builder headerSpaceBuilderWithIpSpaceFilter =
+        HeaderSpace.builder().setDstIps(additionalIp.toIpSpace());
+    FwFromDestinationPrefixList fwFrom = new FwFromDestinationPrefixList(BASE_PREFIX_LIST_NAME);
+
+    // Combine base IP prefix with null headerSpace IpSpace
+    fwFrom.applyTo(headerSpaceBuilder, _jc, _w, _c);
+
+    // Combine base IP prefix with non-null headerSpace IpSpace
+    fwFrom.applyTo(headerSpaceBuilderWithIpSpaceFilter, _jc, _w, _c);
+
+    // Confirm combining base with null IpSpace results in just base IpSpace
+    assertThat(headerSpaceBuilder.build(), hasDstIps(equalTo(baseIpSpace)));
+
+    // Confirm combining base with additional IpSpace results in an IpSpace combining both
+    assertThat(
+        headerSpaceBuilderWithIpSpaceFilter.build(),
+        hasDstIps(
+            isAclIpSpaceThat(
+                hasLines(
+                    containsInAnyOrder(
+                        AclIpSpaceLine.permit(additionalIp.toIpSpace()),
+                        AclIpSpaceLine.permit(baseIpSpace))))));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromSourcePrefixListExceptTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromSourcePrefixListExceptTest.java
@@ -14,10 +14,8 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Ip;
-import org.batfish.datamodel.IpIpSpace;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.IpWildcard;
-import org.batfish.datamodel.IpWildcardIpSpace;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.RouteFilterLine;
@@ -57,10 +55,10 @@ public class FwFromSourcePrefixListExceptTest {
         HeaderSpace.builder().setNotSrcIps(additionalIp.toIpSpace());
     FwFromSourcePrefixListExcept fwFrom = new FwFromSourcePrefixListExcept(BASE_PREFIX_LIST_NAME);
 
-    // Combine base IP prefix with null headerSpace IpSpace
+    // Apply base IP prefix to headerSpace with null IpSpace
     fwFrom.applyTo(headerSpaceBuilder, _jc, _w, _c);
 
-    // Combine base IP prefix with non-null headerSpace IpSpace
+    // Apply base IP prefix to headerSpace with non-null IpSpace
     fwFrom.applyTo(headerSpaceBuilderWithIpSpaceFilter, _jc, _w, _c);
 
     // Confirm combining base with null IpSpace results in just base IpSpace

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromSourcePrefixListExceptTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromSourcePrefixListExceptTest.java
@@ -47,12 +47,12 @@ public class FwFromSourcePrefixListExceptTest {
 
   @Test
   public void testApplyTo() {
-    Ip additionalIp = new Ip("2.2.2.2");
+    IpSpace additionalIpSpace = new Ip("2.2.2.2").toIpSpace();
     IpSpace baseIpSpace = new IpWildcard(BASE_IP_PREFIX).toIpSpace();
 
     HeaderSpace.Builder headerSpaceBuilder = HeaderSpace.builder();
     HeaderSpace.Builder headerSpaceBuilderWithIpSpaceFilter =
-        HeaderSpace.builder().setNotSrcIps(additionalIp.toIpSpace());
+        HeaderSpace.builder().setNotSrcIps(additionalIpSpace);
     FwFromSourcePrefixListExcept fwFrom = new FwFromSourcePrefixListExcept(BASE_PREFIX_LIST_NAME);
 
     // Apply base IP prefix to headerSpace with null IpSpace
@@ -71,7 +71,7 @@ public class FwFromSourcePrefixListExceptTest {
             isAclIpSpaceThat(
                 hasLines(
                     containsInAnyOrder(
-                        AclIpSpaceLine.permit(additionalIp.toIpSpace()),
+                        AclIpSpaceLine.permit(additionalIpSpace),
                         AclIpSpaceLine.permit(baseIpSpace))))));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromSourcePrefixListExceptTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromSourcePrefixListExceptTest.java
@@ -1,0 +1,79 @@
+package org.batfish.representation.juniper;
+
+import static org.batfish.datamodel.matchers.AclIpSpaceMatchers.hasLines;
+import static org.batfish.datamodel.matchers.AclIpSpaceMatchers.isAclIpSpaceThat;
+import static org.batfish.datamodel.matchers.HeaderSpaceMatchers.hasNotSrcIps;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+import com.google.common.collect.ImmutableSet;
+import org.batfish.common.Warnings;
+import org.batfish.datamodel.AclIpSpaceLine;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.HeaderSpace;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpIpSpace;
+import org.batfish.datamodel.IpSpace;
+import org.batfish.datamodel.IpWildcard;
+import org.batfish.datamodel.IpWildcardIpSpace;
+import org.batfish.datamodel.LineAction;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.RouteFilterLine;
+import org.batfish.datamodel.RouteFilterList;
+import org.batfish.datamodel.SubRange;
+import org.junit.Before;
+import org.junit.Test;
+
+public class FwFromSourcePrefixListExceptTest {
+  private JuniperConfiguration _jc;
+  private Warnings _w;
+  private Configuration _c;
+
+  private static final String BASE_PREFIX_LIST_NAME = "prefixList";
+  private static final String BASE_IP_PREFIX = "1.2.3.4/32";
+
+  @Before
+  public void setup() {
+    _jc = new JuniperConfiguration(ImmutableSet.of());
+    _jc.getPrefixLists().put(BASE_PREFIX_LIST_NAME, new PrefixList(BASE_PREFIX_LIST_NAME, -1));
+    _w = new Warnings();
+    _c = new Configuration("test", ConfigurationFormat.FLAT_JUNIPER);
+    RouteFilterList rflist = new RouteFilterList(BASE_PREFIX_LIST_NAME);
+    RouteFilterLine rfline =
+        new RouteFilterLine(LineAction.ACCEPT, Prefix.parse(BASE_IP_PREFIX), new SubRange(0, 0));
+    rflist.addLine(rfline);
+    _c.getRouteFilterLists().put(BASE_PREFIX_LIST_NAME, rflist);
+  }
+
+  @Test
+  public void testApplyTo() {
+    Ip additionalIp = new Ip("2.2.2.2");
+    IpSpace baseIpSpace = new IpWildcard(BASE_IP_PREFIX).toIpSpace();
+
+    HeaderSpace.Builder headerSpaceBuilder = HeaderSpace.builder();
+    HeaderSpace.Builder headerSpaceBuilderWithIpSpaceFilter =
+        HeaderSpace.builder().setNotSrcIps(additionalIp.toIpSpace());
+    FwFromSourcePrefixListExcept fwFrom = new FwFromSourcePrefixListExcept(BASE_PREFIX_LIST_NAME);
+
+    // Combine base IP prefix with null headerSpace IpSpace
+    fwFrom.applyTo(headerSpaceBuilder, _jc, _w, _c);
+
+    // Combine base IP prefix with non-null headerSpace IpSpace
+    fwFrom.applyTo(headerSpaceBuilderWithIpSpaceFilter, _jc, _w, _c);
+
+    // Confirm combining base with null IpSpace results in just base IpSpace
+    assertThat(headerSpaceBuilder.build(), hasNotSrcIps(equalTo(baseIpSpace)));
+
+    // Confirm combining base with additional IpSpace results in an IpSpace combining both
+    assertThat(
+        headerSpaceBuilderWithIpSpaceFilter.build(),
+        hasNotSrcIps(
+            isAclIpSpaceThat(
+                hasLines(
+                    containsInAnyOrder(
+                        AclIpSpaceLine.permit(additionalIp.toIpSpace()),
+                        AclIpSpaceLine.permit(baseIpSpace))))));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromSourcePrefixListTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromSourcePrefixListTest.java
@@ -1,0 +1,79 @@
+package org.batfish.representation.juniper;
+
+import static org.batfish.datamodel.matchers.AclIpSpaceMatchers.hasLines;
+import static org.batfish.datamodel.matchers.AclIpSpaceMatchers.isAclIpSpaceThat;
+import static org.batfish.datamodel.matchers.HeaderSpaceMatchers.hasSrcIps;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+import com.google.common.collect.ImmutableSet;
+import org.batfish.common.Warnings;
+import org.batfish.datamodel.AclIpSpaceLine;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.HeaderSpace;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpIpSpace;
+import org.batfish.datamodel.IpSpace;
+import org.batfish.datamodel.IpWildcard;
+import org.batfish.datamodel.IpWildcardIpSpace;
+import org.batfish.datamodel.LineAction;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.RouteFilterLine;
+import org.batfish.datamodel.RouteFilterList;
+import org.batfish.datamodel.SubRange;
+import org.junit.Before;
+import org.junit.Test;
+
+public class FwFromSourcePrefixListTest {
+  private JuniperConfiguration _jc;
+  private Warnings _w;
+  private Configuration _c;
+
+  private static final String BASE_PREFIX_LIST_NAME = "prefixList";
+  private static final String BASE_IP_PREFIX = "1.2.3.4/32";
+
+  @Before
+  public void setup() {
+    _jc = new JuniperConfiguration(ImmutableSet.of());
+    _jc.getPrefixLists().put(BASE_PREFIX_LIST_NAME, new PrefixList(BASE_PREFIX_LIST_NAME, -1));
+    _w = new Warnings();
+    _c = new Configuration("test", ConfigurationFormat.FLAT_JUNIPER);
+    RouteFilterList rflist = new RouteFilterList(BASE_PREFIX_LIST_NAME);
+    RouteFilterLine rfline =
+        new RouteFilterLine(LineAction.ACCEPT, Prefix.parse(BASE_IP_PREFIX), new SubRange(0, 0));
+    rflist.addLine(rfline);
+    _c.getRouteFilterLists().put(BASE_PREFIX_LIST_NAME, rflist);
+  }
+
+  @Test
+  public void testApplyTo() {
+    Ip additionalIp = new Ip("2.2.2.2");
+    IpSpace baseIpSpace = new IpWildcard(BASE_IP_PREFIX).toIpSpace();
+
+    HeaderSpace.Builder headerSpaceBuilder = HeaderSpace.builder();
+    HeaderSpace.Builder headerSpaceBuilderWithIpSpaceFilter =
+        HeaderSpace.builder().setSrcIps(additionalIp.toIpSpace());
+    FwFromSourcePrefixList fwFrom = new FwFromSourcePrefixList(BASE_PREFIX_LIST_NAME);
+
+    // Combine base IP prefix with null headerSpace IpSpace
+    fwFrom.applyTo(headerSpaceBuilder, _jc, _w, _c);
+
+    // Combine base IP prefix with non-null headerSpace IpSpace
+    fwFrom.applyTo(headerSpaceBuilderWithIpSpaceFilter, _jc, _w, _c);
+
+    // Confirm combining base with null IpSpace results in just base IpSpace
+    assertThat(headerSpaceBuilder.build(), hasSrcIps(equalTo(baseIpSpace)));
+
+    // Confirm combining base with additional IpSpace results in an IpSpace combining both
+    assertThat(
+        headerSpaceBuilderWithIpSpaceFilter.build(),
+        hasSrcIps(
+            isAclIpSpaceThat(
+                hasLines(
+                    containsInAnyOrder(
+                        AclIpSpaceLine.permit(additionalIp.toIpSpace()),
+                        AclIpSpaceLine.permit(baseIpSpace))))));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromSourcePrefixListTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromSourcePrefixListTest.java
@@ -14,10 +14,8 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Ip;
-import org.batfish.datamodel.IpIpSpace;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.IpWildcard;
-import org.batfish.datamodel.IpWildcardIpSpace;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.RouteFilterLine;
@@ -57,10 +55,10 @@ public class FwFromSourcePrefixListTest {
         HeaderSpace.builder().setSrcIps(additionalIp.toIpSpace());
     FwFromSourcePrefixList fwFrom = new FwFromSourcePrefixList(BASE_PREFIX_LIST_NAME);
 
-    // Combine base IP prefix with null headerSpace IpSpace
+    // Apply base IP prefix to headerSpace with null IpSpace
     fwFrom.applyTo(headerSpaceBuilder, _jc, _w, _c);
 
-    // Combine base IP prefix with non-null headerSpace IpSpace
+    // Apply base IP prefix to headerSpace with non-null IpSpace
     fwFrom.applyTo(headerSpaceBuilderWithIpSpaceFilter, _jc, _w, _c);
 
     // Confirm combining base with null IpSpace results in just base IpSpace

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromSourcePrefixListTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromSourcePrefixListTest.java
@@ -47,12 +47,12 @@ public class FwFromSourcePrefixListTest {
 
   @Test
   public void testApplyTo() {
-    Ip additionalIp = new Ip("2.2.2.2");
+    IpSpace additionalIpSpace = new Ip("2.2.2.2").toIpSpace();
     IpSpace baseIpSpace = new IpWildcard(BASE_IP_PREFIX).toIpSpace();
 
     HeaderSpace.Builder headerSpaceBuilder = HeaderSpace.builder();
     HeaderSpace.Builder headerSpaceBuilderWithIpSpaceFilter =
-        HeaderSpace.builder().setSrcIps(additionalIp.toIpSpace());
+        HeaderSpace.builder().setSrcIps(additionalIpSpace);
     FwFromSourcePrefixList fwFrom = new FwFromSourcePrefixList(BASE_PREFIX_LIST_NAME);
 
     // Apply base IP prefix to headerSpace with null IpSpace
@@ -71,7 +71,7 @@ public class FwFromSourcePrefixListTest {
             isAclIpSpaceThat(
                 hasLines(
                     containsInAnyOrder(
-                        AclIpSpaceLine.permit(additionalIp.toIpSpace()),
+                        AclIpSpaceLine.permit(additionalIpSpace),
                         AclIpSpaceLine.permit(baseIpSpace))))));
   }
 }


### PR DESCRIPTION
* Added null checks for IpSpaces when applying `FwFrom`s to headerSpaces