### PR TITLE
Cisco Inspect class map style tracking

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -3726,11 +3726,8 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   @Override
   public void enterCm_ios_inspect(Cm_ios_inspectContext ctx) {
     String name = ctx.name.getText();
-    int line = ctx.name.getStart().getLine();
     _currentInspectClassMap =
-        _configuration
-            .getInspectClassMaps()
-            .computeIfAbsent(name, n -> new InspectClassMap(n, line));
+        _configuration.getInspectClassMaps().computeIfAbsent(name, n -> new InspectClassMap(n));
     defineStructure(INSPECT_CLASS_MAP, name, ctx);
     MatchSemantics matchSemantics =
         ctx.match_semantics() != null

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -3558,7 +3558,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
     recordDocsisPolicies();
     recordDocsisPolicyRules();
     recordStructure(_asPathAccessLists, CiscoStructureType.AS_PATH_ACCESS_LIST);
-    recordStructure(_inspectClassMaps, CiscoStructureType.INSPECT_CLASS_MAP);
     recordStructure(_inspectPolicyMaps, CiscoStructureType.INSPECT_POLICY_MAP);
     recordStructure(_ipsecProfiles, CiscoStructureType.IPSEC_PROFILE);
     recordStructure(_ipsecTransformSets, CiscoStructureType.IPSEC_TRANSFORM_SET);

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/InspectClassMap.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/InspectClassMap.java
@@ -2,9 +2,9 @@ package org.batfish.representation.cisco;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.batfish.common.util.DefinedStructure;
+import org.batfish.common.util.ComparableStructure;
 
-public class InspectClassMap extends DefinedStructure<String> {
+public class InspectClassMap extends ComparableStructure<String> {
 
   /** */
   private static final long serialVersionUID = 1L;
@@ -13,8 +13,8 @@ public class InspectClassMap extends DefinedStructure<String> {
 
   private MatchSemantics _matchSemantics;
 
-  public InspectClassMap(String name, int definitionLine) {
-    super(name, definitionLine);
+  public InspectClassMap(String name) {
+    super(name);
     _matches = new ArrayList<>();
   }
 


### PR DESCRIPTION
For Cisco Inspect class map style tracking, the defineStructure and referenceStructure along with the markConcreteStructure are already present in the code. It is just matter of updating the DefinedStructure -> ComparableStructure and updating the definition Line calculation.