### PR TITLE
CiscoConfiguration: extract policy to suppress summary-only specifics

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -3,6 +3,7 @@ package org.batfish.representation.cisco;
 import static org.batfish.common.util.CommonUtil.toImmutableMap;
 import static org.batfish.datamodel.MultipathEquivalentAsPathMatchMode.EXACT_PATH;
 import static org.batfish.datamodel.MultipathEquivalentAsPathMatchMode.PATH_LENGTH;
+import static org.batfish.representation.cisco.CiscoConversions.suppressSummarizedPrefixes;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -29,6 +30,7 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.common.BatfishException;
@@ -97,7 +99,6 @@ import org.batfish.datamodel.routing_policy.expr.LiteralOrigin;
 import org.batfish.datamodel.routing_policy.expr.MatchPrefix6Set;
 import org.batfish.datamodel.routing_policy.expr.MatchPrefixSet;
 import org.batfish.datamodel.routing_policy.expr.MatchProtocol;
-import org.batfish.datamodel.routing_policy.expr.NamedPrefixSet;
 import org.batfish.datamodel.routing_policy.expr.Not;
 import org.batfish.datamodel.routing_policy.expr.RouteIsClassful;
 import org.batfish.datamodel.routing_policy.expr.SelfNextHop;
@@ -1347,7 +1348,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
     int defaultMetric = proc.getDefaultMetric();
     Ip bgpRouterId = getBgpRouterId(c, vrfName, proc);
     newBgpProcess.setRouterId(bgpRouterId);
-    Set<BgpAggregateIpv4Network> summaryOnlyNetworks = new HashSet<>();
 
     List<BooleanExpr> attributeMapPrefilters = new ArrayList<>();
 
@@ -1355,10 +1355,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
     for (Entry<Prefix, BgpAggregateIpv4Network> e : proc.getAggregateNetworks().entrySet()) {
       Prefix prefix = e.getKey();
       BgpAggregateIpv4Network aggNet = e.getValue();
-      boolean summaryOnly = aggNet.getSummaryOnly();
-      if (summaryOnly) {
-        summaryOnlyNetworks.add(aggNet);
-      }
 
       // create generation policy for aggregate network
       RoutingPolicy currentGeneratedRoutePolicy =
@@ -1461,28 +1457,15 @@ public final class CiscoConfiguration extends VendorConfiguration {
     c.getRoutingPolicies().put(bgpCommonExportPolicyName, bgpCommonExportPolicy);
     List<Statement> bgpCommonExportStatements = bgpCommonExportPolicy.getStatements();
 
-    // create policy for denying suppressed summary-only networks
-    if (summaryOnlyNetworks.size() > 0) {
-      String matchSuppressedSummaryOnlyRoutesName =
-          "~MATCH_SUPPRESSED_SUMMARY_ONLY:" + vrfName + "~";
-      RouteFilterList matchSuppressedSummaryOnlyRoutes =
-          new RouteFilterList(matchSuppressedSummaryOnlyRoutesName);
-      c.getRouteFilterLists()
-          .put(matchSuppressedSummaryOnlyRoutesName, matchSuppressedSummaryOnlyRoutes);
-      for (BgpAggregateIpv4Network summaryOnlyNetwork : summaryOnlyNetworks) {
-        Prefix prefix = summaryOnlyNetwork.getPrefix();
-        RouteFilterLine line =
-            new RouteFilterLine(LineAction.ACCEPT, PrefixRange.moreSpecificThan(prefix));
-        matchSuppressedSummaryOnlyRoutes.addLine(line);
-      }
-      If suppressSummaryOnly =
-          new If(
-              "Suppress summarized of summary-only aggregate-address networks",
-              new MatchPrefixSet(
-                  new DestinationNetwork(),
-                  new NamedPrefixSet(matchSuppressedSummaryOnlyRoutesName)),
-              ImmutableList.of(Statements.ReturnFalse.toStaticStatement()),
-              ImmutableList.of());
+    // Never export routes suppressed because they are more specific than summary-only aggregate
+    Stream<Prefix> summaryOnlyNetworks =
+        proc.getAggregateNetworks()
+            .entrySet()
+            .stream()
+            .filter(e -> e.getValue().getSummaryOnly())
+            .map(Entry::getKey);
+    If suppressSummaryOnly = suppressSummarizedPrefixes(c, vrfName, summaryOnlyNetworks);
+    if (suppressSummaryOnly != null) {
       bgpCommonExportStatements.add(suppressSummaryOnly);
     }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
@@ -7,9 +7,12 @@ import com.google.common.collect.ImmutableList;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.stream.Stream;
+import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.common.util.CommonUtil;
 import org.batfish.datamodel.AsPathAccessList;
@@ -50,6 +53,7 @@ import org.batfish.datamodel.routing_policy.expr.BooleanExpr;
 import org.batfish.datamodel.routing_policy.expr.DestinationNetwork;
 import org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet;
 import org.batfish.datamodel.routing_policy.expr.MatchPrefixSet;
+import org.batfish.datamodel.routing_policy.expr.NamedPrefixSet;
 import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.Statements;
 
@@ -78,6 +82,39 @@ class CiscoConversions {
     policy.setStatements(ImmutableList.of(currentGeneratedRouteConditional));
     c.getRoutingPolicies().put(policy.getName(), policy);
     return policy;
+  }
+
+  /**
+   * Generates and returns a {@link Statement} that suppresses routes that are summarized by the
+   * given set of {@link Prefix prefixes} configured as {@code summary-only}.
+   *
+   * <p>Returns {@code null} if {@code prefixesToSuppress} has no entries.
+   *
+   * <p>If any Batfish-generated structures are generated, does the bookkeeping in the provided
+   * {@link Configuration} to ensure they are available and tracked.
+   */
+  @Nullable
+  static If suppressSummarizedPrefixes(
+      Configuration c, String vrfName, Stream<Prefix> summaryOnlyPrefixes) {
+    Iterator<Prefix> prefixesToSuppress = summaryOnlyPrefixes.iterator();
+    if (!prefixesToSuppress.hasNext()) {
+      return null;
+    }
+    // Create a RouteFilterList that matches any network longer than a prefix marked summary only.
+    RouteFilterList matchLonger =
+        new RouteFilterList("~MATCH_SUPPRESSED_SUMMARY_ONLY:" + vrfName + "~");
+    prefixesToSuppress.forEachRemaining(
+        p ->
+            matchLonger.addLine(
+                new RouteFilterLine(LineAction.ACCEPT, PrefixRange.moreSpecificThan(p))));
+    // Bookkeeping: record that we created this RouteFilterList to match longer networks.
+    c.getRouteFilterLists().put(matchLonger.getName(), matchLonger);
+
+    return new If(
+        "Suppress more specific networks for summary-only aggregate-address networks",
+        new MatchPrefixSet(new DestinationNetwork(), new NamedPrefixSet(matchLonger.getName())),
+        ImmutableList.of(Statements.ReturnFalse.toStaticStatement()),
+        ImmutableList.of());
   }
 
   static AsPathAccessList toAsPathAccessList(AsPathSet asPathSet) {

--- a/test_rigs/parsing-tests/unit-tests-nodes.ref
+++ b/test_rigs/parsing-tests/unit-tests-nodes.ref
@@ -372,7 +372,7 @@
             "statements" : [
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.If",
-                "comment" : "Suppress summarized of summary-only aggregate-address networks",
+                "comment" : "Suppress more specific networks for summary-only aggregate-address networks",
                 "guard" : {
                   "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
                   "prefix" : {
@@ -4908,7 +4908,7 @@
             "statements" : [
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.If",
-                "comment" : "Suppress summarized of summary-only aggregate-address networks",
+                "comment" : "Suppress more specific networks for summary-only aggregate-address networks",
                 "guard" : {
                   "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
                   "prefix" : {

--- a/tests/basic/nodes.ref
+++ b/tests/basic/nodes.ref
@@ -3738,7 +3738,7 @@
             "statements" : [
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.If",
-                "comment" : "Suppress summarized of summary-only aggregate-address networks",
+                "comment" : "Suppress more specific networks for summary-only aggregate-address networks",
                 "guard" : {
                   "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
                   "prefix" : {
@@ -4995,7 +4995,7 @@
             "statements" : [
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.If",
-                "comment" : "Suppress summarized of summary-only aggregate-address networks",
+                "comment" : "Suppress more specific networks for summary-only aggregate-address networks",
                 "guard" : {
                   "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
                   "prefix" : {

--- a/tests/jsonpath-addons/jsonpath-display-hints-prefixofsuffix.ref
+++ b/tests/jsonpath-addons/jsonpath-display-hints-prefixofsuffix.ref
@@ -838,7 +838,7 @@
                   "statements" : [
                     {
                       "class" : "org.batfish.datamodel.routing_policy.statement.If",
-                      "comment" : "Suppress summarized of summary-only aggregate-address networks",
+                      "comment" : "Suppress more specific networks for summary-only aggregate-address networks",
                       "guard" : {
                         "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
                         "prefix" : {

--- a/tests/jsonpath-addons/jsonpath-display-hints-suffixofsuffix.ref
+++ b/tests/jsonpath-addons/jsonpath-display-hints-suffixofsuffix.ref
@@ -838,7 +838,7 @@
                   "statements" : [
                     {
                       "class" : "org.batfish.datamodel.routing_policy.statement.If",
-                      "comment" : "Suppress summarized of summary-only aggregate-address networks",
+                      "comment" : "Suppress more specific networks for summary-only aggregate-address networks",
                       "guard" : {
                         "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
                         "prefix" : {


### PR DESCRIPTION
for later reuse.

after #1360 