### PR TITLE
CiscoConfiguration: reduce cognitive overhead

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -538,12 +538,11 @@ public final class CiscoConfiguration extends VendorConfiguration {
                       iface.getVrrpGroups().put(groupNum, newGroup);
                     });
           } else {
-            int line = vrrpInterface.getDefinitionLine();
             undefined(
                 CiscoStructureType.INTERFACE,
                 ifaceName,
                 CiscoStructureUsage.ROUTER_VRRP_INTERFACE,
-                line);
+                vrrpInterface.getDefinitionLine());
           }
         });
   }
@@ -1024,12 +1023,11 @@ public final class CiscoConfiguration extends VendorConfiguration {
                     + "' not assigned an ip address");
           }
         } else {
-          int updateSourceInterfaceLine = lpg.getUpdateSourceLine();
           undefined(
               CiscoStructureType.INTERFACE,
               updateSourceInterface,
               CiscoStructureUsage.BGP_UPDATE_SOURCE_INTERFACE,
-              updateSourceInterfaceLine);
+              lpg.getUpdateSourceLine());
         }
       } else {
         if (lpg instanceof DynamicIpBgpPeerGroup) {
@@ -1394,7 +1392,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
           .add(new MatchProtocol(RoutingProtocol.AGGREGATE));
       BooleanExpr weInterior = BooleanExprs.True.toStaticBooleanExpr();
       if (attributeMapName != null) {
-        int attributeMapLine = aggNet.getAttributeMapLine();
         RouteMap attributeMap = _routeMaps.get(attributeMapName);
         if (attributeMap != null) {
           // need to apply attribute changes if this specific route is
@@ -1407,7 +1404,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
               CiscoStructureType.ROUTE_MAP,
               attributeMapName,
               CiscoStructureUsage.BGP_AGGREGATE_ATTRIBUTE_MAP,
-              attributeMapLine);
+              aggNet.getAttributeMapLine());
         }
       }
       v.getGeneratedRoutes().add(gr.build());
@@ -1447,7 +1444,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
       // set attribute map for aggregate network
       String attributeMapName = aggNet.getAttributeMap();
       if (attributeMapName != null) {
-        int attributeMapLine = aggNet.getAttributeMapLine();
         RouteMap attributeMap = _routeMaps.get(attributeMapName);
         if (attributeMap != null) {
           attributeMap
@@ -1459,7 +1455,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
               CiscoStructureType.ROUTE_MAP,
               attributeMapName,
               CiscoStructureUsage.BGP_AGGREGATE_ATTRIBUTE_MAP,
-              attributeMapLine);
+              aggNet.getAttributeMapLine());
         }
       }
     }
@@ -1518,7 +1514,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
       exportRipConditions.getConjuncts().add(new MatchProtocol(RoutingProtocol.RIP));
       String mapName = redistributeRipPolicy.getRouteMap();
       if (mapName != null) {
-        int mapLine = redistributeRipPolicy.getRouteMapLine();
         RouteMap redistributeRipRouteMap = _routeMaps.get(mapName);
         if (redistributeRipRouteMap != null) {
           redistributeRipRouteMap.getReferers().put(proc, "RIP redistribution route-map");
@@ -1528,7 +1523,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
               CiscoStructureType.ROUTE_MAP,
               mapName,
               CiscoStructureUsage.BGP_REDISTRIBUTE_RIP_MAP,
-              mapLine);
+              redistributeRipPolicy.getRouteMapLine());
         }
       }
       BooleanExpr we = bgpRedistributeWithEnvironmentExpr(weInterior, OriginType.INCOMPLETE);
@@ -1546,7 +1541,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
       exportStaticConditions.getConjuncts().add(new MatchProtocol(RoutingProtocol.STATIC));
       String mapName = redistributeStaticPolicy.getRouteMap();
       if (mapName != null) {
-        int mapLine = redistributeStaticPolicy.getRouteMapLine();
         RouteMap redistributeStaticRouteMap = _routeMaps.get(mapName);
         if (redistributeStaticRouteMap != null) {
           redistributeStaticRouteMap.getReferers().put(proc, "static redistribution route-map");
@@ -1556,7 +1550,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
               CiscoStructureType.ROUTE_MAP,
               mapName,
               CiscoStructureUsage.BGP_REDISTRIBUTE_STATIC_MAP,
-              mapLine);
+              redistributeStaticPolicy.getRouteMapLine());
         }
       }
       BooleanExpr we = bgpRedistributeWithEnvironmentExpr(weInterior, OriginType.INCOMPLETE);
@@ -1574,7 +1568,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
       exportConnectedConditions.getConjuncts().add(new MatchProtocol(RoutingProtocol.CONNECTED));
       String mapName = redistributeConnectedPolicy.getRouteMap();
       if (mapName != null) {
-        int mapLine = redistributeConnectedPolicy.getRouteMapLine();
         RouteMap redistributeConnectedRouteMap = _routeMaps.get(mapName);
         if (redistributeConnectedRouteMap != null) {
           redistributeConnectedRouteMap
@@ -1586,7 +1579,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
               CiscoStructureType.ROUTE_MAP,
               mapName,
               CiscoStructureUsage.BGP_REDISTRIBUTE_CONNECTED_MAP,
-              mapLine);
+              redistributeConnectedPolicy.getRouteMapLine());
         }
       }
       BooleanExpr we = bgpRedistributeWithEnvironmentExpr(weInterior, OriginType.INCOMPLETE);
@@ -1604,7 +1597,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
       exportOspfConditions.getConjuncts().add(new MatchProtocol(RoutingProtocol.OSPF));
       String mapName = redistributeOspfPolicy.getRouteMap();
       if (mapName != null) {
-        int mapLine = redistributeOspfPolicy.getRouteMapLine();
         RouteMap redistributeOspfRouteMap = _routeMaps.get(mapName);
         if (redistributeOspfRouteMap != null) {
           redistributeOspfRouteMap.getReferers().put(proc, "ospf redistribution route-map");
@@ -1614,7 +1606,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
               CiscoStructureType.ROUTE_MAP,
               mapName,
               CiscoStructureUsage.BGP_REDISTRIBUTE_OSPF_MAP,
-              mapLine);
+              redistributeOspfPolicy.getRouteMapLine());
         }
       }
       BooleanExpr we = bgpRedistributeWithEnvironmentExpr(weInterior, OriginType.INCOMPLETE);
@@ -1685,7 +1677,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
               String mapName = bgpNetwork.getRouteMapName();
               BooleanExpr weExpr = BooleanExprs.True.toStaticBooleanExpr();
               if (mapName != null) {
-                int mapLine = bgpNetwork.getRouteMapLine();
                 RouteMap routeMap = _routeMaps.get(mapName);
                 if (routeMap != null) {
                   weExpr = new CallExpr(mapName);
@@ -1695,7 +1686,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
                       CiscoStructureType.ROUTE_MAP,
                       mapName,
                       CiscoStructureUsage.BGP_NETWORK_ORIGINATION_ROUTE_MAP,
-                      mapLine);
+                      bgpNetwork.getRouteMapLine());
                 }
               }
               BooleanExpr we = bgpRedistributeWithEnvironmentExpr(weExpr, OriginType.IGP);
@@ -1730,7 +1721,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
               localFilter6.addLine(line);
               String mapName = bgpNetwork6.getRouteMapName();
               if (mapName != null) {
-                int mapLine = bgpNetwork6.getRouteMapLine();
                 RouteMap routeMap = _routeMaps.get(mapName);
                 if (routeMap != null) {
                   routeMap.getReferers().put(proc, "bgp ipv6 advertised network route-map");
@@ -1761,7 +1751,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
                       CiscoStructureType.ROUTE_MAP,
                       mapName,
                       CiscoStructureUsage.BGP_NETWORK6_ORIGINATION_ROUTE_MAP,
-                      mapLine);
+                      bgpNetwork6.getRouteMapLine());
                 }
               }
             });
@@ -1780,14 +1770,13 @@ public final class CiscoConfiguration extends VendorConfiguration {
       RoutingPolicy importPolicy = null;
       String inboundRouteMapName = lpg.getInboundRouteMap();
       if (inboundRouteMapName != null) {
-        int inboundRouteMapLine = lpg.getInboundRouteMapLine();
         importPolicy = c.getRoutingPolicies().get(inboundRouteMapName);
         if (importPolicy == null) {
           undefined(
               CiscoStructureType.ROUTE_MAP,
               inboundRouteMapName,
               CiscoStructureUsage.BGP_INBOUND_ROUTE_MAP,
-              inboundRouteMapLine);
+              lpg.getInboundRouteMapLine());
         } else {
           RouteMap inboundRouteMap = _routeMaps.get(inboundRouteMapName);
           inboundRouteMap
@@ -1796,16 +1785,14 @@ public final class CiscoConfiguration extends VendorConfiguration {
         }
       }
       String inboundRoute6MapName = lpg.getInboundRoute6Map();
-      RoutingPolicy importPolicy6 = null;
       if (inboundRoute6MapName != null) {
-        int inboundRoute6MapLine = lpg.getInboundRoute6MapLine();
-        importPolicy6 = c.getRoutingPolicies().get(inboundRoute6MapName);
+        RoutingPolicy importPolicy6 = c.getRoutingPolicies().get(inboundRoute6MapName);
         if (importPolicy6 == null) {
           undefined(
               CiscoStructureType.ROUTE_MAP,
               inboundRoute6MapName,
               CiscoStructureUsage.BGP_INBOUND_ROUTE6_MAP,
-              inboundRoute6MapLine);
+              lpg.getInboundRoute6MapLine());
         } else {
           RouteMap inboundRouteMap = _routeMaps.get(inboundRoute6MapName);
           inboundRouteMap
@@ -1838,14 +1825,13 @@ public final class CiscoConfiguration extends VendorConfiguration {
       localOrCommonOrigination.getDisjuncts().add(new CallExpr(bgpCommonExportPolicyName));
       String outboundRouteMapName = lpg.getOutboundRouteMap();
       if (outboundRouteMapName != null) {
-        int outboundRouteMapLine = lpg.getOutboundRouteMapLine();
         RouteMap outboundRouteMap = _routeMaps.get(outboundRouteMapName);
         if (outboundRouteMap == null) {
           undefined(
               CiscoStructureType.ROUTE_MAP,
               outboundRouteMapName,
               CiscoStructureUsage.BGP_OUTBOUND_ROUTE_MAP,
-              outboundRouteMapLine);
+              lpg.getOutboundRouteMapLine());
         } else {
           outboundRouteMap
               .getReferers()
@@ -1855,14 +1841,13 @@ public final class CiscoConfiguration extends VendorConfiguration {
       }
       String outboundRoute6MapName = lpg.getOutboundRoute6Map();
       if (outboundRoute6MapName != null) {
-        int outboundRoute6MapLine = lpg.getOutboundRoute6MapLine();
         RouteMap outboundRoute6Map = _routeMaps.get(outboundRoute6MapName);
         if (outboundRoute6Map == null) {
           undefined(
               CiscoStructureType.ROUTE_MAP,
               outboundRoute6MapName,
               CiscoStructureUsage.BGP_OUTBOUND_ROUTE6_MAP,
-              outboundRoute6MapLine);
+              lpg.getOutboundRoute6MapLine());
         } else {
           outboundRoute6Map
               .getReferers()
@@ -1889,7 +1874,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
         String defaultOriginateMapName = lpg.getDefaultOriginateMap();
         if (defaultOriginateMapName != null) { // originate contingent on
           // generation policy
-          int defaultOriginateMapLine = lpg.getDefaultOriginateMapLine();
           RoutingPolicy defaultRouteGenerationPolicy =
               c.getRoutingPolicies().get(defaultOriginateMapName);
           if (defaultRouteGenerationPolicy == null) {
@@ -1897,7 +1881,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
                 CiscoStructureType.ROUTE_MAP,
                 defaultOriginateMapName,
                 CiscoStructureUsage.BGP_DEFAULT_ORIGINATE_ROUTE_MAP,
-                defaultOriginateMapLine);
+                lpg.getDefaultOriginateMapLine());
           } else {
             RouteMap defaultRouteGenerationRouteMap = _routeMaps.get(defaultOriginateMapName);
             defaultRouteGenerationRouteMap
@@ -1936,18 +1920,8 @@ public final class CiscoConfiguration extends VendorConfiguration {
       if (clusterId == null) {
         clusterId = bgpRouterId;
       }
-      boolean routeReflectorClient = lpg.getRouteReflectorClient();
-      boolean sendCommunity = lpg.getSendCommunity();
-      boolean additionalPathsReceive = lpg.getAdditionalPathsReceive();
-      boolean additionalPathsSelectAll = lpg.getAdditionalPathsSelectAll();
-      boolean additionalPathsSend = lpg.getAdditionalPathsSend();
-      boolean advertiseInactive = lpg.getAdvertiseInactive();
-      boolean ebgpMultihop = lpg.getEbgpMultihop();
-      boolean allowasIn = lpg.getAllowAsIn();
-      boolean disablePeerAsCheck = lpg.getDisablePeerAsCheck();
       String inboundPrefixListName = lpg.getInboundPrefixList();
       if (inboundPrefixListName != null) {
-        int inboundPrefixListLine = lpg.getInboundPrefixListLine();
         ReferenceCountedStructure inboundPrefixList;
         if (ipv4) {
           inboundPrefixList = _prefixLists.get(inboundPrefixListName);
@@ -1964,19 +1938,18 @@ public final class CiscoConfiguration extends VendorConfiguration {
                 CiscoStructureType.PREFIX_LIST,
                 inboundPrefixListName,
                 CiscoStructureUsage.BGP_INBOUND_PREFIX_LIST,
-                inboundPrefixListLine);
+                lpg.getInboundPrefixListLine());
           } else {
             undefined(
                 CiscoStructureType.PREFIX6_LIST,
                 inboundPrefixListName,
                 CiscoStructureUsage.BGP_INBOUND_PREFIX6_LIST,
-                inboundPrefixListLine);
+                lpg.getInboundPrefixListLine());
           }
         }
       }
       String outboundPrefixListName = lpg.getOutboundPrefixList();
       if (outboundPrefixListName != null) {
-        int outboundPrefixListLine = lpg.getOutboundPrefixListLine();
         ReferenceCountedStructure outboundPrefixList;
         if (ipv4) {
           outboundPrefixList = _prefixLists.get(outboundPrefixListName);
@@ -1993,13 +1966,13 @@ public final class CiscoConfiguration extends VendorConfiguration {
                 CiscoStructureType.PREFIX_LIST,
                 outboundPrefixListName,
                 CiscoStructureUsage.BGP_OUTBOUND_PREFIX_LIST,
-                outboundPrefixListLine);
+                lpg.getOutboundPrefixListLine());
           } else {
             undefined(
                 CiscoStructureType.PREFIX6_LIST,
                 outboundPrefixListName,
                 CiscoStructureUsage.BGP_OUTBOUND_PREFIX6_LIST,
-                outboundPrefixListLine);
+                lpg.getOutboundPrefixListLine());
           }
         }
       }
@@ -2028,17 +2001,17 @@ public final class CiscoConfiguration extends VendorConfiguration {
         }
         newBgpNeighbors.put(newNeighbor.getPrefix(), newNeighbor);
 
-        newNeighbor.setAdditionalPathsReceive(additionalPathsReceive);
-        newNeighbor.setAdditionalPathsSelectAll(additionalPathsSelectAll);
-        newNeighbor.setAdditionalPathsSend(additionalPathsSend);
-        newNeighbor.setAdvertiseInactive(advertiseInactive);
-        newNeighbor.setAllowLocalAsIn(allowasIn);
-        newNeighbor.setAllowRemoteAsOut(disablePeerAsCheck);
-        newNeighbor.setRouteReflectorClient(routeReflectorClient);
+        newNeighbor.setAdditionalPathsReceive(lpg.getAdditionalPathsReceive());
+        newNeighbor.setAdditionalPathsSelectAll(lpg.getAdditionalPathsSelectAll());
+        newNeighbor.setAdditionalPathsSend(lpg.getAdditionalPathsSend());
+        newNeighbor.setAdvertiseInactive(lpg.getAdvertiseInactive());
+        newNeighbor.setAllowLocalAsIn(lpg.getAllowAsIn());
+        newNeighbor.setAllowRemoteAsOut(lpg.getDisablePeerAsCheck());
+        newNeighbor.setRouteReflectorClient(lpg.getRouteReflectorClient());
         newNeighbor.setClusterId(clusterId.asLong());
         newNeighbor.setDefaultMetric(defaultMetric);
         newNeighbor.setDescription(description);
-        newNeighbor.setEbgpMultihop(ebgpMultihop);
+        newNeighbor.setEbgpMultihop(lpg.getEbgpMultihop());
         if (defaultRoute != null) {
           newNeighbor.getGeneratedRoutes().add(defaultRoute.build());
         }
@@ -2050,7 +2023,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
         newNeighbor.setLocalIp(updateSource);
         newNeighbor.setExportPolicy(peerExportPolicyName);
         newNeighbor.setRemoteAs(lpg.getRemoteAs());
-        newNeighbor.setSendCommunity(sendCommunity);
+        newNeighbor.setSendCommunity(lpg.getSendCommunity());
         newNeighbor.setVrf(vrfName);
       }
     }
@@ -2082,13 +2055,12 @@ public final class CiscoConfiguration extends VendorConfiguration {
 
     /* source nat acl */
     IpAccessList sourceNatAcl = ipAccessLists.get(sourceNatAclName);
-    int sourceNatAclLine = nat.getAclNameLine();
     if (sourceNatAcl == null) {
       undefined(
           CiscoStructureType.IP_ACCESS_LIST,
           sourceNatAclName,
           CiscoStructureUsage.IP_NAT_SOURCE_ACCESS_LIST,
-          sourceNatAclLine);
+          nat.getAclNameLine());
     } else {
       convertedNat.setAcl(sourceNatAcl);
       String msg = "source nat acl for interface: " + iface.getName();
@@ -2105,7 +2077,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
     /* source nat pool */
     String sourceNatPoolName = nat.getNatPool();
     if (sourceNatPoolName != null) {
-      int sourceNatPoolLine = nat.getNatPoolLine();
       NatPool sourceNatPool = _natPools.get(sourceNatPoolName);
       if (sourceNatPool != null) {
         sourceNatPool.getReferers().put(iface, "source nat pool for interface: " + iface.getName());
@@ -2120,7 +2091,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
             CiscoStructureType.NAT_POOL,
             sourceNatPoolName,
             CiscoStructureUsage.IP_NAT_SOURCE_POOL,
-            sourceNatPoolLine);
+            nat.getNatPoolLine());
       }
     }
 
@@ -2253,14 +2224,13 @@ public final class CiscoConfiguration extends VendorConfiguration {
 
     String incomingFilterName = iface.getIncomingFilter();
     if (incomingFilterName != null) {
-      int incomingFilterLine = iface.getIncomingFilterLine();
       IpAccessList incomingFilter = ipAccessLists.get(incomingFilterName);
       if (incomingFilter == null) {
         undefined(
             CiscoStructureType.IP_ACCESS_LIST,
             incomingFilterName,
             CiscoStructureUsage.INTERFACE_INCOMING_FILTER,
-            incomingFilterLine);
+            iface.getIncomingFilterLine());
       } else {
         String msg = "incoming acl for interface: " + iface.getName();
         ExtendedAccessList incomingExtendedAccessList =
@@ -2278,14 +2248,13 @@ public final class CiscoConfiguration extends VendorConfiguration {
     }
     String outgoingFilterName = iface.getOutgoingFilter();
     if (outgoingFilterName != null) {
-      int outgoingFilterLine = iface.getOutgoingFilterLine();
       IpAccessList outgoingFilter = ipAccessLists.get(outgoingFilterName);
       if (outgoingFilter == null) {
         undefined(
             CiscoStructureType.IP_ACCESS_LIST,
             outgoingFilterName,
             CiscoStructureUsage.INTERFACE_OUTGOING_FILTER,
-            outgoingFilterLine);
+            iface.getOutgoingFilterLine());
       } else {
         String msg = "outgoing acl for interface: " + iface.getName();
         ExtendedAccessList outgoingExtendedAccessList =
@@ -2318,14 +2287,13 @@ public final class CiscoConfiguration extends VendorConfiguration {
     }
     String routingPolicyName = iface.getRoutingPolicy();
     if (routingPolicyName != null) {
-      int routingPolicyLine = iface.getRoutingPolicyLine();
       RouteMap routingPolicyRouteMap = _routeMaps.get(routingPolicyName);
       if (routingPolicyRouteMap == null) {
         undefined(
             CiscoStructureType.ROUTE_MAP,
             routingPolicyName,
             CiscoStructureUsage.INTERFACE_POLICY_ROUTING_MAP,
-            routingPolicyLine);
+            iface.getRoutingPolicyLine());
       } else {
         routingPolicyRouteMap
             .getReferers()
@@ -2569,7 +2537,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
       String defaultOriginateMapName = proc.getDefaultInformationOriginateMap();
       boolean useAggregateDefaultOnly;
       if (defaultOriginateMapName != null) {
-        int defaultOriginateMapLine = proc.getDefaultInformationOriginateMapLine();
         useAggregateDefaultOnly = true;
         RoutingPolicy ospfDefaultGenerationPolicy =
             c.getRoutingPolicies().get(defaultOriginateMapName);
@@ -2578,7 +2545,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
               CiscoStructureType.ROUTE_MAP,
               defaultOriginateMapName,
               CiscoStructureUsage.OSPF_DEFAULT_ORIGINATE_ROUTE_MAP,
-              defaultOriginateMapLine);
+              proc.getDefaultInformationOriginateMapLine());
         } else {
           RouteMap generationRouteMap = _routeMaps.get(defaultOriginateMapName);
           generationRouteMap.getReferers().put(proc, "ospf default-originate route-map");
@@ -2715,7 +2682,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
       // add default export map with metric
       String defaultOriginateMapName = proc.getDefaultInformationOriginateMap();
       if (defaultOriginateMapName != null) {
-        int defaultOriginateMapLine = proc.getDefaultInformationOriginateMapLine();
         RoutingPolicy ripDefaultGenerationPolicy =
             c.getRoutingPolicies().get(defaultOriginateMapName);
         if (ripDefaultGenerationPolicy == null) {
@@ -2723,7 +2689,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
               CiscoStructureType.ROUTE_MAP,
               defaultOriginateMapName,
               CiscoStructureUsage.RIP_DEFAULT_ORIGINATE_ROUTE_MAP,
-              defaultOriginateMapLine);
+              proc.getDefaultInformationOriginateMapLine());
         } else {
           RouteMap generationRouteMap = _routeMaps.get(defaultOriginateMapName);
           generationRouteMap.getReferers().put(proc, "rip default-originate route-map");
@@ -2764,14 +2730,13 @@ public final class CiscoConfiguration extends VendorConfiguration {
       // add default export map with metric
       String exportConnectedRouteMapName = rcp.getRouteMap();
       if (exportConnectedRouteMapName != null) {
-        int exportConnectedRouteMapLine = rcp.getRouteMapLine();
         RouteMap exportConnectedRouteMap = _routeMaps.get(exportConnectedRouteMapName);
         if (exportConnectedRouteMap == null) {
           undefined(
               CiscoStructureType.ROUTE_MAP,
               exportConnectedRouteMapName,
               CiscoStructureUsage.RIP_REDISTRIBUTE_CONNECTED_MAP,
-              exportConnectedRouteMapLine);
+              rcp.getRouteMapLine());
         } else {
           exportConnectedRouteMap.getReferers().put(proc, "rip redistribute connected route-map");
           ripExportConnectedConditions
@@ -2803,14 +2768,13 @@ public final class CiscoConfiguration extends VendorConfiguration {
       // add export map with metric
       String exportStaticRouteMapName = rsp.getRouteMap();
       if (exportStaticRouteMapName != null) {
-        int exportStaticRouteMapLine = rsp.getRouteMapLine();
         RouteMap exportStaticRouteMap = _routeMaps.get(exportStaticRouteMapName);
         if (exportStaticRouteMap == null) {
           undefined(
               CiscoStructureType.ROUTE_MAP,
               exportStaticRouteMapName,
               CiscoStructureUsage.RIP_REDISTRIBUTE_STATIC_MAP,
-              exportStaticRouteMapLine);
+              rsp.getRouteMapLine());
         } else {
           exportStaticRouteMap.getReferers().put(proc, "rip redistribute static route-map");
           ripExportStaticConditions.getConjuncts().add(new CallExpr(exportStaticRouteMapName));
@@ -2840,14 +2804,13 @@ public final class CiscoConfiguration extends VendorConfiguration {
       // add export map with metric
       String exportBgpRouteMapName = rbp.getRouteMap();
       if (exportBgpRouteMapName != null) {
-        int exportBgpRouteMapLine = rbp.getRouteMapLine();
         RouteMap exportBgpRouteMap = _routeMaps.get(exportBgpRouteMapName);
         if (exportBgpRouteMap == null) {
           undefined(
               CiscoStructureType.ROUTE_MAP,
               exportBgpRouteMapName,
               CiscoStructureUsage.RIP_REDISTRIBUTE_BGP_MAP,
-              exportBgpRouteMapLine);
+              rbp.getRouteMapLine());
         } else {
           exportBgpRouteMap.getReferers().put(proc, "rip redistribute bgp route-map");
           ripExportBgpConditions.getConjuncts().add(new CallExpr(exportBgpRouteMapName));
@@ -2966,7 +2929,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
       RoutingPolicy continueTargetPolicy = null;
       if (continueStatement != null) {
         continueTarget = continueStatement.getTarget();
-        int statementLine = continueStatement.getStatementLine();
         if (continueTarget == null) {
           continueTarget = followingClauseNumber;
         }
@@ -2981,7 +2943,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
                 CiscoStructureType.ROUTE_MAP_CLAUSE,
                 name,
                 CiscoStructureUsage.ROUTE_MAP_CONTINUE,
-                statementLine);
+                continueStatement.getStatementLine());
             continueStatement = null;
           }
         } else {
@@ -3374,13 +3336,11 @@ public final class CiscoConfiguration extends VendorConfiguration {
 
     // warn about references to undefined peer groups
     for (Entry<String, Integer> e : _undefinedPeerGroups.entrySet()) {
-      String name = e.getKey();
-      int line = e.getValue();
       undefined(
           CiscoStructureType.BGP_PEER_GROUP,
-          name,
+          e.getKey(),
           CiscoStructureUsage.BGP_NEIGHBOR_STATEMENT,
-          line);
+          e.getValue());
     }
 
     // mark references to IPv4/6 ACLs that may not appear in data model


### PR DESCRIPTION
Defining variables far from where they're used and then only using them
once just makes the code harder to read and understand.