### PR TITLE
Cisco: keep track or bgp origination space

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpProcess.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpProcess.java
@@ -98,7 +98,8 @@ public class BgpProcess implements Serializable {
    */
   private SortedMap<Prefix, BgpNeighbor> _neighbors;
 
-  private transient PrefixSpace _originationSpace;
+  /** Space of prefixes to be advertised using explicit network statements */
+  private PrefixSpace _originationSpace;
 
   private Ip _routerId;
 
@@ -110,6 +111,16 @@ public class BgpProcess implements Serializable {
     _generatedRoutes = new TreeSet<>();
     _tieBreaker = BgpTieBreaker.ARRIVAL_ORDER;
     _clusterIds = new ClusterIdsSupplier();
+    _originationSpace = new PrefixSpace();
+  }
+
+  /**
+   * Expand the origination space for this prefix
+   *
+   * @param space {@link PrefixSpace} to add
+   */
+  public void addToOriginationSpace(PrefixSpace space) {
+    _originationSpace.addSpace(space);
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -1477,11 +1477,11 @@ public final class CiscoConfiguration extends VendorConfiguration {
           .getIpNetworks()
           .forEach(
               (prefix, routeMapOrEmpty) -> {
+                PrefixSpace exportSpace = new PrefixSpace(PrefixRange.fromPrefix(prefix));
                 List<BooleanExpr> exportNetworkConditions =
                     ImmutableList.of(
                         new MatchPrefixSet(
-                            new DestinationNetwork(),
-                            new ExplicitPrefixSet(new PrefixSpace(PrefixRange.fromPrefix(prefix)))),
+                            new DestinationNetwork(), new ExplicitPrefixSet(exportSpace)),
                         new Not(new MatchProtocol(RoutingProtocol.BGP)),
                         new Not(new MatchProtocol(RoutingProtocol.IBGP)),
                         new Not(new MatchProtocol(RoutingProtocol.AGGREGATE)),
@@ -1490,6 +1490,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
                                 ? new CallExpr(routeMapOrEmpty)
                                 : BooleanExprs.TRUE,
                             OriginType.IGP));
+                newBgpProcess.addToOriginationSpace(exportSpace);
                 exportConditions.add(new Conjunction(exportNetworkConditions));
               });
     }
@@ -1903,6 +1904,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
               Conjunction exportNetworkConditions = new Conjunction();
               PrefixSpace space = new PrefixSpace();
               space.addPrefix(prefix);
+              newBgpProcess.addToOriginationSpace(space);
               exportNetworkConditions
                   .getConjuncts()
                   .add(new MatchPrefixSet(new DestinationNetwork(), new ExplicitPrefixSet(space)));

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -129,6 +129,7 @@ import org.batfish.datamodel.OspfArea;
 import org.batfish.datamodel.OspfProcess;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Prefix6;
+import org.batfish.datamodel.PrefixSpace;
 import org.batfish.datamodel.StaticRoute;
 import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.Vrf;
@@ -1286,6 +1287,16 @@ public class CiscoGrammarTest {
     assertThat(aristaEnabled, equalTo(MultipathEquivalentAsPathMatchMode.PATH_LENGTH));
     assertThat(nxosDisabled, equalTo(MultipathEquivalentAsPathMatchMode.EXACT_PATH));
     assertThat(nxosEnabled, equalTo(MultipathEquivalentAsPathMatchMode.PATH_LENGTH));
+  }
+
+  @Test
+  public void testBgpOriginationSpace() throws IOException {
+    Configuration c = parseConfig("ios-bgp-origination-space");
+    PrefixSpace space =
+        c.getVrfs().get(Configuration.DEFAULT_VRF_NAME).getBgpProcess().getOriginationSpace();
+
+    assertThat(space.containsPrefix(Prefix.parse("1.1.1.1/32")), is(true));
+    assertThat(space.containsPrefix(Prefix.parse("1.1.2.0/24")), is(true));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-bgp-origination-space
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-bgp-origination-space
@@ -1,0 +1,7 @@
+!
+hostname ios-bgp-origination-space
+!
+router bgp 1
+  neighbor 2.2.2.2 remote-as 2
+  network 1.1.1.1/32
+  network 1.1.2.0/24


### PR DESCRIPTION
Keep track of explicit network statements on cisco as an origination space.
Potential uses:
 - Track which have overlapping network statements
 - Combined with the prefix tracer, this could be used to determine which network statements are "wrong" (e.g., no such prefix in the RIB, yet network statement exist) 

*Minor Note*:
Before this `_originationSpace` field was never initialized or used and could throw null pointers.