### PR TITLE
fix juniper wildcard handling

### DIFF
--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/ConfigurationMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/ConfigurationMatchersImpl.java
@@ -1,6 +1,7 @@
 package org.batfish.datamodel.matchers;
 
 import java.util.Map;
+import java.util.NavigableMap;
 import javax.annotation.Nonnull;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.IkeProposal;
@@ -150,6 +151,19 @@ final class ConfigurationMatchersImpl {
     @Override
     protected RouteFilterList featureValueOf(Configuration actual) {
       return actual.getRouteFilterLists().get(_name);
+    }
+  }
+
+  static final class HasRouteFilterLists
+      extends FeatureMatcher<Configuration, NavigableMap<String, RouteFilterList>> {
+    HasRouteFilterLists(
+        @Nonnull Matcher<? super NavigableMap<String, RouteFilterList>> subMatcher) {
+      super(subMatcher, "A Configuration with RouteFilterLists:", "routeFilterLists");
+    }
+
+    @Override
+    protected NavigableMap<String, RouteFilterList> featureValueOf(Configuration actual) {
+      return actual.getRouteFilterLists();
     }
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/ConfigurationMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/ConfigurationMatchersImpl.java
@@ -158,7 +158,7 @@ final class ConfigurationMatchersImpl {
       extends FeatureMatcher<Configuration, NavigableMap<String, RouteFilterList>> {
     HasRouteFilterLists(
         @Nonnull Matcher<? super NavigableMap<String, RouteFilterList>> subMatcher) {
-      super(subMatcher, "A Configuration with RouteFilterLists:", "routeFilterLists");
+      super(subMatcher, "A Configuration with routeFilterLists:", "routeFilterLists");
     }
 
     @Override

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/DataModelMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/DataModelMatchers.java
@@ -3,6 +3,7 @@ package org.batfish.datamodel.matchers;
 import static org.hamcrest.Matchers.equalTo;
 
 import java.util.List;
+import java.util.NavigableMap;
 import java.util.SortedSet;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -36,6 +37,7 @@ import org.batfish.datamodel.matchers.AclTraceMatchers.HasEvents;
 import org.batfish.datamodel.matchers.BgpNeighborMatchersImpl.IsDynamic;
 import org.batfish.datamodel.matchers.ConfigurationMatchersImpl.HasRoute6FilterList;
 import org.batfish.datamodel.matchers.ConfigurationMatchersImpl.HasRouteFilterList;
+import org.batfish.datamodel.matchers.ConfigurationMatchersImpl.HasRouteFilterLists;
 import org.batfish.datamodel.matchers.ConfigurationMatchersImpl.HasZone;
 import org.batfish.datamodel.matchers.ConvertConfigurationAnswerElementMatchers.HasNumReferrers;
 import org.batfish.datamodel.matchers.ConvertConfigurationAnswerElementMatchers.HasRedFlagWarning;
@@ -126,6 +128,15 @@ public final class DataModelMatchers {
   public static Matcher<Configuration> hasRouteFilterList(
       @Nonnull String name, @Nonnull Matcher<? super RouteFilterList> subMatcher) {
     return new HasRouteFilterList(name, subMatcher);
+  }
+
+  /**
+   * Provides a matcher that matches if the provided {@code subMatcher} matches the configuration's
+   * routeFilterLists.
+   */
+  public static Matcher<Configuration> hasRouteFilterLists(
+      @Nonnull Matcher<? super NavigableMap<String, RouteFilterList>> subMatcher) {
+    return new HasRouteFilterLists(subMatcher);
   }
 
   /**

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchers.java
@@ -8,6 +8,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.SortedSet;
 import javax.annotation.Nonnull;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.OspfArea;
 import org.batfish.datamodel.SourceNat;
@@ -16,8 +18,10 @@ import org.batfish.datamodel.SwitchportMode;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasAccessVlan;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasAdditionalArpIps;
+import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasAllAddresses;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasAllowedVlans;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasDeclaredNames;
+import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasDescription;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasMtu;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasOspfArea;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasOspfCost;
@@ -44,6 +48,15 @@ public final class InterfaceMatchers {
    */
   public static HasAccessVlan hasAccessVlan(Matcher<? super Integer> subMatcher) {
     return new HasAccessVlan(subMatcher);
+  }
+
+  /**
+   * Provides a matcher that matches if the provided {@code subMatcher} matches the interface's
+   * allAddresses.
+   */
+  public static Matcher<Interface> hasAllAddresses(
+      Matcher<? super Set<InterfaceAddress>> subMatcher) {
+    return new HasAllAddresses(subMatcher);
   }
 
   /**
@@ -95,6 +108,14 @@ public final class InterfaceMatchers {
   public static HasDeclaredNames hasDeclaredNames(@Nonnull String... expectedDeclaredNames) {
     return new HasDeclaredNames(
         containsInAnyOrder(ImmutableSet.copyOf(expectedDeclaredNames).toArray()));
+  }
+
+  /**
+   * Provides a matcher that matches if the {@link Interface}'s description is {@code
+   * expectedDescription}.
+   */
+  public static Matcher<Interface> hasDescription(String expectedDescription) {
+    return new HasDescription(equalTo(expectedDescription));
   }
 
   /** Provides a matcher that matches if the provided value matches the interface's MTU. */

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchersImpl.java
@@ -5,6 +5,7 @@ import java.util.Set;
 import java.util.SortedSet;
 import javax.annotation.Nonnull;
 import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.OspfArea;
@@ -39,6 +40,17 @@ final class InterfaceMatchersImpl {
     }
   }
 
+  static final class HasAllAddresses extends FeatureMatcher<Interface, Set<InterfaceAddress>> {
+    HasAllAddresses(@Nonnull Matcher<? super Set<InterfaceAddress>> subMatcher) {
+      super(subMatcher, "An Interface with allAddresses:", "allAddresses");
+    }
+
+    @Override
+    protected Set<InterfaceAddress> featureValueOf(Interface actual) {
+      return actual.getAllAddresses();
+    }
+  }
+
   static final class HasAllowedVlans extends FeatureMatcher<Interface, List<SubRange>> {
     HasAllowedVlans(@Nonnull Matcher<? super List<SubRange>> subMatcher) {
       super(subMatcher, "an Interface with allowedVlans:", "allowedVlans");
@@ -69,6 +81,17 @@ final class InterfaceMatchersImpl {
     @Override
     protected Set<String> featureValueOf(Interface actual) {
       return actual.getDeclaredNames();
+    }
+  }
+
+  static final class HasDescription extends FeatureMatcher<Interface, String> {
+    HasDescription(@Nonnull Matcher<? super String> subMatcher) {
+      super(subMatcher, "An Interface with description:", "description");
+    }
+
+    @Override
+    protected String featureValueOf(Interface actual) {
+      return actual.getDescription();
     }
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/VrfMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/VrfMatchers.java
@@ -4,7 +4,9 @@ import java.util.SortedSet;
 import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.OspfProcess;
 import org.batfish.datamodel.StaticRoute;
+import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.matchers.VrfMatchersImpl.HasBgpProcess;
+import org.batfish.datamodel.matchers.VrfMatchersImpl.HasInterfaces;
 import org.batfish.datamodel.matchers.VrfMatchersImpl.HasOspfProcess;
 import org.batfish.datamodel.matchers.VrfMatchersImpl.HasStaticRoutes;
 import org.hamcrest.Matcher;
@@ -34,5 +36,13 @@ public class VrfMatchers {
   public static HasStaticRoutes hasStaticRoutes(
       Matcher<? super SortedSet<StaticRoute>> subMatcher) {
     return new HasStaticRoutes(subMatcher);
+  }
+
+  /**
+   * Provides a matcher that matches if the provided {@code subMatcher} matches the VRF's
+   * interfaces.
+   */
+  public static Matcher<Vrf> hasInterfaces(Matcher<? super SortedSet<String>> subMatcher) {
+    return new HasInterfaces(subMatcher);
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/VrfMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/VrfMatchersImpl.java
@@ -22,6 +22,17 @@ final class VrfMatchersImpl {
     }
   }
 
+  static final class HasInterfaces extends FeatureMatcher<Vrf, SortedSet<String>> {
+    HasInterfaces(@Nonnull Matcher<? super SortedSet<String>> subMatcher) {
+      super(subMatcher, "A VRF with interfaces:", "interfaces");
+    }
+
+    @Override
+    protected SortedSet<String> featureValueOf(Vrf actual) {
+      return actual.getInterfaceNames();
+    }
+  }
+
   static final class HasOspfProcess extends FeatureMatcher<Vrf, OspfProcess> {
     HasOspfProcess(@Nonnull Matcher<? super OspfProcess> subMatcher) {
       super(subMatcher, "A VRF with ospfProcess:", "ospfProcess");

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -5979,7 +5979,12 @@ M_Members_WS
 
 mode M_PrefixListName;
 
-M_PrefixLsitName_VARIABLE
+M_PrefixListName_WILDCARD
+:
+   '<' ~'>'* '>' -> type ( WILDCARD ) , popMode
+;
+
+M_PrefixListName_VARIABLE
 :
    ~[ \t\n\r&|()"]+ -> type ( VARIABLE ) , popMode
 ;

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -8,6 +8,7 @@ options {
 boolean enableIPV6_ADDRESS = true;
 boolean enableIP_ADDRESS = true;
 boolean enableDEC = true;
+boolean _markWildcards = false;
 
 public boolean isPrefix() {
    char nextChar = (char)this.getInputStream().LA(1);
@@ -23,7 +24,16 @@ public String printStateVariables() {
    sb.append("enableIPV6_ADDRESS: " + enableIPV6_ADDRESS + "\n");
    sb.append("enableIP_ADDRESS: " + enableIP_ADDRESS + "\n");
    sb.append("enableDEC: " + enableDEC + "\n");
+   sb.append("markWildcards: " + _markWildcards + "\n");
    return sb.toString();
+}
+
+public void setMarkWildcards(boolean markWildcards) {
+   _markWildcards = markWildcards;
+}
+
+private void setWildcard() {
+  setType(_markWildcards? WILDCARD_ARTIFACT : WILDCARD);
 }
 
 }
@@ -36,7 +46,8 @@ tokens {
    PIPE,
    RST,
    SYN,
-   VERSION_STRING
+   VERSION_STRING,
+   WILDCARD_ARTIFACT
 }
 
 // Juniper Keywords
@@ -5439,7 +5450,7 @@ UNDERSCORE
 
 WILDCARD
 :
-   '<' ~'>'* '>'
+   '<' ~'>'* '>' {setWildcard();}
 ;
 
 WS
@@ -5772,7 +5783,7 @@ M_Interface_VARIABLE
 
 M_Interface_WILDCARD
 :
-   '<' ~'>'* '>' -> type ( WILDCARD ) , popMode
+   '<' ~'>'* '>' {setType(_markWildcards?WILDCARD_ARTIFACT:WILDCARD);} -> popMode
 ;
 
 M_Interface_IP_ADDRESS
@@ -5800,7 +5811,7 @@ M_InterfaceQuote_VARIABLE
 
 M_InterfaceQuote_WILDCARD
 :
-   '<' ~'>'* '>' -> type ( WILDCARD )
+   '<' ~'>'* '>' {setType(_markWildcards?WILDCARD_ARTIFACT:WILDCARD);}
 ;
 
 mode M_ISO;
@@ -5981,7 +5992,7 @@ mode M_PrefixListName;
 
 M_PrefixListName_WILDCARD
 :
-   '<' ~'>'* '>' -> type ( WILDCARD ) , popMode
+   '<' ~'>'* '>' {setType(_markWildcards?WILDCARD_ARTIFACT:WILDCARD);} -> popMode
 ;
 
 M_PrefixListName_VARIABLE
@@ -6228,7 +6239,7 @@ M_VarOrWildcard_VARIABLE
 
 M_VarOrWildcard_WILDCARD
 :
-   '<' ~'>'* '>' -> type ( WILDCARD ) , popMode
+   '<' ~'>'* '>' {setType(_markWildcards?WILDCARD_ARTIFACT:WILDCARD);}-> popMode
 ;
 
 M_VarOrWildcard_WS

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperParser.g4
@@ -80,11 +80,7 @@ s_groups_tail
 
 s_logical_systems
 :
-   LOGICAL_SYSTEMS
-   (
-      name = variable
-      | WILDCARD
-   ) s_logical_systems_tail
+   LOGICAL_SYSTEMS name = variable s_logical_systems_tail
 ;
 
 s_logical_systems_tail

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_bgp.g4
@@ -45,9 +45,9 @@ b_allow
 :
    ALLOW
    (
-       IP_PREFIX
-       | IPV6_PREFIX
-       | ALL
+      IP_PREFIX
+      | IPV6_PREFIX
+      | ALL
    )
 ;
 
@@ -135,11 +135,7 @@ b_family
 
 b_group
 :
-   GROUP
-   (
-      name = variable
-      | WILDCARD
-   )
+   GROUP name = variable
    (
       b_common
       | b_neighbor

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_bgp.g4
@@ -183,7 +183,7 @@ b_neighbor
    (
       IP_ADDRESS
       | IPV6_ADDRESS
-      | WILDCARD
+      | wildcard
    ) b_common
 ;
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_common.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_common.g4
@@ -558,7 +558,7 @@ subrange
 variable
 :
    text = ~( APPLY_GROUPS | APPLY_GROUPS_EXCEPT | APPLY_PATH | NEWLINE |
-   OPEN_PAREN | OPEN_BRACKET | OPEN_BRACE | WILDCARD )
+   OPEN_PAREN | OPEN_BRACKET | OPEN_BRACE )
 ;
 
 variable_permissive

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_common.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_common.g4
@@ -571,6 +571,11 @@ variable_policy
    text = ~( DESCRIPTION | MATCH | THEN )+
 ;
 
+wildcard
+:
+   WILDCARD | WILDCARD_ARTIFACT
+;
+
 wildcard_address
 :
    ip_address = IP_ADDRESS FORWARD_SLASH wildcard_mask = IP_ADDRESS

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_interfaces.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_interfaces.g4
@@ -461,7 +461,6 @@ ifia_vrrp_group
    VRRP_GROUP
    (
       number = DEC
-      | WILDCARD
       | name = variable
    )
    (

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_interfaces.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_interfaces.g4
@@ -228,7 +228,7 @@ i_unit
 :
    UNIT
    (
-      WILDCARD
+      wildcard
       | num = DEC
    )
    (
@@ -387,7 +387,7 @@ ifi_address
    (
       IP_ADDRESS
       | IP_PREFIX
-      | WILDCARD
+      | wildcard
    )
    (
       ifia_arp
@@ -574,7 +574,7 @@ int_interface_range
 int_named
 :
    (
-      WILDCARD
+      wildcard
       | interface_id
    )
    (

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_isis.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_isis.g4
@@ -19,7 +19,7 @@ is_interface
    INTERFACE
    (
       id = interface_id
-      | WILDCARD
+      | wildcard
    )
    (
       apply
@@ -35,7 +35,7 @@ is_level
    LEVEL
    (
       DEC
-      | WILDCARD
+      | wildcard
    )
    (
       isl_disable

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_ospf.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_ospf.g4
@@ -11,7 +11,7 @@ o_area
    AREA
    (
       area = IP_ADDRESS
-      | WILDCARD
+      | wildcard
    )
    (
       apply
@@ -117,7 +117,7 @@ oa_interface
       ALL
       | id = interface_id
       | ip = IP_ADDRESS
-      | WILDCARD
+      | wildcard
    )
    (
       apply

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_ospf.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_ospf.g4
@@ -102,7 +102,11 @@ oa_area_range
    )
    (
       apply
-      | (oaa_override_metric | oaa_restrict)+
+      |
+      (
+         oaa_override_metric
+         | oaa_restrict
+      )+
    )
 ;
 
@@ -133,11 +137,7 @@ oa_interface
 
 oa_label_switched_path
 :
-   LABEL_SWITCHED_PATH
-   (
-      name = variable
-      | WILDCARD
-   )
+   LABEL_SWITCHED_PATH name = variable
    (
       apply
       | oal_metric

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_policy_options.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_policy_options.g4
@@ -68,11 +68,7 @@ po_condition
 
 po_policy_statement
 :
-   POLICY_STATEMENT
-   (
-      WILDCARD
-      | name = variable
-   )
+   POLICY_STATEMENT name = variable
    (
       pops_term
       | pops_common
@@ -170,11 +166,7 @@ pops_from
 
 pops_term
 :
-   TERM
-   (
-      WILDCARD
-      | name = variable
-   ) pops_common
+   TERM name = variable pops_common
 ;
 
 pops_then
@@ -605,7 +597,12 @@ popst_null
 
 popst_origin
 :
-   ORIGIN (EGP | IGP | INCOMPLETE)
+   ORIGIN
+   (
+      EGP
+      | IGP
+      | INCOMPLETE
+   )
 ;
 
 popst_preference

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_routing_instances.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_routing_instances.g4
@@ -226,11 +226,7 @@ ro_null
 
 ro_rib
 :
-   RIB
-   (
-      name = VARIABLE
-      | WILDCARD
-   )
+   RIB name = VARIABLE
    (
       apply
       | ro_aggregate

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_routing_instances.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_routing_instances.g4
@@ -39,10 +39,7 @@ ri_interface
 
 ri_named_routing_instance
 :
-   (
-      WILDCARD
-      | name = variable
-   )
+   name = variable
    (
       ri_common
       | ri_instance_type

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -162,6 +162,7 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Fod_server_groupContext
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Fodg_interfaceContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Hib_protocolContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Hib_system_serviceContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.I_descriptionContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.I_disableContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.I_enableContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.I_mtuContext;
@@ -3203,6 +3204,12 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
       String interfaceName = iface.getName();
       _currentDhcpRelayGroup.getInterfaces().add(interfaceName);
     }
+  }
+
+  @Override
+  public void exitI_description(I_descriptionContext ctx) {
+    String text = unquote(ctx.description().text.getText());
+    _currentInterface.setDescription(text);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/FlatJuniperCombinedParser.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/FlatJuniperCombinedParser.java
@@ -28,4 +28,8 @@ public class FlatJuniperCombinedParser
   public Flat_juniper_configurationContext parse() {
     return _parser.flat_juniper_configuration();
   }
+
+  public void setMarkWildcards(boolean markWildcards) {
+    _lexer.setMarkWildcards(markWildcards);
+  }
 }

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/Hierarchy.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/Hierarchy.java
@@ -279,8 +279,10 @@ public class Hierarchy {
         Settings settings = parserSettings();
         FlatJuniperCombinedParser parser =
             new FlatJuniperCombinedParser(newStatementText, settings);
+        parser.setMarkWildcards(true);
         Flat_juniper_configurationContext newConfiguration =
             parser.getParser().flat_juniper_configuration();
+        parser.setMarkWildcards(false);
         // StatementContext newStatement = parser.getParser().statement();
         StatementContext newStatement = newConfiguration.set_line(0).set_line_tail().statement();
         newStatement.parent = setLineTail;

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/WildcardApplicator.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/WildcardApplicator.java
@@ -6,8 +6,6 @@ import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Flat_juniper_configurationContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Interface_idContext;
-import org.batfish.grammar.flatjuniper.FlatJuniperParser.Poplt_apply_pathContext;
-import org.batfish.grammar.flatjuniper.FlatJuniperParser.S_groupsContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Set_lineContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Set_line_tailContext;
 import org.batfish.grammar.flatjuniper.Hierarchy.HierarchyTree.HierarchyPath;
@@ -25,8 +23,6 @@ public class WildcardApplicator extends FlatJuniperParserBaseListener {
   private List<ParseTree> _newConfigurationLines;
 
   private boolean _reenablePathRecording;
-
-  private boolean _wildcardsEnabled;
 
   public WildcardApplicator(Hierarchy hierarchy) {
     _hierarchy = hierarchy;
@@ -50,16 +46,6 @@ public class WildcardApplicator extends FlatJuniperParserBaseListener {
   }
 
   @Override
-  public void enterPoplt_apply_path(Poplt_apply_pathContext ctx) {
-    _wildcardsEnabled = true;
-  }
-
-  @Override
-  public void enterS_groups(S_groupsContext ctx) {
-    _wildcardsEnabled = true;
-  }
-
-  @Override
   public void enterSet_line_tail(Set_line_tailContext ctx) {
     _enablePathRecording = true;
     _currentPath = new HierarchyPath();
@@ -76,16 +62,6 @@ public class WildcardApplicator extends FlatJuniperParserBaseListener {
       _enablePathRecording = true;
       _reenablePathRecording = false;
     }
-  }
-
-  @Override
-  public void exitPoplt_apply_path(Poplt_apply_pathContext ctx) {
-    _wildcardsEnabled = false;
-  }
-
-  @Override
-  public void exitS_groups(S_groupsContext ctx) {
-    _wildcardsEnabled = false;
   }
 
   @Override
@@ -108,7 +84,7 @@ public class WildcardApplicator extends FlatJuniperParserBaseListener {
   public void visitTerminal(TerminalNode node) {
     if (_enablePathRecording) {
       String text = node.getText();
-      if (_wildcardsEnabled && node.getSymbol().getType() == FlatJuniperLexer.WILDCARD) {
+      if (node.getSymbol().getType() == FlatJuniperLexer.WILDCARD_ARTIFACT) {
         _currentPath.addWildcardNode(text);
       } else {
         _currentPath.addNode(text);

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/WildcardApplicator.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/WildcardApplicator.java
@@ -6,6 +6,8 @@ import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Flat_juniper_configurationContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Interface_idContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Poplt_apply_pathContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.S_groupsContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Set_lineContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Set_line_tailContext;
 import org.batfish.grammar.flatjuniper.Hierarchy.HierarchyTree.HierarchyPath;
@@ -23,6 +25,8 @@ public class WildcardApplicator extends FlatJuniperParserBaseListener {
   private List<ParseTree> _newConfigurationLines;
 
   private boolean _reenablePathRecording;
+
+  private boolean _wildcardsEnabled;
 
   public WildcardApplicator(Hierarchy hierarchy) {
     _hierarchy = hierarchy;
@@ -46,6 +50,16 @@ public class WildcardApplicator extends FlatJuniperParserBaseListener {
   }
 
   @Override
+  public void enterPoplt_apply_path(Poplt_apply_pathContext ctx) {
+    _wildcardsEnabled = true;
+  }
+
+  @Override
+  public void enterS_groups(S_groupsContext ctx) {
+    _wildcardsEnabled = true;
+  }
+
+  @Override
   public void enterSet_line_tail(Set_line_tailContext ctx) {
     _enablePathRecording = true;
     _currentPath = new HierarchyPath();
@@ -62,6 +76,16 @@ public class WildcardApplicator extends FlatJuniperParserBaseListener {
       _enablePathRecording = true;
       _reenablePathRecording = false;
     }
+  }
+
+  @Override
+  public void exitPoplt_apply_path(Poplt_apply_pathContext ctx) {
+    _wildcardsEnabled = false;
+  }
+
+  @Override
+  public void exitS_groups(S_groupsContext ctx) {
+    _wildcardsEnabled = false;
   }
 
   @Override
@@ -84,7 +108,7 @@ public class WildcardApplicator extends FlatJuniperParserBaseListener {
   public void visitTerminal(TerminalNode node) {
     if (_enablePathRecording) {
       String text = node.getText();
-      if (node.getSymbol().getType() == FlatJuniperLexer.WILDCARD) {
+      if (_wildcardsEnabled && node.getSymbol().getType() == FlatJuniperLexer.WILDCARD) {
         _currentPath.addWildcardNode(text);
       } else {
         _currentPath.addNode(text);

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/WildcardPruner.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/WildcardPruner.java
@@ -5,8 +5,6 @@ import java.util.List;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Flat_juniper_configurationContext;
-import org.batfish.grammar.flatjuniper.FlatJuniperParser.Poplt_apply_pathContext;
-import org.batfish.grammar.flatjuniper.FlatJuniperParser.S_groupsContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Set_lineContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Set_line_tailContext;
 import org.batfish.grammar.flatjuniper.Hierarchy.HierarchyTree.HierarchyPath;
@@ -21,23 +19,11 @@ public class WildcardPruner extends FlatJuniperParserBaseListener {
 
   private List<ParseTree> _newConfigurationLines;
 
-  private boolean _wildcardsEnabled;
-
   @Override
   public void enterFlat_juniper_configuration(Flat_juniper_configurationContext ctx) {
     _configurationContext = ctx;
     _newConfigurationLines = new ArrayList<>();
     _newConfigurationLines.addAll(ctx.children);
-  }
-
-  @Override
-  public void enterPoplt_apply_path(Poplt_apply_pathContext ctx) {
-    _wildcardsEnabled = true;
-  }
-
-  @Override
-  public void enterS_groups(S_groupsContext ctx) {
-    _wildcardsEnabled = true;
   }
 
   @Override
@@ -49,16 +35,6 @@ public class WildcardPruner extends FlatJuniperParserBaseListener {
   @Override
   public void exitFlat_juniper_configuration(Flat_juniper_configurationContext ctx) {
     _configurationContext.children = _newConfigurationLines;
-  }
-
-  @Override
-  public void exitPoplt_apply_path(Poplt_apply_pathContext ctx) {
-    _wildcardsEnabled = false;
-  }
-
-  @Override
-  public void exitS_groups(S_groupsContext ctx) {
-    _wildcardsEnabled = false;
   }
 
   @Override
@@ -78,7 +54,7 @@ public class WildcardPruner extends FlatJuniperParserBaseListener {
   public void visitTerminal(TerminalNode node) {
     if (_enablePathRecording) {
       String text = node.getText();
-      if (_wildcardsEnabled && node.getSymbol().getType() == FlatJuniperLexer.WILDCARD) {
+      if (node.getSymbol().getType() == FlatJuniperLexer.WILDCARD_ARTIFACT) {
         _currentPath.addWildcardNode(text);
       } else {
         _currentPath.addNode(text);

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/WildcardPruner.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/WildcardPruner.java
@@ -5,6 +5,8 @@ import java.util.List;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Flat_juniper_configurationContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Poplt_apply_pathContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.S_groupsContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Set_lineContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Set_line_tailContext;
 import org.batfish.grammar.flatjuniper.Hierarchy.HierarchyTree.HierarchyPath;
@@ -19,11 +21,23 @@ public class WildcardPruner extends FlatJuniperParserBaseListener {
 
   private List<ParseTree> _newConfigurationLines;
 
+  private boolean _wildcardsEnabled;
+
   @Override
   public void enterFlat_juniper_configuration(Flat_juniper_configurationContext ctx) {
     _configurationContext = ctx;
     _newConfigurationLines = new ArrayList<>();
     _newConfigurationLines.addAll(ctx.children);
+  }
+
+  @Override
+  public void enterPoplt_apply_path(Poplt_apply_pathContext ctx) {
+    _wildcardsEnabled = true;
+  }
+
+  @Override
+  public void enterS_groups(S_groupsContext ctx) {
+    _wildcardsEnabled = true;
   }
 
   @Override
@@ -35,6 +49,16 @@ public class WildcardPruner extends FlatJuniperParserBaseListener {
   @Override
   public void exitFlat_juniper_configuration(Flat_juniper_configurationContext ctx) {
     _configurationContext.children = _newConfigurationLines;
+  }
+
+  @Override
+  public void exitPoplt_apply_path(Poplt_apply_pathContext ctx) {
+    _wildcardsEnabled = false;
+  }
+
+  @Override
+  public void exitS_groups(S_groupsContext ctx) {
+    _wildcardsEnabled = false;
   }
 
   @Override
@@ -54,7 +78,7 @@ public class WildcardPruner extends FlatJuniperParserBaseListener {
   public void visitTerminal(TerminalNode node) {
     if (_enablePathRecording) {
       String text = node.getText();
-      if (node.getSymbol().getType() == FlatJuniperLexer.WILDCARD) {
+      if (_wildcardsEnabled && node.getSymbol().getType() == FlatJuniperLexer.WILDCARD) {
         _currentPath.addWildcardNode(text);
       } else {
         _currentPath.addNode(text);

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
@@ -50,6 +50,8 @@ public class Interface extends ComparableStructure<String> {
 
   private final int _definitionLine;
 
+  private String _description;
+
   private String _incomingFilter;
 
   private int _incomingFilterLine;
@@ -154,6 +156,10 @@ public class Interface extends ComparableStructure<String> {
     return _definitionLine;
   }
 
+  public String getDescription() {
+    return _description;
+  }
+
   public String getIncomingFilter() {
     return _incomingFilter;
   }
@@ -244,6 +250,9 @@ public class Interface extends ComparableStructure<String> {
     }
     _inherited = true;
     _parent.inheritUnsetFields();
+    if (_description == null) {
+      _description = _parent._description;
+    }
     if (_mtu == null) {
       _mtu = _parent._mtu;
     }
@@ -269,6 +278,10 @@ public class Interface extends ComparableStructure<String> {
 
   public void setBandwidth(Double bandwidth) {
     _bandwidth = bandwidth;
+  }
+
+  public void setDescription(String description) {
+    _description = description;
   }
 
   public void setIncomingFilter(String accessListName) {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -1188,6 +1188,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
     String name = iface.getName();
     org.batfish.datamodel.Interface newIface = new org.batfish.datamodel.Interface(name, _c);
     newIface.setDeclaredNames(ImmutableSortedSet.of(name));
+    newIface.setDescription(iface.getDescription());
     Integer mtu = iface.getMtu();
     if (mtu != null) {
       newIface.setMtu(mtu);

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -8,6 +8,7 @@ import static org.batfish.datamodel.matchers.BgpProcessMatchers.hasNeighbor;
 import static org.batfish.datamodel.matchers.BgpProcessMatchers.hasNeighbors;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasDefaultVrf;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasInterface;
+import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasInterfaces;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasIpAccessList;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasVrf;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasVrfs;
@@ -21,6 +22,7 @@ import static org.batfish.datamodel.matchers.InterfaceMatchers.hasAccessVlan;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasAdditionalArpIps;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasAllAddresses;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasAllowedVlans;
+import static org.batfish.datamodel.matchers.InterfaceMatchers.hasDescription;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasMtu;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasOspfCost;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasSwitchPortMode;
@@ -35,6 +37,7 @@ import static org.batfish.datamodel.matchers.OspfAreaSummaryMatchers.hasMetric;
 import static org.batfish.datamodel.matchers.OspfAreaSummaryMatchers.isAdvertised;
 import static org.batfish.datamodel.matchers.OspfProcessMatchers.hasArea;
 import static org.batfish.datamodel.matchers.OspfProcessMatchers.hasRouterId;
+import static org.batfish.datamodel.matchers.RouteFilterListMatchers.permits;
 import static org.batfish.datamodel.matchers.SetAdministrativeCostMatchers.hasAdmin;
 import static org.batfish.datamodel.matchers.SetAdministrativeCostMatchers.isSetAdministrativeCostThat;
 import static org.batfish.datamodel.matchers.VrfMatchers.hasBgpProcess;
@@ -102,8 +105,6 @@ import org.batfish.datamodel.SwitchportMode;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
 import org.batfish.datamodel.answers.InitInfoAnswerElement;
-import org.batfish.datamodel.matchers.ConfigurationMatchers;
-import org.batfish.datamodel.matchers.InterfaceMatchers;
 import org.batfish.datamodel.matchers.IpAccessListMatchers;
 import org.batfish.datamodel.matchers.OspfAreaMatchers;
 import org.batfish.datamodel.matchers.RouteFilterListMatchers;
@@ -1328,27 +1329,19 @@ public class FlatJuniperGrammarTest {
     Configuration c = parseConfig(hostname);
 
     /* apply-groups using group containing interface wildcard should function as expected. */
-    assertThat(
-        c,
-        ConfigurationMatchers.hasInterface(
-            loopback, hasAllAddresses(contains(new InterfaceAddress(prefix1)))));
+    assertThat(c, hasInterface(loopback, hasAllAddresses(contains(new InterfaceAddress(prefix1)))));
 
     /* The wildcard copied out of groups should disappear and not be treated as an actual interface */
-    assertThat(c, ConfigurationMatchers.hasInterfaces(not(hasKey("*.*"))));
+    assertThat(c, hasInterfaces(not(hasKey("*.*"))));
 
     /* The wildcard-looking interface description should not be pruned since its parse-tree node was not created via preprocessor. */
-    assertThat(
-        c,
-        ConfigurationMatchers.hasInterface(
-            loopback, InterfaceMatchers.hasDescription("<SCRUBBED>")));
+    assertThat(c, hasInterface(loopback, hasDescription("<SCRUBBED>")));
 
     /* apply-path should work with wildcard. Its line should not be pruned since its parse-tree node was not created via preprocessor. */
-    assertThat(
-        c, hasRouteFilterList(prefixList1, RouteFilterListMatchers.permits(Prefix.parse(prefix1))));
+    assertThat(c, hasRouteFilterList(prefixList1, permits(Prefix.parse(prefix1))));
 
     /* prefix-list p2 should get content from g2, but no prefix-list named "<*>" should be created */
-    assertThat(
-        c, hasRouteFilterList(prefixList2, RouteFilterListMatchers.permits(Prefix.parse(prefix2))));
+    assertThat(c, hasRouteFilterList(prefixList2, permits(Prefix.parse(prefix2))));
     assertThat(c, hasRouteFilterLists(not(hasKey("<*>"))));
 
     /* The wildcard-looking BGP group name should not be pruned since its parse-tree node was not created via preprocessor. */

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -70,7 +70,6 @@ import java.util.Map;
 import java.util.SortedMap;
 import java.util.SortedSet;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
-import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.common.util.CommonUtil;
 import org.batfish.config.Settings;
 import org.batfish.datamodel.AclIpSpace;
@@ -1326,12 +1325,7 @@ public class FlatJuniperGrammarTest {
     String prefixList2 = "p2";
     Prefix neighborPrefix = Prefix.parse("2.2.2.2/32");
 
-    Batfish b = getBatfishForConfigurationNames(hostname);
-    b.getSettings().setPrintParseTree(true);
-    Configuration c = b.loadConfigurations().get(hostname);
-
-    System.out.println(
-        BatfishObjectMapper.verboseWriter().writeValueAsString(b.initInfo(false, true)));
+    Configuration c = parseConfig(hostname);
 
     /* apply-groups using group containing interface wildcard should function as expected. */
     assertThat(

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-wildcards
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-wildcards
@@ -1,0 +1,12 @@
+#
+set system host-name juniper-wildcards
+#
+set groups g1 interfaces <*> unit <*> family inet address 1.1.1.1/32
+set groups g2 policy-options prefix-list <*> 3.3.3.3/32
+set interfaces lo0 unit 0 apply-groups g1
+set interfaces lo0 unit 0 description <SCRUBBED>
+set policy-options prefix-list p1 apply-path "interfaces <*> unit <*> family inet address <*>"
+set policy-options prefix-list p2 apply-groups g2
+set routing-options autonomous-system 1
+set protocols bgp group <SCRUBBED> neighbor 2.2.2.2 peer-as 2
+#


### PR DESCRIPTION
Fix improper pruning of strings that look like wildcards but did not get generated via `apply-groups`.

Implementation:
- Create new virtual token called `WILDCARD_ARTIFACT` that is used instead of `WILDCARD` when generating lines.
- Prune only lines with `WILDCARD_ARTIFACT` instead of `WILDCARD` as before
- Update parser rules to allow `WILDCARD` or `WILDCARD_ARTIFACT` via new rule `wildcard` so parsing during group line generation phase still works

