### PR TITLE
ibdp: support neighbor-specific generated routes

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/GeneratedRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/GeneratedRoute.java
@@ -34,23 +34,35 @@ public final class GeneratedRoute extends AbstractRoute {
 
     @Override
     public GeneratedRoute build() {
-      GeneratedRoute gr =
-          new GeneratedRoute(
-              getNetwork(),
-              getAdmin(),
-              getNextHopIp(),
-              new AsPath(_asPath),
-              _attributePolicy,
-              _discard,
-              _generationPolicy,
-              getMetric(),
-              _nextHopInterface);
-      return gr;
+      return new GeneratedRoute(
+          getNetwork(),
+          getAdmin(),
+          getNextHopIp(),
+          new AsPath(_asPath),
+          _attributePolicy,
+          _discard,
+          _generationPolicy,
+          getMetric(),
+          _nextHopInterface);
     }
 
     @Override
     protected Builder getThis() {
       return this;
+    }
+
+    public static Builder fromRoute(GeneratedRoute route) {
+      return new Builder()
+          // General route properties
+          .setNetwork(route.getNetwork())
+          .setMetric(firstNonNull(route.getMetric(), 0L))
+          .setAdmin(route.getAdministrativeCost())
+          // GeneratedRoute properties
+          .setAsPath(route.getAsPath().getAsSets())
+          .setAttributePolicy(route.getAttributePolicy())
+          .setDiscard(route.getDiscard())
+          .setGenerationPolicy(route.getGenerationPolicy())
+          .setNextHopInterface(route.getNextHopInterface());
     }
 
     public Builder setAsPath(List<SortedSet<Long>> asPath) {

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -2413,7 +2413,6 @@ public class VirtualRouter extends ComparableStructure<String> {
    */
   @Nullable
   private BgpRoute processNeighborSpecificGeneratedRoute(@Nonnull GeneratedRoute generatedRoute) {
-
     String policyName = generatedRoute.getGenerationPolicy();
     RoutingPolicy policy = policyName != null ? _c.getRoutingPolicies().get(policyName) : null;
     GeneratedRoute.Builder builder =

--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
@@ -8,8 +8,10 @@ import javax.annotation.Nullable;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.BgpNeighbor;
 import org.batfish.datamodel.BgpRoute;
+import org.batfish.datamodel.GeneratedRoute;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.OriginType;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Route;
 import org.batfish.datamodel.RoutingProtocol;
@@ -203,5 +205,30 @@ public class BgpProtocolHelper {
     transformedIncomingRouteBuilder.setSrcProtocol(targetProtocol);
 
     return transformedIncomingRouteBuilder;
+  }
+
+  /**
+   * Convert an aggregate/generated route to a BGP route.
+   *
+   * @param generatedRoute a {@link GeneratedRoute} to convert to a {@link BgpRoute}.
+   * @param routerId Router ID to set as the originatorIp for the resulting BGP route.
+   */
+  public static BgpRoute convertGeneratedRouteToBgp(GeneratedRoute generatedRoute, Ip routerId) {
+    BgpRoute.Builder b = new BgpRoute.Builder();
+    b.setAdmin(generatedRoute.getAdministrativeCost());
+    b.setAsPath(generatedRoute.getAsPath().getAsSets());
+    b.setMetric(generatedRoute.getMetric());
+    b.setSrcProtocol(RoutingProtocol.AGGREGATE);
+    b.setProtocol(RoutingProtocol.AGGREGATE);
+    b.setNetwork(generatedRoute.getNetwork());
+    b.setLocalPreference(BgpRoute.DEFAULT_LOCAL_PREFERENCE);
+    /*
+     * Note: Origin type and originator IP should get overwritten by export policy,
+     * but are needed initially
+     */
+    b.setOriginatorIp(routerId);
+    b.setOriginType(OriginType.INCOMPLETE);
+    b.setReceivedFromIp(Ip.ZERO);
+    return b.build();
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/GeneratedRouteHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/GeneratedRouteHelper.java
@@ -1,0 +1,60 @@
+package org.batfish.dataplane.protocols;
+
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.batfish.datamodel.AbstractRoute;
+import org.batfish.datamodel.GeneratedRoute;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.routing_policy.Environment.Direction;
+import org.batfish.datamodel.routing_policy.RoutingPolicy;
+
+/**
+ * Contains helper logic for manipulating {@link GeneratedRoute} objects in the context of dataplane
+ * computation.
+ */
+public class GeneratedRouteHelper {
+
+  /**
+   * Check if a given generated route should be activated. If yes, return an appropriate {@link
+   * GeneratedRoute.Builder}. Otherwise return {@code null}.
+   *
+   * @param generatedRoute a {@link GeneratedRoute} that should be run though a routing policy
+   * @param policy a {@link RoutingPolicy} that imposes additional constraints on route activation.
+   *     If {@code null}, then route will be considered ready for activation.
+   * @param contributingRoutes A set of routes that can contribute trigger route's activation.
+   *     Usually a set of routes from the Main RIB.
+   * @param vrfName VRF name in which the {@code generatedRoute} resides.
+   * @return A generated route builder, or {@code null} if the route should not be activated.
+   */
+  @Nullable
+  public static GeneratedRoute.Builder activateGeneratedRoute(
+      GeneratedRoute generatedRoute,
+      @Nullable RoutingPolicy policy,
+      Set<AbstractRoute> contributingRoutes,
+      String vrfName) {
+    boolean active = true;
+    GeneratedRoute.Builder grb = GeneratedRoute.Builder.fromRoute(generatedRoute);
+
+    // Null route if necessary
+    if (generatedRoute.getDiscard()) {
+      grb.setNextHopInterface(Interface.NULL_INTERFACE_NAME);
+    }
+
+    if (policy != null) {
+      active = false;
+      // Find first matching route among candidates
+      for (AbstractRoute contributingCandidate : contributingRoutes) {
+        boolean accept = policy.process(contributingCandidate, grb, null, vrfName, Direction.OUT);
+        if (accept) {
+          if (!generatedRoute.getDiscard()) {
+            grb.setNextHopIp(contributingCandidate.getNextHopIp());
+          }
+          active = true;
+          break;
+        }
+      }
+    }
+
+    return active ? grb : null;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -1934,9 +1934,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
           If defaultRouteGenerationConditional =
               new If(
                   ipv4 ? MATCH_DEFAULT_ROUTE : MATCH_DEFAULT_ROUTE6,
-                  ImmutableList.of(
-                      new SetOrigin(new LiteralOrigin(OriginType.IGP, null)),
-                      Statements.ReturnTrue.toStaticStatement()));
+                  ImmutableList.of(Statements.ReturnTrue.toStaticStatement()));
           RoutingPolicy defaultRouteGenerationPolicy =
               new RoutingPolicy(
                   "~BGP_DEFAULT_ROUTE_GENERATION_POLICY:" + vrfName + ":" + lpg.getName() + "~", c);

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/GeneratedRouteHelperTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/GeneratedRouteHelperTest.java
@@ -1,0 +1,71 @@
+package org.batfish.dataplane.protocols;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.GeneratedRoute;
+import org.batfish.datamodel.GeneratedRoute.Builder;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.routing_policy.RoutingPolicy;
+import org.batfish.datamodel.routing_policy.statement.Statements;
+import org.junit.Before;
+import org.junit.Test;
+
+/** Tests for {@link GeneratedRouteHelper}. */
+public class GeneratedRouteHelperTest {
+
+  private GeneratedRoute.Builder _builder;
+
+  @Before
+  public void setup() {
+    _builder = new Builder();
+  }
+
+  @Test
+  public void activateWhenPolicyIsNull() {
+    GeneratedRoute gr = _builder.setNetwork(Prefix.ZERO).build();
+
+    Builder newRoute =
+        GeneratedRouteHelper.activateGeneratedRoute(gr, null, ImmutableSet.of(), "vrf");
+
+    assertThat(newRoute, notNullValue());
+  }
+
+  @Test
+  public void testDiscardIsHonored() {
+    GeneratedRoute gr = _builder.setDiscard(true).setNetwork(Prefix.ZERO).build();
+
+    GeneratedRouteHelper.activateGeneratedRoute(gr, null, ImmutableSet.of(), "vrf");
+
+    assertThat(gr.getDiscard(), equalTo(true));
+  }
+
+  @Test
+  public void doNotActivateWithoutPolicyMatch() {
+    GeneratedRoute gr = _builder.setDiscard(true).setNetwork(Prefix.parse("1.1.1.0/24")).build();
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c =
+        nf.configurationBuilder()
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .setHostname("n1")
+            .build();
+
+    RoutingPolicy policy =
+        nf.routingPolicyBuilder()
+            .setName("no match")
+            .setOwner(c)
+            .setStatements(ImmutableList.of(Statements.ReturnFalse.toStaticStatement()))
+            .build();
+
+    Builder newRoute =
+        GeneratedRouteHelper.activateGeneratedRoute(gr, policy, ImmutableSet.of(), "vrf");
+    assertThat(newRoute, nullValue());
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/GeneratedRouteHelperTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/GeneratedRouteHelperTest.java
@@ -13,6 +13,7 @@ import org.batfish.datamodel.GeneratedRoute;
 import org.batfish.datamodel.GeneratedRoute.Builder;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.StaticRoute;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
 import org.batfish.datamodel.routing_policy.statement.Statements;
 import org.junit.Before;
@@ -67,5 +68,32 @@ public class GeneratedRouteHelperTest {
     Builder newRoute =
         GeneratedRouteHelper.activateGeneratedRoute(gr, policy, ImmutableSet.of(), "vrf");
     assertThat(newRoute, nullValue());
+  }
+
+  @Test
+  public void activateWithPolicyMatch() {
+    GeneratedRoute gr = _builder.setDiscard(true).setNetwork(Prefix.parse("1.1.1.0/24")).build();
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c =
+        nf.configurationBuilder()
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .setHostname("n1")
+            .build();
+
+    RoutingPolicy policy =
+        nf.routingPolicyBuilder()
+            .setName("always match")
+            .setOwner(c)
+            .setStatements(ImmutableList.of(Statements.ReturnTrue.toStaticStatement()))
+            .build();
+
+    Builder newRoute =
+        GeneratedRouteHelper.activateGeneratedRoute(
+            gr,
+            policy,
+            ImmutableSet.of(new StaticRoute(Prefix.parse("2.2.2.2/32"), null, "eth0", 1, 1)),
+            "vrf");
+
+    assertThat(newRoute, notNullValue());
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoNxosTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoNxosTest.java
@@ -23,7 +23,6 @@ import org.batfish.datamodel.GenericRib;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
 import org.batfish.main.Batfish;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -107,7 +106,6 @@ public class CiscoNxosTest {
 
   // Neighbor default-originate overrides outbound route map.
   @Test
-  @Ignore("https://github.com/batfish/batfish/issues/1351")
   public void testDefaultOriginate() throws Exception {
     GenericRib<AbstractRoute> listenerRib =
         parseDpAndGetRib(

--- a/tests/aws/nodes-example-aws.ref
+++ b/tests/aws/nodes-example-aws.ref
@@ -1237,13 +1237,6 @@
                 },
                 "trueStatements" : [
                   {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.SetOrigin",
-                    "originType" : {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralOrigin",
-                      "originType" : "igp"
-                    }
-                  },
-                  {
                     "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
                     "type" : "ReturnTrue"
                   }
@@ -1270,13 +1263,6 @@
                   }
                 },
                 "trueStatements" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.SetOrigin",
-                    "originType" : {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralOrigin",
-                      "originType" : "igp"
-                    }
-                  },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
                     "type" : "ReturnTrue"


### PR DESCRIPTION
Fixes #1351 

- Send neighbor-specific generated routes upon session establishment
- Split & test some generatedRoute logic from VirtualRouter
- Un-skip NxOs default-originate test

*Note* Change to CiscoConfiguration:
We were using a setOrigin statement on a generatedRoute policy, which would crash. This change uncovered that code path, so made a fix. Proper origin-set is still executed using per-peer bgp export policy (because of #1528)