### PR TITLE
don't make exit code dependent on command pass/fail

### DIFF
--- a/projects/batfish-client/src/main/java/org/batfish/client/Client.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/Client.java
@@ -2849,10 +2849,7 @@ public class Client extends AbstractClient implements IClient {
   private void runBatchFile() {
     Path batchCommandFilePath = Paths.get(_settings.getBatchCommandFile());
     List<String> commands = readCommands(batchCommandFilePath);
-    boolean result = processCommands(commands);
-    if (!result) {
-      System.exit(1);
-    }
+    processCommands(commands);
   }
 
   private void runInteractive() {


### PR DESCRIPTION
After #1503, Client exits with non-zero exit code when a test fails. Because of that Travis does not execute the find and diff commands, which are helpful to spot which test failed. This change fixes that.