### PR TITLE
provide a safe row building function

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/table/Row.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/table/Row.java
@@ -55,7 +55,7 @@ public class Row implements Comparable<Row> {
       Set<String> columnsInMetadata =
           columnMetadata.stream().map(cm -> cm.getName()).collect(Collectors.toSet());
       Set<String> columnsInData = Row.getColumnNames(_data);
-      if (!columnMetadata.equals(columnsInMetadata)) {
+      if (!columnsInData.equals(columnsInMetadata)) {
         throw new InputMismatchException(
             "Set of columns in the row do not match those in the metadata");
       }


### PR DESCRIPTION
To prevent the "type" bug you found today, what do you think of this? Basically, provide a safe build function, which succeeds only if there is type consistency and we'll try to use this function as much as possible going forward.

Another option is to take its core logic and put it in a static function / matcher, and call it from tests. 