### PR TITLE
Fix IPv6 address parsing in Juniper firewall filter

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -14,6 +14,7 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
@@ -4255,7 +4256,9 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   @Nullable
   private IpWildcard formIpWildCard(Fftfa_address_mask_prefixContext ctx) {
     IpWildcard ipWildcard = null;
-    if (ctx.ip_address != null && ctx.wildcard_mask != null) {
+    if (ctx == null) {
+      return null;
+    } else if (ctx.ip_address != null && ctx.wildcard_mask != null) {
       Ip ipAddress = new Ip(ctx.ip_address.getText());
       Ip mask = new Ip(ctx.wildcard_mask.getText());
       ipWildcard = new IpWildcard(ipAddress, mask.inverted());

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -14,7 +14,6 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -1050,17 +1050,19 @@ public class FlatJuniperGrammarTest {
   @Test
   public void testSourceAddress() throws IOException {
     Configuration c = parseConfig("firewall-source-address");
+    String filterNameV4 = "FILTER";
+    String filterNameV6 = "FILTERv6";
 
-    assertThat(c.getIpAccessLists().keySet(), hasSize(1));
+    assertThat(c.getIpAccessLists().keySet(), containsInAnyOrder(filterNameV4, filterNameV6));
 
-    IpAccessList fwSourceAddressAcl = Iterables.getOnlyElement(c.getIpAccessLists().values());
+    IpAccessList fwSourceAddressAcl = c.getIpAccessLists().get(filterNameV4);
     assertThat(fwSourceAddressAcl.getLines(), hasSize(1));
 
     // should have the same acl as defined in the config
     assertThat(
         c,
         hasIpAccessList(
-            "FILTER",
+            filterNameV4,
             hasLines(
                 equalTo(
                     ImmutableList.of(
@@ -1083,17 +1085,19 @@ public class FlatJuniperGrammarTest {
   @Test
   public void testDestinationAddress() throws IOException {
     Configuration c = parseConfig("firewall-destination-address");
+    String filterNameV4 = "FILTER";
+    String filterNameV6 = "FILTERv6";
 
-    assertThat(c.getIpAccessLists().keySet(), hasSize(1));
+    assertThat(c.getIpAccessLists().keySet(), containsInAnyOrder(filterNameV4, filterNameV6));
 
-    IpAccessList fwDestinationAddressAcl = Iterables.getOnlyElement(c.getIpAccessLists().values());
+    IpAccessList fwDestinationAddressAcl = c.getIpAccessLists().get(filterNameV4);
     assertThat(fwDestinationAddressAcl.getLines(), hasSize(1));
 
     // should have the same acl as defined in the config
     assertThat(
         c,
         hasIpAccessList(
-            "FILTER",
+            filterNameV4,
             hasLines(
                 equalTo(
                     ImmutableList.of(
@@ -1117,7 +1121,7 @@ public class FlatJuniperGrammarTest {
   public void testSourceAddressBehavior() throws IOException {
     Configuration c = parseConfig("firewall-source-address");
 
-    assertThat(c.getIpAccessLists().keySet(), hasSize(1));
+    assertThat(c.getIpAccessLists().keySet(), hasSize(2));
 
     Flow whiteListedSrc = createFlow("1.8.3.9", "2.5.6.7");
     Flow blackListedSrc = createFlow("5.8.4.9", "2.5.6.7");
@@ -1135,7 +1139,7 @@ public class FlatJuniperGrammarTest {
   public void testDestinationAddressBehavior() throws IOException {
     Configuration c = parseConfig("firewall-destination-address");
 
-    assertThat(c.getIpAccessLists().keySet(), hasSize(1));
+    assertThat(c.getIpAccessLists().keySet(), hasSize(2));
 
     Flow whiteListedDst = createFlow("2.5.6.7", "1.8.3.9");
     Flow blackListedDst = createFlow("2.5.6.7", "5.8.4.9");

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/firewall-destination-address
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/firewall-destination-address
@@ -4,5 +4,8 @@ set system host-name firewall-destination-address
 set firewall family inet filter FILTER term TERM from destination-address 1.2.3.4/255.0.255.0
 set firewall family inet filter FILTER term TERM from destination-address 2.3.4.5/24
 set firewall family inet filter FILTER term TERM then accept
+set firewall family inet filter FILTERv6 term TERM from source-address 2001:0db8::1234
+set firewall family inet filter FILTERv6 term TERM from source-address 2001:0db8::FFFF/124
+set firewall family inet filter FILTERv6 term TERM then accept
 set interfaces fw-s-add unit 0 family inet address 1.2.3.4/24
 set interfaces fw-s-add unit 0 family inet filter input FILTER

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/firewall-source-address
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/firewall-source-address
@@ -4,5 +4,8 @@ set system host-name firewall-source-address
 set firewall family inet filter FILTER term TERM from source-address 1.2.3.4/255.0.255.0
 set firewall family inet filter FILTER term TERM from source-address 2.3.4.5/24
 set firewall family inet filter FILTER term TERM then accept
+set firewall family inet filter FILTERv6 term TERM from source-address 2001:0db8::1234
+set firewall family inet filter FILTERv6 term TERM from source-address 2001:0db8::FFFF/124
+set firewall family inet filter FILTERv6 term TERM then accept
 set interfaces fw-s-add unit 0 family inet address 1.2.3.4/24
 set interfaces fw-s-add unit 0 family inet filter input FILTER


### PR DESCRIPTION
* Added null check in `formIpWildCard` to stop crashing on ipv6 addresses
* Updated related tests
