### PR TITLE
Prefix tracing infrastructure + some routemap fixes

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/exceptions/BgpRoutePropagationException.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/exceptions/BgpRoutePropagationException.java
@@ -1,0 +1,13 @@
+package org.batfish.dataplane.exceptions;
+
+/**
+ * Thrown if the dataplane fails to propagate a BGP route between two routers due to missing info
+ */
+public class BgpRoutePropagationException extends Exception {
+
+  private static final long serialVersionUID = 1L;
+
+  public BgpRoutePropagationException(String s) {
+    super(s);
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -144,7 +144,6 @@ public class IncrementalBdpEngine {
    *
    * @param nodes nodes that are participating in the computation
    * @param topology network Topology
-   * @param dp data place instance
    * @param iteration iteration number (for stats tracking)
    * @param allNodes all nodes in the network (for correct neighbor referencing)
    * @param bgpTopology the bgp peering relationships
@@ -152,7 +151,6 @@ public class IncrementalBdpEngine {
   private void computeDependentRoutesIteration(
       Map<String, Node> nodes,
       Topology topology,
-      IncrementalDataPlane dp,
       int iteration,
       Map<String, Node> allNodes,
       Network<BgpNeighbor, BgpSession> bgpTopology) {
@@ -246,12 +244,11 @@ public class IncrementalBdpEngine {
               });
     }
 
-    computeIterationOfBgpRoutes(nodes, dp, iteration, allNodes, bgpTopology);
+    computeIterationOfBgpRoutes(nodes, iteration, allNodes, bgpTopology);
   }
 
   private void computeIterationOfBgpRoutes(
       Map<String, Node> nodes,
-      IncrementalDataPlane dp,
       int iteration,
       Map<String, Node> allNodes,
       Network<BgpNeighbor, BgpSession> bgpTopology) {
@@ -281,7 +278,7 @@ public class IncrementalBdpEngine {
                   continue;
                 }
                 Map<BgpMultipathRib, RibDelta<BgpRoute>> deltas =
-                    vr.processBgpMessages(dp.getIpOwners(), bgpTopology);
+                    vr.processBgpMessages(bgpTopology, allNodes);
                 vr.finalizeBgpRoutesAndQueueOutgoingMessages(
                     proc.getMultipathEbgp(),
                     proc.getMultipathIbgp(),
@@ -445,7 +442,7 @@ public class IncrementalBdpEngine {
       while (schedule.hasNext()) {
         Map<String, Node> iterationNodes = schedule.next();
         computeDependentRoutesIteration(
-            iterationNodes, topology, dp, _numIterations, nodes, bgpTopology);
+            iterationNodes, topology, _numIterations, nodes, bgpTopology);
       }
 
       /*

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlane.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlane.java
@@ -137,4 +137,28 @@ public class IncrementalDataPlane implements Serializable, DataPlane {
   void setBgpTopology(Network<BgpNeighbor, BgpSession> bgpTopology) {
     this._bgpTopology = bgpTopology;
   }
+
+  public SortedMap<String, SortedMap<String, PrefixTracer>> getPrefixTracingInfo() {
+    /*
+     * Iterate over nodes, then virtual routers, and extract prefix tracer from each.
+     * Sort hostnames and VRF names
+     */
+    return _nodes
+        .entrySet()
+        .stream()
+        .collect(
+            ImmutableSortedMap.toImmutableSortedMap(
+                String::compareTo,
+                Entry::getKey,
+                e ->
+                    e.getValue()
+                        .getVirtualRouters()
+                        .entrySet()
+                        .stream()
+                        .collect(
+                            ImmutableSortedMap.toImmutableSortedMap(
+                                String::compareTo,
+                                Entry::getKey,
+                                e2 -> e2.getValue().getPrefixTracer()))));
+  }
 }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/PrefixTracer.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/PrefixTracer.java
@@ -1,0 +1,199 @@
+package org.batfish.dataplane.ibdp;
+
+import com.google.common.collect.ImmutableSortedSet;
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.SortedSet;
+import javax.annotation.Nullable;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.routing_policy.Environment.Direction;
+
+/** Keeps data about which prefixes where advertised to neighboring routers */
+public class PrefixTracer implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  public class Neighbor implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final String _hostname;
+    private final Ip _ip;
+    @Nullable private final String _routingPolicy;
+    private final String _vrfName;
+
+    /**
+     * A non-protocol-specific L3 data plane neighbor, identified by hostname, VRF name & IP
+     * address. Optional routing policy can be specified as meta data to indicate a policy that
+     * allowed or filtered the prefix.
+     */
+    Neighbor(String hostname, Ip ip, String vrfName, @Nullable String routingPolicy) {
+      this._hostname = hostname;
+      this._ip = ip;
+      this._routingPolicy = routingPolicy;
+      this._vrfName = vrfName;
+    }
+
+    /** Return the remote neighbor's hostname */
+    public String getHostname() {
+      return _hostname;
+    }
+
+    /** Return the remote neighbor's IP */
+    public Ip getIp() {
+      return _ip;
+    }
+
+    /** Return the routing policy (of the current router) */
+    @Nullable
+    public String getRoutingPolicy() {
+      return _routingPolicy;
+    }
+
+    /** Return remote neighbor's VRF name */
+    public String getVrfname() {
+      return _vrfName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      Neighbor neighbor = (Neighbor) o;
+      return Objects.equals(_hostname, neighbor._hostname)
+          && Objects.equals(_ip, neighbor._ip)
+          && Objects.equals(_vrfName, neighbor._vrfName)
+          && Objects.equals(_routingPolicy, neighbor._routingPolicy);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(_hostname, _vrfName, _ip, _routingPolicy);
+    }
+
+    @Override
+    public String toString() {
+      return "Neighbor{"
+          + "_hostname='"
+          + _hostname
+          + '\''
+          + ", _ip="
+          + _ip
+          + ", _routingPolicy='"
+          + _routingPolicy
+          + '\''
+          + ", _vrfName='"
+          + _vrfName
+          + '\''
+          + '}';
+    }
+  }
+
+  private Map<Prefix, Set<Neighbor>> _filteredOnImport;
+
+  private Map<Prefix, Set<Neighbor>> _filteredOnExport;
+
+  private Set<Prefix> _originated;
+
+  private Map<Prefix, Set<Neighbor>> _installed;
+
+  private Map<Prefix, Set<Neighbor>> _sent;
+
+  PrefixTracer() {
+    _originated = new HashSet<>();
+    _installed = new HashMap<>();
+    _sent = new HashMap<>();
+    _filteredOnImport = new HashMap<>();
+    _filteredOnExport = new HashMap<>();
+  }
+
+  /** Note that we considered given prefix for origination */
+  void originated(Prefix prefix) {
+    _originated.add(prefix);
+  }
+
+  /** Note that we exported given prefix to a given {@link Neighbor} */
+  void sentTo(
+      Prefix prefix,
+      String neighborHostname,
+      Ip neighborIp,
+      String neighborVrf,
+      @Nullable String exportPolicy) {
+    Set<Neighbor> set = _sent.computeIfAbsent(prefix, p -> new HashSet<>());
+    set.add(new Neighbor(neighborHostname, neighborIp, neighborVrf, exportPolicy));
+  }
+
+  /** Note that we installed a prefix received from a given {@link Neighbor} */
+  void installed(
+      Prefix prefix,
+      String neighborHostname,
+      Ip neighborIp,
+      String neighborVrf,
+      @Nullable String importPolicy) {
+    Set<Neighbor> set = _installed.computeIfAbsent(prefix, p -> new HashSet<>());
+    set.add(new Neighbor(neighborHostname, neighborIp, neighborVrf, importPolicy));
+  }
+
+  /**
+   * Note that we did filtered a prefix when sending/receiving routes from given {@link Neighbor}.
+   *
+   * @param direction {@link Direction} indicating whether we were sending ({@link Direction#OUT})
+   *     or receiving ({@link Direction#IN}) the prefix
+   */
+  void filtered(
+      Prefix prefix,
+      String neighborHostname,
+      Ip neighborIp,
+      String neighborVrf,
+      @Nullable String policyName,
+      Direction direction) {
+    if (direction == Direction.IN) {
+      Set<Neighbor> set = _filteredOnImport.computeIfAbsent(prefix, p -> new HashSet<>());
+      set.add(new Neighbor(neighborHostname, neighborIp, neighborVrf, policyName));
+    } else if (direction == Direction.OUT) {
+      Set<Neighbor> set = _filteredOnExport.computeIfAbsent(prefix, p -> new HashSet<>());
+      set.add(new Neighbor(neighborHostname, neighborIp, neighborVrf, policyName));
+    } else {
+      throw new UnsupportedOperationException("Unknown filtering direction");
+    }
+  }
+
+  /** Return the set of prefixes we attempted to originate */
+  public SortedSet<Prefix> getOriginated() {
+    return ImmutableSortedSet.copyOf(_originated);
+  }
+
+  /** Return the set of prefixes we successfully sent/exported. */
+  public Map<Prefix, Set<Neighbor>> getSent() {
+    return _sent;
+  }
+
+  /** Return the set of prefixes we received and installed. */
+  public Map<Prefix, Set<Neighbor>> getInstalled() {
+    return _installed;
+  }
+
+  /**
+   * Return the set of prefixes we filtered (in a given direction)
+   *
+   * @param direction {@link Direction} indicating whether the prefixes were filtered on export
+   *     ({@link Direction#OUT}) or import ({@link Direction#IN}).
+   */
+  public Map<Prefix, Set<Neighbor>> getFiltered(Direction direction) {
+    if (direction == Direction.IN) {
+      return _filteredOnImport;
+    } else if (direction == Direction.OUT) {
+      return _filteredOnExport;
+    } else {
+      throw new UnsupportedOperationException("Unknown filtering direction");
+    }
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -10,7 +10,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.graph.Network;
-import java.io.IOException;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.Collections;
@@ -19,6 +18,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
 import java.util.SortedMap;
@@ -75,6 +75,8 @@ import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.routing_policy.Environment.Direction;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
+import org.batfish.dataplane.exceptions.BgpRoutePropagationException;
+import org.batfish.dataplane.protocols.BgpProtocolHelper;
 import org.batfish.dataplane.rib.BgpBestPathRib;
 import org.batfish.dataplane.rib.BgpMultipathRib;
 import org.batfish.dataplane.rib.ConnectedRib;
@@ -95,29 +97,29 @@ import org.batfish.dataplane.rib.StaticRib;
 public class VirtualRouter extends ComparableStructure<String> {
 
   private static final long serialVersionUID = 1L;
+  final Vrf _vrf;
+  /** Parent configuration for this Virtual router */
+  private final Configuration _c;
 
   /** Route dependency tracker for BGP aggregate routes */
   private transient RouteDependencyTracker<BgpRoute, AbstractRoute> _bgpAggDeps =
       new RouteDependencyTracker<>();
 
-  /** Builder for constructing {@link RibDelta} as pertains to the best-path BGP RIB */
-  private transient RibDelta.Builder<BgpRoute> _bgpBestPathDeltaBuilder;
-
   /** Best-path BGP RIB */
   transient BgpBestPathRib _bgpBestPathRib;
 
-  /** Incoming messages into this router from each bgp neighbor (indexed by prefix) */
+  /** Builder for constructing {@link RibDelta} as pertains to the best-path BGP RIB */
+  private transient RibDelta.Builder<BgpRoute> _bgpBestPathDeltaBuilder;
+
+  /** Incoming messages into this router from each BGP neighbor */
   transient SortedMap<UndirectedBgpSession, Queue<RouteAdvertisement<AbstractRoute>>>
       _bgpIncomingRoutes;
-
-  /** Builder for constructing {@link RibDelta} as pertains to the multipath BGP RIB */
-  private transient RibDelta.Builder<BgpRoute> _bgpMultiPathDeltaBuilder;
 
   /** BGP multipath RIB */
   transient BgpMultipathRib _bgpMultipathRib;
 
-  /** Parent configuration for this Virtual router */
-  private final Configuration _c;
+  /** Builder for constructing {@link RibDelta} as pertains to the multipath BGP RIB */
+  private transient RibDelta.Builder<BgpRoute> _bgpMultiPathDeltaBuilder;
 
   /** The RIB containing connected routes */
   private transient ConnectedRib _connectedRib;
@@ -134,12 +136,6 @@ public class VirtualRouter extends ComparableStructure<String> {
    */
   transient BgpMultipathRib _ebgpStagingRib;
 
-  /** FIB (forwarding information base) built from the main RIB */
-  Fib _fib;
-
-  /** RIB containing generated routes */
-  private transient Rib _generatedRib;
-
   /** Helper RIB containing best paths obtained with iBGP */
   transient BgpBestPathRib _ibgpBestPathRib;
 
@@ -150,18 +146,11 @@ public class VirtualRouter extends ComparableStructure<String> {
    * Helper RIB containing paths obtained with iBGP during current iteration. An Adj-RIB of sorts.
    */
   transient BgpMultipathRib _ibgpStagingRib;
-
   /**
    * The independent RIB contains connected and static routes, which are unaffected by BDP
    * iterations (hence, independent).
    */
   transient Rib _independentRib;
-
-  /** The finalized RIB, a combination different protocol RIBs */
-  Rib _mainRib;
-
-  /** Keeps track of changes to the main RIB */
-  private transient RibDelta.Builder<AbstractRoute> _mainRibRouteDeltaBuiler;
 
   transient OspfExternalType1Rib _ospfExternalType1Rib;
 
@@ -170,8 +159,6 @@ public class VirtualRouter extends ComparableStructure<String> {
   transient OspfExternalType2Rib _ospfExternalType2Rib;
 
   transient OspfExternalType2Rib _ospfExternalType2StagingRib;
-
-  private transient RibDelta.Builder<OspfExternalRoute> _ospfExternalDeltaBuiler;
 
   @VisibleForTesting
   transient SortedMap<Prefix, Queue<RouteAdvertisement<OspfExternalRoute>>>
@@ -185,17 +172,7 @@ public class VirtualRouter extends ComparableStructure<String> {
 
   transient OspfIntraAreaRib _ospfIntraAreaStagingRib;
 
-  private transient Map<Prefix, VirtualRouter> _ospfNeighbors;
-
   transient OspfRib _ospfRib;
-
-  /** Set of all valid OSPF external routes that we know about */
-  private Map<Prefix, SortedSet<OspfExternalType1Route>> _receivedOspExternalType1Routes;
-
-  private Map<Prefix, SortedSet<OspfExternalType2Route>> _receivedOspExternalType2Routes;
-
-  /** Set of all valid BGP "advertisements" we have received */
-  private Map<Prefix, SortedSet<BgpRoute>> _receivedBgpRoutes;
 
   Set<BgpAdvertisement> _receivedBgpAdvertisements;
 
@@ -211,7 +188,33 @@ public class VirtualRouter extends ComparableStructure<String> {
 
   transient StaticRib _staticRib;
 
-  final Vrf _vrf;
+  /** FIB (forwarding information base) built from the main RIB */
+  private Fib _fib;
+  /** RIB containing generated routes */
+  private transient Rib _generatedRib;
+
+  /** The finalized RIB, a combination different protocol RIBs */
+  Rib _mainRib;
+
+  /** Keeps track of changes to the main RIB */
+  private transient RibDelta.Builder<AbstractRoute> _mainRibRouteDeltaBuiler;
+
+  private transient RibDelta.Builder<OspfExternalRoute> _ospfExternalDeltaBuiler;
+
+  private transient Map<Prefix, VirtualRouter> _ospfNeighbors;
+
+  /** Set of all valid OSPF external Type 1 routes that we know about */
+  private Map<Prefix, SortedSet<OspfExternalType1Route>> _receivedOspExternalType1Routes;
+
+  /** Set of all valid OSPF external Type 2 routes that we know about */
+  private Map<Prefix, SortedSet<OspfExternalType2Route>> _receivedOspExternalType2Routes;
+
+  /** Set of all valid BGP "advertisements" we have received */
+  private Map<Prefix, SortedSet<BgpRoute>> _receivedBgpRoutes;
+
+  // TODO: make non-transient. Currently transient because de-serialization crashes.
+  /** Metadata about propagated prefixes to/from neighbors */
+  private final transient PrefixTracer _prefixTracer;
 
   VirtualRouter(final String name, final Configuration c) {
     super(name);
@@ -225,6 +228,182 @@ public class VirtualRouter extends ComparableStructure<String> {
     _receivedOspExternalType2Routes = new TreeMap<>();
     _receivedBgpRoutes = new TreeMap<>();
     _bgpIncomingRoutes = new TreeMap<>();
+    _prefixTracer = new PrefixTracer();
+  }
+
+  /**
+   * Decides whether the current OSPF summary route metric needs to be changed based on the given
+   * route's metric.
+   *
+   * <p>Routes from the same area or outside of areaPrefix have no effect on the summary metric.
+   *
+   * @param route The route in question, whose metric is considered
+   * @param areaPrefix The Ip prefix of the OSPF area
+   * @param currentMetric The current summary metric for the area
+   * @param areaNum Area number.
+   * @param useMin Whether to use the older RFC 1583 computation, which takes the minimum of metrics
+   *     as opposed to the newer RFC 2328, which uses the maximum
+   * @return the newly computed summary metric.
+   */
+  @Nullable
+  static Long computeUpdatedOspfSummaryMetric(
+      OspfInternalRoute route,
+      Prefix areaPrefix,
+      @Nullable Long currentMetric,
+      long areaNum,
+      boolean useMin) {
+    Prefix contributingRoutePrefix = route.getNetwork();
+    // Only update metric for different areas and if the area prefix contains the route prefix
+    if (areaNum == route.getArea() || !areaPrefix.containsPrefix(contributingRoutePrefix)) {
+      return currentMetric;
+    }
+    long contributingRouteMetric = route.getMetric();
+    // Definitely update if we have no previous metric
+    if (currentMetric == null) {
+      return contributingRouteMetric;
+    }
+    // Take the best metric between the route's and current available.
+    // Routers (at least Cisco and Juniper) default to min metric unless using RFC2328 with
+    // RFC1583 compatibility explicitly disabled, in which case they default to max.
+    if (useMin) {
+      return Math.min(currentMetric, contributingRouteMetric);
+    }
+    return Math.max(currentMetric, contributingRouteMetric);
+  }
+
+  private static boolean isOspfInterAreaFromInterAreaPropagationAllowed(
+      long areaNum, Node neighbor, OspfInternalRoute neighborRoute, OspfArea neighborArea) {
+    long neighborRouteAreaNum = neighborRoute.getArea();
+    // May only propagate to or from area 0
+    if (areaNum != neighborRouteAreaNum && areaNum != 0L && neighborRouteAreaNum != 0L) {
+      return false;
+    }
+    Prefix neighborRouteNetwork = neighborRoute.getNetwork();
+    String neighborSummaryFilterName = neighborArea.getSummaryFilter();
+    boolean hasSummaryFilter = neighborSummaryFilterName != null;
+    boolean allowed = !hasSummaryFilter;
+
+    // If there is a summary filter, run the route through it
+    if (hasSummaryFilter) {
+      RouteFilterList neighborSummaryFilter =
+          neighbor.getConfiguration().getRouteFilterLists().get(neighborSummaryFilterName);
+      allowed = neighborSummaryFilter.permits(neighborRouteNetwork);
+    }
+    return allowed;
+  }
+
+  private static boolean isOspfInterAreaFromIntraAreaPropagationAllowed(
+      long areaNum, Node neighbor, OspfInternalRoute neighborRoute, OspfArea neighborArea) {
+    long neighborRouteAreaNum = neighborRoute.getArea();
+    // May only propagate to or from area 0
+    if (areaNum == neighborRouteAreaNum || (areaNum != 0L && neighborRouteAreaNum != 0L)) {
+      return false;
+    }
+    Prefix neighborRouteNetwork = neighborRoute.getNetwork();
+    String neighborSummaryFilterName = neighborArea.getSummaryFilter();
+    boolean hasSummaryFilter = neighborSummaryFilterName != null;
+    boolean allowed = !hasSummaryFilter;
+
+    // If there is a summary filter, run the route through it
+    if (hasSummaryFilter) {
+      RouteFilterList neighborSummaryFilter =
+          neighbor.getConfiguration().getRouteFilterLists().get(neighborSummaryFilterName);
+      allowed = neighborSummaryFilter.permits(neighborRouteNetwork);
+    }
+    return allowed;
+  }
+
+  /**
+   * Convert a given RibDelta into {@link RouteAdvertisement} objects and enqueue them onto a given
+   * queue.
+   *
+   * @param queue the message queue
+   * @param delta {@link RibDelta} representing changes.
+   */
+  @VisibleForTesting
+  static <R extends AbstractRoute, D extends R> void queueDelta(
+      Queue<RouteAdvertisement<R>> queue, @Nullable RibDelta<D> delta) {
+    if (delta == null) {
+      // Nothing to do
+      return;
+    }
+    for (RouteAdvertisement<D> r : delta.getActions()) {
+      // REPLACE does not make sense across routers, update with WITHDRAW
+      Reason reason = r.getReason() == Reason.REPLACE ? Reason.WITHDRAW : r.getReason();
+      queue.add(new RouteAdvertisement<>(r.getRoute(), r.isWithdrawn(), reason));
+    }
+  }
+
+  static Entry<RibDelta<BgpRoute>, RibDelta<BgpRoute>> syncBgpDeltaPropagation(
+      BgpBestPathRib bestPathRib, BgpMultipathRib multiPathRib, RibDelta<BgpRoute> delta) {
+
+    // Build our fist attempt at best path delta
+    Builder<BgpRoute> bestDeltaBuldiler = new Builder<>(bestPathRib);
+    bestDeltaBuldiler.from(importRibDelta(bestPathRib, delta));
+    RibDelta<BgpRoute> bestDelta = bestDeltaBuldiler.build();
+
+    Builder<BgpRoute> mpBuilder = new Builder<>(multiPathRib);
+
+    mpBuilder.from(importRibDelta(multiPathRib, bestDelta));
+    if (bestDelta != null) {
+      /*
+       * Handle mods to the best path RIB
+       */
+      for (Prefix p : bestDelta.getPrefixes()) {
+        List<RouteAdvertisement<BgpRoute>> actions = bestDelta.getActions(p);
+        if (actions != null) {
+          if (actions
+              .stream()
+              .map(RouteAdvertisement::getReason)
+              .anyMatch(Predicate.isEqual(Reason.REPLACE))) {
+            /*
+             * Clear routes for prefixes where best path RIB was modified, because
+             * a better route was chosen, and whatever we had in multipathRib is now invalid
+             */
+            mpBuilder.from(multiPathRib.clearRoutes(p));
+          } else if (actions
+              .stream()
+              .map(RouteAdvertisement::getReason)
+              .anyMatch(Predicate.isEqual(Reason.WITHDRAW))) {
+            /*
+             * Routes for that prefix were withdrawn. See if we have anything in the multipath RIB
+             * to fix it.
+             * Create a fake delta, let the routes fight it out for best path in the merge process
+             */
+            RibDelta<BgpRoute> fakeDelta =
+                new Builder<BgpRoute>(null).add(multiPathRib.getRoutes(p)).build();
+            bestDeltaBuldiler.from(importRibDelta(bestPathRib, fakeDelta));
+          }
+        }
+      }
+    }
+    // Set the (possibly updated) best path delta
+    bestDelta = bestDeltaBuldiler.build();
+    // Update best paths
+    multiPathRib.setBestAsPaths(bestPathRib.getBestAsPaths());
+    // Only iterate over valid prefixes (ones in best-path RIB) and see if anything should go into
+    // multi-path RIB
+    for (Prefix p : bestPathRib.getPrefixes()) {
+      mpBuilder.from(importRibDelta(multiPathRib, delta, p));
+    }
+    return new SimpleImmutableEntry<>(bestDelta, mpBuilder.build());
+  }
+
+  /**
+   * Lookup the VirtualRouter owner of a remote BGP neighbor.
+   *
+   * @param remoteBgpNeighbor the {@link BgpNeighbor} that belongs to a different {@link
+   *     VirtualRouter}
+   * @param allNodes map containing all network nodes
+   * @return a {@link VirtualRouter} that owns the {@code neighbor.getRemoteBgpNeighbor()}
+   */
+  @Nullable
+  @VisibleForTesting
+  static VirtualRouter getRemoteBgpNeighborVR(
+      @Nonnull BgpNeighbor remoteBgpNeighbor, final Map<String, Node> allNodes) {
+    String remoteHostname = remoteBgpNeighbor.getOwner().getHostname();
+    String remoteVrfName = remoteBgpNeighbor.getVrf();
+    return allNodes.get(remoteHostname).getVirtualRouters().get(remoteVrfName);
   }
 
   /**
@@ -430,46 +609,6 @@ public class VirtualRouter extends ComparableStructure<String> {
   /** Compute the FIB from the main RIB */
   public void computeFib() {
     _fib = new FibImpl(_mainRib);
-  }
-
-  /**
-   * Decides whether the current OSPF summary route metric needs to be changed based on the given
-   * route's metric.
-   *
-   * <p>Routes from the same area or outside of areaPrefix have no effect on the summary metric.
-   *
-   * @param route The route in question, whose metric is considered
-   * @param areaPrefix The Ip prefix of the OSPF area
-   * @param currentMetric The current summary metric for the area
-   * @param areaNum Area number.
-   * @param useMin Whether to use the older RFC 1583 computation, which takes the minimum of metrics
-   *     as opposed to the newer RFC 2328, which uses the maximum
-   * @return the newly computed summary metric.
-   */
-  @Nullable
-  static Long computeUpdatedOspfSummaryMetric(
-      OspfInternalRoute route,
-      Prefix areaPrefix,
-      @Nullable Long currentMetric,
-      long areaNum,
-      boolean useMin) {
-    Prefix contributingRoutePrefix = route.getNetwork();
-    // Only update metric for different areas and if the area prefix contains the route prefix
-    if (areaNum == route.getArea() || !areaPrefix.containsPrefix(contributingRoutePrefix)) {
-      return currentMetric;
-    }
-    long contributingRouteMetric = route.getMetric();
-    // Definitely update if we have no previous metric
-    if (currentMetric == null) {
-      return contributingRouteMetric;
-    }
-    // Take the best metric between the route's and current available.
-    // Routers (at least Cisco and Juniper) default to min metric unless using RFC2328 with
-    // RFC1583 compatibility explicitly disabled, in which case they default to max.
-    if (useMin) {
-      return Math.min(currentMetric, contributingRouteMetric);
-    }
-    return Math.max(currentMetric, contributingRouteMetric);
   }
 
   boolean computeInterAreaSummaries() {
@@ -1134,6 +1273,7 @@ public class VirtualRouter extends ComparableStructure<String> {
         candidateRoutes.addAll(_bgpMultipathRib.getRoutes());
       }
       for (AbstractRoute route : candidateRoutes) {
+        // TODO: update this using BgpProtocolHelper
         BgpRoute.Builder transformedOutgoingRouteBuilder = new BgpRoute.Builder();
         RoutingProtocol routeProtocol = route.getProtocol();
         boolean routeIsBgp =
@@ -1256,58 +1396,72 @@ public class VirtualRouter extends ComparableStructure<String> {
                 neighbor.getPrefix(),
                 remoteVrfName,
                 Direction.OUT);
-        if (acceptOutgoing) {
-          BgpRoute transformedOutgoingRoute = transformedOutgoingRouteBuilder.build();
-          // Record sent advertisement
-          BgpAdvertisementType sentType =
-              ebgpSession ? BgpAdvertisementType.EBGP_SENT : BgpAdvertisementType.IBGP_SENT;
-          Ip sentOriginatorIp = transformedOutgoingRoute.getOriginatorIp();
-          SortedSet<Long> sentClusterList =
-              ImmutableSortedSet.copyOf(transformedOutgoingRoute.getClusterList());
-          AsPath sentAsPath = transformedOutgoingRoute.getAsPath();
-          SortedSet<Long> sentCommunities =
-              ImmutableSortedSet.copyOf(transformedOutgoingRoute.getCommunities());
-          Prefix sentNetwork = route.getNetwork();
-          Ip sentNextHopIp;
-          String sentSrcNode = hostname;
-          String sentSrcVrf = _vrf.getName();
-          Ip sentSrcIp = neighbor.getLocalIp();
-          String sentDstNode = remoteHostname;
-          String sentDstVrf = remoteVrfName;
-          Ip sentDstIp = remoteIp;
-          int sentWeight = -1;
-          if (ebgpSession) {
-            sentNextHopIp = nextHopIp;
-          } else {
-            sentNextHopIp = transformedOutgoingRoute.getNextHopIp();
-          }
-          int sentLocalPreference = transformedOutgoingRoute.getLocalPreference();
-          long sentMed = transformedOutgoingRoute.getMetric();
-          OriginType sentOriginType = transformedOutgoingRoute.getOriginType();
-          RoutingProtocol sentSrcProtocol = targetProtocol;
-          BgpAdvertisement sentAdvert =
-              new BgpAdvertisement(
-                  sentType,
-                  sentNetwork,
-                  sentNextHopIp,
-                  sentSrcNode,
-                  sentSrcVrf,
-                  sentSrcIp,
-                  sentDstNode,
-                  sentDstVrf,
-                  sentDstIp,
-                  sentSrcProtocol,
-                  sentOriginType,
-                  sentLocalPreference,
-                  sentMed,
-                  sentOriginatorIp,
-                  sentAsPath,
-                  ImmutableSortedSet.copyOf(sentCommunities),
-                  ImmutableSortedSet.copyOf(sentClusterList),
-                  sentWeight);
-          _sentBgpAdvertisements.add(sentAdvert);
-          numAdvertisements++;
+        if (!acceptOutgoing) {
+          _prefixTracer.filtered(
+              route.getNetwork(),
+              remoteHostname,
+              remoteIp,
+              remoteVrfName,
+              neighbor.getExportPolicy(),
+              Direction.OUT);
+          continue;
         }
+        _prefixTracer.sentTo(
+            route.getNetwork(),
+            remoteHostname,
+            remoteIp,
+            remoteVrfName,
+            neighbor.getExportPolicy());
+        BgpRoute transformedOutgoingRoute = transformedOutgoingRouteBuilder.build();
+        // Record sent advertisement
+        BgpAdvertisementType sentType =
+            ebgpSession ? BgpAdvertisementType.EBGP_SENT : BgpAdvertisementType.IBGP_SENT;
+        Ip sentOriginatorIp = transformedOutgoingRoute.getOriginatorIp();
+        SortedSet<Long> sentClusterList =
+            ImmutableSortedSet.copyOf(transformedOutgoingRoute.getClusterList());
+        AsPath sentAsPath = transformedOutgoingRoute.getAsPath();
+        SortedSet<Long> sentCommunities =
+            ImmutableSortedSet.copyOf(transformedOutgoingRoute.getCommunities());
+        Prefix sentNetwork = route.getNetwork();
+        Ip sentNextHopIp;
+        String sentSrcNode = hostname;
+        String sentSrcVrf = _vrf.getName();
+        Ip sentSrcIp = neighbor.getLocalIp();
+        String sentDstNode = remoteHostname;
+        String sentDstVrf = remoteVrfName;
+        Ip sentDstIp = remoteIp;
+        int sentWeight = -1;
+        if (ebgpSession) {
+          sentNextHopIp = nextHopIp;
+        } else {
+          sentNextHopIp = transformedOutgoingRoute.getNextHopIp();
+        }
+        int sentLocalPreference = transformedOutgoingRoute.getLocalPreference();
+        long sentMed = transformedOutgoingRoute.getMetric();
+        OriginType sentOriginType = transformedOutgoingRoute.getOriginType();
+        RoutingProtocol sentSrcProtocol = targetProtocol;
+        BgpAdvertisement sentAdvert =
+            new BgpAdvertisement(
+                sentType,
+                sentNetwork,
+                sentNextHopIp,
+                sentSrcNode,
+                sentSrcVrf,
+                sentSrcIp,
+                sentDstNode,
+                sentDstVrf,
+                sentDstIp,
+                sentSrcProtocol,
+                sentOriginType,
+                sentLocalPreference,
+                sentMed,
+                sentOriginatorIp,
+                sentAsPath,
+                ImmutableSortedSet.copyOf(sentCommunities),
+                ImmutableSortedSet.copyOf(sentClusterList),
+                sentWeight);
+        _sentBgpAdvertisements.add(sentAdvert);
+        numAdvertisements++;
       }
     }
     return numAdvertisements;
@@ -1316,12 +1470,12 @@ public class VirtualRouter extends ComparableStructure<String> {
   /**
    * Process BGP messages from neighbors, return a list of delta changes to the RIBs
    *
-   * @param ipOwners Mapping of IPs to a set of node names that own that IP
    * @param bgpTopology the bgp peering relationships
+   * @param allNodes all nodes in the network, keyed by hostname
    * @return List of {@link RibDelta objects}
    */
   Map<BgpMultipathRib, RibDelta<BgpRoute>> processBgpMessages(
-      Map<Ip, Set<String>> ipOwners, Network<BgpNeighbor, BgpSession> bgpTopology) {
+      Network<BgpNeighbor, BgpSession> bgpTopology, final Map<String, Node> allNodes) {
 
     // If we have no BGP process, nothing to do
     if (_vrf.getBgpProcess() == null) {
@@ -1333,14 +1487,7 @@ public class VirtualRouter extends ComparableStructure<String> {
     ribDeltas.put(_ebgpStagingRib, new Builder<>(_ebgpStagingRib));
     ribDeltas.put(_ibgpStagingRib, new Builder<>(_ibgpStagingRib));
 
-    // Init default admin costs
-    int ebgpAdminCost =
-        RoutingProtocol.BGP.getDefaultAdministrativeCost(_c.getConfigurationFormat());
-    int ibgpAdminCost =
-        RoutingProtocol.IBGP.getDefaultAdministrativeCost(_c.getConfigurationFormat());
-
     // Process updates from each neighbor
-
     for (BgpNeighbor neighbor : _vrf.getBgpProcess().getNeighbors().values()) {
       if (!bgpTopology.nodes().contains(neighbor)) {
         continue;
@@ -1359,8 +1506,7 @@ public class VirtualRouter extends ComparableStructure<String> {
         Vrf remoteVrf = remoteConfig.getVrfs().get(remoteVrfName);
         RoutingPolicy remoteExportPolicy =
             remoteConfig.getRoutingPolicies().get(remoteBgpNeighbor.getExportPolicy());
-        int remoteAs = neighbor.getRemoteAs();
-        boolean ebgpSession = !neighbor.getLocalAs().equals(neighbor.getRemoteAs());
+        boolean ebgpSession = !Objects.equals(neighbor.getLocalAs(), neighbor.getRemoteAs());
         BgpMultipathRib targetRib = ebgpSession ? _ebgpStagingRib : _ibgpStagingRib;
         RoutingProtocol targetProtocol = ebgpSession ? RoutingProtocol.BGP : RoutingProtocol.IBGP;
 
@@ -1368,159 +1514,25 @@ public class VirtualRouter extends ComparableStructure<String> {
         while (queue.peek() != null) {
           RouteAdvertisement<AbstractRoute> remoteRouteAdvert = queue.remove();
           AbstractRoute remoteRoute = remoteRouteAdvert.getRoute();
-          BgpRoute.Builder transformedOutgoingRouteBuilder = new BgpRoute.Builder();
-          RoutingProtocol remoteRouteProtocol = remoteRoute.getProtocol();
-          boolean remoteRouteIsBgp =
-              remoteRouteProtocol == RoutingProtocol.IBGP
-                  || remoteRouteProtocol == RoutingProtocol.BGP;
-
-          // originatorIP
-          Ip originatorIp;
-          if (!ebgpSession && remoteRouteProtocol == RoutingProtocol.IBGP) {
-            BgpRoute bgpRemoteRoute = (BgpRoute) remoteRoute;
-            originatorIp = bgpRemoteRoute.getOriginatorIp();
-          } else {
-            originatorIp = remoteVrf.getBgpProcess().getRouterId();
-          }
-          transformedOutgoingRouteBuilder.setOriginatorIp(originatorIp);
-          transformedOutgoingRouteBuilder.setReceivedFromIp(remoteBgpNeighbor.getLocalIp());
-          // note whether new route is received from route reflector client
-          transformedOutgoingRouteBuilder.setReceivedFromRouteReflectorClient(
-              !ebgpSession && neighbor.getRouteReflectorClient());
-
+          BgpRoute.Builder transformedOutgoingRouteBuilder;
           /*
-           * clusterList, receivedFromRouteReflectorClient, (originType
-           * for bgp remote route)
+           * TODO: move this transformation & export policy check before we queue routes onto
+           * _bgpIncomingRoutes
            */
-          if (remoteRouteIsBgp) {
-            BgpRoute bgpRemoteRoute = (BgpRoute) remoteRoute;
-            transformedOutgoingRouteBuilder.setOriginType(bgpRemoteRoute.getOriginType());
-            if (ebgpSession
-                && bgpRemoteRoute.getAsPath().containsAs(remoteBgpNeighbor.getRemoteAs())
-                && !remoteBgpNeighbor.getAllowRemoteAsOut()) {
-              // skip routes containing peer's AS unless
-              // disable-peer-as-check (getAllowRemoteAsOut) is set
-              continue;
-            }
-            /*
-             * route reflection: reflect everything received from
-             * clients to clients and non-clients. reflect everything
-             * received from non-clients to clients. Do not reflect to
-             * originator
-             */
-
-            Ip remoteOriginatorIp = bgpRemoteRoute.getOriginatorIp();
-
-            /*
-             *  iBGP speaker should not send out routes to iBGP neighbor whose router-id is
-             *  same as originator id of advertisement
-             */
-            if (!ebgpSession
-                && remoteOriginatorIp != null
-                && _vrf.getBgpProcess().getRouterId().equals(remoteOriginatorIp)) {
-              continue;
-            }
-            if (remoteRouteProtocol == RoutingProtocol.IBGP && !ebgpSession) {
-              /*
-               *  The remote route is iBGP. The session is iBGP. We consider whether to reflect, and
-               *  modify the outgoing route as appropriate.
-               */
-              boolean remoteRouteReceivedFromRouteReflectorClient =
-                  bgpRemoteRoute.getReceivedFromRouteReflectorClient();
-              boolean sendingToRouteReflectorClient = remoteBgpNeighbor.getRouteReflectorClient();
-
-              Ip remoteReceivedFromIp = bgpRemoteRoute.getReceivedFromIp();
-              boolean remoteRouteOriginatedByRemoteNeighbor = remoteReceivedFromIp.equals(Ip.ZERO);
-              if (!remoteRouteReceivedFromRouteReflectorClient
-                  && !sendingToRouteReflectorClient
-                  && !remoteRouteOriginatedByRemoteNeighbor) {
-                /*
-                 * Neither reflecting nor originating this iBGP route, so don't send
-                 */
-                continue;
-              }
-              transformedOutgoingRouteBuilder
-                  .getClusterList()
-                  .addAll(bgpRemoteRoute.getClusterList());
-              if (!remoteRouteOriginatedByRemoteNeighbor) {
-                // we are reflecting, so we need to get the clusterid associated with the
-                // remoteRoute
-                BgpNeighbor remoteReceivedFromSession =
-                    remoteVrf
-                        .getBgpProcess()
-                        .getNeighbors()
-                        .get(new Prefix(remoteReceivedFromIp, Prefix.MAX_PREFIX_LENGTH));
-                long newClusterId = remoteReceivedFromSession.getClusterId();
-                transformedOutgoingRouteBuilder.getClusterList().add(newClusterId);
-              }
-              Set<Long> localClusterIds = _vrf.getBgpProcess().getClusterIds();
-              Set<Long> outgoingClusterList = transformedOutgoingRouteBuilder.getClusterList();
-              if (localClusterIds.stream().anyMatch(outgoingClusterList::contains)) {
-                /*
-                 *  receiver will reject new route if it contains any of its local cluster ids
-                 */
-                continue;
-              }
-            }
+          try {
+            transformedOutgoingRouteBuilder =
+                BgpProtocolHelper.transformBgpRouteOnExport(
+                    remoteBgpNeighbor, neighbor, remoteVrf, _vrf, remoteRoute);
+          } catch (BgpRoutePropagationException e) {
+            // TODO: Log a warning
+            continue;
+          }
+          if (transformedOutgoingRouteBuilder == null) {
+            // This route could not be exported for core bgp protocol reasons
+            continue;
           }
 
-          // Outgoing asPath
-          // Outgoing communities
-          if (remoteRouteIsBgp) {
-            BgpRoute bgpRemoteRoute = (BgpRoute) remoteRoute;
-            transformedOutgoingRouteBuilder.setAsPath(bgpRemoteRoute.getAsPath().getAsSets());
-            if (remoteBgpNeighbor.getSendCommunity()) {
-              transformedOutgoingRouteBuilder
-                  .getCommunities()
-                  .addAll(bgpRemoteRoute.getCommunities());
-            }
-          }
-          if (ebgpSession) {
-            SortedSet<Integer> newAsPathElement = new TreeSet<>();
-            newAsPathElement.add(remoteAs);
-            transformedOutgoingRouteBuilder.getAsPath().add(0, newAsPathElement);
-          }
-
-          // Outgoing protocol
-          transformedOutgoingRouteBuilder.setProtocol(targetProtocol);
-          transformedOutgoingRouteBuilder.setNetwork(remoteRoute.getNetwork());
-
-          // Outgoing metric
-          if (remoteRouteIsBgp) {
-            transformedOutgoingRouteBuilder.setMetric(remoteRoute.getMetric());
-          }
-
-          // Outgoing nextHopIp
-          // Outgoing localPreference
-          Ip nextHopIp;
-          int localPreference;
-          if (ebgpSession || !remoteRouteIsBgp) {
-            nextHopIp = remoteBgpNeighbor.getLocalIp();
-            localPreference = BgpRoute.DEFAULT_LOCAL_PREFERENCE;
-          } else {
-            nextHopIp = remoteRoute.getNextHopIp();
-            BgpRoute remoteIbgpRoute = (BgpRoute) remoteRoute;
-            localPreference = remoteIbgpRoute.getLocalPreference();
-          }
-          if (nextHopIp.equals(Route.UNSET_ROUTE_NEXT_HOP_IP)) {
-            // should only happen for ibgp
-            String nextHopInterface = remoteRoute.getNextHopInterface();
-            InterfaceAddress nextHopAddress =
-                remoteVrf.getInterfaces().get(nextHopInterface).getAddress();
-            if (nextHopAddress == null) {
-              throw new BatfishException("remote route's nextHopInterface has no address");
-            }
-            nextHopIp = nextHopAddress.getIp();
-          }
-          transformedOutgoingRouteBuilder.setNextHopIp(nextHopIp);
-          transformedOutgoingRouteBuilder.setLocalPreference(localPreference);
-
-          // Outgoing srcProtocol
-          transformedOutgoingRouteBuilder.setSrcProtocol(remoteRoute.getProtocol());
-
-          /*
-           * CREATE OUTGOING ROUTE
-           */
+          // Process transformed outgoing route by the export policy
           boolean acceptOutgoing =
               remoteExportPolicy.process(
                   remoteRoute,
@@ -1529,200 +1541,142 @@ public class VirtualRouter extends ComparableStructure<String> {
                   remoteBgpNeighbor.getPrefix(),
                   remoteVrfName,
                   Direction.OUT);
-          if (acceptOutgoing) {
-            BgpRoute transformedOutgoingRoute = transformedOutgoingRouteBuilder.build();
-            // Record sent advertisement
-            BgpAdvertisementType sentType =
-                ebgpSession ? BgpAdvertisementType.EBGP_SENT : BgpAdvertisementType.IBGP_SENT;
-            Ip sentReceivedFromIp = transformedOutgoingRoute.getReceivedFromIp();
-            Ip sentOriginatorIp = transformedOutgoingRoute.getOriginatorIp();
-            SortedSet<Long> sentClusterList =
-                ImmutableSortedSet.copyOf(transformedOutgoingRoute.getClusterList());
-            boolean sentReceivedFromRouteReflectorClient =
-                transformedOutgoingRoute.getReceivedFromRouteReflectorClient();
-            AsPath sentAsPath = transformedOutgoingRoute.getAsPath();
-            SortedSet<Long> sentCommunities =
-                ImmutableSortedSet.copyOf(transformedOutgoingRoute.getCommunities());
-            Prefix sentNetwork = remoteRoute.getNetwork();
-            Ip sentNextHopIp;
-            String sentSrcNode = remoteHostname;
-            String sentSrcVrf = remoteVrfName;
-            Ip sentSrcIp = remoteBgpNeighbor.getLocalIp();
-            String sentDstNode = hostname;
-            String sentDstVrf = _vrf.getName();
-            Ip sentDstIp = neighbor.getLocalIp();
-            int sentWeight = -1;
-            if (ebgpSession) {
-              sentNextHopIp = nextHopIp;
-            } else {
-              sentNextHopIp = transformedOutgoingRoute.getNextHopIp();
-            }
-            int sentLocalPreference = transformedOutgoingRoute.getLocalPreference();
-            long sentMed = transformedOutgoingRoute.getMetric();
-            OriginType sentOriginType = transformedOutgoingRoute.getOriginType();
-            RoutingProtocol sentSrcProtocol = targetProtocol;
-            BgpRoute.Builder transformedIncomingRouteBuilder = new BgpRoute.Builder();
 
-            // Incoming originatorIp
-            transformedIncomingRouteBuilder.setOriginatorIp(sentOriginatorIp);
+          VirtualRouter remoteVr = getRemoteBgpNeighborVR(remoteBgpNeighbor, allNodes);
+          if (!acceptOutgoing) {
+            // This route could not be exported due to export policy
 
-            // Incoming receivedFromIp
-            transformedIncomingRouteBuilder.setReceivedFromIp(sentReceivedFromIp);
+            // This is "backwards" because we do export policy computation on the receiving end.
+            // See todo above for more info
+            Objects.requireNonNull(remoteVr)
+                ._prefixTracer
+                .filtered(
+                    remoteRoute.getNetwork(),
+                    getHostname(),
+                    neighbor.getLocalIp(),
+                    neighbor.getVrf(),
+                    remoteBgpNeighbor.getExportPolicy(),
+                    Direction.OUT);
+            continue;
+          }
+          BgpRoute transformedOutgoingRoute = transformedOutgoingRouteBuilder.build();
+          // This is "backwards" because we do export policy computation on the receiving end.
+          // See todo above for more info
+          Objects.requireNonNull(remoteVr)
+              ._prefixTracer
+              .sentTo(
+                  transformedOutgoingRoute.getNetwork(),
+                  getHostname(),
+                  neighbor.getLocalIp(),
+                  neighbor.getVrf(),
+                  remoteBgpNeighbor.getExportPolicy());
 
-            // Incoming clusterList
-            transformedIncomingRouteBuilder.getClusterList().addAll(sentClusterList);
-
-            // Incoming receivedFromRouteReflectorClient
-            transformedIncomingRouteBuilder.setReceivedFromRouteReflectorClient(
-                sentReceivedFromRouteReflectorClient);
-
-            // Incoming asPath
-            transformedIncomingRouteBuilder.setAsPath(sentAsPath.getAsSets());
-
-            // Incoming communities
-            transformedIncomingRouteBuilder.getCommunities().addAll(sentCommunities);
-
-            // Incoming protocol
-            transformedIncomingRouteBuilder.setProtocol(targetProtocol);
-
-            // Incoming network
-            transformedIncomingRouteBuilder.setNetwork(sentNetwork);
-
-            // Incoming nextHopIp
-            transformedIncomingRouteBuilder.setNextHopIp(sentNextHopIp);
-
-            // Incoming localPreference
-            transformedIncomingRouteBuilder.setLocalPreference(sentLocalPreference);
-
-            // Incoming admin
-            int admin = ebgpSession ? ebgpAdminCost : ibgpAdminCost;
-            transformedIncomingRouteBuilder.setAdmin(admin);
-
-            // Incoming metric
-            transformedIncomingRouteBuilder.setMetric(sentMed);
-
-            // Incoming originType
-            transformedIncomingRouteBuilder.setOriginType(sentOriginType);
-
-            // Incoming srcProtocol
-            transformedIncomingRouteBuilder.setSrcProtocol(sentSrcProtocol);
-            String importPolicyName = neighbor.getImportPolicy();
-            // TODO: ensure there is always an import policy
-
-            if (transformedOutgoingRoute.getAsPath().containsAs(neighbor.getLocalAs())
-                && !neighbor.getAllowLocalAsIn()) {
-              // skip routes containing peer's AS unless
-              // disable-peer-as-check (getAllowRemoteAsOut) is set
-              continue;
-            }
-
+          if (!remoteRouteAdvert.isWithdrawn()) {
+            // Record advert sent by the remote node
+            // TODO: make this a builder for readability
             BgpAdvertisement sentAdvert =
                 new BgpAdvertisement(
-                    sentType,
-                    sentNetwork,
-                    sentNextHopIp,
-                    sentSrcNode,
-                    sentSrcVrf,
-                    sentSrcIp,
-                    sentDstNode,
-                    sentDstVrf,
-                    sentDstIp,
-                    sentSrcProtocol,
-                    sentOriginType,
-                    sentLocalPreference,
-                    sentMed,
-                    sentOriginatorIp,
-                    sentAsPath,
-                    ImmutableSortedSet.copyOf(sentCommunities),
-                    ImmutableSortedSet.copyOf(sentClusterList),
-                    sentWeight);
+                    ebgpSession ? BgpAdvertisementType.EBGP_SENT : BgpAdvertisementType.IBGP_SENT,
+                    remoteRoute.getNetwork(),
+                    transformedOutgoingRoute.getNextHopIp(),
+                    remoteHostname,
+                    remoteVrfName,
+                    remoteBgpNeighbor.getLocalIp(),
+                    hostname,
+                    _vrf.getName(),
+                    neighbor.getLocalIp(),
+                    targetProtocol,
+                    transformedOutgoingRoute.getOriginType(),
+                    transformedOutgoingRoute.getLocalPreference(),
+                    transformedOutgoingRoute.getMetric(),
+                    transformedOutgoingRoute.getOriginatorIp(),
+                    transformedOutgoingRoute.getAsPath(),
+                    transformedOutgoingRoute.getCommunities(),
+                    transformedOutgoingRoute.getClusterList(),
+                    -1);
+            _sentBgpAdvertisements.add(sentAdvert);
+          }
 
+          BgpRoute.Builder transformedIncomingRouteBuilder =
+              BgpProtocolHelper.transformBgpRouteOnImport(
+                  remoteBgpNeighbor, neighbor, transformedOutgoingRoute);
+          if (transformedIncomingRouteBuilder == null) {
+            // Route could not be imported for core protocol reasons
+            continue;
+          }
+          // CREATE INCOMING ROUTE
+          String importPolicyName = neighbor.getImportPolicy();
+          boolean acceptIncoming = true;
+          // TODO: ensure there is always an import policy
+          if (importPolicyName != null) {
+            RoutingPolicy importPolicy = _c.getRoutingPolicies().get(importPolicyName);
+            if (importPolicy != null) {
+              acceptIncoming =
+                  importPolicy.process(
+                      transformedOutgoingRoute,
+                      transformedIncomingRouteBuilder,
+                      remoteBgpNeighbor.getLocalIp(),
+                      remoteBgpNeighbor.getPrefix(),
+                      _key,
+                      Direction.IN);
+            }
+          }
+          if (!acceptIncoming) {
+            // Route could not be imported due to routing policy
+            _prefixTracer.filtered(
+                transformedOutgoingRoute.getNetwork(),
+                remoteVr.getHostname(),
+                remoteBgpNeighbor.getLocalIp(),
+                remoteVrfName,
+                importPolicyName,
+                Direction.IN);
+            continue;
+          }
+          BgpRoute transformedIncomingRoute = transformedIncomingRouteBuilder.build();
+
+          if (remoteRouteAdvert.isWithdrawn()) {
+            // Note this route was removed
+            ribDeltas.get(targetRib).remove(transformedIncomingRoute, Reason.WITHDRAW);
+            SortedSet<BgpRoute> b = _receivedBgpRoutes.get(transformedIncomingRoute.getNetwork());
+            if (b != null) {
+              b.remove(transformedIncomingRoute);
+            }
+          } else {
+            // Merge into staging rib, note delta
+            ribDeltas.get(targetRib).from(targetRib.mergeRouteGetDelta(transformedIncomingRoute));
             if (!remoteRouteAdvert.isWithdrawn()) {
-              _sentBgpAdvertisements.add(sentAdvert);
-            }
-
-            /*
-             * CREATE INCOMING ROUTE
-             */
-            boolean acceptIncoming = true;
-            if (importPolicyName != null) {
-              RoutingPolicy importPolicy = _c.getRoutingPolicies().get(importPolicyName);
-              if (importPolicy != null) {
-                acceptIncoming =
-                    importPolicy.process(
-                        transformedOutgoingRoute,
-                        transformedIncomingRouteBuilder,
-                        remoteBgpNeighbor.getLocalIp(),
-                        remoteBgpNeighbor.getPrefix(),
-                        _key,
-                        Direction.IN);
-              }
-            }
-            if (acceptIncoming) {
-              BgpRoute transformedIncomingRoute = transformedIncomingRouteBuilder.build();
-              BgpAdvertisementType receivedType =
-                  ebgpSession
-                      ? BgpAdvertisementType.EBGP_RECEIVED
-                      : BgpAdvertisementType.IBGP_RECEIVED;
-              Prefix receivedNetwork = sentNetwork;
-              Ip receivedNextHopIp = sentNextHopIp;
-              String receivedSrcNode = sentSrcNode;
-              String receivedSrcVrf = sentSrcVrf;
-              Ip receivedSrcIp = sentSrcIp;
-              String receivedDstNode = sentDstNode;
-              String receivedDstVrf = sentDstVrf;
-              Ip receivedDstIp = sentDstIp;
-              RoutingProtocol receivedSrcProtocol = sentSrcProtocol;
-              OriginType receivedOriginType = transformedIncomingRoute.getOriginType();
-              int receivedLocalPreference = transformedIncomingRoute.getLocalPreference();
-              long receivedMed = transformedIncomingRoute.getMetric();
-              Ip receivedOriginatorIp = sentOriginatorIp;
-              AsPath receivedAsPath = transformedIncomingRoute.getAsPath();
-              SortedSet<Long> receivedCommunities =
-                  ImmutableSortedSet.copyOf(transformedIncomingRoute.getCommunities());
-              SortedSet<Long> receivedClusterList = ImmutableSortedSet.copyOf(sentClusterList);
-              int receivedWeight = transformedIncomingRoute.getWeight();
               BgpAdvertisement receivedAdvert =
                   new BgpAdvertisement(
-                      receivedType,
-                      receivedNetwork,
-                      receivedNextHopIp,
-                      receivedSrcNode,
-                      receivedSrcVrf,
-                      receivedSrcIp,
-                      receivedDstNode,
-                      receivedDstVrf,
-                      receivedDstIp,
-                      receivedSrcProtocol,
-                      receivedOriginType,
-                      receivedLocalPreference,
-                      receivedMed,
-                      receivedOriginatorIp,
-                      receivedAsPath,
-                      receivedCommunities,
-                      receivedClusterList,
-                      receivedWeight);
-
-              if (remoteRouteAdvert.isWithdrawn()) {
-                // Note this route was removed
-                ribDeltas.get(targetRib).remove(transformedIncomingRoute, Reason.WITHDRAW);
-                SortedSet<BgpRoute> b =
-                    _receivedBgpRoutes.get(transformedIncomingRoute.getNetwork());
-                if (b != null) {
-                  b.remove(transformedIncomingRoute);
-                }
-              } else {
-                // Merge into staging rib, note delta
-                ribDeltas
-                    .get(targetRib)
-                    .from(targetRib.mergeRouteGetDelta(transformedIncomingRoute));
-                if (!remoteRouteAdvert.isWithdrawn()) {
-                  _receivedBgpAdvertisements.add(receivedAdvert);
-                }
-                _receivedBgpRoutes
-                    .computeIfAbsent(transformedIncomingRoute.getNetwork(), k -> new TreeSet<>())
-                    .add(transformedIncomingRoute);
-              }
+                      ebgpSession
+                          ? BgpAdvertisementType.EBGP_RECEIVED
+                          : BgpAdvertisementType.IBGP_RECEIVED,
+                      transformedIncomingRoute.getNetwork(),
+                      transformedIncomingRoute.getNextHopIp(),
+                      remoteHostname,
+                      remoteBgpNeighbor.getVrf(),
+                      remoteBgpNeighbor.getLocalIp(),
+                      hostname,
+                      neighbor.getVrf(),
+                      neighbor.getLocalIp(),
+                      transformedIncomingRoute.getProtocol(),
+                      transformedIncomingRoute.getOriginType(),
+                      transformedIncomingRoute.getLocalPreference(),
+                      transformedIncomingRoute.getMetric(),
+                      transformedIncomingRoute.getOriginatorIp(),
+                      transformedIncomingRoute.getAsPath(),
+                      transformedIncomingRoute.getCommunities(),
+                      transformedIncomingRoute.getClusterList(),
+                      transformedIncomingRoute.getWeight());
+              _receivedBgpAdvertisements.add(receivedAdvert);
+              _receivedBgpRoutes
+                  .computeIfAbsent(transformedIncomingRoute.getNetwork(), k -> new TreeSet<>())
+                  .add(transformedIncomingRoute);
+              _prefixTracer.installed(
+                  transformedIncomingRoute.getNetwork(),
+                  remoteHostname,
+                  remoteBgpNeighbor.getLocalIp(),
+                  remoteBgpNeighbor.getVrf(),
+                  importPolicyName);
             }
           }
         }
@@ -1938,48 +1892,6 @@ public class VirtualRouter extends ComparableStructure<String> {
     OspfInterAreaRoute newRoute =
         new OspfInterAreaRoute(neighborRoute.getNetwork(), nextHopIp, adminCost, newCost, areaNum);
     return _ospfInterAreaStagingRib.mergeRoute(newRoute);
-  }
-
-  private static boolean isOspfInterAreaFromInterAreaPropagationAllowed(
-      long areaNum, Node neighbor, OspfInternalRoute neighborRoute, OspfArea neighborArea) {
-    long neighborRouteAreaNum = neighborRoute.getArea();
-    // May only propagate to or from area 0
-    if (areaNum != neighborRouteAreaNum && areaNum != 0L && neighborRouteAreaNum != 0L) {
-      return false;
-    }
-    Prefix neighborRouteNetwork = neighborRoute.getNetwork();
-    String neighborSummaryFilterName = neighborArea.getSummaryFilter();
-    boolean hasSummaryFilter = neighborSummaryFilterName != null;
-    boolean allowed = !hasSummaryFilter;
-
-    // If there is a summary filter, run the route through it
-    if (hasSummaryFilter) {
-      RouteFilterList neighborSummaryFilter =
-          neighbor.getConfiguration().getRouteFilterLists().get(neighborSummaryFilterName);
-      allowed = neighborSummaryFilter.permits(neighborRouteNetwork);
-    }
-    return allowed;
-  }
-
-  private static boolean isOspfInterAreaFromIntraAreaPropagationAllowed(
-      long areaNum, Node neighbor, OspfInternalRoute neighborRoute, OspfArea neighborArea) {
-    long neighborRouteAreaNum = neighborRoute.getArea();
-    // May only propagate to or from area 0
-    if (areaNum == neighborRouteAreaNum || (areaNum != 0L && neighborRouteAreaNum != 0L)) {
-      return false;
-    }
-    Prefix neighborRouteNetwork = neighborRoute.getNetwork();
-    String neighborSummaryFilterName = neighborArea.getSummaryFilter();
-    boolean hasSummaryFilter = neighborSummaryFilterName != null;
-    boolean allowed = !hasSummaryFilter;
-
-    // If there is a summary filter, run the route through it
-    if (hasSummaryFilter) {
-      RouteFilterList neighborSummaryFilter =
-          neighbor.getConfiguration().getRouteFilterLists().get(neighborSummaryFilterName);
-      allowed = neighborSummaryFilter.permits(neighborRouteNetwork);
-    }
-    return allowed;
   }
 
   boolean propagateOspfInterAreaRouteFromIntraAreaRoute(
@@ -2208,27 +2120,6 @@ public class VirtualRouter extends ComparableStructure<String> {
   }
 
   /**
-   * Convert a given RibDelta into {@link RouteAdvertisement} objects and enqueue them onto a given
-   * queue.
-   *
-   * @param queue the message queue
-   * @param delta {@link RibDelta} representing changes.
-   */
-  @VisibleForTesting
-  static <R extends AbstractRoute, D extends R> void queueDelta(
-      Queue<RouteAdvertisement<R>> queue, @Nullable RibDelta<D> delta) {
-    if (delta == null) {
-      // Nothing to do
-      return;
-    }
-    for (RouteAdvertisement<D> r : delta.getActions()) {
-      // REPLACE does not make sense across routers, update with WITHDRAW
-      Reason reason = r.getReason() == Reason.REPLACE ? Reason.WITHDRAW : r.getReason();
-      queue.add(new RouteAdvertisement<>(r.getRoute(), r.isWithdrawn(), reason));
-    }
-  }
-
-  /**
    * Queue advertised BGP routes to all BGP neighbors.
    *
    * @param bgpBestPathDelta a {@link RibDelta} indicating what changed in the {@link
@@ -2384,61 +2275,6 @@ public class VirtualRouter extends ComparableStructure<String> {
         _mainRibRouteDeltaBuiler.build(),
         allNodes,
         bgpTopology);
-  }
-
-  static Entry<RibDelta<BgpRoute>, RibDelta<BgpRoute>> syncBgpDeltaPropagation(
-      BgpBestPathRib bestPathRib, BgpMultipathRib multiPathRib, RibDelta<BgpRoute> delta) {
-
-    // Build our fist attempt at best path delta
-    Builder<BgpRoute> bestDeltaBuldiler = new Builder<>(bestPathRib);
-    bestDeltaBuldiler.from(importRibDelta(bestPathRib, delta));
-    RibDelta<BgpRoute> bestDelta = bestDeltaBuldiler.build();
-
-    Builder<BgpRoute> mpBuilder = new Builder<>(multiPathRib);
-
-    mpBuilder.from(importRibDelta(multiPathRib, bestDelta));
-    if (bestDelta != null) {
-      /*
-       * Handle mods to the best path RIB
-       */
-      for (Prefix p : bestDelta.getPrefixes()) {
-        List<RouteAdvertisement<BgpRoute>> actions = bestDelta.getActions(p);
-        if (actions != null) {
-          if (actions
-              .stream()
-              .map(RouteAdvertisement::getReason)
-              .anyMatch(Predicate.isEqual(Reason.REPLACE))) {
-            /*
-             * Clear routes for prefixes where best path RIB was modified, because
-             * a better route was chosen, and whatever we had in multipathRib is now invalid
-             */
-            mpBuilder.from(multiPathRib.clearRoutes(p));
-          } else if (actions
-              .stream()
-              .map(RouteAdvertisement::getReason)
-              .anyMatch(Predicate.isEqual(Reason.WITHDRAW))) {
-            /*
-             * Routes for that prefix were withdrawn. See if we have anything in the multipath RIB
-             * to fix it.
-             * Create a fake delta, let the routes fight it out for best path in the merge process
-             */
-            RibDelta<BgpRoute> fakeDelta =
-                new Builder<BgpRoute>(null).add(multiPathRib.getRoutes(p)).build();
-            bestDeltaBuldiler.from(importRibDelta(bestPathRib, fakeDelta));
-          }
-        }
-      }
-    }
-    // Set the (possibly updated) best path delta
-    bestDelta = bestDeltaBuldiler.build();
-    // Update best paths
-    multiPathRib.setBestAsPaths(bestPathRib.getBestAsPaths());
-    // Only iterate over valid prefixes (ones in best-path RIB) and see if anything should go into
-    // multi-path RIB
-    for (Prefix p : bestPathRib.getPrefixes()) {
-      mpBuilder.from(importRibDelta(multiPathRib, delta, p));
-    }
-    return new SimpleImmutableEntry<>(bestDelta, mpBuilder.build());
   }
 
   /**
@@ -2618,37 +2454,10 @@ public class VirtualRouter extends ComparableStructure<String> {
       return;
     }
 
+    // Note prefixes we tried to originate
+    _mainRib.getRoutes().forEach(r -> _prefixTracer.originated(r.getNetwork()));
     // Call this on the neighbor's VR!
     remoteVr.enqueBgpMessages(session, _mainRib.getRoutes());
-  }
-
-  /**
-   * Lookup the VirtualRouter owner of a remote BGP neighbor.
-   *
-   * @param remoteBgpNeighbor the {@link BgpNeighbor} that belongs to a different {@link
-   *     VirtualRouter}
-   * @param allNodes map containing all network nodes
-   * @return a {@link VirtualRouter} that owns the {@code neighbor.getRemoteBgpNeighbor()}
-   */
-  @Nullable
-  @VisibleForTesting
-  static VirtualRouter getRemoteBgpNeighborVR(
-      @Nonnull BgpNeighbor remoteBgpNeighbor, final Map<String, Node> allNodes) {
-    String remoteHostname = remoteBgpNeighbor.getOwner().getHostname();
-    String remoteVrfName = remoteBgpNeighbor.getVrf();
-    return allNodes.get(remoteHostname).getVirtualRouters().get(remoteVrfName);
-  }
-
-  /**
-   * This method aids in de-serialization of {@link VirtualRouter}
-   *
-   * @param in input stream to de-serialize from
-   * @throws IOException if processing the stream fails
-   * @throws ClassNotFoundException if deserialization cannot complete due to an unknown class
-   */
-  private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
-    in.defaultReadObject();
-    _bgpIncomingRoutes = ImmutableSortedMap.of();
   }
 
   /**
@@ -2714,7 +2523,7 @@ public class VirtualRouter extends ComparableStructure<String> {
     return _c;
   }
 
-  public ConnectedRib getConnectedRib() {
+  ConnectedRib getConnectedRib() {
     return _connectedRib;
   }
 
@@ -2722,11 +2531,11 @@ public class VirtualRouter extends ComparableStructure<String> {
     return _fib;
   }
 
-  public Rib getMainRib() {
+  Rib getMainRib() {
     return _mainRib;
   }
 
-  public BgpBestPathRib getBgpBestPathRib() {
+  BgpBestPathRib getBgpBestPathRib() {
     return _bgpBestPathRib;
   }
 
@@ -2763,5 +2572,9 @@ public class VirtualRouter extends ComparableStructure<String> {
             .flatMap(Queue::stream)
             .mapToInt(RouteAdvertisement::hashCode)
             .sum();
+  }
+
+  public PrefixTracer getPrefixTracer() {
+    return _prefixTracer;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
@@ -1,0 +1,175 @@
+package org.batfish.dataplane.protocols;
+
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import javax.annotation.Nullable;
+import org.batfish.datamodel.AbstractRoute;
+import org.batfish.datamodel.BgpNeighbor;
+import org.batfish.datamodel.BgpRoute;
+import org.batfish.datamodel.InterfaceAddress;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.Route;
+import org.batfish.datamodel.RoutingProtocol;
+import org.batfish.datamodel.Vrf;
+import org.batfish.dataplane.exceptions.BgpRoutePropagationException;
+
+public class BgpProtocolHelper {
+
+  /**
+   * Perform BGP export transformations on a given route when preparing to send an advertisement
+   * from {@code fromNeighbor} to {@code toNeighbor}
+   *
+   * @param fromNeighbor
+   * @param toNeighbor
+   * @return
+   */
+  @Nullable
+  public static BgpRoute.Builder exportBgpRoute(
+      BgpNeighbor fromNeighbor, BgpNeighbor toNeighbor, Vrf fromVrf, Vrf toVrf, AbstractRoute route)
+      throws BgpRoutePropagationException {
+
+    BgpRoute.Builder transformedOutgoingRouteBuilder = new BgpRoute.Builder();
+    transformedOutgoingRouteBuilder.setReceivedFromIp(fromNeighbor.getLocalIp());
+    RoutingProtocol remoteRouteProtocol = route.getProtocol();
+    boolean ebgpSession = !fromNeighbor.getLocalAs().equals(fromNeighbor.getRemoteAs());
+    boolean remoteRouteIsBgp =
+        remoteRouteProtocol == RoutingProtocol.IBGP || remoteRouteProtocol == RoutingProtocol.BGP;
+    RoutingProtocol targetProtocol = ebgpSession ? RoutingProtocol.BGP : RoutingProtocol.IBGP;
+
+    // Set originatorIP
+    Ip originatorIp;
+    if (!ebgpSession && remoteRouteProtocol.equals(RoutingProtocol.IBGP)) {
+      BgpRoute bgpRemoteRoute = (BgpRoute) route;
+      originatorIp = bgpRemoteRoute.getOriginatorIp();
+    } else {
+      originatorIp = fromVrf.getBgpProcess().getRouterId();
+    }
+    transformedOutgoingRouteBuilder.setOriginatorIp(originatorIp);
+
+    // note whether new route is received from route reflector client
+    transformedOutgoingRouteBuilder.setReceivedFromRouteReflectorClient(
+        !ebgpSession && toNeighbor.getRouteReflectorClient());
+
+    // clusterList, receivedFromRouteReflectorClient, (originType
+    // for bgp remote route)
+    if (remoteRouteIsBgp) {
+      BgpRoute bgpRemoteRoute = (BgpRoute) route;
+      transformedOutgoingRouteBuilder.setOriginType(bgpRemoteRoute.getOriginType());
+      if (ebgpSession
+          && bgpRemoteRoute.getAsPath().containsAs(fromNeighbor.getRemoteAs())
+          && !fromNeighbor.getAllowRemoteAsOut()) {
+        // skip routes containing peer's AS unless
+        // disable-peer-as-check (getAllowRemoteAsOut) is set
+        return null;
+      }
+      /*
+       * route reflection: reflect everything received from
+       * clients to clients and non-clients. reflect everything
+       * received from non-clients to clients. Do not reflect to
+       * originator
+       */
+
+      Ip remoteOriginatorIp = bgpRemoteRoute.getOriginatorIp();
+      /*
+       *  iBGP speaker should not send out routes to iBGP neighbor whose router-id is
+       *  same as originator id of advertisement
+       */
+      if (!ebgpSession && toVrf.getBgpProcess().getRouterId().equals(remoteOriginatorIp)) {
+        return null;
+      }
+      if (remoteRouteProtocol.equals(RoutingProtocol.IBGP) && !ebgpSession) {
+        /*
+         *  The remote route is iBGP. The session is iBGP. We consider whether to reflect, and
+         *  modify the outgoing route as appropriate.
+         */
+        boolean remoteRouteReceivedFromRouteReflectorClient =
+            bgpRemoteRoute.getReceivedFromRouteReflectorClient();
+        boolean sendingToRouteReflectorClient = fromNeighbor.getRouteReflectorClient();
+        Ip remoteReceivedFromIp = bgpRemoteRoute.getReceivedFromIp();
+        boolean remoteRouteOriginatedByRemoteNeighbor = remoteReceivedFromIp.equals(Ip.ZERO);
+        if (!remoteRouteReceivedFromRouteReflectorClient
+            && !sendingToRouteReflectorClient
+            && !remoteRouteOriginatedByRemoteNeighbor) {
+          /*
+           * Neither reflecting nor originating this iBGP route, so don't send
+           */
+          return null;
+        }
+        transformedOutgoingRouteBuilder.getClusterList().addAll(bgpRemoteRoute.getClusterList());
+        if (!remoteRouteOriginatedByRemoteNeighbor) {
+          // we are reflecting, so we need to get the clusterid associated with the
+          // remoteRoute
+          BgpNeighbor remoteReceivedFromSession =
+              fromVrf
+                  .getBgpProcess()
+                  .getNeighbors()
+                  .get(new Prefix(remoteReceivedFromIp, Prefix.MAX_PREFIX_LENGTH));
+          long newClusterId = remoteReceivedFromSession.getClusterId();
+          transformedOutgoingRouteBuilder.getClusterList().add(newClusterId);
+        }
+        Set<Long> localClusterIds = toVrf.getBgpProcess().getClusterIds();
+        Set<Long> outgoingClusterList = transformedOutgoingRouteBuilder.getClusterList();
+        if (localClusterIds.stream().anyMatch(outgoingClusterList::contains)) {
+          /*
+           *  receiver will reject new route if it contains any of its local cluster ids
+           */
+          return null;
+        }
+      }
+    }
+
+    // Outgoing asPath
+    // Outgoing communities
+    if (remoteRouteIsBgp) {
+      BgpRoute bgpRemoteRoute = (BgpRoute) route;
+      transformedOutgoingRouteBuilder.setAsPath(bgpRemoteRoute.getAsPath().getAsSets());
+      if (fromNeighbor.getSendCommunity()) {
+        transformedOutgoingRouteBuilder.getCommunities().addAll(bgpRemoteRoute.getCommunities());
+      }
+    }
+    if (ebgpSession) {
+      SortedSet<Integer> newAsPathElement = new TreeSet<>();
+      newAsPathElement.add(fromNeighbor.getLocalAs());
+      transformedOutgoingRouteBuilder.getAsPath().add(0, newAsPathElement);
+    }
+
+    // Outgoing protocol
+    transformedOutgoingRouteBuilder.setProtocol(targetProtocol);
+    transformedOutgoingRouteBuilder.setNetwork(route.getNetwork());
+
+    // Outgoing metric
+    if (remoteRouteIsBgp) {
+      transformedOutgoingRouteBuilder.setMetric(route.getMetric());
+    }
+
+    // Outgoing nextHopIp
+    // Outgoing localPreference
+    Ip nextHopIp;
+    int localPreference;
+    if (ebgpSession || !remoteRouteIsBgp) {
+      nextHopIp = fromNeighbor.getLocalIp();
+      localPreference = BgpRoute.DEFAULT_LOCAL_PREFERENCE;
+    } else {
+      nextHopIp = route.getNextHopIp();
+      BgpRoute remoteIbgpRoute = (BgpRoute) route;
+      localPreference = remoteIbgpRoute.getLocalPreference();
+    }
+    if (nextHopIp.equals(Route.UNSET_ROUTE_NEXT_HOP_IP)) {
+      // should only happen for ibgp
+      String nextHopInterface = route.getNextHopInterface();
+      InterfaceAddress nextHopAddress = fromVrf.getInterfaces().get(nextHopInterface).getAddress();
+      if (nextHopAddress == null) {
+        throw new BgpRoutePropagationException("Route's nextHopInterface has no address");
+      }
+      nextHopIp = nextHopAddress.getIp();
+    }
+    transformedOutgoingRouteBuilder.setNextHopIp(nextHopIp);
+    transformedOutgoingRouteBuilder.setLocalPreference(localPreference);
+
+    // Outgoing srcProtocol
+    transformedOutgoingRouteBuilder.setSrcProtocol(route.getProtocol());
+    return transformedOutgoingRouteBuilder;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/package-info.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * package org.batfish.dataplane.protocols contains a group of helper classes and functions that
+ * implement logic specific to a given routing protocol. This logic should be re-usable across
+ * different dataplane engines
+ */
+package org.batfish.dataplane.protocols;

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -2955,15 +2955,15 @@ public final class CiscoConfiguration extends VendorConfiguration {
       switch (rmClause.getAction()) {
         case ACCEPT:
           if (continueStatement == null) {
-            onMatchStatements.add(Statements.ReturnTrue.toStaticStatement());
+            onMatchStatements.add(Statements.ExitAccept.toStaticStatement());
           } else {
-            onMatchStatements.add(Statements.SetLocalDefaultActionAccept.toStaticStatement());
+            onMatchStatements.add(Statements.SetDefaultActionAccept.toStaticStatement());
             onMatchStatements.add(new CallStatement(continueTargetPolicy.getName()));
           }
           break;
 
         case REJECT:
-          onMatchStatements.add(Statements.ReturnFalse.toStaticStatement());
+          onMatchStatements.add(Statements.ExitReject.toStaticStatement());
           break;
 
         default:

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRouteMapTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRouteMapTest.java
@@ -1,0 +1,97 @@
+package org.batfish.dataplane.ibdp;
+
+import static org.batfish.dataplane.matchers.PrefixTracerMatchers.fromHostname;
+import static org.batfish.dataplane.matchers.PrefixTracerMatchers.toHostname;
+import static org.batfish.dataplane.matchers.PrefixTracerMatchers.wasFilteredOut;
+import static org.batfish.dataplane.matchers.PrefixTracerMatchers.wasInstalled;
+import static org.batfish.dataplane.matchers.PrefixTracerMatchers.wasSent;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.not;
+
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.util.List;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.Prefix;
+import org.batfish.main.Batfish;
+import org.batfish.main.BatfishTestUtils;
+import org.batfish.main.TestrigText;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Tests of {@link org.batfish.datamodel.routing_policy.RoutingPolicy} as it pertains to modeling of
+ * BGP route maps and dataplane computation
+ */
+public class BgpRouteMapTest {
+  @Rule public TemporaryFolder _folder = new TemporaryFolder();
+  private static final String DP_ENGINE = "ibdp";
+  private static final String TESTRIGS_PREFIX = "org/batfish/grammar/cisco/testrigs/";
+
+  @Test
+  public void testEmptyExportRouteMap() throws IOException {
+    String testrigName = "bgp-empty-routemap";
+    String hostname = "exporter";
+    Prefix advertisedPrefix = Prefix.parse("1.1.1.1/32");
+    List<String> configurationNames = ImmutableList.of(hostname);
+    Batfish batfish =
+        BatfishTestUtils.getBatfishFromTestrigText(
+            TestrigText.builder()
+                .setConfigurationText(TESTRIGS_PREFIX + testrigName, configurationNames)
+                .build(),
+            _folder);
+    batfish.getSettings().setDataplaneEngineName(DP_ENGINE);
+    batfish.computeDataPlane(false);
+    IncrementalDataPlane dp = (IncrementalDataPlane) batfish.loadDataPlane();
+
+    // Test that /32 loopback route is sent to 1.1.1.3, but NOT 1.1.1.4
+
+    PrefixTracer pt = dp.getPrefixTracingInfo().get(hostname).get(Configuration.DEFAULT_VRF_NAME);
+    // Sent should contain neighbor 1.1.1.3, because it uses TEST_EXPORT_PERMIT routemap
+    assertThat(pt, wasSent(advertisedPrefix, toHostname("1.1.1.3")));
+    assertThat(pt, not(wasFilteredOut(advertisedPrefix, toHostname("1.1.1.3"))));
+    // Filtered should contain neighbor 1.1.1.4, because it uses TEST_EXPORT_DENY routemap
+    assertThat(pt, not(wasSent(advertisedPrefix, toHostname("1.1.1.4"))));
+    assertThat(pt, wasFilteredOut(advertisedPrefix, toHostname("1.1.1.4")));
+  }
+
+  /**
+   * Test behavior in the presence of route map continue statments. See testrig config named
+   * "exporter" for detailed construction of the routemap.
+   */
+  @Test
+  public void testMatchWithContinue() throws IOException {
+    String testrigName = "bgp-routemap-with-continue";
+    Prefix advertisedPrefix = Prefix.parse("1.1.1.1/32");
+    Prefix blockedPrefix = Prefix.parse("1.1.1.2/31");
+    List<String> configurationNames = ImmutableList.of("exporter", "importer");
+    Batfish batfish =
+        BatfishTestUtils.getBatfishFromTestrigText(
+            TestrigText.builder()
+                .setConfigurationText(TESTRIGS_PREFIX + testrigName, configurationNames)
+                .build(),
+            _folder);
+    batfish.getSettings().setDataplaneEngineName(DP_ENGINE);
+    batfish.computeDataPlane(false);
+    IncrementalDataPlane dp = (IncrementalDataPlane) batfish.loadDataPlane();
+
+    /*
+     * Test exports: the /32 route should have been exported while the /31 should be blocked
+     */
+
+    PrefixTracer pt = dp.getPrefixTracingInfo().get("exporter").get(Configuration.DEFAULT_VRF_NAME);
+    assertThat(pt, wasFilteredOut(blockedPrefix, toHostname("importer")));
+    assertThat(pt, not(wasSent(blockedPrefix, toHostname("importer"))));
+
+    assertThat(pt, not(wasFilteredOut(advertisedPrefix, toHostname("importer"))));
+    assertThat(pt, wasSent(advertisedPrefix, toHostname("importer")));
+
+    /*
+     * Test imports: the /32 route should have been installed and not filtered
+     */
+    pt = dp.getPrefixTracingInfo().get("importer").get(Configuration.DEFAULT_VRF_NAME);
+    assertThat(pt, wasInstalled(advertisedPrefix, fromHostname("exporter")));
+    assertThat(pt, not(wasInstalled(blockedPrefix, fromHostname("exporter"))));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/dataplane/matchers/PrefixTracerMatchers.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/matchers/PrefixTracerMatchers.java
@@ -1,0 +1,119 @@
+package org.batfish.dataplane.matchers;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.collection.IsMapContaining.hasEntry;
+
+import java.util.Map;
+import java.util.Set;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.routing_policy.Environment.Direction;
+import org.batfish.dataplane.ibdp.PrefixTracer;
+import org.batfish.dataplane.ibdp.PrefixTracer.Neighbor;
+import org.hamcrest.FeatureMatcher;
+import org.hamcrest.Matcher;
+
+/** A set of matchers for testing {@link PrefixTracer} */
+public final class PrefixTracerMatchers {
+
+  static final class FilteredOut extends FeatureMatcher<PrefixTracer, Map<Prefix, Set<Neighbor>>> {
+
+    FilteredOut(Matcher<? super Map<Prefix, Set<Neighbor>>> subMatcher) {
+      super(subMatcher, "Filtered outbound:", "filtered routes");
+    }
+
+    @Override
+    protected Map<Prefix, Set<Neighbor>> featureValueOf(PrefixTracer prefixTracer) {
+      return prefixTracer.getFiltered(Direction.OUT);
+    }
+  }
+
+  static final class FilteredIn extends FeatureMatcher<PrefixTracer, Map<Prefix, Set<Neighbor>>> {
+
+    FilteredIn(Matcher<? super Map<Prefix, Set<Neighbor>>> subMatcher) {
+      super(subMatcher, "Filtered inbound:", "filtered routes");
+    }
+
+    @Override
+    protected Map<Prefix, Set<Neighbor>> featureValueOf(PrefixTracer prefixTracer) {
+      return prefixTracer.getFiltered(Direction.IN);
+    }
+  }
+
+  static final class WasSent extends FeatureMatcher<PrefixTracer, Map<Prefix, Set<Neighbor>>> {
+    WasSent(Matcher<? super Map<Prefix, Set<Neighbor>>> subMatcher) {
+      super(subMatcher, "Sent routes:", "sent routes");
+    }
+
+    @Override
+    protected Map<Prefix, Set<Neighbor>> featureValueOf(PrefixTracer prefixTracer) {
+      return prefixTracer.getSent();
+    }
+  }
+
+  static final class WasInstalled extends FeatureMatcher<PrefixTracer, Map<Prefix, Set<Neighbor>>> {
+
+    public WasInstalled(Matcher<? super Map<Prefix, Set<Neighbor>>> subMatcher) {
+      super(subMatcher, "Installed routes:", "installed routes");
+    }
+
+    @Override
+    protected Map<Prefix, Set<Neighbor>> featureValueOf(PrefixTracer prefixTracer) {
+      return prefixTracer.getInstalled();
+    }
+  }
+
+  static final class HasHostname extends FeatureMatcher<Neighbor, String> {
+
+    HasHostname(Matcher<? super String> subMatcher) {
+      super(subMatcher, "Neighbor with hostname:", "hostname");
+    }
+
+    @Override
+    protected String featureValueOf(Neighbor neighbor) {
+      return neighbor.getHostname();
+    }
+  }
+
+  /** Matches if a matched by the submatcher prefix was sent */
+  public static WasSent wasSent(Matcher<? super Map<Prefix, Set<Neighbor>>> submatcher) {
+    return new WasSent(submatcher);
+  }
+
+  /** Matches if a prefix was received from neighbors specified by the submatcher and installed */
+  public static WasInstalled wasInstalled(
+      Prefix prefix, Matcher<? super Set<Neighbor>> submatcher) {
+    return new WasInstalled(hasEntry(equalTo(prefix), submatcher));
+  }
+
+  /** Matches if a prefix was sent to any neighbors specified by the submatcher */
+  public static WasSent wasSent(Prefix prefix, Matcher<? super Set<Neighbor>> submatcher) {
+    return new WasSent(hasEntry(equalTo(prefix), submatcher));
+  }
+
+  /** Matches if a prefix was filtered on inbound at a neighbor specified by the submatcher */
+  public static FilteredIn wasFilteredIn(Prefix prefix, Matcher<? super Set<Neighbor>> submatcher) {
+    return new FilteredIn(hasEntry(equalTo(prefix), submatcher));
+  }
+
+  /** Matches if a prefix was filtered on outbound at a neighbor specified by the submatcher */
+  public static FilteredOut wasFilteredOut(
+      Prefix prefix, Matcher<? super Set<Neighbor>> submatcher) {
+    return new FilteredOut(hasEntry(equalTo(prefix), submatcher));
+  }
+
+  /** Matches if a neighbor has a specified hostname */
+  public static HasHostname hasHostname(String hostname) {
+    return new HasHostname(equalTo(hostname));
+  }
+
+  /** Matches if any of the neighbors have a specified hostname */
+  public static Matcher<? super Iterable<Neighbor>> toHostname(String hostname) {
+    return hasItem(new HasHostname(equalTo(hostname)));
+  }
+
+  /** Matches if any of the neighbors have a specified hostname */
+  public static Matcher<? super Iterable<Neighbor>> fromHostname(String hostname) {
+    return hasItem(new HasHostname(equalTo(hostname)));
+  }
+}

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/bgp-empty-routemap/configs/exporter
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/bgp-empty-routemap/configs/exporter
@@ -1,0 +1,24 @@
+!
+hostname exporter
+!
+interface Ethernet1
+  ip address 1.1.1.2 255.255.255.248
+  no shutdown
+  speed auto
+!
+interface Loopback0
+  ip address 1.1.1.1 255.255.255.255
+!
+! This routemap should permit everything
+route-map TEST_EXPORT_PERMIT permit 10
+!
+! Whereas this routemap should deny everything
+route-map TEST_EXPORT_DENY deny 10
+!
+router bgp 1
+  router-id 1.1.1.1
+  neighbor 1.1.1.3 remote-as 2
+  neighbor 1.1.1.3 route-map TEST_EXPORT_PERMIT out
+  neighbor 1.1.1.4 remote-as 3
+  neighbor 1.1.1.4 route-map TEST_EXPORT_DENY out
+  network 1.1.1.1/32

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/bgp-routemap-with-continue/configs/exporter
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/bgp-routemap-with-continue/configs/exporter
@@ -1,0 +1,39 @@
+!
+hostname exporter
+!
+interface Ethernet1
+  ip address 1.1.1.2 255.255.255.254
+  no shutdown
+  speed auto
+!
+interface Loopback0
+  ip address 1.1.1.1 255.255.255.255
+!
+! GOAL: /32 route gets exported, /31 does not
+!
+! Allow loopback route, forbid connected route
+ip prefix-list LIST_ALLOWED 
+  permit 1.1.1.1/32 
+!
+! This routemap should permit our loopback /32 route.
+! It intentionally has a continue statement
+! Match + continue should jump to clause 30
+! No match (/31 route) means no continue and we fall through to 20 and return deny
+route-map TEST_EXPORT permit 10
+  match ip address LIST_ALLOWED
+  continue 30 
+!
+! If we fall through to here, block everything
+route-map TEST_EXPORT deny 20
+!
+! And this is a no-op to check that ExitAccept percolates all the way up to 
+! enclosing routing policy
+route-map TEST_EXPORT permit 30
+!
+!
+router bgp 1
+  router-id 1.1.1.1
+  neighbor 1.1.1.3 remote-as 2
+  neighbor 1.1.1.3 route-map TEST_EXPORT out
+  redistribute connected
+!

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/bgp-routemap-with-continue/configs/importer
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/bgp-routemap-with-continue/configs/importer
@@ -1,0 +1,13 @@
+!
+hostname importer 
+!
+interface Ethernet1
+  ip address 1.1.1.3 255.255.255.254
+  no shutdown
+  speed auto
+!
+! This router is here so that a valid peering is established
+!
+router bgp 2
+  router-id 1.1.1.1
+  neighbor 1.1.1.2 remote-as 1

--- a/test_rigs/parsing-tests/unit-tests-nodes.ref
+++ b/test_rigs/parsing-tests/unit-tests-nodes.ref
@@ -8966,7 +8966,7 @@
               },
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                "type" : "ReturnTrue"
+                "type" : "ExitAccept"
               }
             ]
           },
@@ -16108,7 +16108,7 @@
                 "trueStatements" : [
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "SetLocalDefaultActionAccept"
+                    "type" : "SetDefaultActionAccept"
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.CallStatement",
@@ -16141,7 +16141,7 @@
                 "trueStatements" : [
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "ReturnFalse"
+                    "type" : "ExitReject"
                   }
                 ]
               }
@@ -16159,7 +16159,7 @@
               },
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                "type" : "SetLocalDefaultActionAccept"
+                "type" : "SetDefaultActionAccept"
               },
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.CallStatement",
@@ -16197,7 +16197,7 @@
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "SetLocalDefaultActionAccept"
+                    "type" : "SetDefaultActionAccept"
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.CallStatement",
@@ -16237,7 +16237,7 @@
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "SetLocalDefaultActionAccept"
+                    "type" : "SetDefaultActionAccept"
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.CallStatement",
@@ -16277,7 +16277,7 @@
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "SetLocalDefaultActionAccept"
+                    "type" : "SetDefaultActionAccept"
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.CallStatement",
@@ -16317,7 +16317,7 @@
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "SetLocalDefaultActionAccept"
+                    "type" : "SetDefaultActionAccept"
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.CallStatement",
@@ -16357,7 +16357,7 @@
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "SetLocalDefaultActionAccept"
+                    "type" : "SetDefaultActionAccept"
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.CallStatement",
@@ -16397,7 +16397,7 @@
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "SetLocalDefaultActionAccept"
+                    "type" : "SetDefaultActionAccept"
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.CallStatement",
@@ -16437,7 +16437,7 @@
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "SetLocalDefaultActionAccept"
+                    "type" : "SetDefaultActionAccept"
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.CallStatement",
@@ -16477,7 +16477,7 @@
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "SetLocalDefaultActionAccept"
+                    "type" : "SetDefaultActionAccept"
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.CallStatement",
@@ -16517,7 +16517,7 @@
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "SetLocalDefaultActionAccept"
+                    "type" : "SetDefaultActionAccept"
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.CallStatement",
@@ -16550,7 +16550,7 @@
                 "trueStatements" : [
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "ReturnFalse"
+                    "type" : "ExitReject"
                   }
                 ]
               }
@@ -16586,7 +16586,7 @@
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "SetLocalDefaultActionAccept"
+                    "type" : "SetDefaultActionAccept"
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.CallStatement",
@@ -16619,7 +16619,7 @@
                 "trueStatements" : [
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "SetLocalDefaultActionAccept"
+                    "type" : "SetDefaultActionAccept"
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.CallStatement",
@@ -16634,7 +16634,7 @@
             "statements" : [
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                "type" : "ReturnFalse"
+                "type" : "ExitReject"
               }
             ]
           },
@@ -16679,7 +16679,7 @@
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "SetLocalDefaultActionAccept"
+                    "type" : "SetDefaultActionAccept"
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.CallStatement",
@@ -16730,7 +16730,7 @@
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "SetLocalDefaultActionAccept"
+                    "type" : "SetDefaultActionAccept"
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.CallStatement",
@@ -16781,7 +16781,7 @@
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "SetLocalDefaultActionAccept"
+                    "type" : "SetDefaultActionAccept"
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.CallStatement",
@@ -16832,7 +16832,7 @@
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "SetLocalDefaultActionAccept"
+                    "type" : "SetDefaultActionAccept"
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.CallStatement",
@@ -16883,7 +16883,7 @@
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "SetLocalDefaultActionAccept"
+                    "type" : "SetDefaultActionAccept"
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.CallStatement",
@@ -16934,7 +16934,7 @@
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "SetLocalDefaultActionAccept"
+                    "type" : "SetDefaultActionAccept"
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.CallStatement",
@@ -16985,7 +16985,7 @@
               },
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                "type" : "SetLocalDefaultActionAccept"
+                "type" : "SetDefaultActionAccept"
               },
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.CallStatement",
@@ -17016,7 +17016,7 @@
                 "trueStatements" : [
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "SetLocalDefaultActionAccept"
+                    "type" : "SetDefaultActionAccept"
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.CallStatement",
@@ -17031,7 +17031,7 @@
             "statements" : [
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                "type" : "ReturnTrue"
+                "type" : "ExitAccept"
               }
             ]
           },
@@ -17040,7 +17040,7 @@
             "statements" : [
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                "type" : "ReturnFalse"
+                "type" : "ExitReject"
               }
             ]
           },
@@ -17077,7 +17077,7 @@
               },
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                "type" : "SetLocalDefaultActionAccept"
+                "type" : "SetDefaultActionAccept"
               },
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.CallStatement",
@@ -17143,7 +17143,7 @@
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "SetLocalDefaultActionAccept"
+                    "type" : "SetDefaultActionAccept"
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.CallStatement",
@@ -17211,7 +17211,7 @@
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "SetLocalDefaultActionAccept"
+                    "type" : "SetDefaultActionAccept"
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.CallStatement",
@@ -17279,7 +17279,7 @@
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "SetLocalDefaultActionAccept"
+                    "type" : "SetDefaultActionAccept"
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.CallStatement",
@@ -17347,7 +17347,7 @@
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "SetLocalDefaultActionAccept"
+                    "type" : "SetDefaultActionAccept"
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.CallStatement",


### PR DESCRIPTION
Changes as follows (split into individual commits):
- Try to improve readability of VirtualRouter by cleaning up `processBgpMessages`, pulling out some route transformation code
- Add prefix tracing functionality
- Add tests and fix issues found in cisco routemap extraction
- Update refs

*Note*: this is not meant to be a comprehensive testing/overhaul of route map; tackling it in increments.