### PR TITLE
Allow installation of covered static routes in the main RIB

### DIFF
--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/AbstractRouteMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/AbstractRouteMatchers.java
@@ -3,9 +3,11 @@ package org.batfish.datamodel.matchers;
 import static org.hamcrest.Matchers.equalTo;
 
 import javax.annotation.Nonnull;
+import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.matchers.AbstractRouteMatchersImpl.HasMetric;
+import org.batfish.datamodel.matchers.AbstractRouteMatchersImpl.HasNextHopIp;
 import org.batfish.datamodel.matchers.AbstractRouteMatchersImpl.HasPrefix;
 import org.batfish.datamodel.matchers.AbstractRouteMatchersImpl.HasProtocol;
 import org.hamcrest.Matcher;
@@ -26,6 +28,14 @@ public final class AbstractRouteMatchers {
    */
   public static HasMetric hasMetric(@Nonnull Matcher<? super Long> subMatcher) {
     return new HasMetric(subMatcher);
+  }
+
+  /**
+   * Provides a matcher that matches when the {@code nextHopIp} is equal to the {@link
+   * AbstractRoute}'s protocol.
+   */
+  public static HasNextHopIp hasNextHopIp(Ip nextHopIp) {
+    return new HasNextHopIp(equalTo(nextHopIp));
   }
 
   /**

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/AbstractRouteMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/AbstractRouteMatchersImpl.java
@@ -2,6 +2,7 @@ package org.batfish.datamodel.matchers;
 
 import javax.annotation.Nonnull;
 import org.batfish.datamodel.AbstractRoute;
+import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.RoutingProtocol;
 import org.hamcrest.FeatureMatcher;
@@ -16,6 +17,17 @@ final class AbstractRouteMatchersImpl {
     @Override
     protected Long featureValueOf(AbstractRoute actual) {
       return actual.getMetric();
+    }
+  }
+
+  static final class HasNextHopIp extends FeatureMatcher<AbstractRoute, Ip> {
+    HasNextHopIp(@Nonnull Matcher<? super Ip> subMatcher) {
+      super(subMatcher, "An AbstractRoute with nextHopIp:", "nextHopIp");
+    }
+
+    @Override
+    protected Ip featureValueOf(AbstractRoute actual) {
+      return actual.getNextHopIp();
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -410,19 +410,15 @@ public class VirtualRouter extends ComparableStructure<String> {
   void activateStaticRoutes() {
     for (StaticRoute sr : _staticRib.getRoutes()) {
       // See if we have any routes matching this route's next hop IP
+      // remote static route
       Set<AbstractRoute> matchingRoutes = _mainRib.longestPrefixMatch(sr.getNextHopIp());
-      Prefix staticRoutePrefix = sr.getNetwork();
-
       for (AbstractRoute matchingRoute : matchingRoutes) {
-        Prefix matchingRoutePrefix = matchingRoute.getNetwork();
-        /*
-         * check to make sure matching route's prefix does not totally
-         * contain this static route's prefix
-         */
-        if (!matchingRoutePrefix.containsPrefix(staticRoutePrefix)) {
-          _mainRibRouteDeltaBuiler.from(_mainRib.mergeRouteGetDelta(sr));
-          break; // break out of the inner loop but continue processing static routes
+        if (matchingRoute.getNetwork().equals(sr.getNetwork())) {
+          // Do not activate if the route to get to next-hop-ip has the same prefix as static route
+          continue;
         }
+        // TODO: issue https://github.com/batfish/batfish/issues/1375
+        _mainRibRouteDeltaBuiler.from(_mainRib.mergeRouteGetDelta(sr));
       }
     }
   }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/StaticRouteActivationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/StaticRouteActivationTest.java
@@ -1,0 +1,199 @@
+package org.batfish.dataplane;
+
+import static org.batfish.datamodel.matchers.AbstractRouteMatchers.hasNextHopIp;
+import static org.batfish.datamodel.matchers.AbstractRouteMatchers.hasPrefix;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.ImmutableSortedSet;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Set;
+import org.batfish.datamodel.AbstractRoute;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.DataPlane;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.InterfaceAddress;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.Route;
+import org.batfish.datamodel.StaticRoute;
+import org.batfish.datamodel.Vrf;
+import org.batfish.main.Batfish;
+import org.batfish.main.BatfishTestUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+/** Tests for activation conditions of static routes with next hop IP in bdp/ibdp */
+@RunWith(Parameterized.class)
+public class StaticRouteActivationTest {
+
+  private Configuration _n1;
+  private Interface _i1;
+  private Vrf _vrf;
+  private static final int INTERFACE_BITS = 24;
+  private final Ip _interfaceIp = new Ip("1.1.1.1");
+  private final Ip _baseNextHopIp = new Ip("1.1.1.2");
+
+  @Parameters
+  public static Collection<Object[]> data() {
+    return Arrays.asList(new Object[][] {{"bdp"}, {"ibdp"}});
+  }
+
+  @Parameter public String dpEngine;
+
+  @Rule public TemporaryFolder _folder = new TemporaryFolder();
+
+  @Before
+  public void setup() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration.Builder cb = nf.configurationBuilder();
+    Vrf.Builder vb = nf.vrfBuilder();
+    Interface.Builder ib = nf.interfaceBuilder();
+    _n1 = cb.setHostname("n1").setConfigurationFormat(ConfigurationFormat.CISCO_IOS).build();
+    _vrf = vb.setOwner(_n1).setName(Configuration.DEFAULT_VRF_NAME).build();
+    _i1 =
+        ib.setVrf(_vrf)
+            .setName("Eth1")
+            .setOwner(_n1)
+            .setActive(true)
+            .setAddress(new InterfaceAddress(_interfaceIp, INTERFACE_BITS))
+            .build();
+  }
+
+  @Test
+  public void testCoveredStaticRouteIsInstalled() throws IOException {
+    Ip networkIp = new Ip("1.1.1.0");
+    _vrf.setStaticRoutes(
+        ImmutableSortedSet.of(
+            new StaticRoute(new Prefix(networkIp, 27), _baseNextHopIp, _i1.getName(), 1, 1),
+            new StaticRoute(new Prefix(networkIp, 29), _baseNextHopIp, _i1.getName(), 1, 1)));
+
+    ImmutableSortedMap<String, Configuration> configs =
+        ImmutableSortedMap.of(_n1.getHostname(), _n1);
+    Batfish batfish = BatfishTestUtils.getBatfish(configs, _folder);
+
+    batfish.getSettings().setDataplaneEngineName(dpEngine);
+    batfish.computeDataPlane(false);
+    DataPlane dp = batfish.loadDataPlane();
+
+    /*
+     * Connected route covers both static routes, and one static route completely covers the other.
+     * All three should be in the rib.
+     */
+    Set<AbstractRoute> routes =
+        dp.getRibs().get(_n1.getHostname()).get(Configuration.DEFAULT_VRF_NAME).getRoutes();
+
+    assertThat(routes, hasItem(hasPrefix(new Prefix(_interfaceIp, INTERFACE_BITS))));
+    assertThat(routes, hasItem(hasPrefix(new Prefix(networkIp, 27))));
+    assertThat(routes, hasItem(hasPrefix(new Prefix(networkIp, 29))));
+  }
+
+  @Test
+  public void testStaticRouteFlatteningDirect() throws IOException {
+    Ip networkIp = new Ip("2.2.2.0");
+    final int ROUTE_PREFIX_LENGTH = 24;
+    Ip intermediateNextHopIp = new Ip("2.2.2.2");
+    _vrf.setStaticRoutes(
+        ImmutableSortedSet.of(
+            new StaticRoute(
+                new Prefix(networkIp, ROUTE_PREFIX_LENGTH),
+                intermediateNextHopIp,
+                _i1.getName(),
+                1,
+                1),
+            new StaticRoute(
+                new Prefix(networkIp, ROUTE_PREFIX_LENGTH), _baseNextHopIp, _i1.getName(), 1, 1)));
+
+    ImmutableSortedMap<String, Configuration> configs =
+        ImmutableSortedMap.of(_n1.getHostname(), _n1);
+    Batfish batfish = BatfishTestUtils.getBatfish(configs, _folder);
+
+    batfish.getSettings().setDataplaneEngineName(dpEngine);
+    batfish.computeDataPlane(false);
+    DataPlane dp = batfish.loadDataPlane();
+
+    Set<AbstractRoute> routes =
+        dp.getRibs().get(_n1.getHostname()).get(Configuration.DEFAULT_VRF_NAME).getRoutes();
+
+    /*
+     * Ensure that route with intermediate next hop is not installed, as it "collapses"
+     * to baseNextHop
+     */
+    assertThat(routes, hasItem(hasPrefix(new Prefix(_interfaceIp, INTERFACE_BITS))));
+    assertThat(
+        routes,
+        hasItem(
+            allOf(
+                hasPrefix(new Prefix(networkIp, ROUTE_PREFIX_LENGTH)),
+                hasNextHopIp(_baseNextHopIp))));
+    assertThat(routes, not(hasItem(hasNextHopIp(intermediateNextHopIp))));
+  }
+
+  @Test
+  public void testStaticRouteLoop() throws IOException {
+    Ip networkIp = new Ip("2.2.2.0");
+    final int ROUTE_PREFIX_LENGTH = 24;
+    Ip intermediateNextHopIp = new Ip("3.3.3.3");
+    _vrf.setStaticRoutes(
+        ImmutableSortedSet.of(
+            new StaticRoute(
+                new Prefix(networkIp, ROUTE_PREFIX_LENGTH),
+                intermediateNextHopIp,
+                _i1.getName(),
+                1,
+                1),
+            new StaticRoute(
+                new Prefix(networkIp, ROUTE_PREFIX_LENGTH), _baseNextHopIp, _i1.getName(), 1, 1),
+            new StaticRoute(
+                new Prefix(intermediateNextHopIp, Prefix.MAX_PREFIX_LENGTH),
+                // Creates a loop of static routes
+                new Ip("2.2.2.2"),
+                Route.UNSET_NEXT_HOP_INTERFACE,
+                1,
+                1)));
+
+    ImmutableSortedMap<String, Configuration> configs =
+        ImmutableSortedMap.of(_n1.getHostname(), _n1);
+    Batfish batfish = BatfishTestUtils.getBatfish(configs, _folder);
+
+    batfish.getSettings().setDataplaneEngineName(dpEngine);
+    batfish.computeDataPlane(false);
+    DataPlane dp = batfish.loadDataPlane();
+
+    /*
+     * Ensure all (even looped) routes get installed
+     */
+    Set<AbstractRoute> routes =
+        dp.getRibs().get(_n1.getHostname()).get(Configuration.DEFAULT_VRF_NAME).getRoutes();
+
+    assertThat(routes, hasItem(hasPrefix(new Prefix(_interfaceIp, INTERFACE_BITS))));
+    assertThat(
+        routes,
+        hasItem(
+            allOf(
+                hasPrefix(new Prefix(networkIp, ROUTE_PREFIX_LENGTH)),
+                hasNextHopIp(_baseNextHopIp))));
+
+    assertThat(
+        routes,
+        hasItem(
+            allOf(
+                hasPrefix(new Prefix(networkIp, ROUTE_PREFIX_LENGTH)),
+                hasNextHopIp(intermediateNextHopIp))));
+    assertThat(
+        routes, hasItem(hasPrefix(new Prefix(intermediateNextHopIp, Prefix.MAX_PREFIX_LENGTH))));
+  }
+}


### PR DESCRIPTION
*Context*:
- When activating static routes with next-hop-ip we check that next hop ip is routable.
- If main rib contained a route that fully covered the static route we did not install/activate the static route

*Problem*:
It seems like that is not the desired behavior. After firing up GNS3, confirmed that on IOS all static routes get activated (if covered by other static routes or by a connected route)

*Fix*:
Removed the `containsPrefix` check, modeled the test based on the GNS3 setup.
