### PR TITLE
Adding reversed ACLs for AWS SGs in the beginning

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/TcpFlags.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/TcpFlags.java
@@ -130,6 +130,8 @@ public final class TcpFlags implements Serializable, Comparable<TcpFlags> {
 
   public static final int ACK = 0x10;
 
+  public static final TcpFlags ACK_TCP_FLAG = builder().setAck(true).setUseAck(true).build();
+
   private static final Comparator<TcpFlags> COMPARATOR =
       Comparator.comparing(TcpFlags::getAck)
           .thenComparing(TcpFlags::getCwr)
@@ -162,9 +164,6 @@ public final class TcpFlags implements Serializable, Comparable<TcpFlags> {
   private static final long serialVersionUID = 1L;
 
   public static final int SYN = 0x02;
-
-  public static final TcpFlags SYN_ONLY =
-      builder().setSyn(true).setAck(false).setUseSyn(true).setUseAck(true).build();
 
   public static final int URG = 0x20;
 

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/ElasticsearchDomainTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/ElasticsearchDomainTest.java
@@ -1,5 +1,6 @@
 package org.batfish.representation.aws;
 
+import static org.batfish.datamodel.matchers.IpAccessListMatchers.hasLines;
 import static org.batfish.representation.aws.AwsVpcEntity.JSON_KEY_DOMAIN_STATUS_LIST;
 import static org.batfish.representation.aws.matchers.ElasticsearchDomainMatchers.hasAvailable;
 import static org.batfish.representation.aws.matchers.ElasticsearchDomainMatchers.hasId;
@@ -15,7 +16,6 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.util.Collection;
@@ -30,7 +30,6 @@ import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
-import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.IpAccessListLine;
 import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.IpWildcard;
@@ -169,47 +168,45 @@ public class ElasticsearchDomainTest {
     assertThat(configurations, hasKey("es-domain"));
     assertThat(configurations.get("es-domain").getInterfaces().entrySet(), hasSize(2));
 
-    IpAccessListLine rejectSynOnly =
-        IpAccessListLine.rejectingHeaderSpace(
-            HeaderSpace.builder().setTcpFlags(ImmutableSet.of(TcpFlags.SYN_ONLY)).build());
-    IpAccessList expectedIncomingFilter =
-        new IpAccessList(
-            "~SECURITY_GROUP_INGRESS_ACL~",
-            Lists.newArrayList(
-                IpAccessListLine.acceptingHeaderSpace(
-                    HeaderSpace.builder()
-                        .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
-                        .setSrcIps(
-                            Sets.newHashSet(
-                                new IpWildcard("1.2.3.4/32"), new IpWildcard("10.193.16.105/32")))
-                        .setDstPorts(Sets.newHashSet(new SubRange(45, 50)))
-                        .build()),
-                rejectSynOnly,
-                IpAccessListLine.acceptingHeaderSpace(
-                    HeaderSpace.builder()
-                        .setSrcIps(Sets.newHashSet(new IpWildcard("0.0.0.0/0")))
-                        .build())));
-    IpAccessList expectedOutgoingFilter =
-        new IpAccessList(
-            "~SECURITY_GROUP_EGRESS_ACL~",
-            Lists.newArrayList(
-                IpAccessListLine.acceptingHeaderSpace(
-                    HeaderSpace.builder()
-                        .setDstIps(Sets.newHashSet(new IpWildcard("0.0.0.0/0")))
-                        .build()),
-                rejectSynOnly,
-                IpAccessListLine.acceptingHeaderSpace(
-                    HeaderSpace.builder()
-                        .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
-                        .setDstIps(
-                            Sets.newHashSet(
-                                new IpWildcard("1.2.3.4/32"), new IpWildcard("10.193.16.105/32")))
-                        .setSrcPorts(Sets.newHashSet(new SubRange(45, 50)))
-                        .build())));
-
     for (Interface iface : configurations.get("es-domain").getInterfaces().values()) {
-      assertThat(iface.getIncomingFilter(), equalTo(expectedIncomingFilter));
-      assertThat(iface.getOutgoingFilter(), equalTo(expectedOutgoingFilter));
+      assertThat(
+          iface.getOutgoingFilter(),
+          hasLines(
+              equalTo(
+                  ImmutableList.of(
+                      IpAccessListLine.acceptingHeaderSpace(
+                          HeaderSpace.builder()
+                              .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
+                              .setDstIps(
+                                  Sets.newHashSet(
+                                      new IpWildcard("1.2.3.4/32"),
+                                      new IpWildcard("10.193.16.105/32")))
+                              .setSrcPorts(Sets.newHashSet(new SubRange(45, 50)))
+                              .setTcpFlags(ImmutableSet.of(TcpFlags.ACK_TCP_FLAG))
+                              .build()),
+                      IpAccessListLine.acceptingHeaderSpace(
+                          HeaderSpace.builder()
+                              .setDstIps(Sets.newHashSet(new IpWildcard("0.0.0.0/0")))
+                              .build())))));
+      assertThat(
+          iface.getIncomingFilter(),
+          hasLines(
+              equalTo(
+                  ImmutableList.of(
+                      IpAccessListLine.acceptingHeaderSpace(
+                          HeaderSpace.builder()
+                              .setSrcIps(Sets.newHashSet(new IpWildcard("0.0.0.0/0")))
+                              .setTcpFlags(ImmutableSet.of(TcpFlags.ACK_TCP_FLAG))
+                              .build()),
+                      IpAccessListLine.acceptingHeaderSpace(
+                          HeaderSpace.builder()
+                              .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
+                              .setSrcIps(
+                                  Sets.newHashSet(
+                                      new IpWildcard("1.2.3.4/32"),
+                                      new IpWildcard("10.193.16.105/32")))
+                              .setDstPorts(Sets.newHashSet(new SubRange(45, 50)))
+                              .build())))));
     }
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/RdsInstanceTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/RdsInstanceTest.java
@@ -1,5 +1,6 @@
 package org.batfish.representation.aws;
 
+import static org.batfish.datamodel.matchers.IpAccessListMatchers.hasLines;
 import static org.batfish.representation.aws.AwsVpcEntity.JSON_KEY_DB_INSTANCES;
 import static org.batfish.representation.aws.matchers.RdsInstanceMatchers.hasAvailabilityZone;
 import static org.batfish.representation.aws.matchers.RdsInstanceMatchers.hasAzSubnetIds;
@@ -18,7 +19,6 @@ import static org.junit.Assert.assertThat;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import java.io.IOException;
@@ -34,7 +34,6 @@ import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
-import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.IpAccessListLine;
 import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.IpWildcard;
@@ -149,48 +148,45 @@ public class RdsInstanceTest {
     assertThat(configurations, hasKey("test-rds"));
     assertThat(configurations.get("test-rds").getInterfaces().entrySet(), hasSize(2));
 
-    IpAccessListLine rejectSynOnly =
-        IpAccessListLine.rejectingHeaderSpace(
-            HeaderSpace.builder().setTcpFlags(ImmutableSet.of(TcpFlags.SYN_ONLY)).build());
-
-    IpAccessList expectedIncomingFilter =
-        new IpAccessList(
-            "~SECURITY_GROUP_INGRESS_ACL~",
-            Lists.newArrayList(
-                IpAccessListLine.acceptingHeaderSpace(
-                    HeaderSpace.builder()
-                        .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
-                        .setSrcIps(
-                            Sets.newHashSet(
-                                new IpWildcard("1.2.3.4/32"), new IpWildcard("10.193.16.105/32")))
-                        .setDstPorts(Sets.newHashSet(new SubRange(45, 50)))
-                        .build()),
-                rejectSynOnly,
-                IpAccessListLine.acceptingHeaderSpace(
-                    HeaderSpace.builder()
-                        .setSrcIps(Sets.newHashSet(new IpWildcard("0.0.0.0/0")))
-                        .build())));
-    IpAccessList expectedOutgoingFilter =
-        new IpAccessList(
-            "~SECURITY_GROUP_EGRESS_ACL~",
-            Lists.newArrayList(
-                IpAccessListLine.acceptingHeaderSpace(
-                    HeaderSpace.builder()
-                        .setDstIps(Sets.newHashSet(new IpWildcard("0.0.0.0/0")))
-                        .build()),
-                rejectSynOnly,
-                IpAccessListLine.acceptingHeaderSpace(
-                    HeaderSpace.builder()
-                        .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
-                        .setDstIps(
-                            Sets.newHashSet(
-                                new IpWildcard("1.2.3.4/32"), new IpWildcard("10.193.16.105/32")))
-                        .setSrcPorts(Sets.newHashSet(new SubRange(45, 50)))
-                        .build())));
-
     for (Interface iface : configurations.get("test-rds").getInterfaces().values()) {
-      assertThat(iface.getIncomingFilter(), equalTo(expectedIncomingFilter));
-      assertThat(iface.getOutgoingFilter(), equalTo(expectedOutgoingFilter));
+      assertThat(
+          iface.getOutgoingFilter(),
+          hasLines(
+              equalTo(
+                  ImmutableList.of(
+                      IpAccessListLine.acceptingHeaderSpace(
+                          HeaderSpace.builder()
+                              .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
+                              .setDstIps(
+                                  Sets.newHashSet(
+                                      new IpWildcard("1.2.3.4/32"),
+                                      new IpWildcard("10.193.16.105/32")))
+                              .setSrcPorts(Sets.newHashSet(new SubRange(45, 50)))
+                              .setTcpFlags(ImmutableSet.of(TcpFlags.ACK_TCP_FLAG))
+                              .build()),
+                      IpAccessListLine.acceptingHeaderSpace(
+                          HeaderSpace.builder()
+                              .setDstIps(Sets.newHashSet(new IpWildcard("0.0.0.0/0")))
+                              .build())))));
+      assertThat(
+          iface.getIncomingFilter(),
+          hasLines(
+              equalTo(
+                  ImmutableList.of(
+                      IpAccessListLine.acceptingHeaderSpace(
+                          HeaderSpace.builder()
+                              .setSrcIps(Sets.newHashSet(new IpWildcard("0.0.0.0/0")))
+                              .setTcpFlags(ImmutableSet.of(TcpFlags.ACK_TCP_FLAG))
+                              .build()),
+                      IpAccessListLine.acceptingHeaderSpace(
+                          HeaderSpace.builder()
+                              .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
+                              .setSrcIps(
+                                  Sets.newHashSet(
+                                      new IpWildcard("1.2.3.4/32"),
+                                      new IpWildcard("10.193.16.105/32")))
+                              .setDstPorts(Sets.newHashSet(new SubRange(45, 50)))
+                              .build())))));
     }
   }
 

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/SecurityGroupsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/SecurityGroupsTest.java
@@ -32,7 +32,6 @@ import org.junit.Test;
 public class SecurityGroupsTest {
 
   private JSONArray _securityGroups;
-  private IpAccessListLine _rejectSynOnly;
   private IpAccessListLine _allowAllReverseOutboundRule;
   private Flow.Builder _flowBuilder;
   private Region _region;
@@ -45,12 +44,12 @@ public class SecurityGroupsTest {
         new JSONObject(
                 CommonUtil.readResource("org/batfish/representation/aws/SecurityGroupTest.json"))
             .getJSONArray(JSON_KEY_SECURITY_GROUPS);
-    _rejectSynOnly =
-        IpAccessListLine.rejectingHeaderSpace(
-            HeaderSpace.builder().setTcpFlags(ImmutableSet.of(TcpFlags.SYN_ONLY)).build());
     _allowAllReverseOutboundRule =
         IpAccessListLine.acceptingHeaderSpace(
-            HeaderSpace.builder().setSrcIps(Sets.newHashSet(new IpWildcard("0.0.0.0/0"))).build());
+            HeaderSpace.builder()
+                .setSrcIps(Sets.newHashSet(new IpWildcard("0.0.0.0/0")))
+                .setTcpFlags(ImmutableSet.of(TcpFlags.ACK_TCP_FLAG))
+                .build());
     _region = new Region("test");
     _flowBuilder = new Builder();
     _flowBuilder.setIngressNode("foo");
@@ -71,14 +70,13 @@ public class SecurityGroupsTest {
         inboundRules,
         equalTo(
             ImmutableList.of(
+                _allowAllReverseOutboundRule,
                 IpAccessListLine.acceptingHeaderSpace(
                     HeaderSpace.builder()
                         .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
                         .setSrcIps(Sets.newHashSet(new IpWildcard("1.2.3.4/32")))
                         .setDstPorts(Sets.newHashSet(new SubRange(22, 22)))
-                        .build()),
-                _rejectSynOnly,
-                _allowAllReverseOutboundRule)));
+                        .build()))));
   }
 
   @Test
@@ -94,14 +92,13 @@ public class SecurityGroupsTest {
         inboundRules,
         equalTo(
             ImmutableList.of(
+                _allowAllReverseOutboundRule,
                 IpAccessListLine.acceptingHeaderSpace(
                     HeaderSpace.builder()
                         .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
                         .setSrcIps(Sets.newHashSet(new IpWildcard("1.2.3.4/32")))
                         .setDstPorts(Sets.newHashSet(new SubRange(0, 22)))
-                        .build()),
-                _rejectSynOnly,
-                _allowAllReverseOutboundRule)));
+                        .build()))));
   }
 
   @Test
@@ -117,14 +114,13 @@ public class SecurityGroupsTest {
         inboundRules,
         equalTo(
             ImmutableList.of(
+                _allowAllReverseOutboundRule,
                 IpAccessListLine.acceptingHeaderSpace(
                     HeaderSpace.builder()
                         .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
                         .setSrcIps(Sets.newHashSet(new IpWildcard("1.2.3.4/32")))
                         .setDstPorts(Sets.newHashSet(new SubRange(65530, 65535)))
-                        .build()),
-                _rejectSynOnly,
-                _allowAllReverseOutboundRule)));
+                        .build()))));
   }
 
   @Test
@@ -140,13 +136,12 @@ public class SecurityGroupsTest {
         inboundRules,
         equalTo(
             ImmutableList.of(
+                _allowAllReverseOutboundRule,
                 IpAccessListLine.acceptingHeaderSpace(
                     HeaderSpace.builder()
                         .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
                         .setSrcIps(Sets.newHashSet(new IpWildcard("1.2.3.4/32")))
-                        .build()),
-                _rejectSynOnly,
-                _allowAllReverseOutboundRule)));
+                        .build()))));
   }
 
   @Test
@@ -162,13 +157,12 @@ public class SecurityGroupsTest {
         inboundRules,
         equalTo(
             ImmutableList.of(
+                _allowAllReverseOutboundRule,
                 IpAccessListLine.acceptingHeaderSpace(
                     HeaderSpace.builder()
                         .setSrcIps(Sets.newHashSet(new IpWildcard("0.0.0.0/0")))
                         .setDstPorts(Sets.newHashSet())
-                        .build()),
-                _rejectSynOnly,
-                _allowAllReverseOutboundRule)));
+                        .build()))));
   }
 
   @Test
@@ -184,14 +178,13 @@ public class SecurityGroupsTest {
         inboundRules,
         equalTo(
             ImmutableList.of(
+                _allowAllReverseOutboundRule,
                 IpAccessListLine.acceptingHeaderSpace(
                     HeaderSpace.builder()
                         .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
                         .setSrcIps(Sets.newHashSet(new IpWildcard("1.2.3.4/32")))
                         .setDstPorts(Sets.newHashSet(new SubRange(45, 50)))
-                        .build()),
-                _rejectSynOnly,
-                _allowAllReverseOutboundRule)));
+                        .build()))));
   }
 
   @Test
@@ -207,14 +200,13 @@ public class SecurityGroupsTest {
         inboundRules,
         equalTo(
             ImmutableList.of(
+                _allowAllReverseOutboundRule,
                 IpAccessListLine.acceptingHeaderSpace(
                     HeaderSpace.builder()
                         .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
                         .setSrcIps(Sets.newHashSet(new IpWildcard("1.2.3.4/32")))
                         .setDstPorts(Sets.newHashSet(new SubRange(0, 50)))
-                        .build()),
-                _rejectSynOnly,
-                _allowAllReverseOutboundRule)));
+                        .build()))));
   }
 
   @Test
@@ -230,14 +222,13 @@ public class SecurityGroupsTest {
         inboundRules,
         equalTo(
             ImmutableList.of(
+                _allowAllReverseOutboundRule,
                 IpAccessListLine.acceptingHeaderSpace(
                     HeaderSpace.builder()
                         .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
                         .setSrcIps(Sets.newHashSet(new IpWildcard("1.2.3.4/32")))
                         .setDstPorts(Sets.newHashSet(new SubRange(30, 65535)))
-                        .build()),
-                _rejectSynOnly,
-                _allowAllReverseOutboundRule)));
+                        .build()))));
   }
 
   @Test
@@ -253,37 +244,37 @@ public class SecurityGroupsTest {
         inboundRules,
         equalTo(
             ImmutableList.of(
-                IpAccessListLine.acceptingHeaderSpace(
-                    HeaderSpace.builder()
-                        .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
-                        .setSrcIps(Sets.newHashSet(new IpWildcard("1.2.3.4/32")))
-                        .setDstPorts(Sets.newHashSet(new SubRange(22, 22)))
-                        .build()),
-                _rejectSynOnly,
                 // reverse of outbound rule
                 IpAccessListLine.acceptingHeaderSpace(
                     HeaderSpace.builder()
                         .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
                         .setSrcIps(Sets.newHashSet(new IpWildcard("5.6.7.8/32")))
                         .setSrcPorts(Sets.newHashSet(new SubRange(80, 80)))
+                        .setTcpFlags(ImmutableSet.of(TcpFlags.ACK_TCP_FLAG))
+                        .build()),
+                IpAccessListLine.acceptingHeaderSpace(
+                    HeaderSpace.builder()
+                        .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
+                        .setSrcIps(Sets.newHashSet(new IpWildcard("1.2.3.4/32")))
+                        .setDstPorts(Sets.newHashSet(new SubRange(22, 22)))
                         .build()))));
     assertThat(
         outboundRules,
         equalTo(
             ImmutableList.of(
-                IpAccessListLine.acceptingHeaderSpace(
-                    HeaderSpace.builder()
-                        .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
-                        .setDstIps(Sets.newHashSet(new IpWildcard("5.6.7.8/32")))
-                        .setDstPorts(Sets.newHashSet(new SubRange(80, 80)))
-                        .build()),
-                _rejectSynOnly,
                 // reverse of inbound rule
                 IpAccessListLine.acceptingHeaderSpace(
                     HeaderSpace.builder()
                         .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
                         .setDstIps(Sets.newHashSet(new IpWildcard("1.2.3.4/32")))
                         .setSrcPorts(Sets.newHashSet(new SubRange(22, 22)))
+                        .setTcpFlags(ImmutableSet.of(TcpFlags.ACK_TCP_FLAG))
+                        .build()),
+                IpAccessListLine.acceptingHeaderSpace(
+                    HeaderSpace.builder()
+                        .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
+                        .setDstIps(Sets.newHashSet(new IpWildcard("5.6.7.8/32")))
+                        .setDstPorts(Sets.newHashSet(new SubRange(80, 80)))
                         .build()))));
   }
 

--- a/tests/aws/nodes-example-aws.ref
+++ b/tests/aws/nodes-example-aws.ref
@@ -83,28 +83,19 @@
                     "dstIps" : {
                       "class" : "org.batfish.datamodel.IpWildcardSetIpSpace",
                       "whitelist" : [
-                        "0.0.0.0/0"
+                        "192.168.1.3"
                       ]
                     },
-                    "negate" : false
-                  }
-                }
-              },
-              {
-                "action" : "REJECT",
-                "matchCondition" : {
-                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                  "headerSpace" : {
                     "negate" : false,
                     "tcpFlags" : [
                       {
-                        "ack" : false,
+                        "ack" : true,
                         "cwr" : false,
                         "ece" : false,
                         "fin" : false,
                         "psh" : false,
                         "rst" : false,
-                        "syn" : true,
+                        "syn" : false,
                         "urg" : false,
                         "useAck" : true,
                         "useCwr" : false,
@@ -112,7 +103,7 @@
                         "useFin" : false,
                         "usePsh" : false,
                         "useRst" : false,
-                        "useSyn" : true,
+                        "useSyn" : false,
                         "useUrg" : false
                       }
                     ]
@@ -127,7 +118,7 @@
                     "dstIps" : {
                       "class" : "org.batfish.datamodel.IpWildcardSetIpSpace",
                       "whitelist" : [
-                        "192.168.1.3"
+                        "0.0.0.0/0"
                       ]
                     },
                     "negate" : false
@@ -148,27 +139,18 @@
                     "srcIps" : {
                       "class" : "org.batfish.datamodel.IpWildcardSetIpSpace",
                       "whitelist" : [
-                        "192.168.1.3"
+                        "0.0.0.0/0"
                       ]
-                    }
-                  }
-                }
-              },
-              {
-                "action" : "REJECT",
-                "matchCondition" : {
-                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                  "headerSpace" : {
-                    "negate" : false,
+                    },
                     "tcpFlags" : [
                       {
-                        "ack" : false,
+                        "ack" : true,
                         "cwr" : false,
                         "ece" : false,
                         "fin" : false,
                         "psh" : false,
                         "rst" : false,
-                        "syn" : true,
+                        "syn" : false,
                         "urg" : false,
                         "useAck" : true,
                         "useCwr" : false,
@@ -176,7 +158,7 @@
                         "useFin" : false,
                         "usePsh" : false,
                         "useRst" : false,
-                        "useSyn" : true,
+                        "useSyn" : false,
                         "useUrg" : false
                       }
                     ]
@@ -192,7 +174,7 @@
                     "srcIps" : {
                       "class" : "org.batfish.datamodel.IpWildcardSetIpSpace",
                       "whitelist" : [
-                        "0.0.0.0/0"
+                        "192.168.1.3"
                       ]
                     }
                   }
@@ -3405,28 +3387,29 @@
                     "dstIps" : {
                       "class" : "org.batfish.datamodel.IpWildcardSetIpSpace",
                       "whitelist" : [
-                        "0.0.0.0/0"
+                        "10.193.0.0/16",
+                        "67.170.86.87",
+                        "104.236.156.171",
+                        "107.170.243.58",
+                        "162.243.144.192"
                       ]
                     },
-                    "negate" : false
-                  }
-                }
-              },
-              {
-                "action" : "REJECT",
-                "matchCondition" : {
-                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                  "headerSpace" : {
+                    "ipProtocols" : [
+                      "TCP"
+                    ],
                     "negate" : false,
+                    "srcPorts" : [
+                      "3306-3306"
+                    ],
                     "tcpFlags" : [
                       {
-                        "ack" : false,
+                        "ack" : true,
                         "cwr" : false,
                         "ece" : false,
                         "fin" : false,
                         "psh" : false,
                         "rst" : false,
-                        "syn" : true,
+                        "syn" : false,
                         "urg" : false,
                         "useAck" : true,
                         "useCwr" : false,
@@ -3434,7 +3417,7 @@
                         "useFin" : false,
                         "usePsh" : false,
                         "useRst" : false,
-                        "useSyn" : true,
+                        "useSyn" : false,
                         "useUrg" : false
                       }
                     ]
@@ -3449,20 +3432,10 @@
                     "dstIps" : {
                       "class" : "org.batfish.datamodel.IpWildcardSetIpSpace",
                       "whitelist" : [
-                        "10.193.0.0/16",
-                        "67.170.86.87",
-                        "104.236.156.171",
-                        "107.170.243.58",
-                        "162.243.144.192"
+                        "0.0.0.0/0"
                       ]
                     },
-                    "ipProtocols" : [
-                      "TCP"
-                    ],
-                    "negate" : false,
-                    "srcPorts" : [
-                      "3306-3306"
-                    ]
+                    "negate" : false
                   }
                 }
               }
@@ -3471,6 +3444,41 @@
           "~SECURITY_GROUP_INGRESS_ACL~" : {
             "name" : "~SECURITY_GROUP_INGRESS_ACL~",
             "lines" : [
+              {
+                "action" : "ACCEPT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardSetIpSpace",
+                      "whitelist" : [
+                        "0.0.0.0/0"
+                      ]
+                    },
+                    "tcpFlags" : [
+                      {
+                        "ack" : true,
+                        "cwr" : false,
+                        "ece" : false,
+                        "fin" : false,
+                        "psh" : false,
+                        "rst" : false,
+                        "syn" : false,
+                        "urg" : false,
+                        "useAck" : true,
+                        "useCwr" : false,
+                        "useEce" : false,
+                        "useFin" : false,
+                        "usePsh" : false,
+                        "useRst" : false,
+                        "useSyn" : false,
+                        "useUrg" : false
+                      }
+                    ]
+                  }
+                }
+              },
               {
                 "action" : "ACCEPT",
                 "matchCondition" : {
@@ -3491,50 +3499,6 @@
                         "104.236.156.171",
                         "107.170.243.58",
                         "162.243.144.192"
-                      ]
-                    }
-                  }
-                }
-              },
-              {
-                "action" : "REJECT",
-                "matchCondition" : {
-                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                  "headerSpace" : {
-                    "negate" : false,
-                    "tcpFlags" : [
-                      {
-                        "ack" : false,
-                        "cwr" : false,
-                        "ece" : false,
-                        "fin" : false,
-                        "psh" : false,
-                        "rst" : false,
-                        "syn" : true,
-                        "urg" : false,
-                        "useAck" : true,
-                        "useCwr" : false,
-                        "useEce" : false,
-                        "useFin" : false,
-                        "usePsh" : false,
-                        "useRst" : false,
-                        "useSyn" : true,
-                        "useUrg" : false
-                      }
-                    ]
-                  }
-                }
-              },
-              {
-                "action" : "ACCEPT",
-                "matchCondition" : {
-                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                  "headerSpace" : {
-                    "negate" : false,
-                    "srcIps" : {
-                      "class" : "org.batfish.datamodel.IpWildcardSetIpSpace",
-                      "whitelist" : [
-                        "0.0.0.0/0"
                       ]
                     }
                   }


### PR DESCRIPTION
- Based on our previous discussion, tested on an EC2 instance and found that this should be done in both directions, tests are documented [here](https://docs.google.com/document/d/1dDxmZ8aNXSj6qE-xZhkMJAjmkn3sTY4SArkoJeXS2WE/edit#)

- Adding reversed ACLs in the beginning to avoid unreachable ACL lines
