### PR TITLE
Keep all node and VRF names when getting dataplane routes

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/bdp/BdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/bdp/BdpEngine.java
@@ -9,6 +9,7 @@ import com.google.common.graph.Network;
 import io.opentracing.ActiveSpan;
 import io.opentracing.util.GlobalTracer;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -994,7 +995,7 @@ public class BdpEngine {
         .stream()
         .collect(
             ImmutableSortedMap.toImmutableSortedMap(
-                String::compareTo,
+                Comparator.naturalOrder(),
                 Entry::getKey,
                 nodeEntry ->
                     nodeEntry
@@ -1004,7 +1005,7 @@ public class BdpEngine {
                         .stream()
                         .collect(
                             ImmutableSortedMap.toImmutableSortedMap(
-                                String::compareTo,
+                                Comparator.naturalOrder(),
                                 Entry::getKey,
                                 vrfEntry ->
                                     ImmutableSortedSet.copyOf(

--- a/projects/batfish/src/main/java/org/batfish/dataplane/bdp/BdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/bdp/BdpEngine.java
@@ -3,6 +3,7 @@ package org.batfish.dataplane.bdp;
 import static org.batfish.common.util.CommonUtil.initBgpTopology;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.graph.Network;
 import io.opentracing.ActiveSpan;
@@ -983,25 +984,31 @@ public class BdpEngine {
     return errorMessage;
   }
 
+  /**
+   * Return the main RIB routes for each node. Map structure: Hostname -> VRF name -> Set of routes
+   */
   SortedMap<String, SortedMap<String, SortedSet<AbstractRoute>>> getRoutes(BdpDataPlane dp) {
-    SortedMap<String, SortedMap<String, SortedSet<AbstractRoute>>> routesByHostname =
-        new TreeMap<>();
-    for (Entry<String, Node> e : dp._nodes.entrySet()) {
-      String hostname = e.getKey();
-      Node node = e.getValue();
-      for (Entry<String, VirtualRouter> e2 : node._virtualRouters.entrySet()) {
-        String vrfName = e2.getKey();
-        VirtualRouter vrf = e2.getValue();
-        for (AbstractRoute route : vrf._mainRib.getRoutes()) {
-          SortedMap<String, SortedSet<AbstractRoute>> routesByVrf =
-              routesByHostname.computeIfAbsent(hostname, k -> new TreeMap<>());
-          SortedSet<AbstractRoute> routes =
-              routesByVrf.computeIfAbsent(vrfName, k -> new TreeSet<>());
-          routes.add(route);
-        }
-      }
-    }
-    return routesByHostname;
+    // Scan through all Nodes and their virtual routers, retrieve main rib routes
+    return dp._nodes
+        .entrySet()
+        .stream()
+        .collect(
+            ImmutableSortedMap.toImmutableSortedMap(
+                String::compareTo,
+                Entry::getKey,
+                nodeEntry ->
+                    nodeEntry
+                        .getValue()
+                        ._virtualRouters
+                        .entrySet()
+                        .stream()
+                        .collect(
+                            ImmutableSortedMap.toImmutableSortedMap(
+                                String::compareTo,
+                                Entry::getKey,
+                                vrfEntry ->
+                                    ImmutableSortedSet.copyOf(
+                                        vrfEntry.getValue()._mainRib.getRoutes())))));
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -4,6 +4,7 @@ import static org.batfish.common.util.CommonUtil.initBgpTopology;
 import static org.batfish.dataplane.rib.AbstractRib.importRib;
 
 import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Ordering;
 import com.google.common.graph.Network;
 import java.util.HashMap;
@@ -12,7 +13,6 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
-import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -592,26 +592,32 @@ public class IncrementalBdpEngine {
     ae.getMainRibRoutesByIteration().put(dependentRoutesIterations, numMainRibRoutes);
   }
 
+  /**
+   * Return the main RIB routes for each node. Map structure: Hostname -> VRF name -> Set of routes
+   */
   SortedMap<String, SortedMap<String, SortedSet<AbstractRoute>>> getRoutes(
       IncrementalDataPlane dp) {
-    SortedMap<String, SortedMap<String, SortedSet<AbstractRoute>>> routesByHostname =
-        new TreeMap<>();
-    for (Entry<String, Node> e : dp._nodes.entrySet()) {
-      String hostname = e.getKey();
-      Node node = e.getValue();
-      for (Entry<String, VirtualRouter> e2 : node.getVirtualRouters().entrySet()) {
-        String vrfName = e2.getKey();
-        VirtualRouter vrf = e2.getValue();
-        for (AbstractRoute route : vrf._mainRib.getRoutes()) {
-          SortedMap<String, SortedSet<AbstractRoute>> routesByVrf =
-              routesByHostname.computeIfAbsent(hostname, k -> new TreeMap<>());
-          SortedSet<AbstractRoute> routes =
-              routesByVrf.computeIfAbsent(vrfName, k -> new TreeSet<>());
-          routes.add(route);
-        }
-      }
-    }
-    return routesByHostname;
+    // Scan through all Nodes and their virtual routers, retrieve main rib routes
+    return dp.getNodes()
+        .entrySet()
+        .stream()
+        .collect(
+            ImmutableSortedMap.toImmutableSortedMap(
+                String::compareTo,
+                Entry::getKey,
+                nodeEntry ->
+                    nodeEntry
+                        .getValue()
+                        .getVirtualRouters()
+                        .entrySet()
+                        .stream()
+                        .collect(
+                            ImmutableSortedMap.toImmutableSortedMap(
+                                String::compareTo,
+                                Entry::getKey,
+                                vrfEntry ->
+                                    ImmutableSortedSet.copyOf(
+                                        vrfEntry.getValue().getMainRib().getRoutes())))));
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -7,6 +7,7 @@ import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Ordering;
 import com.google.common.graph.Network;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -603,7 +604,7 @@ public class IncrementalBdpEngine {
         .stream()
         .collect(
             ImmutableSortedMap.toImmutableSortedMap(
-                String::compareTo,
+                Comparator.naturalOrder(),
                 Entry::getKey,
                 nodeEntry ->
                     nodeEntry
@@ -613,7 +614,7 @@ public class IncrementalBdpEngine {
                         .stream()
                         .collect(
                             ImmutableSortedMap.toImmutableSortedMap(
-                                String::compareTo,
+                                Comparator.naturalOrder(),
                                 Entry::getKey,
                                 vrfEntry ->
                                     ImmutableSortedSet.copyOf(

--- a/projects/batfish/src/test/java/org/batfish/dataplane/GetRoutesTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/GetRoutesTest.java
@@ -1,0 +1,79 @@
+package org.batfish.dataplane;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyIterableOf;
+import static org.hamcrest.Matchers.hasKey;
+
+import com.google.common.collect.ImmutableSortedMap;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import org.batfish.common.plugin.DataPlanePlugin;
+import org.batfish.common.plugin.DataPlanePlugin.ComputeDataPlaneResult;
+import org.batfish.datamodel.AbstractRoute;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.Vrf;
+import org.batfish.dataplane.ibdp.IncrementalDataPlanePlugin;
+import org.batfish.main.Batfish;
+import org.batfish.main.BatfishTestUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class GetRoutesTest {
+
+  private NetworkFactory _nf;
+
+  private Vrf.Builder _vb;
+
+  @Rule public TemporaryFolder _folder = new TemporaryFolder();
+
+  @Parameters
+  public static Collection<Object[]> data() {
+    return Arrays.asList(new Object[][] {{"bdp"}, {"ibdp"}});
+  }
+
+  @Parameter public String dpEngine;
+
+  @Before
+  public void setup() {
+    _nf = new NetworkFactory();
+    _vb = _nf.vrfBuilder();
+  }
+
+  @Test
+  public void testRoutesOutputHasAllVrfs() throws IOException {
+    Configuration n1 =
+        _nf.configurationBuilder()
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .setHostname("n1")
+            .build();
+
+    Vrf emptyVrf = _vb.setOwner(n1).setName("empty").build();
+
+    Batfish batfish =
+        BatfishTestUtils.getBatfish(ImmutableSortedMap.of(n1.getHostname(), n1), _folder);
+    batfish.getSettings().setDataplaneEngineName(IncrementalDataPlanePlugin.PLUGIN_NAME);
+    DataPlanePlugin dataPlanePlugin = batfish.getDataPlanePlugin();
+    ComputeDataPlaneResult dp = dataPlanePlugin.computeDataPlane(false);
+
+    SortedMap<String, SortedMap<String, SortedSet<AbstractRoute>>> routes =
+        dataPlanePlugin.getRoutes(dp._dataPlane);
+
+    assertThat(routes, hasKey(n1.getHostname()));
+    // Empty VRF is there
+    assertThat(routes.get(n1.getHostname()), hasKey(emptyVrf.getName()));
+    assertThat(
+        routes.get(n1.getHostname()).get(emptyVrf.getName()), emptyIterableOf(AbstractRoute.class));
+  }
+}


### PR DESCRIPTION
*Context*
- We used to not include node/vrf pairs in the output of the routes question if there were no routes for that vrf.
- This created some confusion when doing dataplane validation (both "visually" and when trying to assert rib size of a vrf using scripts)
*Fix*
- Keep all node/vrf pairs, introducing empty sets where necessary
- Also ensure `getRoutes` of both dataplane plugins return immutable data structures.
