### PR TITLE
More Flow fixes.

### DIFF
--- a/projects/allinone/src/test/java/org/batfish/allinone/SpecifiersReachabilityQuestionTest.java
+++ b/projects/allinone/src/test/java/org/batfish/allinone/SpecifiersReachabilityQuestionTest.java
@@ -2,6 +2,7 @@ package org.batfish.allinone;
 
 import static org.batfish.datamodel.matchers.FlowHistoryInfoMatchers.hasFlow;
 import static org.batfish.datamodel.matchers.FlowMatchers.hasDstIp;
+import static org.batfish.datamodel.matchers.FlowMatchers.hasIngressInterface;
 import static org.batfish.datamodel.matchers.FlowMatchers.hasIngressNode;
 import static org.batfish.datamodel.matchers.FlowMatchers.hasSrcIp;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -153,13 +154,39 @@ public class SpecifiersReachabilityQuestionTest {
     AnswerElement answer = new SpecifiersReachabilityAnswerer(question, _batfish).answer();
     assertThat(answer, instanceOf(FlowHistory.class));
     Collection<FlowHistoryInfo> flowHistoryInfos = ((FlowHistory) answer).getTraces().values();
-    assertThat(flowHistoryInfos, hasSize(2));
+    assertThat(flowHistoryInfos, hasSize(4));
     assertThat(
         flowHistoryInfos,
-        hasItem(hasFlow(allOf(hasIngressNode(NODE1), hasSrcIp(new Ip("5.5.5.5"))))));
+        hasItem(
+            hasFlow(
+                allOf(
+                    hasIngressNode(NODE1),
+                    hasIngressInterface(FAST_ETHERNET),
+                    hasSrcIp(new Ip("5.5.5.5"))))));
     assertThat(
         flowHistoryInfos,
-        hasItem(hasFlow(allOf(hasIngressNode(NODE2), hasSrcIp(new Ip("5.5.5.5"))))));
+        hasItem(
+            hasFlow(
+                allOf(
+                    hasIngressNode(NODE1),
+                    hasIngressInterface(LOOPBACK),
+                    hasSrcIp(new Ip("5.5.5.5"))))));
+    assertThat(
+        flowHistoryInfos,
+        hasItem(
+            hasFlow(
+                allOf(
+                    hasIngressNode(NODE2),
+                    hasIngressInterface(FAST_ETHERNET),
+                    hasSrcIp(new Ip("5.5.5.5"))))));
+    assertThat(
+        flowHistoryInfos,
+        hasItem(
+            hasFlow(
+                allOf(
+                    hasIngressNode(NODE2),
+                    hasIngressInterface(LOOPBACK),
+                    hasSrcIp(new Ip("5.5.5.5"))))));
   }
 
   /**

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
@@ -166,6 +166,19 @@ public class CommonUtil {
     return collection == null ? null : collection.isEmpty() ? null : collection;
   }
 
+  /** Compare two nullable comparable objects. null is considered less than non-null. */
+  public static <T extends Comparable<T>> int compareNullable(@Nullable T a, @Nullable T b) {
+    if (a == b) {
+      return 0;
+    } else if (a == null) {
+      return -1;
+    } else if (b == null) {
+      return 1;
+    } else {
+      return a.compareTo(b);
+    }
+  }
+
   private static class TrustAllHostNameVerifier implements HostnameVerifier {
     @Override
     public boolean verify(String hostname, SSLSession session) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Flow.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Flow.java
@@ -535,7 +535,7 @@ public final class Flow implements Comparable<Flow>, Serializable {
   }
 
   @JsonCreator
-  public static Flow createFlow(
+  private static Flow createFlow(
       @JsonProperty(PROP_INGRESS_NODE) String ingressNode,
       @JsonProperty(PROP_INGRESS_INTERFACE) String ingressInterface,
       @JsonProperty(PROP_INGRESS_VRF) String ingressVrf,

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Flow.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Flow.java
@@ -1,61 +1,68 @@
 package org.batfish.datamodel;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
 import java.util.Objects;
-import org.batfish.common.BatfishException;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.common.util.CommonUtil;
 
 public final class Flow implements Comparable<Flow>, Serializable {
   public static class Builder {
 
-    private Integer _dscp;
+    private int _dscp;
 
     private Ip _dstIp;
 
-    private Integer _dstPort;
+    private int _dstPort;
 
-    private Integer _ecn;
+    private int _ecn;
 
-    private Integer _fragmentOffset;
+    private int _fragmentOffset;
 
-    private Integer _icmpCode;
+    private int _icmpCode;
 
-    private Integer _icmpType;
+    private int _icmpType;
 
-    private String _ingressInterface;
+    private @Nullable String _ingressInterface;
 
-    private String _ingressNode;
+    // Nullable because no sensible default. User is required to specify.
+    private @Nullable String _ingressNode;
 
-    private String _ingressVrf;
+    private @Nullable String _ingressVrf;
 
-    private IpProtocol _ipProtocol;
+    private @Nonnull IpProtocol _ipProtocol;
 
-    private Integer _packetLength;
+    private int _packetLength;
 
-    private Ip _srcIp;
+    private @Nonnull Ip _srcIp;
 
-    private Integer _srcPort;
+    private int _srcPort;
 
-    private State _state;
+    private @Nonnull State _state;
 
-    private String _tag;
+    // Nullable because no sensible default. User is required to specify.
+    private @Nullable String _tag;
 
-    private Integer _tcpFlagsAck;
+    private int _tcpFlagsAck;
 
-    private Integer _tcpFlagsCwr;
+    private int _tcpFlagsCwr;
 
-    private Integer _tcpFlagsEce;
+    private int _tcpFlagsEce;
 
-    private Integer _tcpFlagsFin;
+    private int _tcpFlagsFin;
 
-    private Integer _tcpFlagsPsh;
+    private int _tcpFlagsPsh;
 
-    private Integer _tcpFlagsRst;
+    private int _tcpFlagsRst;
 
-    private Integer _tcpFlagsSyn;
+    private int _tcpFlagsSyn;
 
-    private Integer _tcpFlagsUrg;
+    private int _tcpFlagsUrg;
 
     public Builder() {
       _dscp = 0;
@@ -109,12 +116,8 @@ public final class Flow implements Comparable<Flow>, Serializable {
     }
 
     public Flow build() {
-      if (_ingressNode == null) {
-        throw new BatfishException("Cannot build flow without at least specifying ingress node");
-      }
-      if (_tag == null) {
-        throw new BatfishException("Cannot build flow without specifying tag");
-      }
+      checkNotNull(_ingressNode, "Cannot build flow without at least specifying ingress node");
+      checkNotNull(_tag, "Cannot build flow without specifying tag");
       return new Flow(
           _ingressNode,
           _ingressInterface,
@@ -142,7 +145,7 @@ public final class Flow implements Comparable<Flow>, Serializable {
           _tag);
     }
 
-    public Integer getDscp() {
+    public int getDscp() {
       return _dscp;
     }
 
@@ -150,19 +153,19 @@ public final class Flow implements Comparable<Flow>, Serializable {
       return _dstIp;
     }
 
-    public Integer getDstPort() {
+    public int getDstPort() {
       return _dstPort;
     }
 
-    public Integer getEcn() {
+    public int getEcn() {
       return _ecn;
     }
 
-    public Integer getIcmpCode() {
+    public int getIcmpCode() {
       return _icmpCode;
     }
 
-    public Integer getIcmpType() {
+    public int getIcmpType() {
       return _icmpType;
     }
 
@@ -182,7 +185,7 @@ public final class Flow implements Comparable<Flow>, Serializable {
       return _ipProtocol;
     }
 
-    public Integer getPacketLength() {
+    public int getPacketLength() {
       return _packetLength;
     }
 
@@ -190,7 +193,7 @@ public final class Flow implements Comparable<Flow>, Serializable {
       return _srcIp;
     }
 
-    public Integer getSrcPort() {
+    public int getSrcPort() {
       return _srcPort;
     }
 
@@ -202,39 +205,39 @@ public final class Flow implements Comparable<Flow>, Serializable {
       return _tag;
     }
 
-    public Integer getTcpFlagsAck() {
+    public int getTcpFlagsAck() {
       return _tcpFlagsAck;
     }
 
-    public Integer getTcpFlagsCwr() {
+    public int getTcpFlagsCwr() {
       return _tcpFlagsCwr;
     }
 
-    public Integer getTcpFlagsEce() {
+    public int getTcpFlagsEce() {
       return _tcpFlagsEce;
     }
 
-    public Integer getTcpFlagsFin() {
+    public int getTcpFlagsFin() {
       return _tcpFlagsFin;
     }
 
-    public Integer getTcpFlagsPsh() {
+    public int getTcpFlagsPsh() {
       return _tcpFlagsPsh;
     }
 
-    public Integer getTcpFlagsRst() {
+    public int getTcpFlagsRst() {
       return _tcpFlagsRst;
     }
 
-    public Integer getTcpFlagsSyn() {
+    public int getTcpFlagsSyn() {
       return _tcpFlagsSyn;
     }
 
-    public Integer getTcpFlagsUrg() {
+    public int getTcpFlagsUrg() {
       return _tcpFlagsUrg;
     }
 
-    public Builder setDscp(Integer dscp) {
+    public Builder setDscp(int dscp) {
       _dscp = dscp;
       return this;
     }
@@ -249,12 +252,7 @@ public final class Flow implements Comparable<Flow>, Serializable {
       return this;
     }
 
-    public Builder setDstPort(Integer dstPort) {
-      _dstPort = dstPort;
-      return this;
-    }
-
-    public Builder setEcn(Integer ecn) {
+    public Builder setEcn(int ecn) {
       _ecn = ecn;
       return this;
     }
@@ -264,32 +262,42 @@ public final class Flow implements Comparable<Flow>, Serializable {
       return this;
     }
 
-    public Builder setIcmpCode(Integer icmpCode) {
+    public Builder setIcmpCode(int icmpCode) {
       _icmpCode = icmpCode;
       return this;
     }
 
-    public Builder setIcmpType(Integer icmpType) {
+    public Builder setIcmpType(int icmpType) {
       _icmpType = icmpType;
       return this;
     }
 
-    public Builder setIngressInterface(String ingressInterface) {
+    public Builder setIngressInterface(@Nullable String ingressInterface) {
       _ingressInterface = ingressInterface;
+
+      // invariant: either ingressVrf or ingressInterface is always null.
+      if (_ingressInterface != null) {
+        _ingressVrf = null;
+      }
       return this;
     }
 
-    public Builder setIngressNode(String ingressNode) {
+    public Builder setIngressNode(@Nonnull String ingressNode) {
       _ingressNode = ingressNode;
       return this;
     }
 
-    public Builder setIngressVrf(String ingressVrf) {
+    public Builder setIngressVrf(@Nullable String ingressVrf) {
       _ingressVrf = ingressVrf;
+
+      // invariant: either ingressVrf or ingressInterface is always null.
+      if (_ingressVrf != null) {
+        _ingressInterface = null;
+      }
       return this;
     }
 
-    public Builder setIpProtocol(IpProtocol ipProtocol) {
+    public Builder setIpProtocol(@Nonnull IpProtocol ipProtocol) {
       _ipProtocol = ipProtocol;
       return this;
     }
@@ -422,7 +430,7 @@ public final class Flow implements Comparable<Flow>, Serializable {
 
   private final int _dscp;
 
-  private final Ip _dstIp;
+  private final @Nonnull Ip _dstIp;
 
   private final int _dstPort;
 
@@ -434,23 +442,23 @@ public final class Flow implements Comparable<Flow>, Serializable {
 
   private final int _icmpType;
 
-  private String _ingressInterface;
+  private final @Nullable String _ingressInterface;
 
-  private final String _ingressNode;
+  private final @Nonnull String _ingressNode;
 
-  private final String _ingressVrf;
+  private final @Nullable String _ingressVrf;
 
-  private final IpProtocol _ipProtocol;
+  private final @Nonnull IpProtocol _ipProtocol;
 
   private final int _packetLength;
 
-  private final Ip _srcIp;
+  private final @Nonnull Ip _srcIp;
 
   private final int _srcPort;
 
-  private final State _state;
+  private final @Nonnull State _state;
 
-  private final String _tag;
+  private final @Nonnull String _tag;
 
   private final int _tcpFlagsAck;
 
@@ -470,21 +478,21 @@ public final class Flow implements Comparable<Flow>, Serializable {
 
   @JsonCreator
   public Flow(
-      @JsonProperty(PROP_INGRESS_NODE) String ingressNode,
-      @JsonProperty(PROP_INGRESS_INTERFACE) String ingressInterface,
-      @JsonProperty(PROP_INGRESS_VRF) String ingressVrf,
-      @JsonProperty(PROP_SRC_IP) Ip srcIp,
-      @JsonProperty(PROP_DST_IP) Ip dstIp,
+      @Nonnull @JsonProperty(PROP_INGRESS_NODE) String ingressNode,
+      @Nullable @JsonProperty(PROP_INGRESS_INTERFACE) String ingressInterface,
+      @Nullable @JsonProperty(PROP_INGRESS_VRF) String ingressVrf,
+      @Nonnull @JsonProperty(PROP_SRC_IP) Ip srcIp,
+      @Nonnull @JsonProperty(PROP_DST_IP) Ip dstIp,
       @JsonProperty(PROP_SRC_PORT) int srcPort,
       @JsonProperty(PROP_DST_PORT) int dstPort,
-      @JsonProperty(PROP_IP_PROTOCOL) IpProtocol ipProtocol,
+      @Nonnull @JsonProperty(PROP_IP_PROTOCOL) IpProtocol ipProtocol,
       @JsonProperty(PROP_DSCP) int dscp,
       @JsonProperty(PROP_ECN) int ecn,
       @JsonProperty(PROP_FRAGMENT_OFFSET) int fragmentOffset,
       @JsonProperty(PROP_ICMP_TYPE) int icmpType,
       @JsonProperty(PROP_ICMP_CODE) int icmpCode,
       @JsonProperty(PROP_PACKET_LENGTH) int packetLength,
-      @JsonProperty(PROP_STATE) State state,
+      @Nonnull @JsonProperty(PROP_STATE) State state,
       @JsonProperty(PROP_TCP_FLAGS_CWR) int tcpFlagsCwr,
       @JsonProperty(PROP_TCP_FLAGS_ECE) int tcpFlagsEce,
       @JsonProperty(PROP_TCP_FLAGS_URG) int tcpFlagsUrg,
@@ -493,7 +501,13 @@ public final class Flow implements Comparable<Flow>, Serializable {
       @JsonProperty(PROP_TCP_FLAGS_RST) int tcpFlagsRst,
       @JsonProperty(PROP_TCP_FLAGS_SYN) int tcpFlagsSyn,
       @JsonProperty(PROP_TCP_FLAGS_FIN) int tcpFlagsFin,
-      @JsonProperty(PROP_TAG) String tag) {
+      @Nonnull @JsonProperty(PROP_TAG) String tag) {
+    checkArgument(
+        ingressInterface != null || ingressVrf != null,
+        "Either ingressInterface or ingressVrf must not be null.");
+    checkArgument(
+        ingressInterface == null || ingressVrf == null,
+        "Either ingressInterface or ingressVrf must be null.");
     _ingressNode = ingressNode;
     _ingressInterface = ingressInterface;
     _ingressVrf = ingressVrf;
@@ -527,7 +541,11 @@ public final class Flow implements Comparable<Flow>, Serializable {
     if (ret != 0) {
       return ret;
     }
-    ret = _ingressVrf.compareTo(rhs._ingressVrf);
+    ret = CommonUtil.compareNullable(_ingressInterface, rhs._ingressInterface);
+    if (ret != 0) {
+      return ret;
+    }
+    ret = CommonUtil.compareNullable(_ingressVrf, rhs._ingressVrf);
     if (ret != 0) {
       return ret;
     }
@@ -620,21 +638,21 @@ public final class Flow implements Comparable<Flow>, Serializable {
     }
     Flow other = (Flow) o;
     return _dscp == other._dscp
-        && Objects.equals(_dstIp, other._dstIp)
-        && Objects.equals(_dstPort, other._dstPort)
+        && _dstIp.equals(other._dstIp)
+        && _dstPort == other._dstPort
         && _ecn == other._ecn
         && _fragmentOffset == other._fragmentOffset
-        && Objects.equals(_icmpCode, other._icmpCode)
-        && Objects.equals(_icmpType, other._icmpType)
+        && _icmpCode == other._icmpCode
+        && _icmpType == other._icmpType
+        && _ingressNode.equals(other._ingressNode)
         && Objects.equals(_ingressInterface, other._ingressInterface)
-        && Objects.equals(_ingressNode, other._ingressNode)
         && Objects.equals(_ingressVrf, other._ingressVrf)
-        && Objects.equals(_ipProtocol, other._ipProtocol)
+        && _ipProtocol.equals(other._ipProtocol)
         && _packetLength == other._packetLength
-        && Objects.equals(_srcIp, other._srcIp)
-        && Objects.equals(_srcPort, other._srcPort)
-        && Objects.equals(_state, other._state)
-        && Objects.equals(_tag, other._tag)
+        && _srcIp.equals(other._srcIp)
+        && _srcPort == other._srcPort
+        && _state.equals(other._state)
+        && _tag.equals(other._tag)
         && _tcpFlagsAck == other._tcpFlagsAck
         && _tcpFlagsCwr == other._tcpFlagsCwr
         && _tcpFlagsEce == other._tcpFlagsEce
@@ -849,11 +867,6 @@ public final class Flow implements Comparable<Flow>, Serializable {
         + " state:"
         + _state
         + tcpFlagsStr;
-  }
-
-  @JsonProperty(PROP_INGRESS_INTERFACE)
-  public void setIngressInterface(String ingressInterface) {
-    _ingressInterface = ingressInterface;
   }
 
   public Builder toBuilder() {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Flow.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Flow.java
@@ -2,6 +2,7 @@ package org.batfish.datamodel;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -476,32 +477,31 @@ public final class Flow implements Comparable<Flow>, Serializable {
 
   private final int _tcpFlagsUrg;
 
-  @JsonCreator
-  public Flow(
-      @Nonnull @JsonProperty(PROP_INGRESS_NODE) String ingressNode,
-      @Nullable @JsonProperty(PROP_INGRESS_INTERFACE) String ingressInterface,
-      @Nullable @JsonProperty(PROP_INGRESS_VRF) String ingressVrf,
-      @Nonnull @JsonProperty(PROP_SRC_IP) Ip srcIp,
-      @Nonnull @JsonProperty(PROP_DST_IP) Ip dstIp,
-      @JsonProperty(PROP_SRC_PORT) int srcPort,
-      @JsonProperty(PROP_DST_PORT) int dstPort,
-      @Nonnull @JsonProperty(PROP_IP_PROTOCOL) IpProtocol ipProtocol,
-      @JsonProperty(PROP_DSCP) int dscp,
-      @JsonProperty(PROP_ECN) int ecn,
-      @JsonProperty(PROP_FRAGMENT_OFFSET) int fragmentOffset,
-      @JsonProperty(PROP_ICMP_TYPE) int icmpType,
-      @JsonProperty(PROP_ICMP_CODE) int icmpCode,
-      @JsonProperty(PROP_PACKET_LENGTH) int packetLength,
-      @Nonnull @JsonProperty(PROP_STATE) State state,
-      @JsonProperty(PROP_TCP_FLAGS_CWR) int tcpFlagsCwr,
-      @JsonProperty(PROP_TCP_FLAGS_ECE) int tcpFlagsEce,
-      @JsonProperty(PROP_TCP_FLAGS_URG) int tcpFlagsUrg,
-      @JsonProperty(PROP_TCP_FLAGS_ACK) int tcpFlagsAck,
-      @JsonProperty(PROP_TCP_FLAGS_PSH) int tcpFlagsPsh,
-      @JsonProperty(PROP_TCP_FLAGS_RST) int tcpFlagsRst,
-      @JsonProperty(PROP_TCP_FLAGS_SYN) int tcpFlagsSyn,
-      @JsonProperty(PROP_TCP_FLAGS_FIN) int tcpFlagsFin,
-      @Nonnull @JsonProperty(PROP_TAG) String tag) {
+  private Flow(
+      @Nonnull String ingressNode,
+      @Nullable String ingressInterface,
+      @Nullable String ingressVrf,
+      @Nonnull Ip srcIp,
+      @Nonnull Ip dstIp,
+      int srcPort,
+      int dstPort,
+      @Nonnull IpProtocol ipProtocol,
+      int dscp,
+      int ecn,
+      int fragmentOffset,
+      int icmpType,
+      int icmpCode,
+      int packetLength,
+      @Nonnull State state,
+      int tcpFlagsCwr,
+      int tcpFlagsEce,
+      int tcpFlagsUrg,
+      int tcpFlagsAck,
+      int tcpFlagsPsh,
+      int tcpFlagsRst,
+      int tcpFlagsSyn,
+      int tcpFlagsFin,
+      @Nonnull String tag) {
     checkArgument(
         ingressInterface != null || ingressVrf != null,
         "Either ingressInterface or ingressVrf must not be null.");
@@ -532,6 +532,59 @@ public final class Flow implements Comparable<Flow>, Serializable {
     _tcpFlagsSyn = tcpFlagsSyn;
     _tcpFlagsFin = tcpFlagsFin;
     _tag = tag;
+  }
+
+  @JsonCreator
+  public static Flow createFlow(
+      @JsonProperty(PROP_INGRESS_NODE) String ingressNode,
+      @JsonProperty(PROP_INGRESS_INTERFACE) String ingressInterface,
+      @JsonProperty(PROP_INGRESS_VRF) String ingressVrf,
+      @JsonProperty(PROP_SRC_IP) Ip srcIp,
+      @JsonProperty(PROP_DST_IP) Ip dstIp,
+      @JsonProperty(PROP_SRC_PORT) int srcPort,
+      @JsonProperty(PROP_DST_PORT) int dstPort,
+      @JsonProperty(PROP_IP_PROTOCOL) IpProtocol ipProtocol,
+      @JsonProperty(PROP_DSCP) int dscp,
+      @JsonProperty(PROP_ECN) int ecn,
+      @JsonProperty(PROP_FRAGMENT_OFFSET) int fragmentOffset,
+      @JsonProperty(PROP_ICMP_TYPE) int icmpType,
+      @JsonProperty(PROP_ICMP_CODE) int icmpCode,
+      @JsonProperty(PROP_PACKET_LENGTH) int packetLength,
+      @JsonProperty(PROP_STATE) State state,
+      @JsonProperty(PROP_TCP_FLAGS_CWR) int tcpFlagsCwr,
+      @JsonProperty(PROP_TCP_FLAGS_ECE) int tcpFlagsEce,
+      @JsonProperty(PROP_TCP_FLAGS_URG) int tcpFlagsUrg,
+      @JsonProperty(PROP_TCP_FLAGS_ACK) int tcpFlagsAck,
+      @JsonProperty(PROP_TCP_FLAGS_PSH) int tcpFlagsPsh,
+      @JsonProperty(PROP_TCP_FLAGS_RST) int tcpFlagsRst,
+      @JsonProperty(PROP_TCP_FLAGS_SYN) int tcpFlagsSyn,
+      @JsonProperty(PROP_TCP_FLAGS_FIN) int tcpFlagsFin,
+      @JsonProperty(PROP_TAG) String tag) {
+    return new Flow(
+        requireNonNull(ingressNode, PROP_INGRESS_NODE + " must not be null"),
+        ingressInterface,
+        ingressVrf,
+        requireNonNull(srcIp, PROP_SRC_IP + " must not be null"),
+        requireNonNull(dstIp, PROP_DST_IP + " must not be null"),
+        srcPort,
+        dstPort,
+        requireNonNull(ipProtocol, PROP_IP_PROTOCOL + " must not be null"),
+        dscp,
+        ecn,
+        fragmentOffset,
+        icmpType,
+        icmpCode,
+        packetLength,
+        requireNonNull(state, PROP_STATE + " must not be null"),
+        tcpFlagsCwr,
+        tcpFlagsEce,
+        tcpFlagsUrg,
+        tcpFlagsAck,
+        tcpFlagsPsh,
+        tcpFlagsRst,
+        tcpFlagsSyn,
+        tcpFlagsFin,
+        requireNonNull(tag, PROP_TAG + " must not be null"));
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/FlowMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/FlowMatchers.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.equalTo;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.matchers.FlowMatchersImpl.HasDstIp;
+import org.batfish.datamodel.matchers.FlowMatchersImpl.HasIngressInterface;
 import org.batfish.datamodel.matchers.FlowMatchersImpl.HasIngressNode;
 import org.batfish.datamodel.matchers.FlowMatchersImpl.HasSrcIp;
 import org.hamcrest.Matcher;
@@ -22,6 +23,10 @@ public final class FlowMatchers {
 
   public static Matcher<Flow> hasIngressNode(String ingressNode) {
     return new HasIngressNode(equalTo(ingressNode));
+  }
+
+  public static Matcher<Flow> hasIngressInterface(String ingressInterface) {
+    return new HasIngressInterface(equalTo(ingressInterface));
   }
 
   public static Matcher<Flow> hasIngressNode(Matcher<? super String> ingressNodeMatcher) {

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/FlowMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/FlowMatchersImpl.java
@@ -30,6 +30,17 @@ public final class FlowMatchersImpl {
     }
   }
 
+  public static class HasIngressInterface extends FeatureMatcher<Flow, String> {
+    HasIngressInterface(Matcher<? super String> subMatcher) {
+      super(subMatcher, "ingressInterface", "ingressInterface");
+    }
+
+    @Override
+    protected String featureValueOf(Flow flow) {
+      return flow.getIngressInterface();
+    }
+  }
+
   public static class HasSrcIp extends FeatureMatcher<Flow, Ip> {
     HasSrcIp(Matcher<? super Ip> subMatcher) {
       super(subMatcher, "srcIp", "srcIp");

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/FlowMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/FlowMatchersImpl.java
@@ -21,7 +21,7 @@ public final class FlowMatchersImpl {
 
   public static class HasIngressNode extends FeatureMatcher<Flow, String> {
     HasIngressNode(Matcher<? super String> subMatcher) {
-      super(subMatcher, "ingressNode", "ingressNode");
+      super(subMatcher, "A Flow with ingressNode:", "ingressNode");
     }
 
     @Override
@@ -32,7 +32,7 @@ public final class FlowMatchersImpl {
 
   public static class HasIngressInterface extends FeatureMatcher<Flow, String> {
     HasIngressInterface(Matcher<? super String> subMatcher) {
-      super(subMatcher, "ingressInterface", "ingressInterface");
+      super(subMatcher, "A Flow with ingressInterface:", "ingressInterface");
     }
 
     @Override


### PR DESCRIPTION
- Null annotations on all object fields.
- Change builder field types to match corresponding Flow fields.
- Maintain and check the invariant that exactly 1 of _ingressVrf and
  _ingressInterface is non-null.
- Use Object.equals instead of Objects.equals for @Nonnull fields.
- Include _ingressInterface in compareTo
- Remove setter for final field _ingressInterface

The change to compareTo broke a unit test (because more flows are now
considered distinct), so fixed that too.