### PR TITLE
Parsing support for http inspect class-maps

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
@@ -2136,6 +2136,11 @@ CONTACT_NAME
    'contact-name' -> pushMode ( M_Description )
 ;
 
+CONTENT_TYPE
+:
+   'content-type'
+;
+
 CONTEXT
 :
    'context'
@@ -6788,6 +6793,11 @@ MIRROR
    'mirror'
 ;
 
+MISMATCH
+:
+   'mismatch'
+;
+
 MISSING_AS_WORST
 :
    'missing-as-worst'
@@ -9171,6 +9181,11 @@ REPLY_TO
 REOPTIMIZE
 :
    'reoptimize'
+;
+
+REQ_RESP
+:
+   'req-resp'
 ;
 
 REQ_TRANS_POLICY

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_qos.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_qos.g4
@@ -13,23 +13,44 @@ cm_end_class_map
 
 cm_ios_inspect
 :
-   INSPECT match_semantics? name = variable_permissive NEWLINE cm_iosi_match*
+   INSPECT HTTP? match_semantics? name = variable_permissive NEWLINE cm_iosi_match*
 ;
 
 cm_iosi_match
 :
-   cm_iosim_access_group
-   | cm_iosim_protocol
+   MATCH
+   (
+      cm_iosim_access_group
+      | cm_iosim_protocol
+      | cm_iosim_req_resp
+      | cm_iosim_request
+      | cm_iosim_response
+   )
 ;
 
 cm_iosim_access_group
 :
-   MATCH ACCESS_GROUP NAME name = variable_permissive NEWLINE
+   ACCESS_GROUP NAME name = variable_permissive NEWLINE
 ;
 
 cm_iosim_protocol
 :
-   MATCH PROTOCOL inspect_protocol NEWLINE
+   PROTOCOL inspect_protocol NEWLINE
+;
+
+cm_iosim_req_resp
+:
+   NOT? REQ_RESP CONTENT_TYPE MISMATCH
+;
+
+cm_iosim_request
+:
+   NOT? REQUEST null_rest_of_line
+;
+
+cm_iosim_response
+:
+   NOT? RESPONSE null_rest_of_line
 ;
 
 cm_match

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -3705,13 +3705,9 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
     } else if (ctx.cm_iosim_protocol() != null) {
       return new InspectClassMapMatchProtocol(
           toInspectClassMapProtocol(ctx.cm_iosim_protocol().inspect_protocol()));
-    } else if (ctx.cm_iosim_req_resp() != null
-        || ctx.cm_iosim_request() != null
-        || ctx.cm_iosim_response() != null) {
-      _w.redFlag("Http inspection class-map matches not supported yet");
-      return null;
     } else {
-      throw convError(InspectClassMapMatch.class, ctx);
+      _w.redFlag("Class-map match unsupported " + getFullText(ctx));
+      return null;
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -3689,7 +3689,10 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
 
   @Override
   public void exitCm_iosi_match(Cm_iosi_matchContext ctx) {
-    _currentInspectClassMap.getMatches().add(toInspectClassMapMatch(ctx));
+    InspectClassMapMatch match = toInspectClassMapMatch(ctx);
+    if (match != null) {
+      _currentInspectClassMap.getMatches().add(match);
+    }
   }
 
   private InspectClassMapMatch toInspectClassMapMatch(Cm_iosi_matchContext ctx) {
@@ -3702,6 +3705,11 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
     } else if (ctx.cm_iosim_protocol() != null) {
       return new InspectClassMapMatchProtocol(
           toInspectClassMapProtocol(ctx.cm_iosim_protocol().inspect_protocol()));
+    } else if (ctx.cm_iosim_req_resp() != null
+        || ctx.cm_iosim_request() != null
+        || ctx.cm_iosim_response() != null) {
+      _w.redFlag("Http inspection class-map matches not supported yet");
+      return null;
     } else {
       throw convError(InspectClassMapMatch.class, ctx);
     }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -413,6 +413,24 @@ public class CiscoGrammarTest {
   }
 
   @Test
+  public void testIosHttpInspection() throws IOException {
+    String hostname = "ios-http-inspection";
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse();
+
+    assertThat(ccae, hasNumReferrers(hostname, CiscoStructureType.INSPECT_CLASS_MAP, "ci", 1));
+    assertThat(ccae, hasNumReferrers(hostname, CiscoStructureType.INSPECT_CLASS_MAP, "ciunused", 0));
+    assertThat(
+        ccae,
+        hasUndefinedReference(
+            hostname,
+            CiscoStructureType.INSPECT_CLASS_MAP,
+            "ciundefined",
+            CiscoStructureUsage.INSPECT_POLICY_MAP_INSPECT_CLASS));
+  }
+
+  @Test
   public void testIosKeyring() throws IOException {
     String hostname = "ios-keyrings";
     Batfish batfish = getBatfishForConfigurationNames(hostname);

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -420,7 +420,8 @@ public class CiscoGrammarTest {
         batfish.loadConvertConfigurationAnswerElementOrReparse();
 
     assertThat(ccae, hasNumReferrers(hostname, CiscoStructureType.INSPECT_CLASS_MAP, "ci", 1));
-    assertThat(ccae, hasNumReferrers(hostname, CiscoStructureType.INSPECT_CLASS_MAP, "ciunused", 0));
+    assertThat(
+        ccae, hasNumReferrers(hostname, CiscoStructureType.INSPECT_CLASS_MAP, "ciunused", 0));
     assertThat(
         ccae,
         hasUndefinedReference(

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-http-inspection
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-http-inspection
@@ -1,0 +1,17 @@
+!
+hostname ios-http-inspection
+!
+policy-map type inspect pmi
+ class type inspect ci
+  inspect
+ class type inspect ciundefined
+  inspect
+!
+class-map type inspect http match-any ci
+ match request method put
+ match not request body length gt 12345
+!
+class-map type inspect http match-any ciunused
+ match response header length gt 1234
+ match req-resp content-type mismatch
+!


### PR DESCRIPTION
* Added http inspect class-map parsing support (to stop crashing on encountering these structures)

Fixes #1302 