### PR TITLE
batfish-common-protocol: establish parser_common to reduce rebuilding parsers

### DIFF
--- a/projects/batfish-common-protocol/BUILD
+++ b/projects/batfish-common-protocol/BUILD
@@ -2,6 +2,43 @@ package(default_visibility = ["//visibility:public"])
 
 load("@batfish//skylark:junit.bzl", "junit_tests")
 
+filegroup(
+    name = "parser_files",
+    srcs = [
+        "src/main/java/org/batfish/common/BatfishException.java",
+        "src/main/java/org/batfish/common/DebugBatfishException.java",
+        "src/main/java/org/batfish/common/ParseTreeSentences.java",
+        "src/main/java/org/batfish/common/util/BatfishObjectMapper.java",
+        "src/main/java/org/batfish/datamodel/answers/AnswerElement.java",
+        "src/main/java/org/batfish/datamodel/answers/AnswerSummary.java",
+        "src/main/java/org/batfish/grammar/BatfishANTLRErrorStrategy.java",
+        "src/main/java/org/batfish/grammar/BatfishCombinedParser.java",
+        "src/main/java/org/batfish/grammar/BatfishGrammarErrorListener.java",
+        "src/main/java/org/batfish/grammar/BatfishLexer.java",
+        "src/main/java/org/batfish/grammar/BatfishLexerErrorListener.java",
+        "src/main/java/org/batfish/grammar/BatfishLexerRecoveryStrategy.java",
+        "src/main/java/org/batfish/grammar/BatfishParser.java",
+        "src/main/java/org/batfish/grammar/BatfishParserATNSimulator.java",
+        "src/main/java/org/batfish/grammar/BatfishParserErrorListener.java",
+        "src/main/java/org/batfish/grammar/GrammarSettings.java",
+        "src/main/java/org/batfish/grammar/ParseTreePrettyPrinter.java",
+    ],
+)
+
+java_library(
+    name = "parser_common",
+    srcs = [":parser_files"],
+    deps = [
+        "@antlr4_runtime//:compile",
+        "@guava//:compile",
+        "@jackson_annotations//:compile",
+        "@jackson_core//:compile",
+        "@jackson_guava//:compile",
+        "@jackson_jdk8//:compile",
+        "@jackson_jsr310//:compile",
+    ],
+)
+
 java_library(
     name = "common",
     srcs = glob([
@@ -18,6 +55,7 @@ java_library(
         "@commons_beanutils//:runtime",
     ],
     deps = [
+        ":parser_common",
         "//projects/lib/jackson-jsonschema:jackson_jsonschema",
         "//projects/lib/jsonpath",
         "//projects/lib/z3",

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/BatfishException.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/BatfishException.java
@@ -4,10 +4,10 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.base.Throwables;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.batfish.datamodel.answers.AnswerElement;
 
 /**
@@ -29,7 +29,7 @@ public class BatfishException extends RuntimeException {
     private final List<String> _lines;
 
     public BatfishStackTrace(BatfishException exception) {
-      String stackTrace = ExceptionUtils.getStackTrace(exception).replace("\t", "   ");
+      String stackTrace = Throwables.getStackTraceAsString(exception).replace("\t", "   ");
       _lines = Arrays.asList(stackTrace.split("\\n", -1));
       _exception = exception;
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
@@ -736,10 +736,6 @@ public class CommonUtil {
     return differenceSet;
   }
 
-  public static String escape(String offendingTokenText) {
-    return offendingTokenText.replace("\n", "\\n").replace("\t", "\\t").replace("\r", "\\r");
-  }
-
   public static String extractBits(long l, int start, int end) {
     StringBuilder s = new StringBuilder();
     for (int pos = end; pos >= start; pos--) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/BatfishCombinedParser.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/BatfishCombinedParser.java
@@ -91,6 +91,10 @@ public abstract class BatfishCombinedParser<P extends BatfishParser, L extends B
     }
   }
 
+  /**
+   * Escapes certain whitespace {@code \n, \r, \t} in the given token text. This is typically used
+   * when printing token text for debugging purposes.
+   */
   public static String escape(String offendingTokenText) {
     return offendingTokenText.replace("\n", "\\n").replace("\t", "\\t").replace("\r", "\\r");
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/BatfishCombinedParser.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/BatfishCombinedParser.java
@@ -91,6 +91,10 @@ public abstract class BatfishCombinedParser<P extends BatfishParser, L extends B
     }
   }
 
+  public static String escape(String offendingTokenText) {
+    return offendingTokenText.replace("\n", "\\n").replace("\t", "\\t").replace("\r", "\\r");
+  }
+
   public List<String> getErrors() {
     return _errors;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/BatfishParserErrorListener.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/BatfishParserErrorListener.java
@@ -8,7 +8,6 @@ import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Recognizer;
 import org.antlr.v4.runtime.Token;
 import org.batfish.common.DebugBatfishException;
-import org.batfish.common.util.CommonUtil;
 
 public class BatfishParserErrorListener extends BatfishGrammarErrorListener {
 
@@ -20,7 +19,7 @@ public class BatfishParserErrorListener extends BatfishGrammarErrorListener {
     int modeAsInt = _combinedParser.getTokenMode(token);
     String mode = _combinedParser.getLexer().getModeNames()[modeAsInt];
     String rawTokenText = token.getText();
-    String tokenText = CommonUtil.escape(rawTokenText);
+    String tokenText = BatfishCombinedParser.escape(rawTokenText);
     int tokenType = token.getType();
     String channel = token.getChannel() == Lexer.HIDDEN ? "(HIDDEN) " : "";
     String tokenName;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/ParseTreePrettyPrinter.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/ParseTreePrettyPrinter.java
@@ -14,7 +14,6 @@ import org.antlr.v4.runtime.tree.ParseTreeListener;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.batfish.common.ParseTreeSentences;
-import org.batfish.common.util.CommonUtil;
 
 public class ParseTreePrettyPrinter implements ParseTreeListener {
 
@@ -112,7 +111,7 @@ public class ParseTreePrettyPrinter implements ParseTreeListener {
 
   @Override
   public void visitErrorNode(ErrorNode ctx) {
-    String nodeText = CommonUtil.escape(ctx.getText());
+    String nodeText = BatfishCombinedParser.escape(ctx.getText());
     // _sb.append("\n");
     _ptSentences.getSentences().add("");
     for (int i = 0; i < _indent; i++) {
@@ -133,7 +132,7 @@ public class ParseTreePrettyPrinter implements ParseTreeListener {
 
   @Override
   public void visitTerminal(TerminalNode ctx) {
-    String nodeText = CommonUtil.escape(ctx.getText());
+    String nodeText = BatfishCombinedParser.escape(ctx.getText());
     _ptSentences.getSentences().add("");
     for (int i = 0; i < _indent; i++) {
       _ptSentences.appendToLastSentence("  ");

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/BUILD
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/BUILD
@@ -9,7 +9,7 @@ java_library(
         ":CiscoParserListener.java",
     ],
     deps = [
-        "//projects/batfish-common-protocol:common",
+        "//projects/batfish-common-protocol:parser_common",
         "@antlr4_runtime//:compile",
     ],
 )

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/BUILD
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/BUILD
@@ -9,7 +9,7 @@ java_library(
         ":FlatJuniperParserListener.java",
     ],
     deps = [
-        "//projects/batfish-common-protocol:common",
+        "//projects/batfish-common-protocol:parser_common",
         "@antlr4_runtime//:compile",
     ],
 )

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatvyos/BUILD
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatvyos/BUILD
@@ -9,7 +9,7 @@ java_library(
         ":FlatVyosParserListener.java",
     ],
     deps = [
-        "//projects/batfish-common-protocol:common",
+        "//projects/batfish-common-protocol:parser_common",
         "@antlr4_runtime//:compile",
     ],
 )

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/iptables/BUILD
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/iptables/BUILD
@@ -9,7 +9,7 @@ java_library(
         ":IptablesParserListener.java",
     ],
     deps = [
-        "//projects/batfish-common-protocol:common",
+        "//projects/batfish-common-protocol:parser_common",
         "@antlr4_runtime//:compile",
     ],
 )

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/juniper/BUILD
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/juniper/BUILD
@@ -9,7 +9,7 @@ java_library(
         ":JuniperParserListener.java",
     ],
     deps = [
-        "//projects/batfish-common-protocol:common",
+        "//projects/batfish-common-protocol:parser_common",
         "@antlr4_runtime//:compile",
     ],
 )

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/mrv/BUILD
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/mrv/BUILD
@@ -9,7 +9,7 @@ java_library(
         ":MrvParserListener.java",
     ],
     deps = [
-        "//projects/batfish-common-protocol:common",
+        "//projects/batfish-common-protocol:parser_common",
         "@antlr4_runtime//:compile",
     ],
 )

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/routing_table/eos/BUILD
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/routing_table/eos/BUILD
@@ -9,7 +9,7 @@ java_library(
         ":EosRoutingTableParserListener.java",
     ],
     deps = [
-        "//projects/batfish-common-protocol:common",
+        "//projects/batfish-common-protocol:parser_common",
         "@antlr4_runtime//:compile",
     ],
 )

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/routing_table/ios/BUILD
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/routing_table/ios/BUILD
@@ -9,7 +9,7 @@ java_library(
         ":IosRoutingTableParserListener.java",
     ],
     deps = [
-        "//projects/batfish-common-protocol:common",
+        "//projects/batfish-common-protocol:parser_common",
         "@antlr4_runtime//:compile",
     ],
 )

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/routing_table/nxos/BUILD
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/routing_table/nxos/BUILD
@@ -9,7 +9,7 @@ java_library(
         ":NxosRoutingTableParserListener.java",
     ],
     deps = [
-        "//projects/batfish-common-protocol:common",
+        "//projects/batfish-common-protocol:parser_common",
         "@antlr4_runtime//:compile",
     ],
 )

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/vyos/BUILD
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/vyos/BUILD
@@ -9,7 +9,7 @@ java_library(
         ":VyosParserListener.java",
     ],
     deps = [
-        "//projects/batfish-common-protocol:common",
+        "//projects/batfish-common-protocol:parser_common",
         "@antlr4_runtime//:compile",
     ],
 )


### PR DESCRIPTION
This PR is a bit more interesting than other Bazel PRs.

Basically, establish an as-small-as-possible set of files in `batfish-common-protocol` that a parser can be compiled against. This way, we don't have to recompile all parsers any time that anything at all in the data model changes.

Trying to do this type of work highlights where encapsulation and separation of functions are useful. It seems strange that we can't build a parser without depending on `AnswerSummary`. Also, this would have been completely impossible had I not broken one dependence on `CommonUtil`, since that common utility class depends on absolutely everything else in the data model FWICT.