### PR TITLE
ibdp: split some OSPF logic from VirtualRouter

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/OspfProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/OspfProtocolHelper.java
@@ -48,6 +48,15 @@ public class OspfProtocolHelper {
     return Math.max(currentMetric, contributingRouteMetric);
   }
 
+  /**
+   * Decide whether an inter-area OSPF route can be sent from neighbor's area to given area.
+   *
+   * @param areaNum "Our" area number
+   * @param neighbor an adjacent {@link Node} with which route exchange is happening
+   * @param neighborRoute {@link OspfInternalRoute} in questions
+   * @param neighborArea neighbor's area number
+   * @return true if the route should considered for installation into the OSPF RIB
+   */
   public static boolean isOspfInterAreaFromInterAreaPropagationAllowed(
       long areaNum, Node neighbor, OspfInternalRoute neighborRoute, OspfArea neighborArea) {
     long neighborRouteAreaNum = neighborRoute.getArea();
@@ -69,6 +78,15 @@ public class OspfProtocolHelper {
     return allowed;
   }
 
+  /**
+   * Decide whether an intra-area OSPF route can be sent from neighbor's area to given area.
+   *
+   * @param areaNum "Our" area number
+   * @param neighbor an adjacent {@link Node} with which route exchange is happening
+   * @param neighborRoute {@link OspfInternalRoute} in questions
+   * @param neighborArea neighbor's area number
+   * @return true if the route should considered for installation into the OSPF RIB
+   */
   public static boolean isOspfInterAreaFromIntraAreaPropagationAllowed(
       long areaNum, Node neighbor, OspfInternalRoute neighborRoute, OspfArea neighborArea) {
     long neighborRouteAreaNum = neighborRoute.getArea();

--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/OspfProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/OspfProtocolHelper.java
@@ -1,0 +1,92 @@
+package org.batfish.dataplane.protocols;
+
+import javax.annotation.Nullable;
+import org.batfish.datamodel.OspfArea;
+import org.batfish.datamodel.OspfInternalRoute;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.RouteFilterList;
+import org.batfish.dataplane.ibdp.Node;
+
+public class OspfProtocolHelper {
+  /**
+   * Decides whether the current OSPF summary route metric needs to be changed based on the given
+   * route's metric.
+   *
+   * <p>Routes from the same area or outside of areaPrefix have no effect on the summary metric.
+   *
+   * @param route The route in question, whose metric is considered
+   * @param areaPrefix The Ip prefix of the OSPF area
+   * @param currentMetric The current summary metric for the area
+   * @param areaNum Area number.
+   * @param useMin Whether to use the older RFC 1583 computation, which takes the minimum of metrics
+   *     as opposed to the newer RFC 2328, which uses the maximum
+   * @return the newly computed summary metric.
+   */
+  @Nullable
+  public static Long computeUpdatedOspfSummaryMetric(
+      OspfInternalRoute route,
+      Prefix areaPrefix,
+      @Nullable Long currentMetric,
+      long areaNum,
+      boolean useMin) {
+    Prefix contributingRoutePrefix = route.getNetwork();
+    // Only update metric for different areas and if the area prefix contains the route prefix
+    if (areaNum == route.getArea() || !areaPrefix.containsPrefix(contributingRoutePrefix)) {
+      return currentMetric;
+    }
+    long contributingRouteMetric = route.getMetric();
+    // Definitely update if we have no previous metric
+    if (currentMetric == null) {
+      return contributingRouteMetric;
+    }
+    // Take the best metric between the route's and current available.
+    // Routers (at least Cisco and Juniper) default to min metric unless using RFC2328 with
+    // RFC1583 compatibility explicitly disabled, in which case they default to max.
+    if (useMin) {
+      return Math.min(currentMetric, contributingRouteMetric);
+    }
+    return Math.max(currentMetric, contributingRouteMetric);
+  }
+
+  public static boolean isOspfInterAreaFromInterAreaPropagationAllowed(
+      long areaNum, Node neighbor, OspfInternalRoute neighborRoute, OspfArea neighborArea) {
+    long neighborRouteAreaNum = neighborRoute.getArea();
+    // May only propagate to or from area 0
+    if (areaNum != neighborRouteAreaNum && areaNum != 0L && neighborRouteAreaNum != 0L) {
+      return false;
+    }
+    Prefix neighborRouteNetwork = neighborRoute.getNetwork();
+    String neighborSummaryFilterName = neighborArea.getSummaryFilter();
+    boolean hasSummaryFilter = neighborSummaryFilterName != null;
+    boolean allowed = !hasSummaryFilter;
+
+    // If there is a summary filter, run the route through it
+    if (hasSummaryFilter) {
+      RouteFilterList neighborSummaryFilter =
+          neighbor.getConfiguration().getRouteFilterLists().get(neighborSummaryFilterName);
+      allowed = neighborSummaryFilter.permits(neighborRouteNetwork);
+    }
+    return allowed;
+  }
+
+  public static boolean isOspfInterAreaFromIntraAreaPropagationAllowed(
+      long areaNum, Node neighbor, OspfInternalRoute neighborRoute, OspfArea neighborArea) {
+    long neighborRouteAreaNum = neighborRoute.getArea();
+    // May only propagate to or from area 0
+    if (areaNum == neighborRouteAreaNum || (areaNum != 0L && neighborRouteAreaNum != 0L)) {
+      return false;
+    }
+    Prefix neighborRouteNetwork = neighborRoute.getNetwork();
+    String neighborSummaryFilterName = neighborArea.getSummaryFilter();
+    boolean hasSummaryFilter = neighborSummaryFilterName != null;
+    boolean allowed = !hasSummaryFilter;
+
+    // If there is a summary filter, run the route through it
+    if (hasSummaryFilter) {
+      RouteFilterList neighborSummaryFilter =
+          neighbor.getConfiguration().getRouteFilterLists().get(neighborSummaryFilterName);
+      allowed = neighborSummaryFilter.permits(neighborRouteNetwork);
+    }
+    return allowed;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/OspfProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/OspfProtocolHelper.java
@@ -7,7 +7,9 @@ import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.RouteFilterList;
 import org.batfish.dataplane.ibdp.Node;
 
+/** Helper class with functions that implement various bits of OSPF protocol logic. */
 public class OspfProtocolHelper {
+
   /**
    * Decides whether the current OSPF summary route metric needs to be changed based on the given
    * route's metric.

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
@@ -408,59 +408,6 @@ public class VirtualRouterTest {
     assertThat(vr.getMainRib().getRoutes(), not(containsInAnyOrder(dependentRoute)));
   }
 
-  @Test
-  public void testGetBetterOspfRouteMetric() {
-    Prefix ospfInterAreaRoutePrefix = Prefix.parse("1.1.1.1/24");
-    long definedMetric = 5;
-    long definedArea = 1;
-    OspfInterAreaRoute route =
-        new OspfInterAreaRoute(
-            ospfInterAreaRoutePrefix,
-            Ip.MAX,
-            RoutingProtocol.OSPF_IA.getDefaultAdministrativeCost(FORMAT),
-            definedMetric,
-            0);
-
-    // The route is in the prefix and existing metric is null, so return the route's metric
-    assertThat(
-        VirtualRouter.computeUpdatedOspfSummaryMetric(route, Prefix.ZERO, null, definedArea, true),
-        equalTo(definedMetric));
-    // Return the lower metric if the existing not null and using old RFC
-    assertThat(
-        VirtualRouter.computeUpdatedOspfSummaryMetric(route, Prefix.ZERO, 10L, definedArea, true),
-        equalTo(definedMetric));
-    // Return the higher metric if the existing metric is not null and using new RFC
-    assertThat(
-        VirtualRouter.computeUpdatedOspfSummaryMetric(route, Prefix.ZERO, 10L, definedArea, false),
-        equalTo(10L));
-    // The route is in the prefix but the existing metric is lower, so return the existing metric
-    assertThat(
-        VirtualRouter.computeUpdatedOspfSummaryMetric(route, Prefix.ZERO, 4L, definedArea, true),
-        equalTo(4L));
-    // The route is in the prefix but the existing metric is lower, so return the existing metric
-    assertThat(
-        VirtualRouter.computeUpdatedOspfSummaryMetric(route, Prefix.ZERO, 4L, definedArea, false),
-        equalTo(definedMetric));
-    // The route is not in the area's prefix, return the current metric
-    assertThat(
-        VirtualRouter.computeUpdatedOspfSummaryMetric(
-            route, Prefix.parse("2.0.0.0/8"), 4L, definedArea, true),
-        equalTo(4L));
-
-    OspfInterAreaRoute sameAreaRoute =
-        new OspfInterAreaRoute(
-            ospfInterAreaRoutePrefix,
-            Ip.MAX,
-            RoutingProtocol.OSPF_IA.getDefaultAdministrativeCost(FORMAT),
-            definedMetric,
-            1); // the area is the same as definedArea
-    // Thus the metric should remain null
-    assertThat(
-        VirtualRouter.computeUpdatedOspfSummaryMetric(
-            sameAreaRoute, Prefix.ZERO, null, definedArea, true),
-        equalTo(null));
-  }
-
   /** Check that initialization of Connected RIB is as expected */
   @Test
   public void testInitConnectedRib() {

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/OspfProtocolHelperTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/OspfProtocolHelperTest.java
@@ -1,0 +1,71 @@
+package org.batfish.dataplane.protocols;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.OspfInterAreaRoute;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.RoutingProtocol;
+import org.junit.Test;
+
+public class OspfProtocolHelperTest {
+  @Test
+  public void testGetBetterOspfRouteMetric() {
+    Prefix ospfInterAreaRoutePrefix = Prefix.parse("1.1.1.1/24");
+    long definedMetric = 5;
+    long definedArea = 1;
+    OspfInterAreaRoute route =
+        new OspfInterAreaRoute(
+            ospfInterAreaRoutePrefix,
+            Ip.MAX,
+            RoutingProtocol.OSPF_IA.getDefaultAdministrativeCost(ConfigurationFormat.CISCO_IOS),
+            definedMetric,
+            0);
+
+    // The route is in the prefix and existing metric is null, so return the route's metric
+    assertThat(
+        OspfProtocolHelper.computeUpdatedOspfSummaryMetric(
+            route, Prefix.ZERO, null, definedArea, true),
+        equalTo(definedMetric));
+    // Return the lower metric if the existing not null and using old RFC
+    assertThat(
+        OspfProtocolHelper.computeUpdatedOspfSummaryMetric(
+            route, Prefix.ZERO, 10L, definedArea, true),
+        equalTo(definedMetric));
+    // Return the higher metric if the existing metric is not null and using new RFC
+    assertThat(
+        OspfProtocolHelper.computeUpdatedOspfSummaryMetric(
+            route, Prefix.ZERO, 10L, definedArea, false),
+        equalTo(10L));
+    // The route is in the prefix but the existing metric is lower, so return the existing metric
+    assertThat(
+        OspfProtocolHelper.computeUpdatedOspfSummaryMetric(
+            route, Prefix.ZERO, 4L, definedArea, true),
+        equalTo(4L));
+    // The route is in the prefix but the existing metric is lower, so return the existing metric
+    assertThat(
+        OspfProtocolHelper.computeUpdatedOspfSummaryMetric(
+            route, Prefix.ZERO, 4L, definedArea, false),
+        equalTo(definedMetric));
+    // The route is not in the area's prefix, return the current metric
+    assertThat(
+        OspfProtocolHelper.computeUpdatedOspfSummaryMetric(
+            route, Prefix.parse("2.0.0.0/8"), 4L, definedArea, true),
+        equalTo(4L));
+
+    OspfInterAreaRoute sameAreaRoute =
+        new OspfInterAreaRoute(
+            ospfInterAreaRoutePrefix,
+            Ip.MAX,
+            RoutingProtocol.OSPF_IA.getDefaultAdministrativeCost(ConfigurationFormat.CISCO_IOS),
+            definedMetric,
+            1); // the area is the same as definedArea
+    // Thus the metric should remain null
+    assertThat(
+        OspfProtocolHelper.computeUpdatedOspfSummaryMetric(
+            sameAreaRoute, Prefix.ZERO, null, definedArea, true),
+        equalTo(null));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/OspfProtocolHelperTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/OspfProtocolHelperTest.java
@@ -10,7 +10,10 @@ import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.RoutingProtocol;
 import org.junit.Test;
 
+/** Tests for {@link OspfProtocolHelper} */
 public class OspfProtocolHelperTest {
+
+  /** Tests for proper handling of RFC 2328 */
   @Test
   public void testGetBetterOspfRouteMetric() {
     Prefix ospfInterAreaRoutePrefix = Prefix.parse("1.1.1.1/24");


### PR DESCRIPTION
No functionality changes. Just trying to make VirtualRouter smaller/more readable.