### PR TITLE
Add parsing support for alternate PAN config format

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
@@ -25,6 +25,16 @@ COMMENT
     'comment'
 ;
 
+CONFIG
+:
+    'config'
+;
+
+DEVICES
+:
+    'devices'
+;
+
 DEVICECONFIG
 :
     'deviceconfig'

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoParser.g4
@@ -13,7 +13,7 @@ palo_alto_configuration
 :
     NEWLINE?
     (
-        set_line_config_device
+        set_line_config_devices
         | set_line_config_general
     )+ NEWLINE? EOF
 ;
@@ -22,9 +22,9 @@ palo_alto_configuration
  * The distinction between config device and general config statements is needed in order to handle
  * syntax differences in filesystem-style config dumps
  */
-set_line_config_device
+set_line_config_devices
 :
-    SET (CONFIG DEVICES name = variable)? statement_config_device NEWLINE
+    SET (CONFIG DEVICES name = variable)? statement_config_devices NEWLINE
 ;
 
 set_line_config_general
@@ -35,7 +35,7 @@ set_line_config_general
 /*
  * These are settings that show up on the device under /config/devices/<DEV>/...
  */
-statement_config_device
+statement_config_devices
 :
     s_deviceconfig
     | s_network

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoParser.g4
@@ -13,18 +13,38 @@ palo_alto_configuration
 :
     NEWLINE?
     (
-        set_line
+        set_line_config_device
+        | set_line_config_general
     )+ NEWLINE? EOF
 ;
 
-set_line
+/*
+ * The distinction between config device and general config statements is needed in order to handle
+ * syntax differences in filesystem-style config dumps
+ */
+set_line_config_device
 :
-    SET statement NEWLINE
+    SET (CONFIG DEVICES name = variable)? statement_config_device NEWLINE
 ;
 
-statement
+set_line_config_general
+:
+    SET CONFIG? statement_config_general NEWLINE
+;
+
+/*
+ * These are settings that show up on the device under /config/devices/<DEV>/...
+ */
+statement_config_device
 :
     s_deviceconfig
     | s_network
-    | s_shared
+;
+
+/*
+ * These are settings that show up on the device under /config/... (NOT under the devices/ dir)
+ */
+statement_config_general
+:
+    s_shared
 ;

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -28,8 +28,6 @@ import org.batfish.representation.palo_alto.PaloAltoConfiguration;
 import org.batfish.representation.palo_alto.SyslogServer;
 
 public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
-  private static final String DEFAULT_DEVICE_NAME = "localhost.localdomain";
-
   private PaloAltoConfiguration _configuration;
 
   private String _currentDeviceName;

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -1,5 +1,7 @@
 package org.batfish.grammar.palo_alto;
 
+import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
+
 import java.util.Set;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
@@ -12,6 +14,7 @@ import org.batfish.grammar.palo_alto.PaloAltoParser.Sds_hostnameContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sds_ntp_serversContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sdsd_serversContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sdsn_ntp_server_addressContext;
+import org.batfish.grammar.palo_alto.PaloAltoParser.Set_line_config_devicesContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sni_ethernetContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Snie_commentContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Snie_link_statusContext;
@@ -25,8 +28,11 @@ import org.batfish.representation.palo_alto.PaloAltoConfiguration;
 import org.batfish.representation.palo_alto.SyslogServer;
 
 public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
+  private static final String DEFAULT_DEVICE_NAME = "localhost.localdomain";
 
   private PaloAltoConfiguration _configuration;
+
+  private String _currentDeviceName;
 
   private Interface _currentInterface;
 
@@ -52,9 +58,9 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
       Warnings warnings,
       Set<String> unimplementedFeatures,
       boolean unrecognizedAsRedFlag) {
+    _configuration = new PaloAltoConfiguration(unimplementedFeatures);
     _parser = parser;
     _text = text;
-    _configuration = new PaloAltoConfiguration(unimplementedFeatures);
     _unimplementedFeatures = unimplementedFeatures;
     _unrecognizedAsRedFlag = unrecognizedAsRedFlag;
     _w = warnings;
@@ -125,6 +131,19 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
       _configuration.setDnsServerPrimary(ctx.primary_name.getText());
     } else if (ctx.secondary_name != null) {
       _configuration.setDnsServerSecondary(ctx.secondary_name.getText());
+    }
+  }
+
+  @Override
+  public void enterSet_line_config_devices(Set_line_config_devicesContext ctx) {
+    if (ctx.name != null) {
+      String deviceName = ctx.name.getText();
+      _currentDeviceName = firstNonNull(_currentDeviceName, deviceName);
+      if (!_currentDeviceName.equals(deviceName)) {
+        /* Do not currently handle multiple device names, which presumably happens only if multiple
+         * physical devices are configured from a single config */
+        _w.redFlag("Multiple devices encountered: " + deviceName);
+      }
     }
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -1,5 +1,6 @@
 package org.batfish.grammar.palo_alto;
 
+import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasHostname;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasInterface;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasAllAddresses;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasDescription;
@@ -8,6 +9,7 @@ import static org.batfish.datamodel.matchers.InterfaceMatchers.isActive;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 
 import java.io.IOException;
@@ -61,6 +63,18 @@ public class PaloAltoGrammarTest {
 
     // Confirm both dns servers show up
     assertThat(c.getDnsServers(), containsInAnyOrder("1.9.10.99", "100.199.200.255"));
+  }
+
+  @Test
+  public void testFilesystemConfigFormat() throws IOException {
+    String hostname = "config-filesystem-format";
+    Configuration c = parseConfig(hostname);
+
+    // Confirm alternate config format is parsed and extracted properly
+    // Confirm config device set-line extraction works
+    assertThat(c, hasHostname(equalTo(hostname)));
+    // Confirm general config set-line extraction works
+    assertThat(c.getLoggingServers(), contains("2.2.2.2"));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -71,7 +71,7 @@ public class PaloAltoGrammarTest {
     Configuration c = parseConfig(hostname);
 
     // Confirm alternate config format is parsed and extracted properly
-    // Confirm config device set-line extraction works
+    // Confirm config devices set-line extraction works
     assertThat(c, hasHostname(equalTo(hostname)));
     // Confirm general config set-line extraction works
     assertThat(c.getLoggingServers(), contains("2.2.2.2"));

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/config-filesystem-format
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/config-filesystem-format
@@ -1,7 +1,7 @@
 # Filesystem format config
 # Other configs use show format (format seen on the device after issuing `show` command)
 
-# Config device set-line
+# Config devices set-line
 set config devices localhost.localdomain deviceconfig system hostname config-filesystem-format
 # General config set-line
 set config shared log-settings syslog SLFILESYSTEM server SNAME server 2.2.2.2

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/config-filesystem-format
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/config-filesystem-format
@@ -1,0 +1,7 @@
+# Filesystem format config
+# Other configs use show format (format seen on the device after issuing `show` command)
+
+# Config device set-line
+set config devices localhost.localdomain deviceconfig system hostname config-filesystem-format
+# General config set-line
+set config shared log-settings syslog SLFILESYSTEM server SNAME server 2.2.2.2


### PR DESCRIPTION
Add support for `filesystem` format PAN configs.

Previously, only `show` format configs were supported, the kind seen when issuing `show` command on the device CLI.
