### PR TITLE
Flatten Palo Alto nested configs

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
@@ -32,6 +32,15 @@ SYSTEM
 
 // Complex tokens
 
+LINE_COMMENT
+:
+   (
+      '#'
+      | '!'
+   )
+   F_NonNewlineChar* F_Newline+ -> channel ( HIDDEN )
+;
+
 NEWLINE
 :
     F_Newline+
@@ -53,6 +62,12 @@ fragment
 F_Newline
 :
     [\r\n] // carriage return or line feed
+;
+
+fragment
+F_NonNewlineChar
+:
+    ~[\r\n] // carriage return or line feed
 ;
 
 fragment

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -314,6 +314,8 @@ public class Batfish extends PluginConsumer implements IBatfish {
       String header) {
     switch (format) {
       case JUNIPER:
+        // Just use the Juniper flattener for PaloAlto for now since the process is identical
+      case PALO_ALTO_NESTED:
         {
           JuniperCombinedParser parser = new JuniperCombinedParser(input, settings);
           ParserRuleContext tree = parse(parser, logger, settings);

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -44,4 +44,12 @@ public class PaloAltoGrammarTest {
     // Confirm hostname extraction works
     assertThat(parseTextConfigs(filename).keySet(), contains(hostname));
   }
+
+  @Test
+  public void testNestedConfig() throws IOException {
+    String hostname = "nested-config";
+
+    // Confirm a simple extraction (hostname) works for nested config format
+    assertThat(parseTextConfigs(hostname).keySet(), contains(hostname));
+  }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/basic-parsing
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/basic-parsing
@@ -1,2 +1,1 @@
-
 set deviceconfig system hostname my-hostname

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/basic-parsing
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/basic-parsing
@@ -1,1 +1,2 @@
+
 set deviceconfig system hostname my-hostname

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/nested-config
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/nested-config
@@ -1,5 +1,5 @@
 deviceconfig {
     system {
-        hostname my-hostname;
+        hostname nested-config;
     }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/nested-config
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/nested-config
@@ -1,0 +1,5 @@
+deviceconfig {
+    system {
+        hostname my-hostname;
+    }
+}


### PR DESCRIPTION
* Use Juniper flattener on Palo Alto nested configs for now
* Support comment lines in Palo Alto configs
