### PR TITLE
Multipath-relax should enable ebgp multipath 

### DIFF
--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpProcessMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpProcessMatchers.java
@@ -7,8 +7,10 @@ import javax.annotation.Nonnull;
 import org.batfish.datamodel.BgpNeighbor;
 import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.MultipathEquivalentAsPathMatchMode;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.matchers.BgpProcessMatchersImpl.HasMultipathEbgp;
+import org.batfish.datamodel.matchers.BgpProcessMatchersImpl.HasMultipathEquivalentAsPathMatchMode;
 import org.batfish.datamodel.matchers.BgpProcessMatchersImpl.HasMultipathIbgp;
 import org.batfish.datamodel.matchers.BgpProcessMatchersImpl.HasNeighbor;
 import org.batfish.datamodel.matchers.BgpProcessMatchersImpl.HasNeighbors;
@@ -32,6 +34,15 @@ public class BgpProcessMatchers {
    */
   public static HasMultipathEbgp hasMultipathEbgp(@Nonnull Matcher<? super Boolean> subMatcher) {
     return new HasMultipathEbgp(subMatcher);
+  }
+
+  /**
+   * Provides a matcher that matches if the provides {@code subMatcher} matches whther the BGP
+   * process has specified {@link MultipathEquivalentAsPathMatchMode}.
+   */
+  public static HasMultipathEquivalentAsPathMatchMode hasMultipathEquivalentAsPathMatchMode(
+      MultipathEquivalentAsPathMatchMode mode) {
+    return new HasMultipathEquivalentAsPathMatchMode(equalTo(mode));
   }
 
   /**

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpProcessMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpProcessMatchersImpl.java
@@ -5,6 +5,7 @@ import javax.annotation.Nonnull;
 import org.batfish.datamodel.BgpNeighbor;
 import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.MultipathEquivalentAsPathMatchMode;
 import org.batfish.datamodel.Prefix;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
@@ -66,6 +67,22 @@ final class BgpProcessMatchersImpl {
     @Override
     protected Ip featureValueOf(BgpProcess actual) {
       return actual.getRouterId();
+    }
+  }
+
+  static final class HasMultipathEquivalentAsPathMatchMode
+      extends FeatureMatcher<BgpProcess, MultipathEquivalentAsPathMatchMode> {
+    public HasMultipathEquivalentAsPathMatchMode(
+        Matcher<? super MultipathEquivalentAsPathMatchMode> subMatcher) {
+      super(
+          subMatcher,
+          "A BGP process with multipath equivalency match mode:",
+          "multipath equivalency match mode");
+    }
+
+    @Override
+    protected MultipathEquivalentAsPathMatchMode featureValueOf(BgpProcess bgpProcess) {
+      return bgpProcess.getMultipathEquivalentAsPathMatchMode();
     }
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -8,6 +8,8 @@ import static org.batfish.datamodel.matchers.AbstractRouteMatchers.hasPrefix;
 import static org.batfish.datamodel.matchers.AndMatchExprMatchers.hasConjuncts;
 import static org.batfish.datamodel.matchers.AndMatchExprMatchers.isAndMatchExprThat;
 import static org.batfish.datamodel.matchers.BgpNeighborMatchers.hasRemoteAs;
+import static org.batfish.datamodel.matchers.BgpProcessMatchers.hasMultipathEbgp;
+import static org.batfish.datamodel.matchers.BgpProcessMatchers.hasMultipathEquivalentAsPathMatchMode;
 import static org.batfish.datamodel.matchers.BgpProcessMatchers.hasNeighbor;
 import static org.batfish.datamodel.matchers.BgpProcessMatchers.hasNeighbors;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasConfigurationFormat;
@@ -1375,22 +1377,22 @@ public class CiscoGrammarTest {
         configurations.get("nxos_enabled").getDefaultVrf().getBgpProcess();
 
     assertThat(
-        aristaDisabled.getMultipathEquivalentAsPathMatchMode(),
-        equalTo(MultipathEquivalentAsPathMatchMode.EXACT_PATH));
+        aristaDisabled,
+        hasMultipathEquivalentAsPathMatchMode(MultipathEquivalentAsPathMatchMode.EXACT_PATH));
     assertThat(
-        aristaEnabled.getMultipathEquivalentAsPathMatchMode(),
-        equalTo(MultipathEquivalentAsPathMatchMode.PATH_LENGTH));
+        aristaEnabled,
+        hasMultipathEquivalentAsPathMatchMode(MultipathEquivalentAsPathMatchMode.PATH_LENGTH));
     assertThat(
-        nxosDisabled.getMultipathEquivalentAsPathMatchMode(),
-        equalTo(MultipathEquivalentAsPathMatchMode.EXACT_PATH));
+        nxosDisabled,
+        hasMultipathEquivalentAsPathMatchMode(MultipathEquivalentAsPathMatchMode.EXACT_PATH));
     assertThat(
-        nxosEnabled.getMultipathEquivalentAsPathMatchMode(),
-        equalTo(MultipathEquivalentAsPathMatchMode.PATH_LENGTH));
+        nxosEnabled,
+        hasMultipathEquivalentAsPathMatchMode(MultipathEquivalentAsPathMatchMode.PATH_LENGTH));
 
-    assertThat(aristaDisabled.getMultipathEbgp(), equalTo(false));
-    assertThat(aristaEnabled.getMultipathEbgp(), equalTo(true));
-    assertThat(nxosDisabled.getMultipathEbgp(), equalTo(false));
-    assertThat(nxosEnabled.getMultipathEbgp(), equalTo(true));
+    assertThat(aristaDisabled, hasMultipathEbgp(false));
+    assertThat(aristaEnabled, hasMultipathEbgp(true));
+    assertThat(nxosDisabled, hasMultipathEbgp(false));
+    assertThat(nxosEnabled, hasMultipathEbgp(true));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -1365,35 +1365,32 @@ public class CiscoGrammarTest {
     Map<String, Configuration> configurations = batfish.loadConfigurations();
     Map<Ip, Set<String>> ipOwners = CommonUtil.computeIpNodeOwners(configurations, true);
     CommonUtil.initBgpTopology(configurations, ipOwners, false);
-    MultipathEquivalentAsPathMatchMode aristaDisabled =
-        configurations
-            .get("arista_disabled")
-            .getDefaultVrf()
-            .getBgpProcess()
-            .getMultipathEquivalentAsPathMatchMode();
-    MultipathEquivalentAsPathMatchMode aristaEnabled =
-        configurations
-            .get("arista_enabled")
-            .getDefaultVrf()
-            .getBgpProcess()
-            .getMultipathEquivalentAsPathMatchMode();
-    MultipathEquivalentAsPathMatchMode nxosDisabled =
-        configurations
-            .get("nxos_disabled")
-            .getDefaultVrf()
-            .getBgpProcess()
-            .getMultipathEquivalentAsPathMatchMode();
-    MultipathEquivalentAsPathMatchMode nxosEnabled =
-        configurations
-            .get("nxos_enabled")
-            .getDefaultVrf()
-            .getBgpProcess()
-            .getMultipathEquivalentAsPathMatchMode();
+    org.batfish.datamodel.BgpProcess aristaDisabled =
+        configurations.get("arista_disabled").getDefaultVrf().getBgpProcess();
+    org.batfish.datamodel.BgpProcess aristaEnabled =
+        configurations.get("arista_enabled").getDefaultVrf().getBgpProcess();
+    org.batfish.datamodel.BgpProcess nxosDisabled =
+        configurations.get("nxos_disabled").getDefaultVrf().getBgpProcess();
+    org.batfish.datamodel.BgpProcess nxosEnabled =
+        configurations.get("nxos_enabled").getDefaultVrf().getBgpProcess();
 
-    assertThat(aristaDisabled, equalTo(MultipathEquivalentAsPathMatchMode.EXACT_PATH));
-    assertThat(aristaEnabled, equalTo(MultipathEquivalentAsPathMatchMode.PATH_LENGTH));
-    assertThat(nxosDisabled, equalTo(MultipathEquivalentAsPathMatchMode.EXACT_PATH));
-    assertThat(nxosEnabled, equalTo(MultipathEquivalentAsPathMatchMode.PATH_LENGTH));
+    assertThat(
+        aristaDisabled.getMultipathEquivalentAsPathMatchMode(),
+        equalTo(MultipathEquivalentAsPathMatchMode.EXACT_PATH));
+    assertThat(
+        aristaEnabled.getMultipathEquivalentAsPathMatchMode(),
+        equalTo(MultipathEquivalentAsPathMatchMode.PATH_LENGTH));
+    assertThat(
+        nxosDisabled.getMultipathEquivalentAsPathMatchMode(),
+        equalTo(MultipathEquivalentAsPathMatchMode.EXACT_PATH));
+    assertThat(
+        nxosEnabled.getMultipathEquivalentAsPathMatchMode(),
+        equalTo(MultipathEquivalentAsPathMatchMode.PATH_LENGTH));
+
+    assertThat(aristaDisabled.getMultipathEbgp(), equalTo(false));
+    assertThat(aristaEnabled.getMultipathEbgp(), equalTo(true));
+    assertThat(nxosDisabled.getMultipathEbgp(), equalTo(false));
+    assertThat(nxosEnabled.getMultipathEbgp(), equalTo(true));
   }
 
   @Test

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -16325,7 +16325,7 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
-              "multipathEbgp" : false,
+              "multipathEbgp" : true,
               "multipathEquivalentAsPathMatchMode" : "PATH_LENGTH",
               "multipathIbgp" : false,
               "routerId" : "0.0.0.0",


### PR DESCRIPTION
Fixes #1556 

`bestpath as-path multipath-relax` actually enables multipath for ebgp without explicit `max-path n` needing to be set.
Fix the extraction, which in turn fixes the bug found in #1556