### PR TITLE
CiscoConfiguration: one fewer statement in BGP common export policy

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -1541,10 +1541,10 @@ public final class CiscoConfiguration extends VendorConfiguration {
 
     If preFilter = new If();
     bgpCommonExportStatements.add(preFilter);
-    bgpCommonExportStatements.add(Statements.ReturnFalse.toStaticStatement());
     Disjunction preFilterConditions = new Disjunction();
     preFilter.setGuard(preFilterConditions);
-    preFilter.getTrueStatements().add(Statements.ReturnTrue.toStaticStatement());
+    preFilter.setTrueStatements(ImmutableList.of(Statements.ReturnTrue.toStaticStatement()));
+    preFilter.setFalseStatements(ImmutableList.of(Statements.ReturnFalse.toStaticStatement()));
 
     preFilterConditions.getDisjuncts().addAll(attributeMapPrefilters);
 


### PR DESCRIPTION
I know this PR will fail initially b/c the refs are not going to pass.

My question is more educational: the previous design of

```
if(disjunction, return True, fallthrough)
return False
```

seems silly. Is there a design or implementation reason why it it actually is a good idea to structure it as before?