### PR TITLE
Prefix range: simplify

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixRange.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixRange.java
@@ -13,6 +13,9 @@ public final class PrefixRange implements Serializable, Comparable<PrefixRange> 
   /** */
   private static final long serialVersionUID = 2L;
 
+  public static final PrefixRange DEFAULT_PREFIX_ONLY =
+      new PrefixRange(Prefix.ZERO, new SubRange(0, 0));
+
   public PrefixRange(Prefix prefix, SubRange lengthRange) {
     // Canonicalize the prefix by dropping extra bits in the address that are longer than any
     // relevant length.

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixRange.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixRange.java
@@ -13,9 +13,6 @@ public final class PrefixRange implements Serializable, Comparable<PrefixRange> 
   /** */
   private static final long serialVersionUID = 2L;
 
-  public static final PrefixRange DEFAULT_PREFIX_ONLY =
-      new PrefixRange(Prefix.ZERO, new SubRange(0, 0));
-
   public PrefixRange(Prefix prefix, SubRange lengthRange) {
     // Canonicalize the prefix by dropping extra bits in the address that are longer than any
     // relevant length.

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixRange.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixRange.java
@@ -43,6 +43,12 @@ public final class PrefixRange implements Serializable, Comparable<PrefixRange> 
     }
   }
 
+  /** Returns a {@link PrefixRange} that represents all more specific prefixes. */
+  public static PrefixRange moreSpecificThan(Prefix prefix) {
+    return new PrefixRange(
+        prefix, new SubRange(prefix.getPrefixLength() + 1, Prefix.MAX_PREFIX_LENGTH));
+  }
+
   public SubRange getLengthRange() {
     return _lengthRange;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixSpace.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.BitSet;
 import java.util.HashSet;
 import java.util.Set;
@@ -200,11 +201,15 @@ public class PrefixSpace implements Serializable {
   }
 
   @JsonCreator
-  public PrefixSpace(Set<PrefixRange> prefixRanges) {
+  public PrefixSpace(Iterable<PrefixRange> prefixRanges) {
     this();
     for (PrefixRange prefixRange : prefixRanges) {
       _trie.addPrefixRange(prefixRange);
     }
+  }
+
+  public PrefixSpace(PrefixRange... prefixRanges) {
+    this(Arrays.asList(prefixRanges));
   }
 
   /**

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RouteFilterLine.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RouteFilterLine.java
@@ -33,6 +33,10 @@ public class RouteFilterLine implements Serializable {
     _lengthRange = lengthRange;
   }
 
+  public RouteFilterLine(LineAction action, PrefixRange prefixRange) {
+    this(action, prefixRange.getPrefix(), prefixRange.getLengthRange());
+  }
+
   @Override
   public boolean equals(Object o) {
     if (o == this) {

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PrefixRangeTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PrefixRangeTest.java
@@ -1,6 +1,7 @@
 package org.batfish.datamodel;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -31,5 +32,16 @@ public class PrefixRangeTest {
     assertThat(
         BatfishObjectMapper.mapper().readValue("\"1.0.0.0/8:17-19\"", PrefixRange.class),
         equalTo(pr));
+  }
+
+  /**
+   * Tests that getting a range more specific than a /32 does not crash and is empty -- or at least
+   * does not contain the initial /32.
+   */
+  @Test
+  public void testEmptyRange() {
+    Prefix slash32 = Prefix.parse("1.2.3.4/32");
+    PrefixRange empty = PrefixRange.moreSpecificThan(slash32);
+    assertFalse(empty.includesPrefixRange(PrefixRange.fromPrefix(slash32)));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PrefixSpaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PrefixSpaceTest.java
@@ -3,10 +3,8 @@ package org.batfish.datamodel;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
-import com.google.common.collect.ImmutableSet;
 import java.util.BitSet;
 import java.util.Set;
-import java.util.TreeSet;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,7 +37,7 @@ public class PrefixSpaceTest {
 
   @Test
   public void constructPrefixSpaceTest() {
-    _ps = new PrefixSpace(ImmutableSet.of(PrefixRange.fromString("100.0.0.0/32")));
+    _ps = new PrefixSpace(PrefixRange.fromString("100.0.0.0/32"));
     assertThat(_ps.isEmpty(), equalTo(false));
     assertThat(_ps.containsPrefixRange(PrefixRange.fromString("100.0.0.0/32")), equalTo(true));
   }
@@ -54,10 +52,8 @@ public class PrefixSpaceTest {
 
   @Test
   public void addPrefixRangeTest() {
-    Set<PrefixRange> ranges = new TreeSet<>();
     PrefixRange range = PrefixRange.fromString("10.10.10.0/32:16-24");
-    ranges.add(range);
-    _ps = new PrefixSpace(ranges);
+    _ps = new PrefixSpace(range);
     assertThat(_ps.containsPrefixRange(range), equalTo(true));
     assertThat(
         "Shorter prefixes not included",
@@ -87,10 +83,8 @@ public class PrefixSpaceTest {
 
   @Test
   public void addSpaceTest() {
-    Set<PrefixRange> ranges = new TreeSet<>();
     PrefixRange range = PrefixRange.fromString("100.0.0.0/32");
-    ranges.add(range);
-    _ps.addSpace(new PrefixSpace(ranges));
+    _ps.addSpace(new PrefixSpace(range));
     assertThat(_ps.isEmpty(), equalTo(false));
     assertThat(_ps.containsPrefixRange(range), equalTo(true));
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -1384,8 +1384,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
       Prefix prefix = e.getKey();
       BgpAggregateIpv4Network aggNet = e.getValue();
       boolean summaryOnly = aggNet.getSummaryOnly();
-      int prefixLength = prefix.getPrefixLength();
-      SubRange prefixRange = new SubRange(prefixLength + 1, Prefix.MAX_PREFIX_LENGTH);
       if (summaryOnly) {
         summaryOnlyNetworks.add(aggNet);
       }
@@ -1398,7 +1396,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
       currentGeneratedRouteConditional.setGuard(
           new MatchPrefixSet(
               new DestinationNetwork(),
-              new ExplicitPrefixSet(new PrefixSpace(new PrefixRange(prefix, prefixRange)))));
+              new ExplicitPrefixSet(new PrefixSpace(PrefixRange.moreSpecificThan(prefix)))));
       currentGeneratedRouteConditional
           .getTrueStatements()
           .add(Statements.ReturnTrue.toStaticStatement());
@@ -1521,12 +1519,8 @@ public final class CiscoConfiguration extends VendorConfiguration {
           .put(matchSuppressedSummaryOnlyRoutesName, matchSuppressedSummaryOnlyRoutes);
       for (BgpAggregateIpv4Network summaryOnlyNetwork : summaryOnlyNetworks) {
         Prefix prefix = summaryOnlyNetwork.getPrefix();
-        int prefixLength = prefix.getPrefixLength();
         RouteFilterLine line =
-            new RouteFilterLine(
-                LineAction.ACCEPT,
-                prefix,
-                new SubRange(prefixLength + 1, Prefix.MAX_PREFIX_LENGTH));
+            new RouteFilterLine(LineAction.ACCEPT, PrefixRange.moreSpecificThan(prefix));
         matchSuppressedSummaryOnlyRoutes.addLine(line);
       }
       suppressSummaryOnly.setGuard(

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -1365,8 +1365,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
         new MatchPrefixSet(
             new DestinationNetwork(),
             new ExplicitPrefixSet(
-                new PrefixSpace(
-                    Collections.singleton(new PrefixRange(Prefix.ZERO, new SubRange(0, 0))))));
+                new PrefixSpace(new PrefixRange(Prefix.ZERO, new SubRange(0, 0)))));
     matchDefaultRoute.setComment("match default route");
     MatchPrefix6Set matchDefaultRoute6 =
         new MatchPrefix6Set(
@@ -1400,8 +1399,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
       currentGeneratedRouteConditional.setGuard(
           new MatchPrefixSet(
               new DestinationNetwork(),
-              new ExplicitPrefixSet(
-                  new PrefixSpace(Collections.singleton(new PrefixRange(prefix, prefixRange))))));
+              new ExplicitPrefixSet(new PrefixSpace(new PrefixRange(prefix, prefixRange)))));
       currentGeneratedRouteConditional
           .getTrueStatements()
           .add(Statements.ReturnTrue.toStaticStatement());
@@ -1420,8 +1418,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
           .add(
               new MatchPrefixSet(
                   new DestinationNetwork(),
-                  new ExplicitPrefixSet(
-                      new PrefixSpace(Collections.singleton(PrefixRange.fromPrefix(prefix))))));
+                  new ExplicitPrefixSet(new PrefixSpace(PrefixRange.fromPrefix(prefix)))));
       applyCurrentAggregateAttributesConditions
           .getConjuncts()
           .add(new MatchProtocol(RoutingProtocol.AGGREGATE));
@@ -2820,8 +2817,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
           new MatchPrefixSet(
               new DestinationNetwork(),
               new ExplicitPrefixSet(
-                  new PrefixSpace(
-                      Collections.singleton(new PrefixRange(Prefix.ZERO, new SubRange(0, 0)))))));
+                  new PrefixSpace(new PrefixRange(Prefix.ZERO, new SubRange(0, 0))))));
 
   // For testing.
   If convertOspfRedistributionPolicy(
@@ -3003,9 +2999,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
               new MatchPrefixSet(
                   new DestinationNetwork(),
                   new ExplicitPrefixSet(
-                      new PrefixSpace(
-                          Collections.singleton(
-                              new PrefixRange(Prefix.ZERO, new SubRange(0, 0)))))));
+                      new PrefixSpace(new PrefixRange(Prefix.ZERO, new SubRange(0, 0))))));
       long metric = proc.getDefaultInformationMetric();
       ospfExportDefaultStatements.add(new SetMetric(new LiteralLong(metric)));
       OspfMetricType metricType = proc.getDefaultInformationMetricType();
@@ -3160,9 +3154,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
               new MatchPrefixSet(
                   new DestinationNetwork(),
                   new ExplicitPrefixSet(
-                      new PrefixSpace(
-                          Collections.singleton(
-                              new PrefixRange(Prefix.ZERO, new SubRange(0, 0)))))));
+                      new PrefixSpace(new PrefixRange(Prefix.ZERO, new SubRange(0, 0))))));
       long metric = proc.getDefaultInformationMetric();
       ripExportDefaultStatements.add(new SetMetric(new LiteralLong(metric)));
       // add default export map with metric
@@ -3251,9 +3243,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
                   new MatchPrefixSet(
                       new DestinationNetwork(),
                       new ExplicitPrefixSet(
-                          new PrefixSpace(
-                              Collections.singleton(
-                                  new PrefixRange(Prefix.ZERO, new SubRange(0, 0))))))));
+                          new PrefixSpace(new PrefixRange(Prefix.ZERO, new SubRange(0, 0)))))));
 
       Long metric = rsp.getMetric();
       boolean explicitMetric = metric != null;
@@ -3297,9 +3287,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
                   new MatchPrefixSet(
                       new DestinationNetwork(),
                       new ExplicitPrefixSet(
-                          new PrefixSpace(
-                              Collections.singleton(
-                                  new PrefixRange(Prefix.ZERO, new SubRange(0, 0))))))));
+                          new PrefixSpace(new PrefixRange(Prefix.ZERO, new SubRange(0, 0)))))));
 
       Long metric = rbp.getMetric();
       boolean explicitMetric = metric != null;

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -137,6 +137,34 @@ import org.batfish.vendor.VendorConfiguration;
 
 public final class CiscoConfiguration extends VendorConfiguration {
 
+  /** Matches the IPv4 default route. */
+  private static final MatchPrefixSet MATCH_DEFAULT_ROUTE;
+
+  /** Matches the IPv6 default route. */
+  private static final MatchPrefix6Set MATCH_DEFAULT_ROUTE6;
+
+  /** Matches anything but the IPv4 default route. */
+  static final Not NOT_DEFAULT_ROUTE;
+
+  static {
+    MATCH_DEFAULT_ROUTE =
+        new MatchPrefixSet(
+            new DestinationNetwork(),
+            new ExplicitPrefixSet(
+                new PrefixSpace(new PrefixRange(Prefix.ZERO, new SubRange(0, 0)))));
+    MATCH_DEFAULT_ROUTE.setComment("match default route");
+
+    NOT_DEFAULT_ROUTE = new Not(MATCH_DEFAULT_ROUTE);
+
+    MATCH_DEFAULT_ROUTE6 =
+        new MatchPrefix6Set(
+            new DestinationNetwork6(),
+            new ExplicitPrefix6Set(
+                new Prefix6Space(
+                    Collections.singleton(new Prefix6Range(Prefix6.ZERO, new SubRange(0, 0))))));
+    MATCH_DEFAULT_ROUTE6.setComment("match default route");
+  }
+
   private static final int CISCO_AGGREGATE_ROUTE_ADMIN_COST = 200;
 
   /*
@@ -1361,18 +1389,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
     Map<Prefix, BgpNeighbor> newBgpNeighbors = newBgpProcess.getNeighbors();
     int defaultMetric = proc.getDefaultMetric();
     Ip bgpRouterId = getBgpRouterId(c, vrfName, proc);
-    MatchPrefixSet matchDefaultRoute =
-        new MatchPrefixSet(
-            new DestinationNetwork(),
-            new ExplicitPrefixSet(new PrefixSpace(PrefixRange.DEFAULT_PREFIX_ONLY)));
-    matchDefaultRoute.setComment("match default route");
-    MatchPrefix6Set matchDefaultRoute6 =
-        new MatchPrefix6Set(
-            new DestinationNetwork6(),
-            new ExplicitPrefix6Set(
-                new Prefix6Space(
-                    Collections.singleton(new Prefix6Range(Prefix6.ZERO, new SubRange(0, 0))))));
-    matchDefaultRoute.setComment("match default route");
     newBgpProcess.setRouterId(bgpRouterId);
     Set<BgpAggregateIpv4Network> summaryOnlyNetworks = new HashSet<>();
     Set<BgpAggregateIpv6Network> summaryOnlyIpv6Networks = new HashSet<>();
@@ -1906,9 +1922,9 @@ public final class CiscoConfiguration extends VendorConfiguration {
       GeneratedRoute6.Builder defaultRoute6 = null;
       if (lpg.getDefaultOriginate()) {
         if (ipv4) {
-          localOrCommonOrigination.getDisjuncts().add(matchDefaultRoute);
+          localOrCommonOrigination.getDisjuncts().add(MATCH_DEFAULT_ROUTE);
         } else {
-          localOrCommonOrigination.getDisjuncts().add(matchDefaultRoute6);
+          localOrCommonOrigination.getDisjuncts().add(MATCH_DEFAULT_ROUTE6);
         }
         defaultRoute = new GeneratedRoute.Builder();
         defaultRoute.setNetwork(Prefix.ZERO);
@@ -1944,9 +1960,9 @@ public final class CiscoConfiguration extends VendorConfiguration {
           If defaultRouteGenerationConditional = new If();
           defaultRouteGenerationPolicy.getStatements().add(defaultRouteGenerationConditional);
           if (ipv4) {
-            defaultRouteGenerationConditional.setGuard(matchDefaultRoute);
+            defaultRouteGenerationConditional.setGuard(MATCH_DEFAULT_ROUTE);
           } else {
-            defaultRouteGenerationConditional.setGuard(matchDefaultRoute6);
+            defaultRouteGenerationConditional.setGuard(MATCH_DEFAULT_ROUTE6);
           }
           defaultRouteGenerationConditional
               .getTrueStatements()
@@ -2805,12 +2821,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
     allOspfExportStatements.add(redistributionPolicy);
   }
 
-  static final Not NOT_DEFAULT_ROUTE =
-      new Not(
-          new MatchPrefixSet(
-              new DestinationNetwork(),
-              new ExplicitPrefixSet(new PrefixSpace(PrefixRange.DEFAULT_PREFIX_ONLY))));
-
   // For testing.
   If convertOspfRedistributionPolicy(
       OspfRedistributionPolicy policy, OspfProcess proc, CiscoStructureUsage structureType) {
@@ -2985,12 +2995,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
       ospfExportDefault.setComment("OSPF export default route");
       Conjunction ospfExportDefaultConditions = new Conjunction();
       List<Statement> ospfExportDefaultStatements = ospfExportDefault.getTrueStatements();
-      ospfExportDefaultConditions
-          .getConjuncts()
-          .add(
-              new MatchPrefixSet(
-                  new DestinationNetwork(),
-                  new ExplicitPrefixSet(new PrefixSpace(PrefixRange.DEFAULT_PREFIX_ONLY))));
+      ospfExportDefaultConditions.getConjuncts().add(MATCH_DEFAULT_ROUTE);
       long metric = proc.getDefaultInformationMetric();
       ospfExportDefaultStatements.add(new SetMetric(new LiteralLong(metric)));
       OspfMetricType metricType = proc.getDefaultInformationMetricType();
@@ -3139,12 +3144,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
       ripExportDefault.setComment("RIP export default route");
       Conjunction ripExportDefaultConditions = new Conjunction();
       List<Statement> ripExportDefaultStatements = ripExportDefault.getTrueStatements();
-      ripExportDefaultConditions
-          .getConjuncts()
-          .add(
-              new MatchPrefixSet(
-                  new DestinationNetwork(),
-                  new ExplicitPrefixSet(new PrefixSpace(PrefixRange.DEFAULT_PREFIX_ONLY))));
+      ripExportDefaultConditions.getConjuncts().add(MATCH_DEFAULT_ROUTE);
       long metric = proc.getDefaultInformationMetric();
       ripExportDefaultStatements.add(new SetMetric(new LiteralLong(metric)));
       // add default export map with metric
@@ -3226,13 +3226,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
       Conjunction ripExportStaticConditions = new Conjunction();
       ripExportStaticConditions.getConjuncts().add(new MatchProtocol(RoutingProtocol.STATIC));
       List<Statement> ripExportStaticStatements = ripExportStatic.getTrueStatements();
-      ripExportStaticConditions
-          .getConjuncts()
-          .add(
-              new Not(
-                  new MatchPrefixSet(
-                      new DestinationNetwork(),
-                      new ExplicitPrefixSet(new PrefixSpace(PrefixRange.DEFAULT_PREFIX_ONLY)))));
+      ripExportStaticConditions.getConjuncts().add(NOT_DEFAULT_ROUTE);
 
       Long metric = rsp.getMetric();
       boolean explicitMetric = metric != null;
@@ -3269,13 +3263,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
       Conjunction ripExportBgpConditions = new Conjunction();
       ripExportBgpConditions.getConjuncts().add(new MatchProtocol(RoutingProtocol.BGP));
       List<Statement> ripExportBgpStatements = ripExportBgp.getTrueStatements();
-      ripExportBgpConditions
-          .getConjuncts()
-          .add(
-              new Not(
-                  new MatchPrefixSet(
-                      new DestinationNetwork(),
-                      new ExplicitPrefixSet(new PrefixSpace(PrefixRange.DEFAULT_PREFIX_ONLY)))));
+      ripExportBgpConditions.getConjuncts().add(NOT_DEFAULT_ROUTE);
 
       Long metric = rbp.getMetric();
       boolean explicitMetric = metric != null;

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -1364,8 +1364,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
     MatchPrefixSet matchDefaultRoute =
         new MatchPrefixSet(
             new DestinationNetwork(),
-            new ExplicitPrefixSet(
-                new PrefixSpace(new PrefixRange(Prefix.ZERO, new SubRange(0, 0)))));
+            new ExplicitPrefixSet(new PrefixSpace(PrefixRange.DEFAULT_PREFIX_ONLY)));
     matchDefaultRoute.setComment("match default route");
     MatchPrefix6Set matchDefaultRoute6 =
         new MatchPrefix6Set(
@@ -2816,8 +2815,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
       new Not(
           new MatchPrefixSet(
               new DestinationNetwork(),
-              new ExplicitPrefixSet(
-                  new PrefixSpace(new PrefixRange(Prefix.ZERO, new SubRange(0, 0))))));
+              new ExplicitPrefixSet(new PrefixSpace(PrefixRange.DEFAULT_PREFIX_ONLY))));
 
   // For testing.
   If convertOspfRedistributionPolicy(
@@ -2998,8 +2996,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
           .add(
               new MatchPrefixSet(
                   new DestinationNetwork(),
-                  new ExplicitPrefixSet(
-                      new PrefixSpace(new PrefixRange(Prefix.ZERO, new SubRange(0, 0))))));
+                  new ExplicitPrefixSet(new PrefixSpace(PrefixRange.DEFAULT_PREFIX_ONLY))));
       long metric = proc.getDefaultInformationMetric();
       ospfExportDefaultStatements.add(new SetMetric(new LiteralLong(metric)));
       OspfMetricType metricType = proc.getDefaultInformationMetricType();
@@ -3153,8 +3150,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
           .add(
               new MatchPrefixSet(
                   new DestinationNetwork(),
-                  new ExplicitPrefixSet(
-                      new PrefixSpace(new PrefixRange(Prefix.ZERO, new SubRange(0, 0))))));
+                  new ExplicitPrefixSet(new PrefixSpace(PrefixRange.DEFAULT_PREFIX_ONLY))));
       long metric = proc.getDefaultInformationMetric();
       ripExportDefaultStatements.add(new SetMetric(new LiteralLong(metric)));
       // add default export map with metric
@@ -3242,8 +3238,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
               new Not(
                   new MatchPrefixSet(
                       new DestinationNetwork(),
-                      new ExplicitPrefixSet(
-                          new PrefixSpace(new PrefixRange(Prefix.ZERO, new SubRange(0, 0)))))));
+                      new ExplicitPrefixSet(new PrefixSpace(PrefixRange.DEFAULT_PREFIX_ONLY)))));
 
       Long metric = rsp.getMetric();
       boolean explicitMetric = metric != null;
@@ -3286,8 +3281,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
               new Not(
                   new MatchPrefixSet(
                       new DestinationNetwork(),
-                      new ExplicitPrefixSet(
-                          new PrefixSpace(new PrefixRange(Prefix.ZERO, new SubRange(0, 0)))))));
+                      new ExplicitPrefixSet(new PrefixSpace(PrefixRange.DEFAULT_PREFIX_ONLY)))));
 
       Long metric = rbp.getMetric();
       boolean explicitMetric = metric != null;

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineLonger.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineLonger.java
@@ -3,8 +3,8 @@ package org.batfish.representation.juniper;
 import org.batfish.common.BatfishException;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.PrefixRange;
 import org.batfish.datamodel.RouteFilterList;
-import org.batfish.datamodel.SubRange;
 
 public class Route4FilterLineLonger extends Route4FilterLine {
 
@@ -23,7 +23,7 @@ public class Route4FilterLineLonger extends Route4FilterLine {
     }
     org.batfish.datamodel.RouteFilterLine line =
         new org.batfish.datamodel.RouteFilterLine(
-            LineAction.ACCEPT, _prefix, new SubRange(prefixLength + 1, Prefix.MAX_PREFIX_LENGTH));
+            LineAction.ACCEPT, PrefixRange.moreSpecificThan(_prefix));
     rfl.addLine(line);
   }
 

--- a/projects/batfish/src/test/java/org/batfish/dataplane/bdp/OspfTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/bdp/OspfTest.java
@@ -16,7 +16,6 @@ import static org.hamcrest.Matchers.sameInstance;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import java.util.Collections;
 import java.util.List;
@@ -124,8 +123,7 @@ public class OspfTest {
     exportIfMatchL2Prefix.setGuard(
         new MatchPrefixSet(
             new DestinationNetwork(),
-            new ExplicitPrefixSet(
-                new PrefixSpace(ImmutableSet.of(PrefixRange.fromPrefix(address.getPrefix()))))));
+            new ExplicitPrefixSet(new PrefixSpace(PrefixRange.fromPrefix(address.getPrefix())))));
     exportIfMatchL2Prefix.setTrueStatements(
         ImmutableList.of(
             new SetOspfMetricType(OspfMetricType.E1),

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfTest.java
@@ -12,7 +12,6 @@ import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.not;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import java.util.Collections;
 import java.util.List;
@@ -114,8 +113,7 @@ public class OspfTest {
     exportIfMatchL2Prefix.setGuard(
         new MatchPrefixSet(
             new DestinationNetwork(),
-            new ExplicitPrefixSet(
-                new PrefixSpace(ImmutableSet.of(PrefixRange.fromPrefix(address.getPrefix()))))));
+            new ExplicitPrefixSet(new PrefixSpace(PrefixRange.fromPrefix(address.getPrefix())))));
     exportIfMatchL2Prefix.setTrueStatements(
         ImmutableList.of(
             new SetOspfMetricType(OspfMetricType.E1),

--- a/test_rigs/parsing-tests/unit-tests-nodes.ref
+++ b/test_rigs/parsing-tests/unit-tests-nodes.ref
@@ -8549,6 +8549,7 @@
                       "class" : "org.batfish.datamodel.routing_policy.expr.Not",
                       "expr" : {
                         "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                        "comment" : "match default route",
                         "prefix" : {
                           "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
                         },
@@ -12108,6 +12109,7 @@
                 "comment" : "OSPF export default route",
                 "guard" : {
                   "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "comment" : "match default route",
                   "prefix" : {
                     "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
                   },
@@ -15979,6 +15981,7 @@
                       "class" : "org.batfish.datamodel.routing_policy.expr.Not",
                       "expr" : {
                         "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                        "comment" : "match default route",
                         "prefix" : {
                           "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
                         },
@@ -16024,6 +16027,7 @@
                       "class" : "org.batfish.datamodel.routing_policy.expr.Not",
                       "expr" : {
                         "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                        "comment" : "match default route",
                         "prefix" : {
                           "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
                         },

--- a/tests/basic/nodes.ref
+++ b/tests/basic/nodes.ref
@@ -990,6 +990,7 @@
                       "class" : "org.batfish.datamodel.routing_policy.expr.Not",
                       "expr" : {
                         "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                        "comment" : "match default route",
                         "prefix" : {
                           "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
                         },
@@ -2277,6 +2278,7 @@
                       "class" : "org.batfish.datamodel.routing_policy.expr.Not",
                       "expr" : {
                         "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                        "comment" : "match default route",
                         "prefix" : {
                           "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
                         },
@@ -3956,6 +3958,7 @@
                       "class" : "org.batfish.datamodel.routing_policy.expr.Not",
                       "expr" : {
                         "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                        "comment" : "match default route",
                         "prefix" : {
                           "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
                         },
@@ -5217,6 +5220,7 @@
                       "class" : "org.batfish.datamodel.routing_policy.expr.Not",
                       "expr" : {
                         "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                        "comment" : "match default route",
                         "prefix" : {
                           "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
                         },
@@ -8178,6 +8182,7 @@
                       "class" : "org.batfish.datamodel.routing_policy.expr.Not",
                       "expr" : {
                         "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                        "comment" : "match default route",
                         "prefix" : {
                           "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
                         },
@@ -8949,6 +8954,7 @@
                       "class" : "org.batfish.datamodel.routing_policy.expr.Not",
                       "expr" : {
                         "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                        "comment" : "match default route",
                         "prefix" : {
                           "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
                         },
@@ -10126,6 +10132,7 @@
                       "class" : "org.batfish.datamodel.routing_policy.expr.Not",
                       "expr" : {
                         "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                        "comment" : "match default route",
                         "prefix" : {
                           "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
                         },
@@ -11229,6 +11236,7 @@
                       "class" : "org.batfish.datamodel.routing_policy.expr.Not",
                       "expr" : {
                         "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                        "comment" : "match default route",
                         "prefix" : {
                           "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
                         },

--- a/tests/jsonpath-addons/jsonpath-display-hints-prefixofsuffix.ref
+++ b/tests/jsonpath-addons/jsonpath-display-hints-prefixofsuffix.ref
@@ -1043,6 +1043,7 @@
                             "class" : "org.batfish.datamodel.routing_policy.expr.Not",
                             "expr" : {
                               "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                              "comment" : "match default route",
                               "prefix" : {
                                 "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
                               },

--- a/tests/jsonpath-addons/jsonpath-display-hints-suffixofsuffix.ref
+++ b/tests/jsonpath-addons/jsonpath-display-hints-suffixofsuffix.ref
@@ -1043,6 +1043,7 @@
                             "class" : "org.batfish.datamodel.routing_policy.expr.Not",
                             "expr" : {
                               "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                              "comment" : "match default route",
                               "prefix" : {
                                 "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
                               },


### PR DESCRIPTION
Three changes to simplify use of PrefixRange:

* simplify construction PrefixSpace construction - relax `Set<PrefixRange>` to `Iterable<PrefixRange>`, add a varargs version. 
* introduce `DEFAULT_PREFIX_ONLY`, which is the same as `PrefixRange(0.0.0.0/0, [0, 0])`
* introduce `PrefixRange.moreSpecificThan(prefix)`, which is the same as `PrefixRange(p, [p.length+1, 32])`.