### PR TITLE
Use guava's Throwable over commons-lang3's ExceptionUtils

### DIFF
--- a/projects/allinone/BUILD
+++ b/projects/allinone/BUILD
@@ -23,7 +23,6 @@ java_library(
         "//projects/batfish-client:client",
         "//projects/batfish-common-protocol:common",
         "//projects/coordinator",
-        "@commons_lang3//:compile",
         "@guava//:compile",
         "@jaeger_core//:compile",
     ],

--- a/projects/allinone/pom.xml
+++ b/projects/allinone/pom.xml
@@ -131,11 +131,6 @@
       <artifactId>opentracing-util</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-    </dependency>
-
     <!-- Test scope dependencies. -->
     <dependency>
       <groupId>org.batfish</groupId>

--- a/projects/allinone/src/main/java/org/batfish/allinone/AllInOne.java
+++ b/projects/allinone/src/main/java/org/batfish/allinone/AllInOne.java
@@ -1,6 +1,7 @@
 package org.batfish.allinone;
 
 import com.google.common.base.Strings;
+import com.google.common.base.Throwables;
 import com.uber.jaeger.Configuration;
 import com.uber.jaeger.Configuration.ReporterConfiguration;
 import com.uber.jaeger.Configuration.SamplerConfiguration;
@@ -10,7 +11,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.batfish.allinone.config.Settings;
 import org.batfish.client.Client;
 import org.batfish.common.BatfishLogger;
@@ -124,7 +124,7 @@ public class AllInOne {
           _logger.info("allinone: still alive ....\n");
         }
       } catch (Exception ex) {
-        String stackTrace = ExceptionUtils.getStackTrace(ex);
+        String stackTrace = Throwables.getStackTraceAsString(ex);
         System.err.println(stackTrace);
       }
     }

--- a/projects/batfish-client/src/main/java/org/batfish/client/BfCoordWorkHelper.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/BfCoordWorkHelper.java
@@ -2,6 +2,7 @@ package org.batfish.client;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Throwables;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import java.io.File;
@@ -21,7 +22,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.batfish.client.config.Settings;
 import org.batfish.common.BatfishException;
 import org.batfish.common.BatfishLogger;
@@ -59,7 +59,7 @@ public class BfCoordWorkHelper {
       _client = getClientBuilder().build();
     } catch (Exception e) {
       _logger.errorf("exception: ");
-      _logger.error(ExceptionUtils.getStackTrace(e) + "\n");
+      _logger.error(Throwables.getStackTraceAsString(e) + "\n");
       throw new BatfishException("Failed to create HTTP client", e);
     }
   }
@@ -105,7 +105,7 @@ public class BfCoordWorkHelper {
       return jObj.getString(CoordConsts.SVC_KEY_SUGGESTIONS);
     } catch (Exception e) {
       _logger.errorf("exception: ");
-      _logger.error(ExceptionUtils.getStackTrace(e) + "\n");
+      _logger.error(Throwables.getStackTraceAsString(e) + "\n");
       return null;
     }
   }
@@ -127,7 +127,7 @@ public class BfCoordWorkHelper {
       return Boolean.toString(jObj.getBoolean(CoordConsts.SVC_KEY_API_KEY));
     } catch (Exception e) {
       _logger.errorf("exception: ");
-      _logger.error(ExceptionUtils.getStackTrace(e) + "\n");
+      _logger.error(Throwables.getStackTraceAsString(e) + "\n");
       return null;
     }
   }
@@ -170,7 +170,7 @@ public class BfCoordWorkHelper {
             analysisName,
             addQuestionsFileName,
             delQuestionsStr,
-            ExceptionUtils.getStackTrace(e));
+            Throwables.getStackTraceAsString(e));
       }
       return false;
     }
@@ -210,7 +210,7 @@ public class BfCoordWorkHelper {
       _logger.errorf(
           "Exception in configureTemplate from %s using (%s, %s, %s)\n",
           _coordWorkMgr, inTemplate, exceptions, assertion);
-      _logger.error(ExceptionUtils.getStackTrace(e) + "\n");
+      _logger.error(Throwables.getStackTraceAsString(e) + "\n");
       return null;
     }
   }
@@ -230,7 +230,7 @@ public class BfCoordWorkHelper {
     } catch (Exception e) {
       _logger.errorf(
           "Exception when deleting analysis to %s using (%s, %s): %s\n",
-          _coordWorkMgr, containerName, analysisName, ExceptionUtils.getStackTrace(e));
+          _coordWorkMgr, containerName, analysisName, Throwables.getStackTraceAsString(e));
       return false;
     }
   }
@@ -255,7 +255,7 @@ public class BfCoordWorkHelper {
       return true;
     } catch (Exception e) {
       _logger.errorf("Exception in delContainer from %s for %s\n", _coordWorkMgrV2, containerName);
-      _logger.error(ExceptionUtils.getStackTrace(e) + "\n");
+      _logger.error(Throwables.getStackTraceAsString(e) + "\n");
       return false;
     }
   }
@@ -276,7 +276,7 @@ public class BfCoordWorkHelper {
       return jObj != null;
     } catch (Exception e) {
       _logger.errorf("exception: ");
-      _logger.error(ExceptionUtils.getStackTrace(e) + "\n");
+      _logger.error(Throwables.getStackTraceAsString(e) + "\n");
       return false;
     }
   }
@@ -297,7 +297,7 @@ public class BfCoordWorkHelper {
       return jObj != null;
     } catch (Exception e) {
       _logger.errorf("exception: ");
-      _logger.error(ExceptionUtils.getStackTrace(e) + "\n");
+      _logger.error(Throwables.getStackTraceAsString(e) + "\n");
       return false;
     }
   }
@@ -317,7 +317,7 @@ public class BfCoordWorkHelper {
       return jObj != null;
     } catch (Exception e) {
       _logger.errorf("exception: ");
-      _logger.error(ExceptionUtils.getStackTrace(e) + "\n");
+      _logger.error(Throwables.getStackTraceAsString(e) + "\n");
       return false;
     }
   }
@@ -412,7 +412,7 @@ public class BfCoordWorkHelper {
       _logger.errorf(
           "Exception in getAnswer from %s using (%s, %s)\n",
           _coordWorkMgr, baseTestrig, analysisName);
-      _logger.error(ExceptionUtils.getStackTrace(e) + "\n");
+      _logger.error(Throwables.getStackTraceAsString(e) + "\n");
       return null;
     }
   }
@@ -459,7 +459,7 @@ public class BfCoordWorkHelper {
       _logger.errorf(
           "Exception in getAnswer from %s using (%s, %s)\n",
           _coordWorkMgr, baseTestrig, questionName);
-      _logger.error(ExceptionUtils.getStackTrace(e) + "\n");
+      _logger.error(Throwables.getStackTraceAsString(e) + "\n");
       return null;
     }
   }
@@ -514,7 +514,7 @@ public class BfCoordWorkHelper {
       _logger.errorf(
           "Exception in getConfiguration from %s for container %s, testrig %s, configuration %s\n",
           _coordWorkMgr, containerName, testrigName, configName);
-      _logger.error(ExceptionUtils.getStackTrace(e) + "\n");
+      _logger.error(Throwables.getStackTraceAsString(e) + "\n");
       return null;
     }
   }
@@ -550,7 +550,7 @@ public class BfCoordWorkHelper {
       return container;
     } catch (Exception e) {
       _logger.errorf("Exception in getContainer from %s for %s\n", _coordWorkMgrV2, containerName);
-      _logger.error(ExceptionUtils.getStackTrace(e) + "\n");
+      _logger.error(Throwables.getStackTraceAsString(e) + "\n");
       return null;
     }
   }
@@ -592,7 +592,7 @@ public class BfCoordWorkHelper {
       return retMap;
     } catch (Exception e) {
       _logger.errorf("Exception in getInfo from %s\n", _coordWorkMgr);
-      _logger.error(ExceptionUtils.getStackTrace(e) + "\n");
+      _logger.error(Throwables.getStackTraceAsString(e) + "\n");
       return null;
     }
   }
@@ -652,7 +652,7 @@ public class BfCoordWorkHelper {
       _logger.errorf(
           "Exception in getObject from %s using (%s, %s)\n",
           _coordWorkMgr, testrigName, objectName);
-      _logger.error(ExceptionUtils.getStackTrace(e) + "\n");
+      _logger.error(Throwables.getStackTraceAsString(e) + "\n");
       return null;
     }
   }
@@ -686,7 +686,7 @@ public class BfCoordWorkHelper {
       return jObj.getJSONObject(CoordConsts.SVC_KEY_QUESTION_LIST);
     } catch (Exception e) {
       _logger.errorf("Exception in getQuestionTemplates from %s\n", _coordWorkMgr);
-      _logger.error(ExceptionUtils.getStackTrace(e) + "\n");
+      _logger.error(Throwables.getStackTraceAsString(e) + "\n");
       return null;
     }
   }
@@ -746,7 +746,7 @@ public class BfCoordWorkHelper {
       return new Pair<>(workStatus, taskStr);
     } catch (Exception e) {
       _logger.errorf("exception: ");
-      _logger.error(ExceptionUtils.getStackTrace(e) + "\n");
+      _logger.error(Throwables.getStackTraceAsString(e) + "\n");
       return null;
     }
   }
@@ -779,7 +779,7 @@ public class BfCoordWorkHelper {
       return jObj.getString(CoordConsts.SVC_KEY_CONTAINER_NAME);
     } catch (Exception e) {
       _logger.errorf("exception: ");
-      _logger.error(ExceptionUtils.getStackTrace(e) + "\n");
+      _logger.error(Throwables.getStackTraceAsString(e) + "\n");
       return null;
     }
   }
@@ -849,7 +849,7 @@ public class BfCoordWorkHelper {
 
       return jObj.getBoolean(CoordConsts.SVC_KEY_RESULT);
     } catch (Exception e) {
-      _logger.errorf("exception: %s\n", ExceptionUtils.getStackTrace(e));
+      _logger.errorf("exception: %s\n", Throwables.getStackTraceAsString(e));
       return false;
     }
   }
@@ -878,7 +878,7 @@ public class BfCoordWorkHelper {
       return jObj.getJSONObject(CoordConsts.SVC_KEY_ANALYSIS_LIST);
     } catch (Exception e) {
       _logger.errorf("exception: ");
-      _logger.error(ExceptionUtils.getStackTrace(e) + "\n");
+      _logger.error(Throwables.getStackTraceAsString(e) + "\n");
       return null;
     }
   }
@@ -915,7 +915,7 @@ public class BfCoordWorkHelper {
       return containerList;
     } catch (Exception e) {
       _logger.errorf("exception: ");
-      _logger.error(ExceptionUtils.getStackTrace(e) + "\n");
+      _logger.error(Throwables.getStackTraceAsString(e) + "\n");
       return null;
     }
   }
@@ -953,7 +953,7 @@ public class BfCoordWorkHelper {
       return environmentList;
     } catch (Exception e) {
       _logger.errorf("exception: ");
-      _logger.error(ExceptionUtils.getStackTrace(e) + "\n");
+      _logger.error(Throwables.getStackTraceAsString(e) + "\n");
       return null;
     }
   }
@@ -987,7 +987,7 @@ public class BfCoordWorkHelper {
       return workList;
     } catch (Exception e) {
       _logger.errorf("exception: ");
-      _logger.error(ExceptionUtils.getStackTrace(e) + "\n");
+      _logger.error(Throwables.getStackTraceAsString(e) + "\n");
       return null;
     }
   }
@@ -1021,7 +1021,7 @@ public class BfCoordWorkHelper {
       return questionList;
     } catch (Exception e) {
       _logger.errorf("exception: ");
-      _logger.error(ExceptionUtils.getStackTrace(e) + "\n");
+      _logger.error(Throwables.getStackTraceAsString(e) + "\n");
       return null;
     }
   }
@@ -1053,7 +1053,7 @@ public class BfCoordWorkHelper {
       return testrigArray;
     } catch (Exception e) {
       _logger.errorf("exception: ");
-      _logger.error(ExceptionUtils.getStackTrace(e) + "\n");
+      _logger.error(Throwables.getStackTraceAsString(e) + "\n");
       return null;
     }
   }
@@ -1121,7 +1121,7 @@ public class BfCoordWorkHelper {
       return jObj != null;
     } catch (Exception e) {
       _logger.errorf("exception: ");
-      _logger.error(ExceptionUtils.getStackTrace(e) + "\n");
+      _logger.error(Throwables.getStackTraceAsString(e) + "\n");
       return false;
     }
   }
@@ -1143,7 +1143,7 @@ public class BfCoordWorkHelper {
       return jObj != null;
     } catch (Exception e) {
       _logger.errorf("exception: ");
-      _logger.error(ExceptionUtils.getStackTrace(e) + "\n");
+      _logger.error(Throwables.getStackTraceAsString(e) + "\n");
       return false;
     }
   }
@@ -1168,7 +1168,7 @@ public class BfCoordWorkHelper {
       return jObj != null;
     } catch (Exception e) {
       _logger.errorf("exception: ");
-      _logger.error(ExceptionUtils.getStackTrace(e) + "\n");
+      _logger.error(Throwables.getStackTraceAsString(e) + "\n");
       return false;
     }
   }
@@ -1194,7 +1194,7 @@ public class BfCoordWorkHelper {
       } else {
         _logger.errorf(
             "Exception when uploading custom object to %s using (%s, %s, %s): %s\n",
-            _coordWorkMgr, testrigName, objName, objFileName, ExceptionUtils.getStackTrace(e));
+            _coordWorkMgr, testrigName, objName, objFileName, Throwables.getStackTraceAsString(e));
       }
       return false;
     }
@@ -1223,7 +1223,7 @@ public class BfCoordWorkHelper {
       } else {
         _logger.errorf(
             "Exception when uploading environment to %s using (%s, %s, %s): %s\n",
-            _coordWorkMgr, testrigName, envName, zipfileName, ExceptionUtils.getStackTrace(e));
+            _coordWorkMgr, testrigName, envName, zipfileName, Throwables.getStackTraceAsString(e));
       }
       return false;
     }
@@ -1250,7 +1250,7 @@ public class BfCoordWorkHelper {
       } else {
         _logger.errorf(
             "Exception when uploading question to %s using (%s, %s, %s): %s\n",
-            _coordWorkMgr, testrigName, qName, qFileName, ExceptionUtils.getStackTrace(e));
+            _coordWorkMgr, testrigName, qName, qFileName, Throwables.getStackTraceAsString(e));
       }
       return false;
     }
@@ -1282,7 +1282,7 @@ public class BfCoordWorkHelper {
             containerName,
             testrigName,
             zipfileName,
-            ExceptionUtils.getStackTrace(e));
+            Throwables.getStackTraceAsString(e));
       }
       return false;
     }

--- a/projects/batfish-client/src/main/java/org/batfish/client/Client.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/Client.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Throwables;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
@@ -51,7 +52,6 @@ import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import javax.annotation.Nullable;
 import org.apache.commons.io.output.WriterOutputStream;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.batfish.client.Command.TestComparisonMode;
 import org.batfish.client.answer.LoadQuestionAnswerElement;
 import org.batfish.client.config.Settings;
@@ -1679,7 +1679,7 @@ public class Client extends AbstractClient implements IClient {
       } catch (Exception e) {
         _logger.errorf(
             "Exeption while checking reachability to coordinator: %s",
-            ExceptionUtils.getStackTrace(e));
+            Throwables.getStackTraceAsString(e));
         System.exit(1);
       }
     }
@@ -3235,10 +3235,10 @@ public class Client extends AbstractClient implements IClient {
         }
       } catch (JsonProcessingException e) {
         _logger.errorf(
-            "Error deserializing answer %s: %s\n", testOutput, ExceptionUtils.getStackTrace(e));
+            "Error deserializing answer %s: %s\n", testOutput, Throwables.getStackTraceAsString(e));
       } catch (Exception e) {
         _logger.errorf(
-            "Exception in comparing test results: %s\n", ExceptionUtils.getStackTrace(e));
+            "Exception in comparing test results: %s\n", Throwables.getStackTraceAsString(e));
       }
     }
 

--- a/projects/batfish-client/src/main/java/org/batfish/client/Main.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/Main.java
@@ -1,7 +1,7 @@
 package org.batfish.client;
 
+import com.google.common.base.Throwables;
 import java.util.LinkedList;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.batfish.client.config.Settings;
 
 public class Main {
@@ -19,7 +19,7 @@ public class Main {
       settings = new Settings(args);
     } catch (Exception e) {
       System.err.println(Main.class.getName() + ": Initialization failed:\n");
-      System.err.print(ExceptionUtils.getStackTrace(e));
+      System.err.print(Throwables.getStackTraceAsString(e));
       System.exit(1);
     }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/BatfishException.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/BatfishException.java
@@ -4,10 +4,10 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.base.Throwables;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.batfish.datamodel.answers.AnswerElement;
 
 /**
@@ -29,7 +29,7 @@ public class BatfishException extends RuntimeException {
     private final List<String> _lines;
 
     public BatfishStackTrace(BatfishException exception) {
-      String stackTrace = ExceptionUtils.getStackTrace(exception).replace("\t", "   ");
+      String stackTrace = Throwables.getStackTraceAsString(exception).replace("\t", "   ");
       _lines = Arrays.asList(stackTrace.split("\\n", -1));
       _exception = exception;
     }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/RowMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/RowMatchersImpl.java
@@ -3,10 +3,10 @@ package org.batfish.datamodel.matchers;
 import static org.hamcrest.Matchers.hasItem;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.base.Throwables;
 import java.util.Collection;
 import java.util.Optional;
 import javax.annotation.Nonnull;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.batfish.datamodel.table.Row;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -57,7 +57,7 @@ final class RowMatchersImpl {
                 "Value for column '%s' could not be converted to a '%s': %s",
                 columnName,
                 _valueTypeReference.getType().getTypeName(),
-                ExceptionUtils.getStackTrace(e)));
+                Throwables.getStackTraceAsString(e)));
         return false;
       }
       if (!_valueMatcher.matches(value)) {

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ApplyGroupsApplicator.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ApplyGroupsApplicator.java
@@ -1,10 +1,10 @@
 package org.batfish.grammar.flatjuniper;
 
+import com.google.common.base.Throwables;
 import java.util.ArrayList;
 import java.util.List;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.batfish.common.BatfishException;
 import org.batfish.common.Warnings;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Apply_groupsContext;
@@ -50,7 +50,7 @@ public class ApplyGroupsApplicator extends FlatJuniperParserBaseListener {
       HierarchyPath currentPath, String groupName, Throwable e) {
     return String.format(
         "Exception processing apply-groups statement at %s with group '%s': %s: caused by: %s",
-        pathString(), groupName, e.getMessage(), ExceptionUtils.getStackTrace(e));
+        pathString(), groupName, e.getMessage(), Throwables.getStackTraceAsString(e));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/job/BatfishJobExecutor.java
+++ b/projects/batfish/src/main/java/org/batfish/job/BatfishJobExecutor.java
@@ -1,5 +1,6 @@
 package org.batfish.job;
 
+import com.google.common.base.Throwables;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -8,7 +9,6 @@ import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.batfish.common.BatfishException;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.util.CommonUtil;
@@ -222,7 +222,7 @@ public class BatfishJobExecutor {
     }
     // we keep the failure cause and proceed
     result.appendHistory(_logger);
-    _logger.errorf("%s:\n\t%s", failureMessage, ExceptionUtils.getStackTrace(failureCause));
+    _logger.errorf("%s:\n\t%s", failureMessage, Throwables.getStackTraceAsString(failureCause));
     failureCauses.add(bfc);
     if (!haltOnProcessingError) {
       result.applyTo(output, _logger, answerElement);

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -7,6 +7,7 @@ import static org.batfish.main.ReachabilityParametersResolver.resolveReachabilit
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Throwables;
 import com.google.common.base.Verify;
 import com.google.common.cache.Cache;
 import com.google.common.collect.ImmutableList;
@@ -58,7 +59,6 @@ import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
 import org.apache.commons.configuration2.ImmutableConfiguration;
 import org.apache.commons.lang3.SerializationUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.batfish.common.Answerer;
 import org.batfish.common.BatfishException;
 import org.batfish.common.BatfishException.BatfishStackTrace;
@@ -2783,7 +2783,8 @@ public class Batfish extends PluginConsumer implements IBatfish {
         @Nullable String logString = writeLog ? answerString : null;
         writeJsonAnswerWithLog(logString, answerString);
       } catch (Exception e1) {
-        _logger.errorf("Could not serialize failure answer. %s", ExceptionUtils.getStackTrace(e1));
+        _logger.errorf(
+            "Could not serialize failure answer. %s", Throwables.getStackTraceAsString(e1));
       }
       throw be;
     }

--- a/projects/batfish/src/main/java/org/batfish/main/BatfishStorage.java
+++ b/projects/batfish/src/main/java/org/batfish/main/BatfishStorage.java
@@ -26,7 +26,6 @@ import java.util.zip.GZIPInputStream;
 import javax.annotation.Nullable;
 import net.jpountz.lz4.LZ4FrameInputStream;
 import net.jpountz.lz4.LZ4FrameOutputStream;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.batfish.common.BatfishException;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.BfConsts;
@@ -118,7 +117,7 @@ final class BatfishStorage {
     } catch (BatfishException e) {
       _logger.errorf(
           "Failed to deserialize ConvertConfigurationAnswerElement: %s",
-          ExceptionUtils.getStackTrace(e));
+          Throwables.getStackTraceAsString(e));
       return null;
     }
   }

--- a/projects/batfish/src/main/java/org/batfish/main/Driver.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Driver.java
@@ -1,5 +1,6 @@
 package org.batfish.main;
 
+import com.google.common.base.Throwables;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableList;
@@ -43,7 +44,6 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import org.apache.commons.collections4.map.LRUMap;
 import org.apache.commons.lang3.SystemUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.batfish.common.BatfishException;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.BfConsts;
@@ -327,7 +327,7 @@ public class Driver {
       httpServerLogger.setLevel(Level.WARNING);
     } catch (Exception e) {
       System.err.println(
-          "batfish: Initialization failed. Reason: " + ExceptionUtils.getStackTrace(e));
+          "batfish: Initialization failed. Reason: " + Throwables.getStackTraceAsString(e));
       System.exit(1);
     }
   }
@@ -393,12 +393,12 @@ public class Driver {
       try {
         process = builder.start();
       } catch (IOException e) {
-        _mainLogger.errorf("Exception starting process: %s", ExceptionUtils.getStackTrace(e));
+        _mainLogger.errorf("Exception starting process: %s", Throwables.getStackTraceAsString(e));
         _mainLogger.errorf("Will try again in 1 second\n");
         try {
           Thread.sleep(1000);
         } catch (InterruptedException e1) {
-          _mainLogger.errorf("Sleep was interrrupted: %s", ExceptionUtils.getStackTrace(e1));
+          _mainLogger.errorf("Sleep was interrrupted: %s", Throwables.getStackTraceAsString(e1));
         }
         continue;
       }
@@ -408,14 +408,14 @@ public class Driver {
         reader.lines().forEach(line -> _mainLogger.output(line + "\n"));
       } catch (IOException e) {
         _mainLogger.errorf(
-            "Interrupted while reading subprocess stream: %s", ExceptionUtils.getStackTrace(e));
+            "Interrupted while reading subprocess stream: %s", Throwables.getStackTraceAsString(e));
       }
 
       try {
         process.waitFor();
       } catch (InterruptedException e) {
         _mainLogger.infof(
-            "Subprocess was killed: %s.\nRestarting", ExceptionUtils.getStackTrace(e));
+            "Subprocess was killed: %s.\nRestarting", Throwables.getStackTraceAsString(e));
       }
     }
   }
@@ -498,7 +498,7 @@ public class Driver {
       _mainLogger.error(msg);
       System.exit(1);
     } catch (Exception ex) {
-      String stackTrace = ExceptionUtils.getStackTrace(ex);
+      String stackTrace = Throwables.getStackTraceAsString(ex);
       _mainLogger.error(stackTrace);
       System.exit(1);
     }
@@ -603,7 +603,7 @@ public class Driver {
                       e.getClass().getName() + ": " + e.getMessage());
                   answer = Answer.failureAnswer(msg, null);
                 } catch (QuestionException e) {
-                  String stackTrace = ExceptionUtils.getStackTrace(e);
+                  String stackTrace = Throwables.getStackTraceAsString(e);
                   logger.errorf(
                       "Exception in container:%s, testrig:%s; exception:%s",
                       containerName, testrigName, stackTrace);
@@ -612,7 +612,7 @@ public class Driver {
                   answer = e.getAnswer();
                   answer.setStatus(AnswerStatus.FAILURE);
                 } catch (BatfishException e) {
-                  String stackTrace = ExceptionUtils.getStackTrace(e);
+                  String stackTrace = Throwables.getStackTraceAsString(e);
                   logger.errorf(
                       "Exception in container:%s, testrig:%s; exception:%s",
                       containerName, testrigName, stackTrace);
@@ -622,7 +622,7 @@ public class Driver {
                   answer.setStatus(AnswerStatus.FAILURE);
                   answer.addAnswerElement(e.getBatfishStackTrace());
                 } catch (Throwable e) {
-                  String stackTrace = ExceptionUtils.getStackTrace(e);
+                  String stackTrace = Throwables.getStackTraceAsString(e);
                   logger.errorf(
                       "Exception in container:%s, testrig:%s; exception:%s",
                       containerName, testrigName, stackTrace);
@@ -660,7 +660,7 @@ public class Driver {
 
       return batfish.getTerminatingExceptionMessage();
     } catch (Exception e) {
-      String stackTrace = ExceptionUtils.getStackTrace(e);
+      String stackTrace = Throwables.getStackTraceAsString(e);
       logger.error(stackTrace);
       return stackTrace;
     }
@@ -675,7 +675,8 @@ public class Driver {
       // assign taskId for status updates, termination requests
       settings.setTaskId(taskId);
     } catch (Exception e) {
-      return Arrays.asList("failure", "Initialization failed: " + ExceptionUtils.getStackTrace(e));
+      return Arrays.asList(
+          "failure", "Initialization failed: " + Throwables.getStackTraceAsString(e));
     }
 
     try {
@@ -800,10 +801,10 @@ public class Driver {
         throw new BatfishException("Unrecoverable connection error", e);
       }
       logger.errorf("BF: unable to connect to coordinator pool mgr at %s\n", url);
-      logger.debug(ExceptionUtils.getStackTrace(e) + "\n");
+      logger.debug(Throwables.getStackTraceAsString(e) + "\n");
       return null;
     } catch (Exception e) {
-      logger.errorf("exception: " + ExceptionUtils.getStackTrace(e));
+      logger.errorf("exception: " + Throwables.getStackTraceAsString(e));
       return null;
     } finally {
       if (client != null) {

--- a/projects/coordinator/BUILD
+++ b/projects/coordinator/BUILD
@@ -25,7 +25,6 @@ java_library(
         "//projects/question",
         "@azure_storage//:compile",
         "@commons_io//:compile",
-        "@commons_lang3//:compile",
         "@grizzly_server//:compile",
         "@guava//:compile",
         "@jackson_core//:compile",

--- a/projects/coordinator/pom.xml
+++ b/projects/coordinator/pom.xml
@@ -145,11 +145,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.codehaus.jettison</groupId>
       <artifactId>jettison</artifactId>
     </dependency>

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/Main.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/Main.java
@@ -3,6 +3,7 @@ package org.batfish.coordinator;
 import static com.google.common.base.Preconditions.checkState;
 import static java.nio.file.FileVisitOption.FOLLOW_LINKS;
 
+import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.uber.jaeger.Configuration;
 import com.uber.jaeger.Configuration.ReporterConfiguration;
@@ -25,7 +26,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import javax.ws.rs.core.UriBuilder;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.batfish.common.BatfishException;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.BfConsts;
@@ -313,7 +313,7 @@ public class Main {
       httpServerLogger.setLevel(Level.WARNING);
     } catch (Exception e) {
       System.err.print(
-          "org.batfish.coordinator: Initialization failed: " + ExceptionUtils.getStackTrace(e));
+          "org.batfish.coordinator: Initialization failed: " + Throwables.getStackTraceAsString(e));
       System.exit(1);
     }
   }
@@ -329,7 +329,7 @@ public class Main {
     } catch (Exception e) {
       System.err.println(
           "org.batfish.coordinator: Initialization of a helper failed: "
-              + ExceptionUtils.getStackTrace(e));
+              + Throwables.getStackTraceAsString(e));
       System.exit(1);
     }
 
@@ -340,7 +340,7 @@ public class Main {
         _logger.info("Still alive .... waiting for work to show up\n");
       }
     } catch (Exception ex) {
-      String stackTrace = ExceptionUtils.getStackTrace(ex);
+      String stackTrace = Throwables.getStackTraceAsString(ex);
       System.err.println(stackTrace);
     }
   }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/PoolMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/PoolMgr.java
@@ -1,5 +1,6 @@
 package org.batfish.coordinator;
 
+import com.google.common.base.Throwables;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -14,7 +15,6 @@ import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.BfConsts;
 import org.batfish.common.util.CommonUtil;
@@ -181,7 +181,7 @@ public class PoolMgr {
       _logger.error(String.format("unable to connect to %s: %s\n", worker, e.getMessage()));
       updateWorkerStatus(worker, WorkerStatus.StatusCode.UNREACHABLE);
     } catch (Exception e) {
-      String stackTrace = ExceptionUtils.getStackTrace(e);
+      String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.error(String.format("exception: %s\n", stackTrace));
       updateWorkerStatus(worker, WorkerStatus.StatusCode.UNKNOWN);
     } finally {

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/PoolMgrService.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/PoolMgrService.java
@@ -1,5 +1,6 @@
 package org.batfish.coordinator;
 
+import com.google.common.base.Throwables;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -12,7 +13,6 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.CoordConsts;
 import org.batfish.common.Version;
@@ -55,7 +55,8 @@ public class PoolMgrService {
                 new JSONObject().put(CoordConsts.SVC_KEY_QUESTION_LIST, questionTemplates)));
       }
     } catch (Exception e) {
-      _logger.errorf("WMS:getQuestionTemplates exception: %s\n", ExceptionUtils.getStackTrace(e));
+      _logger.errorf(
+          "WMS:getQuestionTemplates exception: %s\n", Throwables.getStackTraceAsString(e));
       return new JSONArray(Arrays.asList(CoordConsts.SVC_KEY_FAILURE, e.getMessage()));
     }
   }
@@ -70,7 +71,7 @@ public class PoolMgrService {
       JSONObject obj = new JSONObject(poolStatus);
       return new JSONArray(Arrays.asList(CoordConsts.SVC_KEY_SUCCESS, obj.toString()));
     } catch (Exception e) {
-      _logger.errorf("PMS:getStatus exception: %s\n", ExceptionUtils.getStackTrace(e));
+      _logger.errorf("PMS:getStatus exception: %s\n", Throwables.getStackTraceAsString(e));
       return new JSONArray(Arrays.asList(CoordConsts.SVC_KEY_FAILURE, e.getMessage()));
     }
   }
@@ -147,7 +148,7 @@ public class PoolMgrService {
         }
       }
     } catch (Exception e) {
-      _logger.errorf("PMS:updatePool exception: %s\n", ExceptionUtils.getStackTrace(e));
+      _logger.errorf("PMS:updatePool exception: %s\n", Throwables.getStackTraceAsString(e));
       return new JSONArray(Arrays.asList(CoordConsts.SVC_KEY_FAILURE, e.getMessage()));
     }
 

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -2,6 +2,7 @@ package org.batfish.coordinator;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import io.opentracing.ActiveSpan;
@@ -42,7 +43,6 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.batfish.common.BatfishException;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.BfConsts;
@@ -150,7 +150,7 @@ public class WorkMgr extends AbstractCoordinator {
 
       assignWork(work, idleWorker);
     } catch (Exception e) {
-      _logger.errorf("Got exception in assignWork: %s\n", ExceptionUtils.getStackTrace(e));
+      _logger.errorf("Got exception in assignWork: %s\n", Throwables.getStackTraceAsString(e));
     }
   }
 
@@ -236,10 +236,10 @@ public class WorkMgr extends AbstractCoordinator {
         }
       }
     } catch (ProcessingException e) {
-      String stackTrace = ExceptionUtils.getStackTrace(e);
+      String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.error(String.format("Unable to connect to worker at %s: %s\n", worker, stackTrace));
     } catch (Exception e) {
-      String stackTrace = ExceptionUtils.getStackTrace(e);
+      String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.error(String.format("Exception assigning work: %s\n", stackTrace));
     } finally {
       if (client != null) {
@@ -259,14 +259,14 @@ public class WorkMgr extends AbstractCoordinator {
       try {
         _workQueueMgr.markAssignmentError(work);
       } catch (Exception e) {
-        String stackTrace = ExceptionUtils.getStackTrace(e);
+        String stackTrace = Throwables.getStackTraceAsString(e);
         _logger.errorf("Unable to markAssignmentError for work %s: %s\n", work, stackTrace);
       }
     } else if (assigned) {
       try {
         _workQueueMgr.markAssignmentSuccess(work, worker);
       } catch (Exception e) {
-        String stackTrace = ExceptionUtils.getStackTrace(e);
+        String stackTrace = Throwables.getStackTraceAsString(e);
         _logger.errorf("Unable to markAssignmentSuccess for work %s: %s\n", work, stackTrace);
       }
 
@@ -290,7 +290,7 @@ public class WorkMgr extends AbstractCoordinator {
         checkTask(work, assignedWorker);
       }
     } catch (Exception e) {
-      _logger.errorf("Got exception in checkTasks: %s\n", ExceptionUtils.getStackTrace(e));
+      _logger.errorf("Got exception in checkTasks: %s\n", Throwables.getStackTraceAsString(e));
     }
   }
 
@@ -376,10 +376,10 @@ public class WorkMgr extends AbstractCoordinator {
         }
       }
     } catch (ProcessingException e) {
-      String stackTrace = ExceptionUtils.getStackTrace(e);
+      String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.error(String.format("unable to connect to %s: %s\n", worker, stackTrace));
     } catch (Exception e) {
-      String stackTrace = ExceptionUtils.getStackTrace(e);
+      String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.error(String.format("exception: %s\n", stackTrace));
     } finally {
       if (client != null) {
@@ -394,7 +394,7 @@ public class WorkMgr extends AbstractCoordinator {
     try {
       _workQueueMgr.processTaskCheckResult(work, task);
     } catch (Exception e) {
-      _logger.errorf("exception: %s\n", ExceptionUtils.getStackTrace(e));
+      _logger.errorf("exception: %s\n", Throwables.getStackTraceAsString(e));
     }
 
     // if the task ended, send a hint to the pool manager to look up worker status
@@ -1232,7 +1232,7 @@ public class WorkMgr extends AbstractCoordinator {
       _workQueueMgr.processTaskCheckResult(work, fakeTask);
       killed = true;
     } catch (Exception e) {
-      _logger.errorf("exception: %s\n", ExceptionUtils.getStackTrace(e));
+      _logger.errorf("exception: %s\n", Throwables.getStackTraceAsString(e));
     }
     return killed;
   }
@@ -1296,9 +1296,9 @@ public class WorkMgr extends AbstractCoordinator {
         }
       }
     } catch (ProcessingException e) {
-      _logger.errorf("unable to connect to %s: %s\n", worker, ExceptionUtils.getStackTrace(e));
+      _logger.errorf("unable to connect to %s: %s\n", worker, Throwables.getStackTraceAsString(e));
     } catch (Exception e) {
-      _logger.errorf("exception: %s\n", ExceptionUtils.getStackTrace(e));
+      _logger.errorf("exception: %s\n", Throwables.getStackTraceAsString(e));
     } finally {
       if (client != null) {
         client.close();

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
@@ -30,7 +30,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import org.apache.commons.io.FileExistsException;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.batfish.common.BatfishException;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.Container;
@@ -103,7 +102,7 @@ public class WorkMgrService {
       _logger.errorf("WMS:autoComplete exception: %s\n", e.getMessage());
       return failureResponse(e.getMessage());
     } catch (Exception e) {
-      String stackTrace = ExceptionUtils.getStackTrace(e);
+      String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf("WMS:autoComplete exception: %s", stackTrace);
       return failureResponse(e.getMessage());
     }
@@ -134,7 +133,7 @@ public class WorkMgrService {
       _logger.errorf("WMS:checkApiKey exception: %s\n", e.getMessage());
       return failureResponse(e.getMessage());
     } catch (Exception e) {
-      String stackTrace = ExceptionUtils.getStackTrace(e);
+      String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf("WMS:checkApiKey exception: %s", stackTrace);
       return failureResponse(e.getMessage());
     }
@@ -241,7 +240,7 @@ public class WorkMgrService {
       _logger.errorf("WMS:configureAnalysis exception: %s\n", e.getMessage());
       return failureResponse(e.getMessage());
     } catch (Exception e) {
-      String stackTrace = ExceptionUtils.getStackTrace(e);
+      String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf(
           "WMS:configureAnalysis exception for apikey:%s in container:%s; exception:%s",
           apiKey, containerName, stackTrace);
@@ -289,7 +288,7 @@ public class WorkMgrService {
       _logger.errorf("WMS:configureQuestionTemplates exception: %s\n", e.getMessage());
       return failureResponse(e.getMessage());
     } catch (Exception e) {
-      String stackTrace = ExceptionUtils.getStackTrace(e);
+      String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf(
           "WMS:configureQuestionTemplates exception for apikey:%s; exception:%s",
           apiKey, stackTrace);
@@ -335,7 +334,7 @@ public class WorkMgrService {
       _logger.errorf("WMS:delAnalysis exception: %s\n", e.getMessage());
       return failureResponse(e.getMessage());
     } catch (Exception e) {
-      String stackTrace = ExceptionUtils.getStackTrace(e);
+      String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf(
           "WMS:delAnalysis exception for apikey:%s in container:%s; exception:%s",
           apiKey, containerName, stackTrace);
@@ -377,7 +376,7 @@ public class WorkMgrService {
       _logger.errorf("WMS:delContainer exception: %s\n", e.getMessage());
       return failureResponse(e.getMessage());
     } catch (Exception e) {
-      String stackTrace = ExceptionUtils.getStackTrace(e);
+      String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf(
           "WMS:delContainer exception for apikey:%s in container:%s; exception:%s",
           apiKey, containerName, stackTrace);
@@ -425,7 +424,7 @@ public class WorkMgrService {
       _logger.errorf("WMS:delEnvironment exception: %s\n", e.getMessage());
       return failureResponse(e.getMessage());
     } catch (Exception e) {
-      String stackTrace = ExceptionUtils.getStackTrace(e);
+      String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf(
           "WMS:delEnvironment exception for apikey:%s in container:%s, testrig:%s; exception:%s",
           apiKey, containerName, testrigName, stackTrace);
@@ -470,7 +469,7 @@ public class WorkMgrService {
       _logger.errorf("WMS:delQuestion exception: %s\n", e.getMessage());
       return failureResponse(e.getMessage());
     } catch (Exception e) {
-      String stackTrace = ExceptionUtils.getStackTrace(e);
+      String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf(
           "WMS:delQuestion exception for apikey:%s in container:%s; exception:%s",
           apiKey, containerName, stackTrace);
@@ -515,7 +514,7 @@ public class WorkMgrService {
       _logger.errorf("WMS:delTestrig exception: %s\n", e.getMessage());
       return failureResponse(e.getMessage());
     } catch (Exception e) {
-      String stackTrace = ExceptionUtils.getStackTrace(e);
+      String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf(
           "WMS:delTestrig exception for apikey:%s in container:%s, testrig:%s; exception:%s",
           apiKey, containerName, testrigName, stackTrace);
@@ -595,7 +594,7 @@ public class WorkMgrService {
       _logger.errorf("WMS:getAnalysisAnswers exception: %s\n", e.getMessage());
       return failureResponse(e.getMessage());
     } catch (Exception e) {
-      String stackTrace = ExceptionUtils.getStackTrace(e);
+      String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf(
           "WMS:getAnalsysisAnswers exception for apikey:%s in container:%s, testrig:%s, "
               + "deltatestrig:%s; exception:%s",
@@ -672,7 +671,7 @@ public class WorkMgrService {
       _logger.errorf("WMS:getAnswer exception: %s\n", e.getMessage());
       return failureResponse(e.getMessage());
     } catch (Exception e) {
-      String stackTrace = ExceptionUtils.getStackTrace(e);
+      String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf(
           "WMS:getAnswer exception for apikey:%s in container:%s, testrig:%s, deltatestrig:%s; "
               + "exception:%s",
@@ -739,7 +738,7 @@ public class WorkMgrService {
           .type(MediaType.TEXT_PLAIN)
           .build();
     } catch (Exception e) {
-      String stackTrace = ExceptionUtils.getStackTrace(e);
+      String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf("WMS:getConfiguration exception: %s", stackTrace);
       return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
           .entity(e.getCause())
@@ -801,7 +800,7 @@ public class WorkMgrService {
           .type(MediaType.TEXT_PLAIN)
           .build();
     } catch (Exception e) {
-      String stackTrace = ExceptionUtils.getStackTrace(e);
+      String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf(
           "WMS:getContainer exception for apikey:%s in container:%s; exception:%s",
           apiKey, containerName, stackTrace);
@@ -824,7 +823,7 @@ public class WorkMgrService {
 
       return successResponse(map);
     } catch (Exception e) {
-      String stackTrace = ExceptionUtils.getStackTrace(e);
+      String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf("WMS:getInfo exception: %s", stackTrace);
       return failureResponse(e.getMessage());
     }
@@ -883,7 +882,7 @@ public class WorkMgrService {
           .type(MediaType.TEXT_PLAIN)
           .build();
     } catch (Exception e) {
-      String stackTrace = ExceptionUtils.getStackTrace(e);
+      String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf(
           "WMS:getObject exception for apikey:%s in container:%s, testrig:%s; exception:%s",
           apiKey, containerName, testrigName, stackTrace);
@@ -915,7 +914,7 @@ public class WorkMgrService {
 
       return successResponse(Main.getWorkMgr().getParsingResults(containerName, testrigName));
     } catch (Exception e) {
-      String stackTrace = ExceptionUtils.getStackTrace(e);
+      String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf(
           "WMS:getParsingResults exception for apikey:%s in container:%s, testrig:%s; exception:%s",
           apiKey, containerName, testrigName, stackTrace);
@@ -943,7 +942,7 @@ public class WorkMgrService {
             new JSONObject().put(CoordConsts.SVC_KEY_QUESTION_LIST, questionTemplates));
       }
     } catch (Exception e) {
-      String stackTrace = ExceptionUtils.getStackTrace(e);
+      String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf("WMS:getQuestionTemplates exception: %s", stackTrace);
       return failureResponse(e.getMessage());
     }
@@ -959,7 +958,7 @@ public class WorkMgrService {
       retObject.put("service-version", Version.getVersion());
       return successResponse(retObject);
     } catch (Exception e) {
-      String stackTrace = ExceptionUtils.getStackTrace(e);
+      String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf("WMS:getStatus exception: %s", stackTrace);
       return failureResponse(e.getMessage());
     }
@@ -1009,7 +1008,7 @@ public class WorkMgrService {
       _logger.errorf("WMS:getWorkStatus exception: %s\n", e.getMessage());
       return failureResponse(e.getMessage());
     } catch (Exception e) {
-      String stackTrace = ExceptionUtils.getStackTrace(e);
+      String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf("WMS:getWorkStatus exception: %s", stackTrace);
       return failureResponse(e.getMessage());
     }
@@ -1056,7 +1055,7 @@ public class WorkMgrService {
       _logger.errorf("WMS:initContainer exception: %s\n", e.getMessage());
       return failureResponse(e.getMessage());
     } catch (Exception e) {
-      String stackTrace = ExceptionUtils.getStackTrace(e);
+      String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf(
           "WMS:initContainer exception for apikey:%s in container:%s; exception:%s",
           apiKey, containerName, stackTrace);
@@ -1104,7 +1103,7 @@ public class WorkMgrService {
       _logger.errorf("WMS:killWork exception: %s\n", e.getMessage());
       return failureResponse(e.getMessage());
     } catch (Exception e) {
-      String stackTrace = ExceptionUtils.getStackTrace(e);
+      String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf("WMS:killWork exception: %s", stackTrace);
       return failureResponse(e.getMessage());
     }
@@ -1162,7 +1161,7 @@ public class WorkMgrService {
       _logger.errorf("WMS:listAnalyses exception: %s\n", e.getMessage());
       return failureResponse(e.getMessage());
     } catch (Exception e) {
-      String stackTrace = ExceptionUtils.getStackTrace(e);
+      String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf(
           "WMS:listAnalyses exception for apikey:%s in container:%s; exception:%s",
           apiKey, containerName, stackTrace);
@@ -1200,7 +1199,7 @@ public class WorkMgrService {
       _logger.errorf("WMS:listContainers exception: %s\n", e.getMessage());
       return failureResponse(e.getMessage());
     } catch (Exception e) {
-      String stackTrace = ExceptionUtils.getStackTrace(e);
+      String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf(
           "WMS:listContainers exception for apikey:%s, exception:%s", apiKey, stackTrace);
       return failureResponse(e.getMessage());
@@ -1246,7 +1245,7 @@ public class WorkMgrService {
       _logger.errorf("WMS:listEnvironments exception: %s\n", e.getMessage());
       return failureResponse(e.getMessage());
     } catch (Exception e) {
-      String stackTrace = ExceptionUtils.getStackTrace(e);
+      String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf("WMS:listEnvironments exception: %s", stackTrace);
       return failureResponse(e.getMessage());
     }
@@ -1300,7 +1299,7 @@ public class WorkMgrService {
       _logger.errorf("WMS:listIncompleteWork exception: %s\n", e.getMessage());
       return failureResponse(e.getMessage());
     } catch (Exception e) {
-      String stackTrace = ExceptionUtils.getStackTrace(e);
+      String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf("WMS:listIncompleteWork exception: %s", stackTrace);
       return failureResponse(e.getMessage());
     }
@@ -1347,7 +1346,7 @@ public class WorkMgrService {
       _logger.errorf("WMS:listQuestions exception: %s\n", e.getMessage());
       return failureResponse(e.getMessage());
     } catch (Exception e) {
-      String stackTrace = ExceptionUtils.getStackTrace(e);
+      String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf(
           "WMS:listQuestions exception for apikey:%s in container:%s; exception:%s",
           apiKey, containerName, stackTrace);
@@ -1410,7 +1409,7 @@ public class WorkMgrService {
     } catch (Exception e) {
       _logger.errorf(
           "WMS:listTestrigs exception for apikey:%s in container:%s; exception:%s",
-          apiKey, containerName, ExceptionUtils.getStackTrace(e));
+          apiKey, containerName, Throwables.getStackTraceAsString(e));
       return failureResponse(e.getMessage());
     }
   }
@@ -1459,7 +1458,7 @@ public class WorkMgrService {
       _logger.errorf("WMS:putObject exception: %s\n", e.getMessage());
       return failureResponse(e.getMessage());
     } catch (Exception e) {
-      String stackTrace = ExceptionUtils.getStackTrace(e);
+      String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf("WMS:putObject exception: %s", stackTrace);
       return failureResponse(e.getMessage());
     }
@@ -1509,7 +1508,7 @@ public class WorkMgrService {
       _logger.errorf("WMS:queueWork exception: %s\n", e.getMessage());
       return failureResponse(e.getMessage());
     } catch (Exception e) {
-      String stackTrace = ExceptionUtils.getStackTrace(e);
+      String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf("WMS:queueWork exception for apikey:%s; exception:%s", apiKey, stackTrace);
       return failureResponse(e.getMessage());
     }
@@ -1554,7 +1553,7 @@ public class WorkMgrService {
       _logger.errorf("WMS:syncTestrigsSyncNow exception: %s\n", e.getMessage());
       return failureResponse(e.getMessage());
     } catch (Exception e) {
-      String stackTrace = ExceptionUtils.getStackTrace(e);
+      String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf(
           "WMS:syncTestrigsSyncNow exception for apikey:%s in container:%s; exception:%s",
           apiKey, containerName, stackTrace);
@@ -1611,7 +1610,7 @@ public class WorkMgrService {
       _logger.errorf("WMS:syncTestrigsUpdateSettings exception: %s\n", e.getMessage());
       return failureResponse(e.getMessage());
     } catch (Exception e) {
-      String stackTrace = ExceptionUtils.getStackTrace(e);
+      String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf(
           "WMS:syncTestrigsUpdateSettings exception for apikey:%s in container:%s; exception:%s",
           apiKey, containerName, stackTrace);
@@ -1636,7 +1635,7 @@ public class WorkMgrService {
       // .allow("OPTIONS")
       // .build();
     } catch (Exception e) {
-      String stackTrace = ExceptionUtils.getStackTrace(e);
+      String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf("WMS:test exception: %s", stackTrace);
       // return Response.serverError().build();
       return "got error";
@@ -1691,7 +1690,7 @@ public class WorkMgrService {
       _logger.errorf("WMS:uploadEnvironment exception: %s\n", e.getMessage());
       return failureResponse(e.getMessage());
     } catch (Exception e) {
-      String stackTrace = ExceptionUtils.getStackTrace(e);
+      String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf("WMS:uploadEnvironment exception: %s", stackTrace);
       return failureResponse(e.getMessage());
     }
@@ -1740,7 +1739,7 @@ public class WorkMgrService {
       _logger.errorf("WMS:uploadQuestion exception: %s\n", e.getMessage());
       return failureResponse(e.getMessage());
     } catch (Exception e) {
-      String stackTrace = ExceptionUtils.getStackTrace(e);
+      String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf(
           "WMS:uploadQuestion exception for apikey:%s in container:%s; exception:%s",
           apiKey, containerName, stackTrace);
@@ -1802,7 +1801,7 @@ public class WorkMgrService {
       _logger.errorf("WMS:uploadTestrig exception: %s\n", e.getMessage());
       return failureResponse(e.getMessage());
     } catch (Exception e) {
-      String stackTrace = ExceptionUtils.getStackTrace(e);
+      String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf(
           "WMS:uploadTestrig exception for apikey:%s in container:%s, testrig:%s; exception:%s",
           apiKey, containerName, testrigName, stackTrace);

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkQueueMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkQueueMgr.java
@@ -1,5 +1,6 @@
 package org.batfish.coordinator;
 
+import com.google.common.base.Throwables;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -9,7 +10,6 @@ import java.util.Set;
 import java.util.UUID;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.batfish.common.BatfishException;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.BfConsts.TaskStatus;
@@ -481,7 +481,7 @@ public class WorkQueueMgr {
                       "Failed to requeue previously blocked work " + requeueWork.getId());
                 }
               } catch (Exception e) {
-                String stackTrace = ExceptionUtils.getStackTrace(e);
+                String stackTrace = Throwables.getStackTraceAsString(e);
                 _logger.errorf("exception: %s\n", stackTrace);
                 // put this work back on incomplete queue and process as if it terminatedabnormally
                 // people may be checking its status and this work may be blocking others

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/authorizer/DbAuthorizer.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/authorizer/DbAuthorizer.java
@@ -1,6 +1,7 @@
 package org.batfish.coordinator.authorizer;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Throwables;
 import java.net.ConnectException;
 import java.net.UnknownHostException;
 import java.sql.Connection;
@@ -12,7 +13,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.batfish.common.BatfishException;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.util.CommonUtil;
@@ -322,7 +322,7 @@ public class DbAuthorizer implements Authorizer {
           throw new BatfishException("No tries left loading JDBC driver: " + _driverClassName);
         }
         _logger.errorf(
-            "SQLException while opening Db connection: %s\n", ExceptionUtils.getStackTrace(e));
+            "SQLException while opening Db connection: %s\n", Throwables.getStackTraceAsString(e));
         _logger.errorf("Tries left = %d\n", triesLeft);
 
       } catch (ClassNotFoundException e) {


### PR DESCRIPTION
Rationale: every module is likely to depend on guava, but less likely to
depend on commons-lang3. Since they're essentially the same function,
prefer the guava one.

This allows us to remove two dependencies on commons-lang3 (in modules
that already depended on guava).