### PR TITLE
VendorConfiguration: add functionality to do structure marking directly

### DIFF
--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/ConvertConfigurationAnswerElementMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/ConvertConfigurationAnswerElementMatchers.java
@@ -198,7 +198,10 @@ final class ConvertConfigurationAnswerElementMatchers {
         mismatchDescription.appendText(
             String.format(
                 "On host '%s', defined structure of type '%s' named '%s' has %d referrers",
-                _hostname, _type, _structureName, _numReferrers));
+                _hostname,
+                _type,
+                _structureName,
+                byStructureName.get(_structureName).getNumReferrers()));
         return false;
       }
       return true;

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -5171,6 +5171,11 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
     Set<String> names = new TreeSet<>();
     for (Variable_access_listContext v : ctx.name_list) {
       names.add(v.getText());
+      _configuration.referenceStructure(
+          CiscoStructureType.IP_ACCESS_LIST,
+          v.getText(),
+          CiscoStructureUsage.ROUTE_MAP_MATCH_IP_ACCESS_LIST,
+          v.getStart().getLine());
     }
     RouteMapMatchIpAccessListLine line = new RouteMapMatchIpAccessListLine(names, statementLine);
     _currentRouteMapClause.addMatchLine(line);
@@ -5182,6 +5187,11 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
     Set<String> names = new TreeSet<>();
     for (VariableContext t : ctx.name_list) {
       names.add(t.getText());
+      _configuration.referenceStructure(
+          CiscoStructureType.PREFIX_LIST,
+          t.getText(),
+          CiscoStructureUsage.ROUTE_MAP_MATCH_IP_PREFIX_LIST,
+          t.getStart().getLine());
     }
     RouteMapMatchIpPrefixListLine line = new RouteMapMatchIpPrefixListLine(names, statementLine);
     _currentRouteMapClause.addMatchLine(line);
@@ -5193,6 +5203,11 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
     Set<String> names = new TreeSet<>();
     for (Variable_access_listContext v : ctx.name_list) {
       names.add(v.getText());
+      _configuration.referenceStructure(
+          CiscoStructureType.IPV6_ACCESS_LIST,
+          v.getText(),
+          CiscoStructureUsage.ROUTE_MAP_MATCH_IPV6_ACCESS_LIST,
+          v.getStart().getLine());
     }
     RouteMapMatchIpv6AccessListLine line =
         new RouteMapMatchIpv6AccessListLine(names, statementLine);
@@ -5205,6 +5220,11 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
     Set<String> names = new TreeSet<>();
     for (VariableContext t : ctx.name_list) {
       names.add(t.getText());
+      _configuration.referenceStructure(
+          CiscoStructureType.PREFIX6_LIST,
+          t.getText(),
+          CiscoStructureUsage.ROUTE_MAP_MATCH_IPV6_PREFIX_LIST,
+          t.getStart().getLine());
     }
     RouteMapMatchIpv6PrefixListLine line =
         new RouteMapMatchIpv6PrefixListLine(names, statementLine);
@@ -5743,7 +5763,7 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
                 .getPrefixLists()
                 .computeIfAbsent(name, n -> new PrefixList(n, _currentPrefixSetDefinitionLine));
         _configuration.defineStructure(
-            CiscoStructureType.PREFIX_LIST, name, _currentPrefixSetDefinitionLine);
+            CiscoStructureType.PREFIX_SET, name, _currentPrefixSetDefinitionLine);
         Prefix prefix;
         if (ctx.ipa != null) {
           prefix = new Prefix(toIp(ctx.ipa), Prefix.MAX_PREFIX_LENGTH);
@@ -8352,6 +8372,11 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
       // named
       String name = ctx.name.getText();
       int expressionLine = ctx.name.getStart().getLine();
+      _configuration.referenceStructure(
+          CiscoStructureType.PREFIX_SET,
+          name,
+          CiscoStructureUsage.ROUTE_POLICY_PREFIX_SET,
+          expressionLine);
       return new RoutePolicyPrefixSetName(name, expressionLine);
     } else {
       // inline

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -115,7 +115,6 @@ import org.batfish.datamodel.routing_policy.statement.Statements;
 import org.batfish.datamodel.vendor_family.cisco.Aaa;
 import org.batfish.datamodel.vendor_family.cisco.AaaAuthentication;
 import org.batfish.datamodel.vendor_family.cisco.AaaAuthenticationLogin;
-import org.batfish.datamodel.vendor_family.cisco.Cable;
 import org.batfish.datamodel.vendor_family.cisco.CiscoFamily;
 import org.batfish.datamodel.vendor_family.cisco.Line;
 import org.batfish.representation.cisco.Tunnel.TunnelMode;
@@ -1089,90 +1088,100 @@ public final class CiscoConfiguration extends VendorConfiguration {
   }
 
   private void markAcls(CiscoStructureUsage usage) {
-    markStructure(
+    markAbstractStructure(
         CiscoStructureType.IP_ACCESS_LIST,
         usage,
-        Arrays.asList(
-            _extendedAccessLists,
-            _standardAccessLists,
-            _extendedIpv6AccessLists,
-            _standardIpv6AccessLists));
+        ImmutableList.of(
+            CiscoStructureType.IP_ACCESS_LIST_STANDARD,
+            CiscoStructureType.IP_ACCESS_LIST_EXTENDED,
+            CiscoStructureType.IPV6_ACCESS_LIST_STANDARD,
+            CiscoStructureType.IPV6_ACCESS_LIST_EXTENDED));
   }
 
   private void markDepiClasses(CiscoStructureUsage usage) {
-    markStructure(CiscoStructureType.DEPI_CLASS, usage, _cf.getDepiClasses());
+    markConcreteStructure(CiscoStructureType.DEPI_CLASS, usage);
   }
 
   private void markDepiTunnels(CiscoStructureUsage usage) {
-    markStructure(CiscoStructureType.DEPI_TUNNEL, usage, _cf.getDepiTunnels());
+    markConcreteStructure(CiscoStructureType.DEPI_TUNNEL, usage);
   }
 
   private void markDocsisPolicies(CiscoStructureUsage usage) {
-    Cable cable = _cf.getCable();
-    markStructure(
-        CiscoStructureType.DOCSIS_POLICY, usage, cable != null ? cable.getDocsisPolicies() : null);
+    markConcreteStructure(CiscoStructureType.DOCSIS_POLICY, usage);
   }
 
   private void markDocsisPolicyRules(CiscoStructureUsage usage) {
-    Cable cable = _cf.getCable();
-    markStructure(
-        CiscoStructureType.DOCSIS_POLICY_RULE,
-        usage,
-        cable != null ? cable.getDocsisPolicyRules() : null);
+    markConcreteStructure(CiscoStructureType.DOCSIS_POLICY_RULE, usage);
   }
 
   private void markInspectClassMaps(CiscoStructureUsage usage) {
-    markStructure(CiscoStructureType.INSPECT_CLASS_MAP, usage, _inspectClassMaps);
+    markConcreteStructure(CiscoStructureType.INSPECT_CLASS_MAP, usage);
   }
 
   private void markInspectPolicyMaps(CiscoStructureUsage usage) {
-    markStructure(CiscoStructureType.INSPECT_POLICY_MAP, usage, _inspectPolicyMaps);
+    markConcreteStructure(CiscoStructureType.INSPECT_POLICY_MAP, usage);
   }
 
   private void markIpOrMacAcls(CiscoStructureUsage usage) {
-    markStructure(
+    markAbstractStructure(
         CiscoStructureType.ACCESS_LIST,
         usage,
         Arrays.asList(
-            _extendedAccessLists,
-            _standardAccessLists,
-            _extendedIpv6AccessLists,
-            _macAccessLists,
-            _standardIpv6AccessLists));
+            CiscoStructureType.IP_ACCESS_LIST_EXTENDED,
+            CiscoStructureType.IP_ACCESS_LIST_STANDARD,
+            CiscoStructureType.IPV6_ACCESS_LIST_EXTENDED,
+            CiscoStructureType.IPV6_ACCESS_LIST_STANDARD,
+            CiscoStructureType.MAC_ACCESS_LIST));
   }
 
   private void markIpsecProfiles(CiscoStructureUsage usage) {
-    markStructure(CiscoStructureType.IPSEC_PROFILE, usage, _ipsecProfiles);
+    markConcreteStructure(CiscoStructureType.IPSEC_PROFILE, usage);
   }
 
   private void markIpsecTransformSets(CiscoStructureUsage usage) {
-    markStructure(CiscoStructureType.IPSEC_TRANSFORM_SET, usage, _ipsecTransformSets);
+    markConcreteStructure(CiscoStructureType.IPSEC_TRANSFORM_SET, usage);
   }
 
   private void markIpv4Acls(CiscoStructureUsage usage) {
-    markStructure(
+    markAbstractStructure(
         CiscoStructureType.IPV4_ACCESS_LIST,
         usage,
-        Arrays.asList(_extendedAccessLists, _standardAccessLists));
+        ImmutableList.of(
+            CiscoStructureType.IP_ACCESS_LIST_STANDARD,
+            CiscoStructureType.IP_ACCESS_LIST_EXTENDED));
   }
 
   private void markIpv6Acls(CiscoStructureUsage usage) {
-    markStructure(
+    markAbstractStructure(
         CiscoStructureType.IPV6_ACCESS_LIST,
         usage,
-        Arrays.asList(_extendedIpv6AccessLists, _standardIpv6AccessLists));
+        ImmutableList.of(
+            CiscoStructureType.IPV6_ACCESS_LIST_STANDARD,
+            CiscoStructureType.IPV6_ACCESS_LIST_EXTENDED));
   }
 
   private void markKeyrings(CiscoStructureUsage usage) {
-    markStructure(CiscoStructureType.KEYRING, usage, _keyrings);
+    markConcreteStructure(CiscoStructureType.KEYRING, usage);
   }
 
   private void markL2tpClasses(CiscoStructureUsage usage) {
-    markStructure(CiscoStructureType.L2TP_CLASS, usage, _cf.getL2tpClasses());
+    markConcreteStructure(CiscoStructureType.L2TP_CLASS, usage);
   }
 
   private void markNetworkObjectGroups(CiscoStructureUsage usage) {
-    markStructure(CiscoStructureType.NETWORK_OBJECT_GROUP, usage, _networkObjectGroups);
+    markConcreteStructure(CiscoStructureType.NETWORK_OBJECT_GROUP, usage);
+  }
+
+  private void markPrefixLists(CiscoStructureUsage usage) {
+    markConcreteStructure(CiscoStructureType.PREFIX_LIST, usage);
+  }
+
+  private void markPrefix6Lists(CiscoStructureUsage usage) {
+    markConcreteStructure(CiscoStructureType.PREFIX6_LIST, usage);
+  }
+
+  private void markPrefixSets(CiscoStructureUsage usage) {
+    markConcreteStructure(CiscoStructureType.PREFIX_SET, usage);
   }
 
   private void markProtocolOrServiceObjectGroups(CiscoStructureUsage usage) {
@@ -1183,21 +1192,19 @@ public final class CiscoConfiguration extends VendorConfiguration {
   }
 
   private void markRouteMaps(CiscoStructureUsage usage) {
-    markStructure(CiscoStructureType.ROUTE_MAP, usage, _routeMaps);
+    markConcreteStructure(CiscoStructureType.ROUTE_MAP, usage);
   }
 
   private void markSecurityZones(CiscoStructureUsage usage) {
-    markStructure(CiscoStructureType.SECURITY_ZONE, usage, _securityZones);
+    markConcreteStructure(CiscoStructureType.SECURITY_ZONE, usage);
   }
 
   private void markServiceClasses(CiscoStructureUsage usage) {
-    Cable cable = _cf.getCable();
-    markStructure(
-        CiscoStructureType.SERVICE_CLASS, usage, cable != null ? cable.getServiceClasses() : null);
+    markConcreteStructure(CiscoStructureType.SERVICE_CLASS, usage);
   }
 
   private void markServiceObjectGroups(CiscoStructureUsage usage) {
-    markStructure(CiscoStructureType.SERVICE_OBJECT_GROUP, usage, _serviceObjectGroups);
+    markConcreteStructure(CiscoStructureType.SERVICE_OBJECT_GROUP, usage);
   }
 
   private void processFailoverSettings() {
@@ -3388,6 +3395,11 @@ public final class CiscoConfiguration extends VendorConfiguration {
     // mark references to mac-ACLs that may not appear in data model
     // TODO: fill in
 
+    markPrefixLists(CiscoStructureUsage.ROUTE_MAP_MATCH_IP_PREFIX_LIST);
+    markPrefix6Lists(CiscoStructureUsage.ROUTE_MAP_MATCH_IPV6_PREFIX_LIST);
+
+    markPrefixSets(CiscoStructureUsage.ROUTE_POLICY_PREFIX_SET);
+
     // mark references to route-maps that may not appear in data model
     markRouteMaps(CiscoStructureUsage.BGP_NEIGHBOR_REMOTE_AS_ROUTE_MAP);
     markRouteMaps(CiscoStructureUsage.BGP_REDISTRIBUTE_OSPFV3_MAP);
@@ -3442,13 +3454,8 @@ public final class CiscoConfiguration extends VendorConfiguration {
     recordStructure(_ipsecProfiles, CiscoStructureType.IPSEC_PROFILE);
     recordStructure(_ipsecTransformSets, CiscoStructureType.IPSEC_TRANSFORM_SET);
     recordIpv6AccessLists();
-    recordKeyrings();
-    recordStructure(_cf.getL2tpClasses(), CiscoStructureType.L2TP_CLASS);
-    recordStructure(_macAccessLists, CiscoStructureType.MAC_ACCESS_LIST);
     recordStructure(_natPools, CiscoStructureType.NAT_POOL);
     recordStructure(_networkObjectGroups, CiscoStructureType.NETWORK_OBJECT_GROUP);
-    recordStructure(_prefixLists, CiscoStructureType.PREFIX_LIST);
-    recordStructure(_prefix6Lists, CiscoStructureType.PREFIX6_LIST);
     recordStructure(_protocolObjectGroups, CiscoStructureType.PROTOCOL_OBJECT_GROUP);
     recordPeerGroups();
     recordPeerSessions();

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoStructureType.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoStructureType.java
@@ -36,6 +36,7 @@ public enum CiscoStructureType implements StructureType {
   NETWORK_OBJECT_GROUP("object-group network"),
   PREFIX_LIST("ipv4 prefix-list"),
   PREFIX6_LIST("ipv6 prefix-list"),
+  PREFIX_SET("prefix-set"),
   PROTOCOL_OBJECT_GROUP("object-group protocol"),
   PROTOCOL_OR_SERVICE_OBJECT_GROUP("object-group protocol or service"),
   ROUTE_MAP("route-map"),

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/RoutePolicyPrefixSetName.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/RoutePolicyPrefixSetName.java
@@ -32,7 +32,7 @@ public class RoutePolicyPrefixSetName extends RoutePolicyPrefixSet {
       return null;
     } else if (!cc.getPrefix6Lists().containsKey(_name)) {
       cc.undefined(
-          CiscoStructureType.PREFIX6_LIST,
+          CiscoStructureType.PREFIX_SET,
           _name,
           CiscoStructureUsage.ROUTE_POLICY_PREFIX_SET,
           _expressionLine);
@@ -50,7 +50,7 @@ public class RoutePolicyPrefixSetName extends RoutePolicyPrefixSet {
       return null;
     } else if (!cc.getPrefixLists().containsKey(_name)) {
       cc.undefined(
-          CiscoStructureType.PREFIX_LIST,
+          CiscoStructureType.PREFIX_SET,
           _name,
           CiscoStructureUsage.ROUTE_POLICY_PREFIX_SET,
           _expressionLine);

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -740,8 +740,8 @@ public class CiscoGrammarTest {
     /*
      * We expected the only unused zone to be zunreferenced
      */
-    assertThat(ccae, hasNumReferrers(hostname, CiscoStructureType.SECURITY_ZONE, "z1", 1));
-    assertThat(ccae, hasNumReferrers(hostname, CiscoStructureType.SECURITY_ZONE, "z2", 1));
+    assertThat(ccae, hasNumReferrers(hostname, CiscoStructureType.SECURITY_ZONE, "z1", 4));
+    assertThat(ccae, hasNumReferrers(hostname, CiscoStructureType.SECURITY_ZONE, "z2", 2));
     assertThat(ccae, hasNumReferrers(hostname, CiscoStructureType.SECURITY_ZONE, "zempty", 1));
     assertThat(
         ccae, hasNumReferrers(hostname, CiscoStructureType.SECURITY_ZONE, "zunreferenced", 0));

--- a/test_rigs/parsing-tests/indirection.ref
+++ b/test_rigs/parsing-tests/indirection.ref
@@ -996,7 +996,7 @@
           }
         },
         "n3" : {
-          "ipv4 prefix-list" : {
+          "prefix-set" : {
             "bgp_sub2_route_filter" : {
               "definitionLines" : [
                 63

--- a/test_rigs/parsing-tests/unit-tests-undefined.ref
+++ b/test_rigs/parsing-tests/unit-tests-undefined.ref
@@ -323,120 +323,6 @@
           ]
         }
       },
-      "undefined:ipv4 prefix-list:usage:route-policy prefix-set:$cust_v4_pfx" : {
-        "description" : "Undefined reference to structure of type: 'ipv4 prefix-list' with usage: 'route-policy prefix-set' named '$cust_v4_pfx'",
-        "files" : {
-          "route_policy_param" : [
-            5
-          ]
-        }
-      },
-      "undefined:ipv4 prefix-list:usage:route-policy prefix-set:CENIC_DC_Internal" : {
-        "description" : "Undefined reference to structure of type: 'ipv4 prefix-list' with usage: 'route-policy prefix-set' named 'CENIC_DC_Internal'",
-        "files" : {
-          "route_policy_as_path" : [
-            25
-          ]
-        }
-      },
-      "undefined:ipv4 prefix-list:usage:route-policy prefix-set:DC_Internal" : {
-        "description" : "Undefined reference to structure of type: 'ipv4 prefix-list' with usage: 'route-policy prefix-set' named 'DC_Internal'",
-        "files" : {
-          "route_policy_metric_type" : [
-            7
-          ]
-        }
-      },
-      "undefined:ipv4 prefix-list:usage:route-policy prefix-set:EBGP-PEER-BOGONS" : {
-        "description" : "Undefined reference to structure of type: 'ipv4 prefix-list' with usage: 'route-policy prefix-set' named 'EBGP-PEER-BOGONS'",
-        "files" : {
-          "ios_xr_route_policy" : [
-            78
-          ]
-        }
-      },
-      "undefined:ipv4 prefix-list:usage:route-policy prefix-set:EBGP-PEER-OTHER-UNDESIRABLES" : {
-        "description" : "Undefined reference to structure of type: 'ipv4 prefix-list' with usage: 'route-policy prefix-set' named 'EBGP-PEER-OTHER-UNDESIRABLES'",
-        "files" : {
-          "ios_xr_route_policy" : [
-            78
-          ]
-        }
-      },
-      "undefined:ipv4 prefix-list:usage:route-policy prefix-set:EBGP-PEER-TOO-SPECIFIC" : {
-        "description" : "Undefined reference to structure of type: 'ipv4 prefix-list' with usage: 'route-policy prefix-set' named 'EBGP-PEER-TOO-SPECIFIC'",
-        "files" : {
-          "ios_xr_route_policy" : [
-            80
-          ]
-        }
-      },
-      "undefined:ipv4 prefix-list:usage:route-policy prefix-set:barbar_blackhole_routes" : {
-        "description" : "Undefined reference to structure of type: 'ipv4 prefix-list' with usage: 'route-policy prefix-set' named 'barbar_blackhole_routes'",
-        "files" : {
-          "ios_xr_route_policy" : [
-            5,
-            51
-          ]
-        }
-      },
-      "undefined:ipv4 prefix-list:usage:route-policy prefix-set:barbar_networks_ipv4" : {
-        "description" : "Undefined reference to structure of type: 'ipv4 prefix-list' with usage: 'route-policy prefix-set' named 'barbar_networks_ipv4'",
-        "files" : {
-          "ios_xr_route_policy" : [
-            51
-          ]
-        }
-      },
-      "undefined:ipv4 prefix-list:usage:route-policy prefix-set:barbar_networks_ipv6" : {
-        "description" : "Undefined reference to structure of type: 'ipv4 prefix-list' with usage: 'route-policy prefix-set' named 'barbar_networks_ipv6'",
-        "files" : {
-          "ios_xr_route_policy" : [
-            21
-          ]
-        }
-      },
-      "undefined:ipv4 prefix-list:usage:route-policy prefix-set:bippetyboppety_ipv4" : {
-        "description" : "Undefined reference to structure of type: 'ipv4 prefix-list' with usage: 'route-policy prefix-set' named 'bippetyboppety_ipv4'",
-        "files" : {
-          "ios_xr_route_policy" : [
-            44,
-            51
-          ]
-        }
-      },
-      "undefined:ipv4 prefix-list:usage:route-policy prefix-set:classful_default" : {
-        "description" : "Undefined reference to structure of type: 'ipv4 prefix-list' with usage: 'route-policy prefix-set' named 'classful_default'",
-        "files" : {
-          "route_policy_as_path" : [
-            14
-          ]
-        }
-      },
-      "undefined:ipv4 prefix-list:usage:route-policy prefix-set:local-peer-aggregates" : {
-        "description" : "Undefined reference to structure of type: 'ipv4 prefix-list' with usage: 'route-policy prefix-set' named 'local-peer-aggregates'",
-        "files" : {
-          "ios_xr_route_policy" : [
-            68
-          ]
-        }
-      },
-      "undefined:ipv4 prefix-list:usage:route-policy prefix-set:null" : {
-        "description" : "Undefined reference to structure of type: 'ipv4 prefix-list' with usage: 'route-policy prefix-set' named 'null'",
-        "files" : {
-          "ios_xr_route_policy" : [
-            114
-          ]
-        }
-      },
-      "undefined:ipv4 prefix-list:usage:route-policy prefix-set:remote-router-loopbacks" : {
-        "description" : "Undefined reference to structure of type: 'ipv4 prefix-list' with usage: 'route-policy prefix-set' named 'remote-router-loopbacks'",
-        "files" : {
-          "ios_xr_route_policy" : [
-            66
-          ]
-        }
-      },
       "undefined:ipv4/6 acl:usage:cops listener access-list:cops-acl" : {
         "description" : "Undefined reference to structure of type: 'ipv4/6 acl' with usage: 'cops listener access-list' named 'cops-acl'",
         "files" : {
@@ -836,6 +722,120 @@
         "files" : {
           "juniper_snmp" : [
             5
+          ]
+        }
+      },
+      "undefined:prefix-set:usage:route-policy prefix-set:$cust_v4_pfx" : {
+        "description" : "Undefined reference to structure of type: 'prefix-set' with usage: 'route-policy prefix-set' named '$cust_v4_pfx'",
+        "files" : {
+          "route_policy_param" : [
+            5
+          ]
+        }
+      },
+      "undefined:prefix-set:usage:route-policy prefix-set:CENIC_DC_Internal" : {
+        "description" : "Undefined reference to structure of type: 'prefix-set' with usage: 'route-policy prefix-set' named 'CENIC_DC_Internal'",
+        "files" : {
+          "route_policy_as_path" : [
+            25
+          ]
+        }
+      },
+      "undefined:prefix-set:usage:route-policy prefix-set:DC_Internal" : {
+        "description" : "Undefined reference to structure of type: 'prefix-set' with usage: 'route-policy prefix-set' named 'DC_Internal'",
+        "files" : {
+          "route_policy_metric_type" : [
+            7
+          ]
+        }
+      },
+      "undefined:prefix-set:usage:route-policy prefix-set:EBGP-PEER-BOGONS" : {
+        "description" : "Undefined reference to structure of type: 'prefix-set' with usage: 'route-policy prefix-set' named 'EBGP-PEER-BOGONS'",
+        "files" : {
+          "ios_xr_route_policy" : [
+            78
+          ]
+        }
+      },
+      "undefined:prefix-set:usage:route-policy prefix-set:EBGP-PEER-OTHER-UNDESIRABLES" : {
+        "description" : "Undefined reference to structure of type: 'prefix-set' with usage: 'route-policy prefix-set' named 'EBGP-PEER-OTHER-UNDESIRABLES'",
+        "files" : {
+          "ios_xr_route_policy" : [
+            78
+          ]
+        }
+      },
+      "undefined:prefix-set:usage:route-policy prefix-set:EBGP-PEER-TOO-SPECIFIC" : {
+        "description" : "Undefined reference to structure of type: 'prefix-set' with usage: 'route-policy prefix-set' named 'EBGP-PEER-TOO-SPECIFIC'",
+        "files" : {
+          "ios_xr_route_policy" : [
+            80
+          ]
+        }
+      },
+      "undefined:prefix-set:usage:route-policy prefix-set:barbar_blackhole_routes" : {
+        "description" : "Undefined reference to structure of type: 'prefix-set' with usage: 'route-policy prefix-set' named 'barbar_blackhole_routes'",
+        "files" : {
+          "ios_xr_route_policy" : [
+            5,
+            51
+          ]
+        }
+      },
+      "undefined:prefix-set:usage:route-policy prefix-set:barbar_networks_ipv4" : {
+        "description" : "Undefined reference to structure of type: 'prefix-set' with usage: 'route-policy prefix-set' named 'barbar_networks_ipv4'",
+        "files" : {
+          "ios_xr_route_policy" : [
+            51
+          ]
+        }
+      },
+      "undefined:prefix-set:usage:route-policy prefix-set:barbar_networks_ipv6" : {
+        "description" : "Undefined reference to structure of type: 'prefix-set' with usage: 'route-policy prefix-set' named 'barbar_networks_ipv6'",
+        "files" : {
+          "ios_xr_route_policy" : [
+            21
+          ]
+        }
+      },
+      "undefined:prefix-set:usage:route-policy prefix-set:bippetyboppety_ipv4" : {
+        "description" : "Undefined reference to structure of type: 'prefix-set' with usage: 'route-policy prefix-set' named 'bippetyboppety_ipv4'",
+        "files" : {
+          "ios_xr_route_policy" : [
+            44,
+            51
+          ]
+        }
+      },
+      "undefined:prefix-set:usage:route-policy prefix-set:classful_default" : {
+        "description" : "Undefined reference to structure of type: 'prefix-set' with usage: 'route-policy prefix-set' named 'classful_default'",
+        "files" : {
+          "route_policy_as_path" : [
+            14
+          ]
+        }
+      },
+      "undefined:prefix-set:usage:route-policy prefix-set:local-peer-aggregates" : {
+        "description" : "Undefined reference to structure of type: 'prefix-set' with usage: 'route-policy prefix-set' named 'local-peer-aggregates'",
+        "files" : {
+          "ios_xr_route_policy" : [
+            68
+          ]
+        }
+      },
+      "undefined:prefix-set:usage:route-policy prefix-set:null" : {
+        "description" : "Undefined reference to structure of type: 'prefix-set' with usage: 'route-policy prefix-set' named 'null'",
+        "files" : {
+          "ios_xr_route_policy" : [
+            114
+          ]
+        }
+      },
+      "undefined:prefix-set:usage:route-policy prefix-set:remote-router-loopbacks" : {
+        "description" : "Undefined reference to structure of type: 'prefix-set' with usage: 'route-policy prefix-set' named 'remote-router-loopbacks'",
+        "files" : {
+          "ios_xr_route_policy" : [
+            66
           ]
         }
       },
@@ -1792,7 +1792,7 @@
             ]
           }
         },
-        "ipv4 prefix-list" : {
+        "prefix-set" : {
           "EBGP-PEER-BOGONS" : {
             "route-policy prefix-set" : [
               78
@@ -1848,7 +1848,7 @@
         }
       },
       "route_policy_as_path_set" : {
-        "ipv4 prefix-list" : {
+        "prefix-set" : {
           "CENIC_DC_Internal" : {
             "route-policy prefix-set" : [
               25
@@ -1862,7 +1862,7 @@
         }
       },
       "route_policy_metric_type" : {
-        "ipv4 prefix-list" : {
+        "prefix-set" : {
           "DC_Internal" : {
             "route-policy prefix-set" : [
               7
@@ -1871,7 +1871,7 @@
         }
       },
       "route_policy_param" : {
-        "ipv4 prefix-list" : {
+        "prefix-set" : {
           "$cust_v4_pfx" : {
             "route-policy prefix-set" : [
               5

--- a/test_rigs/parsing-tests/unit-tests-unused.ref
+++ b/test_rigs/parsing-tests/unit-tests-unused.ref
@@ -627,14 +627,6 @@
           ]
         }
       },
-      "unused:ipv4 prefix-list:default_route" : {
-        "description" : "Unused structure of type: 'ipv4 prefix-list' with name: 'default_route'",
-        "files" : {
-          "ios_xr_prefix_set" : [
-            4
-          ]
-        }
-      },
       "unused:ipv4 prefix-list:foo" : {
         "description" : "Unused structure of type: 'ipv4 prefix-list' with name: 'foo'",
         "files" : {
@@ -650,14 +642,6 @@
           "prefix_list_ipv4" : [
             4,
             5
-          ]
-        }
-      },
-      "unused:ipv4 prefix-list:ucla_networks" : {
-        "description" : "Unused structure of type: 'ipv4 prefix-list' with name: 'ucla_networks'",
-        "files" : {
-          "ios_xr_prefix_set" : [
-            7
           ]
         }
       },
@@ -856,6 +840,22 @@
         "files" : {
           "juniper_route_filter" : [
             11
+          ]
+        }
+      },
+      "unused:prefix-set:default_route" : {
+        "description" : "Unused structure of type: 'prefix-set' with name: 'default_route'",
+        "files" : {
+          "ios_xr_prefix_set" : [
+            4
+          ]
+        }
+      },
+      "unused:prefix-set:ucla_networks" : {
+        "description" : "Unused structure of type: 'prefix-set' with name: 'ucla_networks'",
+        "files" : {
+          "ios_xr_prefix_set" : [
+            7
           ]
         }
       },
@@ -2174,7 +2174,7 @@
         }
       },
       "preSet" : {
-        "ipv4 prefix-list" : {
+        "prefix-set" : {
           "default_route" : [
             4
           ],

--- a/test_rigs/parsing-tests/unit-tests.ref
+++ b/test_rigs/parsing-tests/unit-tests.ref
@@ -53886,7 +53886,7 @@
         "pim" : { },
         "pim_snooping" : { },
         "preSet" : {
-          "ipv4 prefix-list" : {
+          "prefix-set" : {
             "default_route" : {
               "definitionLines" : [
                 4
@@ -54805,7 +54805,7 @@
               ]
             }
           },
-          "ipv4 prefix-list" : {
+          "prefix-set" : {
             "EBGP-PEER-BOGONS" : {
               "route-policy prefix-set" : [
                 78
@@ -54861,7 +54861,7 @@
           }
         },
         "route_policy_as_path_set" : {
-          "ipv4 prefix-list" : {
+          "prefix-set" : {
             "CENIC_DC_Internal" : {
               "route-policy prefix-set" : [
                 25
@@ -54875,7 +54875,7 @@
           }
         },
         "route_policy_metric_type" : {
-          "ipv4 prefix-list" : {
+          "prefix-set" : {
             "DC_Internal" : {
               "route-policy prefix-set" : [
                 7
@@ -54884,7 +54884,7 @@
           }
         },
         "route_policy_param" : {
-          "ipv4 prefix-list" : {
+          "prefix-set" : {
             "$cust_v4_pfx" : {
               "route-policy prefix-set" : [
                 5


### PR DESCRIPTION
Rather than marking a ReferenceCountedStructure and then looping over
them, instead just update the defined structures map (and/or warn
undefined) based on the references made by the extractor.