### PR TITLE
Bazel: Add dependency to access matchers

### DIFF
--- a/projects/batfish/BUILD
+++ b/projects/batfish/BUILD
@@ -75,6 +75,7 @@ java_library(
     deps = [
         ":batfish",
         "//projects/batfish-common-protocol:common",
+        "//projects/batfish-common-protocol:common_testlib",
         "//projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper",
         "//projects/lib/z3",
         "@antlr4_runtime//:compile",


### PR DESCRIPTION
For batfish project, add dependency on common_testlib, as that's where route matchers reside.