### PR TITLE
Catch VI config deserialization errors

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/main/BatfishStorage.java
+++ b/projects/batfish/src/main/java/org/batfish/main/BatfishStorage.java
@@ -99,7 +99,11 @@ final class BatfishStorage {
       throw new BatfishException(
           "Error reading vendor-independent configs directory: '" + indepDir + "'", e);
     }
-    return deserializeObjects(namesByPath, Configuration.class);
+    try {
+      return deserializeObjects(namesByPath, Configuration.class);
+    } catch (BatfishException e) {
+      return null;
+    }
   }
 
   @Nullable
@@ -208,7 +212,7 @@ final class BatfishStorage {
       }
       closer.register(ois);
       return outputClass.cast(ois.readObject());
-    } catch (IOException | ClassNotFoundException e) {
+    } catch (IOException | ClassNotFoundException | ClassCastException e) {
       throw new BatfishException(
           String.format(
               "Failed to deserialize object of type %s from file %s",


### PR DESCRIPTION
If java deserialization fails when loading vendor-independent configs, return `null` which will cause a re-parse.