### PR TITLE
Prune ACL reachability jobs to find blocking lines

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -996,7 +996,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
                     c.getIpAccessLists(),
                     nodeInterfaces);
             NodFirstUnsatJob<AclLine, Integer> job =
-                new NodFirstUnsatJob<>(_settings, aclSynthesizer, query);
+                new NodFirstUnsatJob<>(_settings, aclSynthesizer, query, true);
             jobs.add(job);
           }
         }

--- a/projects/batfish/src/main/java/org/batfish/z3/NodFirstUnsatJob.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/NodFirstUnsatJob.java
@@ -5,6 +5,7 @@ import com.microsoft.z3.Context;
 import com.microsoft.z3.Fixedpoint;
 import com.microsoft.z3.Status;
 import com.microsoft.z3.Z3Exception;
+import javax.annotation.Nonnull;
 import org.batfish.common.BatfishException;
 import org.batfish.config.Settings;
 
@@ -15,20 +16,24 @@ public class NodFirstUnsatJob<KeyT, ResultT>
 
   private final Synthesizer _synthesizer;
 
+  private final boolean _optimize;
+
   public NodFirstUnsatJob(
-      Settings settings, Synthesizer synthesizer, FirstUnsatQuerySynthesizer<KeyT, ResultT> query) {
+      Settings settings,
+      Synthesizer synthesizer,
+      FirstUnsatQuerySynthesizer<KeyT, ResultT> query,
+      boolean optimize) {
     super(settings);
     _synthesizer = synthesizer;
     _query = query;
+    _optimize = optimize;
   }
 
   @Override
   public NodFirstUnsatResult<KeyT, ResultT> call() {
     long startTime = System.currentTimeMillis();
     try (Context ctx = new Context()) {
-      ReachabilityProgram baseProgram = _synthesizer.synthesizeNodProgram();
-      ReachabilityProgram queryProgram = _query.getReachabilityProgram(_synthesizer.getInput());
-      NodProgram program = new NodProgram(ctx, baseProgram, queryProgram);
+      NodProgram program = getNodProgram(ctx);
       Fixedpoint fix = mkFixedpoint(program, false);
       KeyT key = _query.getKey();
       for (int queryNum = 0; queryNum < program.getQueries().size(); queryNum++) {
@@ -61,5 +66,15 @@ public class NodFirstUnsatJob<KeyT, ResultT>
           _logger.getHistory(),
           new BatfishException("Error running NoD on concatenated data plane", e));
     }
+  }
+
+  @Nonnull
+  private NodProgram getNodProgram(Context ctx) {
+    ReachabilityProgram baseProgram = _synthesizer.synthesizeNodProgram();
+    ReachabilityProgram queryProgram = _query.getReachabilityProgram(_synthesizer.getInput());
+
+    return _optimize
+        ? optimizedProgram(ctx, baseProgram, queryProgram)
+        : new NodProgram(ctx, baseProgram, queryProgram);
   }
 }


### PR DESCRIPTION
Moves method `optimizedProgram()` from `NodJob` to its grandparent `Z3ContextJob` so that `NodJob`'s aunt/uncle (auncle?) `NodFirstUnsatJob` can also make use of it.