### PR TITLE
ColumnMetadata: minor fixes

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/table/ColumnMetadata.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/table/ColumnMetadata.java
@@ -1,14 +1,18 @@
 package org.batfish.datamodel.table;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.answers.Schema;
 
-public class ColumnMetadata {
+@ParametersAreNonnullByDefault
+public final class ColumnMetadata {
   private static final String PROP_DESCRIPTION = "description";
   private static final String PROP_IS_KEY = "isKey";
   private static final String PROP_IS_VALUE = "isValue";
@@ -30,21 +34,25 @@ public class ColumnMetadata {
   }
 
   @JsonCreator
+  // visible for testing.
+  static ColumnMetadata jsonCreator(
+      @Nullable @JsonProperty(PROP_NAME) String name,
+      @Nullable @JsonProperty(PROP_SCHEMA) Schema schema,
+      @Nullable @JsonProperty(PROP_DESCRIPTION) String description,
+      @Nullable @JsonProperty(PROP_IS_KEY) Boolean isKey,
+      @Nullable @JsonProperty(PROP_IS_VALUE) Boolean isValue) {
+    checkArgument(name != null, "'name' cannot be null for ColumnMetadata");
+    checkArgument(description != null, "'description' cannot be null for ColumnMetadata");
+    checkArgument(schema != null, "'schema' cannot be null for ColumnMetadata");
+    return new ColumnMetadata(name, schema, description, isKey, isValue);
+  }
+
   public ColumnMetadata(
-      @Nonnull @JsonProperty(PROP_NAME) String name,
-      @Nonnull @JsonProperty(PROP_SCHEMA) Schema schema,
-      @Nonnull @JsonProperty(PROP_DESCRIPTION) String description,
-      @JsonProperty(PROP_IS_KEY) Boolean isKey,
-      @JsonProperty(PROP_IS_VALUE) Boolean isValue) {
-    if (name == null) {
-      throw new IllegalArgumentException("'name' cannot be null for ColumnMetadata");
-    }
-    if (description == null) {
-      throw new IllegalArgumentException("'description' cannot be null for ColumnMetadata");
-    }
-    if (schema == null) {
-      throw new IllegalArgumentException("'schema' cannot be null for ColumnMetadata");
-    }
+      String name,
+      Schema schema,
+      String description,
+      @Nullable Boolean isKey,
+      @Nullable Boolean isValue) {
     if (!isLegalColumnName(name)) {
       throw new IllegalArgumentException(
           String.format(

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/table/ColumnMetadataTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/table/ColumnMetadataTest.java
@@ -1,0 +1,45 @@
+package org.batfish.datamodel.table;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.batfish.datamodel.answers.Schema;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests of {@link ColumnMetadata}. */
+@RunWith(JUnit4.class)
+public class ColumnMetadataTest {
+  @Rule public ExpectedException _thrown = ExpectedException.none();
+
+  @Test
+  public void testJacksonMissingName() {
+    _thrown.expectMessage("'name' cannot be null");
+    ColumnMetadata.jsonCreator(null, Schema.STRING, "desc", Boolean.TRUE, Boolean.FALSE);
+  }
+
+  @Test
+  public void testJacksonMissingDescription() {
+    _thrown.expectMessage("'description' cannot be null");
+    ColumnMetadata.jsonCreator("name", Schema.STRING, null, Boolean.TRUE, Boolean.FALSE);
+  }
+
+  @Test
+  public void testJacksonMissingSchema() {
+    _thrown.expectMessage("'schema' cannot be null");
+    ColumnMetadata.jsonCreator("name", null, "desc", Boolean.TRUE, Boolean.FALSE);
+  }
+
+  @Test
+  public void testJacksonDeserializeWithDefaults() {
+    ColumnMetadata c = ColumnMetadata.jsonCreator("name", Schema.STRING, "desc", null, null);
+    assertThat(c.getName(), equalTo("name"));
+    assertThat(c.getDescription(), equalTo("desc"));
+    assertThat(c.getSchema(), equalTo(Schema.STRING));
+    assertThat(c.getIsKey(), equalTo(true));
+    assertThat(c.getIsValue(), equalTo(true));
+  }
+}


### PR DESCRIPTION
Add a private `@JsonCreator` with all-nullable parameters. We can't
guarantee that all parameters will be present when dynamically
deserializing JSON.

Swap to `@ParametersAreNonNullByDefault`, and add the needed `@Nullable`
annotations.