### PR TITLE
Cisco: parse Certificate Signature Request params

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
@@ -2033,6 +2033,11 @@ COMMON
    'common'
 ;
 
+COMMON_NAME
+:
+   'common-name'
+;
+
 COMMUNITY
 :
    'community'
@@ -2445,6 +2450,11 @@ CSD
 CSNP_INTERVAL
 :
    'csnp-interval'
+;
+
+CSR_PARAMS
+:
+   'csr-params'
 ;
 
 CTIQBE
@@ -6103,6 +6113,11 @@ LOCAL
    'local'
 ;
 
+LOCALITY
+:
+   'locality'
+;
+
 LOCAL_ADDRESS
 :
    'local-address'
@@ -7886,6 +7901,16 @@ OPTIONS
 OR
 :
    'or'
+;
+
+ORGANIZATION_NAME
+:
+   'organization-name'
+;
+
+ORGANIZATION_UNIT
+:
+   'organization-unit'
 ;
 
 ORIGIN

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_crypto.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_crypto.g4
@@ -539,6 +539,23 @@ crypto_ca
    )
 ;
 
+crypto_csr_params
+:
+   CSR_PARAMS name = variable_permissive NEWLINE
+   (
+      (
+         COMMON_NAME
+         | COUNTRY
+         | EMAIL
+         | LOCALITY
+         | ORGANIZATION_NAME
+         | ORGANIZATION_UNIT
+         | SERIAL_NUMBER
+         | STATE
+      ) null_rest_of_line
+   )*
+;
+
 crypto_dynamic_map
 :
    DYNAMIC_MAP name = variable num = DEC
@@ -773,6 +790,7 @@ s_crypto
    NO? CRYPTO
    (
       crypto_ca
+      | crypto_csr_params
       | crypto_dynamic_map
       | crypto_engine
       | crypto_ikev1

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoStructureType.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoStructureType.java
@@ -15,6 +15,7 @@ public enum CiscoStructureType implements StructureType {
   COMMUNITY_LIST("community-list"),
   COMMUNITY_LIST_EXPANDED("expanded community-list"),
   COMMUNITY_LIST_STANDARD("standard community-list"),
+  CSR_PARAMS("csr-params"),
   DEPI_CLASS("depi-class"),
   DEPI_TUNNEL("depi-tunnel"),
   DOCSIS_POLICY("docsis-policy"),

--- a/test_rigs/unit-tests/configs/cisco_crypto
+++ b/test_rigs/unit-tests/configs/cisco_crypto
@@ -82,6 +82,13 @@ crypto ca trustpoint abcdefg
  subject-name cn="ccccccccc";ou="aaaaa";o="bbbbbbb"
  no validation-usage
 crypto ca trustpool policy
+crypto csr-params BATFISH
+  country US
+  state WA
+  locality Seattle
+  organization-name Batfish
+  organization-unit Network Validation
+  common-name batfish.org
 crypto dynamic-map mydefaultcryptomap 65534 set ikev1 transform-set ESP-3DES-MD5-trans ESP-3DES-SHA-TRANS ESP-3DES-MD5 ESP-3DES-SHA
 crypto dynamic-map mydefaultcryptomap 65535 set pfs group1
 crypto dynamic-map mydefaultcryptomap 65535 set ikev1 transform-set ESP-3DES-MD5 ESP-AES-128-SHA ESP-AES-128-MD5 ESP-AES-192-SHA ESP-AES-192-MD5 ESP-AES-256-SHA ESP-AES-256-MD5 ESP-3DES-SHA ESP-DES-SHA ESP-DES-MD5

--- a/tests/parsing-tests/unit-tests-undefined.ref
+++ b/tests/parsing-tests/unit-tests-undefined.ref
@@ -262,7 +262,7 @@
         "description" : "Undefined reference to structure of type: 'crypto ipsec transform-set' with usage: 'crypto map ipsec-isakmp transform-set' named 'mytransformset'",
         "files" : {
           "cisco_crypto" : [
-            211
+            218
           ]
         }
       },
@@ -270,7 +270,7 @@
         "description" : "Undefined reference to structure of type: 'crypto ipsec transform-set' with usage: 'ipsec profile set transform-set' named 'hijklmnop'",
         "files" : {
           "cisco_crypto" : [
-            139
+            146
           ]
         }
       },
@@ -278,7 +278,7 @@
         "description" : "Undefined reference to structure of type: 'crypto isakmp profile' with usage: 'crypto map ipsec-isakmp isakmp-profile' named 'myisakmpprofile'",
         "files" : {
           "cisco_crypto" : [
-            207
+            214
           ]
         }
       },
@@ -286,7 +286,7 @@
         "description" : "Undefined reference to structure of type: 'crypto isakmp profile' with usage: 'ipsec profile set isakmp-profile' named 'someOtherprofile'",
         "files" : {
           "cisco_crypto" : [
-            142
+            149
           ]
         }
       },
@@ -294,7 +294,7 @@
         "description" : "Undefined reference to structure of type: 'crypto keyring' with usage: 'isakmp profile keyring' named 'VRF:MMS:RMT:UPM:1143'",
         "files" : {
           "cisco_crypto" : [
-            168
+            175
           ]
         }
       },
@@ -484,7 +484,7 @@
         "description" : "Undefined reference to structure of type: 'ipv4/6 acl' with usage: 'crypto map ipsec-isakmp acl' named 'myvpnacl'",
         "files" : {
           "cisco_crypto" : [
-            205
+            212
           ]
         }
       },
@@ -1426,38 +1426,38 @@
         "crypto ipsec transform-set" : {
           "hijklmnop" : {
             "ipsec profile set transform-set" : [
-              139
+              146
             ]
           },
           "mytransformset" : {
             "crypto map ipsec-isakmp transform-set" : [
-              211
+              218
             ]
           }
         },
         "crypto isakmp profile" : {
           "myisakmpprofile" : {
             "crypto map ipsec-isakmp isakmp-profile" : [
-              207
+              214
             ]
           },
           "someOtherprofile" : {
             "ipsec profile set isakmp-profile" : [
-              142
+              149
             ]
           }
         },
         "crypto keyring" : {
           "VRF:MMS:RMT:UPM:1143" : {
             "isakmp profile keyring" : [
-              168
+              175
             ]
           }
         },
         "ipv4/6 acl" : {
           "myvpnacl" : {
             "crypto map ipsec-isakmp acl" : [
-              205
+              212
             ]
           }
         }

--- a/tests/parsing-tests/unit-tests-unused.ref
+++ b/tests/parsing-tests/unit-tests-unused.ref
@@ -297,11 +297,11 @@
         "description" : "Unused structure of type: 'crypto ipsec profile' with name: 'abcdefg'",
         "files" : {
           "cisco_crypto" : [
-            138,
-            139,
-            140,
-            141,
-            142
+            145,
+            146,
+            147,
+            148,
+            149
           ]
         }
       },
@@ -309,9 +309,9 @@
         "description" : "Unused structure of type: 'crypto ipsec transform-set' with name: 'ESP-3DES-MD5'",
         "files" : {
           "cisco_crypto" : [
-            147,
-            148,
-            149
+            154,
+            155,
+            156
           ]
         }
       },
@@ -319,7 +319,7 @@
         "description" : "Unused structure of type: 'crypto ipsec transform-set' with name: 'IPSEC_AES_256'",
         "files" : {
           "cisco_crypto" : [
-            150
+            157
           ]
         }
       },
@@ -327,7 +327,7 @@
         "description" : "Unused structure of type: 'crypto ipsec transform-set' with name: 'cipts1'",
         "files" : {
           "cisco_crypto" : [
-            151
+            158
           ]
         }
       },
@@ -335,7 +335,7 @@
         "description" : "Unused structure of type: 'crypto ipsec transform-set' with name: 'cipts2'",
         "files" : {
           "cisco_crypto" : [
-            152
+            159
           ]
         }
       },
@@ -343,7 +343,7 @@
         "description" : "Unused structure of type: 'crypto ipsec transform-set' with name: 'noAuthHeader'",
         "files" : {
           "cisco_crypto" : [
-            153
+            160
           ]
         }
       },
@@ -351,8 +351,8 @@
         "description" : "Unused structure of type: 'crypto keyring' with name: 'VRF:ABC:DEF:GHI:1234'",
         "files" : {
           "cisco_crypto" : [
-            191,
-            192
+            198,
+            199
           ]
         }
       },
@@ -1632,36 +1632,36 @@
       "cisco_crypto" : {
         "crypto ipsec profile" : {
           "abcdefg" : [
-            138,
-            139,
-            140,
-            141,
-            142
+            145,
+            146,
+            147,
+            148,
+            149
           ]
         },
         "crypto ipsec transform-set" : {
           "ESP-3DES-MD5" : [
-            147,
-            148,
-            149
+            154,
+            155,
+            156
           ],
           "IPSEC_AES_256" : [
-            150
+            157
           ],
           "cipts1" : [
-            151
+            158
           ],
           "cipts2" : [
-            152
+            159
           ],
           "noAuthHeader" : [
-            153
+            160
           ]
         },
         "crypto keyring" : {
           "VRF:ABC:DEF:GHI:1234" : [
-            191,
-            192
+            198,
+            199
           ]
         }
       },

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -17371,6 +17371,39 @@
             "  (stanza",
             "    (s_crypto",
             "      CRYPTO:'crypto'  <== mode:DEFAULT_MODE",
+            "      (crypto_csr_params",
+            "        CSR_PARAMS:'csr-params'  <== mode:DEFAULT_MODE",
+            "        name = (variable_permissive",
+            "          VARIABLE:'BATFISH'  <== mode:DEFAULT_MODE)",
+            "        NEWLINE:'\\n'  <== mode:DEFAULT_MODE",
+            "        COUNTRY:'country'  <== mode:DEFAULT_MODE",
+            "        (null_rest_of_line",
+            "          VARIABLE:'US'  <== mode:DEFAULT_MODE",
+            "          NEWLINE:'\\n'  <== mode:DEFAULT_MODE)",
+            "        STATE:'state'  <== mode:DEFAULT_MODE",
+            "        (null_rest_of_line",
+            "          VARIABLE:'WA'  <== mode:DEFAULT_MODE",
+            "          NEWLINE:'\\n'  <== mode:DEFAULT_MODE)",
+            "        LOCALITY:'locality'  <== mode:DEFAULT_MODE",
+            "        (null_rest_of_line",
+            "          VARIABLE:'Seattle'  <== mode:DEFAULT_MODE",
+            "          NEWLINE:'\\n'  <== mode:DEFAULT_MODE)",
+            "        ORGANIZATION_NAME:'organization-name'  <== mode:DEFAULT_MODE",
+            "        (null_rest_of_line",
+            "          VARIABLE:'Batfish'  <== mode:DEFAULT_MODE",
+            "          NEWLINE:'\\n'  <== mode:DEFAULT_MODE)",
+            "        ORGANIZATION_UNIT:'organization-unit'  <== mode:DEFAULT_MODE",
+            "        (null_rest_of_line",
+            "          VARIABLE:'Network'  <== mode:DEFAULT_MODE",
+            "          VARIABLE:'Validation'  <== mode:DEFAULT_MODE",
+            "          NEWLINE:'\\n'  <== mode:DEFAULT_MODE)",
+            "        COMMON_NAME:'common-name'  <== mode:DEFAULT_MODE",
+            "        (null_rest_of_line",
+            "          VARIABLE:'batfish.org'  <== mode:DEFAULT_MODE",
+            "          NEWLINE:'\\n'  <== mode:DEFAULT_MODE))))",
+            "  (stanza",
+            "    (s_crypto",
+            "      CRYPTO:'crypto'  <== mode:DEFAULT_MODE",
             "      (crypto_dynamic_map",
             "        DYNAMIC_MAP:'dynamic-map'  <== mode:DEFAULT_MODE",
             "        name = (variable",
@@ -53261,11 +53294,11 @@
           "crypto ipsec profile" : {
             "abcdefg" : {
               "definitionLines" : [
-                138,
-                139,
-                140,
-                141,
-                142
+                145,
+                146,
+                147,
+                148,
+                149
               ],
               "numReferrers" : 0
             }
@@ -53273,52 +53306,39 @@
           "crypto ipsec transform-set" : {
             "ESP-3DES-MD5" : {
               "definitionLines" : [
-                147,
-                148,
-                149
+                154,
+                155,
+                156
               ],
               "numReferrers" : 0
             },
             "IPSEC_AES_256" : {
               "definitionLines" : [
-                150
+                157
               ],
               "numReferrers" : 0
             },
             "cipts1" : {
               "definitionLines" : [
-                151
+                158
               ],
               "numReferrers" : 0
             },
             "cipts2" : {
               "definitionLines" : [
-                152
+                159
               ],
               "numReferrers" : 0
             },
             "noAuthHeader" : {
               "definitionLines" : [
-                153
+                160
               ],
               "numReferrers" : 0
             }
           },
           "crypto isakmp policy" : {
             "001" : {
-              "definitionLines" : [
-                160,
-                161,
-                162,
-                163,
-                164,
-                165
-              ],
-              "numReferrers" : 1
-            }
-          },
-          "crypto isakmp profile" : {
-            "myprofile" : {
               "definitionLines" : [
                 167,
                 168,
@@ -53330,11 +53350,24 @@
               "numReferrers" : 1
             }
           },
+          "crypto isakmp profile" : {
+            "myprofile" : {
+              "definitionLines" : [
+                174,
+                175,
+                176,
+                177,
+                178,
+                179
+              ],
+              "numReferrers" : 1
+            }
+          },
           "crypto keyring" : {
             "VRF:ABC:DEF:GHI:1234" : {
               "definitionLines" : [
-                191,
-                192
+                198,
+                199
               ],
               "numReferrers" : 0
             }
@@ -54900,38 +54933,38 @@
           "crypto ipsec transform-set" : {
             "hijklmnop" : {
               "ipsec profile set transform-set" : [
-                139
+                146
               ]
             },
             "mytransformset" : {
               "crypto map ipsec-isakmp transform-set" : [
-                211
+                218
               ]
             }
           },
           "crypto isakmp profile" : {
             "myisakmpprofile" : {
               "crypto map ipsec-isakmp isakmp-profile" : [
-                207
+                214
               ]
             },
             "someOtherprofile" : {
               "ipsec profile set isakmp-profile" : [
-                142
+                149
               ]
             }
           },
           "crypto keyring" : {
             "VRF:MMS:RMT:UPM:1143" : {
               "isakmp profile keyring" : [
-                168
+                175
               ]
             }
           },
           "ipv4/6 acl" : {
             "myvpnacl" : {
               "crypto map ipsec-isakmp acl" : [
-                205
+                212
               ]
             }
           }


### PR DESCRIPTION
I initially defined the structure too, but this appears to only be usable for a certificate generate request that is only issuable in interactive console mode. Not sure why it shows in the config at all, except that it does...