### PR TITLE
move ReachabilitySettings into the question project

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
@@ -33,12 +33,12 @@ import org.batfish.datamodel.collections.NamedStructureEquivalenceSets;
 import org.batfish.datamodel.collections.RoutesByVrf;
 import org.batfish.datamodel.pojo.Environment;
 import org.batfish.datamodel.questions.Question;
-import org.batfish.datamodel.questions.ReachabilitySettings;
 import org.batfish.datamodel.questions.smt.HeaderLocationQuestion;
 import org.batfish.datamodel.questions.smt.HeaderQuestion;
 import org.batfish.datamodel.questions.smt.RoleQuestion;
 import org.batfish.grammar.BgpTableFormat;
 import org.batfish.grammar.GrammarSettings;
+import org.batfish.question.ReachabilityParameters;
 import org.batfish.role.NodeRoleDimension;
 import org.batfish.role.NodeRolesData;
 
@@ -127,11 +127,11 @@ public interface IBatfish extends IPluginConsumer {
 
   ParseVendorConfigurationAnswerElement loadParseVendorConfigurationAnswerElement();
 
-  AnswerElement multipath(ReachabilitySettings reachabilitySettings);
+  AnswerElement multipath(ReachabilityParameters reachabilityParameters);
 
   AtomicInteger newBatch(String description, int jobs);
 
-  AnswerElement pathDiff(ReachabilitySettings reachabilitySettings);
+  AnswerElement pathDiff(ReachabilityParameters reachabilityParameters);
 
   void popEnvironment();
 
@@ -146,7 +146,7 @@ public interface IBatfish extends IPluginConsumer {
   @Nullable
   String readExternalBgpAnnouncementsFile();
 
-  AnswerElement reducedReachability(ReachabilitySettings reachabilitySettings);
+  AnswerElement reducedReachability(ReachabilityParameters reachabilityParameters);
 
   void registerAnswerer(
       String questionName,
@@ -189,7 +189,7 @@ public interface IBatfish extends IPluginConsumer {
 
   AnswerElement smtRoutingLoop(HeaderQuestion q);
 
-  AnswerElement standard(ReachabilitySettings reachabilitySettings);
+  AnswerElement standard(ReachabilityParameters reachabilityParameters);
 
   void writeDataPlane(DataPlane dp, DataPlaneAnswerElement ae);
 }

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -148,7 +148,6 @@ import org.batfish.datamodel.pojo.Environment;
 import org.batfish.datamodel.questions.InvalidReachabilityParametersException;
 import org.batfish.datamodel.questions.NodesSpecifier;
 import org.batfish.datamodel.questions.Question;
-import org.batfish.datamodel.questions.ReachabilitySettings;
 import org.batfish.datamodel.questions.smt.HeaderLocationQuestion;
 import org.batfish.datamodel.questions.smt.HeaderQuestion;
 import org.batfish.datamodel.questions.smt.RoleQuestion;
@@ -2747,9 +2746,9 @@ public class Batfish extends PluginConsumer implements IBatfish {
   }
 
   @Override
-  public AnswerElement multipath(ReachabilitySettings reachabilitySettings) {
+  public AnswerElement multipath(ReachabilityParameters reachabilityParameters) {
     return singleReachability(
-        reachabilitySettings, MultipathInconsistencyQuerySynthesizer.builder());
+        reachabilityParameters, MultipathInconsistencyQuerySynthesizer.builder());
   }
 
   @Override
@@ -2984,7 +2983,11 @@ public class Batfish extends PluginConsumer implements IBatfish {
   }
 
   @Override
-  public AnswerElement pathDiff(ReachabilitySettings reachabilitySettings) {
+  public AnswerElement pathDiff(ReachabilityParameters reachabilityParameters) {
+    /* TODO pathDiff deserves its own parameter set type.
+     * Sources are ignored, since we always originate from vrfs that have missing or removed
+     * edges. So the user-facing question shouldn't include a source parameter.
+     */
     Settings settings = getSettings();
     checkDifferentialDataPlaneQuestionDependencies();
     String tag = getDifferentialFlowTag();
@@ -3031,7 +3034,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
           ImmutableMap.of(IngressLocation.vrf(ingressNode, vrf), TrueExpr.INSTANCE);
       ReachEdgeQuerySynthesizer reachQuery =
           new ReachEdgeQuerySynthesizer(
-              ingressNode, vrf, edge, true, reachabilitySettings.getHeaderSpace());
+              ingressNode, vrf, edge, true, reachabilityParameters.getHeaderSpace());
       ReachEdgeQuerySynthesizer noReachQuery =
           new ReachEdgeQuerySynthesizer(ingressNode, vrf, edge, true, new HeaderSpace());
       noReachQuery.setNegate(true);
@@ -3061,7 +3064,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
                 .getName();
         ReachEdgeQuerySynthesizer reachQuery =
             new ReachEdgeQuerySynthesizer(
-                ingressNode, vrf, missingEdge, true, reachabilitySettings.getHeaderSpace());
+                ingressNode, vrf, missingEdge, true, reachabilityParameters.getHeaderSpace());
         List<QuerySynthesizer> queries = ImmutableList.of(reachQuery, blacklistQuery);
         Map<IngressLocation, BooleanExpr> srcIpConstraint =
             ImmutableMap.of(IngressLocation.vrf(ingressNode, vrf), TrueExpr.INSTANCE);
@@ -3485,8 +3488,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
   }
 
   @Override
-  public AnswerElement reducedReachability(ReachabilitySettings reachabilitySettings) {
-    ReachabilityParameters params = reachabilitySettings.toReachabilityParameters();
+  public AnswerElement reducedReachability(ReachabilityParameters params) {
     checkDifferentialDataPlaneQuestionDependencies();
     pushBaseEnvironment();
     ResolvedReachabilityParameters baseParams;
@@ -4202,21 +4204,19 @@ public class Batfish extends PluginConsumer implements IBatfish {
   }
 
   private AnswerElement singleReachability(
-      ReachabilitySettings reachabilitySettings,
+      ReachabilityParameters reachabilityParameters,
       ReachabilityQuerySynthesizer.Builder<?, ?> builder) {
     Settings settings = getSettings();
     String tag = getFlowTag(_testrigSettings);
 
     ResolvedReachabilityParameters parameters;
     try {
-      parameters =
-          resolveReachabilityParameters(
-              this, reachabilitySettings.toReachabilityParameters(), getSnapshot());
+      parameters = resolveReachabilityParameters(this, reachabilityParameters, getSnapshot());
     } catch (InvalidReachabilityParametersException e) {
       return e.getInvalidSettingsAnswer();
     }
 
-    Set<ForwardingAction> actions = reachabilitySettings.getActions();
+    Set<ForwardingAction> actions = reachabilityParameters.getActions();
 
     Map<String, Configuration> configurations = parameters.getConfigurations();
     DataPlane dataPlane = parameters.getDataPlane();
@@ -4232,7 +4232,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
             forbiddenTransitNodes,
             requiredTransitNodes,
             parameters.getSourceIpAssignment(),
-            reachabilitySettings.getSpecialize());
+            reachabilityParameters.getSpecialize());
 
     Map<IngressLocation, BooleanExpr> srcIpConstraints =
         dataPlaneSynthesizer.getInput().getSrcIpConstraints();
@@ -4358,8 +4358,9 @@ public class Batfish extends PluginConsumer implements IBatfish {
   }
 
   @Override
-  public AnswerElement standard(ReachabilitySettings reachabilitySettings) {
-    return singleReachability(reachabilitySettings, StandardReachabilityQuerySynthesizer.builder());
+  public AnswerElement standard(ReachabilityParameters reachabilityParameters) {
+    return singleReachability(
+        reachabilityParameters, StandardReachabilityQuerySynthesizer.builder());
   }
 
   private Synthesizer synthesizeAcls(String hostname, Configuration config, String aclName) {

--- a/projects/question/src/main/java/org/batfish/question/ReachabilityQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/ReachabilityQuestionPlugin.java
@@ -23,7 +23,6 @@ import org.batfish.datamodel.questions.IReachabilityQuestion;
 import org.batfish.datamodel.questions.InterfacesSpecifier;
 import org.batfish.datamodel.questions.NodesSpecifier;
 import org.batfish.datamodel.questions.Question;
-import org.batfish.datamodel.questions.ReachabilitySettings;
 
 @AutoService(Plugin.class)
 public class ReachabilityQuestionPlugin extends QuestionPlugin {
@@ -73,19 +72,20 @@ public class ReachabilityQuestionPlugin extends QuestionPlugin {
     }
 
     private AnswerElement multipath(ReachabilityQuestion question) {
-      return _batfish.multipath(question._reachabilitySettings.build());
+      return _batfish.multipath(question._reachabilitySettings.build().toReachabilityParameters());
     }
 
     private AnswerElement pathDiff(ReachabilityQuestion question) {
-      return _batfish.pathDiff(question._reachabilitySettings.build());
+      return _batfish.pathDiff(question._reachabilitySettings.build().toReachabilityParameters());
     }
 
     private AnswerElement reducedReachability(ReachabilityQuestion question) {
-      return _batfish.reducedReachability(question._reachabilitySettings.build());
+      return _batfish.reducedReachability(
+          question._reachabilitySettings.build().toReachabilityParameters());
     }
 
     private AnswerElement standard(ReachabilityQuestion question) {
-      return _batfish.standard(question._reachabilitySettings.build());
+      return _batfish.standard(question._reachabilitySettings.build().toReachabilityParameters());
     }
   }
 

--- a/projects/question/src/main/java/org/batfish/question/ReachabilitySettings.java
+++ b/projects/question/src/main/java/org/batfish/question/ReachabilitySettings.java
@@ -1,4 +1,4 @@
-package org.batfish.datamodel.questions;
+package org.batfish.question;
 
 import com.google.common.collect.ImmutableSortedSet;
 import java.util.Objects;
@@ -8,8 +8,8 @@ import org.batfish.datamodel.ForwardingAction;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.UniverseIpSpace;
-import org.batfish.question.ReachabilityParameters;
-import org.batfish.question.SrcNattedConstraint;
+import org.batfish.datamodel.questions.InterfacesSpecifier;
+import org.batfish.datamodel.questions.NodesSpecifier;
 import org.batfish.specifier.AllInterfacesLocationSpecifier;
 import org.batfish.specifier.ConstantIpSpaceSpecifier;
 import org.batfish.specifier.DifferenceLocationSpecifier;
@@ -19,9 +19,9 @@ import org.batfish.specifier.LocationSpecifiers;
 import org.batfish.specifier.NodeSpecifiers;
 import org.batfish.specifier.UnionLocationSpecifier;
 
-public class ReachabilitySettings {
+public final class ReachabilitySettings {
 
-  public static class Builder {
+  public static final class Builder {
 
     private SortedSet<ForwardingAction> _actions;
 
@@ -347,25 +347,20 @@ public class ReachabilitySettings {
           new ConstantIpSpaceSpecifier(AclIpSpace.difference(UniverseIpSpace.INSTANCE, notSrcIps));
     }
 
-    // remove src IPs from headerspace since they're specified via an IpSpaceSpecifier
-    IpSpace nullIpSpace = null;
-    HeaderSpace headerSpace =
-        _headerSpace.toBuilder().setNotSrcIps(nullIpSpace).setSrcIps(nullIpSpace).build();
-
     return ReachabilityParameters.builder()
-        .setActions(getActions())
+        .setActions(_actions)
         .setFinalNodesSpecifier(
             NodeSpecifiers.difference(
                 NodeSpecifiers.from(_finalNodes), NodeSpecifiers.from(_notFinalNodes)))
-        .setForbiddenTransitNodesSpecifier(NodeSpecifiers.from(getNonTransitNodes()))
-        .setHeaderSpace(headerSpace)
-        .setMaxChunkSize(getMaxChunkSize())
-        .setRequiredTransitNodesSpecifier(NodeSpecifiers.from(getTransitNodes()))
+        .setForbiddenTransitNodesSpecifier(NodeSpecifiers.from(_nonTransitNodes))
+        .setHeaderSpace(_headerSpace)
+        .setMaxChunkSize(_maxChunkSize)
+        .setRequiredTransitNodesSpecifier(NodeSpecifiers.from(_transitNodes))
         .setSourceIpSpaceSpecifier(sourceIpSpace)
         .setSourceSpecifier(sourceLocations)
-        .setSrcNatted(SrcNattedConstraint.fromBoolean(getSrcNatted()))
-        .setSpecialize(getSpecialize())
-        .setUseCompression(getUseCompression())
+        .setSrcNatted(SrcNattedConstraint.fromBoolean(_srcNatted))
+        .setSpecialize(_specialize)
+        .setUseCompression(_useCompression)
         .build();
   }
 }


### PR DESCRIPTION
* It has been replaced by ReachabilityParameters in IBatfish.
* No longer unset srcIp in the HeaderSpace, because pathDiff doesn't use
  sources (it originates from VRFs with changed or removed edges). In
  the future, we should add a new question for pathDiff that only
  allows the parameters that are used by it.