### PR TITLE
Add the IpOwners question in the new table format

### DIFF
--- a/projects/question/src/main/java/org/batfish/question/ipowners/IpOwnersAnswerElement.java
+++ b/projects/question/src/main/java/org/batfish/question/ipowners/IpOwnersAnswerElement.java
@@ -1,0 +1,48 @@
+package org.batfish.question.ipowners;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.batfish.datamodel.answers.Schema;
+import org.batfish.datamodel.questions.DisplayHints;
+import org.batfish.datamodel.table.ColumnMetadata;
+import org.batfish.datamodel.table.TableAnswerElement;
+import org.batfish.datamodel.table.TableMetadata;
+
+class IpOwnersAnswerElement extends TableAnswerElement {
+
+  static final String COL_HOSTNAME = "Hostname";
+  static final String COL_VRFNAME = "VRF";
+  static final String COL_IP = "IP";
+  static final String COL_INTERFACE_NAME = "Interface";
+
+  @JsonCreator
+  public IpOwnersAnswerElement(@JsonProperty(PROP_METADATA) TableMetadata tableMetadata) {
+    super(tableMetadata);
+  }
+
+  IpOwnersAnswerElement() {
+    super(getTableMetadata());
+  }
+
+  /** Create table metadata for this answer. */
+  private static TableMetadata getTableMetadata() {
+    List<ColumnMetadata> columnMetadata = getColumnMetadata();
+    DisplayHints displayHints = new DisplayHints();
+    displayHints.setTextDesc(
+        String.format(
+            "On node ${%s} in VRF ${%s}, interface ${%s} has IP ${%s}.",
+            COL_HOSTNAME, COL_VRFNAME, COL_INTERFACE_NAME, COL_IP));
+    return new TableMetadata(columnMetadata, displayHints);
+  }
+
+  /** Create column metadata. */
+  private static List<ColumnMetadata> getColumnMetadata() {
+    return ImmutableList.of(
+        new ColumnMetadata(COL_HOSTNAME, Schema.STRING, "Node hostname"),
+        new ColumnMetadata(COL_VRFNAME, Schema.STRING, "VRF name"),
+        new ColumnMetadata(COL_INTERFACE_NAME, Schema.STRING, "Interface name"),
+        new ColumnMetadata(COL_IP, Schema.IP, "IP address"));
+  }
+}

--- a/projects/question/src/main/java/org/batfish/question/ipowners/IpOwnersAnswerElement.java
+++ b/projects/question/src/main/java/org/batfish/question/ipowners/IpOwnersAnswerElement.java
@@ -12,7 +12,7 @@ import org.batfish.datamodel.table.TableMetadata;
 
 class IpOwnersAnswerElement extends TableAnswerElement {
 
-  static final String COL_HOSTNAME = "Hostname";
+  static final String COL_NODE = "Hostname";
   static final String COL_VRFNAME = "VRF";
   static final String COL_IP = "IP";
   static final String COL_INTERFACE_NAME = "Interface";
@@ -34,14 +34,14 @@ class IpOwnersAnswerElement extends TableAnswerElement {
     displayHints.setTextDesc(
         String.format(
             "On node ${%s} in VRF ${%s}, interface ${%s} has IP ${%s}.",
-            COL_HOSTNAME, COL_VRFNAME, COL_INTERFACE_NAME, COL_IP));
+            COL_NODE, COL_VRFNAME, COL_INTERFACE_NAME, COL_IP));
     return new TableMetadata(columnMetadata, displayHints);
   }
 
   /** Create column metadata. */
   private static List<ColumnMetadata> getColumnMetadata() {
     return ImmutableList.of(
-        new ColumnMetadata(COL_HOSTNAME, Schema.NODE, "Node hostname"),
+        new ColumnMetadata(COL_NODE, Schema.NODE, "Node hostname"),
         new ColumnMetadata(COL_VRFNAME, Schema.STRING, "VRF name"),
         new ColumnMetadata(COL_INTERFACE_NAME, Schema.STRING, "Interface name"),
         new ColumnMetadata(COL_IP, Schema.IP, "IP address"),

--- a/projects/question/src/main/java/org/batfish/question/ipowners/IpOwnersAnswerElement.java
+++ b/projects/question/src/main/java/org/batfish/question/ipowners/IpOwnersAnswerElement.java
@@ -16,6 +16,7 @@ class IpOwnersAnswerElement extends TableAnswerElement {
   static final String COL_VRFNAME = "VRF";
   static final String COL_IP = "IP";
   static final String COL_INTERFACE_NAME = "Interface";
+  static final String COL_ACTIVE = "Active";
 
   @JsonCreator
   public IpOwnersAnswerElement(@JsonProperty(PROP_METADATA) TableMetadata tableMetadata) {
@@ -40,9 +41,11 @@ class IpOwnersAnswerElement extends TableAnswerElement {
   /** Create column metadata. */
   private static List<ColumnMetadata> getColumnMetadata() {
     return ImmutableList.of(
-        new ColumnMetadata(COL_HOSTNAME, Schema.STRING, "Node hostname"),
+        new ColumnMetadata(COL_HOSTNAME, Schema.NODE, "Node hostname"),
         new ColumnMetadata(COL_VRFNAME, Schema.STRING, "VRF name"),
         new ColumnMetadata(COL_INTERFACE_NAME, Schema.STRING, "Interface name"),
-        new ColumnMetadata(COL_IP, Schema.IP, "IP address"));
+        new ColumnMetadata(COL_IP, Schema.IP, "IP address"),
+        new ColumnMetadata(
+            COL_ACTIVE, Schema.BOOLEAN, "Whether the interface with given IP is active"));
   }
 }

--- a/projects/question/src/main/java/org/batfish/question/ipowners/IpOwnersAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/ipowners/IpOwnersAnswerer.java
@@ -1,9 +1,9 @@
 package org.batfish.question.ipowners;
 
 import static org.batfish.question.ipowners.IpOwnersAnswerElement.COL_ACTIVE;
-import static org.batfish.question.ipowners.IpOwnersAnswerElement.COL_HOSTNAME;
 import static org.batfish.question.ipowners.IpOwnersAnswerElement.COL_INTERFACE_NAME;
 import static org.batfish.question.ipowners.IpOwnersAnswerElement.COL_IP;
+import static org.batfish.question.ipowners.IpOwnersAnswerElement.COL_NODE;
 import static org.batfish.question.ipowners.IpOwnersAnswerElement.COL_VRFNAME;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -64,7 +64,7 @@ class IpOwnersAnswerer extends Answerer {
                       || !duplicatesOnly) {
                     rows.add(
                         Row.builder()
-                            .put(COL_HOSTNAME, new Node(hostname))
+                            .put(COL_NODE, new Node(hostname))
                             .put(COL_VRFNAME, iface.getVrfName())
                             .put(COL_INTERFACE_NAME, iface.getName())
                             .put(COL_IP, iface.getAddress().getIp())

--- a/projects/question/src/main/java/org/batfish/question/ipowners/IpOwnersAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/ipowners/IpOwnersAnswerer.java
@@ -1,6 +1,6 @@
 package org.batfish.question.ipowners;
 
-import static org.batfish.common.util.CommonUtil.computeIpInterfaceOwners;
+import static org.batfish.question.ipowners.IpOwnersAnswerElement.COL_ACTIVE;
 import static org.batfish.question.ipowners.IpOwnersAnswerElement.COL_HOSTNAME;
 import static org.batfish.question.ipowners.IpOwnersAnswerElement.COL_INTERFACE_NAME;
 import static org.batfish.question.ipowners.IpOwnersAnswerElement.COL_IP;
@@ -8,15 +8,18 @@ import static org.batfish.question.ipowners.IpOwnersAnswerElement.COL_VRFNAME;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.HashMultiset;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multiset;
 import java.util.Map;
 import java.util.Set;
 import org.batfish.common.Answerer;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.common.util.CommonUtil;
+import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.answers.AnswerElement;
+import org.batfish.datamodel.pojo.Node;
 import org.batfish.datamodel.questions.Question;
 import org.batfish.datamodel.table.Row;
 
@@ -29,45 +32,46 @@ class IpOwnersAnswerer extends Answerer {
   @Override
   public AnswerElement answer() {
     IpOwnersQuestion question = (IpOwnersQuestion) _question;
-    Map<String, Set<Interface>> interfaces =
-        CommonUtil.computeNodeInterfaces(_batfish.loadConfigurations());
-    Map<Ip, Map<String, Set<String>>> ipToInterface =
-        computeIpInterfaceOwners(interfaces, question.getExcludeInactive());
-    Map<Ip, Map<String, Set<String>>> ipOwners =
-        CommonUtil.computeIpVrfOwners(question.getExcludeInactive(), interfaces);
+    Map<String, Configuration> configurations = _batfish.loadConfigurations();
+    Map<Ip, Set<String>> ipNodeOwners = CommonUtil.computeIpNodeOwners(configurations, false);
+    Map<String, Set<Interface>> interfaces = CommonUtil.computeNodeInterfaces(configurations);
 
     IpOwnersAnswerElement answerElement = new IpOwnersAnswerElement();
 
     answerElement.postProcessAnswer(
-        _question, generateRows(ipOwners, ipToInterface, question.getDuplicatesOnly()));
+        _question, generateRows(ipNodeOwners, interfaces, question.getDuplicatesOnly()));
     return answerElement;
   }
 
   @VisibleForTesting
   static Multiset<Row> generateRows(
-      Map<Ip, Map<String, Set<String>>> ipOwners,
-      Map<Ip, Map<String, Set<String>>> ipToInterface,
+      Map<Ip, Set<String>> ipNodeOwners,
+      Map<String, Set<Interface>> interfaces,
       boolean duplicatesOnly) {
     Multiset<Row> rows = HashMultiset.create();
-    ipOwners.forEach(
-        (ip, ownerMap) -> {
-          int uniqueNodes = ownerMap.size();
-          ownerMap.forEach(
-              (node, vrfSet) -> {
-                // Skip if returning only duplicates and no duplicates found, otherwise add row
-                if (uniqueNodes * vrfSet.size() > 1 || !duplicatesOnly) {
-                  vrfSet.forEach(
-                      vrfName ->
-                          rows.add(
-                              Row.builder()
-                                  .put(COL_HOSTNAME, node)
-                                  .put(COL_VRFNAME, vrfName)
-                                  .put(COL_INTERFACE_NAME, ipToInterface.get(ip).get(node))
-                                  .put(COL_IP, ip)
-                                  .build()));
-                }
-              });
-        });
+
+    interfaces.forEach(
+        (hostname, interfaceSet) ->
+            interfaceSet.forEach(
+                iface -> {
+                  if (iface.getAddress() == null) {
+                    return;
+                  }
+                  if (ipNodeOwners
+                              .getOrDefault(iface.getAddress().getIp(), ImmutableSet.of())
+                              .size()
+                          > 1
+                      || !duplicatesOnly) {
+                    rows.add(
+                        Row.builder()
+                            .put(COL_HOSTNAME, new Node(hostname))
+                            .put(COL_VRFNAME, iface.getVrfName())
+                            .put(COL_INTERFACE_NAME, iface.getName())
+                            .put(COL_IP, iface.getAddress().getIp())
+                            .put(COL_ACTIVE, iface.getActive())
+                            .build());
+                  }
+                }));
     return rows;
   }
 }

--- a/projects/question/src/main/java/org/batfish/question/ipowners/IpOwnersAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/ipowners/IpOwnersAnswerer.java
@@ -1,0 +1,73 @@
+package org.batfish.question.ipowners;
+
+import static org.batfish.common.util.CommonUtil.computeIpInterfaceOwners;
+import static org.batfish.question.ipowners.IpOwnersAnswerElement.COL_HOSTNAME;
+import static org.batfish.question.ipowners.IpOwnersAnswerElement.COL_INTERFACE_NAME;
+import static org.batfish.question.ipowners.IpOwnersAnswerElement.COL_IP;
+import static org.batfish.question.ipowners.IpOwnersAnswerElement.COL_VRFNAME;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.Multiset;
+import java.util.Map;
+import java.util.Set;
+import org.batfish.common.Answerer;
+import org.batfish.common.plugin.IBatfish;
+import org.batfish.common.util.CommonUtil;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.answers.AnswerElement;
+import org.batfish.datamodel.questions.Question;
+import org.batfish.datamodel.table.Row;
+
+class IpOwnersAnswerer extends Answerer {
+
+  IpOwnersAnswerer(Question question, IBatfish batfish) {
+    super(question, batfish);
+  }
+
+  @Override
+  public AnswerElement answer() {
+    IpOwnersQuestion question = (IpOwnersQuestion) _question;
+    Map<String, Set<Interface>> interfaces =
+        CommonUtil.computeNodeInterfaces(_batfish.loadConfigurations());
+    Map<Ip, Map<String, Set<String>>> ipToInterface =
+        computeIpInterfaceOwners(interfaces, question.getExcludeInactive());
+    Map<Ip, Map<String, Set<String>>> ipOwners =
+        CommonUtil.computeIpVrfOwners(question.getExcludeInactive(), interfaces);
+
+    IpOwnersAnswerElement answerElement = new IpOwnersAnswerElement();
+
+    answerElement.postProcessAnswer(
+        _question, generateRows(ipOwners, ipToInterface, question.getDuplicatesOnly()));
+    return answerElement;
+  }
+
+  @VisibleForTesting
+  static Multiset<Row> generateRows(
+      Map<Ip, Map<String, Set<String>>> ipOwners,
+      Map<Ip, Map<String, Set<String>>> ipToInterface,
+      boolean duplicatesOnly) {
+    Multiset<Row> rows = HashMultiset.create();
+    ipOwners.forEach(
+        (ip, ownerMap) -> {
+          int uniqueNodes = ownerMap.size();
+          ownerMap.forEach(
+              (node, vrfSet) -> {
+                // Skip if returning only duplicates and no duplicates found, otherwise add row
+                if (uniqueNodes * vrfSet.size() > 1 || !duplicatesOnly) {
+                  vrfSet.forEach(
+                      vrfName ->
+                          rows.add(
+                              Row.builder()
+                                  .put(COL_HOSTNAME, node)
+                                  .put(COL_VRFNAME, vrfName)
+                                  .put(COL_INTERFACE_NAME, ipToInterface.get(ip).get(node))
+                                  .put(COL_IP, ip)
+                                  .build()));
+                }
+              });
+        });
+    return rows;
+  }
+}

--- a/projects/question/src/main/java/org/batfish/question/ipowners/IpOwnersQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/ipowners/IpOwnersQuestion.java
@@ -16,14 +16,10 @@ public class IpOwnersQuestion extends Question {
   /** Whether to return duplicate IPs (owned by multiple nodes) only. */
   private boolean _duplicatesOnly;
 
-  /** Whether to exclude inactive interfaces from the computation */
-  private boolean _excludeInactive;
-
   @JsonCreator
   public IpOwnersQuestion(
       @JsonProperty(PROP_DUPLICATES_ONLY) boolean duplicatesOnly,
       @JsonProperty(PROP_EXCLUDE_INACTIVE) boolean excludeInactive) {
-    _excludeInactive = excludeInactive;
     _duplicatesOnly = duplicatesOnly;
   }
 
@@ -45,10 +41,5 @@ public class IpOwnersQuestion extends Question {
   @JsonProperty(PROP_DUPLICATES_ONLY)
   public boolean getDuplicatesOnly() {
     return _duplicatesOnly;
-  }
-
-  @JsonProperty(PROP_EXCLUDE_INACTIVE)
-  public boolean getExcludeInactive() {
-    return _excludeInactive;
   }
 }

--- a/projects/question/src/main/java/org/batfish/question/ipowners/IpOwnersQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/ipowners/IpOwnersQuestion.java
@@ -1,0 +1,54 @@
+package org.batfish.question.ipowners;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.batfish.datamodel.questions.Question;
+
+/** Queries the computed IP owners across all nodes/VRFs/Interfaces in the network. */
+public class IpOwnersQuestion extends Question {
+
+  private static final String PROP_DUPLICATES_ONLY = "duplicatesOnly";
+
+  private static final String PROP_EXCLUDE_INACTIVE = "excludeInactive";
+
+  private static final String QUESTION_NAME = "ipowners";
+
+  /** Whether to return duplicate IPs (owned by multiple nodes) only. */
+  private boolean _duplicatesOnly;
+
+  /** Whether to exclude inactive interfaces from the computation */
+  private boolean _excludeInactive;
+
+  @JsonCreator
+  public IpOwnersQuestion(
+      @JsonProperty(PROP_DUPLICATES_ONLY) boolean duplicatesOnly,
+      @JsonProperty(PROP_EXCLUDE_INACTIVE) boolean excludeInactive) {
+    _excludeInactive = excludeInactive;
+    _duplicatesOnly = duplicatesOnly;
+  }
+
+  /** Initialize with default values */
+  IpOwnersQuestion() {
+    this(false, false);
+  }
+
+  @Override
+  public boolean getDataPlane() {
+    return false;
+  }
+
+  @Override
+  public String getName() {
+    return QUESTION_NAME;
+  }
+
+  @JsonProperty(PROP_DUPLICATES_ONLY)
+  public boolean getDuplicatesOnly() {
+    return _duplicatesOnly;
+  }
+
+  @JsonProperty(PROP_EXCLUDE_INACTIVE)
+  public boolean getExcludeInactive() {
+    return _excludeInactive;
+  }
+}

--- a/projects/question/src/main/java/org/batfish/question/ipowners/IpOwnersQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/ipowners/IpOwnersQuestionPlugin.java
@@ -1,0 +1,22 @@
+package org.batfish.question.ipowners;
+
+import com.google.auto.service.AutoService;
+import org.batfish.common.plugin.IBatfish;
+import org.batfish.common.plugin.Plugin;
+import org.batfish.datamodel.questions.Question;
+import org.batfish.question.QuestionPlugin;
+
+/** Return information about which IP/Node/Interface owns which IP in the network. */
+@AutoService(Plugin.class)
+public class IpOwnersQuestionPlugin extends QuestionPlugin {
+
+  @Override
+  protected IpOwnersAnswerer createAnswerer(Question question, IBatfish batfish) {
+    return new IpOwnersAnswerer(question, batfish);
+  }
+
+  @Override
+  protected Question createQuestion() {
+    return new IpOwnersQuestion();
+  }
+}

--- a/projects/question/src/test/java/org/batfish/question/ipowners/IpOwnersAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/ipowners/IpOwnersAnswererTest.java
@@ -4,6 +4,7 @@ import static org.batfish.question.ipowners.IpOwnersAnswerElement.COL_IP;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
 
 import com.google.common.collect.ImmutableMap;
@@ -11,8 +12,14 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multiset;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.table.Row;
 import org.junit.Before;
 import org.junit.Test;
@@ -22,49 +29,63 @@ public class IpOwnersAnswererTest {
   private Ip _uniqueIp = new Ip("1.1.1.1");
   private Ip _duplicateIp = new Ip("2.2.2.2");
   private Ip _noOwnersIp = new Ip("3.3.3.3");
-  private Map<Ip, Map<String, Set<String>>> _ownersMap;
-  private Map<Ip, Map<String, Set<String>>> _interaceMap;
+  private ImmutableMap<Ip, Set<String>> _ownersMap;
+  private Map<String, Set<Interface>> _interfaceMap;
 
-  /** Setup the maps as would be computed by the */
+  /** Setup the maps that the answerer processes, with mix of active and inactive interfaces */
   @Before
   public void setup() {
+    Vrf vrf = new Vrf(Configuration.DEFAULT_VRF_NAME);
+    Interface.Builder ib = Interface.builder().setVrf(vrf);
+    InterfaceAddress uniqueAddr = new InterfaceAddress(_uniqueIp, Prefix.MAX_PREFIX_LENGTH);
+    InterfaceAddress duplicateAddr = new InterfaceAddress(_duplicateIp, Prefix.MAX_PREFIX_LENGTH);
     _ownersMap =
         ImmutableMap.of(
             _uniqueIp,
-            ImmutableMap.of("n1", ImmutableSet.of(Configuration.DEFAULT_VRF_NAME)),
+            ImmutableSet.of("n1"),
             _duplicateIp,
-            ImmutableMap.of(
-                "n1",
-                ImmutableSet.of(Configuration.DEFAULT_VRF_NAME),
-                "n2",
-                ImmutableSet.of(Configuration.DEFAULT_VRF_NAME)),
+            ImmutableSet.of("n1", "n2"),
             _noOwnersIp,
-            ImmutableMap.of());
-    _interaceMap =
+            ImmutableSet.of());
+    _interfaceMap =
         ImmutableMap.of(
-            _uniqueIp,
-            ImmutableMap.of("n1", ImmutableSet.of("Eth0")),
-            _duplicateIp,
-            ImmutableMap.of("n1", ImmutableSet.of("Eth0"), "n2", ImmutableSet.of("Eth0")));
+            "n1",
+            ImmutableSet.of(
+                ib.setActive(false).setAddress(duplicateAddr).setName("Eth1/1").build()),
+            "n2",
+            ImmutableSet.of(
+                ib.setActive(true).setAddress(duplicateAddr).setName("Eth2/1").build(),
+                ib.setActive(true).setAddress(uniqueAddr).setName("Eth2/2").build()));
   }
 
   /** Test that rows show up correctly if duplicatesOnly is false, and we can handle empty maps */
   @Test
   public void testRowGenerationAllIps() {
-    // Do generation with no IP owners, no Interface Ips
+    // Generate rows with no IP owners, no Interface Ips
     Multiset<Row> rows = IpOwnersAnswerer.generateRows(ImmutableMap.of(), ImmutableMap.of(), false);
     assertThat(rows, empty());
 
-    // Do generation for actual data, expect three rows, one for _uniqueIP, two for _duplicateIp
-    rows = IpOwnersAnswerer.generateRows(_ownersMap, _interaceMap, false);
+    // Generate rows for actual data
+    rows = IpOwnersAnswerer.generateRows(_ownersMap, _interfaceMap, false);
+
+    /*
+     * Test that:
+     * We have three rows, one for _uniqueIP, two for _duplicateIp
+     */
     assertThat(rows, hasSize(3));
+    Map<Ip, Long> counts =
+        rows.stream()
+            .map(r -> r.get(COL_IP, Ip.class))
+            .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+    assertThat(counts, hasEntry(_uniqueIp, 1L));
+    assertThat(counts, hasEntry(_duplicateIp, 2L));
   }
 
   @Test
   public void testRowGenerationDuplicatesOnly() {
 
     // Expect two rows for _duplicateIp only
-    Multiset<Row> rows = IpOwnersAnswerer.generateRows(_ownersMap, _interaceMap, true);
+    Multiset<Row> rows = IpOwnersAnswerer.generateRows(_ownersMap, _interfaceMap, true);
     assertThat(rows, hasSize(2));
     for (Row row : rows) {
       assertThat(row.get(COL_IP, Ip.class), equalTo(_duplicateIp));

--- a/projects/question/src/test/java/org/batfish/question/ipowners/IpOwnersAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/ipowners/IpOwnersAnswererTest.java
@@ -1,0 +1,73 @@
+package org.batfish.question.ipowners;
+
+import static org.batfish.question.ipowners.IpOwnersAnswerElement.COL_IP;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multiset;
+import java.util.Map;
+import java.util.Set;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.table.Row;
+import org.junit.Before;
+import org.junit.Test;
+
+/** Tests for {@link IpOwnersAnswerer} */
+public class IpOwnersAnswererTest {
+  private Ip _uniqueIp = new Ip("1.1.1.1");
+  private Ip _duplicateIp = new Ip("2.2.2.2");
+  private Ip _noOwnersIp = new Ip("3.3.3.3");
+  private Map<Ip, Map<String, Set<String>>> _ownersMap;
+  private Map<Ip, Map<String, Set<String>>> _interaceMap;
+
+  /** Setup the maps as would be computed by the */
+  @Before
+  public void setup() {
+    _ownersMap =
+        ImmutableMap.of(
+            _uniqueIp,
+            ImmutableMap.of("n1", ImmutableSet.of(Configuration.DEFAULT_VRF_NAME)),
+            _duplicateIp,
+            ImmutableMap.of(
+                "n1",
+                ImmutableSet.of(Configuration.DEFAULT_VRF_NAME),
+                "n2",
+                ImmutableSet.of(Configuration.DEFAULT_VRF_NAME)),
+            _noOwnersIp,
+            ImmutableMap.of());
+    _interaceMap =
+        ImmutableMap.of(
+            _uniqueIp,
+            ImmutableMap.of("n1", ImmutableSet.of("Eth0")),
+            _duplicateIp,
+            ImmutableMap.of("n1", ImmutableSet.of("Eth0"), "n2", ImmutableSet.of("Eth0")));
+  }
+
+  /** Test that rows show up correctly if duplicatesOnly is false, and we can handle empty maps */
+  @Test
+  public void testRowGenerationAllIps() {
+    // Do generation with no IP owners, no Interface Ips
+    Multiset<Row> rows = IpOwnersAnswerer.generateRows(ImmutableMap.of(), ImmutableMap.of(), false);
+    assertThat(rows, empty());
+
+    // Do generation for actual data, expect three rows, one for _uniqueIP, two for _duplicateIp
+    rows = IpOwnersAnswerer.generateRows(_ownersMap, _interaceMap, false);
+    assertThat(rows, hasSize(3));
+  }
+
+  @Test
+  public void testRowGenerationDuplicatesOnly() {
+
+    // Expect two rows for _duplicateIp only
+    Multiset<Row> rows = IpOwnersAnswerer.generateRows(_ownersMap, _interaceMap, true);
+    assertThat(rows, hasSize(2));
+    for (Row row : rows) {
+      assertThat(row.get(COL_IP, Ip.class), equalTo(_duplicateIp));
+    }
+  }
+}

--- a/tests/basic/commands
+++ b/tests/basic/commands
@@ -13,6 +13,7 @@ test tests/basic/nodes.ref get nodes summary=false
 test tests/basic/neighbors-summary.ref get neighbors neighborTypes=["ebgp","ibgp","ospf","lan"]
 test tests/basic/neighbors.ref get neighbors style=verbose, neighborTypes=["ebgp","ibgp","ospf","lan"]
 test tests/basic/routes.ref get routes
+test tests/basic/ipowners.ref get ipowners
 
 # some ref tests using delta testrig
 test -compareall tests/basic/init-delta.ref init-delta-testrig test_rigs/example-with-delta basic-example-delta

--- a/tests/basic/ipowners.ref
+++ b/tests/basic/ipowners.ref
@@ -1,0 +1,480 @@
+[
+  {
+    "class" : "org.batfish.question.ipowners.IpOwnersAnswerElement",
+    "metadata" : {
+      "columnMetadata" : [
+        {
+          "description" : "Node hostname",
+          "isKey" : true,
+          "isValue" : true,
+          "name" : "Hostname",
+          "schema" : "String"
+        },
+        {
+          "description" : "VRF name",
+          "isKey" : true,
+          "isValue" : true,
+          "name" : "VRF",
+          "schema" : "String"
+        },
+        {
+          "description" : "Interface name",
+          "isKey" : true,
+          "isValue" : true,
+          "name" : "Interface",
+          "schema" : "String"
+        },
+        {
+          "description" : "IP address",
+          "isKey" : true,
+          "isValue" : true,
+          "name" : "IP",
+          "schema" : "Ip"
+        }
+      ],
+      "displayHints" : {
+        "textDesc" : "On node ${Hostname} in VRF ${VRF}, interface ${Interface} has IP ${IP}."
+      }
+    },
+    "rows" : [
+      {
+        "Hostname" : "as2border2",
+        "VRF" : "default",
+        "Interface" : [
+          "GigabitEthernet2/0"
+        ],
+        "IP" : "2.12.21.1"
+      },
+      {
+        "Hostname" : "as1border2",
+        "VRF" : "default",
+        "Interface" : [
+          "GigabitEthernet1/0"
+        ],
+        "IP" : "1.0.2.1"
+      },
+      {
+        "Hostname" : "as1border1",
+        "VRF" : "default",
+        "Interface" : [
+          "GigabitEthernet0/0"
+        ],
+        "IP" : "1.0.1.1"
+      },
+      {
+        "Hostname" : "as2border2",
+        "VRF" : "default",
+        "Interface" : [
+          "GigabitEthernet1/0"
+        ],
+        "IP" : "2.12.22.1"
+      },
+      {
+        "Hostname" : "as3border2",
+        "VRF" : "default",
+        "Interface" : [
+          "GigabitEthernet0/0"
+        ],
+        "IP" : "10.13.22.3"
+      },
+      {
+        "Hostname" : "as1border2",
+        "VRF" : "default",
+        "Interface" : [
+          "GigabitEthernet2/0"
+        ],
+        "IP" : "10.14.22.1"
+      },
+      {
+        "Hostname" : "as3core1",
+        "VRF" : "default",
+        "Interface" : [
+          "GigabitEthernet0/0"
+        ],
+        "IP" : "3.0.2.2"
+      },
+      {
+        "Hostname" : "as3core1",
+        "VRF" : "default",
+        "Interface" : [
+          "GigabitEthernet1/0"
+        ],
+        "IP" : "3.0.1.2"
+      },
+      {
+        "Hostname" : "as1border2",
+        "VRF" : "default",
+        "Interface" : [
+          "GigabitEthernet0/0"
+        ],
+        "IP" : "10.13.22.1"
+      },
+      {
+        "Hostname" : "host2",
+        "VRF" : "default",
+        "Interface" : [
+          "eth0"
+        ],
+        "IP" : "2.128.1.101"
+      },
+      {
+        "Hostname" : "as2core1",
+        "VRF" : "default",
+        "Interface" : [
+          "GigabitEthernet0/0"
+        ],
+        "IP" : "2.12.11.2"
+      },
+      {
+        "Hostname" : "as2dept1",
+        "VRF" : "default",
+        "Interface" : [
+          "GigabitEthernet0/0"
+        ],
+        "IP" : "2.34.101.4"
+      },
+      {
+        "Hostname" : "as3border1",
+        "VRF" : "default",
+        "Interface" : [
+          "Loopback0"
+        ],
+        "IP" : "3.1.1.1"
+      },
+      {
+        "Hostname" : "as3core1",
+        "VRF" : "default",
+        "Interface" : [
+          "GigabitEthernet3/0"
+        ],
+        "IP" : "90.90.90.2"
+      },
+      {
+        "Hostname" : "as2core2",
+        "VRF" : "default",
+        "Interface" : [
+          "GigabitEthernet1/0"
+        ],
+        "IP" : "2.12.12.2"
+      },
+      {
+        "Hostname" : "as3border1",
+        "VRF" : "default",
+        "Interface" : [
+          "GigabitEthernet1/0"
+        ],
+        "IP" : "10.23.21.3"
+      },
+      {
+        "Hostname" : "as1border2",
+        "VRF" : "default",
+        "Interface" : [
+          "Loopback0"
+        ],
+        "IP" : "1.2.2.2"
+      },
+      {
+        "Hostname" : "as2dept1",
+        "VRF" : "default",
+        "Interface" : [
+          "GigabitEthernet2/0"
+        ],
+        "IP" : "2.128.0.1"
+      },
+      {
+        "Hostname" : "as2dept1",
+        "VRF" : "default",
+        "Interface" : [
+          "GigabitEthernet3/0"
+        ],
+        "IP" : "2.128.1.1"
+      },
+      {
+        "Hostname" : "as1border1",
+        "VRF" : "default",
+        "Interface" : [
+          "GigabitEthernet1/0"
+        ],
+        "IP" : "10.12.11.1"
+      },
+      {
+        "Hostname" : "host1",
+        "VRF" : "default",
+        "Interface" : [
+          "eth0"
+        ],
+        "IP" : "2.128.0.101"
+      },
+      {
+        "Hostname" : "as3border1",
+        "VRF" : "default",
+        "Interface" : [
+          "GigabitEthernet0/0"
+        ],
+        "IP" : "3.0.1.1"
+      },
+      {
+        "Hostname" : "as2border1",
+        "VRF" : "default",
+        "Interface" : [
+          "GigabitEthernet0/0"
+        ],
+        "IP" : "10.12.11.2"
+      },
+      {
+        "Hostname" : "as2dist2",
+        "VRF" : "default",
+        "Interface" : [
+          "GigabitEthernet0/0"
+        ],
+        "IP" : "2.23.22.3"
+      },
+      {
+        "Hostname" : "as3border2",
+        "VRF" : "default",
+        "Interface" : [
+          "GigabitEthernet1/0"
+        ],
+        "IP" : "3.0.2.1"
+      },
+      {
+        "Hostname" : "as2dist1",
+        "VRF" : "default",
+        "Interface" : [
+          "GigabitEthernet1/0"
+        ],
+        "IP" : "2.23.21.3"
+      },
+      {
+        "Hostname" : "as2dist1",
+        "VRF" : "default",
+        "Interface" : [
+          "Loopback0"
+        ],
+        "IP" : "2.1.3.1"
+      },
+      {
+        "Hostname" : "as2border2",
+        "VRF" : "default",
+        "Interface" : [
+          "Loopback0"
+        ],
+        "IP" : "2.1.1.2"
+      },
+      {
+        "Hostname" : "as2core2",
+        "VRF" : "default",
+        "Interface" : [
+          "GigabitEthernet0/0"
+        ],
+        "IP" : "2.12.22.2"
+      },
+      {
+        "Hostname" : "as2core1",
+        "VRF" : "default",
+        "Interface" : [
+          "GigabitEthernet1/0"
+        ],
+        "IP" : "2.12.21.2"
+      },
+      {
+        "Hostname" : "as1core1",
+        "VRF" : "default",
+        "Interface" : [
+          "Loopback0"
+        ],
+        "IP" : "1.10.1.1"
+      },
+      {
+        "Hostname" : "as2dist2",
+        "VRF" : "default",
+        "Interface" : [
+          "Loopback0"
+        ],
+        "IP" : "2.1.3.2"
+      },
+      {
+        "Hostname" : "as2core2",
+        "VRF" : "default",
+        "Interface" : [
+          "GigabitEthernet2/0"
+        ],
+        "IP" : "2.23.22.2"
+      },
+      {
+        "Hostname" : "as2core2",
+        "VRF" : "default",
+        "Interface" : [
+          "GigabitEthernet3/0"
+        ],
+        "IP" : "2.23.21.2"
+      },
+      {
+        "Hostname" : "as2dept1",
+        "VRF" : "default",
+        "Interface" : [
+          "GigabitEthernet1/0"
+        ],
+        "IP" : "2.34.201.4"
+      },
+      {
+        "Hostname" : "as2border1",
+        "VRF" : "default",
+        "Interface" : [
+          "Loopback0"
+        ],
+        "IP" : "2.1.1.1"
+      },
+      {
+        "Hostname" : "as2dist2",
+        "VRF" : "default",
+        "Interface" : [
+          "GigabitEthernet1/0"
+        ],
+        "IP" : "2.23.12.3"
+      },
+      {
+        "Hostname" : "as2core1",
+        "VRF" : "default",
+        "Interface" : [
+          "GigabitEthernet2/0"
+        ],
+        "IP" : "2.23.11.2"
+      },
+      {
+        "Hostname" : "as2border1",
+        "VRF" : "default",
+        "Interface" : [
+          "GigabitEthernet2/0"
+        ],
+        "IP" : "2.12.12.1"
+      },
+      {
+        "Hostname" : "as2dist2",
+        "VRF" : "default",
+        "Interface" : [
+          "GigabitEthernet2/0"
+        ],
+        "IP" : "2.34.201.3"
+      },
+      {
+        "Hostname" : "as2dept1",
+        "VRF" : "default",
+        "Interface" : [
+          "Loopback0"
+        ],
+        "IP" : "2.1.1.2"
+      },
+      {
+        "Hostname" : "as3core1",
+        "VRF" : "default",
+        "Interface" : [
+          "Loopback0"
+        ],
+        "IP" : "3.10.1.1"
+      },
+      {
+        "Hostname" : "as2border1",
+        "VRF" : "default",
+        "Interface" : [
+          "GigabitEthernet1/0"
+        ],
+        "IP" : "2.12.11.1"
+      },
+      {
+        "Hostname" : "as2dist1",
+        "VRF" : "default",
+        "Interface" : [
+          "GigabitEthernet0/0"
+        ],
+        "IP" : "2.23.11.3"
+      },
+      {
+        "Hostname" : "as3border2",
+        "VRF" : "default",
+        "Interface" : [
+          "Loopback0"
+        ],
+        "IP" : "3.2.2.2"
+      },
+      {
+        "Hostname" : "as3core1",
+        "VRF" : "default",
+        "Interface" : [
+          "GigabitEthernet2/0"
+        ],
+        "IP" : "90.90.90.1"
+      },
+      {
+        "Hostname" : "as1core1",
+        "VRF" : "default",
+        "Interface" : [
+          "GigabitEthernet0/0"
+        ],
+        "IP" : "1.0.2.2"
+      },
+      {
+        "Hostname" : "as1core1",
+        "VRF" : "default",
+        "Interface" : [
+          "GigabitEthernet1/0"
+        ],
+        "IP" : "1.0.1.2"
+      },
+      {
+        "Hostname" : "as2dist1",
+        "VRF" : "default",
+        "Interface" : [
+          "GigabitEthernet2/0"
+        ],
+        "IP" : "2.34.101.3"
+      },
+      {
+        "Hostname" : "as2core2",
+        "VRF" : "default",
+        "Interface" : [
+          "Loopback0"
+        ],
+        "IP" : "2.1.2.2"
+      },
+      {
+        "Hostname" : "as2core1",
+        "VRF" : "default",
+        "Interface" : [
+          "Loopback0"
+        ],
+        "IP" : "2.1.2.1"
+      },
+      {
+        "Hostname" : "as1border1",
+        "VRF" : "default",
+        "Interface" : [
+          "Loopback0"
+        ],
+        "IP" : "1.1.1.1"
+      },
+      {
+        "Hostname" : "as2border2",
+        "VRF" : "default",
+        "Interface" : [
+          "GigabitEthernet0/0"
+        ],
+        "IP" : "10.23.21.2"
+      },
+      {
+        "Hostname" : "as2core1",
+        "VRF" : "default",
+        "Interface" : [
+          "GigabitEthernet3/0"
+        ],
+        "IP" : "2.23.12.2"
+      }
+    ],
+    "summary" : {
+      "notes" : "Found 54 results",
+      "numFailed" : 0,
+      "numPassed" : 0,
+      "numResults" : 54
+    }
+  }
+]

--- a/tests/basic/ipowners.ref
+++ b/tests/basic/ipowners.ref
@@ -8,7 +8,7 @@
           "isKey" : true,
           "isValue" : true,
           "name" : "Hostname",
-          "schema" : "String"
+          "schema" : "Node"
         },
         {
           "description" : "VRF name",
@@ -30,6 +30,13 @@
           "isValue" : true,
           "name" : "IP",
           "schema" : "Ip"
+        },
+        {
+          "description" : "Whether the interface with given IP is active",
+          "isKey" : true,
+          "isValue" : true,
+          "name" : "Active",
+          "schema" : "Boolean"
         }
       ],
       "displayHints" : {
@@ -38,436 +45,544 @@
     },
     "rows" : [
       {
-        "Hostname" : "as2border2",
+        "Hostname" : {
+          "id" : "node-as2core1",
+          "name" : "as2core1"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "GigabitEthernet2/0"
-        ],
-        "IP" : "2.12.21.1"
+        "Interface" : "GigabitEthernet2/0",
+        "IP" : "2.23.11.2",
+        "Active" : true
       },
       {
-        "Hostname" : "as1border2",
+        "Hostname" : {
+          "id" : "node-as2core2",
+          "name" : "as2core2"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "GigabitEthernet1/0"
-        ],
-        "IP" : "1.0.2.1"
+        "Interface" : "GigabitEthernet1/0",
+        "IP" : "2.12.12.2",
+        "Active" : true
       },
       {
-        "Hostname" : "as1border1",
+        "Hostname" : {
+          "id" : "node-as2border1",
+          "name" : "as2border1"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "GigabitEthernet0/0"
-        ],
-        "IP" : "1.0.1.1"
+        "Interface" : "GigabitEthernet2/0",
+        "IP" : "2.12.12.1",
+        "Active" : true
       },
       {
-        "Hostname" : "as2border2",
+        "Hostname" : {
+          "id" : "node-as2border1",
+          "name" : "as2border1"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "GigabitEthernet1/0"
-        ],
-        "IP" : "2.12.22.1"
+        "Interface" : "GigabitEthernet1/0",
+        "IP" : "2.12.11.1",
+        "Active" : true
       },
       {
-        "Hostname" : "as3border2",
+        "Hostname" : {
+          "id" : "node-as3core1",
+          "name" : "as3core1"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "GigabitEthernet0/0"
-        ],
-        "IP" : "10.13.22.3"
+        "Interface" : "GigabitEthernet2/0",
+        "IP" : "90.90.90.1",
+        "Active" : true
       },
       {
-        "Hostname" : "as1border2",
+        "Hostname" : {
+          "id" : "node-as3border2",
+          "name" : "as3border2"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "GigabitEthernet2/0"
-        ],
-        "IP" : "10.14.22.1"
+        "Interface" : "Loopback0",
+        "IP" : "3.2.2.2",
+        "Active" : true
       },
       {
-        "Hostname" : "as3core1",
+        "Hostname" : {
+          "id" : "node-as1border2",
+          "name" : "as1border2"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "GigabitEthernet0/0"
-        ],
-        "IP" : "3.0.2.2"
+        "Interface" : "GigabitEthernet1/0",
+        "IP" : "1.0.2.1",
+        "Active" : true
       },
       {
-        "Hostname" : "as3core1",
+        "Hostname" : {
+          "id" : "node-as3border1",
+          "name" : "as3border1"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "GigabitEthernet1/0"
-        ],
-        "IP" : "3.0.1.2"
+        "Interface" : "GigabitEthernet1/0",
+        "IP" : "10.23.21.3",
+        "Active" : true
       },
       {
-        "Hostname" : "as1border2",
+        "Hostname" : {
+          "id" : "node-as3border1",
+          "name" : "as3border1"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "GigabitEthernet0/0"
-        ],
-        "IP" : "10.13.22.1"
+        "Interface" : "Loopback0",
+        "IP" : "3.1.1.1",
+        "Active" : true
       },
       {
-        "Hostname" : "host2",
+        "Hostname" : {
+          "id" : "node-as1border1",
+          "name" : "as1border1"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "eth0"
-        ],
-        "IP" : "2.128.1.101"
+        "Interface" : "GigabitEthernet0/0",
+        "IP" : "1.0.1.1",
+        "Active" : true
       },
       {
-        "Hostname" : "as2core1",
+        "Hostname" : {
+          "id" : "node-as2dist2",
+          "name" : "as2dist2"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "GigabitEthernet0/0"
-        ],
-        "IP" : "2.12.11.2"
+        "Interface" : "GigabitEthernet2/0",
+        "IP" : "2.34.201.3",
+        "Active" : true
       },
       {
-        "Hostname" : "as2dept1",
+        "Hostname" : {
+          "id" : "node-as1border2",
+          "name" : "as1border2"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "GigabitEthernet0/0"
-        ],
-        "IP" : "2.34.101.4"
+        "Interface" : "GigabitEthernet0/0",
+        "IP" : "10.13.22.1",
+        "Active" : true
       },
       {
-        "Hostname" : "as3border1",
+        "Hostname" : {
+          "id" : "node-as3border2",
+          "name" : "as3border2"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "Loopback0"
-        ],
-        "IP" : "3.1.1.1"
+        "Interface" : "GigabitEthernet0/0",
+        "IP" : "10.13.22.3",
+        "Active" : true
       },
       {
-        "Hostname" : "as3core1",
+        "Hostname" : {
+          "id" : "node-as2core2",
+          "name" : "as2core2"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "GigabitEthernet3/0"
-        ],
-        "IP" : "90.90.90.2"
+        "Interface" : "GigabitEthernet3/0",
+        "IP" : "2.23.21.2",
+        "Active" : true
       },
       {
-        "Hostname" : "as2core2",
+        "Hostname" : {
+          "id" : "node-as2dist2",
+          "name" : "as2dist2"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "GigabitEthernet1/0"
-        ],
-        "IP" : "2.12.12.2"
+        "Interface" : "GigabitEthernet0/0",
+        "IP" : "2.23.22.3",
+        "Active" : true
       },
       {
-        "Hostname" : "as3border1",
+        "Hostname" : {
+          "id" : "node-as2core2",
+          "name" : "as2core2"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "GigabitEthernet1/0"
-        ],
-        "IP" : "10.23.21.3"
+        "Interface" : "GigabitEthernet2/0",
+        "IP" : "2.23.22.2",
+        "Active" : true
       },
       {
-        "Hostname" : "as1border2",
+        "Hostname" : {
+          "id" : "node-as1core1",
+          "name" : "as1core1"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "Loopback0"
-        ],
-        "IP" : "1.2.2.2"
+        "Interface" : "Loopback0",
+        "IP" : "1.10.1.1",
+        "Active" : true
       },
       {
-        "Hostname" : "as2dept1",
+        "Hostname" : {
+          "id" : "node-as2core1",
+          "name" : "as2core1"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "GigabitEthernet2/0"
-        ],
-        "IP" : "2.128.0.1"
+        "Interface" : "GigabitEthernet1/0",
+        "IP" : "2.12.21.2",
+        "Active" : true
       },
       {
-        "Hostname" : "as2dept1",
+        "Hostname" : {
+          "id" : "node-as1core1",
+          "name" : "as1core1"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "GigabitEthernet3/0"
-        ],
-        "IP" : "2.128.1.1"
+        "Interface" : "GigabitEthernet1/0",
+        "IP" : "1.0.1.2",
+        "Active" : true
       },
       {
-        "Hostname" : "as1border1",
+        "Hostname" : {
+          "id" : "node-as1core1",
+          "name" : "as1core1"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "GigabitEthernet1/0"
-        ],
-        "IP" : "10.12.11.1"
+        "Interface" : "GigabitEthernet0/0",
+        "IP" : "1.0.2.2",
+        "Active" : true
       },
       {
-        "Hostname" : "host1",
+        "Hostname" : {
+          "id" : "node-as2border2",
+          "name" : "as2border2"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "eth0"
-        ],
-        "IP" : "2.128.0.101"
+        "Interface" : "GigabitEthernet0/0",
+        "IP" : "10.23.21.2",
+        "Active" : true
       },
       {
-        "Hostname" : "as3border1",
+        "Hostname" : {
+          "id" : "node-as2dept1",
+          "name" : "as2dept1"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "GigabitEthernet0/0"
-        ],
-        "IP" : "3.0.1.1"
+        "Interface" : "GigabitEthernet2/0",
+        "IP" : "2.128.0.1",
+        "Active" : true
       },
       {
-        "Hostname" : "as2border1",
+        "Hostname" : {
+          "id" : "node-as1border2",
+          "name" : "as1border2"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "GigabitEthernet0/0"
-        ],
-        "IP" : "10.12.11.2"
+        "Interface" : "Loopback0",
+        "IP" : "1.2.2.2",
+        "Active" : true
       },
       {
-        "Hostname" : "as2dist2",
+        "Hostname" : {
+          "id" : "node-as2dept1",
+          "name" : "as2dept1"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "GigabitEthernet0/0"
-        ],
-        "IP" : "2.23.22.3"
+        "Interface" : "GigabitEthernet3/0",
+        "IP" : "2.128.1.1",
+        "Active" : true
       },
       {
-        "Hostname" : "as3border2",
+        "Hostname" : {
+          "id" : "node-as2dept1",
+          "name" : "as2dept1"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "GigabitEthernet1/0"
-        ],
-        "IP" : "3.0.2.1"
+        "Interface" : "GigabitEthernet0/0",
+        "IP" : "2.34.101.4",
+        "Active" : true
       },
       {
-        "Hostname" : "as2dist1",
+        "Hostname" : {
+          "id" : "node-as2dist2",
+          "name" : "as2dist2"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "GigabitEthernet1/0"
-        ],
-        "IP" : "2.23.21.3"
+        "Interface" : "GigabitEthernet1/0",
+        "IP" : "2.23.12.3",
+        "Active" : true
       },
       {
-        "Hostname" : "as2dist1",
+        "Hostname" : {
+          "id" : "node-as2core1",
+          "name" : "as2core1"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "Loopback0"
-        ],
-        "IP" : "2.1.3.1"
+        "Interface" : "GigabitEthernet0/0",
+        "IP" : "2.12.11.2",
+        "Active" : true
       },
       {
-        "Hostname" : "as2border2",
+        "Hostname" : {
+          "id" : "node-as2dist1",
+          "name" : "as2dist1"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "Loopback0"
-        ],
-        "IP" : "2.1.1.2"
+        "Interface" : "GigabitEthernet1/0",
+        "IP" : "2.23.21.3",
+        "Active" : true
       },
       {
-        "Hostname" : "as2core2",
+        "Hostname" : {
+          "id" : "node-as2border1",
+          "name" : "as2border1"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "GigabitEthernet0/0"
-        ],
-        "IP" : "2.12.22.2"
+        "Interface" : "Loopback0",
+        "IP" : "2.1.1.1",
+        "Active" : true
       },
       {
-        "Hostname" : "as2core1",
+        "Hostname" : {
+          "id" : "node-as2dist1",
+          "name" : "as2dist1"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "GigabitEthernet1/0"
-        ],
-        "IP" : "2.12.21.2"
+        "Interface" : "GigabitEthernet0/0",
+        "IP" : "2.23.11.3",
+        "Active" : true
       },
       {
-        "Hostname" : "as1core1",
+        "Hostname" : {
+          "id" : "node-as2dept1",
+          "name" : "as2dept1"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "Loopback0"
-        ],
-        "IP" : "1.10.1.1"
+        "Interface" : "GigabitEthernet1/0",
+        "IP" : "2.34.201.4",
+        "Active" : true
       },
       {
-        "Hostname" : "as2dist2",
+        "Hostname" : {
+          "id" : "node-as3core1",
+          "name" : "as3core1"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "Loopback0"
-        ],
-        "IP" : "2.1.3.2"
+        "Interface" : "GigabitEthernet3/0",
+        "IP" : "90.90.90.2",
+        "Active" : true
       },
       {
-        "Hostname" : "as2core2",
+        "Hostname" : {
+          "id" : "node-as2core2",
+          "name" : "as2core2"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "GigabitEthernet2/0"
-        ],
-        "IP" : "2.23.22.2"
+        "Interface" : "Loopback0",
+        "IP" : "2.1.2.2",
+        "Active" : true
       },
       {
-        "Hostname" : "as2core2",
+        "Hostname" : {
+          "id" : "node-as2core1",
+          "name" : "as2core1"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "GigabitEthernet3/0"
-        ],
-        "IP" : "2.23.21.2"
+        "Interface" : "Loopback0",
+        "IP" : "2.1.2.1",
+        "Active" : true
       },
       {
-        "Hostname" : "as2dept1",
+        "Hostname" : {
+          "id" : "node-as2dist1",
+          "name" : "as2dist1"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "GigabitEthernet1/0"
-        ],
-        "IP" : "2.34.201.4"
+        "Interface" : "Loopback0",
+        "IP" : "2.1.3.1",
+        "Active" : true
       },
       {
-        "Hostname" : "as2border1",
+        "Hostname" : {
+          "id" : "node-host1",
+          "name" : "host1"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "Loopback0"
-        ],
-        "IP" : "2.1.1.1"
+        "Interface" : "eth0",
+        "IP" : "2.128.0.101",
+        "Active" : true
       },
       {
-        "Hostname" : "as2dist2",
+        "Hostname" : {
+          "id" : "node-as2border1",
+          "name" : "as2border1"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "GigabitEthernet1/0"
-        ],
-        "IP" : "2.23.12.3"
+        "Interface" : "GigabitEthernet0/0",
+        "IP" : "10.12.11.2",
+        "Active" : true
       },
       {
-        "Hostname" : "as2core1",
+        "Hostname" : {
+          "id" : "node-as1border2",
+          "name" : "as1border2"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "GigabitEthernet2/0"
-        ],
-        "IP" : "2.23.11.2"
+        "Interface" : "GigabitEthernet2/0",
+        "IP" : "10.14.22.1",
+        "Active" : true
       },
       {
-        "Hostname" : "as2border1",
+        "Hostname" : {
+          "id" : "node-as2border2",
+          "name" : "as2border2"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "GigabitEthernet2/0"
-        ],
-        "IP" : "2.12.12.1"
+        "Interface" : "Loopback0",
+        "IP" : "2.1.1.2",
+        "Active" : true
       },
       {
-        "Hostname" : "as2dist2",
+        "Hostname" : {
+          "id" : "node-as2core2",
+          "name" : "as2core2"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "GigabitEthernet2/0"
-        ],
-        "IP" : "2.34.201.3"
+        "Interface" : "GigabitEthernet0/0",
+        "IP" : "2.12.22.2",
+        "Active" : true
       },
       {
-        "Hostname" : "as2dept1",
+        "Hostname" : {
+          "id" : "node-as3border2",
+          "name" : "as3border2"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "Loopback0"
-        ],
-        "IP" : "2.1.1.2"
+        "Interface" : "GigabitEthernet1/0",
+        "IP" : "3.0.2.1",
+        "Active" : true
       },
       {
-        "Hostname" : "as3core1",
+        "Hostname" : {
+          "id" : "node-as1border1",
+          "name" : "as1border1"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "Loopback0"
-        ],
-        "IP" : "3.10.1.1"
+        "Interface" : "Loopback0",
+        "IP" : "1.1.1.1",
+        "Active" : true
       },
       {
-        "Hostname" : "as2border1",
+        "Hostname" : {
+          "id" : "node-as2border2",
+          "name" : "as2border2"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "GigabitEthernet1/0"
-        ],
-        "IP" : "2.12.11.1"
+        "Interface" : "GigabitEthernet1/0",
+        "IP" : "2.12.22.1",
+        "Active" : true
       },
       {
-        "Hostname" : "as2dist1",
+        "Hostname" : {
+          "id" : "node-as2border2",
+          "name" : "as2border2"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "GigabitEthernet0/0"
-        ],
-        "IP" : "2.23.11.3"
+        "Interface" : "GigabitEthernet2/0",
+        "IP" : "2.12.21.1",
+        "Active" : true
       },
       {
-        "Hostname" : "as3border2",
+        "Hostname" : {
+          "id" : "node-as3core1",
+          "name" : "as3core1"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "Loopback0"
-        ],
-        "IP" : "3.2.2.2"
+        "Interface" : "Loopback0",
+        "IP" : "3.10.1.1",
+        "Active" : true
       },
       {
-        "Hostname" : "as3core1",
+        "Hostname" : {
+          "id" : "node-as2dist1",
+          "name" : "as2dist1"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "GigabitEthernet2/0"
-        ],
-        "IP" : "90.90.90.1"
+        "Interface" : "GigabitEthernet2/0",
+        "IP" : "2.34.101.3",
+        "Active" : true
       },
       {
-        "Hostname" : "as1core1",
+        "Hostname" : {
+          "id" : "node-as1border1",
+          "name" : "as1border1"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "GigabitEthernet0/0"
-        ],
-        "IP" : "1.0.2.2"
+        "Interface" : "GigabitEthernet1/0",
+        "IP" : "10.12.11.1",
+        "Active" : true
       },
       {
-        "Hostname" : "as1core1",
+        "Hostname" : {
+          "id" : "node-as2dept1",
+          "name" : "as2dept1"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "GigabitEthernet1/0"
-        ],
-        "IP" : "1.0.1.2"
+        "Interface" : "Loopback0",
+        "IP" : "2.1.1.2",
+        "Active" : true
       },
       {
-        "Hostname" : "as2dist1",
+        "Hostname" : {
+          "id" : "node-as2dist2",
+          "name" : "as2dist2"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "GigabitEthernet2/0"
-        ],
-        "IP" : "2.34.101.3"
+        "Interface" : "Loopback0",
+        "IP" : "2.1.3.2",
+        "Active" : true
       },
       {
-        "Hostname" : "as2core2",
+        "Hostname" : {
+          "id" : "node-as3core1",
+          "name" : "as3core1"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "Loopback0"
-        ],
-        "IP" : "2.1.2.2"
+        "Interface" : "GigabitEthernet0/0",
+        "IP" : "3.0.2.2",
+        "Active" : true
       },
       {
-        "Hostname" : "as2core1",
+        "Hostname" : {
+          "id" : "node-as3border1",
+          "name" : "as3border1"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "Loopback0"
-        ],
-        "IP" : "2.1.2.1"
+        "Interface" : "GigabitEthernet0/0",
+        "IP" : "3.0.1.1",
+        "Active" : true
       },
       {
-        "Hostname" : "as1border1",
+        "Hostname" : {
+          "id" : "node-as3core1",
+          "name" : "as3core1"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "Loopback0"
-        ],
-        "IP" : "1.1.1.1"
+        "Interface" : "GigabitEthernet1/0",
+        "IP" : "3.0.1.2",
+        "Active" : true
       },
       {
-        "Hostname" : "as2border2",
+        "Hostname" : {
+          "id" : "node-host2",
+          "name" : "host2"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "GigabitEthernet0/0"
-        ],
-        "IP" : "10.23.21.2"
+        "Interface" : "eth0",
+        "IP" : "2.128.1.101",
+        "Active" : true
       },
       {
-        "Hostname" : "as2core1",
+        "Hostname" : {
+          "id" : "node-as2core1",
+          "name" : "as2core1"
+        },
         "VRF" : "default",
-        "Interface" : [
-          "GigabitEthernet3/0"
-        ],
-        "IP" : "2.23.12.2"
+        "Interface" : "GigabitEthernet3/0",
+        "IP" : "2.23.12.2",
+        "Active" : true
       }
     ],
     "summary" : {


### PR DESCRIPTION
"Proper" version of #1291 
- Add the new question, with the `duplicatesOnly` flag, which can function as uniqueIpAssignments
- Return table containing IP and node, vrf, and interface names