### PR TITLE
Only encode ACLs being analyzed for reachability

### DIFF
--- a/projects/allinone/src/test/java/org/batfish/allinone/AclReachabilityTest.java
+++ b/projects/allinone/src/test/java/org/batfish/allinone/AclReachabilityTest.java
@@ -6,17 +6,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import java.io.IOException;
-import java.util.Map;
-import java.util.Set;
 import java.util.SortedSet;
 import java.util.stream.Collectors;
 import org.batfish.datamodel.Configuration;
@@ -36,7 +31,6 @@ import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
 import org.batfish.question.AclReachabilityQuestionPlugin.AclReachabilityAnswerer;
 import org.batfish.question.AclReachabilityQuestionPlugin.AclReachabilityQuestion;
-import org.batfish.z3.SynthesizerInputImpl;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -135,37 +129,6 @@ public class AclReachabilityTest {
             .first();
     assertThat("Line 0 is blocking", blockedLine.getEarliestMoreGeneralLineIndex(), equalTo(0));
     assertThat("Line 1 is blocked", blockedLine.getIndex(), equalTo(1));
-  }
-
-  @Test
-  public void testCorrectAclsEncoded() throws IOException {
-    // Test that synthesizer only encodes whitelisted ACL when given a configuration with two ACLs.
-    IpAccessList.Builder aclb = _nf.aclBuilder().setOwner(_c);
-    IpAccessList acl1 = aclb.setLines(ImmutableList.of()).setName("acl1").build();
-    IpAccessList acl2 = aclb.setLines(ImmutableList.of()).setName("acl2").build();
-
-    assertThat(_c, hasIpAccessLists(hasEntry(equalTo("acl1"), equalTo(acl1))));
-    assertThat(_c, hasIpAccessLists(hasEntry(equalTo("acl2"), equalTo(acl2))));
-
-    Map<String, Configuration> configurations = ImmutableMap.of(_c.getName(), _c);
-    Map<String, Set<String>> enabledAcls =
-        ImmutableMap.of(_c.getName(), ImmutableSet.of(acl1.getName()));
-    SynthesizerInputImpl inputImpl =
-        SynthesizerInputImpl.builder()
-            .setConfigurations(configurations)
-            .setEnabledAcls(enabledAcls)
-            .build();
-
-    // ACL actions and ACL conditions should both contain acl1 and not acl2.
-    assertThat(
-        inputImpl.getAclActions(),
-        hasEntry(equalTo(_c.getName()), hasKey(equalTo(acl1.getName()))));
-    assertThat(inputImpl.getAclActions().get(_c.getName()).size(), equalTo(1));
-
-    assertThat(
-        inputImpl.getAclConditions(),
-        hasEntry(equalTo(_c.getName()), hasKey(equalTo(acl1.getName()))));
-    assertThat(inputImpl.getAclConditions().get(_c.getName()).size(), equalTo(1));
   }
 
   @Test

--- a/projects/allinone/src/test/java/org/batfish/allinone/AclReachabilityTest.java
+++ b/projects/allinone/src/test/java/org/batfish/allinone/AclReachabilityTest.java
@@ -57,31 +57,78 @@ public class AclReachabilityTest {
   public void testIndirection() throws IOException {
     IpAccessList.Builder aclb = _nf.aclBuilder().setOwner(_c);
 
-    IpAccessList independentAcl = aclb.setLines(ImmutableList.of()).setName("acl1").build();
-    IpAccessList dependentAcl =
+    /*
+    Reference ACL contains 1 line: Permit 1.0.0.0/24
+    Main ACL contains 2 lines:
+    0. Permit anything that reference ACL permits
+    1. Permit 1.0.0.0/24
+
+    Runs two questions:
+    1. General ACL reachability (reference ACL won't be encoded after first NoD step)
+    2. Reachability specifically for main ACL (reference ACL won't be encoded at all)
+    Tests that both find line 1 to be blocked by line 0 in main ACL.
+     */
+
+    IpAccessList referencedAcl =
+        aclb.setLines(
+                ImmutableList.of(
+                    acceptingHeaderSpace(
+                        HeaderSpace.builder()
+                            .setSrcIps(Prefix.parse("1.0.0.0/24").toIpSpace())
+                            .build())))
+            .setName("acl1")
+            .build();
+    IpAccessList acl =
         aclb.setLines(
                 ImmutableList.of(
                     IpAccessListLine.accepting()
-                        .setMatchCondition(new PermittedByAcl(independentAcl.getName()))
-                        .build()))
+                        .setMatchCondition(new PermittedByAcl(referencedAcl.getName()))
+                        .build(),
+                    acceptingHeaderSpace(
+                        HeaderSpace.builder()
+                            .setSrcIps(Prefix.parse("1.0.0.0/24").toIpSpace())
+                            .build())))
             .setName("acl2")
             .build();
 
     Batfish batfish = BatfishTestUtils.getBatfish(ImmutableSortedMap.of(_c.getName(), _c), _folder);
 
-    assertThat(_c, hasIpAccessLists(hasEntry(independentAcl.getName(), independentAcl)));
-    assertThat(_c, hasIpAccessLists(hasEntry(dependentAcl.getName(), dependentAcl)));
+    assertThat(_c, hasIpAccessLists(hasEntry(referencedAcl.getName(), referencedAcl)));
+    assertThat(_c, hasIpAccessLists(hasEntry(acl.getName(), acl)));
 
     AclReachabilityQuestion question = new AclReachabilityQuestion();
     AclReachabilityAnswerer answerer = new AclReachabilityAnswerer(question, batfish);
+    question.setAclNameRegex(acl.getName());
+    AclReachabilityAnswerer specificAnswerer = new AclReachabilityAnswerer(question, batfish);
 
     AnswerElement answer = answerer.answer();
+    AnswerElement specificAnswer = specificAnswerer.answer();
     assertThat(answer, instanceOf(AclLinesAnswerElement.class));
+    assertThat(specificAnswer, instanceOf(AclLinesAnswerElement.class));
     AclLinesAnswerElement aclLinesAnswerElement = (AclLinesAnswerElement) answer;
+    AclLinesAnswerElement specificAclLinesAnswerElement = (AclLinesAnswerElement) specificAnswer;
 
+    // Tests for general ACL reachability answer
     assertThat(
         aclLinesAnswerElement.getUnreachableLines(),
-        hasEntry(equalTo(_c.getName()), hasEntry(equalTo(dependentAcl.getName()), hasSize(1))));
+        hasEntry(equalTo(_c.getName()), hasEntry(equalTo(acl.getName()), hasSize(1))));
+    AclReachabilityEntry blockedLine =
+        aclLinesAnswerElement.getUnreachableLines().get(_c.getName()).get(acl.getName()).first();
+    assertThat("Line 0 is blocking", blockedLine.getEarliestMoreGeneralLineIndex(), equalTo(0));
+    assertThat("Line 1 is blocked", blockedLine.getIndex(), equalTo(1));
+
+    // Tests for ACL reachability of main ACL specifically
+    assertThat(
+        specificAclLinesAnswerElement.getUnreachableLines(),
+        hasEntry(equalTo(_c.getName()), hasEntry(equalTo(acl.getName()), hasSize(1))));
+    blockedLine =
+        specificAclLinesAnswerElement
+            .getUnreachableLines()
+            .get(_c.getName())
+            .get(acl.getName())
+            .first();
+    assertThat("Line 0 is blocking", blockedLine.getEarliestMoreGeneralLineIndex(), equalTo(0));
+    assertThat("Line 1 is blocked", blockedLine.getIndex(), equalTo(1));
   }
 
   @Test

--- a/projects/allinone/src/test/java/org/batfish/allinone/AclReachabilityTest.java
+++ b/projects/allinone/src/test/java/org/batfish/allinone/AclReachabilityTest.java
@@ -6,12 +6,17 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
 import java.util.SortedSet;
 import java.util.stream.Collectors;
 import org.batfish.datamodel.Configuration;
@@ -31,6 +36,7 @@ import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
 import org.batfish.question.AclReachabilityQuestionPlugin.AclReachabilityAnswerer;
 import org.batfish.question.AclReachabilityQuestionPlugin.AclReachabilityQuestion;
+import org.batfish.z3.SynthesizerInputImpl;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -129,6 +135,37 @@ public class AclReachabilityTest {
             .first();
     assertThat("Line 0 is blocking", blockedLine.getEarliestMoreGeneralLineIndex(), equalTo(0));
     assertThat("Line 1 is blocked", blockedLine.getIndex(), equalTo(1));
+  }
+
+  @Test
+  public void testCorrectAclsEncoded() throws IOException {
+    // Test that synthesizer only encodes whitelisted ACL when given a configuration with two ACLs.
+    IpAccessList.Builder aclb = _nf.aclBuilder().setOwner(_c);
+    IpAccessList acl1 = aclb.setLines(ImmutableList.of()).setName("acl1").build();
+    IpAccessList acl2 = aclb.setLines(ImmutableList.of()).setName("acl2").build();
+
+    assertThat(_c, hasIpAccessLists(hasEntry(equalTo("acl1"), equalTo(acl1))));
+    assertThat(_c, hasIpAccessLists(hasEntry(equalTo("acl2"), equalTo(acl2))));
+
+    Map<String, Configuration> configurations = ImmutableMap.of(_c.getName(), _c);
+    Map<String, Set<String>> enabledAcls =
+        ImmutableMap.of(_c.getName(), ImmutableSet.of(acl1.getName()));
+    SynthesizerInputImpl inputImpl =
+        SynthesizerInputImpl.builder()
+            .setConfigurations(configurations)
+            .setEnabledAcls(enabledAcls)
+            .build();
+
+    // ACL actions and ACL conditions should both contain acl1 and not acl2.
+    assertThat(
+        inputImpl.getAclActions(),
+        hasEntry(equalTo(_c.getName()), hasKey(equalTo(acl1.getName()))));
+    assertThat(inputImpl.getAclActions().get(_c.getName()).size(), equalTo(1));
+
+    assertThat(
+        inputImpl.getAclConditions(),
+        hasEntry(equalTo(_c.getName()), hasKey(equalTo(acl1.getName()))));
+    assertThat(inputImpl.getAclConditions().get(_c.getName()).size(), equalTo(1));
   }
 
   @Test

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -680,9 +680,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
             linesToCheck
                 .entrySet()
                 .stream()
-                .collect(
-                    Collectors.toMap(
-                        e -> e.getKey(), e -> ImmutableSet.copyOf(e.getValue().keySet()))));
+                .collect(toMap(e -> e.getKey(), e -> ImmutableSet.copyOf(e.getValue().keySet()))));
     linesToCheck.forEach(
         (hostname, aclNames) -> {
           aclNames.forEach(

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -674,7 +674,15 @@ public class Batfish extends PluginConsumer implements IBatfish {
           Map<String, Configuration> configurations,
           Map<String, Map<String, Set<Integer>>> linesToCheck) {
     List<NodSatJob<AclLine>> jobs = new ArrayList<>();
-    Synthesizer aclSynthesizer = synthesizeAcls(configurations);
+    Synthesizer aclSynthesizer =
+        synthesizeAcls(
+            configurations,
+            linesToCheck
+                .entrySet()
+                .stream()
+                .collect(
+                    Collectors.toMap(
+                        e -> e.getKey(), e -> ImmutableSet.copyOf(e.getValue().keySet()))));
     linesToCheck.forEach(
         (hostname, aclNames) -> {
           aclNames.forEach(
@@ -940,11 +948,13 @@ public class Batfish extends PluginConsumer implements IBatfish {
         }
         AclReachabilityQuerySynthesizer query =
             new AclReachabilityQuerySynthesizer(hostname, aclName, numLines);
-        Synthesizer aclSynthesizer = synthesizeAcls(Collections.singletonMap(hostname, c));
+        Synthesizer aclSynthesizer =
+            synthesizeAcls(
+                Collections.singletonMap(hostname, c),
+                Collections.singletonMap(hostname, ImmutableSet.of(aclName)));
         NodSatJob<AclLine> job = new NodSatJob<>(_settings, aclSynthesizer, query);
         jobs.add(job);
       }
-      // Add current ACL back into ACL list before moving on to next ACL
     }
     return jobs;
   }
@@ -964,8 +974,11 @@ public class Batfish extends PluginConsumer implements IBatfish {
                   .stream()
                   .map(Interface::getName)
                   .collect(Collectors.toList()));
-      Synthesizer aclSynthesizer = synthesizeAcls(Collections.singletonMap(hostname, c));
       Map<String, List<AclLine>> byAclName = e.getValue();
+      Synthesizer aclSynthesizer =
+          synthesizeAcls(
+              Collections.singletonMap(hostname, c),
+              Collections.singletonMap(hostname, ImmutableSet.copyOf(byAclName.keySet())));
       for (Entry<String, List<AclLine>> e2 : byAclName.entrySet()) {
         String aclName = e2.getKey();
         // Generate job for earlier blocking lines in this ACL
@@ -4392,7 +4405,8 @@ public class Batfish extends PluginConsumer implements IBatfish {
     return singleReachability(reachabilitySettings, StandardReachabilityQuerySynthesizer.builder());
   }
 
-  private Synthesizer synthesizeAcls(Map<String, Configuration> configurations) {
+  private Synthesizer synthesizeAcls(
+      Map<String, Configuration> configurations, Map<String, Set<String>> enabledAcls) {
     _logger.info("\n*** GENERATING Z3 LOGIC ***\n");
     _logger.resetTimer();
 
@@ -4401,6 +4415,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
         new Synthesizer(
             SynthesizerInputImpl.builder()
                 .setConfigurations(configurations)
+                .setEnabledAcls(enabledAcls)
                 .setSimplify(_settings.getSimplify())
                 .build());
 

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -973,12 +973,12 @@ public class Batfish extends PluginConsumer implements IBatfish {
                   .map(Interface::getName)
                   .collect(Collectors.toList()));
       Map<String, List<AclLine>> byAclName = e.getValue();
-      Synthesizer aclSynthesizer =
-          synthesizeAcls(
-              Collections.singletonMap(hostname, c),
-              Collections.singletonMap(hostname, ImmutableSet.copyOf(byAclName.keySet())));
       for (Entry<String, List<AclLine>> e2 : byAclName.entrySet()) {
         String aclName = e2.getKey();
+        Synthesizer aclSynthesizer =
+            synthesizeAcls(
+                Collections.singletonMap(hostname, c),
+                Collections.singletonMap(hostname, ImmutableSet.of(aclName)));
         // Generate job for earlier blocking lines in this ACL
         IpAccessList ipAccessList = c.getIpAccessLists().get(aclName);
         List<AclLine> lines = e2.getValue();

--- a/projects/batfish/src/main/java/org/batfish/z3/SynthesizerInputImpl.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/SynthesizerInputImpl.java
@@ -81,6 +81,8 @@ public final class SynthesizerInputImpl implements SynthesizerInput {
 
     private Set<Type> _vectorizedParameters = ImmutableSet.of();
 
+    private Builder() {}
+
     public SynthesizerInputImpl build() {
       return new SynthesizerInputImpl(this);
     }

--- a/projects/batfish/src/main/java/org/batfish/z3/SynthesizerInputImpl.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/SynthesizerInputImpl.java
@@ -55,63 +55,34 @@ public final class SynthesizerInputImpl implements SynthesizerInput {
   static final String SRC_INTERFACE_FIELD_NAME = "SRC_INTERFACE";
 
   public static class Builder {
-    private ForwardingAnalysis _forwardingAnalysis;
-
     private Map<String, Configuration> _configurations;
+
+    private Map<String, Set<String>> _disabledInterfaces = ImmutableMap.of();
+
+    private Set<String> _disabledNodes = ImmutableSet.of();
+
+    private Map<String, Set<String>> _disabledVrfs = ImmutableMap.of();
 
     private Map<String, Set<String>> _enabledAclNames;
 
-    private Map<String, Set<String>> _disabledInterfaces;
-
-    private Set<String> _disabledNodes;
-
-    private Map<String, Set<String>> _disabledVrfs;
+    private ForwardingAnalysis _forwardingAnalysis;
 
     @Nullable private HeaderSpace _headerSpace;
 
-    private Set<String> _nonTransitNodes;
+    private Set<String> _nonTransitNodes = ImmutableSortedSet.of();
 
-    private boolean _simplify;
+    private boolean _simplify = false;
 
-    private boolean _specialize;
+    private boolean _specialize = false;
 
     private Topology _topology;
 
-    private Set<String> _transitNodes;
+    private Set<String> _transitNodes = ImmutableSortedSet.of();
 
-    private boolean _useEnabledAclNames = false;
-
-    private Set<Type> _vectorizedParameters;
-
-    private Builder() {
-      _enabledAclNames = ImmutableMap.of();
-      _disabledInterfaces = ImmutableMap.of();
-      _disabledNodes = ImmutableSet.of();
-      _disabledVrfs = ImmutableMap.of();
-      _headerSpace = null;
-      _nonTransitNodes = ImmutableSortedSet.of();
-      _simplify = false;
-      _specialize = false;
-      _transitNodes = ImmutableSortedSet.of();
-      _vectorizedParameters = ImmutableSet.of();
-    }
+    private Set<Type> _vectorizedParameters = ImmutableSet.of();
 
     public SynthesizerInputImpl build() {
-      return new SynthesizerInputImpl(
-          _forwardingAnalysis,
-          _configurations,
-          _useEnabledAclNames,
-          _enabledAclNames,
-          _disabledInterfaces,
-          _disabledNodes,
-          _disabledVrfs,
-          _headerSpace != null ? _headerSpace : new HeaderSpace(),
-          _nonTransitNodes,
-          _simplify,
-          _specialize,
-          _topology,
-          _transitNodes,
-          _vectorizedParameters);
+      return new SynthesizerInputImpl(this);
     }
 
     public Builder setForwardingAnalysis(ForwardingAnalysis forwardingAnalysis) {
@@ -125,7 +96,6 @@ public final class SynthesizerInputImpl implements SynthesizerInput {
     }
 
     public Builder setEnabledAcls(Map<String, Set<String>> enabledAcls) {
-      _useEnabledAclNames = true;
       _enabledAclNames = enabledAcls;
       return this;
     }
@@ -259,28 +229,17 @@ public final class SynthesizerInputImpl implements SynthesizerInput {
 
   private final @Nonnull Set<Type> _vectorizedParameters;
 
-  public SynthesizerInputImpl(
-      ForwardingAnalysis forwardingAnalysis,
-      Map<String, Configuration> configurations,
-      boolean useEnabledAclNames,
-      Map<String, Set<String>> enabledAclNames,
-      Map<String, Set<String>> disabledInterfaces,
-      Set<String> disabledNodes,
-      Map<String, Set<String>> disabledVrfs,
-      HeaderSpace headerSpace,
-      Set<String> nonTransitNodes,
-      boolean simplify,
-      boolean specialize,
-      Topology topology,
-      Set<String> transitNodes,
-      Set<Type> vectorizedParameters) {
-    if (configurations == null) {
+  private SynthesizerInputImpl(Builder builder) {
+    if (builder._configurations == null) {
       throw new BatfishException("Must supply configurations");
     }
+    _configurations = ImmutableMap.copyOf(builder._configurations);
     _namedIpSpaces =
-        toImmutableMap(configurations, Entry::getKey, entry -> entry.getValue().getIpSpaces());
+        toImmutableMap(_configurations, Entry::getKey, entry -> entry.getValue().getIpSpaces());
+    HeaderSpace headerSpace =
+        builder._headerSpace != null ? builder._headerSpace : new HeaderSpace();
     _specializationIpSpace =
-        specialize
+        builder._specialize
             ? firstNonNull(
                 AclIpSpace.difference(headerSpace.getDstIps(), headerSpace.getNotDstIps()),
                 UniverseIpSpace.INSTANCE)
@@ -292,28 +251,30 @@ public final class SynthesizerInputImpl implements SynthesizerInput {
             namedIpSpacesEntry ->
                 new IpSpaceSpecializer(_specializationIpSpace, namedIpSpacesEntry.getValue()));
     _ipAccessListSpecializers =
-        specialize
+        builder._specialize
             ? toImmutableMap(
                 _namedIpSpaces,
                 Entry::getKey,
                 namedIpSpacesEntry ->
                     new IpAccessListSpecializer(headerSpace, namedIpSpacesEntry.getValue()))
             : ImmutableMap.of();
-    _configurations = ImmutableMap.copyOf(configurations);
-    _disabledInterfaces = ImmutableMap.copyOf(disabledInterfaces);
-    _disabledNodes = ImmutableSet.copyOf(disabledNodes);
-    _disabledVrfs = ImmutableMap.copyOf(disabledVrfs);
+    _disabledInterfaces = ImmutableMap.copyOf(builder._disabledInterfaces);
+    _disabledNodes = ImmutableSet.copyOf(builder._disabledNodes);
+    _disabledVrfs = ImmutableMap.copyOf(builder._disabledVrfs);
     _enabledAcls =
-        useEnabledAclNames ? computeEnabledAcls(enabledAclNames) : computeDefaultEnabledAcls();
+        builder._enabledAclNames != null
+            ? computeEnabledAcls(builder._enabledAclNames)
+            : computeDefaultEnabledAcls();
     _enabledNodes = computeEnabledNodes();
     _enabledVrfs = computeEnabledVrfs();
     _enabledInterfacesByNodeVrf = computeEnabledInterfacesByNodeVrf();
     _enabledInterfaces = computeEnabledInterfaces();
     _incomingAcls = computeIncomingAcls();
     _outgoingAcls = computeOutgoingAcls();
-    _simplify = simplify;
-    _vectorizedParameters = vectorizedParameters;
+    _simplify = builder._simplify;
+    _vectorizedParameters = builder._vectorizedParameters;
 
+    ForwardingAnalysis forwardingAnalysis = builder._forwardingAnalysis;
     _dataPlane = forwardingAnalysis != null;
     if (_dataPlane) {
       _arpTrueEdge = computeArpTrueEdge(forwardingAnalysis.getArpTrueEdge());
@@ -323,7 +284,7 @@ public final class SynthesizerInputImpl implements SynthesizerInput {
       _routableIps = computeRoutableIps(forwardingAnalysis.getRoutableIps());
       _ipsByHostname = computeIpsByHostname();
       _ipsByNodeVrf = computeIpsByNodeVrf();
-      _edges = topology.getEdges();
+      _edges = builder._topology.getEdges();
       _enabledEdges = computeEnabledEdges();
       _topologyInterfaces = computeTopologyInterfaces();
       _sourceNats = computeSourceNats();
@@ -344,8 +305,8 @@ public final class SynthesizerInputImpl implements SynthesizerInput {
     _nodesWithSrcInterfaceConstraints = computeNodesWithSrcInterfaceConstraints();
     _sourceInterfaceField = computeSourceInterfaceField();
     _sourceInterfaceFieldValues = computeSourceInterfaceFieldValues();
-    _nonTransitNodes = ImmutableSortedSet.copyOf(nonTransitNodes);
-    _transitNodes = ImmutableSortedSet.copyOf(transitNodes);
+    _nonTransitNodes = ImmutableSortedSet.copyOf(builder._nonTransitNodes);
+    _transitNodes = ImmutableSortedSet.copyOf(builder._transitNodes);
     _aclConditions = computeAclConditions();
   }
 

--- a/projects/batfish/src/test/java/org/batfish/z3/SynthesizerInputImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/SynthesizerInputImplTest.java
@@ -26,7 +26,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Range;
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -652,11 +651,9 @@ public class SynthesizerInputImplTest {
 
   /**
    * Test that synthesizer only encodes whitelisted ACL when given a configuration with two ACLs.
-   *
-   * @throws IOException
    */
   @Test
-  public void testEnabledAcls() throws IOException {
+  public void testEnabledAcls() {
     Configuration config = _cb.build();
     Builder aclb = _nf.aclBuilder().setOwner(config);
     IpAccessList acl1 = aclb.setLines(ImmutableList.of()).setName("acl1").build();


### PR DESCRIPTION
Removed `disabledAcls` from project. Instead, builder for `SynthesizerInputImpl` has a field `enabledAclNames`. If this field is set, the resulting synthesizer input encodes only the specified ACLs; if it is not set, the synthesizer input encodes all ACLs as usual.

This new setup makes it much simpler to create ACL synthesizers in Batfish because it's easier to assemble ACL whitelists than blacklists.

Before this gets merged, I want to add tests to prove that the appropriate ACLs are getting encoded. Any ideas on how to capture that information?