### PR TITLE
Simplify Coordinator/Batfish communication

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/BatfishLogger.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/BatfishLogger.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 public final class BatfishLogger {
 
@@ -175,7 +176,11 @@ public final class BatfishLogger {
   }
 
   public BatfishLogger(
-      String logLevel, boolean timestamp, String logFile, boolean logTee, boolean rotateLog) {
+      String logLevel,
+      boolean timestamp,
+      @Nullable String logFile,
+      boolean logTee,
+      boolean rotateLog) {
     _history = null;
     _timestamp = timestamp;
     String levelStr = logLevel;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
@@ -37,7 +37,6 @@ public class BfConsts {
   public static final String ABSPATH_DEFAULT_SALT = "org/batfish/common/util/salt";
 
   public static final String ARG_ANALYSIS_NAME = "analysisname";
-  public static final String ARG_ANSWER_JSON_PATH = "answerjsonpath";
   public static final String ARG_BDP_DETAIL = "bdpdetail";
   public static final String ARG_BDP_MAX_OSCILLATION_RECOVERY_ATTEMPTS =
       "bdpmaxoscillationrecoveryattempts";

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
@@ -46,7 +46,6 @@ public class BfConsts {
   public static final String ARG_BDP_PRINT_OSCILLATING_ITERATIONS = "bdpprintoscillatingiterations";
   public static final String ARG_BDP_RECORD_ALL_ITERATIONS = "bdprecordalliterations";
   public static final String ARG_CONTAINER = "container";
-  public static final String ARG_CONTAINER_DIR = "containerdir";
   public static final String ARG_DELTA_ENVIRONMENT_NAME = "deltaenv";
   public static final String ARG_DELTA_TESTRIG = "deltatestrig";
   public static final String ARG_DIFF_ACTIVE = "diffactive";
@@ -72,6 +71,7 @@ public class BfConsts {
   public static final String ARG_SSL_TRUST_ALL_CERTS = "ssltrustallcerts";
   public static final String ARG_SSL_TRUSTSTORE_FILE = "ssltruststorefile";
   public static final String ARG_SSL_TRUSTSTORE_PASSWORD = "ssltruststorepassword";
+  public static final String ARG_STORAGE_BASE = "storagebase";
   public static final String ARG_SYNTHESIZE_JSON_TOPOLOGY = "synthesizejsontopology";
   public static final String ARG_SYNTHESIZE_TOPOLOGY = "synthesizetopology";
   public static final String ARG_TASK_PLUGIN = "taskplugin";

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
@@ -56,7 +56,6 @@ public class BfConsts {
   public static final String ARG_HALT_ON_CONVERT_ERROR = "haltonconverterror";
   public static final String ARG_HALT_ON_PARSE_ERROR = "haltonparseerror";
   public static final String ARG_IGNORE_FILES_WITH_STRINGS = "ignorefileswithstrings";
-  public static final String ARG_LOG_FILE = "logfile";
   public static final String ARG_LOG_LEVEL = "loglevel";
   public static final String ARG_OUTPUT_ENV = "outputenv";
   public static final String ARG_PEDANTIC_AS_ERROR = "pedanticerror";

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
@@ -45,6 +45,7 @@ public class BfConsts {
   public static final String ARG_BDP_PRINT_ALL_ITERATIONS = "bdpprintalliterations";
   public static final String ARG_BDP_PRINT_OSCILLATING_ITERATIONS = "bdpprintoscillatingiterations";
   public static final String ARG_BDP_RECORD_ALL_ITERATIONS = "bdprecordalliterations";
+  public static final String ARG_CONTAINER = "container";
   public static final String ARG_CONTAINER_DIR = "containerdir";
   public static final String ARG_DELTA_ENVIRONMENT_NAME = "deltaenv";
   public static final String ARG_DELTA_TESTRIG = "deltatestrig";

--- a/projects/batfish/src/main/java/org/batfish/config/Settings.java
+++ b/projects/batfish/src/main/java/org/batfish/config/Settings.java
@@ -627,10 +627,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     return _config.getString(BfConsts.ARG_CONTAINER);
   }
 
-  public Path getContainerDir() {
-    return Paths.get(_config.getString(BfConsts.ARG_CONTAINER_DIR));
-  }
-
   public String getCoordinatorHost() {
     return _config.getString(ARG_COORDINATOR_HOST);
   }
@@ -895,6 +891,10 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     return _config.getString(BfConsts.ARG_SSL_TRUSTSTORE_PASSWORD);
   }
 
+  public Path getStorageBase() {
+    return Paths.get(_config.getString(BfConsts.ARG_STORAGE_BASE));
+  }
+
   public boolean getSynthesizeJsonTopology() {
     return _config.getBoolean(BfConsts.ARG_SYNTHESIZE_JSON_TOPOLOGY);
   }
@@ -989,7 +989,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     setDefaultProperty(BfConsts.ARG_BDP_RECORD_ALL_ITERATIONS, false);
     setDefaultProperty(CAN_EXECUTE, true);
     setDefaultProperty(BfConsts.ARG_CONTAINER, null);
-    setDefaultProperty(BfConsts.ARG_CONTAINER_DIR, null);
     setDefaultProperty(ARG_COORDINATOR_REGISTER, false);
     setDefaultProperty(ARG_COORDINATOR_HOST, "localhost");
     setDefaultProperty(ARG_COORDINATOR_POOL_PORT, CoordConsts.SVC_CFG_POOL_PORT);
@@ -1053,6 +1052,7 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     setDefaultProperty(BfConsts.ARG_SSL_TRUST_ALL_CERTS, false);
     setDefaultProperty(BfConsts.ARG_SSL_TRUSTSTORE_FILE, null);
     setDefaultProperty(BfConsts.ARG_SSL_TRUSTSTORE_PASSWORD, null);
+    setDefaultProperty(BfConsts.ARG_STORAGE_BASE, null);
     setDefaultProperty(BfConsts.ARG_SYNTHESIZE_JSON_TOPOLOGY, false);
     setDefaultProperty(BfConsts.ARG_TASK_PLUGIN, null);
     setDefaultProperty(ARG_THROW_ON_LEXER_ERROR, true);
@@ -1123,8 +1123,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
         "whether to check BGP session reachability during data plane computation");
 
     addOption(BfConsts.ARG_CONTAINER, "name of container", ARGNAME_NAME);
-
-    addOption(BfConsts.ARG_CONTAINER_DIR, "path to container directory", ARGNAME_PATH);
 
     addOption(
         ARG_COORDINATOR_HOST,
@@ -1308,6 +1306,8 @@ public final class Settings extends BaseSettings implements GrammarSettings {
         BfConsts.ARG_SSL_TRUST_ALL_CERTS,
         "whether to trust all SSL certificates during communication with coordinator");
 
+    addOption(BfConsts.ARG_STORAGE_BASE, "path to the storage base", ARGNAME_PATH);
+
     addBooleanOption(
         BfConsts.ARG_SYNTHESIZE_JSON_TOPOLOGY,
         "synthesize json topology from interface ip subnet information");
@@ -1414,7 +1414,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     getBooleanOptionValue(ARG_CHECK_BGP_REACHABILITY);
     getBooleanOptionValue(BfConsts.COMMAND_COMPILE_DIFF_ENVIRONMENT);
     getStringOptionValue(BfConsts.ARG_CONTAINER);
-    getPathOptionValue(BfConsts.ARG_CONTAINER_DIR);
     getStringOptionValue(ARG_COORDINATOR_HOST);
     getIntOptionValue(ARG_COORDINATOR_POOL_PORT);
     getBooleanOptionValue(ARG_COORDINATOR_REGISTER);
@@ -1476,6 +1475,7 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     getBooleanOptionValue(BfConsts.ARG_SSL_TRUST_ALL_CERTS);
     getPathOptionValue(BfConsts.ARG_SSL_TRUSTSTORE_FILE);
     getStringOptionValue(BfConsts.ARG_SSL_TRUSTSTORE_PASSWORD);
+    getPathOptionValue(BfConsts.ARG_STORAGE_BASE);
     getBooleanOptionValue(BfConsts.ARG_SYNTHESIZE_JSON_TOPOLOGY);
     getStringOptionValue(BfConsts.ARG_TASK_PLUGIN);
     getStringOptionValue(BfConsts.ARG_TESTRIG);
@@ -1504,10 +1504,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
 
   public void setContainer(String container) {
     _config.setProperty(BfConsts.ARG_CONTAINER, container);
-  }
-
-  public void setContainerDir(Path containerDir) {
-    _config.setProperty(BfConsts.ARG_CONTAINER_DIR, containerDir.toString());
   }
 
   public void setDebugFlags(List<String> debugFlags) {
@@ -1627,6 +1623,10 @@ public final class Settings extends BaseSettings implements GrammarSettings {
 
   public void setSslTruststorePassword(String sslTruststorePassword) {
     _config.setProperty(BfConsts.ARG_SSL_TRUSTSTORE_PASSWORD, sslTruststorePassword);
+  }
+
+  public void setStorageBase(Path storageBase) {
+    _config.setProperty(BfConsts.ARG_STORAGE_BASE, storageBase.toString());
   }
 
   public void setTaskId(String taskId) {

--- a/projects/batfish/src/main/java/org/batfish/config/Settings.java
+++ b/projects/batfish/src/main/java/org/batfish/config/Settings.java
@@ -732,8 +732,17 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     return _config.getInt(ARG_JOBS);
   }
 
+  @Nullable
   public String getLogFile() {
-    return _config.getString(BfConsts.ARG_LOG_FILE);
+    if (getTaskId() == null) {
+      return null;
+    }
+    return getStorageBase()
+        .resolve(getContainer())
+        .resolve(BfConsts.RELPATH_TESTRIGS_DIR)
+        .resolve(getTestrig())
+        .resolve(getTaskId() + BfConsts.SUFFIX_LOG_FILE)
+        .toString();
   }
 
   public BatfishLogger getLogger() {
@@ -899,6 +908,7 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     return _config.getBoolean(BfConsts.ARG_SYNTHESIZE_JSON_TOPOLOGY);
   }
 
+  @Nullable
   public String getTaskId() {
     return _config.getString(TASK_ID);
   }
@@ -1019,7 +1029,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     setDefaultProperty(ARG_IGNORE_UNSUPPORTED, true);
     setDefaultProperty(ARG_IGNORE_UNKNOWN, true);
     setDefaultProperty(ARG_JOBS, Integer.MAX_VALUE);
-    setDefaultProperty(BfConsts.ARG_LOG_FILE, null);
     setDefaultProperty(ARG_LOG_TEE, false);
     setDefaultProperty(BfConsts.ARG_LOG_LEVEL, "debug");
     setDefaultProperty(ARG_MAX_PARSER_CONTEXT_LINES, 10);
@@ -1221,8 +1230,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
 
     addBooleanOption(ARG_HISTOGRAM, "build histogram of unimplemented features");
 
-    addOption(BfConsts.ARG_LOG_FILE, "path to main log file", ARGNAME_PATH);
-
     addBooleanOption(ARG_LOG_TEE, "print output to both logfile and standard out");
 
     addOption(
@@ -1386,7 +1393,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     _config.setProperty(CAN_EXECUTE, true);
 
     // SPECIAL OPTIONS
-    getStringOptionValue(BfConsts.ARG_LOG_FILE);
     getStringOptionValue(BfConsts.ARG_LOG_LEVEL);
     if (getBooleanOptionValue(ARG_HELP)) {
       _config.setProperty(CAN_EXECUTE, false);

--- a/projects/batfish/src/main/java/org/batfish/config/Settings.java
+++ b/projects/batfish/src/main/java/org/batfish/config/Settings.java
@@ -606,11 +606,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     return _config.getBoolean(BfConsts.COMMAND_ANSWER);
   }
 
-  @Nullable
-  public Path getAnswerJsonPath() {
-    return nullablePath(_config.getString(BfConsts.ARG_ANSWER_JSON_PATH));
-  }
-
   public int getAvailableThreads() {
     return Math.min(Runtime.getRuntime().availableProcessors(), getJobs());
   }
@@ -990,7 +985,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
 
   private void initConfigDefaults() {
     setDefaultProperty(BfConsts.ARG_ANALYSIS_NAME, null);
-    setDefaultProperty(BfConsts.ARG_ANSWER_JSON_PATH, null);
     setDefaultProperty(BfConsts.ARG_BDP_DETAIL, false);
     setDefaultProperty(BfConsts.ARG_BDP_MAX_OSCILLATION_RECOVERY_ATTEMPTS, 0);
     setDefaultProperty(BfConsts.ARG_BDP_MAX_RECORDED_ITERATIONS, 5);
@@ -1091,9 +1085,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
   private void initOptions() {
 
     addOption(BfConsts.ARG_ANALYSIS_NAME, "name of analysis", ARGNAME_NAME);
-
-    addOption(
-        BfConsts.ARG_ANSWER_JSON_PATH, "save query json output to specified file", ARGNAME_PATH);
 
     addBooleanOption(
         BfConsts.ARG_BDP_DETAIL,
@@ -1410,7 +1401,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     getStringOptionValue(BfConsts.ARG_ANALYSIS_NAME);
     getBooleanOptionValue(BfConsts.COMMAND_ANALYZE);
     getBooleanOptionValue(BfConsts.COMMAND_ANSWER);
-    getPathOptionValue(BfConsts.ARG_ANSWER_JSON_PATH);
     getBooleanOptionValue(BfConsts.ARG_BDP_RECORD_ALL_ITERATIONS);
     getBooleanOptionValue(BfConsts.ARG_BDP_DETAIL);
     getIntOptionValue(BfConsts.ARG_BDP_MAX_OSCILLATION_RECOVERY_ATTEMPTS);

--- a/projects/batfish/src/main/java/org/batfish/config/Settings.java
+++ b/projects/batfish/src/main/java/org/batfish/config/Settings.java
@@ -623,6 +623,10 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     return _config.getBoolean(BfConsts.COMMAND_COMPILE_DIFF_ENVIRONMENT);
   }
 
+  public String getContainer() {
+    return _config.getString(BfConsts.ARG_CONTAINER);
+  }
+
   public Path getContainerDir() {
     return Paths.get(_config.getString(BfConsts.ARG_CONTAINER_DIR));
   }
@@ -984,6 +988,7 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     setDefaultProperty(BfConsts.ARG_BDP_PRINT_OSCILLATING_ITERATIONS, false);
     setDefaultProperty(BfConsts.ARG_BDP_RECORD_ALL_ITERATIONS, false);
     setDefaultProperty(CAN_EXECUTE, true);
+    setDefaultProperty(BfConsts.ARG_CONTAINER, null);
     setDefaultProperty(BfConsts.ARG_CONTAINER_DIR, null);
     setDefaultProperty(ARG_COORDINATOR_REGISTER, false);
     setDefaultProperty(ARG_COORDINATOR_HOST, "localhost");
@@ -1116,6 +1121,8 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     addBooleanOption(
         ARG_CHECK_BGP_REACHABILITY,
         "whether to check BGP session reachability during data plane computation");
+
+    addOption(BfConsts.ARG_CONTAINER, "name of container", ARGNAME_NAME);
 
     addOption(BfConsts.ARG_CONTAINER_DIR, "path to container directory", ARGNAME_PATH);
 
@@ -1406,6 +1413,7 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     getBooleanOptionValue(BfConsts.ARG_BDP_PRINT_OSCILLATING_ITERATIONS);
     getBooleanOptionValue(ARG_CHECK_BGP_REACHABILITY);
     getBooleanOptionValue(BfConsts.COMMAND_COMPILE_DIFF_ENVIRONMENT);
+    getStringOptionValue(BfConsts.ARG_CONTAINER);
     getPathOptionValue(BfConsts.ARG_CONTAINER_DIR);
     getStringOptionValue(ARG_COORDINATOR_HOST);
     getIntOptionValue(ARG_COORDINATOR_POOL_PORT);
@@ -1492,6 +1500,10 @@ public final class Settings extends BaseSettings implements GrammarSettings {
 
   public void setCanExecute(boolean canExecute) {
     _config.setProperty(CAN_EXECUTE, canExecute);
+  }
+
+  public void setContainer(String container) {
+    _config.setProperty(BfConsts.ARG_CONTAINER, container);
   }
 
   public void setContainerDir(Path containerDir) {

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -4465,8 +4465,14 @@ public class Batfish extends PluginConsumer implements IBatfish {
 
   private void writeJsonAnswerWithLog(@Nullable String logString, String structuredAnswerString) {
     // Write log of WorkItem task to the configured path for logs
-    Path jsonPath = _settings.getAnswerJsonPath();
-    if (jsonPath != null && logString != null) {
+    if (logString != null && _settings.getTaskId() != null) {
+      Path jsonPath =
+          _settings
+              .getStorageBase()
+              .resolve(_settings.getContainer())
+              .resolve(BfConsts.RELPATH_TESTRIGS_DIR)
+              .resolve(_settings.getTestrig())
+              .resolve(_settings.getTaskId() + BfConsts.SUFFIX_ANSWER_JSON_FILE);
       CommonUtil.writeFile(jsonPath, logString);
     }
     // Write answer.json and answer-pretty.json if WorkItem was answering a question

--- a/projects/batfish/src/main/java/org/batfish/main/Driver.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Driver.java
@@ -578,7 +578,7 @@ public class Driver {
                       .startActive()) {
                 assert runBatfishSpan != null;
                 Answer answer = null;
-                String containerName = settings.getContainerDir().getFileName().toString();
+                String containerName = settings.getContainer();
                 String testrigName = settings.getTestrig();
                 try {
                   answer = batfish.run();

--- a/projects/batfish/src/main/java/org/batfish/main/Driver.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Driver.java
@@ -627,7 +627,7 @@ public class Driver {
                   try (ActiveSpan outputAnswerSpan =
                       GlobalTracer.get().buildSpan("Outputting answer").startActive()) {
                     assert outputAnswerSpan != null;
-                    if (settings.getAnswerJsonPath() != null) {
+                    if (settings.getTaskId() != null) {
                       batfish.outputAnswerWithLog(answer);
                     }
                   }

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
@@ -55,8 +55,8 @@ public class BatfishTestUtils {
     final Cache<Snapshot, SortedMap<String, Configuration>> testrigs = makeTestrigCache();
     final Cache<Snapshot, SortedMap<String, Configuration>> compressedTestrigs = makeTestrigCache();
 
-    Path containerDir = tempFolder.newFolder().toPath();
-    settings.setContainerDir(containerDir);
+    settings.setStorageBase(tempFolder.newFolder().toPath());
+    settings.setContainer("tempContainer");
     if (!configurations.isEmpty()) {
       settings.setTestrig("tempTestrig");
       settings.setEnvironmentName("tempEnvironment");
@@ -94,8 +94,8 @@ public class BatfishTestUtils {
     final Cache<Snapshot, SortedMap<String, Configuration>> testrigs = makeTestrigCache();
     final Cache<Snapshot, SortedMap<String, Configuration>> compressedTestrigs = makeTestrigCache();
 
-    Path containerDir = tempFolder.newFolder().toPath();
-    settings.setContainerDir(containerDir);
+    settings.setStorageBase(tempFolder.newFolder().toPath());
+    settings.setContainer("tempContainer");
     if (!baseConfigs.isEmpty()) {
       settings.setTestrig("tempTestrig");
       settings.setEnvironmentName("tempEnvironment");
@@ -166,8 +166,8 @@ public class BatfishTestUtils {
     settings.setThrowOnLexerError(true);
     settings.setThrowOnParserError(true);
     settings.setVerboseParse(true);
-    Path containerDir = tempFolder.newFolder().toPath();
-    settings.setContainerDir(containerDir);
+    settings.setStorageBase(tempFolder.newFolder().toPath());
+    settings.setContainer("tempContainer");
     settings.setTestrig("tempTestrig");
     settings.setEnvironmentName("tempEnvironment");
     Batfish.initTestrigSettings(settings);

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -177,14 +177,15 @@ public class WorkMgr extends AbstractCoordinator {
       // get the task and add other standard stuff
       JSONObject task = new JSONObject(work.getWorkItem().getRequestParams());
       String containerName = work.getWorkItem().getContainerName();
-      Path containerDir = Main.getSettings().getContainersLocation().resolve(containerName);
+      Path storageBase = Main.getSettings().getContainersLocation();
       String testrigName = work.getWorkItem().getTestrigName();
       Path testrigBaseDir =
-          containerDir
+          storageBase
+              .resolve(containerName)
               .resolve(Paths.get(BfConsts.RELPATH_TESTRIGS_DIR, testrigName))
               .toAbsolutePath();
       task.put(BfConsts.ARG_CONTAINER, containerName);
-      task.put(BfConsts.ARG_CONTAINER_DIR, containerDir.toAbsolutePath().toString());
+      task.put(BfConsts.ARG_STORAGE_BASE, storageBase.toAbsolutePath().toString());
       task.put(BfConsts.ARG_TESTRIG, testrigName);
       task.put(
           BfConsts.ARG_LOG_FILE,

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -176,21 +176,11 @@ public class WorkMgr extends AbstractCoordinator {
       assert assignWorkSpan != null; // avoid unused warning
       // get the task and add other standard stuff
       JSONObject task = new JSONObject(work.getWorkItem().getRequestParams());
-      String containerName = work.getWorkItem().getContainerName();
-      Path storageBase = Main.getSettings().getContainersLocation();
-      String testrigName = work.getWorkItem().getTestrigName();
-      task.put(BfConsts.ARG_CONTAINER, containerName);
-      task.put(BfConsts.ARG_STORAGE_BASE, storageBase.toAbsolutePath().toString());
-      task.put(BfConsts.ARG_TESTRIG, testrigName);
+      task.put(BfConsts.ARG_CONTAINER, work.getWorkItem().getContainerName());
       task.put(
-          BfConsts.ARG_ANSWER_JSON_PATH,
-          storageBase
-              .resolve(containerName)
-              .resolve(BfConsts.RELPATH_TESTRIGS_DIR)
-              .resolve(testrigName)
-              .toAbsolutePath()
-              .resolve(work.getId() + BfConsts.SUFFIX_ANSWER_JSON_FILE)
-              .toString());
+          BfConsts.ARG_STORAGE_BASE,
+          Main.getSettings().getContainersLocation().toAbsolutePath().toString());
+      task.put(BfConsts.ARG_TESTRIG, work.getWorkItem().getTestrigName());
 
       client =
           CommonUtil.createHttpClientBuilder(
@@ -507,7 +497,7 @@ public class WorkMgr extends AbstractCoordinator {
       List<String> questionsToDelete,
       @Nullable Boolean suggested) {
     Path containerDir = getdirContainer(containerName);
-    Path aDir = containerDir.resolve(Paths.get(BfConsts.RELPATH_ANALYSES_DIR, aName));
+    Path aDir = containerDir.resolve(BfConsts.RELPATH_ANALYSES_DIR).resolve(aName);
 
     this.configureAnalysisValidityCheck(
         containerName, newAnalysis, aName, questionsToAdd, questionsToDelete, aDir);

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -179,20 +179,18 @@ public class WorkMgr extends AbstractCoordinator {
       String containerName = work.getWorkItem().getContainerName();
       Path storageBase = Main.getSettings().getContainersLocation();
       String testrigName = work.getWorkItem().getTestrigName();
-      Path testrigBaseDir =
-          storageBase
-              .resolve(containerName)
-              .resolve(Paths.get(BfConsts.RELPATH_TESTRIGS_DIR, testrigName))
-              .toAbsolutePath();
       task.put(BfConsts.ARG_CONTAINER, containerName);
       task.put(BfConsts.ARG_STORAGE_BASE, storageBase.toAbsolutePath().toString());
       task.put(BfConsts.ARG_TESTRIG, testrigName);
       task.put(
-          BfConsts.ARG_LOG_FILE,
-          testrigBaseDir.resolve(work.getId() + BfConsts.SUFFIX_LOG_FILE).toString());
-      task.put(
           BfConsts.ARG_ANSWER_JSON_PATH,
-          testrigBaseDir.resolve(work.getId() + BfConsts.SUFFIX_ANSWER_JSON_FILE).toString());
+          storageBase
+              .resolve(containerName)
+              .resolve(BfConsts.RELPATH_TESTRIGS_DIR)
+              .resolve(testrigName)
+              .toAbsolutePath()
+              .resolve(work.getId() + BfConsts.SUFFIX_ANSWER_JSON_FILE)
+              .toString());
 
       client =
           CommonUtil.createHttpClientBuilder(

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -176,13 +176,14 @@ public class WorkMgr extends AbstractCoordinator {
       assert assignWorkSpan != null; // avoid unused warning
       // get the task and add other standard stuff
       JSONObject task = new JSONObject(work.getWorkItem().getRequestParams());
-      Path containerDir =
-          Main.getSettings().getContainersLocation().resolve(work.getWorkItem().getContainerName());
+      String containerName = work.getWorkItem().getContainerName();
+      Path containerDir = Main.getSettings().getContainersLocation().resolve(containerName);
       String testrigName = work.getWorkItem().getTestrigName();
       Path testrigBaseDir =
           containerDir
               .resolve(Paths.get(BfConsts.RELPATH_TESTRIGS_DIR, testrigName))
               .toAbsolutePath();
+      task.put(BfConsts.ARG_CONTAINER, containerName);
       task.put(BfConsts.ARG_CONTAINER_DIR, containerDir.toAbsolutePath().toString());
       task.put(BfConsts.ARG_TESTRIG, testrigName);
       task.put(


### PR DESCRIPTION
Rather than passing lots of (redundant) paths around, pass a single `storageBase` argument and then also pass other keys (`containerName`).

Other paths, which are fully constructable from things like `storageBase`, `containerName`, `testrigName`, and `questionName`, for example, are constructed from those components.

Suggestions for simplification would be great.