### PR TITLE
BatfishTestUtils: prevent test flake under pressure

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
@@ -33,7 +33,7 @@ import org.junit.rules.TemporaryFolder;
 public class BatfishTestUtils {
 
   private static Cache<Snapshot, SortedMap<String, Configuration>> makeTestrigCache() {
-    return CacheBuilder.newBuilder().maximumSize(5).weakValues().build();
+    return CacheBuilder.newBuilder().maximumSize(5).build();
   }
 
   private static Map<EnvironmentSettings, SortedMap<String, BgpAdvertisementsByVrf>>
@@ -46,7 +46,7 @@ public class BatfishTestUtils {
   }
 
   private static Cache<TestrigSettings, DataPlane> makeDataPlaneCache() {
-    return CacheBuilder.newBuilder().maximumSize(2).weakValues().build();
+    return CacheBuilder.newBuilder().maximumSize(2).build();
   }
 
   private static Cache<TestrigSettings, ForwardingAnalysis> makeForwardingAnalysisCache() {


### PR DESCRIPTION
We have some tests that just load the configurations into the cache without
actually generating corresponding config files. However, the cache was using
only weak references, so they could go out of cache under pressure. If this
happened, Batfish would try to re-parse the configs (that don't exist) and
give a stack trace like this:

    org.batfish.common.BatfishException: No valid configurations found
	at org.batfish.main.Batfish.serializeVendorConfigs(Batfish.java:4186)
	at org.batfish.main.Batfish.repairVendorConfigurations(Batfish.java:3718)
	at org.batfish.main.Batfish.loadParseVendorConfigurationAnswerElement(Batfish.java:2668)
	at org.batfish.main.Batfish.loadParseVendorConfigurationAnswerElement(Batfish.java:2653)
	at org.batfish.main.Batfish.repairConfigurations(Batfish.java:3626)
	at org.batfish.main.Batfish.parseConfigurationsAndApplyEnvironment(Batfish.java:2451)
	at org.batfish.main.Batfish.loadConfigurations(Batfish.java:2441)
	at org.batfish.main.Batfish.loadConfigurations(Batfish.java:2396)
	at org.batfish.question.CompareSameNameQuestionPlugin.answer(CompareSameNameQuestionPlugin.java:135)
	at org.batfish.question.aclreachability2.AclReachability2Answerer.answer(AclReachability2Answerer.java:42)
	at org.batfish.allinone.AclReachability2Test.answer(AclReachability2Test.java:247)
	at org.batfish.allinone.AclReachability2Test.testIndependentlyUnmatchableLines(AclReachability2Test.java:195)

Fix this by not using weak values for the cache in tests only.