### PR TITLE
example of token overload

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
@@ -87,6 +87,51 @@ tokens {
    WISPR
 } // Cisco Keywords
 
+AAA1
+:
+   'aaa1'
+;
+
+AAA2
+:
+   'aaa2'
+;
+
+AAA3
+:
+   'aaa3'
+;
+
+AAA4
+:
+   'aaa4'
+;
+
+AAA5
+:
+   'aaa5'
+;
+
+AAA6
+:
+   'aaa6'
+;
+
+AAA7
+:
+   'aaa7'
+;
+
+AAA8
+:
+   'aaa8'
+;
+
+AAA9
+:
+   'aaa9'
+;
+
 AAA
 :
    'aaa'


### PR DESCRIPTION
This is the example where build fails. See 9 extra tokens at the top. 