### PR TITLE
update pathDiff to use the sourceIpAssignment

### DIFF
--- a/projects/allinone/src/test/java/org/batfish/allinone/PathDiffTest.java
+++ b/projects/allinone/src/test/java/org/batfish/allinone/PathDiffTest.java
@@ -1,0 +1,161 @@
+package org.batfish.allinone;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.ImmutableSortedSet;
+import java.io.IOException;
+import java.util.SortedMap;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.FlowHistory;
+import org.batfish.datamodel.ForwardingAction;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.InterfaceAddress;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.StaticRoute;
+import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.answers.AnswerElement;
+import org.batfish.main.Batfish;
+import org.batfish.main.BatfishTestUtils;
+import org.batfish.question.ReachabilityParameters;
+import org.batfish.specifier.AllNodesNodeSpecifier;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class PathDiffTest {
+  /** 3.3.3.3/32 <--- A B ---> 4.4.4.4/32 */
+  private static SortedMap<String, Configuration> disconnectedTwoNodeNetwork() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration.Builder cb =
+        nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+    Configuration cA = cb.build();
+    Configuration cB = cb.build();
+
+    Vrf.Builder vb = nf.vrfBuilder();
+    Vrf vA = vb.setOwner(cA).build();
+    Vrf vB = vb.setOwner(cB).build();
+
+    Interface.Builder ib = nf.interfaceBuilder();
+
+    // A's interface
+    Prefix pA = Prefix.parse("3.3.3.3/32");
+    ib.setOwner(cA)
+        .setVrf(vA)
+        .setAddress(new InterfaceAddress(pA.getStartIp(), pA.getPrefixLength()))
+        .build();
+
+    // B's interface
+    Prefix pB = Prefix.parse("4.4.4.4/32");
+    ib.setOwner(cB)
+        .setVrf(vB)
+        .setAddress(new InterfaceAddress(pB.getStartIp(), pB.getPrefixLength()))
+        .build();
+
+    // A's interface on link to B
+    Prefix pAB = Prefix.parse("10.0.0.0/31");
+    ib.setOwner(cA)
+        .setVrf(vA)
+        .setAddress(new InterfaceAddress(pAB.getStartIp(), pAB.getPrefixLength()))
+        .build();
+
+    // B's interface on link to A
+    ib.setOwner(cB)
+        .setVrf(vB)
+        .setAddress(new InterfaceAddress(pAB.getEndIp(), pAB.getPrefixLength()))
+        .build();
+
+    return ImmutableSortedMap.of(cA.getName(), cA, cB.getName(), cB);
+  }
+
+  /** 3.3.3.3/32 <--- A <---> B ---> 4.4.4.4/32 */
+  private static SortedMap<String, Configuration> connectedTwoNodeNetwork() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration.Builder cb =
+        nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+    Configuration cA = cb.build();
+    Configuration cB = cb.build();
+
+    Vrf.Builder vb = nf.vrfBuilder();
+    Vrf vA = vb.setOwner(cA).build();
+    Vrf vB = vb.setOwner(cB).build();
+
+    Interface.Builder ib = nf.interfaceBuilder().setActive(true).setBandwidth(1E9d);
+
+    // A's interface
+    Prefix pA = Prefix.parse("3.3.3.3/32");
+    ib.setOwner(cA)
+        .setVrf(vA)
+        .setAddress(new InterfaceAddress(pA.getStartIp(), pA.getPrefixLength()))
+        .build();
+
+    // B's interface
+    Prefix pB = Prefix.parse("4.4.4.4/32");
+    ib.setOwner(cB)
+        .setVrf(vB)
+        .setAddress(new InterfaceAddress(pB.getStartIp(), pB.getPrefixLength()))
+        .build();
+
+    // A's interface on link to B
+    Prefix pAB = Prefix.parse("10.0.0.0/31");
+    ib.setOwner(cA)
+        .setVrf(vA)
+        .setAddress(new InterfaceAddress(pAB.getStartIp(), pAB.getPrefixLength()))
+        .build();
+
+    // B's interface on link to A
+    ib.setOwner(cB)
+        .setVrf(vB)
+        .setAddress(new InterfaceAddress(pAB.getEndIp(), pAB.getPrefixLength()))
+        .build();
+
+    // static route from A to pB
+    StaticRoute.Builder rb = StaticRoute.builder();
+    vA.getStaticRoutes().add(rb.setNetwork(pB).setNextHopIp(pAB.getEndIp()).build());
+    // static route from B to pA
+    vB.getStaticRoutes().add(rb.setNetwork(pA).setNextHopIp(pAB.getStartIp()).build());
+
+    return ImmutableSortedMap.of(cA.getName(), cA, cB.getName(), cB);
+  }
+
+  @Test
+  public void testPathDiff() throws IOException {
+    TemporaryFolder tmp = new TemporaryFolder();
+    tmp.create();
+    SortedMap<String, Configuration> baseConfigs = connectedTwoNodeNetwork();
+    SortedMap<String, Configuration> deltaConfigs = disconnectedTwoNodeNetwork();
+    Batfish batfish = BatfishTestUtils.getBatfish(baseConfigs, deltaConfigs, tmp);
+
+    batfish.pushBaseEnvironment();
+    batfish.computeDataPlane(true);
+    batfish.popEnvironment();
+
+    batfish.pushDeltaEnvironment();
+    batfish.computeDataPlane(true);
+    batfish.popEnvironment();
+
+    batfish.checkDifferentialDataPlaneQuestionDependencies();
+    AnswerElement answer =
+        batfish.pathDiff(
+            ReachabilityParameters.builder()
+                .setActions(ImmutableSortedSet.of(ForwardingAction.ACCEPT))
+                .setFinalNodesSpecifier(AllNodesNodeSpecifier.INSTANCE)
+                .build());
+    assertThat(answer, Matchers.instanceOf(FlowHistory.class));
+
+    FlowHistory flowHistory = (FlowHistory) answer;
+
+    assertThat(flowHistory.getTraces().entrySet(), hasSize(2));
+    assertThat(
+        flowHistory.getTraces().keySet(),
+        containsInAnyOrder(
+            ImmutableList.of(
+                Matchers.containsString("dstIp:3.3.3.3"),
+                Matchers.containsString("dstIp:4.4.4.4"))));
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/z3/ReachEdgeQuerySynthesizer.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/ReachEdgeQuerySynthesizer.java
@@ -12,6 +12,7 @@ import org.batfish.z3.expr.HeaderSpaceMatchExpr;
 import org.batfish.z3.expr.QueryStatement;
 import org.batfish.z3.expr.SaneExpr;
 import org.batfish.z3.expr.StateExpr;
+import org.batfish.z3.expr.TrueExpr;
 import org.batfish.z3.expr.VarIntExpr;
 import org.batfish.z3.state.Accept;
 import org.batfish.z3.state.OriginateVrf;
@@ -63,7 +64,9 @@ public class ReachEdgeQuerySynthesizer extends BaseQuerySynthesizer {
                         ImmutableList.of(
                             new EqExpr(
                                 new VarIntExpr(Field.ORIG_SRC_IP), new VarIntExpr(Field.SRC_IP)),
-                            new HeaderSpaceMatchExpr(_headerSpace, ImmutableMap.of()),
+                            _headerSpace == null
+                                ? TrueExpr.INSTANCE
+                                : new HeaderSpaceMatchExpr(_headerSpace, ImmutableMap.of()),
                             SaneExpr.INSTANCE)),
                     new OriginateVrf(_originationNode, _ingressVrf)),
                 new BasicRuleStatement(

--- a/projects/batfish/src/main/java/org/batfish/z3/StandardReachabilityQuerySynthesizer.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/StandardReachabilityQuerySynthesizer.java
@@ -240,7 +240,9 @@ public class StandardReachabilityQuerySynthesizer extends ReachabilityQuerySynth
         .setSmtConstraint(
             new AndExpr(
                 ImmutableList.of(
-                    new HeaderSpaceMatchExpr(_headerSpace, ImmutableMap.of(), true),
+                    _headerSpace == null
+                        ? TrueExpr.INSTANCE
+                        : new HeaderSpaceMatchExpr(_headerSpace, ImmutableMap.of(), true),
                     getSrcNattedConstraint(),
                     SaneExpr.INSTANCE,
                     transitNodesConstraint)))

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
@@ -92,8 +92,8 @@ public class BatfishTestUtils {
   }
 
   private static Batfish initBatfish(
-      SortedMap<String, Configuration> baseConfigs,
-      SortedMap<String, Configuration> deltaConfigs,
+      @Nonnull SortedMap<String, Configuration> baseConfigs,
+      @Nonnull SortedMap<String, Configuration> deltaConfigs,
       @Nonnull TemporaryFolder tempFolder)
       throws IOException {
     Settings settings = new Settings(new String[] {});
@@ -247,8 +247,8 @@ public class BatfishTestUtils {
    * @return New Batfish instance
    */
   public static Batfish getBatfish(
-      SortedMap<String, Configuration> baseConfigs,
-      SortedMap<String, Configuration> deltaConfigs,
+      @Nonnull SortedMap<String, Configuration> baseConfigs,
+      @Nonnull SortedMap<String, Configuration> deltaConfigs,
       @Nonnull TemporaryFolder tempFolder)
       throws IOException {
     return initBatfish(baseConfigs, deltaConfigs, tempFolder);

--- a/projects/question/src/main/java/org/batfish/question/ReachabilitySettings.java
+++ b/projects/question/src/main/java/org/batfish/question/ReachabilitySettings.java
@@ -347,13 +347,18 @@ public final class ReachabilitySettings {
           new ConstantIpSpaceSpecifier(AclIpSpace.difference(UniverseIpSpace.INSTANCE, notSrcIps));
     }
 
+    // remove src IPs from headerspace since they're specified via an IpSpaceSpecifier
+    IpSpace nullIpSpace = null;
+    HeaderSpace headerSpace =
+        _headerSpace.toBuilder().setNotSrcIps(nullIpSpace).setSrcIps(nullIpSpace).build();
+
     return ReachabilityParameters.builder()
         .setActions(_actions)
         .setFinalNodesSpecifier(
             NodeSpecifiers.difference(
                 NodeSpecifiers.from(_finalNodes), NodeSpecifiers.from(_notFinalNodes)))
         .setForbiddenTransitNodesSpecifier(NodeSpecifiers.from(_nonTransitNodes))
-        .setHeaderSpace(_headerSpace)
+        .setHeaderSpace(headerSpace)
         .setMaxChunkSize(_maxChunkSize)
         .setRequiredTransitNodesSpecifier(NodeSpecifiers.from(_transitNodes))
         .setSourceIpSpaceSpecifier(sourceIpSpace)


### PR DESCRIPTION
Go back to removing srcIp from headerspace when converting ReachabilitySettings to ReachabilityParameters.

Now we modify pathDiff to give meaning to the location and srcIp specifiers: we only originate from edges for which the source interface is a specified source location, and we use the source Ip constraint corresponding to that location.

