### PR TITLE
depi class and tunnel reference tracking

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco/DepiClass.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco/DepiClass.java
@@ -1,20 +1,13 @@
 package org.batfish.datamodel.vendor_family.cisco;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import org.batfish.common.util.DefinedStructure;
+import org.batfish.common.util.ComparableStructure;
 
-public class DepiClass extends DefinedStructure<String> {
+public class DepiClass extends ComparableStructure<String> {
 
   /** */
   private static final long serialVersionUID = 1L;
 
-  @JsonCreator
-  private DepiClass(@JsonProperty(PROP_NAME) String name) {
-    super(name, -1);
-  }
-
-  public DepiClass(String number, int definitionLine) {
-    super(number, definitionLine);
+  public DepiClass(String number) {
+    super(number);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco/DepiTunnel.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco/DepiTunnel.java
@@ -1,20 +1,13 @@
 package org.batfish.datamodel.vendor_family.cisco;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import org.batfish.common.util.DefinedStructure;
+import org.batfish.common.util.ComparableStructure;
 
-public class DepiTunnel extends DefinedStructure<String> {
+public class DepiTunnel extends ComparableStructure<String> {
 
   /** */
   private static final long serialVersionUID = 1L;
 
-  @JsonCreator
-  private DepiTunnel(@JsonProperty(PROP_NAME) String name) {
-    super(name, -1);
-  }
-
-  public DepiTunnel(String number, int definitionLine) {
-    super(number, definitionLine);
+  public DepiTunnel(String number) {
+    super(number);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -3000,16 +3000,14 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   @Override
   public void enterS_depi_class(S_depi_classContext ctx) {
     String name = ctx.name.getText();
-    int line = ctx.getStart().getLine();
-    _configuration.getCf().getDepiClasses().computeIfAbsent(name, n -> new DepiClass(n, line));
+    _configuration.getCf().getDepiClasses().computeIfAbsent(name, n -> new DepiClass(n));
     defineStructure(DEPI_CLASS, name, ctx);
   }
 
   @Override
   public void enterS_depi_tunnel(S_depi_tunnelContext ctx) {
     String name = ctx.name.getText();
-    int line = ctx.getStart().getLine();
-    _configuration.getCf().getDepiTunnels().computeIfAbsent(name, n -> new DepiTunnel(n, line));
+    _configuration.getCf().getDepiTunnels().computeIfAbsent(name, n -> new DepiTunnel(n));
     defineStructure(DEPI_TUNNEL, name, ctx);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -3552,8 +3552,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
     markConcreteStructure(CiscoStructureType.NAT_POOL, CiscoStructureUsage.IP_NAT_SOURCE_POOL);
     // record references to defined structures
     recordCommunityLists();
-    recordStructure(_cf.getDepiClasses(), CiscoStructureType.DEPI_CLASS);
-    recordStructure(_cf.getDepiTunnels(), CiscoStructureType.DEPI_TUNNEL);
     recordDocsisPolicies();
     recordDocsisPolicyRules();
     recordStructure(_asPathAccessLists, CiscoStructureType.AS_PATH_ACCESS_LIST);


### PR DESCRIPTION
For Cisco depi class and tunnel reference checking: As the defineStructure and referenceStructure along with the markConcreteStructure are already present in the code. It is just matter of updating the DefinedStructure -> ComparableStructure and updating the definition Line calculation with some code cleanup.