### PR TITLE
Cleanup formatting in PAN parser

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
@@ -159,7 +159,7 @@ DEC
 
 DOUBLE_QUOTED_STRING
 :
-   '"' ~'"'* '"'
+    '"' ~'"'* '"'
 ;
 
 IP_ADDRESS
@@ -174,11 +174,11 @@ IP_PREFIX
 
 LINE_COMMENT
 :
-   (
-      '#'
-      | '!'
-   )
-   F_NonNewlineChar* F_Newline+ -> channel ( HIDDEN )
+    (
+        '#'
+        | '!'
+    )
+    F_NonNewlineChar* F_Newline+ -> channel ( HIDDEN )
 ;
 
 NEWLINE
@@ -188,7 +188,7 @@ NEWLINE
 
 SINGLE_QUOTED_STRING
 :
-   '\'' ~'\''* '\''
+    '\'' ~'\''* '\''
 ;
 
 VARIABLE

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_common.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_common.g4
@@ -6,7 +6,7 @@ options {
 
 null_rest_of_line
 :
-    ~NEWLINE* NEWLINE
+    ~NEWLINE*
 ;
 
 variable

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_deviceconfig.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_deviceconfig.g4
@@ -6,64 +6,59 @@ options {
     tokenVocab = PaloAltoLexer;
 }
 
-null_rest_of_line
-:
-    ~NEWLINE* NEWLINE
-;
-
 s_deviceconfig
 :
-   DEVICECONFIG
-   (
-      sd_system
-   )
+    DEVICECONFIG
+    (
+        sd_system
+    )
 ;
 
 sd_system
 :
-   SYSTEM
-   (
-      sds_dns_setting
-      | sds_hostname
-      | sds_ntp_servers
-   )
+    SYSTEM
+    (
+        sds_dns_setting
+        | sds_hostname
+        | sds_ntp_servers
+    )
 ;
 
 sds_dns_setting
 :
-   DNS_SETTING
-   (
-      sdsd_servers
-   )
+    DNS_SETTING
+    (
+        sdsd_servers
+    )
 ;
 
 sdsd_servers
 :
-   SERVERS
-   (
-      PRIMARY primary_name = IP_ADDRESS
-      | SECONDARY secondary_name = IP_ADDRESS
-   )
+    SERVERS
+    (
+        PRIMARY primary_name = IP_ADDRESS
+        | SECONDARY secondary_name = IP_ADDRESS
+    )
 ;
 
 sds_hostname
 :
-   HOSTNAME name = variable
+    HOSTNAME name = variable
 ;
 
 sds_ntp_servers
 :
-   NTP_SERVERS
-   (
-      PRIMARY_NTP_SERVER
-      | SECONDARY_NTP_SERVER
-   )
-   (
-      sdsn_ntp_server_address
-   )
+    NTP_SERVERS
+    (
+        PRIMARY_NTP_SERVER
+        | SECONDARY_NTP_SERVER
+    )
+    (
+        sdsn_ntp_server_address
+    )
 ;
 
 sdsn_ntp_server_address
 :
-   NTP_SERVER_ADDRESS address = variable
+    NTP_SERVER_ADDRESS address = variable
 ;


### PR DESCRIPTION
* Cleanup formatting in PAN parser
* Remove redundant, unused rule
* Update `null_rest_of_line` to not consume newline token