### PR TITLE
adding stying check for cisco inspect policy map

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -6069,11 +6069,8 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   @Override
   public void enterPm_ios_inspect(Pm_ios_inspectContext ctx) {
     String name = ctx.name.getText();
-    int line = ctx.name.getStart().getLine();
     _currentInspectPolicyMap =
-        _configuration
-            .getInspectPolicyMaps()
-            .computeIfAbsent(name, n -> new InspectPolicyMap(n, line));
+        _configuration.getInspectPolicyMaps().computeIfAbsent(name, n -> new InspectPolicyMap(n));
     defineStructure(INSPECT_POLICY_MAP, name, ctx);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -3558,7 +3558,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
     recordDocsisPolicies();
     recordDocsisPolicyRules();
     recordStructure(_asPathAccessLists, CiscoStructureType.AS_PATH_ACCESS_LIST);
-    recordStructure(_inspectPolicyMaps, CiscoStructureType.INSPECT_POLICY_MAP);
     recordStructure(_ipsecProfiles, CiscoStructureType.IPSEC_PROFILE);
     recordStructure(_ipsecTransformSets, CiscoStructureType.IPSEC_TRANSFORM_SET);
     recordPeerGroups();

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/InspectPolicyMap.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/InspectPolicyMap.java
@@ -2,10 +2,10 @@ package org.batfish.representation.cisco;
 
 import java.util.Map;
 import java.util.TreeMap;
-import org.batfish.common.util.DefinedStructure;
+import org.batfish.common.util.ComparableStructure;
 import org.batfish.datamodel.LineAction;
 
-public class InspectPolicyMap extends DefinedStructure<String> {
+public class InspectPolicyMap extends ComparableStructure<String> {
 
   /** */
   private static final long serialVersionUID = 1L;
@@ -14,8 +14,8 @@ public class InspectPolicyMap extends DefinedStructure<String> {
 
   private Map<String, InspectPolicyMapInspectClass> _inspectClasses;
 
-  public InspectPolicyMap(String name, int definitionLine) {
-    super(name, definitionLine);
+  public InspectPolicyMap(String name) {
+    super(name);
     _classDefaultAction = LineAction.REJECT;
     _inspectClasses = new TreeMap<>();
   }


### PR DESCRIPTION
For Cisco inspect policy, as the defineStructure and referenceStructure along with the markConcreteStructure are already present in the code. It is just matter of updating the DefinedStructure -> ComparableStructure and updating the definition Line calculation.