### PR TITLE
New routes question, first pass

### DIFF
--- a/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswerer.java
@@ -1,0 +1,125 @@
+package org.batfish.question.routes;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multiset;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.regex.Pattern;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.common.Answerer;
+import org.batfish.common.plugin.IBatfish;
+import org.batfish.datamodel.AbstractRoute;
+import org.batfish.datamodel.DataPlane;
+import org.batfish.datamodel.GenericRib;
+import org.batfish.datamodel.answers.AnswerElement;
+import org.batfish.datamodel.answers.Schema;
+import org.batfish.datamodel.pojo.Node;
+import org.batfish.datamodel.questions.DisplayHints;
+import org.batfish.datamodel.questions.Question;
+import org.batfish.datamodel.table.ColumnMetadata;
+import org.batfish.datamodel.table.Row;
+import org.batfish.datamodel.table.TableAnswerElement;
+import org.batfish.datamodel.table.TableMetadata;
+
+/** Answerer for {@link RoutesQuestion} */
+@ParametersAreNonnullByDefault
+public class RoutesAnswerer extends Answerer {
+  static final String COL_NODE = "Node";
+  static final String COL_VRF_NAME = "VRF";
+  static final String COL_NETWORK = "Network";
+  static final String COL_NEXT_HOP = "NextHop";
+  static final String COL_NEXT_HOP_IP = "NextHopIp";
+  static final String COL_PROTOCOL = "Protocol";
+
+  RoutesAnswerer(Question question, IBatfish batfish) {
+    super(question, batfish);
+  }
+
+  @Override
+  public AnswerElement answer() {
+    RoutesQuestion question = (RoutesQuestion) _question;
+    TableAnswerElement answer = new TableAnswerElement(getTableMetadata(question.getProtocol()));
+    DataPlane dp = _batfish.loadDataPlane();
+    answer.postProcessAnswer(
+        _question,
+        generateRows(
+            dp,
+            question.getProtocol(),
+            question.getNodeRegex().getMatchingNodes(_batfish),
+            question.getVrfRegex()));
+    return answer;
+  }
+
+  private static Multiset<Row> generateRows(
+      DataPlane dp, String protocol, Set<String> matchingNodes, String vrfRegex) {
+    switch (protocol) {
+      case "all":
+      default:
+        return getMainRibRoutes(dp.getRibs(), matchingNodes, vrfRegex);
+    }
+  }
+
+  /** Get the rows for MainRib routes. */
+  @VisibleForTesting
+  static Multiset<Row> getMainRibRoutes(
+      SortedMap<String, SortedMap<String, GenericRib<AbstractRoute>>> ribs,
+      Set<String> matchingNodes,
+      String vrfRegex) {
+    HashMultiset<Row> rows = HashMultiset.create();
+    Pattern compiledVrfRegex = Pattern.compile(vrfRegex);
+    ribs.forEach(
+        (node, vrfMap) -> {
+          if (matchingNodes.contains(node)) {
+            vrfMap.forEach(
+                (vrfName, rib) -> {
+                  if (compiledVrfRegex.matcher(vrfName).matches()) {
+                    rows.addAll(getRowsForAbstractRoutes(node, vrfName, rib.getRoutes()));
+                  }
+                });
+          }
+        });
+    return rows;
+  }
+
+  /** Convert a {@link Set} of {@link AbstractRoute} into a set of rows. */
+  private static Set<Row> getRowsForAbstractRoutes(
+      String node, String vrfName, Set<AbstractRoute> routes) {
+    Node nodeObj = new Node(node);
+    return routes
+        .stream()
+        .map(
+            route ->
+                Row.builder()
+                    .put(COL_NODE, nodeObj)
+                    .put(COL_VRF_NAME, vrfName)
+                    .put(COL_NETWORK, route.getNetwork())
+                    .put(COL_NEXT_HOP_IP, route.getNextHopIp())
+                    .put(COL_NEXT_HOP, firstNonNull(route.getNextHop(), "N/A"))
+                    .put(COL_PROTOCOL, route.getProtocol())
+                    .build())
+        .collect(ImmutableSet.toImmutableSet());
+  }
+
+  /** Generate the table metadata based on the protocol for which we are examining the RIBs */
+  @VisibleForTesting
+  static TableMetadata getTableMetadata(String protocol) {
+    switch (protocol) {
+      case "all":
+      default:
+        ImmutableList.Builder<ColumnMetadata> columnBuilder = ImmutableList.builder();
+        columnBuilder.add(new ColumnMetadata(COL_NODE, Schema.NODE, "Node"));
+        columnBuilder.add(new ColumnMetadata(COL_VRF_NAME, Schema.STRING, "VRF name"));
+        columnBuilder.add(new ColumnMetadata(COL_NETWORK, Schema.PREFIX, "Route network (prefix)"));
+        columnBuilder.add(new ColumnMetadata(COL_PROTOCOL, Schema.STRING, "Route protocol"));
+        columnBuilder.add(
+            new ColumnMetadata(COL_NEXT_HOP, Schema.STRING, "Route's next hop (as node hostname)"));
+        columnBuilder.add(new ColumnMetadata(COL_NEXT_HOP_IP, Schema.IP, "Route's next hop IP"));
+        return new TableMetadata(columnBuilder.build(), new DisplayHints());
+    }
+  }
+}

--- a/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswerer.java
@@ -5,8 +5,8 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.HashMultiset;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multiset;
+import java.util.List;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.regex.Pattern;
@@ -25,6 +25,7 @@ import org.batfish.datamodel.table.ColumnMetadata;
 import org.batfish.datamodel.table.Row;
 import org.batfish.datamodel.table.TableAnswerElement;
 import org.batfish.datamodel.table.TableMetadata;
+import org.batfish.question.routes.RoutesQuestion.RibProtocol;
 
 /** Answerer for {@link RoutesQuestion} */
 @ParametersAreNonnullByDefault
@@ -56,9 +57,9 @@ public class RoutesAnswerer extends Answerer {
   }
 
   private static Multiset<Row> generateRows(
-      DataPlane dp, String protocol, Set<String> matchingNodes, String vrfRegex) {
+      DataPlane dp, RibProtocol protocol, Set<String> matchingNodes, String vrfRegex) {
     switch (protocol) {
-      case "all":
+      case ALL:
       default:
         return getMainRibRoutes(dp.getRibs(), matchingNodes, vrfRegex);
     }
@@ -86,8 +87,8 @@ public class RoutesAnswerer extends Answerer {
     return rows;
   }
 
-  /** Convert a {@link Set} of {@link AbstractRoute} into a set of rows. */
-  private static Set<Row> getRowsForAbstractRoutes(
+  /** Convert a {@link Set} of {@link AbstractRoute} into a list of rows. */
+  private static List<Row> getRowsForAbstractRoutes(
       String node, String vrfName, Set<AbstractRoute> routes) {
     Node nodeObj = new Node(node);
     return routes
@@ -102,14 +103,14 @@ public class RoutesAnswerer extends Answerer {
                     .put(COL_NEXT_HOP, firstNonNull(route.getNextHop(), "N/A"))
                     .put(COL_PROTOCOL, route.getProtocol())
                     .build())
-        .collect(ImmutableSet.toImmutableSet());
+        .collect(ImmutableList.toImmutableList());
   }
 
   /** Generate the table metadata based on the protocol for which we are examining the RIBs */
   @VisibleForTesting
-  static TableMetadata getTableMetadata(String protocol) {
+  static TableMetadata getTableMetadata(RibProtocol protocol) {
     switch (protocol) {
-      case "all":
+      case ALL:
       default:
         ImmutableList.Builder<ColumnMetadata> columnBuilder = ImmutableList.builder();
         columnBuilder.add(new ColumnMetadata(COL_NODE, Schema.NODE, "Node"));

--- a/projects/question/src/main/java/org/batfish/question/routes/RoutesQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RoutesQuestion.java
@@ -1,0 +1,77 @@
+package org.batfish.question.routes;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.questions.NodesSpecifier;
+import org.batfish.datamodel.questions.Question;
+
+/** Returns computed routes after dataplane computation. */
+@ParametersAreNonnullByDefault
+public class RoutesQuestion extends Question {
+
+  private static final String PROP_NODE_REGEX = "nodeRegex";
+
+  private static final String PROP_VRF_REGEX = "vrfRegex";
+
+  private static final String PROP_PROTOCOL = "protocol";
+
+  private static final String QUESTION_NAME = "routes2";
+
+  @Nonnull private NodesSpecifier _nodeRegex;
+
+  @Nonnull private String _vrfRegex;
+
+  @Nonnull private String _protocol;
+
+  @JsonCreator
+  private RoutesQuestion(
+      @Nullable @JsonProperty(PROP_NODE_REGEX) NodesSpecifier nodeRegex,
+      @Nullable @JsonProperty(PROP_VRF_REGEX) String vrfRegex,
+      @Nullable @JsonProperty(PROP_PROTOCOL) String protocol) {
+    _nodeRegex = firstNonNull(nodeRegex, NodesSpecifier.ALL);
+    _vrfRegex = firstNonNull(vrfRegex, ".*");
+    _protocol = firstNonNull(protocol, "all");
+  }
+
+  /** Create new routes question with default parameters. */
+  public RoutesQuestion() {
+    this(null, null, null);
+  }
+
+  @Override
+  public boolean getDataPlane() {
+    return true;
+  }
+
+  /**
+   * Returns the short name of this question, used in place of the classname to identify this
+   * question.
+   */
+  @Override
+  public String getName() {
+    return QUESTION_NAME;
+  }
+
+  @JsonProperty(PROP_NODE_REGEX)
+  @Nonnull
+  public NodesSpecifier getNodeRegex() {
+    return _nodeRegex;
+  }
+
+  @JsonProperty(PROP_VRF_REGEX)
+  @Nonnull
+  public String getVrfRegex() {
+    return _vrfRegex;
+  }
+
+  @JsonProperty(PROP_PROTOCOL)
+  @Nonnull
+  public String getProtocol() {
+    return _protocol;
+  }
+}

--- a/projects/question/src/main/java/org/batfish/question/routes/RoutesQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RoutesQuestion.java
@@ -1,9 +1,15 @@
 package org.batfish.question.routes;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static org.batfish.question.routes.RoutesQuestion.RibProtocol.ALL;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.google.common.collect.ImmutableMap;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -13,6 +19,31 @@ import org.batfish.datamodel.questions.Question;
 /** Returns computed routes after dataplane computation. */
 @ParametersAreNonnullByDefault
 public class RoutesQuestion extends Question {
+
+  /** RIBs of these protocols are available for examining routes using {@link RoutesQuestion}. */
+  public enum RibProtocol {
+    ALL("all"),
+    BGP("bgp");
+
+    private final String _protocolName;
+
+    private static final Map<String, RibProtocol> _map = buildMap();
+
+    private static Map<String, RibProtocol> buildMap() {
+      return Arrays.stream(RibProtocol.values())
+          .collect(
+              ImmutableMap.toImmutableMap(p -> p._protocolName.toLowerCase(), Function.identity()));
+    }
+
+    @JsonCreator
+    private static RibProtocol fromName(String name) {
+      return _map.getOrDefault(name.toLowerCase(), ALL);
+    }
+
+    RibProtocol(String protocol) {
+      _protocolName = protocol;
+    }
+  }
 
   private static final String PROP_NODE_REGEX = "nodeRegex";
 
@@ -26,16 +57,23 @@ public class RoutesQuestion extends Question {
 
   @Nonnull private String _vrfRegex;
 
-  @Nonnull private String _protocol;
+  @Nonnull private RibProtocol _protocol;
 
+  /**
+   * Create a new question.
+   *
+   * @param nodeRegex {@link NodesSpecifier} indicating which nodes' RIBs should be considered
+   * @param vrfRegex a regex pattern indicating which VRFs should be considered
+   * @param protocol a specific protocol RIB to return routes from.
+   */
   @JsonCreator
   private RoutesQuestion(
       @Nullable @JsonProperty(PROP_NODE_REGEX) NodesSpecifier nodeRegex,
       @Nullable @JsonProperty(PROP_VRF_REGEX) String vrfRegex,
-      @Nullable @JsonProperty(PROP_PROTOCOL) String protocol) {
+      @Nullable @JsonProperty(PROP_PROTOCOL) RibProtocol protocol) {
     _nodeRegex = firstNonNull(nodeRegex, NodesSpecifier.ALL);
     _vrfRegex = firstNonNull(vrfRegex, ".*");
-    _protocol = firstNonNull(protocol, "all");
+    _protocol = firstNonNull(protocol, ALL);
   }
 
   /** Create new routes question with default parameters. */
@@ -48,30 +86,29 @@ public class RoutesQuestion extends Question {
     return true;
   }
 
-  /**
-   * Returns the short name of this question, used in place of the classname to identify this
-   * question.
-   */
   @Override
   public String getName() {
     return QUESTION_NAME;
   }
 
   @JsonProperty(PROP_NODE_REGEX)
+  @JsonPropertyDescription("Node specifier. Nodes matching this will have their routes reported.")
   @Nonnull
   public NodesSpecifier getNodeRegex() {
     return _nodeRegex;
   }
 
   @JsonProperty(PROP_VRF_REGEX)
+  @JsonPropertyDescription("VRF specifier. Only routes for matching VRFs will be reported.")
   @Nonnull
   public String getVrfRegex() {
     return _vrfRegex;
   }
 
   @JsonProperty(PROP_PROTOCOL)
+  @JsonPropertyDescription("RIB protocol (e.g., bgp). 'all' means main RIB.")
   @Nonnull
-  public String getProtocol() {
+  public RibProtocol getProtocol() {
     return _protocol;
   }
 }

--- a/projects/question/src/main/java/org/batfish/question/routes/RoutesQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RoutesQuestionPlugin.java
@@ -1,0 +1,23 @@
+package org.batfish.question.routes;
+
+import com.google.auto.service.AutoService;
+import org.batfish.common.Answerer;
+import org.batfish.common.plugin.IBatfish;
+import org.batfish.common.plugin.Plugin;
+import org.batfish.datamodel.questions.Question;
+import org.batfish.question.QuestionPlugin;
+
+/** Returns information about dataplane routes. */
+@AutoService(Plugin.class)
+public class RoutesQuestionPlugin extends QuestionPlugin {
+
+  @Override
+  protected Answerer createAnswerer(Question question, IBatfish batfish) {
+    return new RoutesAnswerer(question, batfish);
+  }
+
+  @Override
+  protected Question createQuestion() {
+    return new RoutesQuestion();
+  }
+}

--- a/projects/question/src/test/java/org/batfish/question/routes/MockRib.java
+++ b/projects/question/src/test/java/org/batfish/question/routes/MockRib.java
@@ -1,0 +1,67 @@
+package org.batfish.question.routes;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+import org.batfish.datamodel.AbstractRoute;
+import org.batfish.datamodel.GenericRib;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpSpace;
+import org.batfish.datamodel.Prefix;
+
+/** Mock rib that only supports one operation: returning pre-set routes. */
+class MockRib<R extends AbstractRoute> implements GenericRib<R> {
+
+  private static final long serialVersionUID = 1L;
+
+  private Set<R> _routes;
+
+  MockRib() {
+    _routes = ImmutableSet.of();
+  }
+
+  MockRib(Set<R> routes) {
+    _routes = routes;
+  }
+
+  @Override
+  public int comparePreference(R lhs, R rhs) {
+    return 0;
+  }
+
+  @Override
+  public Map<Prefix, IpSpace> getMatchingIps() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public SortedSet<Prefix> getPrefixes() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public IpSpace getRoutableIps() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Set<R> getRoutes() {
+    return _routes;
+  }
+
+  @Override
+  public Set<R> longestPrefixMatch(Ip address) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean mergeRoute(R route) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Map<Prefix, Set<Ip>> nextHopIpsByPrefix() {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
@@ -10,7 +10,6 @@ import static org.batfish.question.routes.RoutesAnswerer.getMainRibRoutes;
 import static org.batfish.question.routes.RoutesAnswerer.getTableMetadata;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
@@ -95,9 +94,11 @@ public class RoutesAnswererTest {
     List<ColumnMetadata> columnMetadata = getTableMetadata("all").getColumnMetadata();
 
     assertThat(
-        columnMetadata.stream().map(ColumnMetadata::getName).collect(ImmutableSet.toImmutableSet()),
-        containsInAnyOrder(
-            COL_NODE, COL_VRF_NAME, COL_NETWORK, COL_NEXT_HOP, COL_NEXT_HOP_IP, COL_PROTOCOL));
+        columnMetadata
+            .stream()
+            .map(ColumnMetadata::getName)
+            .collect(ImmutableList.toImmutableList()),
+        contains(COL_NODE, COL_VRF_NAME, COL_NETWORK, COL_NEXT_HOP, COL_NEXT_HOP_IP, COL_PROTOCOL));
 
     assertThat(
         columnMetadata

--- a/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
@@ -27,6 +27,7 @@ import org.batfish.datamodel.StaticRoute;
 import org.batfish.datamodel.answers.Schema;
 import org.batfish.datamodel.table.ColumnMetadata;
 import org.batfish.datamodel.table.Row;
+import org.batfish.question.routes.RoutesQuestion.RibProtocol;
 import org.junit.Test;
 
 /** Tests of {@link RoutesAnswerer}. */
@@ -91,7 +92,7 @@ public class RoutesAnswererTest {
 
   @Test
   public void testGetTableMetadataProtocolAll() {
-    List<ColumnMetadata> columnMetadata = getTableMetadata("all").getColumnMetadata();
+    List<ColumnMetadata> columnMetadata = getTableMetadata(RibProtocol.ALL).getColumnMetadata();
 
     assertThat(
         columnMetadata

--- a/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
@@ -1,0 +1,110 @@
+package org.batfish.question.routes;
+
+import static org.batfish.question.routes.RoutesAnswerer.COL_NETWORK;
+import static org.batfish.question.routes.RoutesAnswerer.COL_NEXT_HOP;
+import static org.batfish.question.routes.RoutesAnswerer.COL_NEXT_HOP_IP;
+import static org.batfish.question.routes.RoutesAnswerer.COL_NODE;
+import static org.batfish.question.routes.RoutesAnswerer.COL_PROTOCOL;
+import static org.batfish.question.routes.RoutesAnswerer.COL_VRF_NAME;
+import static org.batfish.question.routes.RoutesAnswerer.getMainRibRoutes;
+import static org.batfish.question.routes.RoutesAnswerer.getTableMetadata;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.Multiset;
+import java.util.List;
+import java.util.SortedMap;
+import org.batfish.datamodel.AbstractRoute;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.GenericRib;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.StaticRoute;
+import org.batfish.datamodel.answers.Schema;
+import org.batfish.datamodel.table.ColumnMetadata;
+import org.batfish.datamodel.table.Row;
+import org.junit.Test;
+
+/** Tests of {@link RoutesAnswerer}. */
+public class RoutesAnswererTest {
+  @Test
+  public void testGetMainRibRoutesWhenEmptyRib() {
+    SortedMap<String, SortedMap<String, GenericRib<AbstractRoute>>> ribs =
+        ImmutableSortedMap.of(
+            "n1", ImmutableSortedMap.of(Configuration.DEFAULT_VRF_NAME, new MockRib<>()));
+
+    Multiset<Row> actual = getMainRibRoutes(ribs, ImmutableSet.of("n1"), ".*");
+
+    assertThat(actual, hasSize(0));
+  }
+
+  @Test
+  public void testHasNodeFiltering() {
+    SortedMap<String, SortedMap<String, GenericRib<AbstractRoute>>> ribs =
+        ImmutableSortedMap.of(
+            "n1",
+            ImmutableSortedMap.of(
+                Configuration.DEFAULT_VRF_NAME,
+                new MockRib<>(
+                    ImmutableSet.of(
+                        StaticRoute.builder()
+                            .setNetwork(Prefix.parse("1.1.1.0/24"))
+                            .setNextHopInterface("Null")
+                            .build()))));
+
+    Multiset<Row> actual = getMainRibRoutes(ribs, ImmutableSet.of("differentNode"), ".*");
+
+    assertThat(actual, hasSize(0));
+  }
+
+  @Test
+  public void testHasVrfFiltering() {
+    SortedMap<String, SortedMap<String, GenericRib<AbstractRoute>>> ribs =
+        ImmutableSortedMap.of(
+            "n1",
+            ImmutableSortedMap.of(
+                Configuration.DEFAULT_VRF_NAME,
+                new MockRib<>(
+                    ImmutableSet.of(
+                        StaticRoute.builder()
+                            .setNetwork(Prefix.parse("1.1.1.0/24"))
+                            .setNextHopInterface("Null")
+                            .build())),
+                "notDefaultVrf",
+                new MockRib<>(
+                    ImmutableSet.of(
+                        StaticRoute.builder()
+                            .setNetwork(Prefix.parse("2.2.2.0/24"))
+                            .setNextHopInterface("Null")
+                            .build()))));
+
+    Multiset<Row> actual = getMainRibRoutes(ribs, ImmutableSet.of("n1"), "^not.*");
+
+    assertThat(actual, hasSize(1));
+    assertThat(
+        actual.iterator().next().getPrefix(COL_NETWORK), equalTo(Prefix.parse("2.2.2.0/24")));
+  }
+
+  @Test
+  public void testGetTableMetadataProtocolAll() {
+    List<ColumnMetadata> columnMetadata = getTableMetadata("all").getColumnMetadata();
+
+    assertThat(
+        columnMetadata.stream().map(ColumnMetadata::getName).collect(ImmutableSet.toImmutableSet()),
+        containsInAnyOrder(
+            COL_NODE, COL_VRF_NAME, COL_NETWORK, COL_NEXT_HOP, COL_NEXT_HOP_IP, COL_PROTOCOL));
+
+    assertThat(
+        columnMetadata
+            .stream()
+            .map(ColumnMetadata::getSchema)
+            .collect(ImmutableList.toImmutableList()),
+        contains(
+            Schema.NODE, Schema.STRING, Schema.PREFIX, Schema.STRING, Schema.STRING, Schema.IP));
+  }
+}

--- a/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
@@ -99,7 +99,7 @@ public class RoutesAnswererTest {
             .stream()
             .map(ColumnMetadata::getName)
             .collect(ImmutableList.toImmutableList()),
-        contains(COL_NODE, COL_VRF_NAME, COL_NETWORK, COL_NEXT_HOP, COL_NEXT_HOP_IP, COL_PROTOCOL));
+        contains(COL_NODE, COL_VRF_NAME, COL_NETWORK, COL_PROTOCOL, COL_NEXT_HOP, COL_NEXT_HOP_IP));
 
     assertThat(
         columnMetadata

--- a/projects/question/src/test/java/org/batfish/question/routes/RoutesQuestionTest.java
+++ b/projects/question/src/test/java/org/batfish/question/routes/RoutesQuestionTest.java
@@ -1,0 +1,22 @@
+package org.batfish.question.routes;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.batfish.datamodel.questions.NodesSpecifier;
+import org.junit.Test;
+
+/** Tests of {@link RoutesQuestion} */
+public class RoutesQuestionTest {
+  @Test
+  public void testDefaultParams() {
+    RoutesQuestion question = new RoutesQuestion();
+
+    assertThat(question.getDataPlane(), equalTo(true));
+    assertThat(question.getName(), equalTo("routes2"));
+
+    assertThat(question.getNodeRegex(), equalTo(NodesSpecifier.ALL));
+    assertThat(question.getVrfRegex(), equalTo(".*"));
+    assertThat(question.getProtocol(), equalTo("all"));
+  }
+}

--- a/projects/question/src/test/java/org/batfish/question/routes/RoutesQuestionTest.java
+++ b/projects/question/src/test/java/org/batfish/question/routes/RoutesQuestionTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import org.batfish.datamodel.questions.NodesSpecifier;
+import org.batfish.question.routes.RoutesQuestion.RibProtocol;
 import org.junit.Test;
 
 /** Tests of {@link RoutesQuestion} */
@@ -17,6 +18,6 @@ public class RoutesQuestionTest {
 
     assertThat(question.getNodeRegex(), equalTo(NodesSpecifier.ALL));
     assertThat(question.getVrfRegex(), equalTo(".*"));
-    assertThat(question.getProtocol(), equalTo("all"));
+    assertThat(question.getProtocol(), equalTo(RibProtocol.ALL));
   }
 }


### PR DESCRIPTION
Begin work addressing #1684 by creating a new routes question that:
- Uses table answer format
- Supports VRF filtering
- Only extracts relevant data based on the type of RIB being examined.

So far only mainRIB is supported, mimicking the existing behavior, more in a separate PR.