### PR TITLE
as-path-set style checking

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -3617,7 +3617,7 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
     if (asPathSet != null) {
       _w.redFlag("Redeclaration of as-path-set: '" + name + "'");
     }
-    asPathSet = new AsPathSet(name, definitionLine);
+    asPathSet = new AsPathSet(name);
     _configuration.getAsPathSets().put(name, asPathSet);
     for (As_path_set_elemContext elemCtx : ctx.elems) {
       AsPathSetElem elem = toAsPathSetElem(elemCtx);

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/AsPathSet.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/AsPathSet.java
@@ -2,18 +2,18 @@ package org.batfish.representation.cisco;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.batfish.common.util.DefinedStructure;
+import org.batfish.common.util.ComparableStructure;
 import org.batfish.datamodel.routing_policy.expr.AsPathSetElem;
 
-public class AsPathSet extends DefinedStructure<String> {
+public class AsPathSet extends ComparableStructure<String> {
 
   /** */
   private static final long serialVersionUID = 1L;
 
   private final List<AsPathSetElem> _elements;
 
-  public AsPathSet(String name, int definitionLine) {
-    super(name, definitionLine);
+  public AsPathSet(String name) {
+    super(name);
     _elements = new ArrayList<>();
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -3551,7 +3551,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
 
     markConcreteStructure(CiscoStructureType.NAT_POOL, CiscoStructureUsage.IP_NAT_SOURCE_POOL);
     // record references to defined structures
-    recordStructure(_asPathSets, CiscoStructureType.AS_PATH_SET);
     recordCommunityLists();
     recordStructure(_cf.getDepiClasses(), CiscoStructureType.DEPI_CLASS);
     recordStructure(_cf.getDepiTunnels(), CiscoStructureType.DEPI_TUNNEL);


### PR DESCRIPTION
For Cisco as-path-set, there is no relevant reference made. Hence, just updated the DefinedStructure -> ComparableStructure and updating the definition Line calculation.