### PR TITLE
Cleanup dataplane interfaces a bit more

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/DataPlanePlugin.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/DataPlanePlugin.java
@@ -13,8 +13,11 @@ import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowTrace;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.answers.DataPlaneAnswerElement;
-import org.batfish.datamodel.collections.IbgpTopology;
 
+/**
+ * Abstract class that defines the behavior expected for a Batfish plugin that implements data plane
+ * capabilities.
+ */
 public abstract class DataPlanePlugin extends BatfishPlugin implements IDataPlanePlugin {
 
   private static DataPlanePlugin DATA_PLANE_PLUGIN;
@@ -38,6 +41,10 @@ public abstract class DataPlanePlugin extends BatfishPlugin implements IDataPlan
     DATA_PLANE_PLUGIN_CLASS = dataPlanePlugin;
   }
 
+  /**
+   * Result of computing the dataplane. Combines a {@link DataPlane} with a {@link
+   * DataPlaneAnswerElement}
+   */
   public static final class ComputeDataPlaneResult {
     public final DataPlaneAnswerElement _answerElement;
     public final DataPlane _dataPlane;
@@ -67,8 +74,6 @@ public abstract class DataPlanePlugin extends BatfishPlugin implements IDataPlan
 
   public abstract List<FlowTrace> getHistoryFlowTraces(DataPlane dataPlane);
 
-  public abstract IbgpTopology getIbgpNeighbors();
-
   public abstract ITracerouteEngine getTracerouteEngine();
 
   public abstract SortedMap<String, SortedMap<String, SortedSet<AbstractRoute>>> getRoutes(
@@ -76,5 +81,6 @@ public abstract class DataPlanePlugin extends BatfishPlugin implements IDataPlan
 
   public abstract void processFlows(Set<Flow> flows, DataPlane dataPlane, boolean ignoreAcls);
 
+  /** Return the name of this plugin */
   public abstract String getName();
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/DataPlane.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/DataPlane.java
@@ -32,10 +32,16 @@ public interface DataPlane extends Serializable {
   /** Return the set of all (main) RIBs. Map structure: hostname -> VRF name -> GenericRib */
   SortedMap<String, SortedMap<String, GenericRib<AbstractRoute>>> getRibs();
 
+  /** Return the network (i.e., layer 3) topology */
   Topology getTopology();
 
+  /** Get a set of all layer 3 edges in the network */
   SortedSet<Edge> getTopologyEdges();
 
+  /**
+   * Return the summary of route prefix propagation. Map structure: Hostname -> VRF name -> Prefix
+   * -> action taken -> set of hostnames (peers).
+   */
   SortedMap<String, SortedMap<String, Map<Prefix, Map<String, Set<String>>>>>
       getPrefixTracingInfoSummary();
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/IncrementalBdpAnswerElement.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/IncrementalBdpAnswerElement.java
@@ -2,12 +2,11 @@ package org.batfish.datamodel.answers;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.SortedMap;
-import java.util.SortedSet;
 import java.util.TreeMap;
-import java.util.TreeSet;
-import org.batfish.datamodel.Prefix;
+import org.batfish.common.Warnings;
 
-public class BdpAnswerElement extends DataPlaneAnswerElement {
+/** This answer contains summary information and warning about dataplane computation. */
+public class IncrementalBdpAnswerElement extends DataPlaneAnswerElement {
 
   private static final String MAIN_RIB_ROUTES_BY_ITERATION = "mainRibRoutesByIteration";
 
@@ -19,34 +18,31 @@ public class BdpAnswerElement extends DataPlaneAnswerElement {
 
   private static final String PROP_DEPENDENT_ROUTES_ITERATIONS = "dependentRoutesIterations";
 
-  private static final String PROP_OSCILLATING_PREFIXES = "oscillatingPrefixes";
-
   private static final String PROP_OSPF_INTERNAL_ITERATIONS = "ospfInternalIterations";
 
-  /** */
+  private static final String PROP_WARNINGS = "warnings";
+
   private static final long serialVersionUID = 1L;
 
   private SortedMap<Integer, Integer> _bgpBestPathRibRoutesByIteration;
 
   private SortedMap<Integer, Integer> _bgpMultipathRibRoutesByIteration;
 
-  private int _completedOscillationRecoveryAttempts;
-
   private int _dependentRoutesIterations;
 
   private SortedMap<Integer, Integer> _mainRibRoutesByIteration;
-
-  private SortedSet<Prefix> _oscillatingPrefixes;
 
   private int _ospfInternalIterations;
 
   private String _version;
 
-  public BdpAnswerElement() {
+  private Warnings _warnings;
+
+  public IncrementalBdpAnswerElement() {
     _bgpBestPathRibRoutesByIteration = new TreeMap<>();
     _bgpMultipathRibRoutesByIteration = new TreeMap<>();
     _mainRibRoutesByIteration = new TreeMap<>();
-    _oscillatingPrefixes = new TreeSet<>();
+    _warnings = new Warnings();
   }
 
   @JsonProperty(PROP_BGP_BEST_PATH_RIB_ROUTES_BY_ITERATION)
@@ -59,10 +55,6 @@ public class BdpAnswerElement extends DataPlaneAnswerElement {
     return _bgpMultipathRibRoutesByIteration;
   }
 
-  public int getCompletedOscillationRecoveryAttempts() {
-    return _completedOscillationRecoveryAttempts;
-  }
-
   @JsonProperty(PROP_DEPENDENT_ROUTES_ITERATIONS)
   public int getDependentRoutesIterations() {
     return _dependentRoutesIterations;
@@ -71,11 +63,6 @@ public class BdpAnswerElement extends DataPlaneAnswerElement {
   @JsonProperty(MAIN_RIB_ROUTES_BY_ITERATION)
   public SortedMap<Integer, Integer> getMainRibRoutesByIteration() {
     return _mainRibRoutesByIteration;
-  }
-
-  @JsonProperty(PROP_OSCILLATING_PREFIXES)
-  public SortedSet<Prefix> getOscillatingPrefixes() {
-    return _oscillatingPrefixes;
   }
 
   @JsonProperty(PROP_OSPF_INTERNAL_ITERATIONS)
@@ -89,18 +76,29 @@ public class BdpAnswerElement extends DataPlaneAnswerElement {
     return _version;
   }
 
+  @JsonProperty(PROP_WARNINGS)
+  public Warnings get_warnings() {
+    return _warnings;
+  }
+
   @Override
   public String prettyPrint() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("Computation summary:\n");
-    sb.append("   OSPF-internal iterations: " + _dependentRoutesIterations + "\n");
-    sb.append("   Dependent-routes iterations: " + _dependentRoutesIterations + "\n");
-    sb.append(
-        "   BGP best-path RIB routes by iteration: " + _bgpBestPathRibRoutesByIteration + "\n");
-    sb.append(
-        "   BGP multipath RIB routes by iteration: " + _bgpMultipathRibRoutesByIteration + "\n");
-    sb.append("   Main RIB routes by iteration: " + _mainRibRoutesByIteration + "\n");
-    return sb.toString();
+    return "Computation summary:\n"
+        + "   OSPF-internal iterations: "
+        + _dependentRoutesIterations
+        + "\n"
+        + "   Dependent-routes iterations: "
+        + _dependentRoutesIterations
+        + "\n"
+        + "   BGP best-path RIB routes by iteration: "
+        + _bgpBestPathRibRoutesByIteration
+        + "\n"
+        + "   BGP multipath RIB routes by iteration: "
+        + _bgpMultipathRibRoutesByIteration
+        + "\n"
+        + "   Main RIB routes by iteration: "
+        + _mainRibRoutesByIteration
+        + "\n";
   }
 
   @JsonProperty(PROP_BGP_BEST_PATH_RIB_ROUTES_BY_ITERATION)
@@ -115,10 +113,6 @@ public class BdpAnswerElement extends DataPlaneAnswerElement {
     _bgpMultipathRibRoutesByIteration = bgpMultipathRibRoutesByIteration;
   }
 
-  public void setCompletedOscillationRecoveryAttempts(int completedOscillationRecoveryAttempts) {
-    _completedOscillationRecoveryAttempts = completedOscillationRecoveryAttempts;
-  }
-
   @JsonProperty(PROP_DEPENDENT_ROUTES_ITERATIONS)
   public void setDependentRoutesIterations(int dependentRoutesIterations) {
     _dependentRoutesIterations = dependentRoutesIterations;
@@ -127,11 +121,6 @@ public class BdpAnswerElement extends DataPlaneAnswerElement {
   @JsonProperty(MAIN_RIB_ROUTES_BY_ITERATION)
   public void setMainRibRoutesByIteration(SortedMap<Integer, Integer> mainRibRoutesByIteration) {
     _mainRibRoutesByIteration = mainRibRoutesByIteration;
-  }
-
-  @JsonProperty(PROP_OSCILLATING_PREFIXES)
-  public void setOscillatingPrefixes(SortedSet<Prefix> oscillatingPrefixes) {
-    _oscillatingPrefixes = oscillatingPrefixes;
   }
 
   @JsonProperty(PROP_OSPF_INTERNAL_ITERATIONS)

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePluginTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePluginTest.java
@@ -59,7 +59,6 @@ import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.StaticRoute;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.Vrf;
-import org.batfish.datamodel.answers.BdpAnswerElement;
 import org.batfish.datamodel.collections.RoutesByVrf;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
 import org.batfish.datamodel.routing_policy.statement.SetDefaultPolicy;
@@ -732,16 +731,12 @@ public class IncrementalDataPlanePluginTest {
             new BatfishLogger(BatfishLogger.LEVELSTR_DEBUG, false),
             (a, b) -> new AtomicInteger());
     Topology topology = new Topology(Collections.emptySortedSet());
-    IncrementalDataPlane dp =
+    ComputeDataPlaneResult dp =
         engine.computeDataPlane(
-            false,
-            ImmutableMap.of(c.getName(), c),
-            topology,
-            Collections.emptySet(),
-            new BdpAnswerElement());
+            false, ImmutableMap.of(c.getName(), c), topology, Collections.emptySet());
 
     // generating fibs should not crash
-    dp.getFibs();
+    dp._dataPlane.getFibs();
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfTest.java
@@ -35,7 +35,6 @@ import org.batfish.datamodel.PrefixSpace;
 import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.Vrf;
-import org.batfish.datamodel.answers.BdpAnswerElement;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
 import org.batfish.datamodel.routing_policy.expr.DestinationNetwork;
 import org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet;
@@ -284,8 +283,9 @@ public class OspfTest {
             (s, i) -> new AtomicInteger());
     Topology topology = CommonUtil.synthesizeTopology(configurations);
     IncrementalDataPlane dp =
-        engine.computeDataPlane(
-            false, configurations, topology, Collections.emptySet(), new BdpAnswerElement());
+        (IncrementalDataPlane)
+            engine.computeDataPlane(false, configurations, topology, Collections.emptySet())
+                ._dataPlane;
 
     return IncrementalBdpEngine.getRoutes(dp);
   }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/RouteReflectionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/RouteReflectionTest.java
@@ -15,6 +15,7 @@ import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.batfish.common.BatfishLogger;
+import org.batfish.common.plugin.DataPlanePlugin.ComputeDataPlaneResult;
 import org.batfish.common.util.CommonUtil;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.AsPath;
@@ -34,7 +35,6 @@ import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.StaticRoute;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.Vrf;
-import org.batfish.datamodel.answers.BdpAnswerElement;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
 import org.batfish.datamodel.routing_policy.expr.Disjunction;
 import org.batfish.datamodel.routing_policy.expr.MatchProtocol;
@@ -226,7 +226,7 @@ public class RouteReflectionTest {
             new BatfishLogger(BatfishLogger.LEVELSTR_OUTPUT, false),
             (s, i) -> new AtomicInteger());
     Topology topology = CommonUtil.synthesizeTopology(configurations);
-    IncrementalDataPlane dp =
+    ComputeDataPlaneResult dpResult =
         engine.computeDataPlane(
             false,
             configurations,
@@ -249,9 +249,8 @@ public class RouteReflectionTest {
                     .setOriginatorIp(as3PeeringIp)
                     .setSrcIp(as3PeeringIp)
                     .setSrcNode("as3Edge")
-                    .build()),
-            new BdpAnswerElement());
-    return IncrementalBdpEngine.getRoutes(dp);
+                    .build()));
+    return IncrementalBdpEngine.getRoutes((IncrementalDataPlane) dpResult._dataPlane);
   }
 
   private SortedMap<String, SortedMap<String, SortedSet<AbstractRoute>>>
@@ -361,21 +360,22 @@ public class RouteReflectionTest {
             (s, i) -> new AtomicInteger());
     Topology topology = CommonUtil.synthesizeTopology(configurations);
     IncrementalDataPlane dp =
-        engine.computeDataPlane(
-            false,
-            configurations,
-            topology,
-            ImmutableSet.of(
-                _ab.setAsPath(AsPath.ofSingletonAsSets(1L))
-                    .setDstIp(edge1EbgpIfaceIp)
-                    .setDstNode(edge1.getName())
-                    .setNetwork(AS1_PREFIX)
-                    .setNextHopIp(as1PeeringIp)
-                    .setOriginatorIp(as1PeeringIp)
-                    .setSrcIp(as1PeeringIp)
-                    .setSrcNode("as1Edge")
-                    .build()),
-            new BdpAnswerElement());
+        (IncrementalDataPlane)
+            engine.computeDataPlane(
+                    false,
+                    configurations,
+                    topology,
+                    ImmutableSet.of(
+                        _ab.setAsPath(AsPath.ofSingletonAsSets(1L))
+                            .setDstIp(edge1EbgpIfaceIp)
+                            .setDstNode(edge1.getName())
+                            .setNetwork(AS1_PREFIX)
+                            .setNextHopIp(as1PeeringIp)
+                            .setOriginatorIp(as1PeeringIp)
+                            .setSrcIp(as1PeeringIp)
+                            .setSrcNode("as1Edge")
+                            .build()))
+                ._dataPlane;
     return IncrementalBdpEngine.getRoutes(dp);
   }
 

--- a/tests/basic/genDp-delta.ref
+++ b/tests/basic/genDp-delta.ref
@@ -1,7 +1,7 @@
 {
   "answerElements" : [
     {
-      "class" : "org.batfish.datamodel.answers.BdpAnswerElement",
+      "class" : "org.batfish.datamodel.answers.IncrementalBdpAnswerElement",
       "bgpBestPathRibRoutesByIteration" : {
         "1" : 26,
         "2" : 61,
@@ -20,7 +20,6 @@
         "6" : 127,
         "7" : 127
       },
-      "completedOscillationRecoveryAttempts" : 0,
       "dependentRoutesIterations" : 7,
       "mainRibRoutesByIteration" : {
         "1" : 213,
@@ -32,7 +31,8 @@
         "7" : 342
       },
       "ospfInternalIterations" : 3,
-      "version" : "0.36.0"
+      "version" : "0.36.0",
+      "warnings" : { }
     }
   ],
   "status" : "SUCCESS",

--- a/tests/basic/genDp-env.ref
+++ b/tests/basic/genDp-env.ref
@@ -1,7 +1,7 @@
 {
   "answerElements" : [
     {
-      "class" : "org.batfish.datamodel.answers.BdpAnswerElement",
+      "class" : "org.batfish.datamodel.answers.IncrementalBdpAnswerElement",
       "bgpBestPathRibRoutesByIteration" : {
         "1" : 20,
         "2" : 50,
@@ -22,7 +22,6 @@
         "7" : 124,
         "8" : 124
       },
-      "completedOscillationRecoveryAttempts" : 0,
       "dependentRoutesIterations" : 8,
       "mainRibRoutesByIteration" : {
         "1" : 206,
@@ -35,7 +34,8 @@
         "8" : 329
       },
       "ospfInternalIterations" : 3,
-      "version" : "0.36.0"
+      "version" : "0.36.0",
+      "warnings" : { }
     }
   ],
   "status" : "SUCCESS",

--- a/tests/basic/genDp.ref
+++ b/tests/basic/genDp.ref
@@ -1,7 +1,7 @@
 {
   "answerElements" : [
     {
-      "class" : "org.batfish.datamodel.answers.BdpAnswerElement",
+      "class" : "org.batfish.datamodel.answers.IncrementalBdpAnswerElement",
       "bgpBestPathRibRoutesByIteration" : {
         "1" : 24,
         "2" : 58,
@@ -20,7 +20,6 @@
         "6" : 124,
         "7" : 124
       },
-      "completedOscillationRecoveryAttempts" : 0,
       "dependentRoutesIterations" : 7,
       "mainRibRoutesByIteration" : {
         "1" : 211,
@@ -32,7 +31,8 @@
         "7" : 339
       },
       "ospfInternalIterations" : 3,
-      "version" : "0.36.0"
+      "version" : "0.36.0",
+      "warnings" : { }
     }
   ],
   "status" : "SUCCESS",


### PR DESCRIPTION
Some further cleanup of dataplane classes:
- Remove unused/unimplemented methods & fields from dataplane and corresponding answer element
- DP engine now returns DataPlaneResult
- Add `Warnings` to dataplane answer element. Currently unused, groundwork for future use.