### PR TITLE
Ipsec proposals (transform-sets) - improve extraction

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EncryptionAlgorithm.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EncryptionAlgorithm.java
@@ -12,6 +12,6 @@ public enum EncryptionAlgorithm {
   AES_256_GMAC,
   DES_CBC,
   NULL,
-  AES_SEAL_160,
+  SEAL_160,
   THREEDES_CBC
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EncryptionAlgorithm.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EncryptionAlgorithm.java
@@ -4,6 +4,14 @@ public enum EncryptionAlgorithm {
   AES_128_CBC,
   AES_192_CBC,
   AES_256_CBC,
+  AES_128_GCM,
+  AES_192_GCM,
+  AES_256_GCM,
+  AES_128_GMAC,
+  AES_192_GMAC,
+  AES_256_GMAC,
   DES_CBC,
+  NULL,
+  AES_SEAL_160,
   THREEDES_CBC
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpsecProposal.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpsecProposal.java
@@ -3,6 +3,7 @@ package org.batfish.datamodel;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableSortedSet;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import org.batfish.common.util.ComparableStructure;
@@ -59,7 +60,6 @@ public class IpsecProposal extends ComparableStructure<String> {
   private static IpsecProposal initNOPFS_ESP_DES_MD5() {
     IpsecProposal p = new IpsecProposal("NOPFS_ESP_DES_MD5");
     p.getProtocols().add(IpsecProtocol.ESP);
-    ;
     p.setAuthenticationAlgorithm(IpsecAuthenticationAlgorithm.HMAC_MD5_96);
     p.setEncryptionAlgorithm(EncryptionAlgorithm.DES_CBC);
     return p;
@@ -145,7 +145,13 @@ public class IpsecProposal extends ComparableStructure<String> {
     _lifetimeSeconds = lifetimeSeconds;
   }
 
-  public void setProtocols(SortedSet<IpsecProtocol> protocol) {
-    _protocols = protocol;
+  /** @deprecated Use {@link #setProtocols(SortedSet)} instead. */
+  @Deprecated
+  public void setProtocol(IpsecProtocol protocol) {
+    setProtocols(ImmutableSortedSet.of(protocol));
+  }
+
+  public void setProtocols(SortedSet<IpsecProtocol> protocols) {
+    _protocols = protocols;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpsecProposal.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpsecProposal.java
@@ -3,6 +3,8 @@ package org.batfish.datamodel;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import org.batfish.common.util.ComparableStructure;
 
 public class IpsecProposal extends ComparableStructure<String> {
@@ -24,7 +26,7 @@ public class IpsecProposal extends ComparableStructure<String> {
 
   private static IpsecProposal initG2_ESP_3DES_SHA() {
     IpsecProposal p = new IpsecProposal("G2_ESP_3DES_SHA");
-    p.setProtocol(IpsecProtocol.ESP);
+    p.getProtocols().add(IpsecProtocol.ESP);
     p.setAuthenticationAlgorithm(IpsecAuthenticationAlgorithm.HMAC_SHA1_96);
     p.setEncryptionAlgorithm(EncryptionAlgorithm.THREEDES_CBC);
     return p;
@@ -32,7 +34,7 @@ public class IpsecProposal extends ComparableStructure<String> {
 
   private static IpsecProposal initG2_ESP_AES128_SHA() {
     IpsecProposal p = new IpsecProposal("G2_ESP_AES128_SHA");
-    p.setProtocol(IpsecProtocol.ESP);
+    p.getProtocols().add(IpsecProtocol.ESP);
     p.setAuthenticationAlgorithm(IpsecAuthenticationAlgorithm.HMAC_SHA1_96);
     p.setEncryptionAlgorithm(EncryptionAlgorithm.AES_128_CBC);
     return p;
@@ -40,7 +42,7 @@ public class IpsecProposal extends ComparableStructure<String> {
 
   private static IpsecProposal initNOPFS_ESP_3DES_MD5() {
     IpsecProposal p = new IpsecProposal("NOPFS_ESP_3DES_MD5");
-    p.setProtocol(IpsecProtocol.ESP);
+    p.getProtocols().add(IpsecProtocol.ESP);
     p.setAuthenticationAlgorithm(IpsecAuthenticationAlgorithm.HMAC_MD5_96);
     p.setEncryptionAlgorithm(EncryptionAlgorithm.THREEDES_CBC);
     return p;
@@ -48,7 +50,7 @@ public class IpsecProposal extends ComparableStructure<String> {
 
   private static IpsecProposal initNOPFS_ESP_3DES_SHA() {
     IpsecProposal p = new IpsecProposal("NOPFS_ESP_3DES_SHA");
-    p.setProtocol(IpsecProtocol.ESP);
+    p.getProtocols().add(IpsecProtocol.ESP);
     p.setAuthenticationAlgorithm(IpsecAuthenticationAlgorithm.HMAC_SHA1_96);
     p.setEncryptionAlgorithm(EncryptionAlgorithm.THREEDES_CBC);
     return p;
@@ -56,7 +58,8 @@ public class IpsecProposal extends ComparableStructure<String> {
 
   private static IpsecProposal initNOPFS_ESP_DES_MD5() {
     IpsecProposal p = new IpsecProposal("NOPFS_ESP_DES_MD5");
-    p.setProtocol(IpsecProtocol.ESP);
+    p.getProtocols().add(IpsecProtocol.ESP);
+    ;
     p.setAuthenticationAlgorithm(IpsecAuthenticationAlgorithm.HMAC_MD5_96);
     p.setEncryptionAlgorithm(EncryptionAlgorithm.DES_CBC);
     return p;
@@ -64,7 +67,7 @@ public class IpsecProposal extends ComparableStructure<String> {
 
   private static IpsecProposal initNOPFS_ESP_DES_SHA() {
     IpsecProposal p = new IpsecProposal("NOPFS_ESP_DES_SHA");
-    p.setProtocol(IpsecProtocol.ESP);
+    p.getProtocols().add(IpsecProtocol.ESP);
     p.setAuthenticationAlgorithm(IpsecAuthenticationAlgorithm.HMAC_SHA1_96);
     p.setEncryptionAlgorithm(EncryptionAlgorithm.DES_CBC);
     return p;
@@ -80,23 +83,25 @@ public class IpsecProposal extends ComparableStructure<String> {
 
   private Integer _lifetimeSeconds;
 
-  private IpsecProtocol _protocol;
+  private SortedSet<IpsecProtocol> _protocols;
 
   @JsonCreator
   private IpsecProposal(@JsonProperty(PROP_NAME) String name) {
     super(name);
     _definitionLine = -1;
+    _protocols = new TreeSet<>();
   }
 
   public IpsecProposal(String name, int definitionLine) {
     super(name);
     _definitionLine = definitionLine;
+    _protocols = new TreeSet<>();
   }
 
   public boolean compatibleWith(IpsecProposal rhs) {
     return (_authenticationAlgorithm == rhs._authenticationAlgorithm
         && _encryptionAlgorithm == rhs._encryptionAlgorithm
-        && _protocol == rhs._protocol);
+        && _protocols.equals(rhs._protocols));
   }
 
   public IpsecAuthenticationAlgorithm getAuthenticationAlgorithm() {
@@ -120,8 +125,8 @@ public class IpsecProposal extends ComparableStructure<String> {
     return _lifetimeSeconds;
   }
 
-  public IpsecProtocol getProtocol() {
-    return _protocol;
+  public SortedSet<IpsecProtocol> getProtocols() {
+    return _protocols;
   }
 
   public void setAuthenticationAlgorithm(IpsecAuthenticationAlgorithm alg) {
@@ -140,7 +145,7 @@ public class IpsecProposal extends ComparableStructure<String> {
     _lifetimeSeconds = lifetimeSeconds;
   }
 
-  public void setProtocol(IpsecProtocol protocol) {
-    _protocol = protocol;
+  public void setProtocols(SortedSet<IpsecProtocol> protocol) {
+    _protocols = protocol;
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/ConfigurationMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/ConfigurationMatchers.java
@@ -11,6 +11,7 @@ import org.batfish.datamodel.IkeProposal;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.IpSpace;
+import org.batfish.datamodel.IpsecProposal;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.matchers.ConfigurationMatchersImpl.HasConfigurationFormat;
 import org.batfish.datamodel.matchers.ConfigurationMatchersImpl.HasDefaultVrf;
@@ -22,6 +23,7 @@ import org.batfish.datamodel.matchers.ConfigurationMatchersImpl.HasIpAccessList;
 import org.batfish.datamodel.matchers.ConfigurationMatchersImpl.HasIpAccessLists;
 import org.batfish.datamodel.matchers.ConfigurationMatchersImpl.HasIpSpace;
 import org.batfish.datamodel.matchers.ConfigurationMatchersImpl.HasIpSpaces;
+import org.batfish.datamodel.matchers.ConfigurationMatchersImpl.HasIpsecProposal;
 import org.batfish.datamodel.matchers.ConfigurationMatchersImpl.HasVendorFamily;
 import org.batfish.datamodel.matchers.ConfigurationMatchersImpl.HasVrf;
 import org.batfish.datamodel.matchers.ConfigurationMatchersImpl.HasVrfs;
@@ -100,6 +102,15 @@ public class ConfigurationMatchers {
   public static HasIpAccessLists hasIpAccessLists(
       @Nonnull Matcher<? super Map<String, IpAccessList>> subMatcher) {
     return new HasIpAccessLists(subMatcher);
+  }
+
+  /**
+   * Provides a matcher that matches if the provided {@code subMatcher} matches the configuration's
+   * Ipsec proposal with specified name.
+   */
+  public static HasIpsecProposal hasIpsecProposal(
+      @Nonnull String name, @Nonnull Matcher<? super IpsecProposal> subMatcher) {
+    return new HasIpsecProposal(name, subMatcher);
   }
 
   /**

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/ConfigurationMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/ConfigurationMatchersImpl.java
@@ -10,6 +10,7 @@ import org.batfish.datamodel.IkeProposal;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.IpSpace;
+import org.batfish.datamodel.IpsecProposal;
 import org.batfish.datamodel.Route6FilterList;
 import org.batfish.datamodel.RouteFilterList;
 import org.batfish.datamodel.Vrf;
@@ -119,6 +120,21 @@ final class ConfigurationMatchersImpl {
     @Override
     protected Map<String, IpAccessList> featureValueOf(Configuration actual) {
       return actual.getIpAccessLists();
+    }
+  }
+
+  static final class HasIpsecProposal extends FeatureMatcher<Configuration, IpsecProposal> {
+    private final String _name;
+
+    HasIpsecProposal(@Nonnull String name, @Nonnull Matcher<? super IpsecProposal> subMatcher) {
+      super(
+          subMatcher, "A Configuration with ipsecProposal " + name + ":", "ipsecProposal " + name);
+      _name = name;
+    }
+
+    @Override
+    protected IpsecProposal featureValueOf(Configuration actual) {
+      return actual.getIpsecProposals().get(_name);
     }
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/IpsecProposalMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/IpsecProposalMatchers.java
@@ -2,7 +2,7 @@ package org.batfish.datamodel.matchers;
 
 import static org.hamcrest.Matchers.equalTo;
 
-import java.util.SortedSet;
+import java.util.Set;
 import org.batfish.datamodel.EncryptionAlgorithm;
 import org.batfish.datamodel.IpsecAuthenticationAlgorithm;
 import org.batfish.datamodel.IpsecProtocol;
@@ -34,7 +34,7 @@ public final class IpsecProposalMatchers {
    * Provides a matcher that matches if the Ipsec Proposal's value of {@code protocols} matches
    * specified {@code protocols}
    */
-  public static HasProtocols hasProtocols(SortedSet<IpsecProtocol> protocols) {
+  public static HasProtocols hasProtocols(Set<IpsecProtocol> protocols) {
     return new HasProtocols(equalTo(protocols));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/IpsecProposalMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/IpsecProposalMatchers.java
@@ -1,0 +1,42 @@
+package org.batfish.datamodel.matchers;
+
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.SortedSet;
+import org.batfish.datamodel.EncryptionAlgorithm;
+import org.batfish.datamodel.IpsecAuthenticationAlgorithm;
+import org.batfish.datamodel.IpsecProtocol;
+import org.batfish.datamodel.matchers.IpsecProposalMatchersImpl.HasAuthenticationAlgorithm;
+import org.batfish.datamodel.matchers.IpsecProposalMatchersImpl.HasEncryptionAlgorithm;
+import org.batfish.datamodel.matchers.IpsecProposalMatchersImpl.HasProtocols;
+
+public final class IpsecProposalMatchers {
+
+  /**
+   * Provides a matcher that matches if the Ipsec Proposal's value of {@code encryptionAlgorithm}
+   * matches specified {@code encryptionAlgorithm}
+   */
+  public static HasEncryptionAlgorithm hasEncryptionAlgorithm(
+      EncryptionAlgorithm encryptionAlgorithm) {
+    return new HasEncryptionAlgorithm(equalTo(encryptionAlgorithm));
+  }
+
+  /**
+   * Provides a matcher that matches if the Ipsec Proposal's value of {@code
+   * authenticationAlgorithm} matches specified {@code authenticationAlgorithm}
+   */
+  public static HasAuthenticationAlgorithm hasAuthenticationAlgorithm(
+      IpsecAuthenticationAlgorithm ipsecAuthenticationAlgorithm) {
+    return new HasAuthenticationAlgorithm(equalTo(ipsecAuthenticationAlgorithm));
+  }
+
+  /**
+   * Provides a matcher that matches if the Ipsec Proposal's value of {@code protocols} matches
+   * specified {@code protocols}
+   */
+  public static HasProtocols hasProtocols(SortedSet<IpsecProtocol> protocols) {
+    return new HasProtocols(equalTo(protocols));
+  }
+
+  private IpsecProposalMatchers() {}
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/IpsecProposalMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/IpsecProposalMatchersImpl.java
@@ -1,0 +1,49 @@
+package org.batfish.datamodel.matchers;
+
+import java.util.SortedSet;
+import javax.annotation.Nonnull;
+import org.batfish.datamodel.EncryptionAlgorithm;
+import org.batfish.datamodel.IpsecAuthenticationAlgorithm;
+import org.batfish.datamodel.IpsecProposal;
+import org.batfish.datamodel.IpsecProtocol;
+import org.hamcrest.FeatureMatcher;
+import org.hamcrest.Matcher;
+
+final class IpsecProposalMatchersImpl {
+
+  static final class HasAuthenticationAlgorithm
+      extends FeatureMatcher<IpsecProposal, IpsecAuthenticationAlgorithm> {
+    HasAuthenticationAlgorithm(@Nonnull Matcher<? super IpsecAuthenticationAlgorithm> subMatcher) {
+      super(
+          subMatcher, "An Ipsec Proposal with AuthenticationAlgorithm:", "AuthenticationAlgorithm");
+    }
+
+    @Override
+    protected IpsecAuthenticationAlgorithm featureValueOf(IpsecProposal actual) {
+      return actual.getAuthenticationAlgorithm();
+    }
+  }
+
+  static final class HasEncryptionAlgorithm
+      extends FeatureMatcher<IpsecProposal, EncryptionAlgorithm> {
+    HasEncryptionAlgorithm(@Nonnull Matcher<? super EncryptionAlgorithm> subMatcher) {
+      super(subMatcher, "An Ipsec Proposal with EncryptionAlgorithm:", "EncryptionAlgorithm");
+    }
+
+    @Override
+    protected EncryptionAlgorithm featureValueOf(IpsecProposal actual) {
+      return actual.getEncryptionAlgorithm();
+    }
+  }
+
+  static final class HasProtocols extends FeatureMatcher<IpsecProposal, SortedSet<IpsecProtocol>> {
+    HasProtocols(@Nonnull Matcher<? super SortedSet<IpsecProtocol>> subMatcher) {
+      super(subMatcher, "An Ipsec Proposal with protocols:", "protocols");
+    }
+
+    @Override
+    protected SortedSet<IpsecProtocol> featureValueOf(IpsecProposal actual) {
+      return actual.getProtocols();
+    }
+  }
+}

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
@@ -539,6 +539,16 @@ AH
    'ah'
 ;
 
+AH_MD5_HMAC
+:
+   'ah-md5-hmac'
+;
+
+AH_SHA_HMAC
+:
+   'ah-sha-hmac'
+;
+
 AHP
 :
    'ahp'
@@ -3941,6 +3951,22 @@ ESP_AES
 :
    'esp-aes'
 ;
+
+ESP_AES128
+:
+   'esp-aes128'
+;
+
+ESP_AES192
+:
+   'esp-aes192'
+;
+
+ESP_AES256
+:
+   'esp-aes256'
+;
+
 
 ESP_DES
 :

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
@@ -3978,6 +3978,16 @@ ESP_GCM
    'esp-gcm'
 ;
 
+ESP_AES128_GCM
+:
+   'esp-aes128-gcm'
+;
+
+ESP_AES256_GCM
+:
+   'esp-aes256-gcm'
+;
+
 ESP_GMAC
 :
    'esp-gmac'

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_crypto.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_crypto.g4
@@ -798,8 +798,14 @@ ipsec_encryption
    )
    | ESP_DES
    | ESP_3DES
-   | ESP_GCM
-   | ESP_GMAC
+   |
+   (
+      ESP_GCM strength = DEC?
+   )
+   |
+   (
+      ESP_GMAC strength = DEC?
+   )
    | ESP_NULL
    | ESP_SEAL
 ;
@@ -809,6 +815,8 @@ ipsec_encryption_aruba
    ESP_AES128
    | ESP_AES192
    | ESP_AES256
+   | ESP_AES128_GCM
+   | ESP_AES256_GCM
    | ESP_DES
    | ESP_3DES
 ;

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_crypto.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_crypto.g4
@@ -243,7 +243,12 @@ cip_profile
 
 cip_transform_set
 :
-   TRANSFORM_SET name = variable ipsec_encryption ipsec_authentication? NEWLINE
+   TRANSFORM_SET name = variable
+   (
+      ipsec_encryption
+      | ipsec_encryption_aruba
+   )
+      ipsec_authentication? NEWLINE
    (
       cipt_mode
    )*
@@ -778,7 +783,9 @@ ike_encryption_aruba
 
 ipsec_authentication
 :
-   ESP_MD5_HMAC
+   AH_MD5_HMAC
+   | AH_SHA_HMAC
+   | ESP_MD5_HMAC
    | ESP_SHA_HMAC
    | ESP_SHA256_HMAC
    | ESP_SHA512_HMAC
@@ -795,6 +802,15 @@ ipsec_encryption
    | ESP_GMAC
    | ESP_NULL
    | ESP_SEAL
+;
+
+ipsec_encryption_aruba
+:
+   ESP_AES128
+   | ESP_AES192
+   | ESP_AES256
+   | ESP_DES
+   | ESP_3DES
 ;
 
 s_crypto

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -177,14 +177,30 @@ AES_128_CMAC_96
    'aes-128-cmac-96'
 ;
 
+AES_128_GCM
+:
+   'aes-128-gcm'
+;
+
+
 AES_192_CBC
 :
    'aes-192-cbc'
 ;
 
+AES_192_GCM
+:
+   'aes-192-gcm'
+;
+
 AES_256_CBC
 :
    'aes-256-cbc'
+;
+
+AES_256_GCM
+:
+   'aes-256-gcm'
 ;
 
 AH

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -532,6 +532,11 @@ BROADCAST_CLIENT
    'broadcast-client'
 ;
 
+BUNDLE
+:
+   'bundle'
+;
+
 CATEGORIES
 :
    'categories'

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_security.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_security.g4
@@ -24,11 +24,14 @@ dh_group
 
 encryption_algorithm
 :
-   THREEDES_CBC
-   | AES_128_CBC
+   AES_128_CBC
+   | AES_128_GCM
    | AES_192_CBC
+   | AES_192_GCM
    | AES_256_CBC
+   | AES_256_GCM
    | DES_CBC
+   | THREEDES_CBC
 ;
 
 hib_protocol
@@ -110,8 +113,8 @@ ipsec_authentication_algorithm
 ipsec_protocol
 :
    AH
-   | ESP
    | BUNDLE
+   | ESP
 ;
 
 nat_rule_set

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_security.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_security.g4
@@ -111,6 +111,7 @@ ipsec_protocol
 :
    AH
    | ESP
+   | BUNDLE
 ;
 
 nat_rule_set

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -8036,9 +8036,8 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   }
 
   private EncryptionAlgorithm toEncryptionAlgorithm(Ipsec_encryptionContext ctx) {
-    int strength;
     if (ctx.ESP_AES() != null) {
-      strength = ctx.strength == null ? 128 : toInteger(ctx.strength);
+      int strength = ctx.strength == null ? 128 : toInteger(ctx.strength);
       switch (strength) {
         case 128:
           return EncryptionAlgorithm.AES_128_CBC;
@@ -8054,7 +8053,7 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
     } else if (ctx.ESP_3DES() != null) {
       return EncryptionAlgorithm.THREEDES_CBC;
     } else if (ctx.ESP_GCM() != null) {
-      strength = ctx.strength == null ? 128 : toInteger(ctx.strength);
+      int strength = ctx.strength == null ? 128 : toInteger(ctx.strength);
       switch (strength) {
         case 128:
           return EncryptionAlgorithm.AES_128_GCM;
@@ -8066,7 +8065,7 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
           throw convError(EncryptionAlgorithm.class, ctx);
       }
     } else if (ctx.ESP_GMAC() != null) {
-      strength = ctx.strength == null ? 128 : toInteger(ctx.strength);
+      int strength = ctx.strength == null ? 128 : toInteger(ctx.strength);
       switch (strength) {
         case 128:
           return EncryptionAlgorithm.AES_128_GMAC;
@@ -8080,7 +8079,7 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
     } else if (ctx.ESP_NULL() != null) {
       return EncryptionAlgorithm.NULL;
     } else if (ctx.ESP_SEAL() != null) {
-      return EncryptionAlgorithm.AES_SEAL_160;
+      return EncryptionAlgorithm.SEAL_160;
     } else {
       throw convError(EncryptionAlgorithm.class, ctx);
     }

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -8036,8 +8036,9 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   }
 
   private EncryptionAlgorithm toEncryptionAlgorithm(Ipsec_encryptionContext ctx) {
+    int strength;
     if (ctx.ESP_AES() != null) {
-      int strength = ctx.strength == null ? 128 : toInteger(ctx.strength);
+      strength = ctx.strength == null ? 128 : toInteger(ctx.strength);
       switch (strength) {
         case 128:
           return EncryptionAlgorithm.AES_128_CBC;
@@ -8052,6 +8053,34 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
       return EncryptionAlgorithm.DES_CBC;
     } else if (ctx.ESP_3DES() != null) {
       return EncryptionAlgorithm.THREEDES_CBC;
+    } else if (ctx.ESP_GCM() != null) {
+      strength = ctx.strength == null ? 128 : toInteger(ctx.strength);
+      switch (strength) {
+        case 128:
+          return EncryptionAlgorithm.AES_128_GCM;
+        case 192:
+          return EncryptionAlgorithm.AES_192_GCM;
+        case 256:
+          return EncryptionAlgorithm.AES_256_GCM;
+        default:
+          throw convError(EncryptionAlgorithm.class, ctx);
+      }
+    } else if (ctx.ESP_GMAC() != null) {
+      strength = ctx.strength == null ? 128 : toInteger(ctx.strength);
+      switch (strength) {
+        case 128:
+          return EncryptionAlgorithm.AES_128_GMAC;
+        case 192:
+          return EncryptionAlgorithm.AES_192_GMAC;
+        case 256:
+          return EncryptionAlgorithm.AES_256_GMAC;
+        default:
+          throw convError(EncryptionAlgorithm.class, ctx);
+      }
+    } else if (ctx.ESP_NULL() != null) {
+      return EncryptionAlgorithm.NULL;
+    } else if (ctx.ESP_SEAL() != null) {
+      return EncryptionAlgorithm.AES_SEAL_160;
     } else {
       throw convError(EncryptionAlgorithm.class, ctx);
     }
@@ -8060,10 +8089,14 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   private EncryptionAlgorithm toEncryptionAlgorithm(Ipsec_encryption_arubaContext ctx) {
     if (ctx.ESP_AES128() != null) {
       return EncryptionAlgorithm.AES_128_CBC;
+    } else if (ctx.ESP_AES128_GCM() != null) {
+      return EncryptionAlgorithm.AES_128_GCM;
     } else if (ctx.ESP_AES192() != null) {
       return EncryptionAlgorithm.AES_192_CBC;
     } else if (ctx.ESP_AES256() != null) {
       return EncryptionAlgorithm.AES_256_CBC;
+    } else if (ctx.ESP_AES256_GCM() != null) {
+      return EncryptionAlgorithm.AES_256_GCM;
     } else if (ctx.ESP_DES() != null) {
       return EncryptionAlgorithm.DES_CBC;
     } else if (ctx.ESP_3DES() != null) {

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -525,6 +525,7 @@ import org.batfish.grammar.cisco.CiscoParser.Ip_route_tailContext;
 import org.batfish.grammar.cisco.CiscoParser.Ip_ssh_versionContext;
 import org.batfish.grammar.cisco.CiscoParser.Ipsec_authenticationContext;
 import org.batfish.grammar.cisco.CiscoParser.Ipsec_encryptionContext;
+import org.batfish.grammar.cisco.CiscoParser.Ipsec_encryption_arubaContext;
 import org.batfish.grammar.cisco.CiscoParser.Ipv6_prefix_list_stanzaContext;
 import org.batfish.grammar.cisco.CiscoParser.Ipv6_prefix_list_tailContext;
 import org.batfish.grammar.cisco.CiscoParser.Is_type_is_stanzaContext;
@@ -1538,15 +1539,20 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
     _currentIpsecTransformSet = new IpsecTransformSet(ctx.name.getText(), ctx.getStart().getLine());
     defineStructure(IPSEC_TRANSFORM_SET, ctx.name.getText(), ctx);
     IpsecProposal proposal = _currentIpsecTransformSet.getProposal();
-    proposal.setEncryptionAlgorithm(toEncryptionAlgorithm(ctx.ipsec_encryption()));
+    if (ctx.ipsec_encryption() != null) {
+      proposal.setEncryptionAlgorithm(toEncryptionAlgorithm(ctx.ipsec_encryption()));
+    } else if (ctx.ipsec_encryption_aruba() != null) {
+      proposal.setEncryptionAlgorithm(toEncryptionAlgorithm(ctx.ipsec_encryption_aruba()));
+    }
+    // If any encryption algorithm was set then ESP protocol is used
+    if (proposal.getEncryptionAlgorithm() != null) {
+      proposal.getProtocols().add(IpsecProtocol.ESP);
+    }
+
     if (ctx.ipsec_authentication() != null) {
       proposal.setAuthenticationAlgorithm(
           toIpsecAuthenticationAlgorithm(ctx.ipsec_authentication()));
-      proposal.setProtocol(toProtocol(ctx.ipsec_authentication()));
-    } else {
-      // default values
-      proposal.setAuthenticationAlgorithm(IpsecAuthenticationAlgorithm.HMAC_SHA1_96);
-      proposal.setProtocol(IpsecProtocol.ESP);
+      proposal.getProtocols().add(toProtocol(ctx.ipsec_authentication()));
     }
   }
 
@@ -1556,6 +1562,8 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
         || ctx.ESP_SHA512_HMAC() != null
         || ctx.ESP_SHA_HMAC() != null) {
       return IpsecProtocol.ESP;
+    } else if (ctx.AH_SHA_HMAC() != null || ctx.AH_MD5_HMAC() != null) {
+      return IpsecProtocol.AH;
     } else {
       throw convError(IpsecProtocol.class, ctx);
     }
@@ -7836,9 +7844,9 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
 
   private IpsecAuthenticationAlgorithm toIpsecAuthenticationAlgorithm(
       Ipsec_authenticationContext ctx) {
-    if (ctx.ESP_MD5_HMAC() != null) {
+    if (ctx.ESP_MD5_HMAC() != null || ctx.AH_MD5_HMAC() != null) {
       return IpsecAuthenticationAlgorithm.HMAC_MD5_96;
-    } else if (ctx.ESP_SHA_HMAC() != null) {
+    } else if (ctx.ESP_SHA_HMAC() != null || ctx.AH_SHA_HMAC() != null) {
       return IpsecAuthenticationAlgorithm.HMAC_SHA1_96;
     } else if (ctx.ESP_SHA256_HMAC() != null) {
       return IpsecAuthenticationAlgorithm.HMAC_SHA_256_128;
@@ -8040,6 +8048,22 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
         default:
           throw convError(EncryptionAlgorithm.class, ctx);
       }
+    } else if (ctx.ESP_DES() != null) {
+      return EncryptionAlgorithm.DES_CBC;
+    } else if (ctx.ESP_3DES() != null) {
+      return EncryptionAlgorithm.THREEDES_CBC;
+    } else {
+      throw convError(EncryptionAlgorithm.class, ctx);
+    }
+  }
+
+  private EncryptionAlgorithm toEncryptionAlgorithm(Ipsec_encryption_arubaContext ctx) {
+    if (ctx.ESP_AES128() != null) {
+      return EncryptionAlgorithm.AES_128_CBC;
+    } else if (ctx.ESP_AES192() != null) {
+      return EncryptionAlgorithm.AES_192_CBC;
+    } else if (ctx.ESP_AES256() != null) {
+      return EncryptionAlgorithm.AES_256_CBC;
     } else if (ctx.ESP_DES() != null) {
       return EncryptionAlgorithm.DES_CBC;
     } else if (ctx.ESP_3DES() != null) {

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -22,6 +22,7 @@ import static org.batfish.representation.juniper.JuniperStructureUsage.SECURITY_
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -1383,11 +1384,13 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
     }
   }
 
-  private static IpsecProtocol toIpsecProtocol(Ipsec_protocolContext ctx) {
+  private static SortedSet<IpsecProtocol> toIpsecProtocol(Ipsec_protocolContext ctx) {
     if (ctx.AH() != null) {
-      return IpsecProtocol.AH;
+      return ImmutableSortedSet.of(IpsecProtocol.AH);
     } else if (ctx.ESP() != null) {
-      return IpsecProtocol.ESP;
+      return ImmutableSortedSet.of(IpsecProtocol.ESP);
+    } else if (ctx.BUNDLE() != null) {
+      return ImmutableSortedSet.of(IpsecProtocol.AH, IpsecProtocol.ESP);
     } else {
       throw new BatfishException("invalid ipsec protocol: " + ctx.getText());
     }
@@ -4226,8 +4229,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
 
   @Override
   public void exitSeippr_protocol(Seippr_protocolContext ctx) {
-    IpsecProtocol protocol = toIpsecProtocol(ctx.ipsec_protocol());
-    _currentIpsecProposal.setProtocol(protocol);
+    _currentIpsecProposal.setProtocols(toIpsecProtocol(ctx.ipsec_protocol()));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -1130,10 +1130,16 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
       return EncryptionAlgorithm.THREEDES_CBC;
     } else if (ctx.AES_128_CBC() != null) {
       return EncryptionAlgorithm.AES_128_CBC;
+    } else if (ctx.AES_128_GCM() != null) {
+      return EncryptionAlgorithm.AES_128_GCM;
     } else if (ctx.AES_192_CBC() != null) {
       return EncryptionAlgorithm.AES_192_CBC;
+    } else if (ctx.AES_192_GCM() != null) {
+      return EncryptionAlgorithm.AES_192_GCM;
     } else if (ctx.AES_256_CBC() != null) {
       return EncryptionAlgorithm.AES_256_CBC;
+    } else if (ctx.AES_256_GCM() != null) {
+      return EncryptionAlgorithm.AES_256_GCM;
     } else if (ctx.DES_CBC() != null) {
       return EncryptionAlgorithm.DES_CBC;
     } else {

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/VpnConnection.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/VpnConnection.java
@@ -253,7 +253,7 @@ public class VpnConnection implements AwsVpcEntity, Serializable {
           toIpsecAuthenticationAlgorithm(ipsecTunnel.getIpsecAuthProtocol()));
       ipsecProposal.setEncryptionAlgorithm(
           toEncryptionAlgorithm(ipsecTunnel.getIpsecEncryptionProtocol()));
-      ipsecProposal.setProtocol(toIpsecProtocol(ipsecTunnel.getIpsecProtocol()));
+      ipsecProposal.getProtocols().add(toIpsecProtocol(ipsecTunnel.getIpsecProtocol()));
       ipsecProposal.setLifetimeSeconds(ipsecTunnel.getIpsecLifetime());
 
       // ike

--- a/projects/batfish/src/main/java/org/batfish/representation/vyos/VyosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/vyos/VyosConfiguration.java
@@ -220,7 +220,7 @@ public class VyosConfiguration extends VendorConfiguration {
               espProposal.getHashAlgorithm().toIpsecAuthenticationAlgorithm());
           newIpsecProposal.setEncryptionAlgorithm(espProposal.getEncryptionAlgorithm());
           newIpsecProposal.setLifetimeSeconds(espGroup.getLifetimeSeconds());
-          newIpsecProposal.setProtocol(IpsecProtocol.ESP);
+          newIpsecProposal.getProtocols().add(IpsecProtocol.ESP);
         }
       }
     }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -1756,6 +1756,24 @@ public class CiscoGrammarTest {
                     IpsecAuthenticationAlgorithm.HMAC_MD5_96),
                 IpsecProposalMatchers.hasEncryptionAlgorithm(EncryptionAlgorithm.THREEDES_CBC),
                 hasProtocols(ImmutableSortedSet.of(IpsecProtocol.ESP)))));
+    assertThat(
+        c,
+        hasIpsecProposal(
+            "ts6",
+            allOf(
+                IpsecProposalMatchers.hasAuthenticationAlgorithm(
+                    IpsecAuthenticationAlgorithm.HMAC_MD5_96),
+                IpsecProposalMatchers.hasEncryptionAlgorithm(EncryptionAlgorithm.AES_128_GCM),
+                hasProtocols(ImmutableSortedSet.of(IpsecProtocol.ESP)))));
+    assertThat(
+        c,
+        hasIpsecProposal(
+            "ts7",
+            allOf(
+                IpsecProposalMatchers.hasAuthenticationAlgorithm(
+                    IpsecAuthenticationAlgorithm.HMAC_MD5_96),
+                IpsecProposalMatchers.hasEncryptionAlgorithm(EncryptionAlgorithm.AES_256_GCM),
+                hasProtocols(ImmutableSortedSet.of(IpsecProtocol.ESP)))));
   }
 
   @Test
@@ -1788,6 +1806,60 @@ public class CiscoGrammarTest {
                     IpsecAuthenticationAlgorithm.HMAC_MD5_96),
                 IpsecProposalMatchers.hasEncryptionAlgorithm(EncryptionAlgorithm.AES_192_CBC),
                 hasProtocols(ImmutableSortedSet.of(IpsecProtocol.ESP, IpsecProtocol.AH)))));
+    assertThat(
+        c,
+        hasIpsecProposal(
+            "ts4",
+            allOf(
+                IpsecProposalMatchers.hasAuthenticationAlgorithm(
+                    IpsecAuthenticationAlgorithm.HMAC_MD5_96),
+                IpsecProposalMatchers.hasEncryptionAlgorithm(EncryptionAlgorithm.AES_128_GCM),
+                hasProtocols(ImmutableSortedSet.of(IpsecProtocol.ESP)))));
+    assertThat(
+        c,
+        hasIpsecProposal(
+            "ts5",
+            allOf(
+                IpsecProposalMatchers.hasAuthenticationAlgorithm(
+                    IpsecAuthenticationAlgorithm.HMAC_MD5_96),
+                IpsecProposalMatchers.hasEncryptionAlgorithm(EncryptionAlgorithm.AES_256_GCM),
+                hasProtocols(ImmutableSortedSet.of(IpsecProtocol.ESP)))));
+    assertThat(
+        c,
+        hasIpsecProposal(
+            "ts6",
+            allOf(
+                IpsecProposalMatchers.hasAuthenticationAlgorithm(
+                    IpsecAuthenticationAlgorithm.HMAC_MD5_96),
+                IpsecProposalMatchers.hasEncryptionAlgorithm(EncryptionAlgorithm.AES_128_GMAC),
+                hasProtocols(ImmutableSortedSet.of(IpsecProtocol.ESP)))));
+    assertThat(
+        c,
+        hasIpsecProposal(
+            "ts7",
+            allOf(
+                IpsecProposalMatchers.hasAuthenticationAlgorithm(
+                    IpsecAuthenticationAlgorithm.HMAC_MD5_96),
+                IpsecProposalMatchers.hasEncryptionAlgorithm(EncryptionAlgorithm.AES_256_GMAC),
+                hasProtocols(ImmutableSortedSet.of(IpsecProtocol.ESP)))));
+    assertThat(
+        c,
+        hasIpsecProposal(
+            "ts8",
+            allOf(
+                IpsecProposalMatchers.hasAuthenticationAlgorithm(
+                    IpsecAuthenticationAlgorithm.HMAC_MD5_96),
+                IpsecProposalMatchers.hasEncryptionAlgorithm(EncryptionAlgorithm.AES_SEAL_160),
+                hasProtocols(ImmutableSortedSet.of(IpsecProtocol.ESP)))));
+    assertThat(
+        c,
+        hasIpsecProposal(
+            "ts9",
+            allOf(
+                IpsecProposalMatchers.hasAuthenticationAlgorithm(
+                    IpsecAuthenticationAlgorithm.HMAC_MD5_96),
+                IpsecProposalMatchers.hasEncryptionAlgorithm(EncryptionAlgorithm.NULL),
+                hasProtocols(ImmutableSortedSet.of(IpsecProtocol.ESP)))));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -1720,6 +1720,42 @@ public class CiscoGrammarTest {
                     IpsecAuthenticationAlgorithm.HMAC_MD5_96),
                 IpsecProposalMatchers.hasEncryptionAlgorithm(EncryptionAlgorithm.AES_128_CBC),
                 hasProtocols(ImmutableSortedSet.of(IpsecProtocol.ESP)))));
+    assertThat(
+        c,
+        hasIpsecProposal(
+            "ts2",
+            allOf(
+                IpsecProposalMatchers.hasAuthenticationAlgorithm(
+                    IpsecAuthenticationAlgorithm.HMAC_SHA1_96),
+                IpsecProposalMatchers.hasEncryptionAlgorithm(EncryptionAlgorithm.AES_192_CBC),
+                hasProtocols(ImmutableSortedSet.of(IpsecProtocol.ESP)))));
+    assertThat(
+        c,
+        hasIpsecProposal(
+            "ts3",
+            allOf(
+                IpsecProposalMatchers.hasAuthenticationAlgorithm(
+                    IpsecAuthenticationAlgorithm.HMAC_MD5_96),
+                IpsecProposalMatchers.hasEncryptionAlgorithm(EncryptionAlgorithm.AES_256_CBC),
+                hasProtocols(ImmutableSortedSet.of(IpsecProtocol.ESP)))));
+    assertThat(
+        c,
+        hasIpsecProposal(
+            "ts4",
+            allOf(
+                IpsecProposalMatchers.hasAuthenticationAlgorithm(
+                    IpsecAuthenticationAlgorithm.HMAC_SHA1_96),
+                IpsecProposalMatchers.hasEncryptionAlgorithm(EncryptionAlgorithm.DES_CBC),
+                hasProtocols(ImmutableSortedSet.of(IpsecProtocol.ESP)))));
+    assertThat(
+        c,
+        hasIpsecProposal(
+            "ts5",
+            allOf(
+                IpsecProposalMatchers.hasAuthenticationAlgorithm(
+                    IpsecAuthenticationAlgorithm.HMAC_MD5_96),
+                IpsecProposalMatchers.hasEncryptionAlgorithm(EncryptionAlgorithm.THREEDES_CBC),
+                hasProtocols(ImmutableSortedSet.of(IpsecProtocol.ESP)))));
   }
 
   @Test
@@ -1742,6 +1778,15 @@ public class CiscoGrammarTest {
                 IpsecProposalMatchers.hasAuthenticationAlgorithm(
                     IpsecAuthenticationAlgorithm.HMAC_SHA1_96),
                 IpsecProposalMatchers.hasEncryptionAlgorithm(EncryptionAlgorithm.THREEDES_CBC),
+                hasProtocols(ImmutableSortedSet.of(IpsecProtocol.ESP, IpsecProtocol.AH)))));
+    assertThat(
+        c,
+        hasIpsecProposal(
+            "ts3",
+            allOf(
+                IpsecProposalMatchers.hasAuthenticationAlgorithm(
+                    IpsecAuthenticationAlgorithm.HMAC_MD5_96),
+                IpsecProposalMatchers.hasEncryptionAlgorithm(EncryptionAlgorithm.AES_192_CBC),
                 hasProtocols(ImmutableSortedSet.of(IpsecProtocol.ESP, IpsecProtocol.AH)))));
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -1849,7 +1849,7 @@ public class CiscoGrammarTest {
             allOf(
                 IpsecProposalMatchers.hasAuthenticationAlgorithm(
                     IpsecAuthenticationAlgorithm.HMAC_MD5_96),
-                IpsecProposalMatchers.hasEncryptionAlgorithm(EncryptionAlgorithm.AES_SEAL_160),
+                IpsecProposalMatchers.hasEncryptionAlgorithm(EncryptionAlgorithm.SEAL_160),
                 hasProtocols(ImmutableSortedSet.of(IpsecProtocol.ESP)))));
     assertThat(
         c,

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -19,6 +19,7 @@ import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasInterfaces
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasIpAccessList;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasIpAccessLists;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasIpSpace;
+import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasIpsecProposal;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasVendorFamily;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasVrfs;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasAclName;
@@ -63,6 +64,7 @@ import static org.batfish.datamodel.matchers.IpAccessListMatchers.accepts;
 import static org.batfish.datamodel.matchers.IpAccessListMatchers.hasLines;
 import static org.batfish.datamodel.matchers.IpAccessListMatchers.rejects;
 import static org.batfish.datamodel.matchers.IpSpaceMatchers.containsIp;
+import static org.batfish.datamodel.matchers.IpsecProposalMatchers.hasProtocols;
 import static org.batfish.datamodel.matchers.MatchHeaderSpaceMatchers.hasHeaderSpace;
 import static org.batfish.datamodel.matchers.MatchHeaderSpaceMatchers.isMatchHeaderSpaceThat;
 import static org.batfish.datamodel.matchers.OrMatchExprMatchers.hasDisjuncts;
@@ -109,6 +111,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.graph.Network;
 import java.io.IOException;
 import java.util.Arrays;
@@ -142,6 +145,8 @@ import org.batfish.datamodel.InterfaceType;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.IpProtocol;
+import org.batfish.datamodel.IpsecAuthenticationAlgorithm;
+import org.batfish.datamodel.IpsecProtocol;
 import org.batfish.datamodel.MultipathEquivalentAsPathMatchMode;
 import org.batfish.datamodel.NamedPort;
 import org.batfish.datamodel.OspfArea;
@@ -156,6 +161,7 @@ import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
 import org.batfish.datamodel.matchers.ConfigurationMatchers;
 import org.batfish.datamodel.matchers.InterfaceMatchers;
+import org.batfish.datamodel.matchers.IpsecProposalMatchers;
 import org.batfish.datamodel.matchers.OspfAreaMatchers;
 import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
@@ -1700,6 +1706,43 @@ public class CiscoGrammarTest {
 
     Interface i1 = configurations.get(iosHostname).getInterfaces().get(i1Name);
     assertThat(i1, hasDeclaredNames("Ethernet0/0", "e0/0", "Eth0/0", "ether0/0-1"));
+  }
+
+  @Test
+  public void testArubaIpsecTransformset() throws IOException {
+    Configuration c = parseConfig("arubaCryptoTransformSet");
+    assertThat(
+        c,
+        hasIpsecProposal(
+            "ts1",
+            allOf(
+                IpsecProposalMatchers.hasAuthenticationAlgorithm(
+                    IpsecAuthenticationAlgorithm.HMAC_MD5_96),
+                IpsecProposalMatchers.hasEncryptionAlgorithm(EncryptionAlgorithm.AES_128_CBC),
+                hasProtocols(ImmutableSortedSet.of(IpsecProtocol.ESP)))));
+  }
+
+  @Test
+  public void testIpsecTransformset() throws IOException {
+    Configuration c = parseConfig("ios-crypto-transform-set");
+    assertThat(
+        c,
+        hasIpsecProposal(
+            "ts1",
+            allOf(
+                IpsecProposalMatchers.hasAuthenticationAlgorithm(
+                    IpsecAuthenticationAlgorithm.HMAC_MD5_96),
+                IpsecProposalMatchers.hasEncryptionAlgorithm(EncryptionAlgorithm.AES_256_CBC),
+                hasProtocols(ImmutableSortedSet.of(IpsecProtocol.ESP)))));
+    assertThat(
+        c,
+        hasIpsecProposal(
+            "ts2",
+            allOf(
+                IpsecProposalMatchers.hasAuthenticationAlgorithm(
+                    IpsecAuthenticationAlgorithm.HMAC_SHA1_96),
+                IpsecProposalMatchers.hasEncryptionAlgorithm(EncryptionAlgorithm.THREEDES_CBC),
+                hasProtocols(ImmutableSortedSet.of(IpsecProtocol.ESP, IpsecProtocol.AH)))));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -1283,6 +1283,33 @@ public class FlatJuniperGrammarTest {
                     IpsecAuthenticationAlgorithm.HMAC_MD5_96),
                 IpsecProposalMatchers.hasEncryptionAlgorithm(EncryptionAlgorithm.THREEDES_CBC),
                 hasProtocols(ImmutableSortedSet.of(IpsecProtocol.ESP)))));
+    assertThat(
+        c,
+        hasIpsecProposal(
+            "prop4",
+            allOf(
+                IpsecProposalMatchers.hasAuthenticationAlgorithm(
+                    IpsecAuthenticationAlgorithm.HMAC_MD5_96),
+                IpsecProposalMatchers.hasEncryptionAlgorithm(EncryptionAlgorithm.AES_128_GCM),
+                hasProtocols(ImmutableSortedSet.of(IpsecProtocol.ESP)))));
+    assertThat(
+        c,
+        hasIpsecProposal(
+            "prop5",
+            allOf(
+                IpsecProposalMatchers.hasAuthenticationAlgorithm(
+                    IpsecAuthenticationAlgorithm.HMAC_MD5_96),
+                IpsecProposalMatchers.hasEncryptionAlgorithm(EncryptionAlgorithm.AES_192_GCM),
+                hasProtocols(ImmutableSortedSet.of(IpsecProtocol.ESP)))));
+    assertThat(
+        c,
+        hasIpsecProposal(
+            "prop6",
+            allOf(
+                IpsecProposalMatchers.hasAuthenticationAlgorithm(
+                    IpsecAuthenticationAlgorithm.HMAC_MD5_96),
+                IpsecProposalMatchers.hasEncryptionAlgorithm(EncryptionAlgorithm.AES_256_GCM),
+                hasProtocols(ImmutableSortedSet.of(IpsecProtocol.ESP)))));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -1265,6 +1265,24 @@ public class FlatJuniperGrammarTest {
                     IpsecAuthenticationAlgorithm.HMAC_MD5_96),
                 IpsecProposalMatchers.hasEncryptionAlgorithm(EncryptionAlgorithm.AES_128_CBC),
                 hasProtocols(ImmutableSortedSet.of(IpsecProtocol.ESP, IpsecProtocol.AH)))));
+    assertThat(
+        c,
+        hasIpsecProposal(
+            "prop2",
+            allOf(
+                IpsecProposalMatchers.hasAuthenticationAlgorithm(
+                    IpsecAuthenticationAlgorithm.HMAC_SHA1_96),
+                IpsecProposalMatchers.hasEncryptionAlgorithm(EncryptionAlgorithm.AES_192_CBC),
+                hasProtocols(ImmutableSortedSet.of(IpsecProtocol.AH)))));
+    assertThat(
+        c,
+        hasIpsecProposal(
+            "prop3",
+            allOf(
+                IpsecProposalMatchers.hasAuthenticationAlgorithm(
+                    IpsecAuthenticationAlgorithm.HMAC_MD5_96),
+                IpsecProposalMatchers.hasEncryptionAlgorithm(EncryptionAlgorithm.THREEDES_CBC),
+                hasProtocols(ImmutableSortedSet.of(IpsecProtocol.ESP)))));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -10,6 +10,7 @@ import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasDefaultVrf
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasInterface;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasInterfaces;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasIpAccessList;
+import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasIpsecProposal;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasVrf;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasVrfs;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasNumReferrers;
@@ -31,6 +32,7 @@ import static org.batfish.datamodel.matchers.InterfaceMatchers.isOspfPassive;
 import static org.batfish.datamodel.matchers.IpAccessListMatchers.accepts;
 import static org.batfish.datamodel.matchers.IpAccessListMatchers.rejects;
 import static org.batfish.datamodel.matchers.IpSpaceMatchers.containsIp;
+import static org.batfish.datamodel.matchers.IpsecProposalMatchers.hasProtocols;
 import static org.batfish.datamodel.matchers.LiteralIntMatcher.hasVal;
 import static org.batfish.datamodel.matchers.LiteralIntMatcher.isLiteralIntThat;
 import static org.batfish.datamodel.matchers.OspfAreaSummaryMatchers.hasMetric;
@@ -49,6 +51,7 @@ import static org.batfish.representation.juniper.JuniperConfiguration.ACL_NAME_S
 import static org.batfish.representation.juniper.JuniperConfiguration.computeOspfExportPolicyName;
 import static org.batfish.representation.juniper.JuniperConfiguration.computePeerExportPolicyName;
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.emptyIterable;
@@ -64,6 +67,7 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Iterables;
 import java.io.IOException;
 import java.util.Arrays;
@@ -81,6 +85,7 @@ import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.BgpRoute;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConnectedRoute;
+import org.batfish.datamodel.EncryptionAlgorithm;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.InterfaceAddress;
@@ -90,6 +95,8 @@ import org.batfish.datamodel.IpAccessListLine;
 import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.IpWildcard;
+import org.batfish.datamodel.IpsecAuthenticationAlgorithm;
+import org.batfish.datamodel.IpsecProtocol;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.LocalRoute;
 import org.batfish.datamodel.MultipathEquivalentAsPathMatchMode;
@@ -106,6 +113,7 @@ import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
 import org.batfish.datamodel.answers.InitInfoAnswerElement;
 import org.batfish.datamodel.matchers.IpAccessListMatchers;
+import org.batfish.datamodel.matchers.IpsecProposalMatchers;
 import org.batfish.datamodel.matchers.OspfAreaMatchers;
 import org.batfish.datamodel.matchers.RouteFilterListMatchers;
 import org.batfish.datamodel.routing_policy.Environment;
@@ -1243,6 +1251,20 @@ public class FlatJuniperGrammarTest {
                                         .build()))
                             .setName("TERM")
                             .build())))));
+  }
+
+  @Test
+  public void testIpsecProposal() throws IOException {
+    Configuration c = parseConfig("ipsec-proposal");
+    assertThat(
+        c,
+        hasIpsecProposal(
+            "prop1",
+            allOf(
+                IpsecProposalMatchers.hasAuthenticationAlgorithm(
+                    IpsecAuthenticationAlgorithm.HMAC_MD5_96),
+                IpsecProposalMatchers.hasEncryptionAlgorithm(EncryptionAlgorithm.AES_128_CBC),
+                hasProtocols(ImmutableSortedSet.of(IpsecProtocol.ESP, IpsecProtocol.AH)))));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/arubaCryptoTransformSet
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/arubaCryptoTransformSet
@@ -2,6 +2,14 @@
 hostname arubaCryptoTransformSet
 !
 crypto ipsec transform-set ts1 esp-aes128 esp-md5-hmac
+!
+crypto ipsec transform-set ts2 esp-aes192 esp-sha-hmac
+!
+crypto ipsec transform-set ts3 esp-aes256 esp-md5-hmac
+!
+crypto ipsec transform-set ts4 esp-des esp-sha-hmac
+!
+crypto ipsec transform-set ts5 esp-3des esp-md5-hmac
 
 
 

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/arubaCryptoTransformSet
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/arubaCryptoTransformSet
@@ -1,0 +1,7 @@
+!
+hostname arubaCryptoTransformSet
+!
+crypto ipsec transform-set ts1 esp-aes128 esp-md5-hmac
+
+
+

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/arubaCryptoTransformSet
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/arubaCryptoTransformSet
@@ -10,6 +10,8 @@ crypto ipsec transform-set ts3 esp-aes256 esp-md5-hmac
 crypto ipsec transform-set ts4 esp-des esp-sha-hmac
 !
 crypto ipsec transform-set ts5 esp-3des esp-md5-hmac
-
-
-
+!
+crypto ipsec transform-set ts6 esp-aes128-gcm esp-md5-hmac
+!
+crypto ipsec transform-set ts7 esp-aes256-gcm esp-md5-hmac
+!

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-crypto-transform-set
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-crypto-transform-set
@@ -7,5 +7,8 @@ crypto ipsec transform-set ts1 esp-aes 256 esp-md5-hmac
 crypto ipsec transform-set ts2 esp-3des ah-sha-hmac
  mode tunnel
 !
+crypto ipsec transform-set ts3 esp-aes 192 ah-md5-hmac
+ mode tunnel
+!
 
 

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-crypto-transform-set
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-crypto-transform-set
@@ -1,0 +1,11 @@
+!
+hostname ios-crypto-transform-set
+!
+crypto ipsec transform-set ts1 esp-aes 256 esp-md5-hmac
+ mode tunnel
+!
+crypto ipsec transform-set ts2 esp-3des ah-sha-hmac
+ mode tunnel
+!
+
+

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-crypto-transform-set
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-crypto-transform-set
@@ -10,5 +10,25 @@ crypto ipsec transform-set ts2 esp-3des ah-sha-hmac
 crypto ipsec transform-set ts3 esp-aes 192 ah-md5-hmac
  mode tunnel
 !
+crypto ipsec transform-set ts4 esp-gcm  esp-md5-hmac
+ mode tunnel
+!
+crypto ipsec transform-set ts5 esp-gcm 256  esp-md5-hmac
+ mode tunnel
+!
+crypto ipsec transform-set ts6 esp-gmac esp-md5-hmac
+ mode tunnel
+!
+crypto ipsec transform-set ts7 esp-gmac 256  esp-md5-hmac
+ mode tunnel
+!
+crypto ipsec transform-set ts8 esp-seal esp-md5-hmac
+ mode tunnel
+!
+crypto ipsec transform-set ts9 esp-null esp-md5-hmac
+ mode tunnel
+!
+
+
 
 

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/ipsec-proposal
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/ipsec-proposal
@@ -1,0 +1,6 @@
+#
+set system host-name ipsec-proposal
+#
+set security ipsec proposal prop1 authentication-algorithm hmac-md5-96
+set security ipsec proposal prop1 encryption-algorithm aes-128-cbc
+set security ipsec proposal prop1 protocol bundle

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/ipsec-proposal
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/ipsec-proposal
@@ -12,3 +12,15 @@ set security ipsec proposal prop2 protocol ah
 set security ipsec proposal prop3 authentication-algorithm hmac-md5-96
 set security ipsec proposal prop3 encryption-algorithm 3des-cbc
 set security ipsec proposal prop3 protocol esp
+#
+set security ipsec proposal prop4 authentication-algorithm hmac-md5-96
+set security ipsec proposal prop4 encryption-algorithm aes-128-gcm
+set security ipsec proposal prop4 protocol esp
+#
+set security ipsec proposal prop5 authentication-algorithm hmac-md5-96
+set security ipsec proposal prop5 encryption-algorithm aes-192-gcm
+set security ipsec proposal prop5 protocol esp
+#
+set security ipsec proposal prop6 authentication-algorithm hmac-md5-96
+set security ipsec proposal prop6 encryption-algorithm aes-256-gcm
+set security ipsec proposal prop6 protocol esp

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/ipsec-proposal
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/ipsec-proposal
@@ -4,3 +4,11 @@ set system host-name ipsec-proposal
 set security ipsec proposal prop1 authentication-algorithm hmac-md5-96
 set security ipsec proposal prop1 encryption-algorithm aes-128-cbc
 set security ipsec proposal prop1 protocol bundle
+#
+set security ipsec proposal prop2 authentication-algorithm hmac-sha1-96
+set security ipsec proposal prop2 encryption-algorithm aes-192-cbc
+set security ipsec proposal prop2 protocol ah
+#
+set security ipsec proposal prop3 authentication-algorithm hmac-md5-96
+set security ipsec proposal prop3 encryption-algorithm 3des-cbc
+set security ipsec proposal prop3 protocol esp

--- a/tests/aws/nodes-example-aws.ref
+++ b/tests/aws/nodes-example-aws.ref
@@ -1018,13 +1018,17 @@
             "name" : "ipsec-prop-vpn-ba2e34a8-0",
             "authenticationAlgorithm" : "HMAC_SHA1_96",
             "encryptionAlgorithm" : "AES_128_CBC",
-            "protocol" : "ESP"
+            "protocols" : [
+              "ESP"
+            ]
           },
           "ipsec-prop-vpn-ba2e34a8-1" : {
             "name" : "ipsec-prop-vpn-ba2e34a8-1",
             "authenticationAlgorithm" : "HMAC_SHA1_96",
             "encryptionAlgorithm" : "AES_128_CBC",
-            "protocol" : "ESP"
+            "protocols" : [
+              "ESP"
+            ]
           }
         },
         "ipsecVpns" : {
@@ -3827,14 +3831,18 @@
             "authenticationAlgorithm" : "HMAC_SHA1_96",
             "encryptionAlgorithm" : "AES_128_CBC",
             "lifetimeSeconds" : 3600,
-            "protocol" : "ESP"
+            "protocols" : [
+              "ESP"
+            ]
           },
           "vpn-ba2e34a8-2" : {
             "name" : "vpn-ba2e34a8-2",
             "authenticationAlgorithm" : "HMAC_SHA1_96",
             "encryptionAlgorithm" : "AES_128_CBC",
             "lifetimeSeconds" : 3600,
-            "protocol" : "ESP"
+            "protocols" : [
+              "ESP"
+            ]
           }
         },
         "ipsecVpns" : {

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -5750,31 +5750,40 @@
             "name" : "ESP-3DES-MD5",
             "authenticationAlgorithm" : "HMAC_MD5_96",
             "encryptionAlgorithm" : "THREEDES_CBC",
-            "protocol" : "ESP"
+            "protocols" : [
+              "ESP"
+            ]
           },
           "IPSEC_AES_256" : {
             "name" : "IPSEC_AES_256",
             "authenticationAlgorithm" : "HMAC_SHA1_96",
             "encryptionAlgorithm" : "AES_256_CBC",
-            "protocol" : "ESP"
+            "protocols" : [
+              "ESP"
+            ]
           },
           "cipts1" : {
             "name" : "cipts1",
             "authenticationAlgorithm" : "HMAC_SHA_256_128",
             "encryptionAlgorithm" : "AES_256_CBC",
-            "protocol" : "ESP"
+            "protocols" : [
+              "ESP"
+            ]
           },
           "cipts2" : {
             "name" : "cipts2",
             "authenticationAlgorithm" : "HMAC_SHA_512",
             "encryptionAlgorithm" : "AES_256_CBC",
-            "protocol" : "ESP"
+            "protocols" : [
+              "ESP"
+            ]
           },
           "noAuthHeader" : {
             "name" : "noAuthHeader",
-            "authenticationAlgorithm" : "HMAC_SHA1_96",
             "encryptionAlgorithm" : "AES_256_CBC",
-            "protocol" : "ESP"
+            "protocols" : [
+              "ESP"
+            ]
           }
         },
         "vendorFamily" : {


### PR DESCRIPTION
 - Included representation for  authentication algorithms  using the `Authentication Header` protocol in Cisco and Juniper transform-sets to the data-model([cisco](https://www.cisco.com/c/en/us/td/docs/ios/12_2/security/command/reference/srfipsec.html#wp1017694), [juniper](https://www.juniper.net/documentation/en_US/junos/topics/task/configuration/services-ipsec-proposals-configuring.html))

- Added rules for parsing  Aruba ESP encryption algorithm names  having the format - `esp-aes[XXX]` 