### PR TITLE
Updating Route filter lines to take IpWildcards and other fixes

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixSpaceList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixSpaceList.java
@@ -12,6 +12,9 @@ public class PrefixSpaceList {
     PrefixSpaceLine currentLine = null;
     PrefixSpace currentPrefixSpace = new PrefixSpace();
     for (RouteFilterLine rfLine : rf.getLines()) {
+      if (!rfLine.getIpWildcard().isPrefix()) {
+        continue;
+      }
       LineAction rflAction = rfLine.getAction();
       if (currentAction != rflAction) {
         currentAction = rflAction;
@@ -19,7 +22,8 @@ public class PrefixSpaceList {
         currentLine = new PrefixSpaceLine(currentPrefixSpace, currentAction);
         lines.add(currentLine);
       }
-      PrefixRange rflRange = new PrefixRange(rfLine.getPrefix(), rfLine.getLengthRange());
+      PrefixRange rflRange =
+          new PrefixRange(rfLine.getIpWildcard().toPrefix(), rfLine.getLengthRange());
       currentPrefixSpace.addPrefixRange(rflRange);
     }
     return list;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Route6FilterLine.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Route6FilterLine.java
@@ -13,7 +13,7 @@ public class Route6FilterLine implements Serializable {
 
   private static final String PROP_LENGTH_RANGE = "lengthRange";
 
-  private static final String PROP_PREFIX = "prefix";
+  private static final String PROP_IP_WILDCARD = "ipWildcard";
 
   private static final long serialVersionUID = 1L;
 
@@ -21,20 +21,26 @@ public class Route6FilterLine implements Serializable {
 
   private final SubRange _lengthRange;
 
-  private final Prefix6 _prefix;
+  private final Ip6Wildcard _ipWildcard;
 
   @JsonCreator
   public Route6FilterLine(
       @JsonProperty(PROP_ACTION) LineAction action,
-      @JsonProperty(PROP_PREFIX) Prefix6 prefix,
+      @JsonProperty(PROP_IP_WILDCARD) Ip6Wildcard ipWildcard,
       @JsonProperty(PROP_LENGTH_RANGE) SubRange lengthRange) {
     _action = action;
-    _prefix = prefix;
+    _ipWildcard = ipWildcard;
+    _lengthRange = lengthRange;
+  }
+
+  public Route6FilterLine(LineAction action, Prefix6 prefix, SubRange lengthRange) {
+    _action = action;
+    _ipWildcard = new Ip6Wildcard(prefix);
     _lengthRange = lengthRange;
   }
 
   public Route6FilterLine(LineAction action, Prefix6Range prefixRange) {
-    this(action, prefixRange.getPrefix6(), prefixRange.getLengthRange());
+    this(action, new Ip6Wildcard(prefixRange.getPrefix6()), prefixRange.getLengthRange());
   }
 
   @Override
@@ -48,7 +54,7 @@ public class Route6FilterLine implements Serializable {
     Route6FilterLine other = (Route6FilterLine) obj;
     return _action == other._action
         && _lengthRange.equals(other._lengthRange)
-        && _prefix.equals(other._prefix);
+        && _ipWildcard.equals(other._ipWildcard);
   }
 
   @JsonProperty(PROP_ACTION)
@@ -64,12 +70,12 @@ public class Route6FilterLine implements Serializable {
     return _lengthRange;
   }
 
-  @JsonProperty(PROP_PREFIX)
+  @JsonProperty(PROP_IP_WILDCARD)
   @JsonPropertyDescription(
-      "The bits against which to compare a route's prefix. The length of this prefix is used to "
-          + "determine how many leading bits must match.")
-  public Prefix6 getPrefix() {
-    return _prefix;
+      "The bits against which to compare a route's prefix. The mask of this IP Wildcard determines "
+          + "which bits must match")
+  public Ip6Wildcard getIpWildcard() {
+    return _ipWildcard;
   }
 
   @Override
@@ -78,14 +84,14 @@ public class Route6FilterLine implements Serializable {
     int result = 1;
     result = prime * result + _action.ordinal();
     result = prime * result + _lengthRange.hashCode();
-    result = prime * result + _prefix.hashCode();
+    result = prime * result + _ipWildcard.hashCode();
     return result;
   }
 
   public String toCompactString() {
     StringBuilder sb = new StringBuilder();
     sb.append(_action + " ");
-    sb.append(_prefix + " ");
+    sb.append(_ipWildcard + " ");
     sb.append(_lengthRange + " ");
     return sb.toString();
   }
@@ -95,7 +101,7 @@ public class Route6FilterLine implements Serializable {
     StringBuilder sb = new StringBuilder();
     sb.append("{ ");
     sb.append("Action=" + _action + " ");
-    sb.append("Prefix=" + _prefix + " ");
+    sb.append("IpWildcard=" + _ipWildcard + " ");
     sb.append("LengthRange=" + _lengthRange + " ");
     sb.append("}");
     return sb.toString();

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Route6FilterList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Route6FilterList.java
@@ -65,16 +65,10 @@ public class Route6FilterList extends ComparableStructure<String> {
   private boolean newPermits(Prefix6 prefix) {
     boolean accept = false;
     for (Route6FilterLine line : _lines) {
-      Prefix6 linePrefix = line.getPrefix();
-      int lineBits = linePrefix.getPrefixLength();
-      Prefix6 truncatedLinePrefix = new Prefix6(linePrefix.getAddress(), lineBits);
-      Prefix6 relevantPortion = new Prefix6(prefix.getAddress(), lineBits).getNetworkPrefix();
-      if (relevantPortion.equals(truncatedLinePrefix)) {
+      if (line.getIpWildcard().contains(prefix.getAddress())) {
         int prefixLength = prefix.getPrefixLength();
         SubRange range = line.getLengthRange();
-        int min = range.getStart();
-        int max = range.getEnd();
-        if (prefixLength >= min && prefixLength <= max) {
+        if (prefixLength >= range.getStart() && prefixLength <= range.getEnd()) {
           accept = line.getAction() == LineAction.ACCEPT;
           break;
         }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Route6FilterList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Route6FilterList.java
@@ -5,6 +5,7 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.google.common.annotations.VisibleForTesting;
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDescription;
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -60,6 +61,12 @@ public class Route6FilterList extends ComparableStructure<String> {
   @JsonPropertyDescription("The lines against which to check an IPV6 route")
   public List<Route6FilterLine> getLines() {
     return _lines;
+  }
+
+  @VisibleForTesting
+  void initCaches() {
+    _deniedCache = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    _permittedCache = Collections.newSetFromMap(new ConcurrentHashMap<>());
   }
 
   private boolean newPermits(Prefix6 prefix) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RouteFilterLine.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RouteFilterLine.java
@@ -6,35 +6,41 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDescription;
 import java.io.Serializable;
 
-@JsonSchemaDescription("A line in an RouteFilterList")
+@JsonSchemaDescription("A line in a RouteFilterList")
 public class RouteFilterLine implements Serializable {
 
   private static final String PROP_ACTION = "action";
 
   private static final String PROP_LENGTH_RANGE = "lengthRange";
 
-  private static final String PROP_PREFIX = "prefix";
+  private static final String PROP_IP_WILDCARD = "ipWildcard";
 
   private static final long serialVersionUID = 1L;
 
   private final LineAction _action;
 
-  private final SubRange _lengthRange;
+  private final IpWildcard _ipWildcard;
 
-  private final Prefix _prefix;
+  private final SubRange _lengthRange;
 
   @JsonCreator
   public RouteFilterLine(
       @JsonProperty(PROP_ACTION) LineAction action,
-      @JsonProperty(PROP_PREFIX) Prefix prefix,
+      @JsonProperty(PROP_IP_WILDCARD) IpWildcard ipWildcard,
       @JsonProperty(PROP_LENGTH_RANGE) SubRange lengthRange) {
     _action = action;
-    _prefix = prefix;
+    _ipWildcard = ipWildcard;
+    _lengthRange = lengthRange;
+  }
+
+  public RouteFilterLine(LineAction action, Prefix prefix, SubRange lengthRange) {
+    _action = action;
+    _ipWildcard = new IpWildcard(prefix);
     _lengthRange = lengthRange;
   }
 
   public RouteFilterLine(LineAction action, PrefixRange prefixRange) {
-    this(action, prefixRange.getPrefix(), prefixRange.getLengthRange());
+    this(action, new IpWildcard(prefixRange.getPrefix()), prefixRange.getLengthRange());
   }
 
   @Override
@@ -51,7 +57,7 @@ public class RouteFilterLine implements Serializable {
     if (!_lengthRange.equals(other._lengthRange)) {
       return false;
     }
-    if (!_prefix.equals(other._prefix)) {
+    if (!_ipWildcard.equals(other._ipWildcard)) {
       return false;
     }
     return true;
@@ -70,12 +76,12 @@ public class RouteFilterLine implements Serializable {
     return _lengthRange;
   }
 
-  @JsonProperty(PROP_PREFIX)
+  @JsonProperty(PROP_IP_WILDCARD)
   @JsonPropertyDescription(
-      "The bits against which to compare a route's prefix. The length of this prefix is used to "
-          + "determine how many leading bits must match.")
-  public Prefix getPrefix() {
-    return _prefix;
+      "The bits against which to compare a route's prefix. The mask of this IP Wildcard determines "
+          + "which bits must match")
+  public IpWildcard getIpWildcard() {
+    return _ipWildcard;
   }
 
   @Override
@@ -84,14 +90,14 @@ public class RouteFilterLine implements Serializable {
     int result = 1;
     result = prime * result + _action.ordinal();
     result = prime * result + _lengthRange.hashCode();
-    result = prime * result + _prefix.hashCode();
+    result = prime * result + _ipWildcard.hashCode();
     return result;
   }
 
   public String toCompactString() {
     StringBuilder sb = new StringBuilder();
     sb.append(_action + " ");
-    sb.append(_prefix + " ");
+    sb.append(_ipWildcard + " ");
     sb.append(_lengthRange + " ");
     return sb.toString();
   }
@@ -101,7 +107,7 @@ public class RouteFilterLine implements Serializable {
     StringBuilder sb = new StringBuilder();
     sb.append("{ ");
     sb.append("Action=" + _action + " ");
-    sb.append("Prefix=" + _prefix + " ");
+    sb.append("IpWildcard=" + _ipWildcard + " ");
     sb.append("LengthRange=" + _lengthRange + " ");
     sb.append("}");
     return sb.toString();

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RouteFilterList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RouteFilterList.java
@@ -61,7 +61,6 @@ public class RouteFilterList extends ComparableStructure<String> {
     return _lines;
   }
 
-
   @VisibleForTesting
   void initCaches() {
     _deniedCache = Collections.newSetFromMap(new ConcurrentHashMap<>());

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RouteFilterList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RouteFilterList.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDescription;
 import java.io.IOException;
@@ -58,6 +59,13 @@ public class RouteFilterList extends ComparableStructure<String> {
   @JsonPropertyDescription("The lines against which to check an IPV4 route")
   public List<RouteFilterLine> getLines() {
     return _lines;
+  }
+
+
+  @VisibleForTesting
+  void initCaches() {
+    _deniedCache = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    _permittedCache = Collections.newSetFromMap(new ConcurrentHashMap<>());
   }
 
   private boolean newPermits(Prefix prefix) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RouteFilterList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RouteFilterList.java
@@ -63,16 +63,10 @@ public class RouteFilterList extends ComparableStructure<String> {
   private boolean newPermits(Prefix prefix) {
     boolean accept = false;
     for (RouteFilterLine line : _lines) {
-      Prefix linePrefix = line.getPrefix();
-      int lineBits = linePrefix.getPrefixLength();
-      Prefix truncatedLinePrefix = new Prefix(linePrefix.getStartIp(), lineBits);
-      Prefix relevantPortion = new Prefix(prefix.getStartIp(), lineBits);
-      if (relevantPortion.equals(truncatedLinePrefix)) {
+      if (line.getIpWildcard().containsIp(prefix.getStartIp())) {
         int prefixLength = prefix.getPrefixLength();
         SubRange range = line.getLengthRange();
-        int min = range.getStart();
-        int max = range.getEnd();
-        if (prefixLength >= min && prefixLength <= max) {
+        if (prefixLength >= range.getStart() && prefixLength <= range.getEnd()) {
           accept = line.getAction() == LineAction.ACCEPT;
           break;
         }
@@ -111,7 +105,7 @@ public class RouteFilterList extends ComparableStructure<String> {
                 throw new BatfishException(
                     "Expected accept action for routerfilterlist from juniper");
               } else {
-                return new IpWildcard(rfLine.getPrefix());
+                return rfLine.getIpWildcard();
               }
             })
         .collect(Collectors.toList());

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/Route6FilterListTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/Route6FilterListTest.java
@@ -1,0 +1,83 @@
+package org.batfish.datamodel;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Before;
+import org.junit.Test;
+
+/** Test for {@link RouteFilterList} */
+public class Route6FilterListTest {
+
+  private Route6FilterList _rfAddressMask;
+  private Route6FilterList _rfPrefixMoreSpecific;
+  private Route6FilterList _rfPrefixExact;
+
+  @Before
+  public void setup() {
+    _rfAddressMask =
+        new Route6FilterList(
+            "test-route6-filter-mask",
+            ImmutableList.of(
+                new Route6FilterLine(
+                    LineAction.ACCEPT,
+                    new Ip6Wildcard(
+                        "2001:db8:1234:2345:3456:4567:5678:6789;0:ffff:0:0:0:ffff:ffff:ffff"),
+                    new SubRange(64, 64))));
+    _rfAddressMask.initCaches();
+    _rfPrefixMoreSpecific =
+        new Route6FilterList(
+            "test-route6-filter-prefix",
+            ImmutableList.of(
+                new Route6FilterLine(
+                    LineAction.ACCEPT,
+                    new Ip6Wildcard(
+                        "2001:db8:1234:2345:3456:4567:5678:6789;0:0:0:0:ffff:ffff:ffff:ffff"),
+                    new SubRange(65, 70))));
+    _rfPrefixMoreSpecific.initCaches();
+    _rfPrefixExact =
+        new Route6FilterList(
+            "test-route6-filter-prefix",
+            ImmutableList.of(
+                new Route6FilterLine(
+                    LineAction.ACCEPT,
+                    new Ip6Wildcard(
+                        "2001:db8:1234:2345:3456:4567:5678:6789;0:0:0:0:ffff:ffff:ffff:ffff"),
+                    new SubRange(64, 64))));
+    _rfPrefixExact.initCaches();
+  }
+
+  @Test
+  public void testRfAddressMask() {
+    Prefix6 acceptedPrefix1 = new Prefix6("2001:db9:1234:2345:3456:8373:8728:1239/64");
+    Prefix6 deniedPrefix1 = new Prefix6("2002:db8:2346:2347:5353:4567:5678:6789/64");
+    Prefix6 deniedPrefix2 = new Prefix6("2001:db8:1234:2345:3456:4567:5678:6789/66");
+
+    assertThat(_rfAddressMask.permits(acceptedPrefix1), equalTo(true));
+    assertThat(_rfAddressMask.permits(deniedPrefix1), equalTo(false));
+    assertThat(_rfAddressMask.permits(deniedPrefix2), equalTo(false));
+  }
+
+  @Test
+  public void testRfPrefixMoreSpecific() {
+    Prefix6 acceptedPrefix1 = new Prefix6("2001:db8:1234:2345:5353:8373:8728:1239/66");
+    Prefix6 deniedPrefix1 = new Prefix6("2001:db8:4567:2345:5353:8373:8728:1239/66");
+    // matching prefix but is less specific
+    Prefix6 deniedPrefix2 = new Prefix6("2001:db8:1234:2345:5353:8373:8728:1239/62");
+
+    assertThat(_rfPrefixMoreSpecific.permits(acceptedPrefix1), equalTo(true));
+    assertThat(_rfPrefixMoreSpecific.permits(deniedPrefix1), equalTo(false));
+    assertThat(_rfPrefixMoreSpecific.permits(deniedPrefix2), equalTo(false));
+  }
+
+  @Test
+  public void testRfPrefixExact() {
+    Prefix6 acceptedPrefix1 = new Prefix6("2001:db8:1234:2345:5353:8373:8728:1239/64");
+    // matching prefix with non-equal prefix length
+    Prefix6 deniedPrefix1 = new Prefix6("2001:db8:1234:2345:5353:8373:8728:1239/65");
+
+    assertThat(_rfPrefixExact.permits(acceptedPrefix1), equalTo(true));
+    assertThat(_rfPrefixExact.permits(deniedPrefix1), equalTo(false));
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/RouteFilterListTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/RouteFilterListTest.java
@@ -1,0 +1,80 @@
+package org.batfish.datamodel;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Before;
+import org.junit.Test;
+
+/** Test for {@link RouteFilterList} */
+public class RouteFilterListTest {
+
+  private RouteFilterList _rfAddressMask;
+  private RouteFilterList _rfPrefixMoreSpecific;
+  private RouteFilterList _rfPrefixExact;
+
+  @Before
+  public void setup() {
+    _rfAddressMask =
+        new RouteFilterList(
+            "test-route-filter-mask",
+            ImmutableList.of(
+                new RouteFilterLine(
+                    LineAction.ACCEPT,
+                    new IpWildcard("1.2.3.4:0.255.0.255"),
+                    new SubRange(24, 24))));
+    _rfAddressMask.initCaches();
+    _rfPrefixMoreSpecific =
+        new RouteFilterList(
+            "test-route-filter-prefix",
+            ImmutableList.of(
+                new RouteFilterLine(
+                    LineAction.ACCEPT,
+                    new IpWildcard("1.2.3.4:0.0.255.255"),
+                    new SubRange(26, 32))));
+    _rfPrefixMoreSpecific.initCaches();
+    _rfPrefixExact =
+        new RouteFilterList(
+            "test-route-filter-prefix",
+            ImmutableList.of(
+                new RouteFilterLine(
+                    LineAction.ACCEPT,
+                    new IpWildcard("1.2.3.4:0.0.255.255"),
+                    new SubRange(26, 26))));
+    _rfPrefixExact.initCaches();
+  }
+
+  @Test
+  public void testRfAddressMask() {
+    Prefix acceptedPrefix1 = Prefix.parse("1.5.3.127/24");
+    Prefix deniedPrefix1 = Prefix.parse("2.5.6.127/24");
+    Prefix deniedPrefix2 = Prefix.parse("1.5.3.127/26");
+
+    assertThat(_rfAddressMask.permits(acceptedPrefix1), equalTo(true));
+    assertThat(_rfAddressMask.permits(deniedPrefix1), equalTo(false));
+    assertThat(_rfAddressMask.permits(deniedPrefix2), equalTo(false));
+  }
+
+  @Test
+  public void testRfPrefixMoreSpecific() {
+    Prefix acceptedPrefix1 = Prefix.parse("1.2.16.0/27");
+    Prefix deniedPrefix1 = Prefix.parse("1.3.5.6/27");
+    // matching prefix but is less specific
+    Prefix deniedPrefix2 = Prefix.parse("1.2.16.0/25");
+
+    assertThat(_rfPrefixMoreSpecific.permits(acceptedPrefix1), equalTo(true));
+    assertThat(_rfPrefixMoreSpecific.permits(deniedPrefix1), equalTo(false));
+    assertThat(_rfPrefixMoreSpecific.permits(deniedPrefix2), equalTo(false));
+  }
+
+  @Test
+  public void testRfPrefixExact() {
+    Prefix acceptedPrefix1 = Prefix.parse("1.2.16.0/26");
+    // matching prefix with non-equal prefix length
+    Prefix deniedPrefix1 = Prefix.parse("1.2.16.0/27");
+
+    assertThat(_rfPrefixExact.permits(acceptedPrefix1), equalTo(true));
+    assertThat(_rfPrefixExact.permits(deniedPrefix1), equalTo(false));
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/RouteFilterListMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/RouteFilterListMatchers.java
@@ -1,0 +1,20 @@
+package org.batfish.datamodel.matchers;
+
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.batfish.datamodel.RouteFilterLine;
+import org.batfish.datamodel.matchers.RouteFilterListMatchersImpl.HasLines;
+import org.hamcrest.Matcher;
+
+public class RouteFilterListMatchers {
+
+  /**
+   * Provides a matcher that matches if the provided {@code subMatcher} matches the {@link
+   * org.batfish.datamodel.RouteFilterList}'s lines.
+   */
+  public static HasLines hasLines(@Nonnull Matcher<? super List<RouteFilterLine>> subMatcher) {
+    return new HasLines(subMatcher);
+  }
+
+  private RouteFilterListMatchers() {}
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/RouteFilterListMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/RouteFilterListMatchersImpl.java
@@ -1,9 +1,13 @@
 package org.batfish.datamodel.matchers;
 
+import java.util.List;
 import javax.annotation.Nonnull;
 import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.RouteFilterLine;
 import org.batfish.datamodel.RouteFilterList;
 import org.hamcrest.Description;
+import org.hamcrest.FeatureMatcher;
+import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 final class RouteFilterListMatchersImpl {
@@ -28,6 +32,18 @@ final class RouteFilterListMatchersImpl {
       }
       mismatchDescription.appendText(String.format("does not permit prefix '%s'", _prefix));
       return false;
+    }
+  }
+
+  static class HasLines extends FeatureMatcher<RouteFilterList, List<RouteFilterLine>> {
+
+    public HasLines(Matcher<? super List<RouteFilterLine>> subMatcher) {
+      super(subMatcher, "a routeFilterList with lines:", "lines");
+    }
+
+    @Override
+    protected List<RouteFilterLine> featureValueOf(RouteFilterList actual) {
+      return actual.getLines();
     }
   }
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_policy_options.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_policy_options.g4
@@ -348,12 +348,22 @@ popsfpl_orlonger
 
 popsfrf_common
 :
-   popsfrf_exact
+   popsfrf_address_mask
+   | popsfrf_exact
    | popsfrf_longer
    | popsfrf_orlonger
    | popsfrf_prefix_length_range
    | popsfrf_through
    | popsfrf_upto
+;
+
+popsfrf_address_mask
+:
+   ADDRESS_MASK
+   (
+      IP_ADDRESS
+      | IPV6_ADDRESS
+   )
 ;
 
 popsfrf_exact

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -2057,7 +2057,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
       if (ctx.IP_ADDRESS().getText() != null) {
         Route4FilterLine line =
             new Route4FilterLineAddressMask(
-                _currentRouteFilterPrefix, new Ip(ctx.IP_ADDRESS().getText()));
+                _currentRouteFilterPrefix, new Ip(ctx.IP_ADDRESS().getText()).inverted());
         _currentRouteFilterLine = _currentRouteFilter.insertLine(line, Route4FilterLine.class);
       } else {
         _w.redFlag(
@@ -2069,7 +2069,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
       if (ctx.IPV6_ADDRESS().getText() != null) {
         Route6FilterLine line =
             new Route6FilterLineAddressMask(
-                _currentRoute6FilterPrefix, new Ip6(ctx.IPV6_ADDRESS().getText()));
+                _currentRoute6FilterPrefix, new Ip6(ctx.IPV6_ADDRESS().getText()).inverted());
         _currentRoute6FilterLine = _currentRouteFilter.insertLine(line, Route6FilterLine.class);
       } else {
         _w.redFlag(

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -36,6 +36,7 @@ import org.batfish.datamodel.IkeAuthenticationMethod;
 import org.batfish.datamodel.IkeProposal;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.Ip6;
 import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.IpsecAuthenticationAlgorithm;
@@ -207,6 +208,7 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsf_prefix_listContex
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsf_prefix_list_filterContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsf_protocolContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsf_route_filterContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsfrf_address_maskContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsfrf_exactContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsfrf_longerContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsfrf_orlongerContext;
@@ -441,6 +443,7 @@ import org.batfish.representation.juniper.PsThenNextHopIp;
 import org.batfish.representation.juniper.PsThenNextPolicy;
 import org.batfish.representation.juniper.PsThenReject;
 import org.batfish.representation.juniper.Route4FilterLine;
+import org.batfish.representation.juniper.Route4FilterLineAddressMask;
 import org.batfish.representation.juniper.Route4FilterLineExact;
 import org.batfish.representation.juniper.Route4FilterLineLengthRange;
 import org.batfish.representation.juniper.Route4FilterLineLonger;
@@ -448,6 +451,7 @@ import org.batfish.representation.juniper.Route4FilterLineOrLonger;
 import org.batfish.representation.juniper.Route4FilterLineThrough;
 import org.batfish.representation.juniper.Route4FilterLineUpTo;
 import org.batfish.representation.juniper.Route6FilterLine;
+import org.batfish.representation.juniper.Route6FilterLineAddressMask;
 import org.batfish.representation.juniper.Route6FilterLineExact;
 import org.batfish.representation.juniper.Route6FilterLineLengthRange;
 import org.batfish.representation.juniper.Route6FilterLineLonger;
@@ -2039,6 +2043,35 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
     } else if (ctx.IPV6_PREFIX() != null) {
       _currentRoute6FilterPrefix = new Prefix6(ctx.IPV6_PREFIX().getText());
       _currentRouteFilter.setIpv6(true);
+    }
+  }
+
+  @Override
+  public void exitPopsfrf_address_mask(Popsfrf_address_maskContext ctx) {
+    if (_currentRouteFilterPrefix != null) { // ipv4
+      if (ctx.IP_ADDRESS().getText() != null) {
+        Route4FilterLine line =
+            new Route4FilterLineAddressMask(
+                _currentRouteFilterPrefix, new Ip(ctx.IP_ADDRESS().getText()));
+        _currentRouteFilterLine = _currentRouteFilter.insertLine(line, Route4FilterLine.class);
+      } else {
+        _w.redFlag(
+            String.format(
+                "Route filter mask does not match version for prefix %s",
+                _currentRouteFilterPrefix));
+      }
+    } else if (_currentRoute6FilterPrefix != null) { // ipv6
+      if (ctx.IPV6_ADDRESS().getText() != null) {
+        Route6FilterLine line =
+            new Route6FilterLineAddressMask(
+                _currentRoute6FilterPrefix, new Ip6(ctx.IPV6_ADDRESS().getText()));
+        _currentRoute6FilterLine = _currentRouteFilter.insertLine(line, Route6FilterLine.class);
+      } else {
+        _w.redFlag(
+            String.format(
+                "Route filter mask does not match version for prefix %s",
+                _currentRouteFilterPrefix));
+      }
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -53,6 +53,7 @@ import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Ip6AccessList;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.IpAccessListLine;
+import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.IpsecPolicy;
 import org.batfish.datamodel.IpsecVpn;
 import org.batfish.datamodel.IsisInterfaceMode;
@@ -2749,13 +2750,15 @@ public final class CiscoConfiguration extends VendorConfiguration {
         summaryFilter.addLine(
             new RouteFilterLine(
                 LineAction.REJECT,
-                prefix,
+                new IpWildcard(prefix),
                 new SubRange(filterMinPrefixLength, Prefix.MAX_PREFIX_LENGTH)));
       }
       area.setSummaries(ImmutableSortedMap.copyOf(summaries));
       summaryFilter.addLine(
           new RouteFilterLine(
-              LineAction.ACCEPT, Prefix.ZERO, new SubRange(0, Prefix.MAX_PREFIX_LENGTH)));
+              LineAction.ACCEPT,
+              new IpWildcard(Prefix.ZERO),
+              new SubRange(0, Prefix.MAX_PREFIX_LENGTH)));
     }
 
     String ospfExportPolicyName = "~OSPF_EXPORT_POLICY:" + vrfName + "~";

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
@@ -252,7 +252,10 @@ class CiscoConversions {
     List<RouteFilterLine> newLines =
         list.getLines()
             .stream()
-            .map(l -> new RouteFilterLine(l.getAction(), l.getPrefix(), l.getLengthRange()))
+            .map(
+                l ->
+                    new RouteFilterLine(
+                        l.getAction(), new IpWildcard(l.getPrefix()), l.getLengthRange()))
             .collect(ImmutableList.toImmutableList());
     newRouteFilterList.setLines(newLines);
     return newRouteFilterList;
@@ -356,7 +359,8 @@ class CiscoConversions {
     int statedPrefixLength = srcIpWildcard.getWildcard().inverted().numSubnetBits();
     int prefixLength = Math.min(statedPrefixLength, minPrefixLength);
     Prefix prefix = new Prefix(ip, prefixLength);
-    return new RouteFilterLine(action, prefix, new SubRange(minPrefixLength, maxPrefixLength));
+    return new RouteFilterLine(
+        action, new IpWildcard(prefix), new SubRange(minPrefixLength, maxPrefixLength));
   }
 
   private CiscoConversions() {} // prevent instantiation of utility class

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsFromPrefixListFilterLonger.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsFromPrefixListFilterLonger.java
@@ -38,7 +38,7 @@ public final class PsFromPrefixListFilterLonger extends PsFrom {
       if (longerList == null) {
         longerList = new RouteFilterList(longerListName);
         for (RouteFilterLine line : rf.getLines()) {
-          Prefix prefix = line.getPrefix();
+          Prefix prefix = line.getIpWildcard().toPrefix();
           LineAction action = line.getAction();
           SubRange longerLineRange =
               new SubRange(line.getLengthRange().getStart() + 1, Prefix.MAX_PREFIX_LENGTH);

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsFromPrefixListFilterOrLonger.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsFromPrefixListFilterOrLonger.java
@@ -38,7 +38,7 @@ public final class PsFromPrefixListFilterOrLonger extends PsFrom {
       if (orLongerList == null) {
         orLongerList = new RouteFilterList(orLongerListName);
         for (RouteFilterLine line : rf.getLines()) {
-          Prefix prefix = line.getPrefix();
+          Prefix prefix = line.getIpWildcard().toPrefix();
           LineAction action = line.getAction();
           SubRange orLongerLineRange =
               new SubRange(line.getLengthRange().getStart(), Prefix.MAX_PREFIX_LENGTH);

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineAddressMask.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineAddressMask.java
@@ -1,0 +1,51 @@
+package org.batfish.representation.juniper;
+
+import java.util.Objects;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpWildcard;
+import org.batfish.datamodel.LineAction;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.RouteFilterList;
+import org.batfish.datamodel.SubRange;
+
+public final class Route4FilterLineAddressMask extends Route4FilterLine {
+
+  /** */
+  private static final long serialVersionUID = 1L;
+
+  private final Ip _addressMask;
+
+  public Route4FilterLineAddressMask(Prefix prefix, Ip addressMask) {
+    super(prefix);
+    _addressMask = addressMask;
+  }
+
+  @Override
+  public void applyTo(RouteFilterList rfl) {
+    int prefixLength = _prefix.getPrefixLength();
+    org.batfish.datamodel.RouteFilterLine line =
+        new org.batfish.datamodel.RouteFilterLine(
+            LineAction.ACCEPT,
+            new IpWildcard(
+                new Prefix(_prefix.getStartIp(), prefixLength).getStartIp(), _addressMask),
+            new SubRange(prefixLength, prefixLength));
+    rfl.addLine(line);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof Route4FilterLineAddressMask)) {
+      return false;
+    }
+
+    Route4FilterLineAddressMask rhs = (Route4FilterLineAddressMask) o;
+    return _prefix.equals(rhs._prefix) && _addressMask.equals(rhs._addressMask);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_prefix, _addressMask);
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineThrough.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineThrough.java
@@ -15,7 +15,7 @@ public final class Route4FilterLineThrough extends Route4FilterLine {
 
   public Route4FilterLineThrough(Prefix prefix, Prefix throughPrefix) {
     super(prefix);
-    _throughPrefix = prefix;
+    _throughPrefix = throughPrefix;
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Route6FilterLineAddressMask.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Route6FilterLineAddressMask.java
@@ -1,0 +1,51 @@
+package org.batfish.representation.juniper;
+
+import java.util.Objects;
+import org.batfish.datamodel.Ip6;
+import org.batfish.datamodel.Ip6Wildcard;
+import org.batfish.datamodel.LineAction;
+import org.batfish.datamodel.Prefix6;
+import org.batfish.datamodel.Route6FilterList;
+import org.batfish.datamodel.SubRange;
+
+public final class Route6FilterLineAddressMask extends Route6FilterLine {
+
+  /** */
+  private static final long serialVersionUID = 1L;
+
+  private final Ip6 _addressMask;
+
+  public Route6FilterLineAddressMask(Prefix6 prefix6, Ip6 addressMask) {
+    super(prefix6);
+    _addressMask = addressMask;
+  }
+
+  @Override
+  public void applyTo(Route6FilterList rfl) {
+    int prefixLength = _prefix6.getPrefixLength();
+    org.batfish.datamodel.Route6FilterLine line =
+        new org.batfish.datamodel.Route6FilterLine(
+            LineAction.ACCEPT,
+            new Ip6Wildcard(
+                new Prefix6(_prefix6.getAddress(), prefixLength).getAddress(), _addressMask),
+            new SubRange(prefixLength, prefixLength));
+    rfl.addLine(line);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof Route6FilterLineAddressMask)) {
+      return false;
+    }
+
+    Route6FilterLineAddressMask rhs = (Route6FilterLineAddressMask) o;
+    return _prefix6.equals(rhs._prefix6) && _addressMask.equals(rhs._addressMask);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_prefix6, _addressMask);
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/symbolic/bdd/TransferBDD.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/bdd/TransferBDD.java
@@ -848,7 +848,7 @@ class TransferBDD {
     List<RouteFilterLine> lines = new ArrayList<>(x.getLines());
     Collections.reverse(lines);
     for (RouteFilterLine line : lines) {
-      Prefix pfx = line.getPrefix();
+      Prefix pfx = line.getIpWildcard().toPrefix();
       if (!PrefixUtils.isContainedBy(pfx, _ignoredNetworks)) {
         SubRange r = line.getLengthRange();
         PrefixRange range = new PrefixRange(pfx, r);

--- a/projects/batfish/src/main/java/org/batfish/symbolic/smt/Optimizations.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/smt/Optimizations.java
@@ -524,7 +524,7 @@ class Optimizations {
                       (name, filter) -> {
                         if (name.contains(AGGREGATION_SUPPRESS_NAME)) {
                           for (RouteFilterLine line : filter.getLines()) {
-                            prefixes.add(line.getPrefix());
+                            prefixes.add(line.getIpWildcard().toPrefix());
                           }
                         }
                       });

--- a/projects/batfish/src/main/java/org/batfish/symbolic/smt/TransferSSA.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/smt/TransferSSA.java
@@ -214,7 +214,7 @@ class TransferSSA {
     Collections.reverse(lines);
 
     for (RouteFilterLine line : lines) {
-      Prefix p = line.getPrefix();
+      Prefix p = line.getIpWildcard().toPrefix();
       SubRange r = line.getLengthRange();
       PrefixRange range = new PrefixRange(p, r);
       BoolExpr matches = _enc.isRelevantFor(other.getPrefixLength(), range);

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -157,10 +157,10 @@ public class FlatJuniperGrammarTest {
     return fb.build();
   }
 
-  private static Flow createFlow(IpProtocol protocol, int port) {
+  private static Flow createTcpFlow(int port) {
     Flow.Builder fb = new Flow.Builder();
     fb.setIngressNode("node");
-    fb.setIpProtocol(protocol);
+    fb.setIpProtocol(IpProtocol.TCP);
     fb.setDstPort(port);
     fb.setSrcPort(port);
     fb.setTag("test");
@@ -309,8 +309,8 @@ public class FlatJuniperGrammarTest {
     IpAccessList aclNested = c.getIpAccessLists().get(aclNameNested);
     IpAccessList aclMultiNested = c.getIpAccessLists().get(aclNameMultiNested);
     /* Allowed application permits TCP from port 1 only */
-    Flow permittedFlow = createFlow(IpProtocol.TCP, 1);
-    Flow rejectedFlow = createFlow(IpProtocol.TCP, 2);
+    Flow permittedFlow = createTcpFlow(1);
+    Flow rejectedFlow = createTcpFlow(2);
 
     /*
      * Confirm non-nested application-set acl accepts the allowed protocol-port combo and reject
@@ -496,9 +496,9 @@ public class FlatJuniperGrammarTest {
     IpAccessList aclApplicationSetAny = c.getIpAccessLists().get(aclApplicationSetAnyName);
     IpAccessList aclApplicationAny = c.getIpAccessLists().get(aclApplicationAnyName);
     /* Allowed applications permits TCP to port 80 and 443 */
-    Flow permittedHttpFlow = createFlow(IpProtocol.TCP, 80);
-    Flow permittedHttpsFlow = createFlow(IpProtocol.TCP, 443);
-    Flow rejectedFlow = createFlow(IpProtocol.TCP, 100);
+    Flow permittedHttpFlow = createTcpFlow(80);
+    Flow permittedHttpsFlow = createTcpFlow(443);
+    Flow rejectedFlow = createTcpFlow(100);
 
     /*
      * Confirm there are no undefined references
@@ -560,7 +560,7 @@ public class FlatJuniperGrammarTest {
   }
 
   @Test
-  public void testEnforceFirstAs() throws IOException {
+  public void testEnforceFistAs() throws IOException {
     String hostname = "bgp-enforce-first-as";
     Configuration c = parseConfig(hostname);
     assertThat(c, hasDefaultVrf(hasBgpProcess(hasNeighbors(hasValue(hasEnforceFirstAs())))));
@@ -1147,16 +1147,8 @@ public class FlatJuniperGrammarTest {
   }
 
   @Test
-  public void testIpProtocol() throws IOException {
-    String hostname = "firewall-filter-ip-protocol";
-    Configuration c = parseConfig(hostname);
-
-    Flow tcpFlow = createFlow(IpProtocol.TCP, 0);
-    Flow icmpFlow = createFlow(IpProtocol.ICMP, 0);
-
-    // Tcp flow should be accepted by the filter and others should be rejected
-    assertThat(c, hasIpAccessList("FILTER", accepts(tcpFlow, null, c)));
-    assertThat(c, hasIpAccessList("FILTER", rejects(icmpFlow, null, c)));
+  public void testRouteFilter() throws IOException{
+    Configuration c = parseConfig("route-filter");
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -28,7 +28,6 @@ import static org.batfish.datamodel.matchers.InterfaceMatchers.isOspfPassive;
 import static org.batfish.datamodel.matchers.IpAccessListLineMatchers.hasAction;
 import static org.batfish.datamodel.matchers.IpAccessListLineMatchers.hasMatchCondition;
 import static org.batfish.datamodel.matchers.IpAccessListMatchers.accepts;
-import static org.batfish.datamodel.matchers.IpAccessListMatchers.hasLines;
 import static org.batfish.datamodel.matchers.IpAccessListMatchers.rejects;
 import static org.batfish.datamodel.matchers.IpSpaceMatchers.containsIp;
 import static org.batfish.datamodel.matchers.OrMatchExprMatchers.hasDisjuncts;
@@ -73,6 +72,7 @@ import org.batfish.datamodel.BgpNeighbor;
 import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.BgpRoute;
 import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConnectedRoute;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.InterfaceAddress;
@@ -88,6 +88,8 @@ import org.batfish.datamodel.MultipathEquivalentAsPathMatchMode;
 import org.batfish.datamodel.OspfAreaSummary;
 import org.batfish.datamodel.OspfExternalType2Route;
 import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.RouteFilterLine;
+import org.batfish.datamodel.RouteFilterList;
 import org.batfish.datamodel.State;
 import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.SwitchportMode;
@@ -212,7 +214,7 @@ public class FlatJuniperGrammarTest {
         c,
         hasIpAccessList(
             ACL_NAME_GLOBAL_POLICY,
-            hasLines(
+            org.batfish.datamodel.matchers.IpAccessListMatchers.hasLines(
                 equalTo(
                     ImmutableList.of(
                         IpAccessListLine.acceptingHeaderSpace(
@@ -354,7 +356,7 @@ public class FlatJuniperGrammarTest {
         c,
         hasIpAccessList(
             ACL_NAME_GLOBAL_POLICY,
-            hasLines(
+            org.batfish.datamodel.matchers.IpAccessListMatchers.hasLines(
                 equalTo(
                     ImmutableList.of(
                         IpAccessListLine.acceptingHeaderSpace(
@@ -1187,7 +1189,7 @@ public class FlatJuniperGrammarTest {
         c,
         hasIpAccessList(
             filterNameV4,
-            hasLines(
+            org.batfish.datamodel.matchers.IpAccessListMatchers.hasLines(
                 equalTo(
                     ImmutableList.of(
                         IpAccessListLine.builder()
@@ -1222,7 +1224,7 @@ public class FlatJuniperGrammarTest {
         c,
         hasIpAccessList(
             filterNameV4,
-            hasLines(
+            org.batfish.datamodel.matchers.IpAccessListMatchers.hasLines(
                 equalTo(
                     ImmutableList.of(
                         IpAccessListLine.builder()
@@ -1546,6 +1548,28 @@ public class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testRouteFilters() throws IOException {
+    Configuration c = parseConfig("route-filter");
+    RouteFilterList rfl = c.getRouteFilterLists().get("route-filter-test:t1");
+    assertThat(
+        rfl,
+        org.batfish.datamodel.matchers.RouteFilterListMatchers.hasLines(
+            containsInAnyOrder(
+                new RouteFilterLine(
+                    LineAction.ACCEPT, Prefix.parse("1.2.0.0/16"), new SubRange(16, 16)),
+                new RouteFilterLine(
+                    LineAction.ACCEPT, Prefix.parse("1.2.0.0/16"), new SubRange(17, 32)),
+                new RouteFilterLine(
+                    LineAction.ACCEPT, Prefix.parse("1.7.0.0/16"), new SubRange(16, 16)),
+                new RouteFilterLine(
+                    LineAction.ACCEPT, Prefix.parse("1.7.0.0/17"), new SubRange(17, 17)),
+                new RouteFilterLine(
+                    LineAction.ACCEPT,
+                    new IpWildcard("1.0.0.0:0.255.0.255"),
+                    new SubRange(16, 16)))));
+  }
+
+  @Test
   public void testRoutingInstanceType() throws IOException {
     Configuration c = parseConfig("routing-instance-type");
 
@@ -1556,6 +1580,104 @@ public class FlatJuniperGrammarTest {
     assertThat(c, hasVrfs(hasKey("ri-virtual-router")));
     assertThat(c, hasVrfs(hasKey("ri-virtual-switch")));
     assertThat(c, hasVrfs(hasKey("ri-vrf")));
+  }
+
+  @Test
+  public void testRoutingPolicy() throws IOException {
+    Configuration c = parseConfig("routing-policy");
+    Environment.Builder eb = Environment.builder(c).setDirection(Direction.IN);
+
+    RoutingPolicy policyExact = c.getRoutingPolicies().get("route-filter-exact");
+    RoutingPolicy policyLonger = c.getRoutingPolicies().get("route-filter-longer");
+    RoutingPolicy policyPrange = c.getRoutingPolicies().get("route-filter-prange");
+    RoutingPolicy policyThrough = c.getRoutingPolicies().get("route-filter-through");
+    RoutingPolicy policyAddressmask = c.getRoutingPolicies().get("route-filter-addressmask");
+
+    ConnectedRoute connectedRouteExact =
+        new ConnectedRoute(Prefix.parse("1.2.3.4/16"), "nhinttest");
+    ConnectedRoute connectedRouteLonger =
+        new ConnectedRoute(Prefix.parse("1.2.3.4/19"), "nhinttest");
+    ConnectedRoute connectedRouteInRange =
+        new ConnectedRoute(Prefix.parse("1.2.3.4/17"), "nhinttest");
+    ConnectedRoute connectedRouteInvalidPrefix =
+        new ConnectedRoute(Prefix.parse("2.3.3.4/17"), "nhinttest");
+    ConnectedRoute connectedRouteInvalidLength =
+        new ConnectedRoute(Prefix.parse("2.3.3.4/29"), "nhinttest");
+
+    ConnectedRoute connectedRouteMaskInvalidPrefix =
+        new ConnectedRoute(Prefix.parse("9.2.9.4/16"), "nhinttest");
+    ConnectedRoute connectedRouteMaskValid =
+        new ConnectedRoute(Prefix.parse("1.9.3.9/16"), "nhinttest");
+    ConnectedRoute connectedRouteMaskInvalidLength =
+        new ConnectedRoute(Prefix.parse("1.9.3.9/17"), "nhinttest");
+
+    eb.setVrf("vrf1");
+
+    assertThat(
+        policyExact.call(eb.setOriginalRoute(connectedRouteExact).build()).getBooleanValue(),
+        equalTo(true));
+    assertThat(
+        policyExact.call(eb.setOriginalRoute(connectedRouteLonger).build()).getBooleanValue(),
+        equalTo(false));
+    assertThat(
+        policyExact
+            .call(eb.setOriginalRoute(connectedRouteInvalidPrefix).build())
+            .getBooleanValue(),
+        equalTo(false));
+
+    assertThat(
+        policyLonger.call(eb.setOriginalRoute(connectedRouteLonger).build()).getBooleanValue(),
+        equalTo(true));
+    assertThat(
+        policyLonger
+            .call(eb.setOriginalRoute(connectedRouteInvalidLength).build())
+            .getBooleanValue(),
+        equalTo(false));
+    assertThat(
+        policyLonger
+            .call(eb.setOriginalRoute(connectedRouteInvalidPrefix).build())
+            .getBooleanValue(),
+        equalTo(false));
+
+    assertThat(
+        policyPrange.call(eb.setOriginalRoute(connectedRouteInRange).build()).getBooleanValue(),
+        equalTo(true));
+    assertThat(
+        policyPrange.call(eb.setOriginalRoute(connectedRouteLonger).build()).getBooleanValue(),
+        equalTo(false));
+    assertThat(
+        policyPrange
+            .call(eb.setOriginalRoute(connectedRouteInvalidPrefix).build())
+            .getBooleanValue(),
+        equalTo(false));
+
+    assertThat(
+        policyThrough.call(eb.setOriginalRoute(connectedRouteInRange).build()).getBooleanValue(),
+        equalTo(true));
+    assertThat(
+        policyThrough.call(eb.setOriginalRoute(connectedRouteLonger).build()).getBooleanValue(),
+        equalTo(false));
+    assertThat(
+        policyThrough
+            .call(eb.setOriginalRoute(connectedRouteInvalidPrefix).build())
+            .getBooleanValue(),
+        equalTo(false));
+
+    assertThat(
+        policyAddressmask
+            .call(eb.setOriginalRoute(connectedRouteMaskValid).build())
+            .getBooleanValue(),
+        equalTo(true));
+    assertThat(
+        policyAddressmask
+            .call(eb.setOriginalRoute(connectedRouteMaskInvalidPrefix).build())
+            .getBooleanValue(),
+        equalTo(false));
+    assertThat(
+        policyAddressmask
+            .call(eb.setOriginalRoute(connectedRouteMaskInvalidLength).build())
+            .getBooleanValue(),
+        equalTo(false));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/policy-options
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/policy-options
@@ -1,1 +1,0 @@
-set policy-options policy-statement COR-IMPORT-SPN term LOOPBACKS from route-filter 10.0.253.0/32 address-mask 255.0.255.248

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/policy-options
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/policy-options
@@ -1,0 +1,1 @@
+set policy-options policy-statement COR-IMPORT-SPN term LOOPBACKS from route-filter 10.0.253.0/32 address-mask 255.0.255.248

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/route-filter
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/route-filter
@@ -1,10 +1,7 @@
 #
-set system host-name route_filter
+set system host-name route-filter
 #
-set policy-options policy-statement route-filter-test-v4 term t1 from route-filter 1.2.0.0/16 exact
-set policy-options policy-statement route-filter-test-v4 term t1 from route-filter 1.3.0.0/17 longer
-set policy-options policy-statement route-filter-test-v4 term t1 from route-filter 1.4.0.0/18 orlonger
-set policy-options policy-statement route-filter-test-v4 term t1 from route-filter 1.5.0.0/19 upto /24
-set policy-options policy-statement route-filter-test-v4 term t1 from route-filter 1.6.0.0/20 prefix-length-range /26-/29
-set policy-options policy-statement route-filter-test-v4 term t1 from route-filter 1.7.0.0/21 through 1.7.0.0/24
-#
+set policy-options policy-statement route-filter-test term t1 from route-filter 1.2.0.0/16 exact
+set policy-options policy-statement route-filter-test term t1 from route-filter 1.2.0.0/16 longer
+set policy-options policy-statement route-filter-test term t1 from route-filter 1.7.0.0/16 through 1.7.0.0/17
+set policy-options policy-statement route-filter-test term t1 from route-filter 1.2.3.4/16 address-mask 255.0.255.0

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/route-filter
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/route-filter
@@ -1,0 +1,10 @@
+#
+set system host-name route_filter
+#
+set policy-options policy-statement route-filter-test-v4 term t1 from route-filter 1.2.0.0/16 exact
+set policy-options policy-statement route-filter-test-v4 term t1 from route-filter 1.3.0.0/17 longer
+set policy-options policy-statement route-filter-test-v4 term t1 from route-filter 1.4.0.0/18 orlonger
+set policy-options policy-statement route-filter-test-v4 term t1 from route-filter 1.5.0.0/19 upto /24
+set policy-options policy-statement route-filter-test-v4 term t1 from route-filter 1.6.0.0/20 prefix-length-range /26-/29
+set policy-options policy-statement route-filter-test-v4 term t1 from route-filter 1.7.0.0/21 through 1.7.0.0/24
+#

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/routing-policy
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/routing-policy
@@ -1,0 +1,23 @@
+#
+set system host-name routing-policy
+#
+set interfaces xe-0/0/1 unit 0 family inet address 1.0.0.0/31
+
+set routing-instances vrf1 instance-type virtual-router
+set routing-instances vrf1 interface xe-0/0/1.0
+
+set policy-options policy-statement route-filter-exact term t1 from route-filter 1.2.0.0/16 exact
+set policy-options policy-statement route-filter-exact term t1 then accept
+
+set policy-options policy-statement route-filter-longer term t1 from route-filter 1.2.0.0/16 longer
+set policy-options policy-statement route-filter-longer term t1 then accept
+
+set policy-options policy-statement route-filter-prange term t1 from route-filter 1.2.0.0/16 prefix-length-range /16-/18
+set policy-options policy-statement route-filter-prange term t1 then accept
+
+set policy-options policy-statement route-filter-through term t1 from route-filter 1.2.0.0/16 through 1.2.0.0/18
+set policy-options policy-statement route-filter-through term t1 then accept
+
+set policy-options policy-statement route-filter-addressmask term t1 from route-filter 1.2.3.4/16 address-mask 255.0.255.0
+set policy-options policy-statement route-filter-addressmask term t1 then accept
+#

--- a/test_rigs/parsing-tests/unit-tests-nodes.ref
+++ b/test_rigs/parsing-tests/unit-tests-nodes.ref
@@ -275,8 +275,8 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "52-128",
-                "prefix" : "2607:f010:3f9:8000:0:0:0:0/52"
+                "ipWildcard" : "2607:f010:3f9:8000:0:0:0:0/52",
+                "lengthRange" : "52-128"
               }
             ],
             "name" : "ScienceDMZ-networks"
@@ -285,8 +285,8 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "52-52",
-                "prefix" : "2607:f010:3f9:8000:0:0:0:0/52"
+                "ipWildcard" : "2607:f010:3f9:8000:0:0:0:0/52",
+                "lengthRange" : "52-52"
               }
             ],
             "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
@@ -298,8 +298,8 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-32",
-                "prefix" : "192.154.2.0/24"
+                "ipWildcard" : "192.154.2.0/24",
+                "lengthRange" : "24-32"
               }
             ]
           },
@@ -308,8 +308,8 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "25-32",
-                "prefix" : "192.154.2.0/24"
+                "ipWildcard" : "192.154.2.0/24",
+                "lengthRange" : "25-32"
               }
             ]
           }
@@ -2882,8 +2882,8 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "32-32",
-                "prefix" : "2607:f380:0:0:0:0:0:0/32"
+                "ipWildcard" : "2607:f380:0:0:0:0:0:0/32",
+                "lengthRange" : "32-32"
               }
             ],
             "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
@@ -4082,13 +4082,13 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "128-128",
-                "prefix" : "0:0:0:0:0:0:0:0/128"
+                "ipWildcard" : "0:0:0:0:0:0:0:0",
+                "lengthRange" : "128-128"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "64-64",
-                "prefix" : "dead:beef:0:0:0:0:0:0/26"
+                "ipWildcard" : "dead:beef:0:0:0:0:0:0/26",
+                "lengthRange" : "64-64"
               }
             ],
             "name" : "bar"
@@ -4100,8 +4100,8 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-32",
-                "prefix" : "2.2.0.0/19"
+                "ipWildcard" : "2.2.0.0/19",
+                "lengthRange" : "24-32"
               }
             ]
           },
@@ -4110,13 +4110,13 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "32-32",
-                "prefix" : "1.1.1.1/32"
+                "ipWildcard" : "1.1.1.1",
+                "lengthRange" : "32-32"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-32",
-                "prefix" : "2.2.0.0/19"
+                "ipWildcard" : "2.2.0.0/19",
+                "lengthRange" : "24-32"
               }
             ]
           }
@@ -4746,13 +4746,13 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-24",
-                "prefix" : "192.0.2.0/24"
+                "ipWildcard" : "192.0.2.0/24",
+                "lengthRange" : "24-24"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-32",
-                "prefix" : "209.165.201.0/24"
+                "ipWildcard" : "209.165.201.0/24",
+                "lengthRange" : "24-32"
               }
             ]
           },
@@ -4761,13 +4761,13 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-32",
-                "prefix" : "192.0.2.0/24"
+                "ipWildcard" : "192.0.2.0/24",
+                "lengthRange" : "24-32"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-32",
-                "prefix" : "209.165.201.0/24"
+                "ipWildcard" : "209.165.201.0/24",
+                "lengthRange" : "24-32"
               }
             ]
           }
@@ -4878,8 +4878,8 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "17-32",
-                "prefix" : "192.168.0.0/16"
+                "ipWildcard" : "192.168.0.0/16",
+                "lengthRange" : "17-32"
               }
             ]
           }
@@ -8356,8 +8356,8 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "120-120",
-                "prefix" : "fe80:0:0:0:0:0:0:0/120"
+                "ipWildcard" : "fe80:0:0:0:0:0:0:0/120",
+                "lengthRange" : "120-120"
               }
             ],
             "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
@@ -8579,13 +8579,13 @@
             "lines" : [
               {
                 "action" : "REJECT",
-                "lengthRange" : "25-32",
-                "prefix" : "1.2.3.0/24"
+                "ipWildcard" : "1.2.3.0/24",
+                "lengthRange" : "25-32"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "0-32",
-                "prefix" : "0.0.0.0/0"
+                "ipWildcard" : "0.0.0.0/0",
+                "lengthRange" : "0-32"
               }
             ]
           },
@@ -8594,13 +8594,13 @@
             "lines" : [
               {
                 "action" : "REJECT",
-                "lengthRange" : "24-32",
-                "prefix" : "1.2.3.0/24"
+                "ipWildcard" : "1.2.3.0/24",
+                "lengthRange" : "24-32"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "0-32",
-                "prefix" : "0.0.0.0/0"
+                "ipWildcard" : "0.0.0.0/0",
+                "lengthRange" : "0-32"
               }
             ]
           }
@@ -10028,8 +10028,8 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "15-32",
-                "prefix" : "10.0.0.0/15"
+                "ipWildcard" : "10.0.0.0/15",
+                "lengthRange" : "15-32"
               }
             ]
           }
@@ -12147,13 +12147,13 @@
             "lines" : [
               {
                 "action" : "REJECT",
-                "lengthRange" : "16-32",
-                "prefix" : "10.0.0.0/15"
+                "ipWildcard" : "10.0.0.0/15",
+                "lengthRange" : "16-32"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "0-32",
-                "prefix" : "0.0.0.0/0"
+                "ipWildcard" : "0.0.0.0/0",
+                "lengthRange" : "0-32"
               }
             ]
           }
@@ -12395,8 +12395,8 @@
             "lines" : [
               {
                 "action" : "REJECT",
-                "lengthRange" : "0-32",
-                "prefix" : "0.0.0.0/0"
+                "ipWildcard" : "0.0.0.0/0",
+                "lengthRange" : "0-32"
               }
             ]
           }
@@ -13896,33 +13896,33 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "48-48",
-                "prefix" : "2001:db8:1234:0:0:0:0:0/48"
+                "ipWildcard" : "2001:db8:1234:0:0:0:0:0/48",
+                "lengthRange" : "48-48"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "59-128",
-                "prefix" : "2001:db8:1235:0:0:0:0:0/58"
+                "ipWildcard" : "2001:db8:1235:0:0:0:0:0/58",
+                "lengthRange" : "59-128"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "68-128",
-                "prefix" : "2001:db8:1236:0:0:0:0:0/68"
+                "ipWildcard" : "2001:db8:1236:0:0:0:0:0/68",
+                "lengthRange" : "68-128"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "78-88",
-                "prefix" : "2001:db8:1237:0:0:0:0:0/78"
+                "ipWildcard" : "2001:db8:1237:0:0:0:0:0/78",
+                "lengthRange" : "78-88"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "100-110",
-                "prefix" : "2001:db8:1238:0:0:0:0:0/88"
+                "ipWildcard" : "2001:db8:1238:0:0:0:0:0/88",
+                "lengthRange" : "100-110"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "98-98",
-                "prefix" : "2001:db8:1239:0:0:0:0:0/98"
+                "ipWildcard" : "2001:db8:1239:0:0:0:0:0/98",
+                "lengthRange" : "98-98"
               }
             ],
             "name" : "route-filter-test-v6:t1"
@@ -13934,33 +13934,48 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "16-16",
-                "prefix" : "1.2.0.0/16"
+                "ipWildcard" : "1.2.0.0/16",
+                "lengthRange" : "16-16"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "18-32",
-                "prefix" : "1.3.0.0/17"
+                "ipWildcard" : "1.3.0.0/17",
+                "lengthRange" : "18-32"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "18-32",
-                "prefix" : "1.4.0.0/18"
+                "ipWildcard" : "1.4.0.0/18",
+                "lengthRange" : "18-32"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "19-24",
-                "prefix" : "1.5.0.0/19"
+                "ipWildcard" : "1.5.0.0/19",
+                "lengthRange" : "19-24"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "26-29",
-                "prefix" : "1.6.0.0/20"
+                "ipWildcard" : "1.6.0.0/20",
+                "lengthRange" : "26-29"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "21-21",
-                "prefix" : "1.7.0.0/21"
+                "ipWildcard" : "1.7.0.0/21",
+                "lengthRange" : "21-21"
+              },
+              {
+                "action" : "ACCEPT",
+                "ipWildcard" : "1.7.0.0/22",
+                "lengthRange" : "22-22"
+              },
+              {
+                "action" : "ACCEPT",
+                "ipWildcard" : "1.7.0.0/23",
+                "lengthRange" : "23-23"
+              },
+              {
+                "action" : "ACCEPT",
+                "ipWildcard" : "1.7.0.0/24",
+                "lengthRange" : "24-24"
               }
             ]
           }
@@ -14052,8 +14067,8 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "9-32",
-                "prefix" : "10.0.0.0/8"
+                "ipWildcard" : "10.0.0.0/8",
+                "lengthRange" : "9-32"
               }
             ]
           }
@@ -15241,8 +15256,8 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "64-64",
-                "prefix" : "1a01:111:a100:1001:0:0:0:0/64"
+                "ipWildcard" : "1a01:111:a100:1001:0:0:0:0/64",
+                "lengthRange" : "64-64"
               }
             ],
             "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
@@ -15393,8 +15408,8 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "120-120",
-                "prefix" : "0:0:0:0:0:0:102:300/120"
+                "ipWildcard" : "0:0:0:0:0:0:102:300/120",
+                "lengthRange" : "120-120"
               }
             ],
             "name" : "~BGP_NETWORK6_NETWORKS_FILTER:default~"
@@ -18113,8 +18128,8 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "32-32",
-                "prefix" : "0.0.0.0/32"
+                "ipWildcard" : "0.0.0.0",
+                "lengthRange" : "32-32"
               }
             ]
           },
@@ -18123,43 +18138,43 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "16-32",
-                "prefix" : "128.97.0.0/16"
+                "ipWildcard" : "128.97.0.0/16",
+                "lengthRange" : "16-32"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "16-32",
-                "prefix" : "131.179.0.0/16"
+                "ipWildcard" : "131.179.0.0/16",
+                "lengthRange" : "16-32"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "16-32",
-                "prefix" : "149.142.0.0/16"
+                "ipWildcard" : "149.142.0.0/16",
+                "lengthRange" : "16-32"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "16-32",
-                "prefix" : "164.67.0.0/16"
+                "ipWildcard" : "164.67.0.0/16",
+                "lengthRange" : "16-32"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "16-32",
-                "prefix" : "169.232.0.0/16"
+                "ipWildcard" : "169.232.0.0/16",
+                "lengthRange" : "16-32"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-32",
-                "prefix" : "192.35.225.0/24"
+                "ipWildcard" : "192.35.225.0/24",
+                "lengthRange" : "24-32"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-32",
-                "prefix" : "192.154.2.0/24"
+                "ipWildcard" : "192.154.2.0/24",
+                "lengthRange" : "24-32"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-32",
-                "prefix" : "198.17.109.0/24"
+                "ipWildcard" : "198.17.109.0/24",
+                "lengthRange" : "24-32"
               }
             ]
           }
@@ -18190,8 +18205,8 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "0-0",
-                "prefix" : "0.0.0.0/0"
+                "ipWildcard" : "0.0.0.0/0",
+                "lengthRange" : "0-0"
               }
             ]
           },
@@ -18200,8 +18215,8 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "31-31",
-                "prefix" : "192.168.100.2/31"
+                "ipWildcard" : "192.168.100.2/31",
+                "lengthRange" : "31-31"
               }
             ]
           }
@@ -20166,8 +20181,8 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "128-128",
-                "prefix" : "0:0:0:0:0:0:0:0/128"
+                "ipWildcard" : "0:0:0:0:0:0:0:0",
+                "lengthRange" : "128-128"
               }
             ],
             "name" : "v6_list"
@@ -20179,8 +20194,8 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "0-0",
-                "prefix" : "0.0.0.0/0"
+                "ipWildcard" : "0.0.0.0/0",
+                "lengthRange" : "0-0"
               }
             ]
           }

--- a/tests/aws/nodes-example-aws.ref
+++ b/tests/aws/nodes-example-aws.ref
@@ -1065,8 +1065,8 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "0-32",
-                "prefix" : "0.0.0.0/0"
+                "ipWildcard" : "0.0.0.0/0",
+                "lengthRange" : "0-32"
               }
             ]
           },
@@ -1075,13 +1075,13 @@
             "lines" : [
               {
                 "action" : "REJECT",
-                "lengthRange" : "28-32",
-                "prefix" : "10.10.255.0/28"
+                "ipWildcard" : "10.10.255.0/28",
+                "lengthRange" : "28-32"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "0-32",
-                "prefix" : "0.0.0.0/0"
+                "ipWildcard" : "0.0.0.0/0",
+                "lengthRange" : "0-32"
               }
             ]
           }
@@ -3821,8 +3821,8 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "16-16",
-                "prefix" : "10.100.0.0/16"
+                "ipWildcard" : "10.100.0.0/16",
+                "lengthRange" : "16-16"
               }
             ]
           },
@@ -3831,8 +3831,8 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "16-16",
-                "prefix" : "10.100.0.0/16"
+                "ipWildcard" : "10.100.0.0/16",
+                "lengthRange" : "16-16"
               }
             ]
           }

--- a/tests/basic/nodes.ref
+++ b/tests/basic/nodes.ref
@@ -298,13 +298,13 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-24",
-                "prefix" : "1.0.1.0/24"
+                "ipWildcard" : "1.0.1.0/24",
+                "lengthRange" : "24-24"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-24",
-                "prefix" : "1.0.2.0/24"
+                "ipWildcard" : "1.0.2.0/24",
+                "lengthRange" : "24-24"
               }
             ]
           },
@@ -313,13 +313,13 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "8-8",
-                "prefix" : "2.0.0.0/8"
+                "ipWildcard" : "2.0.0.0/8",
+                "lengthRange" : "8-8"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "16-16",
-                "prefix" : "2.128.0.0/16"
+                "ipWildcard" : "2.128.0.0/16",
+                "lengthRange" : "16-16"
               }
             ]
           },
@@ -328,13 +328,13 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-24",
-                "prefix" : "3.0.1.0/24"
+                "ipWildcard" : "3.0.1.0/24",
+                "lengthRange" : "24-24"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-24",
-                "prefix" : "3.0.2.0/24"
+                "ipWildcard" : "3.0.2.0/24",
+                "lengthRange" : "24-24"
               }
             ]
           },
@@ -343,8 +343,8 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "0-0",
-                "prefix" : "0.0.0.0/0"
+                "ipWildcard" : "0.0.0.0/0",
+                "lengthRange" : "0-0"
               }
             ]
           },
@@ -353,13 +353,13 @@
             "lines" : [
               {
                 "action" : "REJECT",
-                "lengthRange" : "8-32",
-                "prefix" : "1.0.0.0/8"
+                "ipWildcard" : "1.0.0.0/8",
+                "lengthRange" : "8-32"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "0-32",
-                "prefix" : "0.0.0.0/0"
+                "ipWildcard" : "0.0.0.0/0",
+                "lengthRange" : "0-32"
               }
             ]
           }
@@ -1565,13 +1565,13 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-24",
-                "prefix" : "1.0.1.0/24"
+                "ipWildcard" : "1.0.1.0/24",
+                "lengthRange" : "24-24"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-24",
-                "prefix" : "1.0.2.0/24"
+                "ipWildcard" : "1.0.2.0/24",
+                "lengthRange" : "24-24"
               }
             ]
           },
@@ -1580,13 +1580,13 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "8-8",
-                "prefix" : "2.0.0.0/8"
+                "ipWildcard" : "2.0.0.0/8",
+                "lengthRange" : "8-8"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "16-16",
-                "prefix" : "2.128.0.0/16"
+                "ipWildcard" : "2.128.0.0/16",
+                "lengthRange" : "16-16"
               }
             ]
           },
@@ -1595,8 +1595,8 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-24",
-                "prefix" : "3.0.1.0/24"
+                "ipWildcard" : "3.0.1.0/24",
+                "lengthRange" : "24-24"
               }
             ]
           },
@@ -1605,8 +1605,8 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "8-32",
-                "prefix" : "4.0.0.0/8"
+                "ipWildcard" : "4.0.0.0/8",
+                "lengthRange" : "8-32"
               }
             ]
           },
@@ -1615,13 +1615,13 @@
             "lines" : [
               {
                 "action" : "REJECT",
-                "lengthRange" : "8-32",
-                "prefix" : "1.0.0.0/8"
+                "ipWildcard" : "1.0.0.0/8",
+                "lengthRange" : "8-32"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "0-32",
-                "prefix" : "0.0.0.0/0"
+                "ipWildcard" : "0.0.0.0/0",
+                "lengthRange" : "0-32"
               }
             ]
           }
@@ -3333,13 +3333,13 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-24",
-                "prefix" : "1.0.1.0/24"
+                "ipWildcard" : "1.0.1.0/24",
+                "lengthRange" : "24-24"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-24",
-                "prefix" : "1.0.2.0/24"
+                "ipWildcard" : "1.0.2.0/24",
+                "lengthRange" : "24-24"
               }
             ]
           },
@@ -3348,13 +3348,13 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-24",
-                "prefix" : "3.0.1.0/24"
+                "ipWildcard" : "3.0.1.0/24",
+                "lengthRange" : "24-24"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-24",
-                "prefix" : "3.0.2.0/24"
+                "ipWildcard" : "3.0.2.0/24",
+                "lengthRange" : "24-24"
               }
             ]
           },
@@ -3363,13 +3363,13 @@
             "lines" : [
               {
                 "action" : "REJECT",
-                "lengthRange" : "8-32",
-                "prefix" : "2.0.0.0/8"
+                "ipWildcard" : "2.0.0.0/8",
+                "lengthRange" : "8-32"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "0-32",
-                "prefix" : "0.0.0.0/0"
+                "ipWildcard" : "0.0.0.0/0",
+                "lengthRange" : "0-32"
               }
             ]
           },
@@ -3378,8 +3378,8 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "16-32",
-                "prefix" : "2.128.0.0/9"
+                "ipWildcard" : "2.128.0.0/9",
+                "lengthRange" : "16-32"
               }
             ]
           },
@@ -3388,8 +3388,8 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "17-32",
-                "prefix" : "2.128.0.0/16"
+                "ipWildcard" : "2.128.0.0/16",
+                "lengthRange" : "17-32"
               }
             ]
           }
@@ -4590,13 +4590,13 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-24",
-                "prefix" : "1.0.1.0/24"
+                "ipWildcard" : "1.0.1.0/24",
+                "lengthRange" : "24-24"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-24",
-                "prefix" : "1.0.2.0/24"
+                "ipWildcard" : "1.0.2.0/24",
+                "lengthRange" : "24-24"
               }
             ]
           },
@@ -4605,13 +4605,13 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-24",
-                "prefix" : "3.0.1.0/24"
+                "ipWildcard" : "3.0.1.0/24",
+                "lengthRange" : "24-24"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-24",
-                "prefix" : "3.0.2.0/24"
+                "ipWildcard" : "3.0.2.0/24",
+                "lengthRange" : "24-24"
               }
             ]
           },
@@ -4620,13 +4620,13 @@
             "lines" : [
               {
                 "action" : "REJECT",
-                "lengthRange" : "8-32",
-                "prefix" : "2.0.0.0/8"
+                "ipWildcard" : "2.0.0.0/8",
+                "lengthRange" : "8-32"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "0-32",
-                "prefix" : "0.0.0.0/0"
+                "ipWildcard" : "0.0.0.0/0",
+                "lengthRange" : "0-32"
               }
             ]
           },
@@ -4635,8 +4635,8 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "16-32",
-                "prefix" : "2.128.0.0/9"
+                "ipWildcard" : "2.128.0.0/9",
+                "lengthRange" : "16-32"
               }
             ]
           },
@@ -4645,8 +4645,8 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "17-32",
-                "prefix" : "2.128.0.0/16"
+                "ipWildcard" : "2.128.0.0/16",
+                "lengthRange" : "17-32"
               }
             ]
           }
@@ -7095,13 +7095,13 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-24",
-                "prefix" : "2.128.0.0/24"
+                "ipWildcard" : "2.128.0.0/24",
+                "lengthRange" : "24-24"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-24",
-                "prefix" : "2.128.1.0/24"
+                "ipWildcard" : "2.128.1.0/24",
+                "lengthRange" : "24-24"
               }
             ]
           }
@@ -7892,23 +7892,23 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-24",
-                "prefix" : "1.0.1.0/24"
+                "ipWildcard" : "1.0.1.0/24",
+                "lengthRange" : "24-24"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-24",
-                "prefix" : "1.0.2.0/24"
+                "ipWildcard" : "1.0.2.0/24",
+                "lengthRange" : "24-24"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-24",
-                "prefix" : "3.0.1.0/24"
+                "ipWildcard" : "3.0.1.0/24",
+                "lengthRange" : "24-24"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-24",
-                "prefix" : "3.0.2.0/24"
+                "ipWildcard" : "3.0.2.0/24",
+                "lengthRange" : "24-24"
               }
             ]
           }
@@ -8659,23 +8659,23 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-24",
-                "prefix" : "1.0.1.0/24"
+                "ipWildcard" : "1.0.1.0/24",
+                "lengthRange" : "24-24"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-24",
-                "prefix" : "1.0.2.0/24"
+                "ipWildcard" : "1.0.2.0/24",
+                "lengthRange" : "24-24"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-24",
-                "prefix" : "3.0.1.0/24"
+                "ipWildcard" : "3.0.1.0/24",
+                "lengthRange" : "24-24"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-24",
-                "prefix" : "3.0.2.0/24"
+                "ipWildcard" : "3.0.2.0/24",
+                "lengthRange" : "24-24"
               }
             ]
           }
@@ -9440,13 +9440,13 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-24",
-                "prefix" : "1.0.1.0/24"
+                "ipWildcard" : "1.0.1.0/24",
+                "lengthRange" : "24-24"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-24",
-                "prefix" : "1.0.2.0/24"
+                "ipWildcard" : "1.0.2.0/24",
+                "lengthRange" : "24-24"
               }
             ]
           },
@@ -9455,13 +9455,13 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "8-8",
-                "prefix" : "2.0.0.0/8"
+                "ipWildcard" : "2.0.0.0/8",
+                "lengthRange" : "8-8"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "16-16",
-                "prefix" : "2.128.0.0/16"
+                "ipWildcard" : "2.128.0.0/16",
+                "lengthRange" : "16-16"
               }
             ]
           },
@@ -9470,13 +9470,13 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-24",
-                "prefix" : "3.0.1.0/24"
+                "ipWildcard" : "3.0.1.0/24",
+                "lengthRange" : "24-24"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-24",
-                "prefix" : "3.0.2.0/24"
+                "ipWildcard" : "3.0.2.0/24",
+                "lengthRange" : "24-24"
               }
             ]
           },
@@ -9485,8 +9485,8 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "0-0",
-                "prefix" : "0.0.0.0/0"
+                "ipWildcard" : "0.0.0.0/0",
+                "lengthRange" : "0-0"
               }
             ]
           },
@@ -9495,13 +9495,13 @@
             "lines" : [
               {
                 "action" : "REJECT",
-                "lengthRange" : "8-32",
-                "prefix" : "3.0.0.0/8"
+                "ipWildcard" : "3.0.0.0/8",
+                "lengthRange" : "8-32"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "0-32",
-                "prefix" : "0.0.0.0/0"
+                "ipWildcard" : "0.0.0.0/0",
+                "lengthRange" : "0-32"
               }
             ]
           }
@@ -10596,13 +10596,13 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-24",
-                "prefix" : "1.0.1.0/24"
+                "ipWildcard" : "1.0.1.0/24",
+                "lengthRange" : "24-24"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-24",
-                "prefix" : "1.0.2.0/24"
+                "ipWildcard" : "1.0.2.0/24",
+                "lengthRange" : "24-24"
               }
             ]
           },
@@ -10611,13 +10611,13 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "8-8",
-                "prefix" : "2.0.0.0/8"
+                "ipWildcard" : "2.0.0.0/8",
+                "lengthRange" : "8-8"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "16-16",
-                "prefix" : "2.128.0.0/16"
+                "ipWildcard" : "2.128.0.0/16",
+                "lengthRange" : "16-16"
               }
             ]
           },
@@ -10626,13 +10626,13 @@
             "lines" : [
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-24",
-                "prefix" : "3.0.1.0/24"
+                "ipWildcard" : "3.0.1.0/24",
+                "lengthRange" : "24-24"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "24-24",
-                "prefix" : "3.0.2.0/24"
+                "ipWildcard" : "3.0.2.0/24",
+                "lengthRange" : "24-24"
               }
             ]
           },
@@ -10641,13 +10641,13 @@
             "lines" : [
               {
                 "action" : "REJECT",
-                "lengthRange" : "8-32",
-                "prefix" : "3.0.0.0/8"
+                "ipWildcard" : "3.0.0.0/8",
+                "lengthRange" : "8-32"
               },
               {
                 "action" : "ACCEPT",
-                "lengthRange" : "0-32",
-                "prefix" : "0.0.0.0/0"
+                "ipWildcard" : "0.0.0.0/0",
+                "lengthRange" : "0-32"
               }
             ]
           }

--- a/tests/basic/outliers-verbose.ref
+++ b/tests/basic/outliers-verbose.ref
@@ -189,13 +189,13 @@
           "lines" : [
             {
               "action" : "ACCEPT",
-              "lengthRange" : "24-24",
-              "prefix" : "1.0.1.0/24"
+              "ipWildcard" : "1.0.1.0/24",
+              "lengthRange" : "24-24"
             },
             {
               "action" : "ACCEPT",
-              "lengthRange" : "24-24",
-              "prefix" : "1.0.2.0/24"
+              "ipWildcard" : "1.0.2.0/24",
+              "lengthRange" : "24-24"
             }
           ]
         },
@@ -508,23 +508,23 @@
           "lines" : [
             {
               "action" : "ACCEPT",
-              "lengthRange" : "24-24",
-              "prefix" : "1.0.1.0/24"
+              "ipWildcard" : "1.0.1.0/24",
+              "lengthRange" : "24-24"
             },
             {
               "action" : "ACCEPT",
-              "lengthRange" : "24-24",
-              "prefix" : "1.0.2.0/24"
+              "ipWildcard" : "1.0.2.0/24",
+              "lengthRange" : "24-24"
             },
             {
               "action" : "ACCEPT",
-              "lengthRange" : "24-24",
-              "prefix" : "3.0.1.0/24"
+              "ipWildcard" : "3.0.1.0/24",
+              "lengthRange" : "24-24"
             },
             {
               "action" : "ACCEPT",
-              "lengthRange" : "24-24",
-              "prefix" : "3.0.2.0/24"
+              "ipWildcard" : "3.0.2.0/24",
+              "lengthRange" : "24-24"
             }
           ]
         },
@@ -542,8 +542,8 @@
           "lines" : [
             {
               "action" : "ACCEPT",
-              "lengthRange" : "0-0",
-              "prefix" : "0.0.0.0/0"
+              "ipWildcard" : "0.0.0.0/0",
+              "lengthRange" : "0-0"
             }
           ]
         },
@@ -561,8 +561,8 @@
           "lines" : [
             {
               "action" : "ACCEPT",
-              "lengthRange" : "16-32",
-              "prefix" : "2.128.0.0/9"
+              "ipWildcard" : "2.128.0.0/9",
+              "lengthRange" : "16-32"
             }
           ]
         },
@@ -751,13 +751,13 @@
           "lines" : [
             {
               "action" : "ACCEPT",
-              "lengthRange" : "24-24",
-              "prefix" : "3.0.1.0/24"
+              "ipWildcard" : "3.0.1.0/24",
+              "lengthRange" : "24-24"
             },
             {
               "action" : "ACCEPT",
-              "lengthRange" : "24-24",
-              "prefix" : "3.0.2.0/24"
+              "ipWildcard" : "3.0.2.0/24",
+              "lengthRange" : "24-24"
             }
           ]
         },
@@ -1118,8 +1118,8 @@
           "lines" : [
             {
               "action" : "ACCEPT",
-              "lengthRange" : "8-32",
-              "prefix" : "4.0.0.0/8"
+              "ipWildcard" : "4.0.0.0/8",
+              "lengthRange" : "8-32"
             }
           ]
         },
@@ -1349,13 +1349,13 @@
           "lines" : [
             {
               "action" : "ACCEPT",
-              "lengthRange" : "8-8",
-              "prefix" : "2.0.0.0/8"
+              "ipWildcard" : "2.0.0.0/8",
+              "lengthRange" : "8-8"
             },
             {
               "action" : "ACCEPT",
-              "lengthRange" : "16-16",
-              "prefix" : "2.128.0.0/16"
+              "ipWildcard" : "2.128.0.0/16",
+              "lengthRange" : "16-16"
             }
           ]
         },
@@ -2088,13 +2088,13 @@
           "lines" : [
             {
               "action" : "REJECT",
-              "lengthRange" : "8-32",
-              "prefix" : "1.0.0.0/8"
+              "ipWildcard" : "1.0.0.0/8",
+              "lengthRange" : "8-32"
             },
             {
               "action" : "ACCEPT",
-              "lengthRange" : "0-32",
-              "prefix" : "0.0.0.0/0"
+              "ipWildcard" : "0.0.0.0/0",
+              "lengthRange" : "0-32"
             }
           ]
         },

--- a/tests/basic/outliers.ref
+++ b/tests/basic/outliers.ref
@@ -76,13 +76,13 @@
           "lines" : [
             {
               "action" : "ACCEPT",
-              "lengthRange" : "24-24",
-              "prefix" : "3.0.1.0/24"
+              "ipWildcard" : "3.0.1.0/24",
+              "lengthRange" : "24-24"
             },
             {
               "action" : "ACCEPT",
-              "lengthRange" : "24-24",
-              "prefix" : "3.0.2.0/24"
+              "ipWildcard" : "3.0.2.0/24",
+              "lengthRange" : "24-24"
             }
           ]
         },
@@ -105,13 +105,13 @@
           "lines" : [
             {
               "action" : "ACCEPT",
-              "lengthRange" : "8-8",
-              "prefix" : "2.0.0.0/8"
+              "ipWildcard" : "2.0.0.0/8",
+              "lengthRange" : "8-8"
             },
             {
               "action" : "ACCEPT",
-              "lengthRange" : "16-16",
-              "prefix" : "2.128.0.0/16"
+              "ipWildcard" : "2.128.0.0/16",
+              "lengthRange" : "16-16"
             }
           ]
         },

--- a/tests/jsonpath-addons/jsonpath-display-hints-prefixofsuffix.ref
+++ b/tests/jsonpath-addons/jsonpath-display-hints-prefixofsuffix.ref
@@ -433,13 +433,13 @@
                   "lines" : [
                     {
                       "action" : "ACCEPT",
-                      "lengthRange" : "24-24",
-                      "prefix" : "1.0.1.0/24"
+                      "ipWildcard" : "1.0.1.0/24",
+                      "lengthRange" : "24-24"
                     },
                     {
                       "action" : "ACCEPT",
-                      "lengthRange" : "24-24",
-                      "prefix" : "1.0.2.0/24"
+                      "ipWildcard" : "1.0.2.0/24",
+                      "lengthRange" : "24-24"
                     }
                   ]
                 },
@@ -448,13 +448,13 @@
                   "lines" : [
                     {
                       "action" : "ACCEPT",
-                      "lengthRange" : "24-24",
-                      "prefix" : "3.0.1.0/24"
+                      "ipWildcard" : "3.0.1.0/24",
+                      "lengthRange" : "24-24"
                     },
                     {
                       "action" : "ACCEPT",
-                      "lengthRange" : "24-24",
-                      "prefix" : "3.0.2.0/24"
+                      "ipWildcard" : "3.0.2.0/24",
+                      "lengthRange" : "24-24"
                     }
                   ]
                 },
@@ -463,13 +463,13 @@
                   "lines" : [
                     {
                       "action" : "REJECT",
-                      "lengthRange" : "8-32",
-                      "prefix" : "2.0.0.0/8"
+                      "ipWildcard" : "2.0.0.0/8",
+                      "lengthRange" : "8-32"
                     },
                     {
                       "action" : "ACCEPT",
-                      "lengthRange" : "0-32",
-                      "prefix" : "0.0.0.0/0"
+                      "ipWildcard" : "0.0.0.0/0",
+                      "lengthRange" : "0-32"
                     }
                   ]
                 },
@@ -478,8 +478,8 @@
                   "lines" : [
                     {
                       "action" : "ACCEPT",
-                      "lengthRange" : "16-32",
-                      "prefix" : "2.128.0.0/9"
+                      "ipWildcard" : "2.128.0.0/9",
+                      "lengthRange" : "16-32"
                     }
                   ]
                 },
@@ -488,8 +488,8 @@
                   "lines" : [
                     {
                       "action" : "ACCEPT",
-                      "lengthRange" : "17-32",
-                      "prefix" : "2.128.0.0/16"
+                      "ipWildcard" : "2.128.0.0/16",
+                      "lengthRange" : "17-32"
                     }
                   ]
                 }

--- a/tests/jsonpath-addons/jsonpath-display-hints-suffixofsuffix.ref
+++ b/tests/jsonpath-addons/jsonpath-display-hints-suffixofsuffix.ref
@@ -433,13 +433,13 @@
                   "lines" : [
                     {
                       "action" : "ACCEPT",
-                      "lengthRange" : "24-24",
-                      "prefix" : "1.0.1.0/24"
+                      "ipWildcard" : "1.0.1.0/24",
+                      "lengthRange" : "24-24"
                     },
                     {
                       "action" : "ACCEPT",
-                      "lengthRange" : "24-24",
-                      "prefix" : "1.0.2.0/24"
+                      "ipWildcard" : "1.0.2.0/24",
+                      "lengthRange" : "24-24"
                     }
                   ]
                 },
@@ -448,13 +448,13 @@
                   "lines" : [
                     {
                       "action" : "ACCEPT",
-                      "lengthRange" : "24-24",
-                      "prefix" : "3.0.1.0/24"
+                      "ipWildcard" : "3.0.1.0/24",
+                      "lengthRange" : "24-24"
                     },
                     {
                       "action" : "ACCEPT",
-                      "lengthRange" : "24-24",
-                      "prefix" : "3.0.2.0/24"
+                      "ipWildcard" : "3.0.2.0/24",
+                      "lengthRange" : "24-24"
                     }
                   ]
                 },
@@ -463,13 +463,13 @@
                   "lines" : [
                     {
                       "action" : "REJECT",
-                      "lengthRange" : "8-32",
-                      "prefix" : "2.0.0.0/8"
+                      "ipWildcard" : "2.0.0.0/8",
+                      "lengthRange" : "8-32"
                     },
                     {
                       "action" : "ACCEPT",
-                      "lengthRange" : "0-32",
-                      "prefix" : "0.0.0.0/0"
+                      "ipWildcard" : "0.0.0.0/0",
+                      "lengthRange" : "0-32"
                     }
                   ]
                 },
@@ -478,8 +478,8 @@
                   "lines" : [
                     {
                       "action" : "ACCEPT",
-                      "lengthRange" : "16-32",
-                      "prefix" : "2.128.0.0/9"
+                      "ipWildcard" : "2.128.0.0/9",
+                      "lengthRange" : "16-32"
                     }
                   ]
                 },
@@ -488,8 +488,8 @@
                   "lines" : [
                     {
                       "action" : "ACCEPT",
-                      "lengthRange" : "17-32",
-                      "prefix" : "2.128.0.0/16"
+                      "ipWildcard" : "2.128.0.0/16",
+                      "lengthRange" : "17-32"
                     }
                   ]
                 }

--- a/tests/roles/perRoleOutliers.ref
+++ b/tests/roles/perRoleOutliers.ref
@@ -173,13 +173,13 @@
           "lines" : [
             {
               "action" : "ACCEPT",
-              "lengthRange" : "8-8",
-              "prefix" : "2.0.0.0/8"
+              "ipWildcard" : "2.0.0.0/8",
+              "lengthRange" : "8-8"
             },
             {
               "action" : "ACCEPT",
-              "lengthRange" : "16-16",
-              "prefix" : "2.128.0.0/16"
+              "ipWildcard" : "2.128.0.0/16",
+              "lengthRange" : "16-16"
             }
           ]
         },


### PR DESCRIPTION
 - update route filter lines to take `IpWildcard`
- fix `Route4FilterLineThrough` to use the `throughPrefix` which it was ignoring earlier