### PR TITLE
Fix Juniper flattener to work with bracketed lists

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/juniper/JuniperFlattener.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/juniper/JuniperFlattener.java
@@ -117,6 +117,7 @@ public class JuniperFlattener extends JuniperParserBaseListener implements Flatt
           constructSetLine();
           _stack.remove(_stack.size() - 1);
         }
+        _currentBracketedWords = null;
       } else {
         constructSetLine();
       }

--- a/projects/batfish/src/test/java/org/batfish/job/FlattenVendorConfigurationJobTest.java
+++ b/projects/batfish/src/test/java/org/batfish/job/FlattenVendorConfigurationJobTest.java
@@ -38,6 +38,17 @@ public class FlattenVendorConfigurationJobTest {
   }
 
   @Test
+  public void testFlattenVendorConfigurationJobJuniperBrackets() {
+    String nestedConfig = "nested-config-brackets";
+    String flattenedConfig = "nested-config-brackets-flattened";
+
+    String flatText = getFlattenedText(JUNIPER_TESTCONFIGS_PREFIX + nestedConfig);
+    // Confirm Juniper nested config with bracketed list is flattened properly
+    assertThat(
+        flatText, equalTo(CommonUtil.readResource(JUNIPER_TESTCONFIGS_PREFIX + flattenedConfig)));
+  }
+
+  @Test
   public void testFlattenVendorConfigurationJobPaloAlto() {
     String nestedConfig = "nested-config";
     String flattenedConfig = "nested-config-flattened";
@@ -45,6 +56,17 @@ public class FlattenVendorConfigurationJobTest {
     assertThat(
         getFlattenedText(PAN_TESTCONFIGS_PREFIX + nestedConfig),
         equalTo(CommonUtil.readResource(PAN_TESTCONFIGS_PREFIX + flattenedConfig)));
+  }
+
+  @Test
+  public void testFlattenVendorConfigurationJobPaloAltoBrackets() {
+    String nestedConfig = "nested-config-brackets";
+    String flattenedConfig = "nested-config-brackets-flattened";
+
+    String flatText = getFlattenedText(PAN_TESTCONFIGS_PREFIX + nestedConfig);
+    // Confirm Palo Alto nested config with bracketed list is flattened properly
+    assertThat(
+        flatText, equalTo(CommonUtil.readResource(PAN_TESTCONFIGS_PREFIX + flattenedConfig)));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/nested-config-brackets
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/nested-config-brackets
@@ -1,0 +1,25 @@
+#
+security {
+    policies {
+        global {
+            policy GLOBAL {
+                match {
+                    source-address [ ADDR1 ADDRSET ];
+                    destination-address any;
+                }
+                then {
+                    permit;
+                }
+            }
+        }
+    }
+    zones {
+        security-zone trust {
+            host-inbound-traffic {
+                system-services {
+                    ssh;
+                }
+            }
+        }
+    }
+}

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/nested-config-brackets-flattened
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/nested-config-brackets-flattened
@@ -1,0 +1,6 @@
+####BATFISH FLATTENED JUNIPER CONFIG####
+set security policies global policy GLOBAL match source-address ADDR1
+set security policies global policy GLOBAL match source-address ADDRSET
+set security policies global policy GLOBAL match destination-address any
+set security policies global policy GLOBAL then permit
+set security zones security-zone trust host-inbound-traffic system-services ssh

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/nested-config-brackets
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/nested-config-brackets
@@ -3,8 +3,14 @@ deviceconfig {
         hostname nested-config-brackets;
     }
 }
+mgt-config {
+    access-domain {
+        All {
+            vsys [ VSYSNAME1 VSYSNAME2];
+        }
+    }
+}
 shared {
-    vsys [ VSYSNAME1 VSYSNAME2 ];
     log-settings {
         syslog {
             SYSLOGNAME {

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/nested-config-brackets
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/nested-config-brackets
@@ -1,0 +1,19 @@
+deviceconfig {
+    system {
+        hostname nested-config-brackets;
+    }
+}
+shared {
+    vsys [ VSYSNAME1 VSYSNAME2 ];
+    log-settings {
+        syslog {
+            SYSLOGNAME {
+                server {
+                    SERVERNAME {
+                        server 1.1.1.1;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/nested-config-brackets-flattened
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/nested-config-brackets-flattened
@@ -1,0 +1,5 @@
+####BATFISH FLATTENED PALO ALTO CONFIG####
+set deviceconfig system hostname nested-config-brackets
+set shared vsys VSYSNAME1
+set shared vsys VSYSNAME2
+set shared log-settings syslog SYSLOGNAME server SERVERNAME server 1.1.1.1

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/nested-config-brackets-flattened
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/nested-config-brackets-flattened
@@ -1,5 +1,5 @@
 ####BATFISH FLATTENED PALO ALTO CONFIG####
 set deviceconfig system hostname nested-config-brackets
-set shared vsys VSYSNAME1
-set shared vsys VSYSNAME2
+set mgt-config access-domain All vsys VSYSNAME1
+set mgt-config access-domain All vsys VSYSNAME2
 set shared log-settings syslog SYSLOGNAME server SERVERNAME server 1.1.1.1


### PR DESCRIPTION
Previously, after a bracketed list was flattened, lines following the list were also duplicated (once per bracketed list item).

This PR fixes that behavior, by clearing the list of bracketed words once they have been flattened.
