### PR TITLE
Parsing storm-control

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -4492,6 +4492,11 @@ STATION_PORT
    'station-port'
 ;
 
+STORM_CONTROL
+:
+   'storm-control'
+;
+
 STORM_CONTROL_PROFILES
 :
    'storm-control-profiles'

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_interfaces.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_interfaces.g4
@@ -257,6 +257,7 @@ if_bridge
    BRIDGE
    (
       apply
+      | if_storm_control
       | ifbr_filter
       | ifbr_interface_mode
       | ifbr_vlan_id_list
@@ -273,6 +274,7 @@ if_ethernet_switching
    ETHERNET_SWITCHING
    (
       apply
+      | if_storm_control
       | ife_filter
       | ife_interface_mode
       | ife_native_vlan_id
@@ -319,6 +321,11 @@ if_mpls
       | ifm_maximum_labels
       | ifm_mtu
    )
+;
+
+if_storm_control
+:
+    STORM_CONTROL null_filler
 ;
 
 ifbr_filter

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -1017,4 +1017,10 @@ public class FlatJuniperGrammarTest {
     assertThat(c, hasDefaultVrf(hasStaticRoutes(hasItem(hasPrefix(Prefix.parse("1.0.0.0/8"))))));
     assertThat(c, hasVrf("ri2", hasStaticRoutes(hasItem(hasPrefix(Prefix.parse("2.0.0.0/8"))))));
   }
+
+  @Test
+  public void testStormControl() throws IOException {
+    /* allow storm-control configuration in an interface */
+    parseConfig("storm-control");
+  }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/storm-control
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/storm-control
@@ -1,0 +1,4 @@
+#
+set system host-name storm-control
+#
+set interfaces ae42 unit 0 family ethernet-switching storm-control sc


### PR DESCRIPTION
We can parse and ignore storm-control in Juniper like we are doing in Cisco