### PR TITLE
AclReachability2AnswerElement: not an AnswerElement

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AclLinesAnswerElementInterface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AclLinesAnswerElementInterface.java
@@ -3,8 +3,10 @@ package org.batfish.datamodel.answers;
 import java.util.List;
 import java.util.SortedMap;
 import java.util.SortedSet;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.IpAccessList;
 
+@ParametersAreNonnullByDefault
 public interface AclLinesAnswerElementInterface {
 
   class AclSpecs {

--- a/projects/question/src/main/java/org/batfish/question/aclreachability2/AclReachability2Answerer.java
+++ b/projects/question/src/main/java/org/batfish/question/aclreachability2/AclReachability2Answerer.java
@@ -3,20 +3,23 @@ package org.batfish.question.aclreachability2;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;
 import java.util.List;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.common.Answerer;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.datamodel.IpAccessList;
-import org.batfish.datamodel.answers.AclLines2AnswerElement;
+import org.batfish.datamodel.answers.AclLines2Rows;
 import org.batfish.datamodel.answers.Schema;
 import org.batfish.datamodel.collections.NamedStructureEquivalenceSets;
 import org.batfish.datamodel.questions.DisplayHints;
 import org.batfish.datamodel.questions.Question;
 import org.batfish.datamodel.table.ColumnMetadata;
+import org.batfish.datamodel.table.TableAnswerElement;
 import org.batfish.datamodel.table.TableMetadata;
 import org.batfish.question.CompareSameNameQuestionPlugin.CompareSameNameAnswerElement;
 import org.batfish.question.CompareSameNameQuestionPlugin.CompareSameNameAnswerer;
 import org.batfish.question.CompareSameNameQuestionPlugin.CompareSameNameQuestion;
 
+@ParametersAreNonnullByDefault
 public class AclReachability2Answerer extends Answerer {
 
   public AclReachability2Answerer(Question question, IBatfish batfish) {
@@ -24,7 +27,7 @@ public class AclReachability2Answerer extends Answerer {
   }
 
   @Override
-  public AclLines2AnswerElement answer() {
+  public TableAnswerElement answer() {
     AclReachability2Question question = (AclReachability2Question) _question;
     // get comparesamename results for acls
     CompareSameNameQuestion csnQuestion =
@@ -40,9 +43,10 @@ public class AclReachability2Answerer extends Answerer {
     NamedStructureEquivalenceSets<?> aclEqSets =
         csnAnswer.getEquivalenceSets().get(IpAccessList.class.getSimpleName());
 
-    AclLines2AnswerElement answer = new AclLines2AnswerElement(createMetadata(question));
-    _batfish.answerAclReachability(question.getAclNameRegex(), aclEqSets, answer);
-    answer.postProcessAnswer(question, answer.getInitialRows().getData());
+    AclLines2Rows answerRows = new AclLines2Rows();
+    _batfish.answerAclReachability(question.getAclNameRegex(), aclEqSets, answerRows);
+    TableAnswerElement answer = new TableAnswerElement(createMetadata(question));
+    answer.postProcessAnswer(question, answerRows.getRows());
     return answer;
   }
 
@@ -52,56 +56,42 @@ public class AclReachability2Answerer extends Answerer {
    * @param question The question
    * @return The resulting {@link TableMetadata} object
    */
-  static TableMetadata createMetadata(AclReachability2Question question) {
+  private static TableMetadata createMetadata(AclReachability2Question question) {
     List<ColumnMetadata> columnMetadata =
         new ImmutableList.Builder<ColumnMetadata>()
             .add(
                 new ColumnMetadata(
-                    AclLines2AnswerElement.COL_NODES,
-                    Schema.list(Schema.NODE),
-                    "Nodes",
-                    true,
-                    false))
+                    AclLines2Rows.COL_NODES, Schema.list(Schema.NODE), "Nodes", true, false))
+            .add(new ColumnMetadata(AclLines2Rows.COL_ACL, Schema.STRING, "ACL name", true, false))
             .add(
                 new ColumnMetadata(
-                    AclLines2AnswerElement.COL_ACL, Schema.STRING, "ACL name", true, false))
+                    AclLines2Rows.COL_LINES, Schema.list(Schema.STRING), "ACL lines", false, false))
             .add(
                 new ColumnMetadata(
-                    AclLines2AnswerElement.COL_LINES,
-                    Schema.list(Schema.STRING),
-                    "ACL lines",
-                    false,
-                    false))
-            .add(
-                new ColumnMetadata(
-                    AclLines2AnswerElement.COL_BLOCKED_LINE_NUM,
+                    AclLines2Rows.COL_BLOCKED_LINE_NUM,
                     Schema.INTEGER,
                     "Blocked line number",
                     true,
                     false))
             .add(
                 new ColumnMetadata(
-                    AclLines2AnswerElement.COL_BLOCKING_LINE_NUMS,
+                    AclLines2Rows.COL_BLOCKING_LINE_NUMS,
                     Schema.list(Schema.INTEGER),
                     "Blocking line numbers",
                     false,
                     true))
             .add(
                 new ColumnMetadata(
-                    AclLines2AnswerElement.COL_DIFF_ACTION,
-                    Schema.BOOLEAN,
-                    "Different action",
-                    false,
-                    true))
+                    AclLines2Rows.COL_DIFF_ACTION, Schema.BOOLEAN, "Different action", false, true))
             .add(
                 new ColumnMetadata(
-                    AclLines2AnswerElement.COL_MESSAGE, Schema.STRING, "Message", false, false))
+                    AclLines2Rows.COL_MESSAGE, Schema.STRING, "Message", false, false))
             .build();
 
     DisplayHints dhints = question.getDisplayHints();
     if (dhints == null) {
       dhints = new DisplayHints();
-      dhints.setTextDesc(String.format("${%s}", AclLines2AnswerElement.COL_MESSAGE));
+      dhints.setTextDesc(String.format("${%s}", AclLines2Rows.COL_MESSAGE));
     }
     return new TableMetadata(columnMetadata, dhints);
   }

--- a/tests/basic/aclReachability2.ref
+++ b/tests/basic/aclReachability2.ref
@@ -1,6 +1,6 @@
 [
   {
-    "class" : "org.batfish.datamodel.answers.AclLines2AnswerElement",
+    "class" : "org.batfish.datamodel.table.TableAnswerElement",
     "metadata" : {
       "columnMetadata" : [
         {


### PR DESCRIPTION
AclReachability2AnswerElement was already not an answer element -- it didn't use super.rows.

- remove inheritance
- rename class
- simplify API now that it can calls its results things like getRows
- remove Jackson stuff now that it's not JSON-serialized

And a little very minor cleanup like removing an erroneous @Nullable
annotation.