### PR TITLE
New script to generate local jacoco reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ org.eclipse.core.resources.prefs
 # based on the name of the directory bazel is cloned into.
 /bazel-*
 
+# Ignore jacoco coverage reports
+coverage*
+

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -1,26 +1,5 @@
 #!/usr/bin/env bash
-JACOCO_VERSION=0.8.1
-JACOCO_AGENT_JAR_NAME="org.jacoco.agent-${JACOCO_VERSION}-runtime.jar"
-JACOCO_AGENT_JAR="${HOME}/.m2/repository/org/jacoco/org.jacoco.agent/${JACOCO_VERSION}/${JACOCO_AGENT_JAR_NAME}"
-JACOCO_CLI_JAR_NAME="org.jacoco.cli-${JACOCO_VERSION}-nodeps.jar"
-JACOCO_CLI_JAR="${HOME}/.m2/repository/org/jacoco/org.jacoco.cli/${JACOCO_VERSION}/${JACOCO_CLI_JAR_NAME}"
-
-# the destfile for ref tests
-JACOCO_REF_DESTFILE=projects/target/jacoco-ref.exec
-
-# the destfile for the aggregate of the ref tests and all junit project tests
-JACOCO_ALL_DESTFILE=projects/target/jacoco-all.exec
-
-JACOCO_COVERAGE_REPORT_XML=coverage.xml
-
-
-if [ ! -f ${JACOCO_AGENT_JAR} ]; then
-  mvn dependency:get -Dartifact=org.jacoco:org.jacoco.agent:${JACOCO_VERSION}:jar:runtime
-fi
-
-if [ ! -f ${JACOCO_CLI_JAR} ]; then
-  mvn dependency:get -Dartifact=org.jacoco:org.jacoco.cli:${JACOCO_VERSION}:jar:nodeps
-fi
+source $(dirname $0)/jacoco-common.sh
 
 if [[ $(uname) == 'Darwin' && $(which gfind) ]]; then
    GNU_FIND=gfind
@@ -78,7 +57,6 @@ java -jar $JACOCO_CLI_JAR merge $(find -name 'jacoco*.exec') --destfile $JACOCO_
 
 echo -e "\n .... Building coverage report"
 # have to collect all classes into one dir
-JACOCO_CLASSES_DIR="$(mktemp -d)"
 cp -r projects/*/target/classes/* $JACOCO_CLASSES_DIR
 java -jar $JACOCO_CLI_JAR report $JACOCO_ALL_DESTFILE  --classfiles $JACOCO_CLASSES_DIR --xml $JACOCO_COVERAGE_REPORT_XML
 

--- a/.travis/jacoco-common.sh
+++ b/.travis/jacoco-common.sh
@@ -1,0 +1,27 @@
+JACOCO_VERSION=0.8.1
+JACOCO_AGENT_JAR_NAME="org.jacoco.agent-${JACOCO_VERSION}-runtime.jar"
+JACOCO_AGENT_JAR="${HOME}/.m2/repository/org/jacoco/org.jacoco.agent/${JACOCO_VERSION}/${JACOCO_AGENT_JAR_NAME}"
+JACOCO_CLI_JAR_NAME="org.jacoco.cli-${JACOCO_VERSION}-nodeps.jar"
+JACOCO_CLI_JAR="${HOME}/.m2/repository/org/jacoco/org.jacoco.cli/${JACOCO_VERSION}/${JACOCO_CLI_JAR_NAME}"
+
+# the destfile for ref tests
+JACOCO_REF_DESTFILE=projects/target/jacoco-ref.exec
+
+# the destfile for the aggregate of all junit project tests
+JACOCO_JUNIT_DESTFILE=projects/target/jacoco-junit.exec
+
+# the destfile for the aggregate of the ref tests and all junit project tests
+JACOCO_ALL_DESTFILE=projects/target/jacoco-all.exec
+
+JACOCO_COVERAGE_REPORT_XML=coverage.xml
+JACOCO_COVERAGE_REPORT_HTML=coverage
+
+if [ ! -f ${JACOCO_AGENT_JAR} ]; then
+  mvn dependency:get -Dartifact=org.jacoco:org.jacoco.agent:${JACOCO_VERSION}:jar:runtime
+fi
+
+if [ ! -f ${JACOCO_CLI_JAR} ]; then
+  mvn dependency:get -Dartifact=org.jacoco:org.jacoco.cli:${JACOCO_VERSION}:jar:nodeps
+fi
+
+JACOCO_CLASSES_DIR="$(mktemp -d)"

--- a/.travis/jacoco-report.sh
+++ b/.travis/jacoco-report.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+TRAVIS_DIR=$(dirname $0)
+
+source $TRAVIS_DIR/jacoco-common.sh
+
+# usage: $0 [junit]
+arg=$1
+
+cp -r projects/*/target/classes/* $JACOCO_CLASSES_DIR
+
+if [ $arg = 'junit' ]; then
+  java -jar $JACOCO_CLI_JAR merge $(find -name 'jacoco.exec') --destfile $JACOCO_JUNIT_DESTFILE
+  JACOCO_REPORT_DESTFILE=$JACOCO_JUNIT_DESTFILE
+else
+  JACOCO_REPORT_DESTFILE=$JACOCO_ALL_DESTFILE
+fi    
+
+java -jar $JACOCO_CLI_JAR report $JACOCO_REPORT_DESTFILE  --classfiles $JACOCO_CLASSES_DIR --html $JACOCO_COVERAGE_REPORT_HTML
+
+open $JACOCO_COVERAGE_REPORT_HTML/index.html


### PR DESCRIPTION
Though codecov reports are nicer, we may sometimes want to be
able to view jacoco's reports locally. Added a script
.travis/jacoco-report.sh to do this. It takes an optional parameter
that, when set to "junit", will be a report for junit test coverage only
(excluding ref tests).

Also add jacoco coverage (html and xml) reports to .gitignore