### PR TITLE
Ensure originType is always set on BGP routes during transformation

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpRoute.java
@@ -212,7 +212,7 @@ public class BgpRoute extends AbstractRoute {
 
   private final Ip _originatorIp;
 
-  private final OriginType _originType;
+  @Nonnull private final OriginType _originType;
 
   private final RoutingProtocol _protocol;
 
@@ -237,7 +237,7 @@ public class BgpRoute extends AbstractRoute {
       @JsonProperty(PROP_CLUSTER_LIST) SortedSet<Long> clusterList,
       @JsonProperty(PROP_RECEIVED_FROM_ROUTE_REFLECTOR_CLIENT)
           boolean receivedFromRouteReflectorClient,
-      @JsonProperty(PROP_ORIGIN_TYPE) OriginType originType,
+      @Nonnull @JsonProperty(PROP_ORIGIN_TYPE) OriginType originType,
       @JsonProperty(PROP_PROTOCOL) RoutingProtocol protocol,
       @JsonProperty(PROP_RECEIVED_FROM_IP) Ip receivedFromIp,
       @JsonProperty(PROP_SRC_PROTOCOL) RoutingProtocol srcProtocol,
@@ -413,7 +413,7 @@ public class BgpRoute extends AbstractRoute {
     result = prime * result + Long.hashCode(_med);
     result = prime * result + _network.hashCode();
     result = prime * result + ((_nextHopIp == null) ? 0 : _nextHopIp.hashCode());
-    result = prime * result + ((_originType == null) ? 0 : _originType.ordinal());
+    result = prime * result + _originType.ordinal();
     result = prime * result + ((_originatorIp == null) ? 0 : _originatorIp.hashCode());
     result = prime * result + ((_protocol == null) ? 0 : _protocol.ordinal());
     result = prime * result + ((_receivedFromIp == null) ? 0 : _receivedFromIp.hashCode());

--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
@@ -10,6 +10,7 @@ import org.batfish.datamodel.BgpNeighbor;
 import org.batfish.datamodel.BgpRoute;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.OriginType;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Route;
 import org.batfish.datamodel.RoutingProtocol;
@@ -116,6 +117,8 @@ public class BgpProtocolHelper {
           return null;
         }
       }
+    } else {
+      transformedOutgoingRouteBuilder.setOriginType(OriginType.INCOMPLETE);
     }
 
     // Outgoing asPath


### PR DESCRIPTION
BgpRoute.Builder crashes when originType is not set (rightfully so), so ensure we set it when propagating routes.