### PR TITLE
Cisco: set BGP origin type when using default originate

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpRoute.java
@@ -212,7 +212,7 @@ public class BgpRoute extends AbstractRoute {
 
   private final Ip _originatorIp;
 
-  private final OriginType _originType;
+  @Nonnull private final OriginType _originType;
 
   private final RoutingProtocol _protocol;
 
@@ -237,7 +237,7 @@ public class BgpRoute extends AbstractRoute {
       @JsonProperty(PROP_CLUSTER_LIST) SortedSet<Long> clusterList,
       @JsonProperty(PROP_RECEIVED_FROM_ROUTE_REFLECTOR_CLIENT)
           boolean receivedFromRouteReflectorClient,
-      @JsonProperty(PROP_ORIGIN_TYPE) OriginType originType,
+      @Nonnull @JsonProperty(PROP_ORIGIN_TYPE) OriginType originType,
       @JsonProperty(PROP_PROTOCOL) RoutingProtocol protocol,
       @JsonProperty(PROP_RECEIVED_FROM_IP) Ip receivedFromIp,
       @JsonProperty(PROP_SRC_PROTOCOL) RoutingProtocol srcProtocol,
@@ -413,7 +413,7 @@ public class BgpRoute extends AbstractRoute {
     result = prime * result + Long.hashCode(_med);
     result = prime * result + _network.hashCode();
     result = prime * result + ((_nextHopIp == null) ? 0 : _nextHopIp.hashCode());
-    result = prime * result + ((_originType == null) ? 0 : _originType.ordinal());
+    result = prime * result + _originType.ordinal();
     result = prime * result + ((_originatorIp == null) ? 0 : _originatorIp.hashCode());
     result = prime * result + ((_protocol == null) ? 0 : _protocol.ordinal());
     result = prime * result + ((_receivedFromIp == null) ? 0 : _receivedFromIp.hashCode());

--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
@@ -10,7 +10,6 @@ import org.batfish.datamodel.BgpNeighbor;
 import org.batfish.datamodel.BgpRoute;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
-import org.batfish.datamodel.OriginType;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Route;
 import org.batfish.datamodel.RoutingProtocol;
@@ -117,8 +116,6 @@ public class BgpProtocolHelper {
           return null;
         }
       }
-    } else {
-      transformedOutgoingRouteBuilder.setOriginType(OriginType.INCOMPLETE);
     }
 
     // Outgoing asPath

--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
@@ -10,6 +10,7 @@ import org.batfish.datamodel.BgpNeighbor;
 import org.batfish.datamodel.BgpRoute;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.OriginType;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Route;
 import org.batfish.datamodel.RoutingProtocol;
@@ -116,6 +117,8 @@ public class BgpProtocolHelper {
           return null;
         }
       }
+    } else {
+      transformedOutgoingRouteBuilder.setOriginType(OriginType.INCOMPLETE);
     }
 
     // Outgoing asPath

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoNxConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoNxConversions.java
@@ -335,6 +335,7 @@ final class CiscoNxConversions {
             ImmutableList.of(Statements.ExitReject.toStaticStatement())));
     List<BooleanExpr> localOrCommonOrigination = new LinkedList<>();
     localOrCommonOrigination.add(new CallExpr(computeBgpCommonExportPolicyName(vrf.getName())));
+
     // If `default-originate [route-map NAME]` is configured for this neighbor, generate the
     // default route and inject it.
     if (naf4 != null && firstNonNull(naf4.getDefaultOriginate(), Boolean.FALSE)) {
@@ -346,12 +347,11 @@ final class CiscoNxConversions {
               vrf.getName(), dynamic ? prefix : prefix.getStartIp());
       RoutingPolicy defaultRouteExportPolicy = new RoutingPolicy(defaultRouteExportPolicyName, c);
       c.getRoutingPolicies().put(defaultRouteExportPolicyName, defaultRouteExportPolicy);
-      Disjunction matchDefaultRoute = new Disjunction();
       defaultRouteExportPolicy
           .getStatements()
           .add(
               new If(
-                  matchDefaultRoute,
+                  MATCH_DEFAULT_ROUTE,
                   ImmutableList.of(
                       new SetOrigin(new LiteralOrigin(OriginType.IGP, null)),
                       Statements.ReturnTrue.toStaticStatement())));
@@ -365,7 +365,6 @@ final class CiscoNxConversions {
               .setGenerationPolicy(naf4.getDefaultOriginateMap())
               .build();
       newNeighbor.getGeneratedRoutes().add(defaultRoute);
-      matchDefaultRoute.getDisjuncts().add(MATCH_DEFAULT_ROUTE);
     }
     peerExportConditions.add(new Disjunction(localOrCommonOrigination));
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoNxConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoNxConversions.java
@@ -27,6 +27,7 @@ import org.batfish.datamodel.GeneratedRoute;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.OriginType;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
@@ -34,9 +35,11 @@ import org.batfish.datamodel.routing_policy.expr.BooleanExpr;
 import org.batfish.datamodel.routing_policy.expr.CallExpr;
 import org.batfish.datamodel.routing_policy.expr.Conjunction;
 import org.batfish.datamodel.routing_policy.expr.Disjunction;
+import org.batfish.datamodel.routing_policy.expr.LiteralOrigin;
 import org.batfish.datamodel.routing_policy.expr.SelfNextHop;
 import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.SetNextHop;
+import org.batfish.datamodel.routing_policy.statement.SetOrigin;
 import org.batfish.datamodel.routing_policy.statement.Statement;
 import org.batfish.datamodel.routing_policy.statement.Statements;
 import org.batfish.representation.cisco.nx.CiscoNxBgpGlobalConfiguration;
@@ -335,6 +338,26 @@ final class CiscoNxConversions {
     // If `default-originate [route-map NAME]` is configured for this neighbor, generate the
     // default route and inject it.
     if (naf4 != null && firstNonNull(naf4.getDefaultOriginate(), Boolean.FALSE)) {
+
+      String defaultRouteExportPolicyName;
+      defaultRouteExportPolicyName =
+          String.format(
+              "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:%s:%s~",
+              vrf.getName(), dynamic ? prefix : prefix.getStartIp());
+      RoutingPolicy defaultRouteExportPolicy = new RoutingPolicy(defaultRouteExportPolicyName, c);
+      c.getRoutingPolicies().put(defaultRouteExportPolicyName, defaultRouteExportPolicy);
+      Disjunction matchDefaultRoute = new Disjunction();
+      defaultRouteExportPolicy
+          .getStatements()
+          .add(
+              new If(
+                  matchDefaultRoute,
+                  ImmutableList.of(
+                      new SetOrigin(new LiteralOrigin(OriginType.IGP, null)),
+                      Statements.ReturnTrue.toStaticStatement())));
+      defaultRouteExportPolicy.getStatements().add(Statements.ReturnFalse.toStaticStatement());
+      localOrCommonOrigination.add(new CallExpr(defaultRouteExportPolicy.getName()));
+
       GeneratedRoute defaultRoute =
           new GeneratedRoute.Builder()
               .setNetwork(Prefix.ZERO)
@@ -342,7 +365,7 @@ final class CiscoNxConversions {
               .setGenerationPolicy(naf4.getDefaultOriginateMap())
               .build();
       newNeighbor.getGeneratedRoutes().add(defaultRoute);
-      localOrCommonOrigination.add(MATCH_DEFAULT_ROUTE);
+      matchDefaultRoute.getDisjuncts().add(MATCH_DEFAULT_ROUTE);
     }
     peerExportConditions.add(new Disjunction(localOrCommonOrigination));
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -4,6 +4,7 @@ import static org.batfish.datamodel.matchers.AaaAuthenticationLoginListMatchers.
 import static org.batfish.datamodel.matchers.AaaAuthenticationLoginMatchers.hasListForKey;
 import static org.batfish.datamodel.matchers.AaaAuthenticationMatchers.hasLogin;
 import static org.batfish.datamodel.matchers.AaaMatchers.hasAuthentication;
+import static org.batfish.datamodel.matchers.AbstractRouteMatchers.hasPrefix;
 import static org.batfish.datamodel.matchers.AndMatchExprMatchers.hasConjuncts;
 import static org.batfish.datamodel.matchers.AndMatchExprMatchers.isAndMatchExprThat;
 import static org.batfish.datamodel.matchers.BgpNeighborMatchers.hasRemoteAs;
@@ -116,6 +117,7 @@ import org.batfish.datamodel.BgpSession;
 import org.batfish.datamodel.CommunityList;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.InterfaceAddress;
@@ -615,6 +617,26 @@ public class CiscoGrammarTest {
             CiscoStructureType.KEYRING,
             "kundefined",
             CiscoStructureUsage.ISAKMP_PROFILE_KEYRING));
+  }
+
+  @Test
+  public void testIosNeighborDefaultOriginate() throws IOException {
+    String testrigName = "ios-default-originate";
+    Batfish batfish =
+        BatfishTestUtils.getBatfishFromTestrigText(
+            TestrigText.builder()
+                .setConfigurationText(
+                    TESTRIGS_PREFIX + testrigName, ImmutableList.of("originator", "listener"))
+                .build(),
+            _folder);
+
+    batfish.computeDataPlane(false);
+    DataPlane dp = batfish.loadDataPlane();
+    Set<AbstractRoute> routesOnListener =
+        dp.getRibs().get("listener").get(Configuration.DEFAULT_VRF_NAME).getRoutes();
+
+    // Ensure that default route is advertised to and installed on listener
+    assertThat(routesOnListener, hasItem(hasPrefix(Prefix.ZERO)));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/ios-default-originate/configs/listener
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/ios-default-originate/configs/listener
@@ -1,0 +1,16 @@
+!
+! Real GNS3 config, trimmed
+!
+hostname listener
+!
+!
+interface FastEthernet0/0
+  ip address 1.1.1.3 255.255.255.254
+  speed auto
+  no shutdown
+  duplex half
+!
+router bgp 2
+  neighbor 1.1.1.2 remote-as 1
+  bgp router-id 1.1.1.3
+!

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/ios-default-originate/configs/originator
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/ios-default-originate/configs/originator
@@ -1,0 +1,18 @@
+!
+! Real GNS3 config, trimmed
+!
+hostname originator
+!
+interface FastEthernet0/0
+ ip address 1.1.1.2 255.255.255.254
+ speed auto
+ duplex half
+!
+router bgp 1
+ bgp router-id 1.1.1.2
+ neighbor 1.1.1.3 remote-as 2
+ ! Inject default route
+ neighbor 1.1.1.3 default-originate
+!
+ip route 0.0.0.0 0.0.0.0 Null0
+!

--- a/tests/aws/nodes-example-aws.ref
+++ b/tests/aws/nodes-example-aws.ref
@@ -1237,6 +1237,13 @@
                 },
                 "trueStatements" : [
                   {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetOrigin",
+                    "originType" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralOrigin",
+                      "originType" : "igp"
+                    }
+                  },
+                  {
                     "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
                     "type" : "ReturnTrue"
                   }
@@ -1264,10 +1271,93 @@
                 },
                 "trueStatements" : [
                   {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetOrigin",
+                    "originType" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralOrigin",
+                      "originType" : "igp"
+                    }
+                  },
+                  {
                     "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
                     "type" : "ReturnTrue"
                   }
                 ]
+              }
+            ]
+          },
+          "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:default:169.254.13.237~" : {
+            "name" : "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:default:169.254.13.237~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "comment" : "match default route",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                    "prefixSpace" : [
+                      "0.0.0.0/0"
+                    ]
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetOrigin",
+                    "originType" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralOrigin",
+                      "originType" : "igp"
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              },
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                "type" : "ReturnFalse"
+              }
+            ]
+          },
+          "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:default:169.254.15.193~" : {
+            "name" : "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:default:169.254.15.193~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "comment" : "match default route",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                    "prefixSpace" : [
+                      "0.0.0.0/0"
+                    ]
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetOrigin",
+                    "originType" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralOrigin",
+                      "originType" : "igp"
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              },
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                "type" : "ReturnFalse"
               }
             ]
           },
@@ -1398,17 +1488,8 @@
                       "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
                     },
                     {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                      "comment" : "match default route",
-                      "prefix" : {
-                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                      },
-                      "prefixSet" : {
-                        "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
-                        "prefixSpace" : [
-                          "0.0.0.0/0"
-                        ]
-                      }
+                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                      "calledPolicyName" : "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:default:169.254.13.237~"
                     }
                   ]
                 },
@@ -1441,17 +1522,8 @@
                       "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
                     },
                     {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                      "comment" : "match default route",
-                      "prefix" : {
-                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                      },
-                      "prefixSet" : {
-                        "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
-                        "prefixSpace" : [
-                          "0.0.0.0/0"
-                        ]
-                      }
+                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                      "calledPolicyName" : "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:default:169.254.15.193~"
                     }
                   ]
                 },

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -2658,6 +2658,44 @@
                 "type" : "ReturnFalse"
               }
             ]
+          },
+          "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:default:AUTO/NONE(-1l)~" : {
+            "name" : "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:default:AUTO/NONE(-1l)~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "comment" : "match default route",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                    "prefixSpace" : [
+                      "0.0.0.0/0"
+                    ]
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetOrigin",
+                    "originType" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralOrigin",
+                      "originType" : "igp"
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              },
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                "type" : "ReturnFalse"
+              }
+            ]
           }
         },
         "vendorFamily" : {


### PR DESCRIPTION
*Context*:
Routing policy would not set OriginType on default routes, causing ibdp to crash

*Fix*:
When matching default routes, also use `SetOrigin` statements.
Since there is no easy way to nest put an `If` into a disjuction, just pulled this out into a separate policy, hence the ref changes.

*Note*
Made test for IOS; Test for nxos already exists, but is skipped (it needs more dataplane support, coming soon).