### PR TITLE
Cisco: proper ref tracking of NAT ACLs

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -2003,13 +2003,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
 
     /* source nat acl */
     IpAccessList sourceNatAcl = ipAccessLists.get(sourceNatAclName);
-    if (sourceNatAcl == null) {
-      undefined(
-          CiscoStructureType.IP_ACCESS_LIST,
-          sourceNatAclName,
-          CiscoStructureUsage.IP_NAT_SOURCE_ACCESS_LIST,
-          nat.getAclNameLine());
-    } else {
+    if (sourceNatAcl != null) {
       convertedNat.setAcl(sourceNatAcl);
       String msg = "source nat acl for interface: " + iface.getName();
       ExtendedAccessList sourceNatExtendedAccessList = _extendedAccessLists.get(sourceNatAclName);
@@ -2034,12 +2028,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
           convertedNat.setPoolIpFirst(firstIp);
           convertedNat.setPoolIpLast(lastIp);
         }
-      } else {
-        undefined(
-            CiscoStructureType.NAT_POOL,
-            sourceNatPoolName,
-            CiscoStructureUsage.IP_NAT_SOURCE_POOL,
-            nat.getNatPoolLine());
       }
     }
 
@@ -3297,6 +3285,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
         CiscoStructureUsage.INSPECT_CLASS_MAP_MATCH_ACCESS_GROUP,
         CiscoStructureUsage.INTERFACE_IGMP_ACCESS_GROUP_ACL,
         CiscoStructureUsage.INTERFACE_IP_INBAND_ACCESS_GROUP,
+        CiscoStructureUsage.IP_NAT_SOURCE_ACCESS_LIST,
         CiscoStructureUsage.RIP_DISTRIBUTE_LIST,
         CiscoStructureUsage.ROUTER_ISIS_DISTRIBUTE_LIST_ACL,
         CiscoStructureUsage.SNMP_SERVER_FILE_TRANSFER_ACL,

--- a/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoConfigurationTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
@@ -95,35 +94,6 @@ public class CiscoConfigurationTest {
     _config.setHostname("host");
     _config.setAnswerElement(new ConvertConfigurationAnswerElement());
     _interface = new Interface("iface", _config);
-  }
-
-  @Test
-  public void processSourceNatDropsRuleMissingAcl() {
-    CiscoSourceNat nat = new CiscoSourceNat();
-    nat.setAclName(ACL);
-    nat.setNatPool(POOL);
-
-    assertThat(_config.processSourceNat(nat, _interface, Collections.emptyMap()), nullValue());
-    assertUndefined(
-        CiscoStructureType.IP_ACCESS_LIST, ACL, CiscoStructureUsage.IP_NAT_SOURCE_ACCESS_LIST);
-    assertUndefined(CiscoStructureType.NAT_POOL, POOL, CiscoStructureUsage.IP_NAT_SOURCE_POOL);
-  }
-
-  @Test
-  public void processSourceNatDropsRuleMissingPool() {
-    CiscoSourceNat nat = new CiscoSourceNat();
-    nat.setAclName(ACL);
-    nat.setNatPool(POOL);
-
-    assertThat(
-        _config.processSourceNat(
-            nat,
-            _interface,
-            Collections.singletonMap(ACL, new IpAccessList(ACL, Collections.emptyList()))),
-        nullValue());
-    assertDefined(
-        CiscoStructureType.IP_ACCESS_LIST, ACL, CiscoStructureUsage.IP_NAT_SOURCE_ACCESS_LIST);
-    assertUndefined(CiscoStructureType.NAT_POOL, POOL, CiscoStructureUsage.IP_NAT_SOURCE_POOL);
   }
 
   @Test

--- a/tests/parsing-tests/unit-tests-undefined.ref
+++ b/tests/parsing-tests/unit-tests-undefined.ref
@@ -766,14 +766,6 @@
           ]
         }
       },
-      "undefined:ipv4/6 acl:usage:ip nat source dynamic access-list:def" : {
-        "description" : "Undefined reference to structure of type: 'ipv4/6 acl' with usage: 'ip nat source dynamic access-list' named 'def'",
-        "files" : {
-          "cisco_interface" : [
-            90
-          ]
-        }
-      },
       "undefined:ipv4/6 acl:usage:ip wccp group-list:wccp-cachelist" : {
         "description" : "Undefined reference to structure of type: 'ipv4/6 acl' with usage: 'ip wccp group-list' named 'wccp-cachelist'",
         "files" : {
@@ -1289,7 +1281,7 @@
     "summary" : {
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 159
+      "numResults" : 158
     },
     "undefinedReferences" : {
       "IosXrMultiCast" : {
@@ -1611,11 +1603,6 @@
           "1" : {
             "interface igmp access-group acl" : [
               77
-            ]
-          },
-          "def" : {
-            "ip nat source dynamic access-list" : [
-              90
             ]
           }
         },

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -57129,11 +57129,6 @@
               "interface igmp access-group acl" : [
                 77
               ]
-            },
-            "def" : {
-              "ip nat source dynamic access-list" : [
-                90
-              ]
             }
           },
           "nat pool" : {


### PR DESCRIPTION
Fixes a duplicate warning: one under ipv4-only, one under v4/v6 both.