### PR TITLE
VendorConfigurationFormatDetector: recognize Palo Alto configs

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ConfigurationFormat.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ConfigurationFormat.java
@@ -28,6 +28,7 @@ public enum ConfigurationFormat {
   MRV("mrv"),
   MRV_COMMANDS("mrv_commands"),
   MSS("mss"),
+  PALO_ALTO("paloalto"),
   UNKNOWN("unknown"),
   VXWORKS("vxworks"),
   VYOS("vyos");

--- a/projects/batfish/src/main/java/org/batfish/grammar/VendorConfigurationFormatDetector.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/VendorConfigurationFormatDetector.java
@@ -39,6 +39,8 @@ public final class VendorConfigurationFormatDetector {
       Pattern.compile("(?m)^!RANCID-CONTENT-TYPE: juniper$");
   private static final Pattern RANCID_MRV_PATTERN =
       Pattern.compile("(?m)^!RANCID-CONTENT-TYPE: mrv$");
+  private static final Pattern RANCID_PALO_ALTO_PATTERN =
+      Pattern.compile("(?m)^!RANCID-CONTENT-TYPE: paloalto");
 
   // checkCisco patterns
   private static final Pattern ASA_VERSION_LINE_PATTERN = Pattern.compile("(?m)(^ASA Version.*$)");
@@ -61,6 +63,10 @@ public final class VendorConfigurationFormatDetector {
       Pattern.compile("(?m)^policy-options *\\{");
   private static final Pattern JUNIPER_SNMP_PATTERN = Pattern.compile("(?m)^snmp *\\{");
   private static final Pattern SET_PATTERN = Pattern.compile("(?m)^set ");
+
+  // checkPaloAlto patterns
+  private static final Pattern PALO_ALTO_PANORAMA_PATTERN =
+      Pattern.compile("(?m)(send-to-panorama|panorama-server)");
 
   private String _fileText;
 
@@ -228,6 +234,14 @@ public final class VendorConfigurationFormatDetector {
   }
 
   @Nullable
+  private ConfigurationFormat checkPaloAlto() {
+    if (fileTextMatches(PALO_ALTO_PANORAMA_PATTERN)) {
+      return ConfigurationFormat.PALO_ALTO;
+    }
+    return null;
+  }
+
+  @Nullable
   private ConfigurationFormat checkMss() {
     if (fileTextMatches(MSS_PATTERN)) {
       return ConfigurationFormat.MSS;
@@ -250,6 +264,8 @@ public final class VendorConfigurationFormatDetector {
       return checkJuniper();
     } else if (fileTextMatches(RANCID_MRV_PATTERN)) {
       return ConfigurationFormat.MRV;
+    } else if (fileTextMatches(RANCID_PALO_ALTO_PATTERN)) {
+      return ConfigurationFormat.PALO_ALTO;
     }
     return null;
   }
@@ -318,6 +334,10 @@ public final class VendorConfigurationFormatDetector {
       return format;
     }
     format = checkMrvCommands();
+    if (format != null) {
+      return format;
+    }
+    format = checkPaloAlto();
     if (format != null) {
       return format;
     }

--- a/projects/batfish/src/main/java/org/batfish/job/ParseVendorConfigurationJob.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ParseVendorConfigurationJob.java
@@ -270,6 +270,7 @@ public class ParseVendorConfigurationJob extends BatfishJob<ParseVendorConfigura
       case METAMAKO:
       case MRV_COMMANDS:
       case MSS:
+      case PALO_ALTO:
       case VXWORKS:
         String unsupportedError =
             "Unsupported configuration format: '" + format + "' for file: '" + currentPath + "'\n";

--- a/projects/batfish/src/test/java/org/batfish/grammar/VendorConfigurationFormatDetectorTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/VendorConfigurationFormatDetectorTest.java
@@ -47,4 +47,17 @@ public class VendorConfigurationFormatDetectorTest {
           equalTo(ConfigurationFormat.CISCO_NX));
     }
   }
+
+  @Test
+  public void recognizePaloAlto() {
+    String rancid = "!RANCID-CONTENT-TYPE: paloalto\n!\n";
+    String panorama = "deviceconfig {\n  system {\n    panorama-server 1.2.3.4;\n  }\n}";
+    String sendPanorama = "alarm {\n  informational {\n    send-to-panorama yes;\n  }\n}";
+
+    for (String fileText : ImmutableList.of(rancid, panorama, sendPanorama)) {
+      assertThat(
+          VendorConfigurationFormatDetector.identifyConfigurationFormat(fileText),
+          equalTo(ConfigurationFormat.PALO_ALTO));
+    }
+  }
 }


### PR DESCRIPTION
And, for now, declare unsupported.