### PR TITLE
avoid NPE when we can't figure out the local address in a isakmp profile

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/Keyring.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/Keyring.java
@@ -1,5 +1,6 @@
 package org.batfish.representation.cisco;
 
+import java.util.Objects;
 import org.batfish.common.util.DefinedStructure;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
@@ -31,7 +32,7 @@ public class Keyring extends DefinedStructure<String> {
   }
 
   public boolean match(Ip localAddress, Prefix matchIdentity) {
-    return localAddress.equals(_localAddress) && matchIdentity.containsIp(_remoteAddress);
+    return Objects.equals(localAddress, _localAddress) && matchIdentity.containsIp(_remoteAddress);
   }
 
   public void setKey(String key) {


### PR DESCRIPTION
Avoid NPE, which I think is related to this warning:
RedFlag MISCELLANEOUS : Can't get IkeGateway: Local or remote address is not set for isakmpProfile 

(not sure why/when the warning happens)