### PR TITLE
small role parsing bug fix

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/role/InferRoles.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/role/InferRoles.java
@@ -92,7 +92,7 @@ public class InferRoles implements Callable<SortedSet<NodeRoleDimension>> {
         case ALPHA_PLUS_DIGIT_PLUS:
           return plus(ALPHABETIC_REGEX) + plus(DIGIT_REGEX);
         case ALNUM_PLUS:
-          return ALPHABETIC_REGEX + plus(ALPHANUMERIC_REGEX);
+          return ALPHABETIC_REGEX + star(ALPHANUMERIC_REGEX);
         case DELIMITER:
           return Pattern.quote(s);
         case DIGIT_PLUS:

--- a/tests/roles/inferRoles.ref
+++ b/tests/roles/inferRoles.ref
@@ -10,24 +10,24 @@
         {
           "name" : "auto0",
           "roleRegexes" : [
-            "\\p{Alpha}\\p{Alnum}+\\Q-\\E(\\p{Alpha}+)\\p{Alnum}*\\Q-\\E\\p{Digit}+"
+            "\\p{Alpha}\\p{Alnum}*\\Q-\\E(\\p{Alpha}+)\\p{Alnum}*\\Q-\\E\\p{Digit}+"
           ],
           "roles" : [
             {
               "name" : "border",
-              "regex" : "\\p{Alpha}\\p{Alnum}+\\Q-\\Eborder\\p{Alnum}*\\Q-\\E\\p{Digit}+"
+              "regex" : "\\p{Alpha}\\p{Alnum}*\\Q-\\Eborder\\p{Alnum}*\\Q-\\E\\p{Digit}+"
             },
             {
               "name" : "core",
-              "regex" : "\\p{Alpha}\\p{Alnum}+\\Q-\\Ecore\\p{Alnum}*\\Q-\\E\\p{Digit}+"
+              "regex" : "\\p{Alpha}\\p{Alnum}*\\Q-\\Ecore\\p{Alnum}*\\Q-\\E\\p{Digit}+"
             },
             {
               "name" : "leaf",
-              "regex" : "\\p{Alpha}\\p{Alnum}+\\Q-\\Eleaf\\p{Alnum}*\\Q-\\E\\p{Digit}+"
+              "regex" : "\\p{Alpha}\\p{Alnum}*\\Q-\\Eleaf\\p{Alnum}*\\Q-\\E\\p{Digit}+"
             },
             {
               "name" : "spine",
-              "regex" : "\\p{Alpha}\\p{Alnum}+\\Q-\\Espine\\p{Alnum}*\\Q-\\E\\p{Digit}+"
+              "regex" : "\\p{Alpha}\\p{Alnum}*\\Q-\\Espine\\p{Alnum}*\\Q-\\E\\p{Digit}+"
             }
           ],
           "type" : "AUTO"
@@ -35,16 +35,16 @@
         {
           "name" : "auto1",
           "roleRegexes" : [
-            "(\\p{Alpha}+)\\p{Alnum}*\\Q-\\E\\p{Alpha}\\p{Alnum}+\\Q-\\E\\p{Digit}+"
+            "(\\p{Alpha}+)\\p{Alnum}*\\Q-\\E\\p{Alpha}\\p{Alnum}*\\Q-\\E\\p{Digit}+"
           ],
           "roles" : [
             {
               "name" : "bb",
-              "regex" : "bb\\p{Alnum}*\\Q-\\E\\p{Alpha}\\p{Alnum}+\\Q-\\E\\p{Digit}+"
+              "regex" : "bb\\p{Alnum}*\\Q-\\E\\p{Alpha}\\p{Alnum}*\\Q-\\E\\p{Digit}+"
             },
             {
               "name" : "dc",
-              "regex" : "dc\\p{Alnum}*\\Q-\\E\\p{Alpha}\\p{Alnum}+\\Q-\\E\\p{Digit}+"
+              "regex" : "dc\\p{Alnum}*\\Q-\\E\\p{Alpha}\\p{Alnum}*\\Q-\\E\\p{Digit}+"
             }
           ],
           "type" : "AUTO"


### PR DESCRIPTION
fixed a bug in node-name parsing that was requiring 2+ characters in certain tokens where only 1+ character should be required