### PR TITLE
BfCoordWorkHelper: remove all warnings

### DIFF
--- a/projects/batfish-client/src/main/java/org/batfish/client/BfCoordWorkHelper.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/BfCoordWorkHelper.java
@@ -50,7 +50,7 @@ public class BfCoordWorkHelper {
   private final Settings _settings;
   private final Client _client;
 
-  public BfCoordWorkHelper(BatfishLogger logger, Settings settings) {
+  BfCoordWorkHelper(BatfishLogger logger, Settings settings) {
     _logger = logger;
     _settings = settings;
     _coordWorkMgr = _settings.getCoordinatorHost() + ":" + _settings.getCoordinatorWorkPort();
@@ -64,16 +64,16 @@ public class BfCoordWorkHelper {
     }
   }
 
-  private void addFileMultiPart(MultiPart multiPart, String key, String filename) {
+  private static void addFileMultiPart(MultiPart multiPart, String key, String filename) {
     multiPart.bodyPart(
         new FormDataBodyPart(key, new File(filename), MediaType.APPLICATION_OCTET_STREAM_TYPE));
   }
 
-  private void addTextMultiPart(MultiPart multiPart, String key, String value) {
+  private static void addTextMultiPart(MultiPart multiPart, String key, String value) {
     multiPart.bodyPart(new FormDataBodyPart(key, value, MediaType.TEXT_PLAIN_TYPE));
   }
 
-  public String autoComplete(
+  String autoComplete(
       String containerName,
       String testrigName,
       CompletionType completionType,
@@ -111,7 +111,7 @@ public class BfCoordWorkHelper {
   }
 
   @Nullable
-  public String checkApiKey() {
+  String checkApiKey() {
     try {
       WebTarget webTarget = getTarget(CoordConsts.SVC_RSC_CHECK_API_KEY);
 
@@ -132,7 +132,7 @@ public class BfCoordWorkHelper {
     }
   }
 
-  public boolean configureAnalysis(
+  boolean configureAnalysis(
       String containerName,
       boolean newAnalysis,
       String analysisName,
@@ -177,7 +177,7 @@ public class BfCoordWorkHelper {
   }
 
   @Nullable
-  public String configureTemplate(String inTemplate, JsonNode exceptions, JsonNode assertion) {
+  String configureTemplate(String inTemplate, JsonNode exceptions, JsonNode assertion) {
     try {
       WebTarget webTarget = getTarget(CoordConsts.SVC_RSC_CONFIGURE_QUESTION_TEMPLATE);
 
@@ -203,9 +203,7 @@ public class BfCoordWorkHelper {
         return null;
       }
 
-      String outTemplate = jObj.getString(CoordConsts.SVC_KEY_QUESTION);
-
-      return outTemplate;
+      return jObj.getString(CoordConsts.SVC_KEY_QUESTION);
     } catch (Exception e) {
       _logger.errorf(
           "Exception in configureTemplate from %s using (%s, %s, %s)\n",
@@ -215,7 +213,7 @@ public class BfCoordWorkHelper {
     }
   }
 
-  public boolean delAnalysis(String containerName, String analysisName) {
+  boolean delAnalysis(String containerName, String analysisName) {
     try {
       WebTarget webTarget = getTarget(CoordConsts.SVC_RSC_DEL_ANALYSIS);
 
@@ -235,7 +233,7 @@ public class BfCoordWorkHelper {
     }
   }
 
-  public boolean delContainer(String containerName) {
+  boolean delContainer(String containerName) {
     try {
       WebTarget webTarget =
           getTargetV2(Lists.newArrayList(CoordConstsV2.RSC_CONTAINERS, containerName));
@@ -260,7 +258,7 @@ public class BfCoordWorkHelper {
     }
   }
 
-  public boolean delEnvironment(String containerName, String testrigName, String envName) {
+  boolean delEnvironment(String containerName, String testrigName, String envName) {
     try {
       WebTarget webTarget = getTarget(CoordConsts.SVC_RSC_DEL_ENVIRONMENT);
 
@@ -281,7 +279,7 @@ public class BfCoordWorkHelper {
     }
   }
 
-  public boolean delQuestion(String containerName, String testrigName, String questionName) {
+  boolean delQuestion(String containerName, String testrigName, String questionName) {
     try {
       WebTarget webTarget = getTarget(CoordConsts.SVC_RSC_DEL_QUESTION);
 
@@ -302,7 +300,7 @@ public class BfCoordWorkHelper {
     }
   }
 
-  public boolean delTestrig(String containerName, String testrigName) {
+  boolean delTestrig(String containerName, String testrigName) {
     try {
       WebTarget webTarget = getTarget(CoordConsts.SVC_RSC_DEL_TESTRIG);
 
@@ -372,7 +370,7 @@ public class BfCoordWorkHelper {
   // }
 
   @Nullable
-  public String getAnalysisAnswers(
+  String getAnalysisAnswers(
       String containerName,
       String baseTestrig,
       String baseEnvironment,
@@ -405,9 +403,7 @@ public class BfCoordWorkHelper {
         return null;
       }
 
-      String answer = jObj.getString(CoordConsts.SVC_KEY_ANSWERS);
-
-      return answer;
+      return jObj.getString(CoordConsts.SVC_KEY_ANSWERS);
     } catch (Exception e) {
       _logger.errorf(
           "Exception in getAnswer from %s using (%s, %s)\n",
@@ -418,7 +414,7 @@ public class BfCoordWorkHelper {
   }
 
   @Nullable
-  public String getAnswer(
+  String getAnswer(
       String containerName,
       String baseTestrig,
       String baseEnv,
@@ -451,9 +447,7 @@ public class BfCoordWorkHelper {
         return null;
       }
 
-      String answer = jObj.getString(CoordConsts.SVC_KEY_ANSWER);
-
-      return answer;
+      return jObj.getString(CoordConsts.SVC_KEY_ANSWER);
 
     } catch (Exception e) {
       _logger.errorf(
@@ -482,7 +476,7 @@ public class BfCoordWorkHelper {
    * no access to the container {@code containerName}
    */
   @Nullable
-  public String getConFiguration(String containerName, String testrigName, String configName) {
+  String getConFiguration(String containerName, String testrigName, String configName) {
     try {
       WebTarget webTarget = getTarget(CoordConsts.SVC_RSC_GET_CONFIGURATION);
 
@@ -508,8 +502,7 @@ public class BfCoordWorkHelper {
         return null;
       }
 
-      String configContent = response.readEntity(String.class);
-      return configContent;
+      return response.readEntity(String.class);
     } catch (Exception e) {
       _logger.errorf(
           "Exception in getConfiguration from %s for container %s, testrig %s, configuration %s\n",
@@ -525,7 +518,7 @@ public class BfCoordWorkHelper {
    * has no access to the container
    */
   @Nullable
-  public Container getContainer(String containerName) {
+  Container getContainer(String containerName) {
     try {
       WebTarget webTarget =
           getTargetV2(Lists.newArrayList(CoordConstsV2.RSC_CONTAINERS, containerName));
@@ -546,8 +539,7 @@ public class BfCoordWorkHelper {
       }
 
       String containerStr = response.readEntity(String.class);
-      Container container = BatfishObjectMapper.mapper().readValue(containerStr, Container.class);
-      return container;
+      return BatfishObjectMapper.mapper().readValue(containerStr, Container.class);
     } catch (Exception e) {
       _logger.errorf("Exception in getContainer from %s for %s\n", _coordWorkMgrV2, containerName);
       _logger.error(Throwables.getStackTraceAsString(e) + "\n");
@@ -556,7 +548,7 @@ public class BfCoordWorkHelper {
   }
 
   @Nullable
-  public Map<String, String> getInfo() {
+  Map<String, String> getInfo() {
     try {
       WebTarget webTarget = getTarget("");
 
@@ -565,7 +557,7 @@ public class BfCoordWorkHelper {
       _logger.debugf(response.getStatus() + " " + response.getStatusInfo() + " " + response + "\n");
 
       if (response.getStatus() != Response.Status.OK.getStatusCode()) {
-        System.err.printf("GET did not get an OK response\n");
+        System.err.print("GET did not get an OK response\n");
         return null;
       }
 
@@ -598,7 +590,7 @@ public class BfCoordWorkHelper {
   }
 
   @Nullable
-  public String getObject(String containerName, String testrigName, String objectName) {
+  String getObject(String containerName, String testrigName, String objectName) {
     try {
       WebTarget webTarget = getTarget(CoordConsts.SVC_RSC_GET_OBJECT);
 
@@ -715,7 +707,7 @@ public class BfCoordWorkHelper {
   }
 
   @Nullable
-  public Pair<WorkStatusCode, String> getWorkStatus(UUID workId) {
+  Pair<WorkStatusCode, String> getWorkStatus(UUID workId) {
     try {
       WebTarget webTarget = getTarget(CoordConsts.SVC_RSC_GET_WORKSTATUS);
 
@@ -752,7 +744,7 @@ public class BfCoordWorkHelper {
   }
 
   @Nullable
-  public String initContainer(@Nullable String containerName, @Nullable String containerPrefix) {
+  String initContainer(@Nullable String containerName, @Nullable String containerPrefix) {
     try {
       WebTarget webTarget = getTarget(CoordConsts.SVC_RSC_INIT_CONTAINER);
 
@@ -784,13 +776,11 @@ public class BfCoordWorkHelper {
     }
   }
 
-  public boolean isReachable(boolean chatty) {
+  boolean isReachable(boolean chatty) {
 
-    WebTarget webTarget = null;
+    WebTarget webTarget = getTarget("");
 
     try {
-      webTarget = getTarget("");
-
       Response response = webTarget.request().get();
 
       _logger.info(response.getStatus() + " " + response.getStatusInfo() + " " + response + "\n");
@@ -827,7 +817,7 @@ public class BfCoordWorkHelper {
     }
   }
 
-  public boolean killWork(UUID workId) {
+  boolean killWork(UUID workId) {
     try {
       WebTarget webTarget = getTarget(CoordConsts.SVC_RSC_KILL_WORK);
 
@@ -855,7 +845,7 @@ public class BfCoordWorkHelper {
   }
 
   @Nullable
-  public JSONObject listAnalyses(String containerName) {
+  JSONObject listAnalyses(String containerName) {
     try {
       WebTarget webTarget = getTarget(CoordConsts.SVC_RSC_LIST_ANALYSES);
 
@@ -884,7 +874,7 @@ public class BfCoordWorkHelper {
   }
 
   @Nullable
-  public String[] listContainers() {
+  String[] listContainers() {
     try {
       WebTarget webTarget = getTarget(CoordConsts.SVC_RSC_LIST_CONTAINERS);
 
@@ -921,7 +911,7 @@ public class BfCoordWorkHelper {
   }
 
   @Nullable
-  public String[] listEnvironments(String containerName, String testrigName) {
+  String[] listEnvironments(String containerName, String testrigName) {
     try {
       WebTarget webTarget = getTarget(CoordConsts.SVC_RSC_LIST_ENVIRONMENTS);
 
@@ -959,7 +949,7 @@ public class BfCoordWorkHelper {
   }
 
   @Nullable
-  public List<WorkStatus> listIncompleteWork(String containerName) {
+  List<WorkStatus> listIncompleteWork(String containerName) {
     try {
       WebTarget webTarget = getTarget(CoordConsts.SVC_RSC_LIST_INCOMPLETE_WORK);
 
@@ -981,10 +971,8 @@ public class BfCoordWorkHelper {
 
       String result = jObj.getString(CoordConsts.SVC_KEY_WORK_LIST);
 
-      List<WorkStatus> workList =
-          BatfishObjectMapper.mapper().readValue(result, new TypeReference<List<WorkStatus>>() {});
-
-      return workList;
+      return BatfishObjectMapper.mapper()
+          .readValue(result, new TypeReference<List<WorkStatus>>() {});
     } catch (Exception e) {
       _logger.errorf("exception: ");
       _logger.error(Throwables.getStackTraceAsString(e) + "\n");
@@ -993,7 +981,7 @@ public class BfCoordWorkHelper {
   }
 
   @Nullable
-  public String[] listQuestions(String containerName, String testrigName) {
+  String[] listQuestions(String containerName, String testrigName) {
     try {
       WebTarget webTarget = getTarget(CoordConsts.SVC_RSC_LIST_QUESTIONS);
 
@@ -1027,7 +1015,7 @@ public class BfCoordWorkHelper {
   }
 
   @Nullable
-  public JSONArray listTestrigs(String containerName) {
+  JSONArray listTestrigs(String containerName) {
     try {
       WebTarget webTarget = getTarget(CoordConsts.SVC_RSC_LIST_TESTRIGS);
 
@@ -1049,8 +1037,7 @@ public class BfCoordWorkHelper {
         return null;
       }
 
-      JSONArray testrigArray = jObj.getJSONArray(CoordConsts.SVC_KEY_TESTRIG_LIST);
-      return testrigArray;
+      return jObj.getJSONArray(CoordConsts.SVC_KEY_TESTRIG_LIST);
     } catch (Exception e) {
       _logger.errorf("exception: ");
       _logger.error(Throwables.getStackTraceAsString(e) + "\n");
@@ -1059,7 +1046,7 @@ public class BfCoordWorkHelper {
   }
 
   @Nullable
-  public JSONObject postData(WebTarget webTarget, MultiPart multiPart) throws Exception {
+  private JSONObject postData(WebTarget webTarget, MultiPart multiPart) throws Exception {
     try {
 
       addTextMultiPart(multiPart, CoordConsts.SVC_KEY_VERSION, Version.getVersion());
@@ -1072,7 +1059,7 @@ public class BfCoordWorkHelper {
       _logger.debugf(response.getStatus() + " " + response.getStatusInfo() + " " + response + "\n");
 
       if (response.getStatus() != Response.Status.OK.getStatusCode()) {
-        System.err.printf("PostData: Did not get an OK response\n");
+        System.err.print("PostData: Did not get an OK response\n");
         return null;
       }
 
@@ -1105,7 +1092,7 @@ public class BfCoordWorkHelper {
     }
   }
 
-  public boolean queueWork(WorkItem wItem) {
+  boolean queueWork(WorkItem wItem) {
 
     try {
       WebTarget webTarget = getTarget(CoordConsts.SVC_RSC_QUEUE_WORK);
@@ -1126,7 +1113,7 @@ public class BfCoordWorkHelper {
     }
   }
 
-  public boolean syncTestrigsSyncNow(String pluginId, String containerName, boolean force) {
+  boolean syncTestrigsSyncNow(String pluginId, String containerName, boolean force) {
     try {
       WebTarget webTarget = getTarget(CoordConsts.SVC_RSC_SYNC_TESTRIGS_SYNC_NOW);
 
@@ -1148,7 +1135,7 @@ public class BfCoordWorkHelper {
     }
   }
 
-  public boolean syncTestrigsUpdateSettings(
+  boolean syncTestrigsUpdateSettings(
       String pluginId, String containerName, Map<String, String> settings) {
     try {
       String settingsStr = BatfishObjectMapper.writePrettyString(settings);
@@ -1173,7 +1160,7 @@ public class BfCoordWorkHelper {
     }
   }
 
-  public boolean uploadCustomObject(
+  boolean uploadCustomObject(
       String containerName, String testrigName, String objName, String objFileName) {
     try {
       WebTarget webTarget = getTarget(CoordConsts.SVC_RSC_PUT_OBJECT);
@@ -1200,7 +1187,7 @@ public class BfCoordWorkHelper {
     }
   }
 
-  public boolean uploadEnvironment(
+  boolean uploadEnvironment(
       String containerName,
       String testrigName,
       String baseEnvName,
@@ -1229,8 +1216,7 @@ public class BfCoordWorkHelper {
     }
   }
 
-  public boolean uploadQuestion(
-      String containerName, String testrigName, String qName, String qFileName) {
+  boolean uploadQuestion(String containerName, String testrigName, String qName, String qFileName) {
     try {
       WebTarget webTarget = getTarget(CoordConsts.SVC_RSC_UPLOAD_QUESTION);
 
@@ -1256,7 +1242,7 @@ public class BfCoordWorkHelper {
     }
   }
 
-  public boolean uploadTestrig(
+  boolean uploadTestrig(
       String containerName, String testrigName, String zipfileName, boolean autoAnalyze) {
     try {
       WebTarget webTarget = getTarget(CoordConsts.SVC_RSC_UPLOAD_TESTRIG);


### PR DESCRIPTION
* static functions can be static
* tighten access from public to package or private
* unnecessary printf concerted to print
