### PR TITLE
Isis route float up

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IsisRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IsisRoute.java
@@ -21,6 +21,8 @@ public class IsisRoute extends AbstractRoute {
 
     private RoutingProtocol _protocol;
 
+    private String _systemId;
+
     @Override
     public IsisRoute build() {
       return new IsisRoute(
@@ -31,7 +33,8 @@ public class IsisRoute extends AbstractRoute {
           getMetric(),
           requireNonNull(getNetwork()),
           requireNonNull(getNextHopIp()),
-          requireNonNull(_protocol));
+          requireNonNull(_protocol),
+          requireNonNull(_systemId));
     }
 
     @Override
@@ -58,6 +61,11 @@ public class IsisRoute extends AbstractRoute {
       _protocol = protocol;
       return this;
     }
+
+    public Builder setSystemId(@Nonnull String systemId) {
+      _systemId = systemId;
+      return this;
+    }
   }
 
   public static final long DEFAULT_METRIC = 10L;
@@ -79,7 +87,8 @@ public class IsisRoute extends AbstractRoute {
       @JsonProperty(PROP_METRIC) long metric,
       @JsonProperty(PROP_NETWORK) Prefix network,
       @JsonProperty(PROP_NEXT_HOP_IP) Ip nextHopIp,
-      @JsonProperty(PROP_PROTOCOL) RoutingProtocol protocol) {
+      @JsonProperty(PROP_PROTOCOL) RoutingProtocol protocol,
+      @JsonProperty(PROP_PROTOCOL) String systemId) {
     return new IsisRoute(
         administrativeCost,
         requireNonNull(area),
@@ -88,7 +97,8 @@ public class IsisRoute extends AbstractRoute {
         metric,
         requireNonNull(network),
         requireNonNull(nextHopIp),
-        requireNonNull(protocol));
+        requireNonNull(protocol),
+        requireNonNull(systemId));
   }
 
   private final int _administrativeCost;
@@ -105,6 +115,8 @@ public class IsisRoute extends AbstractRoute {
 
   private final RoutingProtocol _protocol;
 
+  private final String _systemId;
+
   private IsisRoute(
       int administrativeCost,
       @Nonnull String area,
@@ -113,7 +125,8 @@ public class IsisRoute extends AbstractRoute {
       long metric,
       @Nonnull Prefix network,
       @Nonnull Ip nextHopIp,
-      @Nonnull RoutingProtocol protocol) {
+      @Nonnull RoutingProtocol protocol,
+      @Nonnull String systemId) {
     super(network);
     _administrativeCost = administrativeCost;
     _area = area;
@@ -122,6 +135,7 @@ public class IsisRoute extends AbstractRoute {
     _metric = metric;
     _nextHopIp = nextHopIp;
     _protocol = protocol;
+    _systemId = systemId;
   }
 
   @Override
@@ -140,7 +154,8 @@ public class IsisRoute extends AbstractRoute {
         && _metric == rhs._metric
         && _network.equals(rhs._network)
         && _nextHopIp.equals(rhs._nextHopIp)
-        && _protocol == rhs._protocol;
+        && _protocol == rhs._protocol
+        && _systemId.equals(rhs._systemId);
   }
 
   @JsonIgnore(false)
@@ -190,6 +205,11 @@ public class IsisRoute extends AbstractRoute {
     return _protocol;
   }
 
+  @Nonnull
+  public String getSystemId() {
+    return _systemId;
+  }
+
   @Override
   public int getTag() {
     return NO_TAG;
@@ -204,7 +224,8 @@ public class IsisRoute extends AbstractRoute {
         _level.ordinal(),
         _metric,
         _nextHopIp,
-        _protocol.ordinal());
+        _protocol.ordinal(),
+        _systemId);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IsisRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IsisRoute.java
@@ -76,6 +76,8 @@ public class IsisRoute extends AbstractRoute {
 
   private static final String PROP_LEVEL = "level";
 
+  private static final String PROP_SYSTEM_ID = "systemId";
+
   private static final long serialVersionUID = 1L;
 
   @JsonCreator
@@ -88,7 +90,7 @@ public class IsisRoute extends AbstractRoute {
       @JsonProperty(PROP_NETWORK) Prefix network,
       @JsonProperty(PROP_NEXT_HOP_IP) Ip nextHopIp,
       @JsonProperty(PROP_PROTOCOL) RoutingProtocol protocol,
-      @JsonProperty(PROP_PROTOCOL) String systemId) {
+      @JsonProperty(PROP_SYSTEM_ID) String systemId) {
     return new IsisRoute(
         administrativeCost,
         requireNonNull(area),
@@ -206,6 +208,7 @@ public class IsisRoute extends AbstractRoute {
   }
 
   @Nonnull
+  @JsonProperty(PROP_SYSTEM_ID)
   public String getSystemId() {
     return _systemId;
   }
@@ -231,7 +234,8 @@ public class IsisRoute extends AbstractRoute {
   @Override
   protected String protocolRouteString() {
     return String.format(
-        " %s:%s %s:%s %s:%s", PROP_AREA, _area, PROP_DOWN, _down, PROP_LEVEL, _level);
+        " %s:%s %s:%s %s:%s %s:%s",
+        PROP_AREA, _area, PROP_DOWN, _down, PROP_LEVEL, _level, PROP_SYSTEM_ID, _systemId);
   }
 
   @Override
@@ -243,6 +247,7 @@ public class IsisRoute extends AbstractRoute {
     return Comparator.comparing(IsisRoute::getArea)
         .thenComparing(IsisRoute::getDown)
         .thenComparing(IsisRoute::getLevel)
+        .thenComparing(IsisRoute::getSystemId)
         .compare(this, castRhs);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IsoAddress.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IsoAddress.java
@@ -134,6 +134,15 @@ public final class IsoAddress implements Serializable {
     return _systemId;
   }
 
+  @Nonnull
+  public String getSystemIdString() {
+    StringBuilder sb = new StringBuilder();
+    for (byte b : _systemId) {
+      sb.append(String.format("%02X", b));
+    }
+    return sb.toString();
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(_afi, _areaId, _nSel, _systemId);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/IsisRouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/IsisRouteTest.java
@@ -15,7 +15,8 @@ public class IsisRouteTest {
             .setLevel(IsisLevel.LEVEL_1)
             .setArea("0")
             .setNextHopIp(new Ip("2.2.2.2"))
-            .setProtocol(RoutingProtocol.ISIS_L1);
+            .setProtocol(RoutingProtocol.ISIS_L1)
+            .setSystemId("id");
 
     IsisRoute original = b.build();
     // use StringBuilder to get fresh instance

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -1665,7 +1665,11 @@ public class VirtualRouter extends ComparableStructure<String> {
           while (queue.peek() != null) {
             RouteAdvertisement<IsisRoute> routeAdvert = queue.remove();
             IsisRoute neighborRoute = routeAdvert.getRoute();
-            routeBuilder.setNetwork(neighborRoute.getNetwork()).setArea(neighborRoute.getArea());
+
+            routeBuilder
+                .setNetwork(neighborRoute.getNetwork())
+                .setArea(neighborRoute.getArea())
+                .setSystemId(neighborRoute.getSystemId());
             boolean withdraw = routeAdvert.isWithdrawn();
             // TODO: simplify
             if (neighborRoute.getLevel() == IsisLevel.LEVEL_1) {
@@ -1677,7 +1681,6 @@ public class VirtualRouter extends ComparableStructure<String> {
                       .setLevel(IsisLevel.LEVEL_1)
                       .setMetric(incrementalMetric + neighborRoute.getMetric())
                       .setProtocol(RoutingProtocol.ISIS_L1)
-                      .setSystemId(neighborRoute.getSystemId())
                       .build();
               if (withdraw) {
                 l1DeltaBuilder.remove(newL1Route, Reason.WITHDRAW);
@@ -1691,7 +1694,7 @@ public class VirtualRouter extends ComparableStructure<String> {
                     .computeIfAbsent(newL1Route.getNetwork(), k -> new TreeSet<>())
                     .add(newL1Route);
               }
-            } else {
+            } else { // neighborRoute is level2
               long incrementalMetric =
                   firstNonNull(iface.getIsis().getLevel2().getCost(), IsisRoute.DEFAULT_METRIC);
               IsisRoute newL2Route =
@@ -1700,7 +1703,6 @@ public class VirtualRouter extends ComparableStructure<String> {
                       .setLevel(IsisLevel.LEVEL_2)
                       .setMetric(incrementalMetric + neighborRoute.getMetric())
                       .setProtocol(RoutingProtocol.ISIS_L2)
-                      .setSystemId(neighborRoute.getSystemId())
                       .build();
               if (withdraw) {
                 l2DeltaBuilder.remove(newL2Route, Reason.WITHDRAW);

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -1074,7 +1074,9 @@ public class VirtualRouter extends ComparableStructure<String> {
     IsisLevelSettings l1Settings = proc.getLevel1();
     IsisLevelSettings l2Settings = proc.getLevel2();
     IsisRoute.Builder builder =
-        new IsisRoute.Builder().setArea(proc.getNetAddress().getAreaIdString());
+        new IsisRoute.Builder()
+            .setArea(proc.getNetAddress().getAreaIdString())
+            .setSystemId(proc.getNetAddress().getSystemIdString());
     _vrf.getInterfaces()
         .values()
         .forEach(
@@ -1674,6 +1676,7 @@ public class VirtualRouter extends ComparableStructure<String> {
                       .setLevel(IsisLevel.LEVEL_1)
                       .setMetric(incrementalMetric + neighborRoute.getMetric())
                       .setProtocol(RoutingProtocol.ISIS_L1)
+                      .setSystemId(neighborRoute.getSystemId())
                       .build();
               if (withdraw) {
                 l1DeltaBuilder.remove(newL1Route, Reason.WITHDRAW);
@@ -1697,6 +1700,7 @@ public class VirtualRouter extends ComparableStructure<String> {
                       .setLevel(IsisLevel.LEVEL_2)
                       .setMetric(incrementalMetric + neighborRoute.getMetric())
                       .setProtocol(RoutingProtocol.ISIS_L2)
+                      .setSystemId()
                       .build();
               if (withdraw) {
                 l2DeltaBuilder.remove(newL2Route, Reason.WITHDRAW);

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -3,6 +3,7 @@ package org.batfish.dataplane.ibdp;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static org.batfish.common.util.CommonUtil.toImmutableSortedMap;
 import static org.batfish.datamodel.MultipathEquivalentAsPathMatchMode.EXACT_PATH;
+import static org.batfish.dataplane.protocols.IsisProtocolHelper.convertRouteLevel1ToLevel2;
 import static org.batfish.dataplane.protocols.StaticRouteHelper.isInterfaceRoute;
 import static org.batfish.dataplane.protocols.StaticRouteHelper.shouldActivateNextHopIpRoute;
 import static org.batfish.dataplane.rib.AbstractRib.importRib;
@@ -22,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import java.util.SortedMap;
@@ -1659,15 +1661,14 @@ public class VirtualRouter extends ComparableStructure<String> {
         (edge, queue) -> {
           Ip nextHopIp = edge.getNode2().getInterface(nodes).getAddress().getIp();
           Interface iface = edge.getNode1().getInterface(nodes);
-          IsisLevel circuitType = edge.getCircuitType();
           routeBuilder.setNextHopIp(nextHopIp);
           while (queue.peek() != null) {
             RouteAdvertisement<IsisRoute> routeAdvert = queue.remove();
             IsisRoute neighborRoute = routeAdvert.getRoute();
             routeBuilder.setNetwork(neighborRoute.getNetwork()).setArea(neighborRoute.getArea());
             boolean withdraw = routeAdvert.isWithdrawn();
-            if (neighborRoute.getLevel() == IsisLevel.LEVEL_1
-                && (circuitType == IsisLevel.LEVEL_1_2 || circuitType == IsisLevel.LEVEL_1)) {
+            // TODO: simplify
+            if (neighborRoute.getLevel() == IsisLevel.LEVEL_1) {
               long incrementalMetric =
                   firstNonNull(iface.getIsis().getLevel1().getCost(), IsisRoute.DEFAULT_METRIC);
               IsisRoute newL1Route =
@@ -1690,8 +1691,7 @@ public class VirtualRouter extends ComparableStructure<String> {
                     .computeIfAbsent(newL1Route.getNetwork(), k -> new TreeSet<>())
                     .add(newL1Route);
               }
-            }
-            if (circuitType == IsisLevel.LEVEL_1_2 || circuitType == IsisLevel.LEVEL_2) {
+            } else {
               long incrementalMetric =
                   firstNonNull(iface.getIsis().getLevel2().getCost(), IsisRoute.DEFAULT_METRIC);
               IsisRoute newL2Route =
@@ -1700,7 +1700,7 @@ public class VirtualRouter extends ComparableStructure<String> {
                       .setLevel(IsisLevel.LEVEL_2)
                       .setMetric(incrementalMetric + neighborRoute.getMetric())
                       .setProtocol(RoutingProtocol.ISIS_L2)
-                      .setSystemId()
+                      .setSystemId(neighborRoute.getSystemId())
                       .build();
               if (withdraw) {
                 l2DeltaBuilder.remove(newL2Route, Reason.WITHDRAW);
@@ -2317,6 +2317,7 @@ public class VirtualRouter extends ComparableStructure<String> {
     if (_vrf.getIsisProcess() == null || _isisIncomingRoutes == null) {
       return;
     }
+    // Loop over neighbors, enqueue messages
     _isisIncomingRoutes
         .keySet()
         .forEach(
@@ -2334,6 +2335,32 @@ public class VirtualRouter extends ComparableStructure<String> {
               }
               if (circuitType == IsisLevel.LEVEL_1_2 || circuitType == IsisLevel.LEVEL_2) {
                 queueDelta(queue, l2delta);
+                if (_vrf.getIsisProcess().getLevel1() != null
+                    && _vrf.getIsisProcess().getLevel2() != null
+                    && l1delta != null) {
+
+                  // We are a L1_L2 router, we must "upgrade" L1 routes to L2 routes
+                  // TODO: a little cumbersome, simplify later
+                  RibDelta.Builder<IsisRoute> upgradedRoutes = new RibDelta.Builder<>(null);
+                  l1delta
+                      .getActions()
+                      .forEach(
+                          ra -> {
+                            Optional<IsisRoute> newRoute =
+                                convertRouteLevel1ToLevel2(
+                                    ra.getRoute(),
+                                    RoutingProtocol.ISIS_L2.getDefaultAdministrativeCost(
+                                        _c.getConfigurationFormat()));
+                            if (newRoute.isPresent()) {
+                              if (ra.isWithdrawn()) {
+                                upgradedRoutes.remove(newRoute.get(), ra.getReason());
+                              } else {
+                                upgradedRoutes.add(newRoute.get());
+                              }
+                            }
+                          });
+                  queueDelta(queue, upgradedRoutes.build());
+                }
               }
             });
   }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/IsisProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/IsisProtocolHelper.java
@@ -1,0 +1,37 @@
+package org.batfish.dataplane.protocols;
+
+import java.util.Optional;
+import org.batfish.datamodel.IsisLevel;
+import org.batfish.datamodel.IsisRoute;
+import org.batfish.datamodel.RoutingProtocol;
+
+/** Helper class that implements various IS-IS protocol logic. */
+public class IsisProtocolHelper {
+
+  /**
+   * Convert a level-1 IS-IS route to a level-2 IS-IS route. All route attributes except
+   * level/protcol and the admin distance remain unchanged.
+   *
+   * @param route the route to convert
+   * @param l2Admin the new L2 admin distance to use.
+   * @return an {@link Optional<IsisRoute>}. It will be empty if the route given is not level 1 or
+   *     has its down bit set.
+   */
+  public static Optional<IsisRoute> convertRouteLevel1ToLevel2(IsisRoute route, int l2Admin) {
+    if (route.getLevel() != IsisLevel.LEVEL_1 || route.getDown()) {
+      return Optional.empty();
+    }
+
+    return Optional.of(
+        new IsisRoute.Builder()
+            .setProtocol(RoutingProtocol.ISIS_L2)
+            .setLevel(IsisLevel.LEVEL_2)
+            .setAdmin(l2Admin)
+            .setMetric(route.getMetric())
+            .setNetwork(route.getNetwork())
+            .setNextHopIp(route.getNextHopIp())
+            .setArea(route.getArea())
+            .setSystemId(route.getSystemId())
+            .build());
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IsisTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IsisTest.java
@@ -9,10 +9,12 @@ import static org.batfish.datamodel.matchers.IsisRouteMatchers.hasDown;
 import static org.batfish.datamodel.matchers.IsisRouteMatchers.isIsisRouteThat;
 import static org.batfish.dataplane.ibdp.TestUtils.assertRoute;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasKey;
 
 import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.Sets;
 import java.util.Collections;
 import java.util.SortedMap;
 import java.util.SortedSet;
@@ -262,6 +264,30 @@ public class IsisTest {
     // assertInterAreaRoute(routes, r5Name, Prefix.parse("10.2.2.2/32"), 148L);
     // assertInterAreaRoute(routes, r5Name, Prefix.parse("10.2.3.0/24"), 148L);
     // assertRoute(routes, ISIS_L1, r5Name, Prefix.parse("10.3.3.100/32"), 10L);
+
+    // Assert r1/r2 have empty l1 rib
+    assertThat(
+        dp.getNodes()
+            .get("r1")
+            .getVirtualRouters()
+            .get(Configuration.DEFAULT_VRF_NAME)
+            ._isisL1Rib
+            .getRoutes(),
+        empty());
+    assertThat(
+        dp.getNodes()
+            .get("r2")
+            .getVirtualRouters()
+            .get(Configuration.DEFAULT_VRF_NAME)
+            ._isisL1Rib
+            .getRoutes(),
+        empty());
+
+    // Assert r3 has disjoint l1/l2 ribs
+    VirtualRouter r3Vr =
+        dp.getNodes().get("r3").getVirtualRouters().get(Configuration.DEFAULT_VRF_NAME);
+    assertThat(
+        Sets.intersection(r3Vr._isisL1Rib.getRoutes(), r3Vr._isisL2Rib.getRoutes()), empty());
   }
 
   private static void assertInterAreaRoute(


### PR DESCRIPTION
Commits separate/self-contained
- Add systemId to IsisRoute
- Fix route propagation, L1 routes now get advertised to L2 on L1-L2 routers
- Add extra negative assertions to test.