### PR TITLE
Cisco_qos: use more permissive variable names

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_qos.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_qos.g4
@@ -218,7 +218,7 @@ match_semantics
 
 o_network
 :
-   NETWORK name = variable NEWLINE
+   NETWORK name = variable_permissive NEWLINE
    (
       on_description
       | on_fqdn
@@ -231,7 +231,7 @@ o_network
 
 o_service
 :
-   SERVICE name = variable NEWLINE
+   SERVICE name = variable_permissive NEWLINE
    (
       os_description
       | os_service
@@ -240,7 +240,7 @@ o_service
 
 og_icmp_type
 :
-   ICMP_TYPE name = variable NEWLINE
+   ICMP_TYPE name = variable_permissive NEWLINE
    (
       ogit_group_object
       | ogit_icmp_object
@@ -249,7 +249,7 @@ og_icmp_type
 
 og_ip_address
 :
-   IP ADDRESS name = variable NEWLINE
+   IP ADDRESS name = variable_permissive NEWLINE
    (
       ogipa_host_info
       | ogipa_ip_addresses
@@ -258,7 +258,7 @@ og_ip_address
 
 og_network
 :
-   NETWORK name = variable NEWLINE
+   NETWORK name = variable_permissive NEWLINE
    (
       ogn_description
       | ogn_group_object
@@ -270,7 +270,7 @@ og_network
 
 og_protocol
 :
-   PROTOCOL name = variable NEWLINE
+   PROTOCOL name = variable_permissive NEWLINE
    (
       ogp_description
       | ogp_group_object
@@ -280,7 +280,7 @@ og_protocol
 
 og_service
 :
-   SERVICE name = variable NEWLINE
+   SERVICE name = variable_permissive NEWLINE
    (
       ogs_description
       | ogs_group_object
@@ -293,7 +293,7 @@ og_service
 
 og_user
 :
-   USER name = variable NEWLINE
+   USER name = variable_permissive NEWLINE
    (
       ogu_description
       | ogu_group_object
@@ -324,7 +324,7 @@ ogipa_ip_addresses
 
 ogit_group_object
 :
-   GROUP_OBJECT name = variable NEWLINE
+   GROUP_OBJECT name = variable_permissive NEWLINE
 ;
 
 ogit_icmp_object
@@ -339,7 +339,7 @@ ogn_description
 
 ogn_group_object
 :
-   GROUP_OBJECT name = variable NEWLINE
+   GROUP_OBJECT name = variable_permissive NEWLINE
 ;
 
 ogn_host_ip
@@ -356,23 +356,19 @@ ogn_network_object
 :
    NETWORK_OBJECT
    (
-      prefix = IP_PREFIX
-      | prefix6 = IPV6_PREFIX
-      |
+      HOST
       (
-         HOST
-         (
-            address = IP_ADDRESS
-            | address6 = IPV6_ADDRESS
-            | host = variable
-         )
+         address = IP_ADDRESS
+         | address6 = IPV6_ADDRESS
+         // Do not reorder: variable_permissive captures all tokens in line
+         | host = variable_permissive
       )
-      |
-      (
-         OBJECT name = variable
-      )
-      | host = variable
       | wildcard_address = IP_ADDRESS wildcard_mask = IP_ADDRESS
+      | prefix = IP_PREFIX
+      | prefix6 = IPV6_PREFIX
+      | OBJECT name = variable_permissive
+      // Do not reorder: variable_permissive captures all tokens in line
+      | host = variable_permissive
    ) NEWLINE
 ;
 
@@ -383,7 +379,7 @@ ogp_description
 
 ogp_group_object
 :
-   GROUP_OBJECT name = variable NEWLINE
+   GROUP_OBJECT name = variable_permissive NEWLINE
 ;
 
 ogp_protocol_object
@@ -398,7 +394,7 @@ ogs_description
 
 ogs_group_object
 :
-   GROUP_OBJECT name = variable NEWLINE
+   GROUP_OBJECT name = variable_permissive NEWLINE
 ;
 
 ogs_icmp
@@ -437,17 +433,17 @@ ogu_description
 
 ogu_group_object
 :
-   GROUP_OBJECT name = variable NEWLINE
+   GROUP_OBJECT name = variable_permissive NEWLINE
 ;
 
 ogu_user
 :
-   USER name = variable NEWLINE
+   USER name = variable_permissive NEWLINE
 ;
 
 ogu_user_group
 :
-   name = variable NEWLINE
+   name = variable_permissive NEWLINE
 ;
 
 on_description
@@ -461,7 +457,7 @@ on_fqdn
    (
       V4
       | V6
-   )? fqdn = variable NEWLINE
+   )? fqdn = variable_permissive NEWLINE
 ;
 
 on_host
@@ -523,7 +519,7 @@ pm_end_policy_map
 
 pm_ios_inspect
 :
-   INSPECT name = variable NEWLINE
+   INSPECT name = variable_permissive NEWLINE
    (
       pm_iosi_class_default
       | pm_iosi_class_type_inspect

--- a/test_rigs/unit-tests/configs/cisco_qos
+++ b/test_rigs/unit-tests/configs/cisco_qos
@@ -23,6 +23,8 @@ object-group ip address BIPPETY
  30 host 3.4.5.6
 object network obj_any
  subnet 0.0.0.0 0.0.0.0
+object-group network 1.2.3.4-24
+ network-object 1.2.3.4 255.255.255.0
 object-group network dns_servers
  description External DNS Servers
  network-object host 1.2.2.1

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -8836,6 +8836,10 @@
           }
         },
         "ipSpaces" : {
+          "1.2.3.4-24" : {
+            "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+            "ipWildcard" : "1.2.3.0/24"
+          },
           "dns_servers" : {
             "class" : "org.batfish.datamodel.IpWildcardIpSpace",
             "ipWildcard" : "1.2.2.1"

--- a/tests/parsing-tests/unit-tests-undefined.ref
+++ b/tests/parsing-tests/unit-tests-undefined.ref
@@ -126,7 +126,7 @@
         "description" : "Undefined reference to structure of type: 'class-map type inspect' with usage: 'policy-map type inspect class type inspect' named 'cinspect'",
         "files" : {
           "cisco_qos" : [
-            34
+            36
           ]
         }
       },
@@ -1436,7 +1436,7 @@
         "class-map type inspect" : {
           "cinspect" : {
             "policy-map type inspect class type inspect" : [
-              34
+              36
             ]
           }
         }

--- a/tests/parsing-tests/unit-tests-unused.ref
+++ b/tests/parsing-tests/unit-tests-unused.ref
@@ -744,13 +744,22 @@
           ]
         }
       },
+      "unused:object-group network:1.2.3.4-24" : {
+        "description" : "Unused structure of type: 'object-group network' with name: '1.2.3.4-24'",
+        "files" : {
+          "cisco_qos" : [
+            26,
+            27
+          ]
+        }
+      },
       "unused:object-group network:dns_servers" : {
         "description" : "Unused structure of type: 'object-group network' with name: 'dns_servers'",
         "files" : {
           "cisco_qos" : [
-            26,
-            27,
-            28
+            28,
+            29,
+            30
           ]
         }
       },
@@ -758,10 +767,10 @@
         "description" : "Unused structure of type: 'object-group network' with name: 'ntp_servers'",
         "files" : {
           "cisco_qos" : [
-            29,
-            30,
             31,
-            32
+            32,
+            33,
+            34
           ]
         }
       },
@@ -778,12 +787,12 @@
         "description" : "Unused structure of type: 'policy-map type inspect' with name: 'pminspect'",
         "files" : {
           "cisco_qos" : [
-            33,
-            34,
             35,
             36,
             37,
-            38
+            38,
+            39,
+            40
           ]
         }
       },
@@ -1264,7 +1273,7 @@
     "summary" : {
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 126
+      "numResults" : 127
     },
     "unusedStructures" : {
       "aggAddress" : {
@@ -1665,26 +1674,30 @@
       },
       "cisco_qos" : {
         "object-group network" : {
-          "dns_servers" : [
+          "1.2.3.4-24" : [
             26,
-            27,
-            28
+            27
+          ],
+          "dns_servers" : [
+            28,
+            29,
+            30
           ],
           "ntp_servers" : [
-            29,
-            30,
             31,
-            32
+            32,
+            33,
+            34
           ]
         },
         "policy-map type inspect" : {
           "pminspect" : [
-            33,
-            34,
             35,
             36,
             37,
-            38
+            38,
+            39,
+            40
           ]
         }
       },

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -19474,7 +19474,7 @@
             "      (og_ip_address",
             "        IP:'ip'  <== mode:M_ObjectGroup",
             "        ADDRESS:'address'  <== mode:DEFAULT_MODE",
-            "        (variable",
+            "        (variable_permissive",
             "          VARIABLE:'_anonymized_'  <== mode:DEFAULT_MODE)",
             "        NEWLINE:'\\n'  <== mode:DEFAULT_MODE",
             "        (ogipa_ip_addresses",
@@ -19487,7 +19487,7 @@
             "      (og_ip_address",
             "        IP:'ip'  <== mode:M_ObjectGroup",
             "        ADDRESS:'address'  <== mode:DEFAULT_MODE",
-            "        (variable",
+            "        (variable_permissive",
             "          VARIABLE:'_anonymized2_'  <== mode:DEFAULT_MODE)",
             "        NEWLINE:'\\n'  <== mode:DEFAULT_MODE",
             "        (ogipa_host_info",
@@ -27439,7 +27439,7 @@
             "      OBJECT_GROUP:'object-group'  <== mode:DEFAULT_MODE",
             "      (og_service",
             "        SERVICE:'service'  <== mode:M_ObjectGroup",
-            "        (variable",
+            "        (variable_permissive",
             "          VARIABLE:'SVCGRP-ICMP'  <== mode:DEFAULT_MODE)",
             "        NEWLINE:'\\n'  <== mode:DEFAULT_MODE",
             "        (ogs_service_object",
@@ -30093,7 +30093,7 @@
             "      (og_ip_address",
             "        IP:'ip'  <== mode:M_ObjectGroup",
             "        ADDRESS:'address'  <== mode:DEFAULT_MODE",
-            "        (variable",
+            "        (variable_permissive",
             "          VARIABLE:'BIPPETY'  <== mode:DEFAULT_MODE)",
             "        NEWLINE:'\\n'  <== mode:DEFAULT_MODE",
             "        (ogipa_ip_addresses",
@@ -30114,7 +30114,7 @@
             "      OBJECT:'object'  <== mode:DEFAULT_MODE",
             "      (o_network",
             "        NETWORK:'network'  <== mode:DEFAULT_MODE",
-            "        (variable",
+            "        (variable_permissive",
             "          VARIABLE:'obj_any'  <== mode:DEFAULT_MODE)",
             "        NEWLINE:'\\n'  <== mode:DEFAULT_MODE",
             "        (on_subnet",
@@ -30127,7 +30127,22 @@
             "      OBJECT_GROUP:'object-group'  <== mode:DEFAULT_MODE",
             "      (og_network",
             "        NETWORK:'network'  <== mode:M_ObjectGroup",
-            "        (variable",
+            "        (variable_permissive",
+            "          IP_ADDRESS:'1.2.3.4'  <== mode:DEFAULT_MODE",
+            "          DASH:'-'  <== mode:DEFAULT_MODE",
+            "          DEC:'24'  <== mode:DEFAULT_MODE)",
+            "        NEWLINE:'\\n'  <== mode:DEFAULT_MODE",
+            "        (ogn_network_object",
+            "          NETWORK_OBJECT:'network-object'  <== mode:DEFAULT_MODE",
+            "          IP_ADDRESS:'1.2.3.4'  <== mode:DEFAULT_MODE",
+            "          IP_ADDRESS:'255.255.255.0'  <== mode:DEFAULT_MODE",
+            "          NEWLINE:'\\n'  <== mode:DEFAULT_MODE))))",
+            "  (stanza",
+            "    (s_object_group",
+            "      OBJECT_GROUP:'object-group'  <== mode:DEFAULT_MODE",
+            "      (og_network",
+            "        NETWORK:'network'  <== mode:M_ObjectGroup",
+            "        (variable_permissive",
             "          VARIABLE:'dns_servers'  <== mode:DEFAULT_MODE)",
             "        NEWLINE:'\\n'  <== mode:DEFAULT_MODE",
             "        (ogn_description",
@@ -30145,7 +30160,7 @@
             "      OBJECT_GROUP:'object-group'  <== mode:DEFAULT_MODE",
             "      (og_network",
             "        NETWORK:'network'  <== mode:M_ObjectGroup",
-            "        (variable",
+            "        (variable_permissive",
             "          VARIABLE:'ntp_servers'  <== mode:DEFAULT_MODE)",
             "        NEWLINE:'\\n'  <== mode:DEFAULT_MODE",
             "        (ogn_description",
@@ -30169,7 +30184,7 @@
             "      TYPE:'type'  <== mode:DEFAULT_MODE",
             "      (pm_ios_inspect",
             "        INSPECT:'inspect'  <== mode:DEFAULT_MODE",
-            "        (variable",
+            "        (variable_permissive",
             "          VARIABLE:'pminspect'  <== mode:DEFAULT_MODE)",
             "        NEWLINE:'\\n'  <== mode:DEFAULT_MODE",
             "        (pm_iosi_class_type_inspect",
@@ -53310,20 +53325,27 @@
         "cisco_privilege" : { },
         "cisco_qos" : {
           "object-group network" : {
-            "dns_servers" : {
+            "1.2.3.4-24" : {
               "definitionLines" : [
                 26,
-                27,
-                28
+                27
+              ],
+              "numReferrers" : 0
+            },
+            "dns_servers" : {
+              "definitionLines" : [
+                28,
+                29,
+                30
               ],
               "numReferrers" : 0
             },
             "ntp_servers" : {
               "definitionLines" : [
-                29,
-                30,
                 31,
-                32
+                32,
+                33,
+                34
               ],
               "numReferrers" : 0
             }
@@ -53331,12 +53353,12 @@
           "policy-map type inspect" : {
             "pminspect" : {
               "definitionLines" : [
-                33,
-                34,
                 35,
                 36,
                 37,
-                38
+                38,
+                39,
+                40
               ],
               "numReferrers" : 0
             }
@@ -54711,7 +54733,7 @@
           "class-map type inspect" : {
             "cinspect" : {
               "policy-map type inspect class type inspect" : [
-                34
+                36
               ]
             }
           }


### PR DESCRIPTION
Apparently on Cisco ASA at least, something like `1.2.3.4-24` would be a valid name.