### PR TITLE
A whole bunch of Cisco parsing fixes

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
@@ -11841,6 +11841,11 @@ TRAFFIC_ENG
    'traffic-eng'
 ;
 
+TRAFFIC_EXPORT
+:
+   'traffic-export'
+;
+
 TRAFFIC_INDEX
 :
    'traffic-index'

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
@@ -14384,6 +14384,11 @@ M_Interface_DOLLAR
    '$' -> type ( DOLLAR ) , popMode
 ;
 
+M_Interface_EIGRP
+:
+   'eigrp' -> type ( EIGRP ) , popMode
+;
+
 M_Interface_EQ
 :
    'eq' -> type ( EQ ) , popMode

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoParser.g4
@@ -4251,6 +4251,7 @@ vpc_null
       AUTO_RECOVERY
       | DELAY
       | IP
+      | PEER_CONFIG_CHECK_BYPASS
       | PEER_GATEWAY
       | PEER_KEEPALIVE
       | PEER_SWITCH

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_interface.g4
@@ -813,6 +813,7 @@ if_null_single
       | LINKDEBOUNCE
       | MAB
       | PHY
+      | REDUNDANCY
       | SWITCHPORT CAPTURE
       | SUPPRESS_ARP
       | TRIMODE

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_interface.g4
@@ -269,6 +269,11 @@ if_ip_ospf_passive_interface
    NO? IP OSPF PASSIVE_INTERFACE NEWLINE
 ;
 
+if_ip_ospf_shutdown
+:
+   NO? IP OSPF SHUTDOWN NEWLINE
+;
+
 if_ip_passive_interface_eigrp
 :
    NO? IP PASSIVE_INTERFACE EIGRP tag = DEC NEWLINE
@@ -1330,6 +1335,7 @@ s_interface
       | if_ip_ospf_hello_interval
       | if_ip_ospf_network
       | if_ip_ospf_passive_interface
+      | if_ip_ospf_shutdown
       | if_ip_passive_interface_eigrp
       | if_ip_pim_neighbor_filter
       | if_ip_policy

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_interface.g4
@@ -269,6 +269,11 @@ if_ip_ospf_passive_interface
    NO? IP OSPF PASSIVE_INTERFACE NEWLINE
 ;
 
+if_ip_passive_interface_eigrp
+:
+   NO? IP PASSIVE_INTERFACE EIGRP tag = DEC NEWLINE
+;
+
 if_ip_pim_neighbor_filter
 :
    IP PIM NEIGHBOR_FILTER acl = variable NEWLINE
@@ -1324,6 +1329,7 @@ s_interface
       | if_ip_ospf_hello_interval
       | if_ip_ospf_network
       | if_ip_ospf_passive_interface
+      | if_ip_passive_interface_eigrp
       | if_ip_pim_neighbor_filter
       | if_ip_policy
       | if_ip_router_isis

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_interface.g4
@@ -814,6 +814,7 @@ if_null_single
    (
       BCMC_OPTIMIZATION
       | DOT1X
+      | IP TRAFFIC_EXPORT
       | JUMBO
       | LINKDEBOUNCE
       | MAB

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_ospf.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_ospf.g4
@@ -358,14 +358,25 @@ ro_redistribute_connected
    )* NEWLINE
 ;
 
-ro_redistribute_rip
+ro_redistribute_eigrp
 :
-   REDISTRIBUTE RIP null_rest_of_line
+   REDISTRIBUTE EIGRP tag = DEC
+   (
+      METRIC metric = DEC
+      | METRIC_TYPE type = DEC
+      | ROUTE_MAP map = variable
+      | SUBNETS
+   )* NEWLINE
 ;
 
 ro_redistribute_ospf_null
 :
    REDISTRIBUTE OSPF null_rest_of_line
+;
+
+ro_redistribute_rip
+:
+   REDISTRIBUTE RIP null_rest_of_line
 ;
 
 ro_redistribute_static
@@ -640,6 +651,7 @@ s_router_ospf
       | ro_passive_interface
       | ro_redistribute_bgp
       | ro_redistribute_connected
+      | ro_redistribute_eigrp
       | ro_redistribute_ospf_null
       | ro_redistribute_rip
       | ro_redistribute_static

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -476,6 +476,7 @@ import org.batfish.grammar.cisco.CiscoParser.If_ip_ospf_dead_intervalContext;
 import org.batfish.grammar.cisco.CiscoParser.If_ip_ospf_dead_interval_minimalContext;
 import org.batfish.grammar.cisco.CiscoParser.If_ip_ospf_networkContext;
 import org.batfish.grammar.cisco.CiscoParser.If_ip_ospf_passive_interfaceContext;
+import org.batfish.grammar.cisco.CiscoParser.If_ip_ospf_shutdownContext;
 import org.batfish.grammar.cisco.CiscoParser.If_ip_pim_neighbor_filterContext;
 import org.batfish.grammar.cisco.CiscoParser.If_ip_policyContext;
 import org.batfish.grammar.cisco.CiscoParser.If_ip_proxy_arpContext;
@@ -4736,6 +4737,13 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
       for (Interface iface : _currentInterfaces) {
         iface.setOspfPassive(true);
       }
+    }
+  }
+
+  @Override
+  public void exitIf_ip_ospf_shutdown(If_ip_ospf_shutdownContext ctx) {
+    for (Interface iface : _currentInterfaces) {
+      iface.setOspfShutdown(ctx.NO() == null);
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -138,6 +138,7 @@ import static org.batfish.representation.cisco.CiscoStructureUsage.OSPF_AREA_FIL
 import static org.batfish.representation.cisco.CiscoStructureUsage.OSPF_DEFAULT_ORIGINATE_ROUTE_MAP;
 import static org.batfish.representation.cisco.CiscoStructureUsage.OSPF_REDISTRIBUTE_BGP_MAP;
 import static org.batfish.representation.cisco.CiscoStructureUsage.OSPF_REDISTRIBUTE_CONNECTED_MAP;
+import static org.batfish.representation.cisco.CiscoStructureUsage.OSPF_REDISTRIBUTE_EIGRP_MAP;
 import static org.batfish.representation.cisco.CiscoStructureUsage.OSPF_REDISTRIBUTE_STATIC_MAP;
 import static org.batfish.representation.cisco.CiscoStructureUsage.PIM_ACCEPT_REGISTER_ACL;
 import static org.batfish.representation.cisco.CiscoStructureUsage.PIM_ACCEPT_REGISTER_ROUTE_MAP;
@@ -725,6 +726,7 @@ import org.batfish.grammar.cisco.CiscoParser.Ro_passive_interfaceContext;
 import org.batfish.grammar.cisco.CiscoParser.Ro_passive_interface_defaultContext;
 import org.batfish.grammar.cisco.CiscoParser.Ro_redistribute_bgpContext;
 import org.batfish.grammar.cisco.CiscoParser.Ro_redistribute_connectedContext;
+import org.batfish.grammar.cisco.CiscoParser.Ro_redistribute_eigrpContext;
 import org.batfish.grammar.cisco.CiscoParser.Ro_redistribute_ripContext;
 import org.batfish.grammar.cisco.CiscoParser.Ro_redistribute_staticContext;
 import org.batfish.grammar.cisco.CiscoParser.Ro_rfc1583_compatibilityContext;
@@ -1087,6 +1089,8 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
       "ospf - not-so-stubby areas - no-redistribution";
 
   private static final String F_OSPF_MAXIMUM_PATHS = "ospf - maximum-paths";
+
+  private static final String F_OSPF_REDISTRIBUTE_EIGRP = "ospf - redistribute eigrp";
 
   private static final String F_OSPF_REDISTRIBUTE_RIP = "ospf - redistribute rip";
 
@@ -6690,6 +6694,15 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
       r.setTag(tag);
     }
     r.setOnlyClassfulRoutes(ctx.subnets == null && !ospfRedistributeSubnetsByDefault(_format));
+  }
+
+  @Override
+  public void exitRo_redistribute_eigrp(Ro_redistribute_eigrpContext ctx) {
+    if (ctx.map != null) {
+      _configuration.referenceStructure(
+          ROUTE_MAP, ctx.map.getText(), OSPF_REDISTRIBUTE_EIGRP_MAP, ctx.map.getStart().getLine());
+    }
+    todo(ctx, F_OSPF_REDISTRIBUTE_EIGRP);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -3240,6 +3240,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
         CiscoStructureUsage.OSPF_DEFAULT_ORIGINATE_ROUTE_MAP,
         CiscoStructureUsage.OSPF_REDISTRIBUTE_BGP_MAP,
         CiscoStructureUsage.OSPF_REDISTRIBUTE_CONNECTED_MAP,
+        CiscoStructureUsage.OSPF_REDISTRIBUTE_EIGRP_MAP,
         CiscoStructureUsage.OSPF_REDISTRIBUTE_STATIC_MAP,
         CiscoStructureUsage.PIM_ACCEPT_REGISTER_ROUTE_MAP,
         CiscoStructureUsage.RIP_DEFAULT_ORIGINATE_ROUTE_MAP,

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoStructureUsage.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoStructureUsage.java
@@ -96,6 +96,7 @@ public enum CiscoStructureUsage implements StructureUsage {
   OSPF_DEFAULT_ORIGINATE_ROUTE_MAP("ospf default-originate route-map"),
   OSPF_REDISTRIBUTE_BGP_MAP("ospf redistribute bgp route-map"),
   OSPF_REDISTRIBUTE_CONNECTED_MAP("ospf redistribute connected route-map"),
+  OSPF_REDISTRIBUTE_EIGRP_MAP("ospf redistribute eigrp route-map"),
   OSPF_REDISTRIBUTE_STATIC_MAP("ospf redistribute static route-map"),
   PIM_ACCEPT_REGISTER_ACL("pim accept-register acl"),
   PIM_ACCEPT_REGISTER_ROUTE_MAP("pim accept-register route-map"),

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/Interface.java
@@ -152,6 +152,8 @@ public class Interface extends ComparableStructure<String> {
 
   private boolean _ospfPointToPoint;
 
+  private boolean _ospfShutdown;
+
   private String _outgoingFilter;
 
   private int _outgoingFilterLine;
@@ -335,6 +337,10 @@ public class Interface extends ComparableStructure<String> {
     return _ospfPointToPoint;
   }
 
+  public boolean getOspfShutdown() {
+    return _ospfShutdown;
+  }
+
   public String getOutgoingFilter() {
     return _outgoingFilter;
   }
@@ -488,6 +494,10 @@ public class Interface extends ComparableStructure<String> {
 
   public void setOspfPointToPoint(boolean ospfPointToPoint) {
     _ospfPointToPoint = ospfPointToPoint;
+  }
+
+  public void setOspfShutdown(boolean ospfShutdown) {
+    _ospfShutdown = ospfShutdown;
   }
 
   public void setOutgoingFilter(String accessListName) {

--- a/test_rigs/unit-tests/configs/cisco_interface
+++ b/test_rigs/unit-tests/configs/cisco_interface
@@ -123,6 +123,7 @@ interface Ethernet0
  no ip sticky-arp
  ip sticky-arp ignore
  ip summary-address eigrp 11 10.1.2.3 255.255.255.255 leak-map eigrp-leak-map
+ ip traffic-export apply some-traffix-export size 10000000
  no ip unreachables
  no ip verify source dhcp-snooping-vlan
  ip verify unicast source reachable-via rx 167

--- a/test_rigs/unit-tests/configs/cisco_interface
+++ b/test_rigs/unit-tests/configs/cisco_interface
@@ -102,6 +102,8 @@ interface Ethernet0
  ip ospf priority 1
  ip ospf retransmit-interval 5
  ip ospf transmit-delay 1
+ ip passive-interface eigrp 15
+ no ip passive-interface eigrp 15
  ip pim dense-mode
  ip pim dr-priority 1
  ip pim hello-interval 30000

--- a/test_rigs/unit-tests/configs/cisco_interface
+++ b/test_rigs/unit-tests/configs/cisco_interface
@@ -192,6 +192,8 @@ interface Ethernet0
   protocol ppp dialer
  !
  queue-monitor length thresholds 12 1
+ redundancy rii 1
+ redundancy group 1 ip 1.2.3.4 exclusive
  service instance 1 ethernet
   bridge-domain 710
   encapsulation default

--- a/test_rigs/unit-tests/configs/cisco_misc
+++ b/test_rigs/unit-tests/configs/cisco_misc
@@ -281,6 +281,7 @@ vpc domain 32
   auto-recovery
   delay restore 150
   ip arp synchronize
+  peer-config-check-bypass
   peer-gateway
   peer-keepalive destination 1.2.3.4 source 1.2.3.5
   peer-switch

--- a/test_rigs/unit-tests/configs/cisco_ospf
+++ b/test_rigs/unit-tests/configs/cisco_ospf
@@ -53,6 +53,7 @@ router ospf 1
   log-adj-changes
   maximum-paths 32
   redistribute direct route-map DIRECT_OSPF
+  redistribute eigrp 5 metric 6 route-map eigrp-ospf-route-map
   redistribute ospf 2 match internal
   router-id 1.2.3.4
   fast-reroute per-prefix

--- a/test_rigs/unit-tests/configs/cisco_ospf
+++ b/test_rigs/unit-tests/configs/cisco_ospf
@@ -7,6 +7,7 @@ interface loopback0
 interface ethernet0/0
  ip address 2.2.2.0 255.255.255.0
  ip router ospf 1 area 0.0.0.0
+ ip ospf shutdown
 !
 interface ethernet0/0
  ip address 3.3.3.0 255.255.255.0

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -8652,10 +8652,8 @@
             ],
             "mtu" : 1500,
             "nativeVlan" : 1,
-            "ospfArea" : 0,
-            "ospfCost" : 4000,
             "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
+            "ospfEnabled" : false,
             "ospfHelloMultiplier" : 0,
             "ospfPassive" : false,
             "ospfPointToPoint" : false,
@@ -8806,14 +8804,7 @@
               "areas" : {
                 "0" : {
                   "name" : 0,
-                  "interfaces" : [
-                    "Ethernet0/0"
-                  ],
-                  "nssa" : {
-                    "defaultOriginateType" : "INTER_AREA",
-                    "suppressType3" : true
-                  },
-                  "stubType" : "NSSA",
+                  "stubType" : "NONE",
                   "summaries" : {
                     "1.2.3.0/24" : {
                       "advertise" : true,

--- a/tests/parsing-tests/unit-tests-undefined.ref
+++ b/tests/parsing-tests/unit-tests-undefined.ref
@@ -434,7 +434,7 @@
         "description" : "Undefined reference to structure of type: 'ipv4 acl' with usage: 'interface ip verify access-list' named '167'",
         "files" : {
           "cisco_interface" : [
-            126
+            129
           ]
         }
       },
@@ -442,7 +442,7 @@
         "description" : "Undefined reference to structure of type: 'ipv4 acl' with usage: 'interface outgoing ip access-list' named '310-systems'",
         "files" : {
           "cisco_interface" : [
-            129
+            132
           ]
         }
       },
@@ -1254,7 +1254,7 @@
         "description" : "Undefined reference to structure of type: 'route-map' with usage: 'interface summary-address eigrp leak-map' named 'eigrp-leak-map'",
         "files" : {
           "cisco_interface" : [
-            123
+            125
           ]
         }
       },
@@ -1262,7 +1262,7 @@
         "description" : "Undefined reference to structure of type: 'route-map' with usage: 'ospf redistribute connected route-map' named 'DIRECT_OSPF'",
         "files" : {
           "cisco_ospf" : [
-            54
+            55
           ]
         }
       },
@@ -1271,6 +1271,14 @@
         "files" : {
           "nxos_ospf" : [
             9
+          ]
+        }
+      },
+      "undefined:route-map:usage:ospf redistribute eigrp route-map:eigrp-ospf-route-map" : {
+        "description" : "Undefined reference to structure of type: 'route-map' with usage: 'ospf redistribute eigrp route-map' named 'eigrp-ospf-route-map'",
+        "files" : {
+          "cisco_ospf" : [
+            56
           ]
         }
       },
@@ -1318,7 +1326,7 @@
         "description" : "Undefined reference to structure of type: 'zone security' with usage: 'interface zone-member' named 'z1'",
         "files" : {
           "cisco_interface" : [
-            280
+            285
           ]
         }
       }
@@ -1326,7 +1334,7 @@
     "summary" : {
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 163
+      "numResults" : 164
     },
     "undefinedReferences" : {
       "IosXrMultiCast" : {
@@ -1615,12 +1623,12 @@
         "ipv4 acl" : {
           "167" : {
             "interface ip verify access-list" : [
-              126
+              129
             ]
           },
           "310-systems" : {
             "interface outgoing ip access-list" : [
-              129
+              132
             ]
           },
           "ag1" : {
@@ -1661,14 +1669,14 @@
         "route-map" : {
           "eigrp-leak-map" : {
             "interface summary-address eigrp leak-map" : [
-              123
+              125
             ]
           }
         },
         "zone security" : {
           "z1" : {
             "interface zone-member" : [
-              280
+              285
             ]
           }
         }
@@ -1776,7 +1784,12 @@
         "route-map" : {
           "DIRECT_OSPF" : {
             "ospf redistribute connected route-map" : [
-              54
+              55
+            ]
+          },
+          "eigrp-ospf-route-map" : {
+            "ospf redistribute eigrp route-map" : [
+              56
             ]
           }
         }

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -21885,6 +21885,19 @@
             "        TRANSMIT_DELAY:'transmit-delay'  <== mode:DEFAULT_MODE",
             "        DEC:'1'  <== mode:DEFAULT_MODE",
             "        NEWLINE:'\\n'  <== mode:DEFAULT_MODE)",
+            "      (if_ip_passive_interface_eigrp",
+            "        IP:'ip'  <== mode:DEFAULT_MODE",
+            "        PASSIVE_INTERFACE:'passive-interface'  <== mode:DEFAULT_MODE",
+            "        EIGRP:'eigrp'  <== mode:M_Interface",
+            "        tag = DEC:'15'  <== mode:DEFAULT_MODE",
+            "        NEWLINE:'\\n'  <== mode:DEFAULT_MODE)",
+            "      (if_ip_passive_interface_eigrp",
+            "        NO:'no'  <== mode:DEFAULT_MODE",
+            "        IP:'ip'  <== mode:DEFAULT_MODE",
+            "        PASSIVE_INTERFACE:'passive-interface'  <== mode:DEFAULT_MODE",
+            "        EIGRP:'eigrp'  <== mode:M_Interface",
+            "        tag = DEC:'15'  <== mode:DEFAULT_MODE",
+            "        NEWLINE:'\\n'  <== mode:DEFAULT_MODE)",
             "      (if_null_block",
             "        IP:'ip'  <== mode:DEFAULT_MODE",
             "        PIM:'pim'  <== mode:DEFAULT_MODE",
@@ -21993,6 +22006,14 @@
             "        LEAK_MAP:'leak-map'  <== mode:DEFAULT_MODE",
             "        mapname = (variable",
             "          VARIABLE:'eigrp-leak-map'  <== mode:DEFAULT_MODE)",
+            "        NEWLINE:'\\n'  <== mode:DEFAULT_MODE)",
+            "      (if_null_single",
+            "        IP:'ip'  <== mode:DEFAULT_MODE",
+            "        TRAFFIC_EXPORT:'traffic-export'  <== mode:DEFAULT_MODE",
+            "        APPLY:'apply'  <== mode:DEFAULT_MODE",
+            "        VARIABLE:'some-traffix-export'  <== mode:DEFAULT_MODE",
+            "        SIZE:'size'  <== mode:DEFAULT_MODE",
+            "        DEC:'10000000'  <== mode:DEFAULT_MODE",
             "        NEWLINE:'\\n'  <== mode:DEFAULT_MODE)",
             "      (if_null_block",
             "        NO:'no'  <== mode:DEFAULT_MODE",
@@ -22340,6 +22361,19 @@
             "        VARIABLE:'thresholds'  <== mode:DEFAULT_MODE",
             "        DEC:'12'  <== mode:DEFAULT_MODE",
             "        DEC:'1'  <== mode:DEFAULT_MODE",
+            "        NEWLINE:'\\n'  <== mode:DEFAULT_MODE)",
+            "      (if_null_single",
+            "        REDUNDANCY:'redundancy'  <== mode:DEFAULT_MODE",
+            "        VARIABLE:'rii'  <== mode:DEFAULT_MODE",
+            "        DEC:'1'  <== mode:DEFAULT_MODE",
+            "        NEWLINE:'\\n'  <== mode:DEFAULT_MODE)",
+            "      (if_null_single",
+            "        REDUNDANCY:'redundancy'  <== mode:DEFAULT_MODE",
+            "        GROUP:'group'  <== mode:DEFAULT_MODE",
+            "        DEC:'1'  <== mode:DEFAULT_MODE",
+            "        IP:'ip'  <== mode:DEFAULT_MODE",
+            "        IP_ADDRESS:'1.2.3.4'  <== mode:DEFAULT_MODE",
+            "        VARIABLE:'exclusive'  <== mode:DEFAULT_MODE",
             "        NEWLINE:'\\n'  <== mode:DEFAULT_MODE)",
             "      (if_service_instance",
             "        SERVICE:'service'  <== mode:DEFAULT_MODE",
@@ -28531,6 +28565,10 @@
             "          VARIABLE:'synchronize'  <== mode:DEFAULT_MODE",
             "          NEWLINE:'\\n'  <== mode:DEFAULT_MODE))",
             "      (vpc_null",
+            "        PEER_CONFIG_CHECK_BYPASS:'peer-config-check-bypass'  <== mode:DEFAULT_MODE",
+            "        (null_rest_of_line",
+            "          NEWLINE:'\\n'  <== mode:DEFAULT_MODE))",
+            "      (vpc_null",
             "        PEER_GATEWAY:'peer-gateway'  <== mode:DEFAULT_MODE",
             "        (null_rest_of_line",
             "          NEWLINE:'\\n'  <== mode:DEFAULT_MODE))",
@@ -29422,6 +29460,11 @@
             "        procnum = DEC:'1'  <== mode:DEFAULT_MODE",
             "        AREA:'area'  <== mode:DEFAULT_MODE",
             "        area = IP_ADDRESS:'0.0.0.0'  <== mode:DEFAULT_MODE",
+            "        NEWLINE:'\\n'  <== mode:DEFAULT_MODE)",
+            "      (if_ip_ospf_shutdown",
+            "        IP:'ip'  <== mode:DEFAULT_MODE",
+            "        OSPF:'ospf'  <== mode:DEFAULT_MODE",
+            "        SHUTDOWN:'shutdown'  <== mode:DEFAULT_MODE",
             "        NEWLINE:'\\n'  <== mode:DEFAULT_MODE)))",
             "  (stanza",
             "    (s_interface",
@@ -29705,6 +29748,16 @@
             "        DIRECT:'direct'  <== mode:DEFAULT_MODE",
             "        ROUTE_MAP:'route-map'  <== mode:DEFAULT_MODE",
             "        map = VARIABLE:'DIRECT_OSPF'  <== mode:M_RouteMap",
+            "        NEWLINE:'\\n'  <== mode:DEFAULT_MODE)",
+            "      (ro_redistribute_eigrp",
+            "        REDISTRIBUTE:'redistribute'  <== mode:DEFAULT_MODE",
+            "        EIGRP:'eigrp'  <== mode:DEFAULT_MODE",
+            "        tag = DEC:'5'  <== mode:DEFAULT_MODE",
+            "        METRIC:'metric'  <== mode:DEFAULT_MODE",
+            "        metric = DEC:'6'  <== mode:DEFAULT_MODE",
+            "        ROUTE_MAP:'route-map'  <== mode:DEFAULT_MODE",
+            "        map = (variable",
+            "          VARIABLE:'eigrp-ospf-route-map'  <== mode:M_RouteMap)",
             "        NEWLINE:'\\n'  <== mode:DEFAULT_MODE)",
             "      (ro_redistribute_ospf_null",
             "        REDISTRIBUTE:'redistribute'  <== mode:DEFAULT_MODE",
@@ -54747,25 +54800,25 @@
           "interface" : {
             "Async1" : {
               "definitionLines" : [
-                282
+                287
               ],
               "numReferrers" : 1
             },
             "Cable1/2/3:4" : {
               "definitionLines" : [
-                284
+                289
               ],
               "numReferrers" : 1
             },
             "Crypto-Engine1/2/3" : {
               "definitionLines" : [
-                286
+                291
               ],
               "numReferrers" : 1
             },
             "Dot11Radio0" : {
               "definitionLines" : [
-                288
+                293
               ],
               "numReferrers" : 1
             },
@@ -55044,114 +55097,119 @@
                 277,
                 278,
                 279,
-                280
+                280,
+                281,
+                282,
+                283,
+                284,
+                285
               ],
               "numReferrers" : 1
             },
             "Ethernet1/11" : {
               "definitionLines" : [
-                290
+                295
               ],
               "numReferrers" : 1
             },
             "Ethernet1/12" : {
               "definitionLines" : [
-                327,
-                328
+                332,
+                333
               ],
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
               "definitionLines" : [
-                292,
-                293,
-                294,
-                295,
-                296
+                297,
+                298,
+                299,
+                300,
+                301
               ],
               "numReferrers" : 1
             },
             "Loopback0" : {
               "definitionLines" : [
-                298
+                303
               ],
               "numReferrers" : 1
             },
             "Modular-Cable1/2/3:4" : {
               "definitionLines" : [
-                300
+                305
               ],
               "numReferrers" : 1
             },
             "Null0" : {
               "definitionLines" : [
-                302
+                307
               ],
               "numReferrers" : 1
             },
             "Vlan1" : {
               "definitionLines" : [
-                311
+                316
               ],
               "numReferrers" : 1
             },
             "Vlan1005" : {
               "definitionLines" : [
-                317
+                322
               ],
               "numReferrers" : 1
             },
             "Vlan1006" : {
               "definitionLines" : [
-                319
+                324
               ],
               "numReferrers" : 1
             },
             "Vlan111" : {
               "definitionLines" : [
-                306
+                311
               ],
               "numReferrers" : 1
             },
             "Vlan1234" : {
               "definitionLines" : [
-                321
+                326
               ],
               "numReferrers" : 1
             },
             "Vlan2" : {
               "definitionLines" : [
-                313
+                318
               ],
               "numReferrers" : 1
             },
             "Vlan3" : {
               "definitionLines" : [
-                315
+                320
               ],
               "numReferrers" : 1
             },
             "Vlan4094" : {
               "definitionLines" : [
-                323
+                328
               ],
               "numReferrers" : 1
             },
             "Vxlan1" : {
               "definitionLines" : [
-                308
+                313
               ],
               "numReferrers" : 1
             },
             "Wideband-Cable1/2/3:4" : {
               "definitionLines" : [
-                325
+                330
               ],
               "numReferrers" : 1
             },
             "tunnel-ip6" : {
               "definitionLines" : [
-                304
+                309
               ],
               "numReferrers" : 1
             }
@@ -55412,10 +55470,11 @@
                 7,
                 8,
                 9,
-                11,
+                10,
                 12,
                 13,
-                14
+                14,
+                15
               ],
               "numReferrers" : 2
             },
@@ -57189,12 +57248,12 @@
           "ipv4 acl" : {
             "167" : {
               "interface ip verify access-list" : [
-                126
+                129
               ]
             },
             "310-systems" : {
               "interface outgoing ip access-list" : [
-                129
+                132
               ]
             },
             "ag1" : {
@@ -57235,14 +57294,14 @@
           "route-map" : {
             "eigrp-leak-map" : {
               "interface summary-address eigrp leak-map" : [
-                123
+                125
               ]
             }
           },
           "zone security" : {
             "z1" : {
               "interface zone-member" : [
-                280
+                285
               ]
             }
           }
@@ -57350,7 +57409,12 @@
           "route-map" : {
             "DIRECT_OSPF" : {
               "ospf redistribute connected route-map" : [
-                54
+                55
+              ]
+            },
+            "eigrp-ospf-route-map" : {
+              "ospf redistribute eigrp route-map" : [
+                56
               ]
             }
           }


### PR DESCRIPTION
Most of these constructs we don't parse. Interesting ones:

* support OSPF shutdown. Per recent discussion, we should probably redo the data model around this, but I'm assuming that's for future work.
* ref-tracking for redistribute eigrp route-maps.