### PR TITLE
Update Palo Alto Networks config format detection

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ConfigurationFormat.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ConfigurationFormat.java
@@ -16,6 +16,7 @@ public enum ConfigurationFormat {
   EMPTY("empty"),
   F5("f5"),
   FLAT_JUNIPER("juniper"),
+  FLAT_PALO_ALTO("paloalto"),
   FLAT_VYOS("vyos"),
   FORCE10("force10"),
   FOUNDRY("foundry"),

--- a/projects/batfish/src/main/java/org/batfish/grammar/VendorConfigurationFormatDetector.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/VendorConfigurationFormatDetector.java
@@ -9,6 +9,9 @@ public final class VendorConfigurationFormatDetector {
   public static final String BATFISH_FLATTENED_JUNIPER_HEADER =
       "####BATFISH FLATTENED JUNIPER CONFIG####\n";
 
+  public static final String BATFISH_FLATTENED_PALO_ALTO_HEADER =
+      "####BATFISH FLATTENED PALO ALTO CONFIG####\n";
+
   public static final String BATFISH_FLATTENED_VYOS_HEADER =
       "####BATFISH FLATTENED VYOS CONFIG####\n";
 
@@ -65,6 +68,9 @@ public final class VendorConfigurationFormatDetector {
   private static final Pattern SET_PATTERN = Pattern.compile("(?m)^set ");
 
   // checkPaloAlto patterns
+  private static final Pattern FLAT_PALO_ALTO_PATTERN =
+      Pattern.compile(Pattern.quote(BATFISH_FLATTENED_PALO_ALTO_HEADER));
+  private static final Pattern PALO_ALTO_DEVICECONFIG_PATTERN = Pattern.compile("(?m)deviceconfig");
   private static final Pattern PALO_ALTO_PANORAMA_PATTERN =
       Pattern.compile("(?m)(send-to-panorama|panorama-server)");
 
@@ -238,8 +244,15 @@ public final class VendorConfigurationFormatDetector {
 
   @Nullable
   private ConfigurationFormat checkPaloAlto() {
-    if (fileTextMatches(PALO_ALTO_PANORAMA_PATTERN)) {
-      return ConfigurationFormat.PALO_ALTO;
+    if (fileTextMatches(FLAT_PALO_ALTO_PATTERN)) {
+      return ConfigurationFormat.FLAT_PALO_ALTO;
+    } else if (fileTextMatches(PALO_ALTO_DEVICECONFIG_PATTERN)
+        || fileTextMatches(PALO_ALTO_PANORAMA_PATTERN)
+        || fileTextMatches(RANCID_PALO_ALTO_PATTERN)) {
+      if (_fileText.contains("{")) {
+        return ConfigurationFormat.PALO_ALTO;
+      }
+      return ConfigurationFormat.FLAT_PALO_ALTO;
     }
     return null;
   }
@@ -268,7 +281,7 @@ public final class VendorConfigurationFormatDetector {
     } else if (fileTextMatches(RANCID_MRV_PATTERN)) {
       return ConfigurationFormat.MRV;
     } else if (fileTextMatches(RANCID_PALO_ALTO_PATTERN)) {
-      return ConfigurationFormat.PALO_ALTO;
+      return checkPaloAlto();
     }
     return null;
   }

--- a/projects/batfish/src/main/java/org/batfish/grammar/VendorConfigurationFormatDetector.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/VendorConfigurationFormatDetector.java
@@ -243,6 +243,14 @@ public final class VendorConfigurationFormatDetector {
   }
 
   @Nullable
+  private ConfigurationFormat checkMss() {
+    if (fileTextMatches(MSS_PATTERN)) {
+      return ConfigurationFormat.MSS;
+    }
+    return null;
+  }
+
+  @Nullable
   private ConfigurationFormat checkPaloAlto() {
     if (fileTextMatches(FLAT_PALO_ALTO_PATTERN)) {
       return ConfigurationFormat.FLAT_PALO_ALTO;
@@ -253,14 +261,6 @@ public final class VendorConfigurationFormatDetector {
         return ConfigurationFormat.PALO_ALTO;
       }
       return ConfigurationFormat.FLAT_PALO_ALTO;
-    }
-    return null;
-  }
-
-  @Nullable
-  private ConfigurationFormat checkMss() {
-    if (fileTextMatches(MSS_PATTERN)) {
-      return ConfigurationFormat.MSS;
     }
     return null;
   }

--- a/projects/batfish/src/main/java/org/batfish/job/ParseVendorConfigurationJob.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ParseVendorConfigurationJob.java
@@ -266,6 +266,7 @@ public class ParseVendorConfigurationJob extends BatfishJob<ParseVendorConfigura
       case AWS:
       case BLADENETWORK:
       case F5:
+      case FLAT_PALO_ALTO:
       case JUNIPER_SWITCH:
       case METAMAKO:
       case MRV_COMMANDS:

--- a/projects/batfish/src/test/java/org/batfish/grammar/VendorConfigurationFormatDetectorTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/VendorConfigurationFormatDetectorTest.java
@@ -1,8 +1,6 @@
 package org.batfish.grammar;
 
-import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
@@ -75,8 +73,6 @@ public class VendorConfigurationFormatDetectorTest {
     String flatDeviceConfig = "set deviceconfig system blah\n";
     String flattened = "####BATFISH FLATTENED PALO ALTO CONFIG####\n";
 
-    String notPaloAlto = "other config line\n";
-
     /* Confirm hierarchical PAN configs are correctly identified */
     for (String fileText : ImmutableList.of(rancid, panorama, sendPanorama, deviceConfig)) {
       assertThat(
@@ -91,14 +87,6 @@ public class VendorConfigurationFormatDetectorTest {
           VendorConfigurationFormatDetector.identifyConfigurationFormat(fileText),
           equalTo(ConfigurationFormat.FLAT_PALO_ALTO));
     }
-
-    /* Make sure non-Palo Alto config line is not misidentified */
-    assertThat(
-        VendorConfigurationFormatDetector.identifyConfigurationFormat(notPaloAlto),
-        not(
-            anyOf(
-                equalTo(ConfigurationFormat.FLAT_PALO_ALTO),
-                equalTo(ConfigurationFormat.PALO_ALTO))));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/VendorConfigurationFormatDetectorTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/VendorConfigurationFormatDetectorTest.java
@@ -77,14 +77,14 @@ public class VendorConfigurationFormatDetectorTest {
 
     String notPaloAlto = "other config line\n";
 
-    /* Identify hierarchical PAN configs */
+    /* Confirm hierarchical PAN configs are correctly identified */
     for (String fileText : ImmutableList.of(rancid, panorama, sendPanorama, deviceConfig)) {
       assertThat(
           VendorConfigurationFormatDetector.identifyConfigurationFormat(fileText),
           equalTo(ConfigurationFormat.PALO_ALTO));
     }
 
-    /* Identify flat (set-style) PAN configs */
+    /* Confirm flat (set-style) PAN configs are correctly identified */
     for (String fileText :
         ImmutableList.of(flatRancid, flatPanorama, flatSendPanorama, flatDeviceConfig, flattened)) {
       assertThat(
@@ -92,7 +92,7 @@ public class VendorConfigurationFormatDetectorTest {
           equalTo(ConfigurationFormat.FLAT_PALO_ALTO));
     }
 
-    /* Make sure non-Palo Alto config line is not mis-identified */
+    /* Make sure non-Palo Alto config line is not misidentified */
     assertThat(
         VendorConfigurationFormatDetector.identifyConfigurationFormat(notPaloAlto),
         not(

--- a/projects/batfish/src/test/java/org/batfish/grammar/VendorConfigurationFormatDetectorTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/VendorConfigurationFormatDetectorTest.java
@@ -62,14 +62,28 @@ public class VendorConfigurationFormatDetectorTest {
 
   @Test
   public void recognizePaloAlto() {
-    String rancid = "!RANCID-CONTENT-TYPE: paloalto\n!\n";
+    String rancid = "!RANCID-CONTENT-TYPE: paloalto\n!\nstructure {";
     String panorama = "deviceconfig {\n  system {\n    panorama-server 1.2.3.4;\n  }\n}";
     String sendPanorama = "alarm {\n  informational {\n    send-to-panorama yes;\n  }\n}";
+    String deviceConfig = "deviceconfig {\n  system {\n    blah;\n  }\n}";
 
-    for (String fileText : ImmutableList.of(rancid, panorama, sendPanorama)) {
+    String flatRancid = "!RANCID-CONTENT-TYPE: paloalto\n!\n";
+    String flatPanorama = "set deviceconfig system panorama-server 1.2.3.4\n}";
+    String flatSendPanorama = "set alarm informational send-to-panorama yes\n";
+    String flatDeviceConfig = "set deviceconfig system blah\n";
+    String flattened = "####BATFISH FLATTENED PALO ALTO CONFIG####\n";
+
+    for (String fileText : ImmutableList.of(rancid, panorama, sendPanorama, deviceConfig)) {
       assertThat(
           VendorConfigurationFormatDetector.identifyConfigurationFormat(fileText),
           equalTo(ConfigurationFormat.PALO_ALTO));
+    }
+
+    for (String fileText :
+        ImmutableList.of(flatRancid, flatPanorama, flatSendPanorama, flatDeviceConfig, flattened)) {
+      assertThat(
+          VendorConfigurationFormatDetector.identifyConfigurationFormat(fileText),
+          equalTo(ConfigurationFormat.FLAT_PALO_ALTO));
     }
   }
 }


### PR DESCRIPTION
Update format detection to find other palo alto lines and differentiate between normal and flat (set) format.
