### PR TITLE
Fix for OpenTrace client register logs

### DIFF
--- a/projects/batfish-client/src/main/java/org/batfish/client/BfCoordWorkHelper.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/BfCoordWorkHelper.java
@@ -470,7 +470,8 @@ public class BfCoordWorkHelper {
             _settings.getSslKeystoreFile(),
             _settings.getSslKeystorePassword(),
             _settings.getSslTruststoreFile(),
-            _settings.getSslTruststorePassword())
+            _settings.getSslTruststorePassword(),
+            true)
         .register(MultiPartFeature.class);
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
@@ -512,13 +512,27 @@ public class CommonUtil {
     }
   }
 
+  /**
+   * Returns a {@link ClientBuilder} with supplied settings
+   *
+   * @param noSsl {@link javax.ws.rs.client.Client} will use plain HTTP with no SSL if set to true
+   * @param trustAllSslCerts {@link javax.ws.rs.client.Client} will not verify URL's hostname
+   *     against server's identification hostname
+   * @param keystoreFile File to be used to load the {@link KeyStore}
+   * @param keystorePassword Password to be used with the keyStoreFile
+   * @param truststoreFile File to be used to load the {@link TrustManager}
+   * @param truststorePassword Password to be used with the data in the trustStoreFile
+   * @param registerTracing Whether to register JAX-RS tracing on the {@link ClientBuilder}
+   * @return {@link ClientBuilder} with the supplied settings
+   */
   public static ClientBuilder createHttpClientBuilder(
       boolean noSsl,
       boolean trustAllSslCerts,
       Path keystoreFile,
       String keystorePassword,
       Path truststoreFile,
-      String truststorePassword) {
+      String truststorePassword,
+      boolean registerTracing) {
     ClientBuilder clientBuilder = ClientBuilder.newBuilder();
     try {
       if (!noSsl) {
@@ -561,7 +575,7 @@ public class CommonUtil {
         KeyManager[] keyManagers;
         if (keystoreFile != null) {
           if (keystorePassword == null) {
-            throw new BatfishException("Keystore file supplied but keystore password");
+            throw new BatfishException("Keystore file supplied but keystore password missing");
           }
           char[] ksPass = keystorePassword.toCharArray();
           try (FileInputStream keystoreStream = new FileInputStream(keystoreFile.toFile())) {
@@ -575,7 +589,9 @@ public class CommonUtil {
         sslcontext.init(keyManagers, trustManagers, new java.security.SecureRandom());
         clientBuilder.sslContext(sslcontext);
       }
-      if (GlobalTracer.isRegistered()) {
+      /* register tracing feature if a tracer was initialized and caller wants client to
+      send tracing information */
+      if (GlobalTracer.isRegistered() && registerTracing) {
         clientBuilder.register(ClientTracingFeature.class);
       }
     } catch (Exception e) {

--- a/projects/batfish/src/main/java/org/batfish/main/Driver.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Driver.java
@@ -766,7 +766,8 @@ public class Driver {
                   _mainSettings.getSslKeystoreFile(),
                   _mainSettings.getSslKeystorePassword(),
                   _mainSettings.getSslTruststoreFile(),
-                  _mainSettings.getSslTruststorePassword())
+                  _mainSettings.getSslTruststorePassword(),
+                  true)
               .build();
       WebTarget webTarget = client.target(url);
       for (Map.Entry<String, String> entry : params.entrySet()) {

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/PoolMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/PoolMgr.java
@@ -129,7 +129,8 @@ public class PoolMgr {
                   _settings.getSslPoolKeystoreFile(),
                   _settings.getSslPoolKeystorePassword(),
                   _settings.getSslPoolTruststoreFile(),
-                  _settings.getSslPoolTruststorePassword())
+                  _settings.getSslPoolTruststorePassword(),
+                  false)
               .build();
       String protocol = _settings.getSslPoolDisable() ? "http" : "https";
       WebTarget webTarget =

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -192,7 +192,8 @@ public class WorkMgr extends AbstractCoordinator {
                   _settings.getSslPoolKeystoreFile(),
                   _settings.getSslPoolKeystorePassword(),
                   _settings.getSslPoolTruststoreFile(),
-                  _settings.getSslPoolTruststorePassword())
+                  _settings.getSslPoolTruststorePassword(),
+                  true)
               .build();
 
       String protocol = _settings.getSslPoolDisable() ? "http" : "https";
@@ -349,7 +350,8 @@ public class WorkMgr extends AbstractCoordinator {
                   _settings.getSslPoolKeystoreFile(),
                   _settings.getSslPoolKeystorePassword(),
                   _settings.getSslPoolTruststoreFile(),
-                  _settings.getSslPoolTruststorePassword())
+                  _settings.getSslPoolTruststorePassword(),
+                  true)
               .build();
 
       String protocol = _settings.getSslPoolDisable() ? "http" : "https";
@@ -1215,7 +1217,8 @@ public class WorkMgr extends AbstractCoordinator {
                   _settings.getSslPoolKeystoreFile(),
                   _settings.getSslPoolKeystorePassword(),
                   _settings.getSslPoolTruststoreFile(),
-                  _settings.getSslPoolTruststorePassword())
+                  _settings.getSslPoolTruststorePassword(),
+                  true)
               .build();
 
       String protocol = _settings.getSslPoolDisable() ? "http" : "https";


### PR DESCRIPTION
- Make registering tracing on `ClientBuilder` optional
- Do not register tracing with the `javax.ws.rs.Client` used by coordinators to poll the workers. 
  Because
      - They do not have any useful tracing information
      - Logs keep crowding the client prompt
- Although there will be logs from `WorkMgr.checkTask()`  still as we create a new `Client` for each ping and they look like: 
```
May 21, 2018 12:22:04 PM io.opentracing.contrib.jaxrs2.client.ClientTracingFeature configure
INFO: Registering client OpenTracing, with configuration:io.opentracing.contrib.jaxrs2.client.ClientTracingFeature$Builder@513ba759
```
But they are not as intrusive as they appear when `batfish-client` is performing some task for the user. This will probably get fixed when https://github.com/opentracing-contrib/java-jaxrs/pull/86 is released.
