### PR TITLE
use specialization in reachability queries by default

### DIFF
--- a/projects/question/src/main/java/org/batfish/question/ReachabilityQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/ReachabilityQuestionPlugin.java
@@ -126,7 +126,7 @@ public class ReachabilityQuestionPlugin extends QuestionPlugin {
 
     private static final NodesSpecifier DEFAULT_NOT_INGRESS_NODE_REGEX = NodesSpecifier.NONE;
 
-    private static final boolean DEFAULT_SPECIALIZE = false;
+    private static final boolean DEFAULT_SPECIALIZE = true;
 
     private static final NodesSpecifier DEFAULT_TRANSIT_NODES = NodesSpecifier.NONE;
 

--- a/tests/basic/commands
+++ b/tests/basic/commands
@@ -72,4 +72,4 @@ test tests/basic/example-iptables-protection.ref get reachability notIngressNode
 # z3 timeout - 1 millisecond
 add-batfish-option z3timeout 1
 init-testrig test_rigs/fattree-examples/fattree2
-test tests/basic/z3timeout.ref -error get reachability dstIps=['70.0.2.0']
+test tests/basic/z3timeout.ref -error get reachability dstIps=['70.0.2.0'], specialize=false


### PR DESCRIPTION
missed a spot.