### PR TITLE
CiscoConfiguration: only create BGP_NETWORK6_NETWORKS_FILTER if there are IPv6 networks

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -1710,53 +1710,55 @@ public final class CiscoConfiguration extends VendorConfiguration {
               exportNetworkConditions.getConjuncts().add(we);
               preFilterConditions.getDisjuncts().add(exportNetworkConditions);
             });
-    String localFilter6Name = "~BGP_NETWORK6_NETWORKS_FILTER:" + vrfName + "~";
-    Route6FilterList localFilter6 = new Route6FilterList(localFilter6Name);
-    proc.getIpv6Networks()
-        .forEach(
-            (prefix6, bgpNetwork6) -> {
-              int prefixLen = prefix6.getPrefixLength();
-              Route6FilterLine line =
-                  new Route6FilterLine(
-                      LineAction.ACCEPT, prefix6, new SubRange(prefixLen, prefixLen));
-              localFilter6.addLine(line);
-              String mapName = bgpNetwork6.getRouteMapName();
-              if (mapName != null) {
-                RouteMap routeMap = _routeMaps.get(mapName);
-                if (routeMap != null) {
-                  routeMap.getReferers().put(proc, "bgp ipv6 advertised network route-map");
-                  BooleanExpr we =
-                      bgpRedistributeWithEnvironmentExpr(new CallExpr(mapName), OriginType.IGP);
-                  Conjunction exportNetwork6Conditions = new Conjunction();
-                  Prefix6Space space6 = new Prefix6Space();
-                  space6.addPrefix6(prefix6);
-                  exportNetwork6Conditions
-                      .getConjuncts()
-                      .add(
-                          new MatchPrefix6Set(
-                              new DestinationNetwork6(), new ExplicitPrefix6Set(space6)));
-                  exportNetwork6Conditions
-                      .getConjuncts()
-                      .add(new Not(new MatchProtocol(RoutingProtocol.BGP)));
-                  exportNetwork6Conditions
-                      .getConjuncts()
-                      .add(new Not(new MatchProtocol(RoutingProtocol.IBGP)));
-                  // TODO: ban aggregates?
-                  exportNetwork6Conditions
-                      .getConjuncts()
-                      .add(new Not(new MatchProtocol(RoutingProtocol.AGGREGATE)));
-                  exportNetwork6Conditions.getConjuncts().add(we);
-                  preFilterConditions.getDisjuncts().add(exportNetwork6Conditions);
-                } else {
-                  undefined(
-                      CiscoStructureType.ROUTE_MAP,
-                      mapName,
-                      CiscoStructureUsage.BGP_NETWORK6_ORIGINATION_ROUTE_MAP,
-                      bgpNetwork6.getRouteMapLine());
+    if (!proc.getIpv6Networks().isEmpty()) {
+      String localFilter6Name = "~BGP_NETWORK6_NETWORKS_FILTER:" + vrfName + "~";
+      Route6FilterList localFilter6 = new Route6FilterList(localFilter6Name);
+      proc.getIpv6Networks()
+          .forEach(
+              (prefix6, bgpNetwork6) -> {
+                int prefixLen = prefix6.getPrefixLength();
+                Route6FilterLine line =
+                    new Route6FilterLine(
+                        LineAction.ACCEPT, prefix6, new SubRange(prefixLen, prefixLen));
+                localFilter6.addLine(line);
+                String mapName = bgpNetwork6.getRouteMapName();
+                if (mapName != null) {
+                  RouteMap routeMap = _routeMaps.get(mapName);
+                  if (routeMap != null) {
+                    routeMap.getReferers().put(proc, "bgp ipv6 advertised network route-map");
+                    BooleanExpr we =
+                        bgpRedistributeWithEnvironmentExpr(new CallExpr(mapName), OriginType.IGP);
+                    Conjunction exportNetwork6Conditions = new Conjunction();
+                    Prefix6Space space6 = new Prefix6Space();
+                    space6.addPrefix6(prefix6);
+                    exportNetwork6Conditions
+                        .getConjuncts()
+                        .add(
+                            new MatchPrefix6Set(
+                                new DestinationNetwork6(), new ExplicitPrefix6Set(space6)));
+                    exportNetwork6Conditions
+                        .getConjuncts()
+                        .add(new Not(new MatchProtocol(RoutingProtocol.BGP)));
+                    exportNetwork6Conditions
+                        .getConjuncts()
+                        .add(new Not(new MatchProtocol(RoutingProtocol.IBGP)));
+                    // TODO: ban aggregates?
+                    exportNetwork6Conditions
+                        .getConjuncts()
+                        .add(new Not(new MatchProtocol(RoutingProtocol.AGGREGATE)));
+                    exportNetwork6Conditions.getConjuncts().add(we);
+                    preFilterConditions.getDisjuncts().add(exportNetwork6Conditions);
+                  } else {
+                    undefined(
+                        CiscoStructureType.ROUTE_MAP,
+                        mapName,
+                        CiscoStructureUsage.BGP_NETWORK6_ORIGINATION_ROUTE_MAP,
+                        bgpNetwork6.getRouteMapLine());
+                  }
                 }
-              }
-            });
-    c.getRoute6FilterLists().put(localFilter6Name, localFilter6);
+              });
+      c.getRoute6FilterLists().put(localFilter6Name, localFilter6);
+    }
 
     MatchProtocol isEbgp = new MatchProtocol(RoutingProtocol.BGP);
     MatchProtocol isIbgp = new MatchProtocol(RoutingProtocol.IBGP);

--- a/test_rigs/parsing-tests/unit-tests-nodes.ref
+++ b/test_rigs/parsing-tests/unit-tests-nodes.ref
@@ -160,11 +160,6 @@
         "defaultCrossZoneAction" : "ACCEPT",
         "defaultInboundAction" : "ACCEPT",
         "deviceType" : "ROUTER",
-        "route6FilterLists" : {
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-          }
-        },
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
             "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
@@ -723,11 +718,6 @@
         "defaultCrossZoneAction" : "ACCEPT",
         "defaultInboundAction" : "ACCEPT",
         "deviceType" : "ROUTER",
-        "route6FilterLists" : {
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-          }
-        },
         "routingPolicies" : {
           "ROUTE_MAP" : {
             "name" : "ROUTE_MAP",
@@ -2310,11 +2300,6 @@
         "defaultCrossZoneAction" : "ACCEPT",
         "defaultInboundAction" : "ACCEPT",
         "deviceType" : "ROUTER",
-        "route6FilterLists" : {
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-          }
-        },
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
             "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
@@ -2615,11 +2600,6 @@
         "defaultCrossZoneAction" : "ACCEPT",
         "defaultInboundAction" : "ACCEPT",
         "deviceType" : "ROUTER",
-        "route6FilterLists" : {
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-          }
-        },
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
             "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
@@ -2680,11 +2660,6 @@
         "defaultCrossZoneAction" : "ACCEPT",
         "defaultInboundAction" : "ACCEPT",
         "deviceType" : "ROUTER",
-        "route6FilterLists" : {
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-          }
-        },
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
             "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
@@ -2815,11 +2790,6 @@
         "defaultCrossZoneAction" : "ACCEPT",
         "defaultInboundAction" : "ACCEPT",
         "deviceType" : "ROUTER",
-        "route6FilterLists" : {
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-          }
-        },
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
             "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
@@ -3317,11 +3287,6 @@
         "defaultCrossZoneAction" : "ACCEPT",
         "defaultInboundAction" : "ACCEPT",
         "deviceType" : "ROUTER",
-        "route6FilterLists" : {
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-          }
-        },
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
             "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
@@ -4800,11 +4765,6 @@
         "defaultCrossZoneAction" : "ACCEPT",
         "defaultInboundAction" : "ACCEPT",
         "deviceType" : "ROUTER",
-        "route6FilterLists" : {
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-          }
-        },
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
             "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
@@ -4885,14 +4845,6 @@
         "defaultCrossZoneAction" : "ACCEPT",
         "defaultInboundAction" : "ACCEPT",
         "deviceType" : "ROUTER",
-        "route6FilterLists" : {
-          "~BGP_NETWORK6_NETWORKS_FILTER:aVrfWithInnerStatements~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:aVrfWithInnerStatements~"
-          },
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-          }
-        },
         "routeFilterLists" : {
           "~MATCH_SUPPRESSED_SUMMARY_ONLY:aVrfWithInnerStatements~" : {
             "name" : "~MATCH_SUPPRESSED_SUMMARY_ONLY:aVrfWithInnerStatements~",
@@ -5468,11 +5420,6 @@
         "defaultCrossZoneAction" : "ACCEPT",
         "defaultInboundAction" : "ACCEPT",
         "deviceType" : "ROUTER",
-        "route6FilterLists" : {
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-          }
-        },
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
             "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
@@ -8377,11 +8324,6 @@
         "defaultCrossZoneAction" : "ACCEPT",
         "defaultInboundAction" : "ACCEPT",
         "deviceType" : "ROUTER",
-        "route6FilterLists" : {
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-          }
-        },
         "routingPolicies" : {
           "MATCH_ASN" : {
             "name" : "MATCH_ASN",
@@ -9688,11 +9630,6 @@
         "defaultCrossZoneAction" : "ACCEPT",
         "defaultInboundAction" : "ACCEPT",
         "deviceType" : "ROUTER",
-        "route6FilterLists" : {
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-          }
-        },
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
             "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
@@ -10240,11 +10177,6 @@
         "defaultCrossZoneAction" : "ACCEPT",
         "defaultInboundAction" : "ACCEPT",
         "deviceType" : "ROUTER",
-        "route6FilterLists" : {
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-          }
-        },
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
             "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
@@ -11411,11 +11343,6 @@
         "defaultCrossZoneAction" : "ACCEPT",
         "defaultInboundAction" : "ACCEPT",
         "deviceType" : "ROUTER",
-        "route6FilterLists" : {
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-          }
-        },
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
             "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
@@ -11496,11 +11423,6 @@
         "defaultCrossZoneAction" : "ACCEPT",
         "defaultInboundAction" : "ACCEPT",
         "deviceType" : "ROUTER",
-        "route6FilterLists" : {
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-          }
-        },
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
             "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
@@ -11561,11 +11483,6 @@
         "defaultCrossZoneAction" : "ACCEPT",
         "defaultInboundAction" : "ACCEPT",
         "deviceType" : "ROUTER",
-        "route6FilterLists" : {
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-          }
-        },
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
             "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
@@ -14168,11 +14085,6 @@
         "defaultCrossZoneAction" : "ACCEPT",
         "defaultInboundAction" : "ACCEPT",
         "deviceType" : "ROUTER",
-        "route6FilterLists" : {
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-          }
-        },
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
             "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
@@ -14517,11 +14429,6 @@
         "defaultCrossZoneAction" : "ACCEPT",
         "defaultInboundAction" : "ACCEPT",
         "deviceType" : "ROUTER",
-        "route6FilterLists" : {
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-          }
-        },
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
             "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
@@ -14632,11 +14539,6 @@
         "defaultCrossZoneAction" : "ACCEPT",
         "defaultInboundAction" : "ACCEPT",
         "deviceType" : "ROUTER",
-        "route6FilterLists" : {
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-          }
-        },
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
             "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
@@ -14697,11 +14599,6 @@
         "defaultCrossZoneAction" : "ACCEPT",
         "defaultInboundAction" : "ACCEPT",
         "deviceType" : "ROUTER",
-        "route6FilterLists" : {
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-          }
-        },
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
             "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
@@ -14812,11 +14709,6 @@
         "defaultCrossZoneAction" : "ACCEPT",
         "defaultInboundAction" : "ACCEPT",
         "deviceType" : "ROUTER",
-        "route6FilterLists" : {
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-          }
-        },
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
             "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
@@ -15096,11 +14988,6 @@
         "defaultCrossZoneAction" : "ACCEPT",
         "defaultInboundAction" : "ACCEPT",
         "deviceType" : "ROUTER",
-        "route6FilterLists" : {
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-          }
-        },
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
             "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
@@ -15278,11 +15165,6 @@
         "defaultCrossZoneAction" : "ACCEPT",
         "defaultInboundAction" : "ACCEPT",
         "deviceType" : "ROUTER",
-        "route6FilterLists" : {
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-          }
-        },
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
             "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
@@ -15605,11 +15487,6 @@
         "defaultCrossZoneAction" : "ACCEPT",
         "defaultInboundAction" : "ACCEPT",
         "deviceType" : "ROUTER",
-        "route6FilterLists" : {
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-          }
-        },
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
             "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
@@ -15841,11 +15718,6 @@
         "defaultCrossZoneAction" : "ACCEPT",
         "defaultInboundAction" : "ACCEPT",
         "deviceType" : "ROUTER",
-        "route6FilterLists" : {
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-          }
-        },
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
             "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
@@ -17486,11 +17358,6 @@
         "defaultCrossZoneAction" : "ACCEPT",
         "defaultInboundAction" : "ACCEPT",
         "deviceType" : "ROUTER",
-        "route6FilterLists" : {
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-          }
-        },
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
             "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
@@ -20072,9 +19939,6 @@
               }
             ],
             "name" : "v6_list"
-          },
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
           }
         },
         "routeFilterLists" : {
@@ -22015,11 +21879,6 @@
         "defaultCrossZoneAction" : "ACCEPT",
         "defaultInboundAction" : "ACCEPT",
         "deviceType" : "ROUTER",
-        "route6FilterLists" : {
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-          }
-        },
         "routingPolicies" : {
           "EBGP-PEER" : {
             "name" : "EBGP-PEER",

--- a/tests/aws/nodes-example-aws.ref
+++ b/tests/aws/nodes-example-aws.ref
@@ -1059,11 +1059,6 @@
             "ipsecPolicy" : "ipsec-vpn-ba2e34a8-1"
           }
         },
-        "route6FilterLists" : {
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-          }
-        },
         "routeFilterLists" : {
           "MATCH_ALL_BGP" : {
             "name" : "MATCH_ALL_BGP",

--- a/tests/basic/nodes.ref
+++ b/tests/basic/nodes.ref
@@ -292,11 +292,6 @@
             ]
           }
         },
-        "route6FilterLists" : {
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-          }
-        },
         "routeFilterLists" : {
           "101" : {
             "name" : "101",
@@ -1564,11 +1559,6 @@
           "18.18.18.18",
           "23.23.23.23"
         ],
-        "route6FilterLists" : {
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-          }
-        },
         "routeFilterLists" : {
           "101" : {
             "name" : "101",
@@ -2669,11 +2659,6 @@
           "1.1.1.1",
           "2.2.2.2"
         ],
-        "route6FilterLists" : {
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-          }
-        },
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
             "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
@@ -3342,11 +3327,6 @@
           "18.18.18.18",
           "23.23.23.23"
         ],
-        "route6FilterLists" : {
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-          }
-        },
         "routeFilterLists" : {
           "101" : {
             "name" : "101",
@@ -4604,11 +4584,6 @@
         "ntpServers" : [
           "18.18.18.18"
         ],
-        "route6FilterLists" : {
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-          }
-        },
         "routeFilterLists" : {
           "101" : {
             "name" : "101",
@@ -5731,11 +5706,6 @@
           "1.1.1.1",
           "2.1.2.2"
         ],
-        "route6FilterLists" : {
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-          }
-        },
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
             "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
@@ -6307,11 +6277,6 @@
           "1.1.1.1",
           "2.2.2.2"
         ],
-        "route6FilterLists" : {
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-          }
-        },
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
             "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
@@ -7124,11 +7089,6 @@
             ]
           }
         },
-        "route6FilterLists" : {
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-          }
-        },
         "routeFilterLists" : {
           "102" : {
             "name" : "102",
@@ -7926,11 +7886,6 @@
             ]
           }
         },
-        "route6FilterLists" : {
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-          }
-        },
         "routeFilterLists" : {
           "105" : {
             "name" : "105",
@@ -8696,11 +8651,6 @@
                 "name" : "permit ip host 3.0.2.0 host 255.255.255.0"
               }
             ]
-          }
-        },
-        "route6FilterLists" : {
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
           }
         },
         "routeFilterLists" : {
@@ -9484,11 +9434,6 @@
           "18.18.18.18",
           "23.23.23.23"
         ],
-        "route6FilterLists" : {
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-          }
-        },
         "routeFilterLists" : {
           "101" : {
             "name" : "101",
@@ -10645,11 +10590,6 @@
           "18.18.18.18",
           "23.23.23.23"
         ],
-        "route6FilterLists" : {
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-          }
-        },
         "routeFilterLists" : {
           "101" : {
             "name" : "101",
@@ -11656,11 +11596,6 @@
           "1.1.1.1",
           "2.2.2.2"
         ],
-        "route6FilterLists" : {
-          "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-            "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-          }
-        },
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
             "name" : "~BGP_COMMON_EXPORT_POLICY:default~",

--- a/tests/jsonpath-addons/jsonpath-display-hints-prefixofsuffix.ref
+++ b/tests/jsonpath-addons/jsonpath-display-hints-prefixofsuffix.ref
@@ -427,11 +427,6 @@
                 "18.18.18.18",
                 "23.23.23.23"
               ],
-              "route6FilterLists" : {
-                "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-                  "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-                }
-              },
               "routeFilterLists" : {
                 "101" : {
                   "name" : "101",

--- a/tests/jsonpath-addons/jsonpath-display-hints-suffixofsuffix.ref
+++ b/tests/jsonpath-addons/jsonpath-display-hints-suffixofsuffix.ref
@@ -427,11 +427,6 @@
                 "18.18.18.18",
                 "23.23.23.23"
               ],
-              "route6FilterLists" : {
-                "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
-                  "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
-                }
-              },
               "routeFilterLists" : {
                 "101" : {
                   "name" : "101",


### PR DESCRIPTION
Less clutter in the data model, it's never called anyway, and we definitely shouldn't create it on devices where IPv6 address family isn't even enabled.