### PR TITLE
new equals, hashCode implementations for location specifiers

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/IntersectionLocationSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/IntersectionLocationSpecifier.java
@@ -1,19 +1,22 @@
 package org.batfish.specifier;
 
 import com.google.common.collect.Sets;
+import java.util.Objects;
 import java.util.Set;
+import javax.annotation.Nonnull;
 
 /**
  * A {@link LocationSpecifier} that specifies the set intersection of nodes specified by two other
  * specifiers.
  */
 public final class IntersectionLocationSpecifier implements LocationSpecifier {
-  private final LocationSpecifier _locationSpecifier1;
+  private final @Nonnull LocationSpecifier _locationSpecifier1;
 
-  private final LocationSpecifier _locationSpecifier2;
+  private final @Nonnull LocationSpecifier _locationSpecifier2;
 
   public IntersectionLocationSpecifier(
-      LocationSpecifier locationSpecifier1, LocationSpecifier locationSpecifier2) {
+      @Nonnull LocationSpecifier locationSpecifier1,
+      @Nonnull LocationSpecifier locationSpecifier2) {
     _locationSpecifier1 = locationSpecifier1;
     _locationSpecifier2 = locationSpecifier2;
   }
@@ -21,5 +24,23 @@ public final class IntersectionLocationSpecifier implements LocationSpecifier {
   @Override
   public Set<Location> resolve(SpecifierContext ctxt) {
     return Sets.intersection(_locationSpecifier1.resolve(ctxt), _locationSpecifier2.resolve(ctxt));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof IntersectionLocationSpecifier)) {
+      return false;
+    }
+    IntersectionLocationSpecifier other = (IntersectionLocationSpecifier) o;
+    return _locationSpecifier1.equals(other._locationSpecifier1)
+        && _locationSpecifier2.equals(other._locationSpecifier2);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_locationSpecifier1, _locationSpecifier2);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/UnionLocationSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/UnionLocationSpecifier.java
@@ -1,19 +1,22 @@
 package org.batfish.specifier;
 
 import com.google.common.collect.Sets;
+import java.util.Objects;
 import java.util.Set;
+import javax.annotation.Nonnull;
 
 /**
  * A {@link LocationSpecifier} that specifies the set union of nodes specified by two other
  * specifiers.
  */
 public final class UnionLocationSpecifier implements LocationSpecifier {
-  private final LocationSpecifier _locationSpecifier1;
+  private final @Nonnull LocationSpecifier _locationSpecifier1;
 
-  private final LocationSpecifier _locationSpecifier2;
+  private final @Nonnull LocationSpecifier _locationSpecifier2;
 
   public UnionLocationSpecifier(
-      LocationSpecifier locationSpecifier1, LocationSpecifier locationSpecifier2) {
+      @Nonnull LocationSpecifier locationSpecifier1,
+      @Nonnull LocationSpecifier locationSpecifier2) {
     _locationSpecifier1 = locationSpecifier1;
     _locationSpecifier2 = locationSpecifier2;
   }
@@ -21,5 +24,23 @@ public final class UnionLocationSpecifier implements LocationSpecifier {
   @Override
   public Set<Location> resolve(SpecifierContext ctxt) {
     return Sets.union(_locationSpecifier1.resolve(ctxt), _locationSpecifier2.resolve(ctxt));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof UnionLocationSpecifier)) {
+      return false;
+    }
+    UnionLocationSpecifier other = (UnionLocationSpecifier) o;
+    return _locationSpecifier1.equals(other._locationSpecifier1)
+        && _locationSpecifier2.equals(other._locationSpecifier2);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_locationSpecifier1, _locationSpecifier2);
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/specifier/LocationSpecifierTest.java
+++ b/projects/batfish/src/test/java/org/batfish/specifier/LocationSpecifierTest.java
@@ -3,6 +3,7 @@ package org.batfish.specifier;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -129,6 +130,25 @@ public class LocationSpecifierTest {
   }
 
   @Test
+  public void testIntersectionLocationSpecifier_equalsHashCode() {
+    LocationSpecifier spec1a =
+        new IntersectionLocationSpecifier(
+            AllInterfacesLocationSpecifier.INSTANCE, NullLocationSpecifier.INSTANCE);
+    LocationSpecifier spec1b =
+        new IntersectionLocationSpecifier(
+            AllInterfacesLocationSpecifier.INSTANCE, NullLocationSpecifier.INSTANCE);
+    LocationSpecifier spec2 =
+        new IntersectionLocationSpecifier(
+            AllInterfaceLinksLocationSpecifier.INSTANCE, NullLocationSpecifier.INSTANCE);
+
+    assertThat(spec1a, equalTo(spec1a));
+    assertThat(spec1a, equalTo(spec1b));
+    assertThat(spec1a.hashCode(), equalTo(spec1b.hashCode()));
+    assertThat(spec1a, not(equalTo(spec2)));
+    assertThat(spec1a, not(equalTo(NullLocationSpecifier.INSTANCE)));
+  }
+
+  @Test
   public void testNameRegexInterfaceLocationSpecifiers() {
     // choose 1 interface from each node
     List<Interface> interfaces =
@@ -233,6 +253,25 @@ public class LocationSpecifierTest {
     assertThat(
         new DifferenceLocationSpecifier(locationSpecifier01, locationSpecifier12).resolve(_context),
         equalTo(Sets.difference(locations01, locations12)));
+  }
+
+  @Test
+  public void testUnionLocationSpecifier_equalsHashCode() {
+    LocationSpecifier spec1a =
+        new UnionLocationSpecifier(
+            AllInterfacesLocationSpecifier.INSTANCE, NullLocationSpecifier.INSTANCE);
+    LocationSpecifier spec1b =
+        new UnionLocationSpecifier(
+            AllInterfacesLocationSpecifier.INSTANCE, NullLocationSpecifier.INSTANCE);
+    LocationSpecifier spec2 =
+        new UnionLocationSpecifier(
+            AllInterfaceLinksLocationSpecifier.INSTANCE, NullLocationSpecifier.INSTANCE);
+
+    assertThat(spec1a, equalTo(spec1a));
+    assertThat(spec1a, equalTo(spec1b));
+    assertThat(spec1a.hashCode(), equalTo(spec1b.hashCode()));
+    assertThat(spec1a, not(equalTo(spec2)));
+    assertThat(spec1a, not(equalTo(NullLocationSpecifier.INSTANCE)));
   }
 
   @Test


### PR DESCRIPTION
Added missing equals and hashCode implementations needed to test location specifier factories (will be used in a separate PR).