### PR TITLE
move ForwardingAnalysis to DataPlane, make IncrementalDataPlane immutable

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/DataPlanePlugin.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/DataPlanePlugin.java
@@ -11,7 +11,6 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowTrace;
-import org.batfish.datamodel.ForwardingAnalysis;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.answers.DataPlaneAnswerElement;
 import org.batfish.datamodel.collections.IbgpTopology;
@@ -75,11 +74,7 @@ public abstract class DataPlanePlugin extends BatfishPlugin implements IDataPlan
   public abstract SortedMap<String, SortedMap<String, SortedSet<AbstractRoute>>> getRoutes(
       DataPlane dataPlane);
 
-  public abstract void processFlows(
-      Set<Flow> flows,
-      DataPlane dataPlane,
-      boolean ignoreAcls,
-      ForwardingAnalysis forwardingAnalysis);
+  public abstract void processFlows(Set<Flow> flows, DataPlane dataPlane, boolean ignoreAcls);
 
   public abstract String getName();
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/ITracerouteEngine.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/ITracerouteEngine.java
@@ -7,7 +7,6 @@ import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.Fib;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowTrace;
-import org.batfish.datamodel.ForwardingAnalysis;
 
 /**
  * Indicates ability to process a set of {@link Flow} objects and return a set of {@link FlowTrace},
@@ -15,9 +14,5 @@ import org.batfish.datamodel.ForwardingAnalysis;
  */
 public interface ITracerouteEngine {
   SortedMap<Flow, Set<FlowTrace>> processFlows(
-      DataPlane dataPlane,
-      Set<Flow> flows,
-      Map<String, Map<String, Fib>> fibs,
-      boolean ignoreAcls,
-      ForwardingAnalysis forwardingAnalysis);
+      DataPlane dataPlane, Set<Flow> flows, Map<String, Map<String, Fib>> fibs, boolean ignoreAcls);
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
@@ -95,7 +95,6 @@ import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowDisposition;
 import org.batfish.datamodel.FlowTrace;
-import org.batfish.datamodel.ForwardingAnalysis;
 import org.batfish.datamodel.IkeGateway;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.InterfaceAddress;
@@ -906,8 +905,7 @@ public class CommonUtil {
       BgpNeighbor src,
       BgpNeighbor dst,
       @Nullable ITracerouteEngine tracerouteEngine,
-      @Nullable DataPlane dp,
-      @Nullable ForwardingAnalysis forwardingAnalysis) {
+      @Nullable DataPlane dp) {
     Ip srcAddress = src.getLocalIp();
     Ip dstAddress = src.getAddress();
     if (dstAddress == null) {
@@ -935,8 +933,7 @@ public class CommonUtil {
 
     // Execute the "initiate connection" traceroute
     SortedMap<Flow, Set<FlowTrace>> traces =
-        tracerouteEngine.processFlows(
-            dp, ImmutableSet.of(forwardFlow), dp.getFibs(), false, forwardingAnalysis);
+        tracerouteEngine.processFlows(dp, ImmutableSet.of(forwardFlow), dp.getFibs(), false);
 
     SortedSet<FlowTrace> acceptedFlows =
         traces
@@ -973,9 +970,7 @@ public class CommonUtil {
     fb.setSrcPort(forwardFlow.getDstPort());
     fb.setDstPort(forwardFlow.getSrcPort());
     Flow backwardFlow = fb.build();
-    traces =
-        tracerouteEngine.processFlows(
-            dp, ImmutableSet.of(backwardFlow), dp.getFibs(), false, forwardingAnalysis);
+    traces = tracerouteEngine.processFlows(dp, ImmutableSet.of(backwardFlow), dp.getFibs(), false);
 
     /*
      * If backward traceroutes fail, do not consider the neighbor reachable
@@ -1008,7 +1003,7 @@ public class CommonUtil {
       Map<String, Configuration> configurations,
       Map<Ip, Set<String>> ipOwners,
       boolean keepInvalid) {
-    return initBgpTopology(configurations, ipOwners, keepInvalid, false, null, null, null);
+    return initBgpTopology(configurations, ipOwners, keepInvalid, false, null, null);
   }
 
   /**
@@ -1034,8 +1029,7 @@ public class CommonUtil {
       boolean keepInvalid,
       boolean checkReachability,
       @Nullable ITracerouteEngine tracerouteEngine,
-      @Nullable DataPlane dp,
-      @Nullable ForwardingAnalysis forwardingAnalysis) {
+      @Nullable DataPlane dp) {
 
     // TODO: handle duplicate ips on different vrfs
 
@@ -1120,8 +1114,7 @@ public class CommonUtil {
          * Perform reachability checks.
          */
         if (checkReachability) {
-          if (isReachableBgpNeighbor(
-              neighbor, candidateNeighbor, tracerouteEngine, dp, forwardingAnalysis)) {
+          if (isReachableBgpNeighbor(neighbor, candidateNeighbor, tracerouteEngine, dp)) {
             graph.addEdge(neighbor, candidateNeighbor, new BgpSession(neighbor, candidateNeighbor));
           }
         } else {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/DataPlane.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/DataPlane.java
@@ -15,6 +15,8 @@ public interface DataPlane extends Serializable {
 
   Map<String, Map<String, Fib>> getFibs();
 
+  ForwardingAnalysis getForwardingAnalysis();
+
   /**
    * Return the map of Ip owners (as computed during dataplane computation). Map structure: Ip ->
    * Set of hostnames

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockDataPlane.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockDataPlane.java
@@ -21,7 +21,7 @@ public class MockDataPlane implements DataPlane {
 
     private Map<String, Map<String, Fib>> _fibs;
 
-    public ForwardingAnalysis _forwardingAnalysis;
+    private ForwardingAnalysis _forwardingAnalysis;
 
     private SortedMap<String, SortedMap<String, GenericRib<AbstractRoute>>> _ribs;
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockDataPlane.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockDataPlane.java
@@ -21,6 +21,8 @@ public class MockDataPlane implements DataPlane {
 
     private Map<String, Map<String, Fib>> _fibs;
 
+    public ForwardingAnalysis _forwardingAnalysis;
+
     private SortedMap<String, SortedMap<String, GenericRib<AbstractRoute>>> _ribs;
 
     @Nullable private Topology _topology;
@@ -54,6 +56,11 @@ public class MockDataPlane implements DataPlane {
       return this;
     }
 
+    public Builder setForwardingAnalysis(ForwardingAnalysis forwardingAnalysis) {
+      _forwardingAnalysis = forwardingAnalysis;
+      return this;
+    }
+
     public Builder setRibs(SortedMap<String, SortedMap<String, GenericRib<AbstractRoute>>> ribs) {
       _ribs = ribs;
       return this;
@@ -82,6 +89,8 @@ public class MockDataPlane implements DataPlane {
 
   private final Map<String, Map<String, Fib>> _fibs;
 
+  private final ForwardingAnalysis _forwardingAnalysis;
+
   private final Map<Ip, Set<String>> _ipOwners;
 
   private final Map<Ip, Map<String, Set<String>>> _ipVrfOwners;
@@ -96,6 +105,7 @@ public class MockDataPlane implements DataPlane {
     _bgpTopology = builder._bgpTopology;
     _configurations = builder._configurations;
     _fibs = builder._fibs;
+    _forwardingAnalysis = builder._forwardingAnalysis;
     _ipOwners = builder._ipOwners;
     _ipVrfOwners = builder._ipVrfOwners;
     _ribs = ImmutableSortedMap.copyOf(builder._ribs);
@@ -106,6 +116,11 @@ public class MockDataPlane implements DataPlane {
   @Override
   public Map<String, Map<String, Fib>> getFibs() {
     return _fibs;
+  }
+
+  @Override
+  public ForwardingAnalysis getForwardingAnalysis() {
+    return _forwardingAnalysis;
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/dataplane/TracerouteEngineImpl.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/TracerouteEngineImpl.java
@@ -8,7 +8,6 @@ import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.Fib;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowTrace;
-import org.batfish.datamodel.ForwardingAnalysis;
 
 public class TracerouteEngineImpl implements ITracerouteEngine {
   private static ITracerouteEngine _instance = new TracerouteEngineImpl();
@@ -24,9 +23,7 @@ public class TracerouteEngineImpl implements ITracerouteEngine {
       DataPlane dataPlane,
       Set<Flow> flows,
       Map<String, Map<String, Fib>> fibs,
-      boolean ignoreAcls,
-      ForwardingAnalysis forwardingAnalysis) {
-    return new TracerouteEngineImplContext(dataPlane, flows, fibs, ignoreAcls, forwardingAnalysis)
-        .processFlows();
+      boolean ignoreAcls) {
+    return new TracerouteEngineImplContext(dataPlane, flows, fibs, ignoreAcls).processFlows();
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/TracerouteEngineImplContext.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/TracerouteEngineImplContext.java
@@ -179,15 +179,14 @@ class TracerouteEngineImplContext {
       DataPlane dataPlane,
       Set<Flow> flows,
       Map<String, Map<String, Fib>> fibs,
-      boolean ignoreAcls,
-      ForwardingAnalysis forwardingAnalysis) {
+      boolean ignoreAcls) {
     _configurations = dataPlane.getConfigurations();
     _dataPlane = dataPlane;
     _flows = flows;
     _flowTraces = new ConcurrentHashMap<>();
     _fibs = fibs;
     _ignoreAcls = ignoreAcls;
-    _forwardingAnalysis = forwardingAnalysis;
+    _forwardingAnalysis = _dataPlane.getForwardingAnalysis();
   }
 
   private void collectFlowTraces(

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -98,13 +98,7 @@ public class IncrementalBdpEngine {
 
     Network<BgpNeighbor, BgpSession> bgpTopology =
         initBgpTopology(
-            configurations,
-            ipOwners,
-            false,
-            true,
-            TracerouteEngineImpl.getInstance(),
-            dp,
-            dp.getForwardingAnalysis());
+            configurations, ipOwners, false, true, TracerouteEngineImpl.getInstance(), dp);
 
     boolean isOscillating =
         computeNonMonotonicPortionOfDataPlane(
@@ -122,13 +116,7 @@ public class IncrementalBdpEngine {
       computeFibs(nodes);
       bgpTopology =
           initBgpTopology(
-              configurations,
-              ipOwners,
-              false,
-              true,
-              TracerouteEngineImpl.getInstance(),
-              dp,
-              dp.getForwardingAnalysis());
+              configurations, ipOwners, false, true, TracerouteEngineImpl.getInstance(), dp);
       // Update queues (if necessary) based on new neighbor relationships
       final Network<BgpNeighbor, BgpSession> finalBgpTopology = bgpTopology;
       nodes

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -1,15 +1,15 @@
 package org.batfish.dataplane.ibdp;
 
+import static org.batfish.common.util.CommonUtil.computeIpNodeOwners;
+import static org.batfish.common.util.CommonUtil.computeIpOwnersSimple;
 import static org.batfish.common.util.CommonUtil.computeIpVrfOwners;
 import static org.batfish.common.util.CommonUtil.computeNodeInterfaces;
 import static org.batfish.common.util.CommonUtil.initBgpTopology;
+import static org.batfish.common.util.CommonUtil.toImmutableSortedMap;
 import static org.batfish.dataplane.rib.AbstractRib.importRib;
 
-import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
-import com.google.common.collect.Ordering;
 import com.google.common.graph.Network;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -23,7 +23,6 @@ import java.util.function.BiFunction;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.BdpOscillationException;
 import org.batfish.common.Version;
-import org.batfish.common.util.CommonUtil;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.BgpAdvertisement;
 import org.batfish.datamodel.BgpNeighbor;
@@ -31,7 +30,6 @@ import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.BgpRoute;
 import org.batfish.datamodel.BgpSession;
 import org.batfish.datamodel.Configuration;
-import org.batfish.datamodel.ForwardingAnalysisImpl;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.OspfExternalType1Route;
 import org.batfish.datamodel.OspfExternalType2Route;
@@ -69,22 +67,22 @@ public class IncrementalBdpEngine {
       Set<BgpAdvertisement> externalAdverts,
       BdpAnswerElement ae) {
     _bfLogger.resetTimer();
-    IncrementalDataPlane dp = new IncrementalDataPlane();
+    IncrementalDataPlane.Builder dpBuilder = IncrementalDataPlane.builder();
     _bfLogger.info("\nComputing Data Plane using iBDP\n");
 
-    Map<Ip, Set<String>> ipOwners = CommonUtil.computeIpNodeOwners(configurations, true);
-    Map<Ip, String> ipOwnersSimple = CommonUtil.computeIpOwnersSimple(ipOwners);
+    Map<Ip, Set<String>> ipOwners = computeIpNodeOwners(configurations, true);
+    Map<Ip, String> ipOwnersSimple = computeIpOwnersSimple(ipOwners);
     Map<Ip, Map<String, Set<String>>> ipVrfOwners =
         computeIpVrfOwners(true, computeNodeInterfaces(configurations));
-    dp.initIpOwners(ipOwners, ipOwnersSimple, ipVrfOwners);
+    dpBuilder.setIpOwners(ipOwners);
+    dpBuilder.setIpOwnersSimple(ipOwnersSimple);
+    dpBuilder.setIpVrfOwners(ipVrfOwners);
 
     // Generate our nodes, keyed by name, sorted for determinism
-    ImmutableSortedMap.Builder<String, Node> builder =
-        new ImmutableSortedMap.Builder<>(Ordering.natural());
-    configurations.values().forEach(c -> builder.put(c.getHostname(), new Node(c)));
-    ImmutableSortedMap<String, Node> nodes = builder.build();
-    dp.setNodes(nodes);
-    dp.setTopology(topology);
+    SortedMap<String, Node> nodes =
+        toImmutableSortedMap(configurations.values(), Configuration::getHostname, Node::new);
+    dpBuilder.setNodes(nodes);
+    dpBuilder.setTopology(topology);
 
     /*
      * Run the data plane computation here:
@@ -96,16 +94,17 @@ public class IncrementalBdpEngine {
     computeIgpDataPlane(nodes, topology, ae);
     computeFibs(nodes);
 
+    IncrementalDataPlane dp = dpBuilder.build();
+
     Network<BgpNeighbor, BgpSession> bgpTopology =
         initBgpTopology(
             configurations,
-            dp.getIpOwners(),
+            ipOwners,
             false,
             true,
             TracerouteEngineImpl.getInstance(),
             dp,
-            new ForwardingAnalysisImpl(
-                dp.getConfigurations(), dp.getRibs(), dp.getFibs(), dp.getTopology()));
+            dp.getForwardingAnalysis());
 
     boolean isOscillating =
         computeNonMonotonicPortionOfDataPlane(
@@ -115,18 +114,21 @@ public class IncrementalBdpEngine {
       throw new BdpOscillationException("Network has no stable solution");
     }
 
+    // update the dataplane with bgpTopology.
+    // this will cause forwarding analysis, etc to be reinitialized
+    dp = dpBuilder.setBgpTopology(bgpTopology).build();
+
     if (_settings.getCheckBgpSessionReachability()) {
       computeFibs(nodes);
       bgpTopology =
           initBgpTopology(
               configurations,
-              dp.getIpOwners(),
+              ipOwners,
               false,
               true,
               TracerouteEngineImpl.getInstance(),
               dp,
-              new ForwardingAnalysisImpl(
-                  dp.getConfigurations(), dp.getRibs(), dp.getFibs(), topology));
+              dp.getForwardingAnalysis());
       // Update queues (if necessary) based on new neighbor relationships
       final Network<BgpNeighbor, BgpSession> finalBgpTopology = bgpTopology;
       nodes
@@ -508,12 +510,11 @@ public class IncrementalBdpEngine {
               computeBgpAdvertisementsToOutsideCompleted.incrementAndGet();
             });
 
-    dp.setBgpTopology(bgpTopology);
     ae.setDependentRoutesIterations(_numIterations);
     return false; // No oscillations
   }
 
-  private void compareToPreviousIteration(
+  private static void compareToPreviousIteration(
       Map<String, Node> nodes,
       AtomicBoolean dependentRoutesChanged,
       AtomicInteger checkFixedPointCompleted) {
@@ -607,29 +608,18 @@ public class IncrementalBdpEngine {
   /**
    * Return the main RIB routes for each node. Map structure: Hostname -> VRF name -> Set of routes
    */
-  SortedMap<String, SortedMap<String, SortedSet<AbstractRoute>>> getRoutes(
+  static SortedMap<String, SortedMap<String, SortedSet<AbstractRoute>>> getRoutes(
       IncrementalDataPlane dp) {
     // Scan through all Nodes and their virtual routers, retrieve main rib routes
-    return dp.getNodes()
-        .entrySet()
-        .stream()
-        .collect(
-            ImmutableSortedMap.toImmutableSortedMap(
-                Comparator.naturalOrder(),
+    return toImmutableSortedMap(
+        dp.getNodes(),
+        Entry::getKey,
+        nodeEntry ->
+            toImmutableSortedMap(
+                nodeEntry.getValue().getVirtualRouters(),
                 Entry::getKey,
-                nodeEntry ->
-                    nodeEntry
-                        .getValue()
-                        .getVirtualRouters()
-                        .entrySet()
-                        .stream()
-                        .collect(
-                            ImmutableSortedMap.toImmutableSortedMap(
-                                Comparator.naturalOrder(),
-                                Entry::getKey,
-                                vrfEntry ->
-                                    ImmutableSortedSet.copyOf(
-                                        vrfEntry.getValue().getMainRib().getRoutes())))));
+                vrfEntry ->
+                    ImmutableSortedSet.copyOf(vrfEntry.getValue().getMainRib().getRoutes())));
   }
 
   /**
@@ -639,7 +629,7 @@ public class IncrementalBdpEngine {
    * @param topology the network topology
    * @return the number of iterations it took for internal OSPF routes to converge
    */
-  int initOspfInternalRoutes(Map<String, Node> nodes, Topology topology) {
+  private int initOspfInternalRoutes(Map<String, Node> nodes, Topology topology) {
     AtomicBoolean ospfInternalChanged = new AtomicBoolean(true);
     int ospfInternalIterations = 0;
     while (ospfInternalChanged.get()) {

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlane.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlane.java
@@ -1,10 +1,11 @@
 package org.batfish.dataplane.ibdp;
 
+import static org.batfish.common.util.CommonUtil.toImmutableMap;
+import static org.batfish.common.util.CommonUtil.toImmutableSortedMap;
+
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.graph.Network;
 import java.io.Serializable;
-import java.util.Comparator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -17,44 +18,126 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.Edge;
 import org.batfish.datamodel.Fib;
+import org.batfish.datamodel.ForwardingAnalysis;
+import org.batfish.datamodel.ForwardingAnalysisImpl;
 import org.batfish.datamodel.GenericRib;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Topology;
 
-public class IncrementalDataPlane implements Serializable, DataPlane {
+public final class IncrementalDataPlane implements Serializable, DataPlane {
 
   private static final long serialVersionUID = 1L;
 
-  private transient Network<BgpNeighbor, BgpSession> _bgpTopology;
+  public static class Builder {
 
-  private Map<Ip, Set<String>> _ipOwners;
+    private Network<BgpNeighbor, BgpSession> _bgpTopology;
 
-  private Map<Ip, String> _ipOwnersSimple;
+    private Map<Ip, Set<String>> _ipOwners;
 
-  private Map<Ip, Map<String, Set<String>>> _ipVrfOwners;
+    private Map<Ip, String> _ipOwnersSimple;
 
-  Map<String, Node> _nodes;
+    private Map<Ip, Map<String, Set<String>>> _ipVrfOwners;
 
-  private Topology _topology;
+    private Map<String, Node> _nodes;
+
+    private Topology _topology;
+
+    public Builder setBgpTopology(Network<BgpNeighbor, BgpSession> bgpTopology) {
+      _bgpTopology = bgpTopology;
+      return this;
+    }
+
+    public Builder setIpOwners(Map<Ip, Set<String>> ipOwners) {
+      _ipOwners = ImmutableMap.copyOf(ipOwners);
+      return this;
+    }
+
+    public Builder setIpOwnersSimple(Map<Ip, String> ipOwnersSimple) {
+      _ipOwnersSimple = ImmutableMap.copyOf(ipOwnersSimple);
+      return this;
+    }
+
+    public Builder setIpVrfOwners(Map<Ip, Map<String, Set<String>>> ipVrfOwners) {
+      _ipVrfOwners = ImmutableMap.copyOf(ipVrfOwners);
+      return this;
+    }
+
+    public Builder setNodes(Map<String, Node> nodes) {
+      _nodes = ImmutableMap.copyOf(nodes);
+      return this;
+    }
+
+    public Builder setTopology(Topology topology) {
+      _topology = topology;
+      return this;
+    }
+
+    public IncrementalDataPlane build() {
+      return new IncrementalDataPlane(this);
+    }
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  private final transient Network<BgpNeighbor, BgpSession> _bgpTopology;
+
+  private transient Map<String, Configuration> _configurations;
+
+  private transient Map<String, Map<String, Fib>> _fibs;
+
+  private transient ForwardingAnalysis _forwardingAnalysis;
+
+  private final Map<Ip, Set<String>> _ipOwners;
+
+  private final Map<Ip, String> _ipOwnersSimple;
+
+  private final Map<Ip, Map<String, Set<String>>> _ipVrfOwners;
+
+  private final Map<String, Node> _nodes;
+
+  private transient SortedMap<String, SortedMap<String, GenericRib<AbstractRoute>>> _ribs;
+
+  private final Topology _topology;
+
+  private IncrementalDataPlane(Builder builder) {
+    _bgpTopology = builder._bgpTopology;
+    _ipOwners = builder._ipOwners;
+    _ipOwnersSimple = builder._ipOwnersSimple;
+    _ipVrfOwners = builder._ipVrfOwners;
+    _nodes = builder._nodes;
+    _topology = builder._topology;
+  }
+
+  @Override
+  public Network<BgpNeighbor, BgpSession> getBgpTopology() {
+    return _bgpTopology;
+  }
+
+  @Override
+  public Map<String, Configuration> getConfigurations() {
+    if (_configurations == null) {
+      _configurations = initConfigurations();
+    }
+    return _configurations;
+  }
 
   @Override
   public Map<String, Map<String, Fib>> getFibs() {
-    return _nodes
-        .entrySet()
-        .stream()
-        .collect(
-            ImmutableMap.toImmutableMap(
-                Entry::getKey,
-                eNode ->
-                    eNode
-                        .getValue()
-                        .getVirtualRouters()
-                        .entrySet()
-                        .stream()
-                        .collect(
-                            ImmutableMap.toImmutableMap(
-                                Entry::getKey, eVr -> eVr.getValue().getFib()))));
+    if (_fibs == null) {
+      _fibs = initFibs();
+    }
+    return _fibs;
+  }
+
+  @Override
+  public ForwardingAnalysis getForwardingAnalysis() {
+    if (_forwardingAnalysis == null) {
+      _forwardingAnalysis = initForwardingAnalysis();
+    }
+    return _forwardingAnalysis;
   }
 
   @Override
@@ -75,23 +158,48 @@ public class IncrementalDataPlane implements Serializable, DataPlane {
     return _nodes;
   }
 
+  /**
+   * Retrieve the {@link PrefixTracer} for each {@link VirtualRouter} after dataplane computation.
+   * Map structure: Hostname -> VRF name -> prefix tracer.
+   */
+  public SortedMap<String, SortedMap<String, PrefixTracer>> getPrefixTracingInfo() {
+    /*
+     * Iterate over nodes, then virtual routers, and extract prefix tracer from each.
+     * Sort hostnames and VRF names
+     */
+    return toImmutableSortedMap(
+        _nodes,
+        Entry::getKey,
+        nodeEntry ->
+            toImmutableSortedMap(
+                nodeEntry.getValue().getVirtualRouters(),
+                Entry::getKey,
+                vrfEntry -> vrfEntry.getValue().getPrefixTracer()));
+  }
+
+  @Override
+  public SortedMap<String, SortedMap<String, Map<Prefix, Map<String, Set<String>>>>>
+      getPrefixTracingInfoSummary() {
+    /*
+     * Iterate over nodes, then virtual routers, and extract prefix tracer from each.
+     * Sort hostnames and VRF names
+     */
+    return toImmutableSortedMap(
+        _nodes,
+        Entry::getKey,
+        nodeEntry ->
+            toImmutableSortedMap(
+                nodeEntry.getValue().getVirtualRouters(),
+                Entry::getKey,
+                vrfEntry -> vrfEntry.getValue().getPrefixTracer().summarize()));
+  }
+
   @Override
   public SortedMap<String, SortedMap<String, GenericRib<AbstractRoute>>> getRibs() {
-    ImmutableSortedMap.Builder<String, SortedMap<String, GenericRib<AbstractRoute>>> ribs =
-        new ImmutableSortedMap.Builder<>(Comparator.naturalOrder());
-    _nodes.forEach(
-        (hostname, node) -> {
-          ImmutableSortedMap.Builder<String, GenericRib<AbstractRoute>> byVrf =
-              new ImmutableSortedMap.Builder<>(Comparator.naturalOrder());
-          node.getVirtualRouters()
-              .forEach(
-                  (vrf, virtualRouter) -> {
-                    GenericRib<AbstractRoute> rib = virtualRouter.getMainRib();
-                    byVrf.put(vrf, rib);
-                  });
-          ribs.put(hostname, byVrf.build());
-        });
-    return ribs.build();
+    if (_ribs == null) {
+      _ribs = initRibs();
+    }
+    return _ribs;
   }
 
   @Override
@@ -104,103 +212,36 @@ public class IncrementalDataPlane implements Serializable, DataPlane {
     return _topology.getEdges();
   }
 
-  protected void initIpOwners(
-      Map<Ip, Set<String>> ipOwners,
-      Map<Ip, String> ipOwnersSimple,
-      Map<Ip, Map<String, Set<String>>> ipVrfOwners) {
-    setIpOwners(ipOwners);
-    setIpOwnersSimple(ipOwnersSimple);
-    setIpVrfOwners(ipVrfOwners);
-  }
-
-  public void setIpOwners(Map<Ip, Set<String>> ipOwners) {
-    _ipOwners = ipOwners;
-  }
-
-  public void setIpOwnersSimple(Map<Ip, String> ipOwnersSimple) {
-    _ipOwnersSimple = ipOwnersSimple;
-  }
-
-  public void setIpVrfOwners(Map<Ip, Map<String, Set<String>>> ipVrfOwners) {
-    this._ipVrfOwners = ipVrfOwners;
-  }
-
-  public void setNodes(Map<String, Node> nodes) {
-    _nodes = nodes;
-  }
-
-  public void setTopology(Topology topology) {
-    _topology = topology;
-  }
-
-  @Override
-  public Network<BgpNeighbor, BgpSession> getBgpTopology() {
-    return _bgpTopology;
-  }
-
-  @Override
-  public Map<String, Configuration> getConfigurations() {
+  private Map<String, Configuration> initConfigurations() {
     return _nodes
         .entrySet()
         .stream()
         .collect(ImmutableMap.toImmutableMap(Entry::getKey, e -> e.getValue().getConfiguration()));
   }
 
-  void setBgpTopology(Network<BgpNeighbor, BgpSession> bgpTopology) {
-    this._bgpTopology = bgpTopology;
+  private Map<String, Map<String, Fib>> initFibs() {
+    return toImmutableMap(
+        _nodes,
+        Entry::getKey,
+        nodeEntry ->
+            toImmutableMap(
+                nodeEntry.getValue().getVirtualRouters(),
+                Entry::getKey,
+                vrfEntry -> vrfEntry.getValue().getFib()));
   }
 
-  /**
-   * Retrieve the {@link PrefixTracer} for each {@link VirtualRouter} after dataplane computation.
-   * Map structure: Hostname -> VRF name -> prefix tracer.
-   */
-  public SortedMap<String, SortedMap<String, PrefixTracer>> getPrefixTracingInfo() {
-    /*
-     * Iterate over nodes, then virtual routers, and extract prefix tracer from each.
-     * Sort hostnames and VRF names
-     */
-    return _nodes
-        .entrySet()
-        .stream()
-        .collect(
-            ImmutableSortedMap.toImmutableSortedMap(
-                Comparator.naturalOrder(),
-                Entry::getKey,
-                e ->
-                    e.getValue()
-                        .getVirtualRouters()
-                        .entrySet()
-                        .stream()
-                        .collect(
-                            ImmutableSortedMap.toImmutableSortedMap(
-                                Comparator.naturalOrder(),
-                                Entry::getKey,
-                                e2 -> e2.getValue().getPrefixTracer()))));
+  private ForwardingAnalysis initForwardingAnalysis() {
+    return new ForwardingAnalysisImpl(getConfigurations(), getRibs(), getFibs(), getTopology());
   }
 
-  @Override
-  public SortedMap<String, SortedMap<String, Map<Prefix, Map<String, Set<String>>>>>
-      getPrefixTracingInfoSummary() {
-    /*
-     * Iterate over nodes, then virtual routers, and extract prefix tracer from each.
-     * Sort hostnames and VRF names
-     */
-    return _nodes
-        .entrySet()
-        .stream()
-        .collect(
-            ImmutableSortedMap.toImmutableSortedMap(
-                Comparator.naturalOrder(),
+  private SortedMap<String, SortedMap<String, GenericRib<AbstractRoute>>> initRibs() {
+    return toImmutableSortedMap(
+        _nodes,
+        Entry::getKey,
+        nodeEntry ->
+            toImmutableSortedMap(
+                nodeEntry.getValue().getVirtualRouters(),
                 Entry::getKey,
-                e ->
-                    e.getValue()
-                        .getVirtualRouters()
-                        .entrySet()
-                        .stream()
-                        .collect(
-                            ImmutableSortedMap.toImmutableSortedMap(
-                                Comparator.naturalOrder(),
-                                Entry::getKey,
-                                e2 -> e2.getValue().getPrefixTracer().summarize()))));
+                vrfEntry -> vrfEntry.getValue().getMainRib()));
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlane.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlane.java
@@ -80,7 +80,7 @@ public final class IncrementalDataPlane implements Serializable, DataPlane {
     }
   }
 
-  public class ConfigurationsSupplier
+  private final class ConfigurationsSupplier
       implements Serializable, Supplier<Map<String, Configuration>> {
 
     private static final long serialVersionUID = 1L;
@@ -91,7 +91,8 @@ public final class IncrementalDataPlane implements Serializable, DataPlane {
     }
   }
 
-  public class FibsSupplier implements Serializable, Supplier<Map<String, Map<String, Fib>>> {
+  private final class FibsSupplier
+      implements Serializable, Supplier<Map<String, Map<String, Fib>>> {
 
     private static final long serialVersionUID = 1L;
 
@@ -101,7 +102,8 @@ public final class IncrementalDataPlane implements Serializable, DataPlane {
     }
   }
 
-  public class ForwardingAnalysisSupplier implements Serializable, Supplier<ForwardingAnalysis> {
+  private final class ForwardingAnalysisSupplier
+      implements Serializable, Supplier<ForwardingAnalysis> {
 
     private static final long serialVersionUID = 1L;
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePlugin.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePlugin.java
@@ -132,7 +132,7 @@ public class IncrementalDataPlanePlugin extends DataPlanePlugin {
 
   @Override
   public SortedMap<String, SortedMap<String, SortedSet<AbstractRoute>>> getRoutes(DataPlane dp) {
-    return _engine.getRoutes((IncrementalDataPlane) dp);
+    return IncrementalBdpEngine.getRoutes((IncrementalDataPlane) dp);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePlugin.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePlugin.java
@@ -20,7 +20,6 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowTrace;
-import org.batfish.datamodel.ForwardingAnalysis;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.answers.Answer;
 import org.batfish.datamodel.answers.BdpAnswerElement;
@@ -136,15 +135,11 @@ public class IncrementalDataPlanePlugin extends DataPlanePlugin {
   }
 
   @Override
-  public void processFlows(
-      Set<Flow> flows,
-      DataPlane dataPlane,
-      boolean ignoreAcls,
-      ForwardingAnalysis forwardingAnalysis) {
+  public void processFlows(Set<Flow> flows, DataPlane dataPlane, boolean ignoreAcls) {
     _flowTraces.put(
         (IncrementalDataPlane) dataPlane,
         TracerouteEngineImpl.getInstance()
-            .processFlows(dataPlane, flows, dataPlane.getFibs(), ignoreAcls, forwardingAnalysis));
+            .processFlows(dataPlane, flows, dataPlane.getFibs(), ignoreAcls));
   }
 
   private IncrementalDataPlane loadDataPlane() {

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -96,7 +96,6 @@ import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowHistory;
 import org.batfish.datamodel.FlowTrace;
 import org.batfish.datamodel.ForwardingAction;
-import org.batfish.datamodel.ForwardingAnalysis;
 import org.batfish.datamodel.GenericConfigObject;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Interface;
@@ -3102,13 +3101,11 @@ public class Batfish extends PluginConsumer implements IBatfish {
     Set<Flow> flows = computeCompositeNodOutput(jobs, new NodAnswerElement());
     pushBaseEnvironment();
     DataPlane baseDataPlane = loadDataPlane();
-    ForwardingAnalysis baseForwardingAnalysis = baseDataPlane.getForwardingAnalysis();
-    getDataPlanePlugin().processFlows(flows, baseDataPlane, false, baseForwardingAnalysis);
+    getDataPlanePlugin().processFlows(flows, baseDataPlane, false);
     popEnvironment();
     pushDeltaEnvironment();
     DataPlane deltaDataPlane = loadDataPlane();
-    ForwardingAnalysis deltaForwardingAnalysis = deltaDataPlane.getForwardingAnalysis();
-    getDataPlanePlugin().processFlows(flows, deltaDataPlane, false, deltaForwardingAnalysis);
+    getDataPlanePlugin().processFlows(flows, deltaDataPlane, false);
     popEnvironment();
 
     AnswerElement answerElement = getHistory();
@@ -3319,7 +3316,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
   @Override
   public void processFlows(Set<Flow> flows, boolean ignoreAcls) {
     DataPlane dp = loadDataPlane();
-    getDataPlanePlugin().processFlows(flows, dp, ignoreAcls, dp.getForwardingAnalysis());
+    getDataPlanePlugin().processFlows(flows, dp, ignoreAcls);
   }
 
   /**
@@ -3624,14 +3621,10 @@ public class Batfish extends PluginConsumer implements IBatfish {
     // TODO: maybe do something with nod answer element
     Set<Flow> flows = computeCompositeNodOutput(jobs, new NodAnswerElement());
     pushBaseEnvironment();
-    DataPlane baseDataPlane = loadDataPlane();
-    ForwardingAnalysis baseForwardingAnalysis = baseDataPlane.getForwardingAnalysis();
-    getDataPlanePlugin().processFlows(flows, baseDataPlane, false, baseForwardingAnalysis);
+    getDataPlanePlugin().processFlows(flows, loadDataPlane(), false);
     popEnvironment();
     pushDeltaEnvironment();
-    DataPlane deltaDataPlane = loadDataPlane();
-    ForwardingAnalysis deltaForwardingAnalysis = deltaDataPlane.getForwardingAnalysis();
-    getDataPlanePlugin().processFlows(flows, deltaDataPlane, false, deltaForwardingAnalysis);
+    getDataPlanePlugin().processFlows(flows, loadDataPlane(), false);
     popEnvironment();
 
     AnswerElement answerElement = getHistory();
@@ -4260,7 +4253,6 @@ public class Batfish extends PluginConsumer implements IBatfish {
         synthesizeDataPlane(
             configurations,
             dataPlane,
-            dataPlane.getForwardingAnalysis(),
             headerSpace,
             forbiddenTransitNodes,
             requiredTransitNodes,
@@ -4316,7 +4308,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
     Set<Flow> flows = computeNodOutput(jobs);
 
     DataPlane dp = loadDataPlane();
-    getDataPlanePlugin().processFlows(flows, dp, false, dp.getForwardingAnalysis());
+    getDataPlanePlugin().processFlows(flows, dp, false);
 
     AnswerElement answerElement = getHistory();
     return answerElement;
@@ -4434,11 +4426,9 @@ public class Batfish extends PluginConsumer implements IBatfish {
 
   private Synthesizer synthesizeDataPlane(
       Map<String, Configuration> configurations, DataPlane dataPlane) {
-    ForwardingAnalysis forwardingAnalysis = dataPlane.getForwardingAnalysis();
     return synthesizeDataPlane(
         configurations,
         dataPlane,
-        forwardingAnalysis,
         new HeaderSpace(),
         ImmutableSet.of(),
         ImmutableSet.of(),
@@ -4453,7 +4443,6 @@ public class Batfish extends PluginConsumer implements IBatfish {
     return synthesizeDataPlane(
         configs,
         dataPlane,
-        dataPlane.getForwardingAnalysis(),
         parameters.getHeaderSpace(),
         parameters.getForbiddenTransitNodes(),
         parameters.getRequiredTransitNodes(),
@@ -4465,7 +4454,6 @@ public class Batfish extends PluginConsumer implements IBatfish {
   public Synthesizer synthesizeDataPlane(
       Map<String, Configuration> configurations,
       DataPlane dataPlane,
-      ForwardingAnalysis forwardingAnalysis,
       HeaderSpace headerSpace,
       Set<String> nonTransitNodes,
       Set<String> transitNodes,
@@ -4481,7 +4469,6 @@ public class Batfish extends PluginConsumer implements IBatfish {
             computeSynthesizerInput(
                 configurations,
                 dataPlane,
-                forwardingAnalysis,
                 headerSpace,
                 ipSpaceAssignment,
                 transitNodes,
@@ -4505,7 +4492,6 @@ public class Batfish extends PluginConsumer implements IBatfish {
   public static SynthesizerInputImpl computeSynthesizerInput(
       Map<String, Configuration> configurations,
       DataPlane dataPlane,
-      ForwardingAnalysis forwardingAnalysis,
       HeaderSpace headerSpace,
       IpSpaceAssignment ipSpaceAssignment,
       Set<String> transitNodes,
@@ -4532,7 +4518,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
 
     return SynthesizerInputImpl.builder()
         .setConfigurations(configurations)
-        .setForwardingAnalysis(forwardingAnalysis)
+        .setForwardingAnalysis(dataPlane.getForwardingAnalysis())
         .setHeaderSpace(headerSpace)
         .setSrcIpConstraints(ipSpacePerLocation)
         .setNonTransitNodes(nonTransitNodes)

--- a/projects/batfish/src/main/java/org/batfish/main/Driver.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Driver.java
@@ -62,7 +62,6 @@ import org.batfish.config.Settings.EnvironmentSettings;
 import org.batfish.config.Settings.TestrigSettings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DataPlane;
-import org.batfish.datamodel.ForwardingAnalysis;
 import org.batfish.datamodel.answers.Answer;
 import org.batfish.datamodel.answers.AnswerStatus;
 import org.batfish.datamodel.collections.BgpAdvertisementsByVrf;
@@ -137,9 +136,6 @@ public class Driver {
   private static final Cache<Snapshot, SortedMap<String, Configuration>>
       CACHED_COMPRESSED_TESTRIGS = buildTestrigCache();
 
-  private static final Cache<TestrigSettings, ForwardingAnalysis> CACHED_FORWARDING_ANALYSES =
-      buildForwardingAnalysisCache();
-
   private static final int COORDINATOR_CHECK_INTERVAL_MS = 1 * 60 * 1000; // 1 min
 
   private static final int COORDINATOR_POLL_TIMEOUT_MS = 30 * 1000; // 30 secs
@@ -155,8 +151,6 @@ public class Driver {
   private static final int MAX_CACHED_ENVIRONMENT_BGP_TABLES = 4;
 
   private static final int MAX_CACHED_ENVIRONMENT_ROUTING_TABLES = 4;
-
-  private static final int MAX_CACHED_FORWARDING_ANALYSES = 5;
 
   private static final int MAX_CACHED_TESTRIGS = 5;
 
@@ -179,10 +173,6 @@ public class Driver {
     return Collections.synchronizedMap(
         new LRUMap<EnvironmentSettings, SortedMap<String, RoutesByVrf>>(
             MAX_CACHED_ENVIRONMENT_ROUTING_TABLES));
-  }
-
-  private static Cache<TestrigSettings, ForwardingAnalysis> buildForwardingAnalysisCache() {
-    return CacheBuilder.newBuilder().maximumSize(MAX_CACHED_FORWARDING_ANALYSES).build();
   }
 
   private static Cache<Snapshot, SortedMap<String, Configuration>> buildTestrigCache() {
@@ -569,8 +559,7 @@ public class Driver {
               CACHED_COMPRESSED_DATA_PLANES,
               CACHED_DATA_PLANES,
               CACHED_ENVIRONMENT_BGP_TABLES,
-              CACHED_ENVIRONMENT_ROUTING_TABLES,
-              CACHED_FORWARDING_ANALYSES);
+              CACHED_ENVIRONMENT_ROUTING_TABLES);
 
       @Nullable
       SpanContext runBatfishSpanContext =

--- a/projects/batfish/src/test/java/org/batfish/dataplane/TracerouteEngineTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/TracerouteEngineTest.java
@@ -30,7 +30,6 @@ import org.batfish.datamodel.FlowDisposition;
 import org.batfish.datamodel.FlowHistory;
 import org.batfish.datamodel.FlowHistory.FlowHistoryInfo;
 import org.batfish.datamodel.FlowTrace;
-import org.batfish.datamodel.ForwardingAnalysisImpl;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
@@ -186,12 +185,7 @@ public class TracerouteEngineTest {
     // Compute flow traces
     SortedMap<Flow, Set<FlowTrace>> flowTraces =
         TracerouteEngineImpl.getInstance()
-            .processFlows(
-                dp,
-                ImmutableSet.of(flow1, flow2),
-                dp.getFibs(),
-                false,
-                new ForwardingAnalysisImpl(configs, dp.getRibs(), dp.getFibs(), dp.getTopology()));
+            .processFlows(dp, ImmutableSet.of(flow1, flow2), dp.getFibs(), false);
 
     assertThat(flowTraces, hasEntry(equalTo(flow1), contains(hasDisposition(NO_ROUTE))));
     assertThat(flowTraces, hasEntry(equalTo(flow2), contains(hasDisposition(ACCEPTED))));

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfTest.java
@@ -287,7 +287,7 @@ public class OspfTest {
         engine.computeDataPlane(
             false, configurations, topology, Collections.emptySet(), new BdpAnswerElement());
 
-    return engine.getRoutes(dp);
+    return IncrementalBdpEngine.getRoutes(dp);
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/RouteReflectionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/RouteReflectionTest.java
@@ -251,7 +251,7 @@ public class RouteReflectionTest {
                     .setSrcNode("as3Edge")
                     .build()),
             new BdpAnswerElement());
-    return engine.getRoutes(dp);
+    return IncrementalBdpEngine.getRoutes(dp);
   }
 
   private SortedMap<String, SortedMap<String, SortedSet<AbstractRoute>>>
@@ -376,7 +376,7 @@ public class RouteReflectionTest {
                     .setSrcNode("as1Edge")
                     .build()),
             new BdpAnswerElement());
-    return engine.getRoutes(dp);
+    return IncrementalBdpEngine.getRoutes(dp);
   }
 
   /** Initialize builders with values common to all tests */

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
@@ -78,8 +78,7 @@ public class BatfishTestUtils {
             makeDataPlaneCache(),
             makeDataPlaneCache(),
             makeEnvBgpCache(),
-            makeEnvRouteCache(),
-            makeForwardingAnalysisCache());
+            makeEnvRouteCache());
     if (!configurations.isEmpty()) {
       Batfish.serializeAsJson(
           settings.getBaseTestrigSettings().getEnvironmentSettings().getSerializedTopologyPath(),
@@ -122,8 +121,7 @@ public class BatfishTestUtils {
             makeDataPlaneCache(),
             makeDataPlaneCache(),
             makeEnvBgpCache(),
-            makeEnvRouteCache(),
-            makeForwardingAnalysisCache());
+            makeEnvRouteCache());
     batfish.getSettings().setDiffQuestion(true);
     if (!baseConfigs.isEmpty()) {
       Batfish.serializeAsJson(
@@ -197,8 +195,7 @@ public class BatfishTestUtils {
             makeDataPlaneCache(),
             makeDataPlaneCache(),
             makeEnvBgpCache(),
-            makeEnvRouteCache(),
-            makeForwardingAnalysisCache());
+            makeEnvRouteCache());
     registerDataPlanePlugins(batfish);
     return batfish;
   }

--- a/projects/batfish/src/test/java/org/batfish/z3/NodJobAclTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/NodJobAclTest.java
@@ -189,11 +189,7 @@ public class NodJobAclTest {
 
     Set<Flow> flows = nodJob.getFlows(ingressLocationConstraints);
     DataPlanePlugin dpPlugin = batfish.getDataPlanePlugin();
-    dpPlugin.processFlows(
-        flows,
-        dataPlane,
-        false,
-        new ForwardingAnalysisImpl(configs, dataPlane.getRibs(), dataPlane.getFibs(), topology));
+    dpPlugin.processFlows(flows, dataPlane, false);
     List<FlowTrace> flowTraces = dpPlugin.getHistoryFlowTraces(dataPlane);
     assertThat(flowTraces, hasSize(2));
     assertThat(
@@ -334,11 +330,7 @@ public class NodJobAclTest {
 
     Set<Flow> flows = nodJob.getFlows(ingressLocationConstraints);
     DataPlanePlugin dpPlugin = batfish.getDataPlanePlugin();
-    dpPlugin.processFlows(
-        flows,
-        dataPlane,
-        false,
-        new ForwardingAnalysisImpl(configs, dataPlane.getRibs(), dataPlane.getFibs(), topology));
+    dpPlugin.processFlows(flows, dataPlane, false);
     List<FlowTrace> flowTraces = dpPlugin.getHistoryFlowTraces(dataPlane);
     assertThat(flowTraces, hasSize(1));
     assertThat(

--- a/projects/batfish/src/test/java/org/batfish/z3/NodJobChunkingTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/NodJobChunkingTest.java
@@ -19,7 +19,6 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.ForwardingAction;
-import org.batfish.datamodel.ForwardingAnalysisImpl;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.InterfaceAddress;
@@ -30,7 +29,6 @@ import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.StaticRoute;
-import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.Vrf;
 import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
@@ -158,11 +156,6 @@ public class NodJobChunkingTest {
             Batfish.computeSynthesizerInput(
                 _configs,
                 _dataPlane,
-                new ForwardingAnalysisImpl(
-                    _configs,
-                    _dataPlane.getRibs(),
-                    _dataPlane.getFibs(),
-                    new Topology(_dataPlane.getTopologyEdges())),
                 new HeaderSpace(),
                 IpSpaceAssignment.empty(),
                 ImmutableSortedSet.of(),

--- a/projects/batfish/src/test/java/org/batfish/z3/NodJobTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/NodJobTest.java
@@ -216,12 +216,7 @@ public class NodJobTest {
     assertThat(fieldConstraints, hasEntry(Field.SRC_IP.getName(), new Ip("1.0.0.10").asLong()));
 
     Set<Flow> flows = nodJob.getFlows(ingressLocationConstraints);
-    _dataPlanePlugin.processFlows(
-        flows,
-        _dataPlane,
-        false,
-        new ForwardingAnalysisImpl(
-            _configs, _dataPlane.getRibs(), _dataPlane.getFibs(), _dataPlane.getTopology()));
+    _dataPlanePlugin.processFlows(flows, _dataPlane, false);
     List<FlowTrace> flowTraces = _dataPlanePlugin.getHistoryFlowTraces(_dataPlane);
 
     flowTraces.forEach(
@@ -285,12 +280,7 @@ public class NodJobTest {
     assertThat(fieldConstraints, hasEntry(Field.SRC_IP.getName(), new Ip("3.0.0.1").asLong()));
 
     Set<Flow> flows = nodJob.getFlows(ingressLocationConstraints);
-    _dataPlanePlugin.processFlows(
-        flows,
-        _dataPlane,
-        false,
-        new ForwardingAnalysisImpl(
-            _configs, _dataPlane.getRibs(), _dataPlane.getFibs(), _dataPlane.getTopology()));
+    _dataPlanePlugin.processFlows(flows, _dataPlane, false);
     List<FlowTrace> flowTraces = _dataPlanePlugin.getHistoryFlowTraces(_dataPlane);
 
     flowTraces.forEach(

--- a/projects/question/src/main/java/org/batfish/question/NeighborsQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/NeighborsQuestionPlugin.java
@@ -719,7 +719,7 @@ public class NeighborsQuestionPlugin extends QuestionPlugin {
       if (!_remoteBgpNeighborsInitialized) {
         Map<Ip, Set<String>> ipOwners = CommonUtil.computeIpNodeOwners(configurations, true);
         _bgpTopology =
-            CommonUtil.initBgpTopology(configurations, ipOwners, false, false, null, null, null);
+            CommonUtil.initBgpTopology(configurations, ipOwners, false, false, null, null);
         _remoteBgpNeighborsInitialized = true;
       }
     }

--- a/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionStatusAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionStatusAnswerer.java
@@ -19,7 +19,6 @@ import org.batfish.datamodel.BgpNeighbor;
 import org.batfish.datamodel.BgpSession;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DataPlane;
-import org.batfish.datamodel.ForwardingAnalysisImpl;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.answers.AnswerElement;
@@ -100,9 +99,7 @@ public class BgpSessionStatusAnswerer extends Answerer {
               false,
               true,
               _batfish.getDataPlanePlugin().getTracerouteEngine(),
-              dp,
-              new ForwardingAnalysisImpl(
-                  configurations, dp.getRibs(), dp.getFibs(), dp.getTopology()));
+              dp);
     } else {
       establishedBgpTopology = null;
     }


### PR DESCRIPTION
- move cached ForwardingAnalysis objects out of Batfish and into their
  corresponding DataPlane. This reduces the opportunity for bugs caused
  by using the wrong key to look up the ForwardingAnalysis (thus getting
  the wrong one).
- Made IncrementalDataPlane immutable (except for transient fields) and 
  added a builder. This required some small changes to IncrementalDataPlaneEngine.
- Now that IncrementalDataPlane is immutable, we can cache the results
  of its expensive non-getter methods. This is also how we cache 
  ForwardingAnalysis (so it is still computed lazily).
- Use CommonUtil.toImmutable(Sorted)Map when possible, for improved
  readability.