### PR TITLE
Setting Static route preference for Juniper

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -270,6 +270,7 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ros_routeContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Rosr_discardContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Rosr_metricContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Rosr_next_hopContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Rosr_preferenceContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Rosr_rejectContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Rosr_tagContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Routing_protocolContext;
@@ -3847,6 +3848,11 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
       initInterface(ctx.interface_id());
       _currentStaticRoute.setNextHopInterface(ctx.interface_id().getText());
     }
+  }
+
+  @Override
+  public void exitRosr_preference(Rosr_preferenceContext ctx) {
+    _currentStaticRoute.setDistance(toInt(ctx.pref));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -1842,7 +1842,6 @@ public final class JuniperConfiguration extends VendorConfiguration {
   }
 
   private org.batfish.datamodel.StaticRoute toStaticRoute(StaticRoute route) {
-    Prefix prefix = route.getPrefix();
     Ip nextHopIp = route.getNextHopIp();
     if (nextHopIp == null) {
       nextHopIp = Route.UNSET_ROUTE_NEXT_HOP_IP;
@@ -1851,18 +1850,18 @@ public final class JuniperConfiguration extends VendorConfiguration {
         route.getDrop()
             ? org.batfish.datamodel.Interface.NULL_INTERFACE_NAME
             : route.getNextHopInterface();
-    int administrativeCost = route.getMetric();
-    Integer oldTag = route.getTag();
-    int tag;
-    tag = oldTag != null ? oldTag : -1;
+    int tag = route.getTag() != null ? route.getTag() : -1;
+
     org.batfish.datamodel.StaticRoute newStaticRoute =
         org.batfish.datamodel.StaticRoute.builder()
-            .setNetwork(prefix)
+            .setNetwork(route.getPrefix())
             .setNextHopIp(nextHopIp)
             .setNextHopInterface(nextHopInterface)
-            .setAdministrativeCost(administrativeCost)
+            .setAdministrativeCost(route.getDistance())
+            .setMetric(route.getMetric())
             .setTag(tag)
             .build();
+
     return newStaticRoute;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/StaticRoute.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/StaticRoute.java
@@ -11,8 +11,7 @@ public class StaticRoute implements Serializable {
   /** */
   private static final long serialVersionUID = 1L;
 
-  /* https://www.juniper.net/documentation/en_US/junos/topics/reference/general/routing-
-  protocols-default-route-preference-values.html */
+  /* https://www.juniper.net/documentation/en_US/junos/topics/reference/general/routing-protocols-default-route-preference-values.html */
   private static final int DEFAULT_ADMIN_DISTANCE = 5;
 
   private int _distance;

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/StaticRoute.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/StaticRoute.java
@@ -11,6 +11,8 @@ public class StaticRoute implements Serializable {
   /** */
   private static final long serialVersionUID = 1L;
 
+  private static final int DEFAULT_ADMIN_DISTANCE = 5;
+
   private int _distance;
 
   private boolean _drop;
@@ -30,6 +32,8 @@ public class StaticRoute implements Serializable {
   public StaticRoute(Prefix prefix) {
     _prefix = prefix;
     _policies = new ArrayList<>();
+    // default admin costs for static routes in Juniper
+    _distance = DEFAULT_ADMIN_DISTANCE;
   }
 
   public int getDistance() {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/StaticRoute.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/StaticRoute.java
@@ -11,6 +11,8 @@ public class StaticRoute implements Serializable {
   /** */
   private static final long serialVersionUID = 1L;
 
+  /* https://www.juniper.net/documentation/en_US/junos/topics/reference/general/routing-
+  protocols-default-route-preference-values.html */
   private static final int DEFAULT_ADMIN_DISTANCE = 5;
 
   private int _distance;

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/StaticRoute.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/StaticRoute.java
@@ -11,6 +11,8 @@ public class StaticRoute implements Serializable {
   /** */
   private static final long serialVersionUID = 1L;
 
+  private int _distance;
+
   private boolean _drop;
 
   private int _metric;
@@ -28,6 +30,10 @@ public class StaticRoute implements Serializable {
   public StaticRoute(Prefix prefix) {
     _prefix = prefix;
     _policies = new ArrayList<>();
+  }
+
+  public int getDistance() {
+    return _distance;
   }
 
   public boolean getDrop() {
@@ -56,6 +62,10 @@ public class StaticRoute implements Serializable {
 
   public Integer getTag() {
     return _tag;
+  }
+
+  public void setDistance(int distance) {
+    _distance = distance;
   }
 
   public void setDrop(boolean drop) {

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -1629,29 +1629,6 @@ public class FlatJuniperGrammarTest {
   }
 
   @Test
-  public void testStaticRoutePreference() throws IOException {
-    Configuration c = parseConfig("static-route-preference");
-    c.getInterfaces();
-    assertThat(
-        c,
-        hasVrf(
-            "default",
-            hasStaticRoutes(
-                equalTo(
-                    ImmutableSet.of(
-                        StaticRoute.builder()
-                            .setNetwork(Prefix.parse("1.2.3.4/24"))
-                            .setNextHopIp(new Ip("10.0.0.1"))
-                            .setAdministrativeCost(250)
-                            .build(),
-                        StaticRoute.builder()
-                            .setNetwork(Prefix.parse("2.3.4.5/24"))
-                            .setNextHopIp(new Ip("10.0.0.2"))
-                            .setAdministrativeCost(5)
-                            .build())))));
-  }
-
-  @Test
   public void testParsingRecovery() {
     String recoveryText =
         CommonUtil.readResource("org/batfish/grammar/juniper/testconfigs/recovery");
@@ -1866,6 +1843,28 @@ public class FlatJuniperGrammarTest {
             .call(eb.setOriginalRoute(connectedRouteMaskInvalidLength).build())
             .getBooleanValue(),
         equalTo(false));
+  }
+
+  @Test
+  public void testStaticRoutePreference() throws IOException {
+    Configuration c = parseConfig("static-route-preference");
+    assertThat(
+        c,
+        hasVrf(
+            "default",
+            hasStaticRoutes(
+                equalTo(
+                    ImmutableSet.of(
+                        StaticRoute.builder()
+                            .setNetwork(Prefix.parse("1.2.3.4/24"))
+                            .setNextHopIp(new Ip("10.0.0.1"))
+                            .setAdministrativeCost(250)
+                            .build(),
+                        StaticRoute.builder()
+                            .setNetwork(Prefix.parse("2.3.4.5/24"))
+                            .setNextHopIp(new Ip("10.0.0.2"))
+                            .setAdministrativeCost(5)
+                            .build())))));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -107,7 +107,6 @@ import org.batfish.datamodel.acl.PermittedByAcl;
 import org.batfish.datamodel.acl.TrueExpr;
 import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
 import org.batfish.datamodel.answers.InitInfoAnswerElement;
-import org.batfish.datamodel.matchers.ConfigurationMatchers;
 import org.batfish.datamodel.matchers.IpAccessListMatchers;
 import org.batfish.datamodel.matchers.OspfAreaMatchers;
 import org.batfish.datamodel.matchers.RouteFilterListMatchers;
@@ -1632,18 +1631,23 @@ public class FlatJuniperGrammarTest {
   @Test
   public void testStaticRoutePreference() throws IOException {
     Configuration c = parseConfig("static-route-preference");
-
+    c.getInterfaces();
     assertThat(
         c,
-        ConfigurationMatchers.hasVrf(
+        hasVrf(
             "default",
             hasStaticRoutes(
                 equalTo(
                     ImmutableSet.of(
                         StaticRoute.builder()
-                            .setNetwork(Prefix.ZERO)
+                            .setNetwork(Prefix.parse("1.2.3.4/24"))
                             .setNextHopIp(new Ip("10.0.0.1"))
                             .setAdministrativeCost(250)
+                            .build(),
+                        StaticRoute.builder()
+                            .setNetwork(Prefix.parse("2.3.4.5/24"))
+                            .setNextHopIp(new Ip("10.0.0.2"))
+                            .setAdministrativeCost(5)
                             .build())))));
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -62,6 +62,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import java.io.IOException;
 import java.util.Arrays;
@@ -106,6 +107,7 @@ import org.batfish.datamodel.acl.PermittedByAcl;
 import org.batfish.datamodel.acl.TrueExpr;
 import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
 import org.batfish.datamodel.answers.InitInfoAnswerElement;
+import org.batfish.datamodel.matchers.ConfigurationMatchers;
 import org.batfish.datamodel.matchers.IpAccessListMatchers;
 import org.batfish.datamodel.matchers.OspfAreaMatchers;
 import org.batfish.datamodel.matchers.RouteFilterListMatchers;
@@ -1625,6 +1627,24 @@ public class FlatJuniperGrammarTest {
     Configuration c = parseConfig("ospf-router-id");
 
     assertThat(c, hasVrf("default", hasOspfProcess(hasRouterId(equalTo(new Ip("1.0.0.0"))))));
+  }
+
+  @Test
+  public void testStaticRoutePreference() throws IOException {
+    Configuration c = parseConfig("static-route-preference");
+
+    assertThat(
+        c,
+        ConfigurationMatchers.hasVrf(
+            "default",
+            hasStaticRoutes(
+                equalTo(
+                    ImmutableSet.of(
+                        StaticRoute.builder()
+                            .setNetwork(Prefix.ZERO)
+                            .setNextHopIp(new Ip("10.0.0.1"))
+                            .setAdministrativeCost(250)
+                            .build())))));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/static-route-preference
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/static-route-preference
@@ -1,0 +1,5 @@
+
+set system host-name static-route-preference
+
+set routing-options static route 0.0.0.0/0 next-hop 10.0.0.1
+set routing-options static route 0.0.0.0/0 preference 250

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/static-route-preference
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/static-route-preference
@@ -1,5 +1,7 @@
 
 set system host-name static-route-preference
 
-set routing-options static route 0.0.0.0/0 next-hop 10.0.0.1
-set routing-options static route 0.0.0.0/0 preference 250
+set routing-options static route 1.2.3.4/24 next-hop 10.0.0.1
+set routing-options static route 1.2.3.4/24 preference 250
+
+set routing-options static route 2.3.4.5/24 next-hop 10.0.0.2


### PR DESCRIPTION
 - preference is treated as admin distance
 - corrected conversion of Juniper static routes where we were storing metric as admin cost