### PR TITLE
check for coverage files

### DIFF
--- a/.travis/jacoco-report.sh
+++ b/.travis/jacoco-report.sh
@@ -7,6 +7,12 @@ source $TRAVIS_DIR/jacoco-common.sh
 # usage: $0 [junit]
 arg=$1
 
+if [ -z "$(find -name 'jacoco*.exec')" ]
+then
+    echo "No coverage data files found. Try again after running .travis/build.sh"
+    exit 1
+fi
+
 cp -r projects/*/target/classes/* $JACOCO_CLASSES_DIR
 
 if [ $arg = 'junit' ]; then


### PR DESCRIPTION
Before trying to build the jacoco report, check if any coverage files
exist. If not, give a helpful error message and exit.