### PR TITLE
Rename BgpNeighbor

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
@@ -86,7 +86,7 @@ import org.batfish.common.BfConsts;
 import org.batfish.common.Pair;
 import org.batfish.common.plugin.ITracerouteEngine;
 import org.batfish.datamodel.AclIpSpace;
-import org.batfish.datamodel.BgpNeighbor;
+import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.BgpSession;
 import org.batfish.datamodel.Configuration;
@@ -916,8 +916,8 @@ public class CommonUtil {
    */
   @Nullable
   private static boolean isReachableBgpNeighbor(
-      BgpNeighbor src,
-      BgpNeighbor dst,
+      BgpPeerConfig src,
+      BgpPeerConfig dst,
       @Nullable ITracerouteEngine tracerouteEngine,
       @Nullable DataPlane dp) {
     Ip srcAddress = src.getLocalIp();
@@ -1002,9 +1002,9 @@ public class CommonUtil {
   }
 
   /**
-   * Compute the BGP topology -- a network of {@link BgpNeighbor}s connected by {@link BgpSession}s.
-   * See {@link #initBgpTopology(Map, Map, boolean, boolean, ITracerouteEngine, DataPlane)} for more
-   * details.
+   * Compute the BGP topology -- a network of {@link BgpPeerConfig}s connected by {@link
+   * BgpSession}s. See {@link #initBgpTopology(Map, Map, boolean, boolean, ITracerouteEngine,
+   * DataPlane)} for more details.
    *
    * @param configurations configuration keyed by hostname
    * @param ipOwners Ip owners (see {@link #computeIpNodeOwners(boolean, Map)}
@@ -1013,7 +1013,7 @@ public class CommonUtil {
    *     you want this to be {@code false}.
    * @return A graph ({@link Network}) representing all BGP peerings.
    */
-  public static Network<BgpNeighbor, BgpSession> initBgpTopology(
+  public static Network<BgpPeerConfig, BgpSession> initBgpTopology(
       Map<String, Configuration> configurations,
       Map<Ip, Set<String>> ipOwners,
       boolean keepInvalid) {
@@ -1021,7 +1021,8 @@ public class CommonUtil {
   }
 
   /**
-   * Compute the BGP topology -- a network of {@link BgpNeighbor}s connected by {@link BgpSession}s.
+   * Compute the BGP topology -- a network of {@link BgpPeerConfig}s connected by {@link
+   * BgpSession}s.
    *
    * @param configurations node configurations, keyed by hostname
    * @param ipOwners network Ip owners (see {@link #computeIpNodeOwners(Map, boolean)} for
@@ -1037,7 +1038,7 @@ public class CommonUtil {
    * @param dp (partially) computed dataplane.
    * @return A graph ({@link Network}) representing all BGP peerings.
    */
-  public static Network<BgpNeighbor, BgpSession> initBgpTopology(
+  public static Network<BgpPeerConfig, BgpSession> initBgpTopology(
       Map<String, Configuration> configurations,
       Map<Ip, Set<String>> ipOwners,
       boolean keepInvalid,
@@ -1051,8 +1052,8 @@ public class CommonUtil {
      * First pass: identify all addresses "owned" by BgpNeighbors,
      * add neighbors as vertices to the graph
      */
-    Map<Ip, Set<BgpNeighbor>> localAddresses = new HashMap<>();
-    MutableNetwork<BgpNeighbor, BgpSession> graph =
+    Map<Ip, Set<BgpPeerConfig>> localAddresses = new HashMap<>();
+    MutableNetwork<BgpPeerConfig, BgpSession> graph =
         NetworkBuilder.directed().allowsParallelEdges(false).allowsSelfLoops(false).build();
     for (Configuration node : configurations.values()) {
       String hostname = node.getHostname();
@@ -1062,8 +1063,8 @@ public class CommonUtil {
           // nothing to do if no bgp process on this VRF
           continue;
         }
-        for (BgpNeighbor bgpNeighbor : proc.getNeighbors().values()) {
-          Ip localAddress = bgpNeighbor.getLocalIp();
+        for (BgpPeerConfig bgpPeerConfig : proc.getNeighbors().values()) {
+          Ip localAddress = bgpPeerConfig.getLocalIp();
 
           /*
            * Do these checks as a short-circuit to avoid extra reachability checks.
@@ -1078,24 +1079,24 @@ public class CommonUtil {
             // Local address is not owned by anybody
             continue;
           }
-          graph.addNode(bgpNeighbor);
+          graph.addNode(bgpPeerConfig);
 
           // Add this neighbor as owner of its local address
           localAddresses
               .computeIfAbsent(
                   localAddress, k -> Collections.newSetFromMap(new IdentityHashMap<>()))
-              .add(bgpNeighbor);
+              .add(bgpPeerConfig);
         }
       }
     }
 
     // Second pass: add edges to the graph
-    for (BgpNeighbor neighbor : graph.nodes()) {
+    for (BgpPeerConfig neighbor : graph.nodes()) {
       if (neighbor.getDynamic()) {
         // Passive end of the peering cannot initiate a connection
         continue;
       }
-      Set<BgpNeighbor> candidates = localAddresses.get(neighbor.getAddress());
+      Set<BgpPeerConfig> candidates = localAddresses.get(neighbor.getAddress());
       if (candidates == null) {
         // Check maybe it's trying to reach a dynamic neighbor
         candidates = localAddresses.get(Ip.AUTO);
@@ -1114,7 +1115,7 @@ public class CommonUtil {
       }
       long localLocalAs = neighbor.getLocalAs();
       long localRemoteAs = neighbor.getRemoteAs();
-      for (BgpNeighbor candidateNeighbor : candidates) {
+      for (BgpPeerConfig candidateNeighbor : candidates) {
         long remoteLocalAs = candidateNeighbor.getLocalAs();
         long remoteRemoteAs = candidateNeighbor.getRemoteAs();
         if (neighbor.getLocalIp() == null

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpPeerConfig.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpPeerConfig.java
@@ -16,9 +16,9 @@ import org.batfish.datamodel.NetworkFactory.NetworkFactoryBuilder;
 
 /** Represents a configured BGP peering, at the control plane level */
 @JsonSchemaDescription("A configured e/iBGP peering relationship")
-public final class BgpNeighbor extends ComparableStructure<Prefix> {
+public final class BgpPeerConfig extends ComparableStructure<Prefix> {
 
-  public static class Builder extends NetworkFactoryBuilder<BgpNeighbor> {
+  public static class Builder extends NetworkFactoryBuilder<BgpPeerConfig> {
     private Configuration _owner;
     private Ip _localIp;
     private Ip _peerIpAddress;
@@ -36,51 +36,51 @@ public final class BgpNeighbor extends ComparableStructure<Prefix> {
     private boolean _dynamic = false;
 
     Builder(NetworkFactory networkFactory) {
-      super(networkFactory, BgpNeighbor.class);
+      super(networkFactory, BgpPeerConfig.class);
     }
 
     @Override
-    public BgpNeighbor build() {
-      BgpNeighbor bgpNeighbor;
+    public BgpPeerConfig build() {
+      BgpPeerConfig bgpPeerConfig;
       Ip peerIpAddress = _peerIpAddress != null ? _peerIpAddress : new Ip(generateLong());
-      bgpNeighbor = new BgpNeighbor(peerIpAddress, _owner, _dynamic);
+      bgpPeerConfig = new BgpPeerConfig(peerIpAddress, _owner, _dynamic);
       if (_clusterId != null) {
-        bgpNeighbor.setClusterId(_clusterId);
+        bgpPeerConfig.setClusterId(_clusterId);
       }
       if (_localIp != null) {
-        bgpNeighbor.setLocalIp(_localIp);
+        bgpPeerConfig.setLocalIp(_localIp);
       }
       if (_localAs != null) {
-        bgpNeighbor.setLocalAs(_localAs);
+        bgpPeerConfig.setLocalAs(_localAs);
       }
       if (_remoteAs != null) {
-        bgpNeighbor.setRemoteAs(_remoteAs);
+        bgpPeerConfig.setRemoteAs(_remoteAs);
       }
       if (_bgpProcess != null) {
-        _bgpProcess.getNeighbors().put(bgpNeighbor.getPrefix(), bgpNeighbor);
+        _bgpProcess.getNeighbors().put(bgpPeerConfig.getPrefix(), bgpPeerConfig);
       }
       if (_exportPolicy != null) {
-        bgpNeighbor.setExportPolicy(_exportPolicy);
+        bgpPeerConfig.setExportPolicy(_exportPolicy);
       }
       if (_advertiseInactive != null) {
-        bgpNeighbor.setAdvertiseInactive(_advertiseInactive);
+        bgpPeerConfig.setAdvertiseInactive(_advertiseInactive);
       }
       if (_advertiseExternal != null) {
-        bgpNeighbor.setAdvertiseExternal(_advertiseExternal);
+        bgpPeerConfig.setAdvertiseExternal(_advertiseExternal);
       }
       if (_additionalPathSend != null) {
-        bgpNeighbor.setAdditionalPathsSend(_additionalPathSend);
+        bgpPeerConfig.setAdditionalPathsSend(_additionalPathSend);
       }
       if (_additionalPathSelectAll != null) {
-        bgpNeighbor.setAdditionalPathsSelectAll(_additionalPathSelectAll);
+        bgpPeerConfig.setAdditionalPathsSelectAll(_additionalPathSelectAll);
       }
       if (_routeReflectorClient != null) {
-        bgpNeighbor.setRouteReflectorClient(_routeReflectorClient);
+        bgpPeerConfig.setRouteReflectorClient(_routeReflectorClient);
       }
       if (_vrf != null) {
-        bgpNeighbor.setVrf(_vrf.getName());
+        bgpPeerConfig.setVrf(_vrf.getName());
       }
-      return bgpNeighbor;
+      return bgpPeerConfig;
     }
 
     public Builder setOwner(Configuration owner) {
@@ -292,12 +292,12 @@ public final class BgpNeighbor extends ComparableStructure<Prefix> {
   private String _vrf;
 
   @SuppressWarnings("unused")
-  private BgpNeighbor() {
+  private BgpPeerConfig() {
     this(null);
   }
 
   /**
-   * Constructs a BgpNeighbor with the given peer ip address for {@code address} and owner for
+   * Constructs a BgpPeerConfig with the given peer ip address for {@code address} and owner for
    * {@code owner}. Allows specifying whether the end of this session is passive with {@code
    * passive}
    *
@@ -305,12 +305,12 @@ public final class BgpNeighbor extends ComparableStructure<Prefix> {
    * @param owner The owner of this neighbor
    * @param dynamic Whether the peering is passive (a.k.a dynamic)
    */
-  public BgpNeighbor(Ip address, Configuration owner, boolean dynamic) {
+  public BgpPeerConfig(Ip address, Configuration owner, boolean dynamic) {
     this(new Prefix(address, Prefix.MAX_PREFIX_LENGTH), owner, dynamic);
   }
 
   @JsonCreator
-  public BgpNeighbor(@JsonProperty(PROP_NAME) Prefix prefix) {
+  public BgpPeerConfig(@JsonProperty(PROP_NAME) Prefix prefix) {
     super(prefix);
     _exportPolicySources = new TreeSet<>();
     _generatedRoutes = new LinkedHashSet<>();
@@ -319,14 +319,14 @@ public final class BgpNeighbor extends ComparableStructure<Prefix> {
   }
 
   /**
-   * Constructs a BgpNeighbor with the given peer dynamic ip range for {@code prefix} and owner for
-   * {@code owner}
+   * Constructs a BgpPeerConfig with the given peer dynamic ip range for {@code prefix} and owner
+   * for {@code owner}
    *
    * @param prefix The dynamic ip range of this neighbor
    * @param owner The owner of this neighbor
    * @param dynamic Whether the peering is passive (a.k.a dynamic)
    */
-  public BgpNeighbor(Prefix prefix, Configuration owner, boolean dynamic) {
+  public BgpPeerConfig(Prefix prefix, Configuration owner, boolean dynamic) {
     this(prefix);
     _owner = owner;
     _dynamic = dynamic;
@@ -336,10 +336,10 @@ public final class BgpNeighbor extends ComparableStructure<Prefix> {
   public boolean equals(Object o) {
     if (o == this) {
       return true;
-    } else if (!(o instanceof BgpNeighbor)) {
+    } else if (!(o instanceof BgpPeerConfig)) {
       return false;
     }
-    BgpNeighbor other = (BgpNeighbor) o;
+    BgpPeerConfig other = (BgpPeerConfig) o;
     if (this._advertiseExternal != other._advertiseExternal) {
       return false;
     }
@@ -736,6 +736,6 @@ public final class BgpNeighbor extends ComparableStructure<Prefix> {
 
   @Override
   public String toString() {
-    return "BgpNeighbor<Prefix:" + _key + ", AS:" + _remoteAs + ">";
+    return "BgpPeerConfig<Prefix:" + _key + ", AS:" + _remoteAs + ">";
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpPeerConfigId.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpPeerConfigId.java
@@ -1,0 +1,50 @@
+package org.batfish.datamodel;
+
+import java.util.Objects;
+import javax.annotation.Nonnull;
+
+/** Uniquely identifies a {@link BgpPeerConfig} in a network. */
+public final class BgpPeerConfigId {
+  private final String _hostname;
+  private final String _vrfName;
+  private final Prefix _remotePeerPrefix;
+
+  /** Create a new ID. */
+  public BgpPeerConfigId(
+      @Nonnull String hostname, @Nonnull String vrfName, @Nonnull Prefix remotePeerPrefix) {
+    _hostname = hostname;
+    _vrfName = vrfName;
+    _remotePeerPrefix = remotePeerPrefix;
+  }
+
+  public String getHostname() {
+    return _hostname;
+  }
+
+  public String getVrfName() {
+    return _vrfName;
+  }
+
+  public Prefix getRemotePeerPrefix() {
+    return _remotePeerPrefix;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof BgpPeerConfigId)) {
+      return false;
+    }
+    BgpPeerConfigId other = (BgpPeerConfigId) o;
+    return Objects.equals(_hostname, other._hostname)
+        && Objects.equals(_vrfName, other._vrfName)
+        && Objects.equals(_remotePeerPrefix, other._remotePeerPrefix);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_hostname, _vrfName, _remotePeerPrefix);
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpProcess.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpProcess.java
@@ -58,7 +58,7 @@ public class BgpProcess implements Serializable {
       return _neighbors
           .values()
           .stream()
-          .map(BgpNeighbor::getClusterId)
+          .map(BgpPeerConfig::getClusterId)
           .collect(ImmutableSet.toImmutableSet());
     }
   }
@@ -96,7 +96,7 @@ public class BgpProcess implements Serializable {
    * A map of all the bgp neighbors with which the router owning this process is configured to peer,
    * keyed by prefix
    */
-  private SortedMap<Prefix, BgpNeighbor> _neighbors;
+  private SortedMap<Prefix, BgpPeerConfig> _neighbors;
 
   /** Space of prefixes to be advertised using explicit network statements */
   private PrefixSpace _originationSpace;
@@ -157,7 +157,7 @@ public class BgpProcess implements Serializable {
   /** @return {@link #_neighbors} */
   @JsonProperty(PROP_NEIGHBORS)
   @JsonPropertyDescription("Neighbor relationships configured for this BGP process")
-  public SortedMap<Prefix, BgpNeighbor> getNeighbors() {
+  public SortedMap<Prefix, BgpPeerConfig> getNeighbors() {
     return _neighbors;
   }
 
@@ -200,7 +200,7 @@ public class BgpProcess implements Serializable {
   }
 
   @JsonProperty(PROP_NEIGHBORS)
-  public void setNeighbors(SortedMap<Prefix, BgpNeighbor> neighbors) {
+  public void setNeighbors(SortedMap<Prefix, BgpPeerConfig> neighbors) {
     _neighbors = neighbors;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpSession.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpSession.java
@@ -4,13 +4,13 @@ import java.util.Comparator;
 import java.util.Objects;
 import javax.annotation.Nonnull;
 
-/** Represents a peering session between two {@link BgpNeighbor}s */
+/** Represents a peering session between two {@link BgpPeerConfig}s */
 public class BgpSession implements Comparable<BgpSession> {
 
   private final boolean _isEbgp;
 
-  @Nonnull private BgpNeighbor _src;
-  @Nonnull private BgpNeighbor _dst;
+  @Nonnull private BgpPeerConfig _src;
+  @Nonnull private BgpPeerConfig _dst;
 
   /**
    * Create a new session
@@ -18,17 +18,17 @@ public class BgpSession implements Comparable<BgpSession> {
    * @param src session initiator
    * @param dst session acceptor
    */
-  public BgpSession(@Nonnull BgpNeighbor src, @Nonnull BgpNeighbor dst) {
+  public BgpSession(@Nonnull BgpPeerConfig src, @Nonnull BgpPeerConfig dst) {
     _src = src;
     _dst = dst;
     _isEbgp = !src.getLocalAs().equals(dst.getLocalAs());
   }
 
-  public BgpNeighbor getSrc() {
+  public BgpPeerConfig getSrc() {
     return _src;
   }
 
-  public BgpNeighbor getDst() {
+  public BgpPeerConfig getDst() {
     return _dst;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Configuration.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Configuration.java
@@ -299,7 +299,7 @@ public final class Configuration extends ComparableStructure<String> {
     for (Vrf vrf : _vrfs.values()) {
       BgpProcess bgpProcess = vrf.getBgpProcess();
       if (bgpProcess != null) {
-        for (BgpNeighbor neighbor : bgpProcess.getNeighbors().values()) {
+        for (BgpPeerConfig neighbor : bgpProcess.getNeighbors().values()) {
           neighbor.setExportPolicySources(getRoutingPolicySources(neighbor.getExportPolicy()));
           neighbor.setImportPolicySources(getRoutingPolicySources(neighbor.getImportPolicy()));
         }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/DataPlane.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/DataPlane.java
@@ -9,7 +9,7 @@ import java.util.SortedSet;
 
 public interface DataPlane extends Serializable {
 
-  Network<BgpNeighbor, BgpSession> getBgpTopology();
+  Network<BgpPeerConfig, BgpSession> getBgpTopology();
 
   Map<String, Configuration> getConfigurations();
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/NeighborsDiff.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/NeighborsDiff.java
@@ -9,17 +9,17 @@ public class NeighborsDiff extends ConfigDiffElement {
   @JsonCreator
   private NeighborsDiff() {}
 
-  public NeighborsDiff(Map<Prefix, BgpNeighbor> before, Map<Prefix, BgpNeighbor> after) {
+  public NeighborsDiff(Map<Prefix, BgpPeerConfig> before, Map<Prefix, BgpPeerConfig> after) {
     super(new TreeSet<>(), new TreeSet<>());
 
     for (Prefix beforePrefix : before.keySet()) {
-      BgpNeighbor beforeNeighbor = before.get(beforePrefix);
+      BgpPeerConfig beforeNeighbor = before.get(beforePrefix);
       String beforeDescription = beforeNeighbor.getDescription();
       if (beforeDescription == null) {
         beforeDescription = beforePrefix.toString();
       }
       if (after.containsKey(beforePrefix)) {
-        BgpNeighbor bNeighbor = after.get(beforePrefix);
+        BgpPeerConfig bNeighbor = after.get(beforePrefix);
         if (beforeNeighbor.equals(bNeighbor)) {
           super._identical.add(beforeDescription);
         } else {
@@ -31,7 +31,7 @@ public class NeighborsDiff extends ConfigDiffElement {
     }
 
     for (Prefix afterPrefix : after.keySet()) {
-      BgpNeighbor afterNeighbor = after.get(afterPrefix);
+      BgpPeerConfig afterNeighbor = after.get(afterPrefix);
       if (!before.containsKey(afterPrefix)) {
         String afterDescription = afterNeighbor.getDescription();
         if (afterDescription == null) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/NetworkFactory.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/NetworkFactory.java
@@ -55,8 +55,8 @@ public class NetworkFactory {
     return new IpAccessList.Builder(this);
   }
 
-  public BgpNeighbor.Builder bgpNeighborBuilder() {
-    return new BgpNeighbor.Builder(this);
+  public BgpPeerConfig.Builder bgpNeighborBuilder() {
+    return new BgpPeerConfig.Builder(this);
   }
 
   public BgpProcess.Builder bgpProcessBuilder() {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/VerboseBgpEdge.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/VerboseBgpEdge.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
 import javax.annotation.Nonnull;
-import org.batfish.datamodel.BgpNeighbor;
+import org.batfish.datamodel.BgpPeerConfig;
 
 public final class VerboseBgpEdge implements Serializable, Comparable<VerboseBgpEdge> {
 
@@ -17,13 +17,13 @@ public final class VerboseBgpEdge implements Serializable, Comparable<VerboseBgp
   private static final long serialVersionUID = 1L;
 
   @Nonnull private final IpEdge _edgeSummary;
-  @Nonnull private final BgpNeighbor _session1;
-  @Nonnull private final BgpNeighbor _session2;
+  @Nonnull private final BgpPeerConfig _session1;
+  @Nonnull private final BgpPeerConfig _session2;
 
   @JsonCreator
   public VerboseBgpEdge(
-      @Nonnull @JsonProperty(PROP_NODE1_SESSION) BgpNeighbor s1,
-      @Nonnull @JsonProperty(PROP_NODE2_SESSION) BgpNeighbor s2,
+      @Nonnull @JsonProperty(PROP_NODE1_SESSION) BgpPeerConfig s1,
+      @Nonnull @JsonProperty(PROP_NODE2_SESSION) BgpPeerConfig s2,
       @Nonnull @JsonProperty(PROP_EDGE_SUMMARY) IpEdge e) {
     this._session1 = s1;
     this._session2 = s2;
@@ -36,12 +36,12 @@ public final class VerboseBgpEdge implements Serializable, Comparable<VerboseBgp
   }
 
   @JsonProperty(PROP_NODE1_SESSION)
-  public BgpNeighbor getNode1Session() {
+  public BgpPeerConfig getNode1Session() {
     return _session1;
   }
 
   @JsonProperty(PROP_NODE2_SESSION)
-  public BgpNeighbor getNode2Session() {
+  public BgpPeerConfig getNode2Session() {
     return _session2;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/AutoAs.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/AutoAs.java
@@ -1,7 +1,7 @@
 package org.batfish.datamodel.routing_policy.expr;
 
 import org.batfish.common.BatfishException;
-import org.batfish.datamodel.BgpNeighbor;
+import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
@@ -40,7 +40,7 @@ public class AutoAs extends AsExpr {
       throw new BatfishException("Expected a peer address");
     }
     Prefix peerPrefix = new Prefix(peerAddress, Prefix.MAX_PREFIX_LENGTH);
-    BgpNeighbor neighbor = proc.getNeighbors().get(peerPrefix);
+    BgpPeerConfig neighbor = proc.getNeighbors().get(peerPrefix);
     if (neighbor == null) {
       throw new BatfishException("Expected a peer with address: " + peerAddress);
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/SelfNextHop.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/SelfNextHop.java
@@ -1,7 +1,7 @@
 package org.batfish.datamodel.routing_policy.expr;
 
 import javax.annotation.Nullable;
-import org.batfish.datamodel.BgpNeighbor;
+import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.routing_policy.Environment;
@@ -31,7 +31,7 @@ public class SelfNextHop extends NextHopExpr {
     if (peerPrefix == null) {
       return null;
     }
-    BgpNeighbor neighbor = environment.getVrf().getBgpProcess().getNeighbors().get(peerPrefix);
+    BgpPeerConfig neighbor = environment.getVrf().getBgpProcess().getNeighbors().get(peerPrefix);
     if (neighbor == null) {
       return null;
     }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ConfigurationTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ConfigurationTest.java
@@ -64,8 +64,8 @@ public class ConfigurationTest {
     // BGP
     BgpProcess bgpProcess = new BgpProcess();
     vrf.setBgpProcess(bgpProcess);
-    BgpNeighbor neighbor =
-        bgpProcess.getNeighbors().computeIfAbsent(neighborPrefix, BgpNeighbor::new);
+    BgpPeerConfig neighbor =
+        bgpProcess.getNeighbors().computeIfAbsent(neighborPrefix, BgpPeerConfig::new);
     neighbor.setExportPolicy(
         c.getRoutingPolicies()
             .computeIfAbsent(bgpExportPolicyName, n -> new RoutingPolicy(n, c))
@@ -74,10 +74,10 @@ public class ConfigurationTest {
         c.getRoutingPolicies()
             .computeIfAbsent(bgpImportPolicyName, n -> new RoutingPolicy(n, c))
             .getName());
-    BgpNeighbor neighborWithMissingPolicies =
+    BgpPeerConfig neighborWithMissingPolicies =
         bgpProcess
             .getNeighbors()
-            .computeIfAbsent(neigborWithMissingPoliciesPrefix, BgpNeighbor::new);
+            .computeIfAbsent(neigborWithMissingPoliciesPrefix, BgpPeerConfig::new);
     neighborWithMissingPolicies.setExportPolicy(bgpMissingExportPolicyName);
     neighborWithMissingPolicies.setImportPolicy(bgpMissingImportPolicyName);
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockDataPlane.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockDataPlane.java
@@ -15,7 +15,7 @@ public class MockDataPlane implements DataPlane {
 
   public static class Builder {
 
-    private Network<BgpNeighbor, BgpSession> _bgpTopology;
+    private Network<BgpPeerConfig, BgpSession> _bgpTopology;
 
     private Map<String, Configuration> _configurations;
 
@@ -46,7 +46,7 @@ public class MockDataPlane implements DataPlane {
       return new MockDataPlane(this);
     }
 
-    public Builder setBgpTopology(Network<BgpNeighbor, BgpSession> bgpTopology) {
+    public Builder setBgpTopology(Network<BgpPeerConfig, BgpSession> bgpTopology) {
       _bgpTopology = bgpTopology;
       return this;
     }
@@ -83,7 +83,7 @@ public class MockDataPlane implements DataPlane {
     return new Builder();
   }
 
-  private final Network<BgpNeighbor, BgpSession> _bgpTopology;
+  private final Network<BgpPeerConfig, BgpSession> _bgpTopology;
 
   private final Map<String, Configuration> _configurations;
 
@@ -150,7 +150,7 @@ public class MockDataPlane implements DataPlane {
   }
 
   @Override
-  public Network<BgpNeighbor, BgpSession> getBgpTopology() {
+  public Network<BgpPeerConfig, BgpSession> getBgpTopology() {
     return _bgpTopology;
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpNeighborMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpNeighborMatchers.java
@@ -4,7 +4,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.batfish.datamodel.BgpNeighbor;
+import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.matchers.BgpNeighborMatchersImpl.HasClusterId;
 import org.batfish.datamodel.matchers.BgpNeighborMatchersImpl.HasEnforceFirstAs;
 import org.batfish.datamodel.matchers.BgpNeighborMatchersImpl.HasLocalAs;
@@ -14,10 +14,10 @@ import org.hamcrest.Matcher;
 public class BgpNeighborMatchers {
 
   /**
-   * Provides a matcher that matches if the {@link BgpNeighbor}'s clusterId is {@code
+   * Provides a matcher that matches if the {@link BgpPeerConfig}'s clusterId is {@code
    * expectedClusterId}.
    */
-  public static @Nonnull Matcher<BgpNeighbor> hasClusterId(@Nullable Long expectedClusterId) {
+  public static @Nonnull Matcher<BgpPeerConfig> hasClusterId(@Nullable Long expectedClusterId) {
     return new HasClusterId(equalTo(expectedClusterId));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpNeighborMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpNeighborMatchersImpl.java
@@ -1,63 +1,63 @@
 package org.batfish.datamodel.matchers;
 
 import javax.annotation.Nonnull;
-import org.batfish.datamodel.BgpNeighbor;
+import org.batfish.datamodel.BgpPeerConfig;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 
 final class BgpNeighborMatchersImpl {
 
-  static final class HasClusterId extends FeatureMatcher<BgpNeighbor, Long> {
+  static final class HasClusterId extends FeatureMatcher<BgpPeerConfig, Long> {
     HasClusterId(@Nonnull Matcher<? super Long> subMatcher) {
-      super(subMatcher, "A BgpNeighbor with clusterId:", "clusterId");
+      super(subMatcher, "A BgpPeerConfig with clusterId:", "clusterId");
     }
 
     @Override
-    protected Long featureValueOf(BgpNeighbor actual) {
+    protected Long featureValueOf(BgpPeerConfig actual) {
       return actual.getClusterId();
     }
   }
 
-  static final class HasLocalAs extends FeatureMatcher<BgpNeighbor, Long> {
+  static final class HasLocalAs extends FeatureMatcher<BgpPeerConfig, Long> {
     HasLocalAs(@Nonnull Matcher<? super Long> subMatcher) {
-      super(subMatcher, "A BgpNeighbor with localAs:", "localAs");
+      super(subMatcher, "A BgpPeerConfig with localAs:", "localAs");
     }
 
     @Override
-    protected Long featureValueOf(BgpNeighbor actual) {
+    protected Long featureValueOf(BgpPeerConfig actual) {
       return actual.getLocalAs();
     }
   }
 
-  static final class HasEnforceFirstAs extends FeatureMatcher<BgpNeighbor, Boolean> {
+  static final class HasEnforceFirstAs extends FeatureMatcher<BgpPeerConfig, Boolean> {
     HasEnforceFirstAs(@Nonnull Matcher<? super Boolean> subMatcher) {
-      super(subMatcher, "A BgpNeighbor with enforce-first-as:", "enforce-first-as");
+      super(subMatcher, "A BgpPeerConfig with enforce-first-as:", "enforce-first-as");
     }
 
     @Override
-    protected Boolean featureValueOf(BgpNeighbor actual) {
+    protected Boolean featureValueOf(BgpPeerConfig actual) {
       return actual.getEnforceFirstAs();
     }
   }
 
-  static final class HasRemoteAs extends FeatureMatcher<BgpNeighbor, Long> {
+  static final class HasRemoteAs extends FeatureMatcher<BgpPeerConfig, Long> {
     HasRemoteAs(@Nonnull Matcher<? super Long> subMatcher) {
-      super(subMatcher, "A BgpNeighbor with remoteAs:", "remoteAs");
+      super(subMatcher, "A BgpPeerConfig with remoteAs:", "remoteAs");
     }
 
     @Override
-    protected Long featureValueOf(BgpNeighbor actual) {
+    protected Long featureValueOf(BgpPeerConfig actual) {
       return actual.getRemoteAs();
     }
   }
 
-  static final class IsDynamic extends FeatureMatcher<BgpNeighbor, Boolean> {
+  static final class IsDynamic extends FeatureMatcher<BgpPeerConfig, Boolean> {
     IsDynamic(@Nonnull Matcher<? super Boolean> subMatcher) {
-      super(subMatcher, "A BgpNeighbor with dynamic set to:", "dynamic");
+      super(subMatcher, "A BgpPeerConfig with dynamic set to:", "dynamic");
     }
 
     @Override
-    protected Boolean featureValueOf(BgpNeighbor actual) {
+    protected Boolean featureValueOf(BgpPeerConfig actual) {
       return actual.getDynamic();
     }
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpProcessMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpProcessMatchers.java
@@ -4,7 +4,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 import java.util.Map;
 import javax.annotation.Nonnull;
-import org.batfish.datamodel.BgpNeighbor;
+import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.MultipathEquivalentAsPathMatchMode;
@@ -66,7 +66,7 @@ public class BgpProcessMatchers {
    * neighbor with specified prefix.
    */
   public static HasNeighbor hasNeighbor(
-      @Nonnull Prefix prefix, @Nonnull Matcher<? super BgpNeighbor> subMatcher) {
+      @Nonnull Prefix prefix, @Nonnull Matcher<? super BgpPeerConfig> subMatcher) {
     return new HasNeighbor(prefix, subMatcher);
   }
 
@@ -75,7 +75,7 @@ public class BgpProcessMatchers {
    * neighbors.
    */
   public static HasNeighbors hasNeighbors(
-      @Nonnull Matcher<? super Map<Prefix, BgpNeighbor>> subMatcher) {
+      @Nonnull Matcher<? super Map<Prefix, BgpPeerConfig>> subMatcher) {
     return new HasNeighbors(subMatcher);
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpProcessMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpProcessMatchersImpl.java
@@ -2,7 +2,7 @@ package org.batfish.datamodel.matchers;
 
 import java.util.Map;
 import javax.annotation.Nonnull;
-import org.batfish.datamodel.BgpNeighbor;
+import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.MultipathEquivalentAsPathMatchMode;
@@ -34,27 +34,27 @@ final class BgpProcessMatchersImpl {
     }
   }
 
-  static final class HasNeighbor extends FeatureMatcher<BgpProcess, BgpNeighbor> {
+  static final class HasNeighbor extends FeatureMatcher<BgpProcess, BgpPeerConfig> {
     private final Prefix _prefix;
 
-    HasNeighbor(@Nonnull Prefix prefix, @Nonnull Matcher<? super BgpNeighbor> subMatcher) {
+    HasNeighbor(@Nonnull Prefix prefix, @Nonnull Matcher<? super BgpPeerConfig> subMatcher) {
       super(subMatcher, "A BGP process with neighbor " + prefix + ":", "neighbor " + prefix);
       _prefix = prefix;
     }
 
     @Override
-    protected BgpNeighbor featureValueOf(BgpProcess actual) {
+    protected BgpPeerConfig featureValueOf(BgpProcess actual) {
       return actual.getNeighbors().get(_prefix);
     }
   }
 
-  static final class HasNeighbors extends FeatureMatcher<BgpProcess, Map<Prefix, BgpNeighbor>> {
-    HasNeighbors(@Nonnull Matcher<? super Map<Prefix, BgpNeighbor>> subMatcher) {
+  static final class HasNeighbors extends FeatureMatcher<BgpProcess, Map<Prefix, BgpPeerConfig>> {
+    HasNeighbors(@Nonnull Matcher<? super Map<Prefix, BgpPeerConfig>> subMatcher) {
       super(subMatcher, "A BGP process with neighbors:", "neighbors");
     }
 
     @Override
-    protected Map<Prefix, BgpNeighbor> featureValueOf(BgpProcess actual) {
+    protected Map<Prefix, BgpPeerConfig> featureValueOf(BgpProcess actual) {
       return actual.getNeighbors();
     }
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/DataModelMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/DataModelMatchers.java
@@ -8,7 +8,7 @@ import java.util.Set;
 import java.util.SortedSet;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.batfish.datamodel.BgpNeighbor;
+import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Interface;
@@ -412,10 +412,10 @@ public final class DataModelMatchers {
   }
 
   /**
-   * Provides a matcher that matches if the {@link BgpNeighbor} is configured as a listening end of
-   * a dynamic BGP peering.
+   * Provides a matcher that matches if the {@link BgpPeerConfig} is configured as a listening end
+   * of a dynamic BGP peering.
    */
-  public static @Nonnull Matcher<BgpNeighbor> isDynamic() {
+  public static @Nonnull Matcher<BgpPeerConfig> isDynamic() {
     return new IsDynamic(equalTo(true));
   }
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -31,7 +31,7 @@ import org.batfish.common.Version;
 import org.batfish.common.plugin.DataPlanePlugin.ComputeDataPlaneResult;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.BgpAdvertisement;
-import org.batfish.datamodel.BgpNeighbor;
+import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.BgpRoute;
 import org.batfish.datamodel.BgpSession;
@@ -105,7 +105,7 @@ class IncrementalBdpEngine {
 
     IncrementalDataPlane dp = dpBuilder.build();
 
-    Network<BgpNeighbor, BgpSession> bgpTopology =
+    Network<BgpPeerConfig, BgpSession> bgpTopology =
         initBgpTopology(
             configurations, ipOwners, false, true, TracerouteEngineImpl.getInstance(), dp);
 
@@ -129,7 +129,7 @@ class IncrementalBdpEngine {
           initBgpTopology(
               configurations, ipOwners, false, true, TracerouteEngineImpl.getInstance(), dp);
       // Update queues (if necessary) based on new neighbor relationships
-      final Network<BgpNeighbor, BgpSession> finalBgpTopology = bgpTopology;
+      final Network<BgpPeerConfig, BgpSession> finalBgpTopology = bgpTopology;
       nodes
           .values()
           .parallelStream()
@@ -198,7 +198,7 @@ class IncrementalBdpEngine {
       Topology topology,
       int iteration,
       Map<String, Node> allNodes,
-      Network<BgpNeighbor, BgpSession> bgpTopology) {
+      Network<BgpPeerConfig, BgpSession> bgpTopology) {
 
     // (Re)initialization of dependent route calculation
     nodes
@@ -324,7 +324,7 @@ class IncrementalBdpEngine {
       Map<String, Node> nodes,
       int iteration,
       Map<String, Node> allNodes,
-      Network<BgpNeighbor, BgpSession> bgpTopology) {
+      Network<BgpPeerConfig, BgpSession> bgpTopology) {
     // BGP routes
     // first let's initialize nodes-level generated/aggregate routes
     nodes
@@ -456,7 +456,7 @@ class IncrementalBdpEngine {
       Set<BgpAdvertisement> externalAdverts,
       IncrementalBdpAnswerElement ae,
       boolean firstPass,
-      Network<BgpNeighbor, BgpSession> bgpTopology,
+      Network<BgpPeerConfig, BgpSession> bgpTopology,
       Network<IsisNode, IsisEdge> isisTopology) {
 
     /*
@@ -600,7 +600,7 @@ class IncrementalBdpEngine {
    * @return true iff all queues are empty
    */
   private boolean areQueuesEmpty(
-      Map<String, Node> nodes, Network<BgpNeighbor, BgpSession> bgpTopology) {
+      Map<String, Node> nodes, Network<BgpPeerConfig, BgpSession> bgpTopology) {
     AtomicInteger computeQueuesAreEmpty =
         _newBatch.apply("Check for convergence (are queues empty?)", nodes.size());
     AtomicBoolean areEmpty = new AtomicBoolean(true);

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlane.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlane.java
@@ -14,7 +14,7 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
 import org.batfish.datamodel.AbstractRoute;
-import org.batfish.datamodel.BgpNeighbor;
+import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpSession;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DataPlane;
@@ -33,7 +33,7 @@ public final class IncrementalDataPlane implements Serializable, DataPlane {
 
   public static class Builder {
 
-    private Network<BgpNeighbor, BgpSession> _bgpTopology;
+    private Network<BgpPeerConfig, BgpSession> _bgpTopology;
 
     private Map<Ip, Set<String>> _ipOwners;
 
@@ -45,7 +45,7 @@ public final class IncrementalDataPlane implements Serializable, DataPlane {
 
     private Topology _topology;
 
-    public Builder setBgpTopology(Network<BgpNeighbor, BgpSession> bgpTopology) {
+    public Builder setBgpTopology(Network<BgpPeerConfig, BgpSession> bgpTopology) {
       _bgpTopology = bgpTopology;
       return this;
     }
@@ -117,7 +117,7 @@ public final class IncrementalDataPlane implements Serializable, DataPlane {
     return new Builder();
   }
 
-  private final transient Network<BgpNeighbor, BgpSession> _bgpTopology;
+  private final transient Network<BgpPeerConfig, BgpSession> _bgpTopology;
 
   private final Supplier<Map<String, Configuration>> _configurations =
       Suppliers.memoize(new ConfigurationsSupplier());
@@ -183,7 +183,7 @@ public final class IncrementalDataPlane implements Serializable, DataPlane {
   }
 
   @Override
-  public Network<BgpNeighbor, BgpSession> getBgpTopology() {
+  public Network<BgpPeerConfig, BgpSession> getBgpTopology() {
     return _bgpTopology;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/UndirectedBgpSession.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/UndirectedBgpSession.java
@@ -3,7 +3,7 @@ package org.batfish.dataplane.ibdp;
 import java.util.Comparator;
 import java.util.Objects;
 import javax.annotation.Nonnull;
-import org.batfish.datamodel.BgpNeighbor;
+import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpSession;
 
 /**
@@ -11,17 +11,17 @@ import org.batfish.datamodel.BgpSession;
  * {@link UndirectedBgpSession} is immutable.
  */
 public class UndirectedBgpSession implements Comparable<UndirectedBgpSession> {
-  @Nonnull private final BgpNeighbor _first;
-  @Nonnull private final BgpNeighbor _second;
+  @Nonnull private final BgpPeerConfig _first;
+  @Nonnull private final BgpPeerConfig _second;
 
   /**
    * Compare BGP neighbors using prefix and hostname. This comparator is **NOT** consistent with
    * equals
    */
-  private static final Comparator<BgpNeighbor> COMPARATOR =
-      Comparator.comparing(BgpNeighbor::getPrefix).thenComparing(BgpNeighbor::getOwner);
+  private static final Comparator<BgpPeerConfig> COMPARATOR =
+      Comparator.comparing(BgpPeerConfig::getPrefix).thenComparing(BgpPeerConfig::getOwner);
 
-  UndirectedBgpSession(@Nonnull BgpNeighbor n1, @Nonnull BgpNeighbor n2) {
+  UndirectedBgpSession(@Nonnull BgpPeerConfig n1, @Nonnull BgpPeerConfig n2) {
     if (COMPARATOR.compare(n1, n2) < 0) {
       _first = n1;
       _second = n2;
@@ -32,12 +32,12 @@ public class UndirectedBgpSession implements Comparable<UndirectedBgpSession> {
   }
 
   @Nonnull
-  public BgpNeighbor getFirst() {
+  public BgpPeerConfig getFirst() {
     return _first;
   }
 
   @Nonnull
-  public BgpNeighbor getSecond() {
+  public BgpPeerConfig getSecond() {
     return _second;
   }
 
@@ -77,7 +77,7 @@ public class UndirectedBgpSession implements Comparable<UndirectedBgpSession> {
     return new UndirectedBgpSession(session.getSrc(), session.getDst());
   }
 
-  public static UndirectedBgpSession from(@Nonnull BgpNeighbor n1, @Nonnull BgpNeighbor n2) {
+  public static UndirectedBgpSession from(@Nonnull BgpPeerConfig n1, @Nonnull BgpPeerConfig n2) {
     return new UndirectedBgpSession(n1, n2);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/schedule/IbdpSchedule.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/schedule/IbdpSchedule.java
@@ -7,7 +7,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import org.batfish.common.BatfishException;
-import org.batfish.datamodel.BgpNeighbor;
+import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpSession;
 import org.batfish.dataplane.ibdp.IncrementalDataPlaneSettings;
 import org.batfish.dataplane.ibdp.Node;
@@ -78,7 +78,7 @@ public abstract class IbdpSchedule implements Iterator<Map<String, Node>> {
   public static IbdpSchedule getSchedule(
       IncrementalDataPlaneSettings settings,
       Map<String, Node> allNodes,
-      Network<BgpNeighbor, BgpSession> bgpTopology) {
+      Network<BgpPeerConfig, BgpSession> bgpTopology) {
     Schedule schedule = settings.getScheduleName();
     switch (schedule) {
       case ALL:

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/schedule/NodeColoredSchedule.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/schedule/NodeColoredSchedule.java
@@ -7,7 +7,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.batfish.datamodel.BgpNeighbor;
+import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpSession;
 import org.batfish.dataplane.ibdp.Node;
 import org.jgrapht.Graph;
@@ -37,7 +37,7 @@ public class NodeColoredSchedule extends IbdpSchedule {
    * @param bgpTopology the bgp peering relationships
    */
   public NodeColoredSchedule(
-      Map<String, Node> nodes, Coloring algorithm, Network<BgpNeighbor, BgpSession> bgpTopology) {
+      Map<String, Node> nodes, Coloring algorithm, Network<BgpPeerConfig, BgpSession> bgpTopology) {
     super(nodes);
     makeGraph(nodes, bgpTopology);
 
@@ -74,7 +74,7 @@ public class NodeColoredSchedule extends IbdpSchedule {
    *
    * @param nodes all nodes in the network
    */
-  private void makeGraph(Map<String, Node> nodes, Network<BgpNeighbor, BgpSession> bgpTopology) {
+  private void makeGraph(Map<String, Node> nodes, Network<BgpPeerConfig, BgpSession> bgpTopology) {
     /*
      * For the purposes of coloring, two nodes are adjacent if:
      * - They have established a BGP session

--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
@@ -6,7 +6,7 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.AbstractRoute;
-import org.batfish.datamodel.BgpNeighbor;
+import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpRoute;
 import org.batfish.datamodel.GeneratedRoute;
 import org.batfish.datamodel.InterfaceAddress;
@@ -26,7 +26,11 @@ public class BgpProtocolHelper {
    */
   @Nullable
   public static BgpRoute.Builder transformBgpRouteOnExport(
-      BgpNeighbor fromNeighbor, BgpNeighbor toNeighbor, Vrf fromVrf, Vrf toVrf, AbstractRoute route)
+      BgpPeerConfig fromNeighbor,
+      BgpPeerConfig toNeighbor,
+      Vrf fromVrf,
+      Vrf toVrf,
+      AbstractRoute route)
       throws BgpRoutePropagationException {
 
     BgpRoute.Builder transformedOutgoingRouteBuilder = new BgpRoute.Builder();
@@ -101,7 +105,7 @@ public class BgpProtocolHelper {
         if (!remoteRouteOriginatedByRemoteNeighbor) {
           // we are reflecting, so we need to get the clusterid associated with the
           // remoteRoute
-          BgpNeighbor remoteReceivedFromSession =
+          BgpPeerConfig remoteReceivedFromSession =
               fromVrf
                   .getBgpProcess()
                   .getNeighbors()
@@ -175,7 +179,7 @@ public class BgpProtocolHelper {
   /** Perform BGP import transformations on a given route after receiving an advertisement */
   @Nullable
   public static BgpRoute.Builder transformBgpRouteOnImport(
-      BgpNeighbor fromNeighbor, BgpNeighbor toNeighbor, BgpRoute route) {
+      BgpPeerConfig fromNeighbor, BgpPeerConfig toNeighbor, BgpRoute route) {
 
     if (route.getAsPath().containsAs(toNeighbor.getLocalAs()) && !toNeighbor.getAllowLocalAsIn()) {
       // skip routes containing peer's AS unless

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -1436,7 +1436,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
     // if (!config.getRoles().contains(inputRole)) {
     // continue;
     // }
-    // for (BgpNeighbor neighbor : config.getBgpProcess().getNeighbors()
+    // for (BgpPeerConfig neighbor : config.getBgpProcess().getNeighbors()
     // .values()) {
     // if (!neighbor.getRemoteAs().equals(stubAs)) {
     // continue;
@@ -1523,7 +1523,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
     // stubInterface.setBandwidth(10E9d);
     //
     // // create neighbor within bgp process
-    // BgpNeighbor edgeNeighbor = new BgpNeighbor(prefix, stub);
+    // BgpPeerConfig edgeNeighbor = new BgpPeerConfig(prefix, stub);
     // edgeNeighbor.getOriginationPolicies()
     // .add(stubOriginationPolicy);
     // edgeNeighbor.setRemoteAs(edgeAs);

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/VpnConnection.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/VpnConnection.java
@@ -12,7 +12,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.batfish.common.BatfishException;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.Warnings;
-import org.batfish.datamodel.BgpNeighbor;
+import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DiffieHellmanGroup;
@@ -281,15 +281,15 @@ public class VpnConnection implements AwsVpcEntity, Serializable {
           proc.setMultipathEquivalentAsPathMatchMode(MultipathEquivalentAsPathMatchMode.EXACT_PATH);
           vpnGatewayCfgNode.getDefaultVrf().setBgpProcess(proc);
         }
-        BgpNeighbor cgBgpNeighbor =
-            new BgpNeighbor(ipsecTunnel.getCgwInsideAddress(), vpnGatewayCfgNode, false);
-        cgBgpNeighbor.setVrf(Configuration.DEFAULT_VRF_NAME);
-        proc.getNeighbors().put(cgBgpNeighbor.getPrefix(), cgBgpNeighbor);
-        cgBgpNeighbor.setRemoteAs(ipsecTunnel.getCgwBgpAsn());
-        cgBgpNeighbor.setLocalAs(ipsecTunnel.getVgwBgpAsn());
-        cgBgpNeighbor.setLocalIp(ipsecTunnel.getVgwInsideAddress());
-        cgBgpNeighbor.setDefaultMetric(BGP_NEIGHBOR_DEFAULT_METRIC);
-        cgBgpNeighbor.setSendCommunity(false);
+        BgpPeerConfig cgBgpPeerConfig =
+            new BgpPeerConfig(ipsecTunnel.getCgwInsideAddress(), vpnGatewayCfgNode, false);
+        cgBgpPeerConfig.setVrf(Configuration.DEFAULT_VRF_NAME);
+        proc.getNeighbors().put(cgBgpPeerConfig.getPrefix(), cgBgpPeerConfig);
+        cgBgpPeerConfig.setRemoteAs(ipsecTunnel.getCgwBgpAsn());
+        cgBgpPeerConfig.setLocalAs(ipsecTunnel.getVgwBgpAsn());
+        cgBgpPeerConfig.setLocalIp(ipsecTunnel.getVgwInsideAddress());
+        cgBgpPeerConfig.setDefaultMetric(BGP_NEIGHBOR_DEFAULT_METRIC);
+        cgBgpPeerConfig.setSendCommunity(false);
 
         VpnGateway vpnGateway = region.getVpnGateways().get(_vpnGatewayId);
         List<String> attachmentVpcIds = vpnGateway.getAttachmentVpcIds();
@@ -307,30 +307,31 @@ public class VpnConnection implements AwsVpcEntity, Serializable {
         Configuration vpcNode = awsConfiguration.getConfigurationNodes().get(vpcId);
         Ip vpcIfaceAddress = vpcNode.getInterfaces().get(_vpnGatewayId).getAddress().getIp();
         Ip vgwToVpcIfaceAddress = vpnGatewayCfgNode.getInterfaces().get(vpcId).getAddress().getIp();
-        BgpNeighbor vgwToVpcBgpNeighbor =
-            new BgpNeighbor(vpcIfaceAddress, vpnGatewayCfgNode, false);
-        proc.getNeighbors().put(vgwToVpcBgpNeighbor.getPrefix(), vgwToVpcBgpNeighbor);
-        vgwToVpcBgpNeighbor.setVrf(Configuration.DEFAULT_VRF_NAME);
-        vgwToVpcBgpNeighbor.setLocalAs(ipsecTunnel.getVgwBgpAsn());
-        vgwToVpcBgpNeighbor.setLocalIp(vgwToVpcIfaceAddress);
-        vgwToVpcBgpNeighbor.setRemoteAs(ipsecTunnel.getVgwBgpAsn());
-        vgwToVpcBgpNeighbor.setDefaultMetric(BGP_NEIGHBOR_DEFAULT_METRIC);
-        vgwToVpcBgpNeighbor.setSendCommunity(true);
+        BgpPeerConfig vgwToVpcBgpPeerConfig =
+            new BgpPeerConfig(vpcIfaceAddress, vpnGatewayCfgNode, false);
+        proc.getNeighbors().put(vgwToVpcBgpPeerConfig.getPrefix(), vgwToVpcBgpPeerConfig);
+        vgwToVpcBgpPeerConfig.setVrf(Configuration.DEFAULT_VRF_NAME);
+        vgwToVpcBgpPeerConfig.setLocalAs(ipsecTunnel.getVgwBgpAsn());
+        vgwToVpcBgpPeerConfig.setLocalIp(vgwToVpcIfaceAddress);
+        vgwToVpcBgpPeerConfig.setRemoteAs(ipsecTunnel.getVgwBgpAsn());
+        vgwToVpcBgpPeerConfig.setDefaultMetric(BGP_NEIGHBOR_DEFAULT_METRIC);
+        vgwToVpcBgpPeerConfig.setSendCommunity(true);
 
         // iBGP connection from VPC
-        BgpNeighbor vpcToVgwBgpNeighbor = new BgpNeighbor(vgwToVpcIfaceAddress, vpcNode, false);
+        BgpPeerConfig vpcToVgwBgpPeerConfig =
+            new BgpPeerConfig(vgwToVpcIfaceAddress, vpcNode, false);
         BgpProcess vpcProc = new BgpProcess();
         vpcNode.getDefaultVrf().setBgpProcess(vpcProc);
         vpcProc.setMultipathEquivalentAsPathMatchMode(
             MultipathEquivalentAsPathMatchMode.EXACT_PATH);
         vpcProc.setRouterId(vpcIfaceAddress);
-        vpcProc.getNeighbors().put(vpcToVgwBgpNeighbor.getPrefix(), vpcToVgwBgpNeighbor);
-        vpcToVgwBgpNeighbor.setVrf(Configuration.DEFAULT_VRF_NAME);
-        vpcToVgwBgpNeighbor.setLocalAs(ipsecTunnel.getVgwBgpAsn());
-        vpcToVgwBgpNeighbor.setLocalIp(vpcIfaceAddress);
-        vpcToVgwBgpNeighbor.setRemoteAs(ipsecTunnel.getVgwBgpAsn());
-        vpcToVgwBgpNeighbor.setDefaultMetric(BGP_NEIGHBOR_DEFAULT_METRIC);
-        vpcToVgwBgpNeighbor.setSendCommunity(true);
+        vpcProc.getNeighbors().put(vpcToVgwBgpPeerConfig.getPrefix(), vpcToVgwBgpPeerConfig);
+        vpcToVgwBgpPeerConfig.setVrf(Configuration.DEFAULT_VRF_NAME);
+        vpcToVgwBgpPeerConfig.setLocalAs(ipsecTunnel.getVgwBgpAsn());
+        vpcToVgwBgpPeerConfig.setLocalIp(vpcIfaceAddress);
+        vpcToVgwBgpPeerConfig.setRemoteAs(ipsecTunnel.getVgwBgpAsn());
+        vpcToVgwBgpPeerConfig.setDefaultMetric(BGP_NEIGHBOR_DEFAULT_METRIC);
+        vpcToVgwBgpPeerConfig.setSendCommunity(true);
 
         String rpRejectAllName = "~REJECT_ALL~";
 
@@ -346,26 +347,26 @@ public class VpnConnection implements AwsVpcEntity, Serializable {
         vpnGatewayCfgNode.getRoutingPolicies().put(vgwRpAcceptAllBgp.getName(), vgwRpAcceptAllBgp);
         vgwRpAcceptAllBgp.setStatements(
             ImmutableList.of(new SetNextHop(SelfNextHop.getInstance(), false), acceptIffEbgp));
-        vgwToVpcBgpNeighbor.setExportPolicy(rpAcceptAllEbgpAndSetNextHopSelfName);
+        vgwToVpcBgpPeerConfig.setExportPolicy(rpAcceptAllEbgpAndSetNextHopSelfName);
         RoutingPolicy vgwRpRejectAll = new RoutingPolicy(rpRejectAllName, vpnGatewayCfgNode);
         vpnGatewayCfgNode.getRoutingPolicies().put(rpRejectAllName, vgwRpRejectAll);
-        vgwToVpcBgpNeighbor.setImportPolicy(rpRejectAllName);
+        vgwToVpcBgpPeerConfig.setImportPolicy(rpRejectAllName);
 
         String rpAcceptAllName = "~ACCEPT_ALL~";
         RoutingPolicy vpcRpAcceptAll = new RoutingPolicy(rpAcceptAllName, vpcNode);
         vpcNode.getRoutingPolicies().put(rpAcceptAllName, vpcRpAcceptAll);
         vpcRpAcceptAll.setStatements(ImmutableList.of(Statements.ExitAccept.toStaticStatement()));
-        vpcToVgwBgpNeighbor.setImportPolicy(rpAcceptAllName);
+        vpcToVgwBgpPeerConfig.setImportPolicy(rpAcceptAllName);
         RoutingPolicy vpcRpRejectAll = new RoutingPolicy(rpRejectAllName, vpcNode);
         vpcNode.getRoutingPolicies().put(rpRejectAllName, vpcRpRejectAll);
-        vpcToVgwBgpNeighbor.setExportPolicy(rpRejectAllName);
+        vpcToVgwBgpPeerConfig.setExportPolicy(rpRejectAllName);
 
         Vpc vpc = region.getVpcs().get(vpcId);
         String originationPolicyName = vpnId + "_origination";
         RoutingPolicy originationRoutingPolicy =
             new RoutingPolicy(originationPolicyName, vpnGatewayCfgNode);
         vpnGatewayCfgNode.getRoutingPolicies().put(originationPolicyName, originationRoutingPolicy);
-        cgBgpNeighbor.setExportPolicy(originationPolicyName);
+        cgBgpPeerConfig.setExportPolicy(originationPolicyName);
         If originationIf = new If();
         List<Statement> statements = originationRoutingPolicy.getStatements();
         statements.add(originationIf);

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoNxConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoNxConversions.java
@@ -20,7 +20,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.common.Warnings;
-import org.batfish.datamodel.BgpNeighbor;
+import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.GeneratedRoute;
@@ -148,7 +148,7 @@ final class CiscoNxConversions {
   }
 
   @Nonnull
-  static Map<Ip, BgpNeighbor> getNeighbors(
+  static Map<Ip, BgpPeerConfig> getNeighbors(
       Configuration c,
       Vrf vrf,
       BgpProcess proc,
@@ -178,7 +178,7 @@ final class CiscoNxConversions {
   }
 
   @Nonnull
-  static Map<Prefix, BgpNeighbor> getPassiveNeighbors(
+  static Map<Prefix, BgpPeerConfig> getPassiveNeighbors(
       Configuration c,
       Vrf vrf,
       BgpProcess proc,
@@ -258,7 +258,7 @@ final class CiscoNxConversions {
   }
 
   @Nonnull
-  private static BgpNeighbor toBgpNeighbor(
+  private static BgpPeerConfig toBgpNeighbor(
       Configuration c,
       Vrf vrf,
       BgpProcess proc,
@@ -268,7 +268,7 @@ final class CiscoNxConversions {
       CiscoNxBgpVrfNeighborConfiguration neighbor,
       boolean dynamic,
       Warnings warnings) {
-    BgpNeighbor newNeighbor = new BgpNeighbor(prefix, c, dynamic);
+    BgpPeerConfig newNeighbor = new BgpPeerConfig(prefix, c, dynamic);
 
     newNeighbor.setClusterId(firstNonNull(vrfConfig.getClusterId(), proc.getRouterId()).asLong());
 

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -32,7 +32,7 @@ import org.batfish.datamodel.AuthenticationKey;
 import org.batfish.datamodel.AuthenticationKeyChain;
 import org.batfish.datamodel.BgpAuthenticationAlgorithm;
 import org.batfish.datamodel.BgpAuthenticationSettings;
-import org.batfish.datamodel.BgpNeighbor;
+import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
@@ -319,7 +319,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
     for (Entry<Prefix, IpBgpGroup> e : routingInstance.getIpBgpGroups().entrySet()) {
       Prefix prefix = e.getKey();
       IpBgpGroup ig = e.getValue();
-      BgpNeighbor neighbor = new BgpNeighbor(prefix, _c, ig.getDynamic());
+      BgpPeerConfig neighbor = new BgpPeerConfig(prefix, _c, ig.getDynamic());
       neighbor.setVrf(vrfName);
 
       // route reflection

--- a/projects/batfish/src/main/java/org/batfish/symbolic/abstraction/AbstractionBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/abstraction/AbstractionBuilder.java
@@ -15,7 +15,7 @@ import java.util.Stack;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import org.batfish.common.plugin.IBatfish;
-import org.batfish.datamodel.BgpNeighbor;
+import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.HeaderSpace;
@@ -470,7 +470,7 @@ class AbstractionBuilder {
 
     SortedSet<Interface> toRetain = new TreeSet<>();
     SortedSet<IpLink> ipNeighbors = new TreeSet<>();
-    SortedSet<BgpNeighbor> bgpNeighbors = new TreeSet<>();
+    SortedSet<BgpPeerConfig> bgpPeerConfigs = new TreeSet<>();
 
     List<GraphEdge> edges = _graph.getEdgeMap().get(conf.getName());
     for (GraphEdge ge : edges) {
@@ -483,9 +483,9 @@ class AbstractionBuilder {
           Ip end = ge.getEnd().getAddress().getIp();
           ipNeighbors.add(new IpLink(start, end));
         }
-        BgpNeighbor n = _graph.getEbgpNeighbors().get(ge);
+        BgpPeerConfig n = _graph.getEbgpNeighbors().get(ge);
         if (n != null) {
-          bgpNeighbors.add(n);
+          bgpPeerConfigs.add(n);
         }
       }
     }
@@ -554,12 +554,12 @@ class AbstractionBuilder {
         abstractBgp.setOriginationSpace(bgp.getOriginationSpace());
         // TODO: set bgp neighbors accordingly
         // Copy over neighbors
-        SortedMap<Prefix, BgpNeighbor> abstractBgpNeighbors = new TreeMap<>();
+        SortedMap<Prefix, BgpPeerConfig> abstractBgpNeighbors = new TreeMap<>();
         if (bgp.getNeighbors() != null) {
-          for (Entry<Prefix, BgpNeighbor> entry2 : bgp.getNeighbors().entrySet()) {
+          for (Entry<Prefix, BgpPeerConfig> entry2 : bgp.getNeighbors().entrySet()) {
             Prefix prefix = entry2.getKey();
-            BgpNeighbor neighbor = entry2.getValue();
-            if (bgpNeighbors.contains(neighbor)) {
+            BgpPeerConfig neighbor = entry2.getValue();
+            if (bgpPeerConfigs.contains(neighbor)) {
               abstractBgpNeighbors.put(prefix, neighbor);
             }
           }

--- a/projects/batfish/src/main/java/org/batfish/symbolic/abstraction/BatfishCompressor.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/abstraction/BatfishCompressor.java
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.common.plugin.IBatfish;
-import org.batfish.datamodel.BgpNeighbor;
+import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.IpWildcard;
@@ -143,9 +143,9 @@ public class BatfishCompressor {
 
   private String internalRegex() {
     StringBuilder matchInternal = new StringBuilder("(,|\\\\{|\\\\}|^|\\$| )(");
-    Collection<BgpNeighbor> neighbors = _graph.getEbgpNeighbors().values();
+    Collection<BgpPeerConfig> neighbors = _graph.getEbgpNeighbors().values();
     Set<Long> allAsns = new HashSet<>();
-    for (BgpNeighbor n : neighbors) {
+    for (BgpPeerConfig n : neighbors) {
       Long asn = n.getLocalAs();
       allAsns.add(asn);
     }

--- a/projects/batfish/src/main/java/org/batfish/symbolic/smt/CounterExample.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/smt/CounterExample.java
@@ -19,7 +19,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.batfish.datamodel.AsPath;
 import org.batfish.datamodel.BgpAdvertisement;
 import org.batfish.datamodel.BgpAdvertisement.BgpAdvertisementType;
-import org.batfish.datamodel.BgpNeighbor;
+import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.Edge;
 import org.batfish.datamodel.FilterResult;
 import org.batfish.datamodel.Flow;
@@ -171,7 +171,7 @@ class CounterExample {
           int pathLength = intVal(r.getMetric());
 
           // Create dummy information
-          BgpNeighbor n = slice.getGraph().getEbgpNeighbors().get(lge.getEdge());
+          BgpPeerConfig n = slice.getGraph().getEbgpNeighbors().get(lge.getEdge());
           String srcNode = "as" + n.getRemoteAs();
           Ip zeroIp = new Ip(0);
           Ip dstIp = n.getLocalIp();

--- a/projects/batfish/src/main/java/org/batfish/symbolic/smt/Encoder.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/smt/Encoder.java
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
 import org.batfish.common.BatfishException;
 import org.batfish.common.Pair;
 import org.batfish.config.Settings;
-import org.batfish.datamodel.BgpNeighbor;
+import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
@@ -239,9 +239,9 @@ public class Encoder {
     if (_modelIgp) {
       SortedSet<Pair<String, Ip>> ibgpRouters = new TreeSet<>();
 
-      for (Entry<GraphEdge, BgpNeighbor> entry : g.getIbgpNeighbors().entrySet()) {
+      for (Entry<GraphEdge, BgpPeerConfig> entry : g.getIbgpNeighbors().entrySet()) {
         GraphEdge ge = entry.getKey();
-        BgpNeighbor n = entry.getValue();
+        BgpPeerConfig n = entry.getValue();
         String router = ge.getRouter();
         Ip ip = n.getLocalIp();
         Pair<String, Ip> pair = new Pair<>(router, ip);

--- a/projects/batfish/src/main/java/org/batfish/symbolic/smt/EncoderSlice.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/smt/EncoderSlice.java
@@ -17,7 +17,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import javax.annotation.Nullable;
-import org.batfish.datamodel.BgpNeighbor;
+import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Interface;
@@ -820,7 +820,7 @@ class EncoderSlice {
             for (LogicalEdge e : eList) {
               if (e.getEdgeType() == EdgeType.IMPORT) {
                 GraphEdge ge = e.getEdge();
-                BgpNeighbor n = getGraph().getEbgpNeighbors().get(ge);
+                BgpPeerConfig n = getGraph().getEbgpNeighbors().get(ge);
                 if (n != null && ge.getEnd() == null) {
 
                   if (!isMainSlice()) {

--- a/projects/batfish/src/main/java/org/batfish/symbolic/smt/Optimizations.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/smt/Optimizations.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.batfish.common.BatfishException;
-import org.batfish.datamodel.BgpNeighbor;
+import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.GeneratedRoute;
@@ -408,8 +408,8 @@ class Optimizations {
 
                   boolean acc = true;
                   BgpProcess p = conf.getDefaultVrf().getBgpProcess();
-                  for (Map.Entry<Prefix, BgpNeighbor> e : p.getNeighbors().entrySet()) {
-                    BgpNeighbor n = e.getValue();
+                  for (Map.Entry<Prefix, BgpPeerConfig> e : p.getNeighbors().entrySet()) {
+                    BgpPeerConfig n = e.getValue();
                     // If iBGP used, then don't merge
                     if (n.getLocalAs().equals(n.getRemoteAs())) {
                       acc = false;
@@ -537,7 +537,7 @@ class Optimizations {
   /*
    * Determine if a BGP neighbor uses the default export policy
    */
-  private boolean isDefaultBgpExport(Configuration conf, BgpNeighbor n) {
+  private boolean isDefaultBgpExport(Configuration conf, BgpPeerConfig n) {
 
     // Check if valid neighbor
     if (n == null || n.getExportPolicy() == null) {

--- a/projects/batfish/src/main/java/org/batfish/symbolic/smt/TransferSSA.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/smt/TransferSSA.java
@@ -13,7 +13,7 @@ import java.util.Map;
 import java.util.Set;
 import org.batfish.common.BatfishException;
 import org.batfish.common.Pair;
-import org.batfish.datamodel.BgpNeighbor;
+import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.CommunityList;
 import org.batfish.datamodel.CommunityListLine;
 import org.batfish.datamodel.Configuration;
@@ -645,10 +645,10 @@ class TransferSSA {
   }
 
   /*
-   * Get the BgpNeighbor object given the current
+   * Get the BgpPeerConfig object given the current
    * graph edge and protocol information
    */
-  private BgpNeighbor getBgpNeighbor() {
+  private BgpPeerConfig getBgpNeighbor() {
     Graph g = _enc.getGraph();
     if (_graphEdge.isAbstract()) {
       return g.getIbgpNeighbors().get(_graphEdge);
@@ -666,7 +666,7 @@ class TransferSSA {
       if (!_isExport) {
         return true;
       }
-      BgpNeighbor n = getBgpNeighbor();
+      BgpPeerConfig n = getBgpNeighbor();
       return n.getSendCommunity();
     } else {
       return false;

--- a/projects/batfish/src/test/java/org/batfish/dataplane/DynamicBgpTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/DynamicBgpTest.java
@@ -11,7 +11,7 @@ import com.google.common.graph.Network;
 import java.io.IOException;
 import java.util.List;
 import org.batfish.datamodel.AbstractRoute;
-import org.batfish.datamodel.BgpNeighbor;
+import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpSession;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DataPlane;
@@ -55,7 +55,7 @@ public class DynamicBgpTest {
 
     batfish.computeDataPlane(false); // compute and cache the dataPlane
     DataPlane dp = batfish.loadDataPlane();
-    Network<BgpNeighbor, BgpSession> bgpTopology = dp.getBgpTopology();
+    Network<BgpPeerConfig, BgpSession> bgpTopology = dp.getBgpTopology();
 
     /*
      * Check peering edges. r1 <---> r2 has two edges, one in each direction. r2<--r3 and r2<--r4
@@ -87,7 +87,7 @@ public class DynamicBgpTest {
     batfish.computeDataPlane(false); // compute and cache the dataPlane
 
     DataPlane dp = batfish.loadDataPlane();
-    Network<BgpNeighbor, BgpSession> bgpTopology = dp.getBgpTopology();
+    Network<BgpPeerConfig, BgpSession> bgpTopology = dp.getBgpTopology();
 
     /*
      * Check peering edges. r1 <---> r2 has two edges, one in each direction. r2<--r3 and r2<--r4
@@ -130,7 +130,7 @@ public class DynamicBgpTest {
     batfish.computeDataPlane(false); // compute and cache the dataPlane
 
     DataPlane dp = batfish.loadDataPlane();
-    Network<BgpNeighbor, BgpSession> bgpTopology = dp.getBgpTopology();
+    Network<BgpPeerConfig, BgpSession> bgpTopology = dp.getBgpTopology();
 
     /*
      * Check peering edges. r1 <---> r2 has two edges, one in each direction. r2<--r3 valid

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePluginTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePluginTest.java
@@ -37,7 +37,7 @@ import org.batfish.common.plugin.DataPlanePlugin;
 import org.batfish.common.plugin.DataPlanePlugin.ComputeDataPlaneResult;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.AsPath;
-import org.batfish.datamodel.BgpNeighbor;
+import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.BgpRoute;
 import org.batfish.datamodel.BgpSession;
@@ -86,7 +86,7 @@ public class IncrementalDataPlanePluginTest {
   private NetworkFactory _nf;
   private Configuration.Builder _cb;
   private Interface.Builder _ib;
-  private BgpNeighbor.Builder _nb;
+  private BgpPeerConfig.Builder _nb;
   private BgpProcess.Builder _pb;
   private Vrf.Builder _vb;
   private RoutingPolicy.Builder _epb;
@@ -749,16 +749,16 @@ public class IncrementalDataPlanePluginTest {
     DataPlanePlugin dataPlanePlugin = batfish.getDataPlanePlugin();
     DataPlane dp = dataPlanePlugin.computeDataPlane(false)._dataPlane;
 
-    Network<BgpNeighbor, BgpSession> bgpTopology = dp.getBgpTopology();
+    Network<BgpPeerConfig, BgpSession> bgpTopology = dp.getBgpTopology();
 
     // N2 has proper neighbor relationship
-    Collection<BgpNeighbor> n2Neighbors =
+    Collection<BgpPeerConfig> n2Neighbors =
         configs.get("n2").getVrfs().get(DEFAULT_VRF_NAME).getBgpProcess().getNeighbors().values();
     assertThat(n2Neighbors, hasSize(1));
     assertThat(bgpTopology.degree(n2Neighbors.iterator().next()), is(2));
 
     // N1 does not have a full session established, because it's not reachable
-    Collection<BgpNeighbor> n1Neighbors =
+    Collection<BgpPeerConfig> n1Neighbors =
         configs.get("n1").getVrfs().get(DEFAULT_VRF_NAME).getBgpProcess().getNeighbors().values();
     assertThat(n1Neighbors, hasSize(1));
     assertThat(bgpTopology.degree(n1Neighbors.iterator().next()), is(0));

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/RouteReflectionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/RouteReflectionTest.java
@@ -21,7 +21,7 @@ import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.AsPath;
 import org.batfish.datamodel.BgpAdvertisement;
 import org.batfish.datamodel.BgpAdvertisement.BgpAdvertisementType;
-import org.batfish.datamodel.BgpNeighbor;
+import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
@@ -94,7 +94,7 @@ public class RouteReflectionTest {
 
   private Interface.Builder _ib;
 
-  private BgpNeighbor.Builder _nb;
+  private BgpPeerConfig.Builder _nb;
 
   private NetworkFactory _nf;
 

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
@@ -44,7 +44,7 @@ import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.AsPath;
 import org.batfish.datamodel.BgpAdvertisement;
 import org.batfish.datamodel.BgpAdvertisement.BgpAdvertisementType;
-import org.batfish.datamodel.BgpNeighbor;
+import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.BgpRoute;
 import org.batfish.datamodel.BgpSession;
@@ -122,7 +122,7 @@ public class VirtualRouterTest {
   private static final Ip TEST_NEXT_HOP_IP2 = new Ip("2.3.4.5");
   private static final String TEST_VIRTUAL_ROUTER_NAME = "testvirtualrouter";
 
-  private BgpNeighbor.Builder _bgpNeighborBuilder;
+  private BgpPeerConfig.Builder _bgpNeighborBuilder;
   private BgpRoute.Builder _bgpRouteBuilder;
   private Statement _exitAcceptStatement = Statements.ExitAccept.toStaticStatement();
   private Statement _exitRejectStatement = Statements.ExitReject.toStaticStatement();
@@ -766,7 +766,7 @@ public class VirtualRouterTest {
 
     Map<String, Configuration> configs =
         ImmutableMap.of("r1", n1.getConfiguration(), "r2", n2.getConfiguration());
-    Network<BgpNeighbor, BgpSession> bgpTopology =
+    Network<BgpPeerConfig, BgpSession> bgpTopology =
         initBgpTopology(configs, computeIpNodeOwners(configs, false), false);
     Network<IsisNode, IsisEdge> isisTopology = initIsisTopology(configs, topology);
 
@@ -855,7 +855,7 @@ public class VirtualRouterTest {
 
     Map<String, Configuration> configs = ImmutableMap.of(c1.getName(), c1, c2.getName(), c2);
     Topology topology = synthesizeTopology(configs);
-    Network<BgpNeighbor, BgpSession> bgpTopology =
+    Network<BgpPeerConfig, BgpSession> bgpTopology =
         ImmutableNetwork.copyOf(
             NetworkBuilder.directed().allowsParallelEdges(false).allowsSelfLoops(false).build());
     Map<String, Node> nodes =

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/schedule/NodeColoredScheduleTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/schedule/NodeColoredScheduleTest.java
@@ -17,7 +17,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.SortedMap;
-import org.batfish.datamodel.BgpNeighbor;
+import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.BgpSession;
 import org.batfish.datamodel.Configuration;
@@ -53,7 +53,7 @@ public class NodeColoredScheduleTest {
     Node n = TestUtils.makeIosRouter("r1");
     Map<String, Node> nodes = ImmutableMap.of("r1", n);
     Map<String, Configuration> configs = ImmutableMap.of("r1", n.getConfiguration());
-    Network<BgpNeighbor, BgpSession> bgpTopology =
+    Network<BgpPeerConfig, BgpSession> bgpTopology =
         initBgpTopology(configs, computeIpNodeOwners(configs, false), false);
     NodeColoredSchedule schedule = new NodeColoredSchedule(nodes, _coloring, bgpTopology);
 
@@ -73,7 +73,7 @@ public class NodeColoredScheduleTest {
             .stream()
             .collect(
                 ImmutableMap.toImmutableMap(Entry::getKey, e -> e.getValue().getConfiguration()));
-    Network<BgpNeighbor, BgpSession> bgpTopology =
+    Network<BgpPeerConfig, BgpSession> bgpTopology =
         initBgpTopology(configs, computeIpNodeOwners(configs, false), false);
     NodeColoredSchedule schedule = new NodeColoredSchedule(nodes, _coloring, bgpTopology);
 
@@ -92,7 +92,7 @@ public class NodeColoredScheduleTest {
     Vrf.Builder vb = nf.vrfBuilder();
     Interface.Builder ib = nf.interfaceBuilder();
     BgpProcess.Builder pb = nf.bgpProcessBuilder();
-    BgpNeighbor.Builder nb = nf.bgpNeighborBuilder();
+    BgpPeerConfig.Builder nb = nf.bgpNeighborBuilder();
 
     Configuration r1 = cb.setHostname("r1").build();
     Vrf vEdge1 = vb.setOwner(r1).build();
@@ -129,7 +129,7 @@ public class NodeColoredScheduleTest {
             .put(r2.getName(), r2)
             .build();
 
-    Network<BgpNeighbor, BgpSession> bgpTopology =
+    Network<BgpPeerConfig, BgpSession> bgpTopology =
         initBgpTopology(configurations, computeIpNodeOwners(configurations, false), false);
     ImmutableMap<String, Node> nodes = ImmutableMap.of("r1", new Node(r1), "r2", new Node(r2));
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -154,7 +154,7 @@ import org.batfish.common.util.CommonUtil;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.AsPath;
 import org.batfish.datamodel.BgpAdvertisement;
-import org.batfish.datamodel.BgpNeighbor;
+import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpSession;
 import org.batfish.datamodel.CommunityList;
 import org.batfish.datamodel.Configuration;
@@ -1486,7 +1486,7 @@ public class CiscoGrammarTest {
             _folder);
     Map<String, Configuration> configurations = batfish.loadConfigurations();
     Map<Ip, Set<String>> ipOwners = CommonUtil.computeIpNodeOwners(configurations, true);
-    Network<BgpNeighbor, BgpSession> bgpTopology =
+    Network<BgpPeerConfig, BgpSession> bgpTopology =
         CommonUtil.initBgpTopology(configurations, ipOwners, false);
     Configuration r1 = configurations.get("r1");
     Configuration r2 = configurations.get("r2");

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -103,7 +103,7 @@ import org.batfish.common.BatfishLogger;
 import org.batfish.common.util.CommonUtil;
 import org.batfish.config.Settings;
 import org.batfish.datamodel.AclIpSpace;
-import org.batfish.datamodel.BgpNeighbor;
+import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.BgpRoute;
 import org.batfish.datamodel.Configuration;
@@ -522,9 +522,9 @@ public class FlatJuniperGrammarTest {
 
     Configuration rr = configurations.get(configName);
     BgpProcess proc = rr.getDefaultVrf().getBgpProcess();
-    BgpNeighbor neighbor1 =
+    BgpPeerConfig neighbor1 =
         proc.getNeighbors().get(new Prefix(neighbor1Ip, Prefix.MAX_PREFIX_LENGTH));
-    BgpNeighbor neighbor2 =
+    BgpPeerConfig neighbor2 =
         proc.getNeighbors().get(new Prefix(neighbor2Ip, Prefix.MAX_PREFIX_LENGTH));
 
     assertThat(neighbor1, hasClusterId(new Ip("3.3.3.3").asLong()));

--- a/projects/question/src/main/java/org/batfish/question/BgpAsnUseQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/BgpAsnUseQuestionPlugin.java
@@ -10,7 +10,7 @@ import java.util.Set;
 import org.batfish.common.Answerer;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.common.plugin.Plugin;
-import org.batfish.datamodel.BgpNeighbor;
+import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Vrf;
@@ -75,7 +75,7 @@ public class BgpAsnUseQuestionPlugin extends QuestionPlugin {
         for (Vrf vrf : c.getVrfs().values()) {
           BgpProcess bgpProc = vrf.getBgpProcess();
           if (bgpProc != null) {
-            for (BgpNeighbor neighbor : bgpProc.getNeighbors().values()) {
+            for (BgpPeerConfig neighbor : bgpProc.getNeighbors().values()) {
               asns.put(neighbor.getLocalAs(), hostname);
             }
           }

--- a/projects/question/src/main/java/org/batfish/question/BgpLoopbacksQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/BgpLoopbacksQuestionPlugin.java
@@ -13,7 +13,7 @@ import java.util.TreeSet;
 import org.batfish.common.Answerer;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.common.plugin.Plugin;
-import org.batfish.datamodel.BgpNeighbor;
+import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.BgpRoute;
 import org.batfish.datamodel.Configuration;
@@ -121,7 +121,7 @@ public class BgpLoopbacksQuestionPlugin extends QuestionPlugin {
           }
           BgpProcess proc = vrf.getBgpProcess();
           Set<RoutingPolicy> exportPolicies = new TreeSet<>();
-          for (BgpNeighbor neighbor : proc.getNeighbors().values()) {
+          for (BgpPeerConfig neighbor : proc.getNeighbors().values()) {
             String exportPolicyName = neighbor.getExportPolicy();
             if (exportPolicyName != null) {
               RoutingPolicy exportPolicy = c.getRoutingPolicies().get(exportPolicyName);

--- a/projects/question/src/main/java/org/batfish/question/NeighborsQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/NeighborsQuestionPlugin.java
@@ -18,7 +18,7 @@ import org.batfish.common.BatfishException;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.common.plugin.Plugin;
 import org.batfish.common.util.CommonUtil;
-import org.batfish.datamodel.BgpNeighbor;
+import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpSession;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Edge;
@@ -417,7 +417,7 @@ public class NeighborsQuestionPlugin extends QuestionPlugin {
 
   public static class NeighborsAnswerer extends Answerer {
 
-    private Network<BgpNeighbor, BgpSession> _bgpTopology;
+    private Network<BgpPeerConfig, BgpSession> _bgpTopology;
 
     private SortedMap<String, SortedSet<String>> _nodeRolesMap;
 
@@ -571,13 +571,13 @@ public class NeighborsQuestionPlugin extends QuestionPlugin {
         initRemoteBgpNeighbors(configurations);
         SortedSet<VerboseBgpEdge> vedges = new TreeSet<>();
         for (BgpSession session : _bgpTopology.edges()) {
-          BgpNeighbor bgpNeighbor = session.getSrc();
-          BgpNeighbor remoteBgpNeighbor = session.getDst();
+          BgpPeerConfig bgpPeerConfig = session.getSrc();
+          BgpPeerConfig remoteBgpPeerConfig = session.getDst();
           boolean ebgp = session.isEbgp();
           if (ebgp) {
             VerboseBgpEdge edge =
                 constructVerboseBgpEdge(
-                    includeNodes1, includeNodes2, bgpNeighbor, remoteBgpNeighbor);
+                    includeNodes1, includeNodes2, bgpPeerConfig, remoteBgpPeerConfig);
             if (edge != null) {
               vedges.add(edge);
             }
@@ -607,14 +607,14 @@ public class NeighborsQuestionPlugin extends QuestionPlugin {
         SortedSet<VerboseBgpEdge> vedges = new TreeSet<>();
         initRemoteBgpNeighbors(configurations);
         for (BgpSession session : _bgpTopology.edges()) {
-          BgpNeighbor bgpNeighbor = session.getSrc();
-          BgpNeighbor remoteBgpNeighbor = session.getDst();
-          if (remoteBgpNeighbor != null) {
+          BgpPeerConfig bgpPeerConfig = session.getSrc();
+          BgpPeerConfig remoteBgpPeerConfig = session.getDst();
+          if (remoteBgpPeerConfig != null) {
             boolean ibgp = !session.isEbgp();
             if (ibgp) {
               VerboseBgpEdge edge =
                   constructVerboseBgpEdge(
-                      includeNodes1, includeNodes2, bgpNeighbor, remoteBgpNeighbor);
+                      includeNodes1, includeNodes2, bgpPeerConfig, remoteBgpPeerConfig);
               if (edge != null) {
                 vedges.add(edge);
               }
@@ -693,8 +693,8 @@ public class NeighborsQuestionPlugin extends QuestionPlugin {
      *
      * @param includeNodes1 Allowed src hostnames
      * @param includeNodes2 Allowed dst hostnames
-     * @param bgpNeighbor node1 bgp neighbor
-     * @param remoteBgpNeighbor node2 bgp neighbor
+     * @param bgpPeerConfig node1 bgp neighbor
+     * @param remoteBgpPeerConfig node2 bgp neighbor
      * @return a new {@link VerboseBgpEdge} describing the BGP peering or {@code null} if hostname
      *     filters are not satisfied.
      */
@@ -702,15 +702,15 @@ public class NeighborsQuestionPlugin extends QuestionPlugin {
     private static VerboseBgpEdge constructVerboseBgpEdge(
         Set<String> includeNodes1,
         Set<String> includeNodes2,
-        BgpNeighbor bgpNeighbor,
-        BgpNeighbor remoteBgpNeighbor) {
-      String hostname = bgpNeighbor.getOwner().getHostname();
-      String remoteHostname = remoteBgpNeighbor.getOwner().getHostname();
+        BgpPeerConfig bgpPeerConfig,
+        BgpPeerConfig remoteBgpPeerConfig) {
+      String hostname = bgpPeerConfig.getOwner().getHostname();
+      String remoteHostname = remoteBgpPeerConfig.getOwner().getHostname();
       if (includeNodes1.contains(hostname) && includeNodes2.contains(remoteHostname)) {
-        Ip localIp = bgpNeighbor.getLocalIp();
-        Ip remoteIp = remoteBgpNeighbor.getLocalIp();
+        Ip localIp = bgpPeerConfig.getLocalIp();
+        Ip remoteIp = remoteBgpPeerConfig.getLocalIp();
         IpEdge edge = new IpEdge(hostname, localIp, remoteHostname, remoteIp);
-        return new VerboseBgpEdge(bgpNeighbor, remoteBgpNeighbor, edge);
+        return new VerboseBgpEdge(bgpPeerConfig, remoteBgpPeerConfig, edge);
       }
       return null;
     }

--- a/projects/question/src/test/java/org/batfish/question/bgpsessionstatus/BgpSessionStatusAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/bgpsessionstatus/BgpSessionStatusAnswererTest.java
@@ -4,7 +4,7 @@ import static org.batfish.question.bgpsessionstatus.BgpSessionStatusAnswerer.get
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
-import org.batfish.datamodel.BgpNeighbor;
+import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.Prefix;
 import org.batfish.question.bgpsessionstatus.BgpSessionInfo.SessionStatus;
 import org.batfish.question.bgpsessionstatus.BgpSessionInfo.SessionType;
@@ -17,19 +17,19 @@ public class BgpSessionStatusAnswererTest {
   public void testLocalIpUnknownStatically() {
     assertThat(
         getLocallyBrokenStatus(
-            new BgpNeighbor(Prefix.parse("1.1.1.1/32"), null, true), SessionType.EBGP_SINGLEHOP),
+            new BgpPeerConfig(Prefix.parse("1.1.1.1/32"), null, true), SessionType.EBGP_SINGLEHOP),
         equalTo(SessionStatus.DYNAMIC_LISTEN));
     assertThat(
         getLocallyBrokenStatus(
-            new BgpNeighbor(Prefix.parse("1.1.1.1/32"), null, false), SessionType.EBGP_SINGLEHOP),
+            new BgpPeerConfig(Prefix.parse("1.1.1.1/32"), null, false), SessionType.EBGP_SINGLEHOP),
         equalTo(SessionStatus.NO_LOCAL_IP));
     assertThat(
         getLocallyBrokenStatus(
-            new BgpNeighbor(Prefix.parse("1.1.1.1/32"), null, false), SessionType.EBGP_MULTIHOP),
+            new BgpPeerConfig(Prefix.parse("1.1.1.1/32"), null, false), SessionType.EBGP_MULTIHOP),
         equalTo(SessionStatus.LOCAL_IP_UNKNOWN_STATICALLY));
     assertThat(
         getLocallyBrokenStatus(
-            new BgpNeighbor(Prefix.parse("1.1.1.1/32"), null, false), SessionType.IBGP),
+            new BgpPeerConfig(Prefix.parse("1.1.1.1/32"), null, false), SessionType.IBGP),
         equalTo(SessionStatus.LOCAL_IP_UNKNOWN_STATICALLY));
   }
 }


### PR DESCRIPTION
BgpNeighbor really only represents the configuration parts of a single peer, so we should reflect that in the name.

1. Automatic refactoring of the class to BgpPeerConfig
2. Add a BgpPeerConfigId class which should be used to uniquely identify a BgpPeerConfig in the network based on the node/vrf/peer prefix combo.
