### PR TITLE
New FlexibleIpSpaceSpecifierFactory

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/FlexibleIpSpaceSpecifierFactory.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/FlexibleIpSpaceSpecifierFactory.java
@@ -1,0 +1,29 @@
+package org.batfish.specifier;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.auto.service.AutoService;
+
+/**
+ * An IpSpaceSpecifierFactory that delegates to {@link ConstantWildcardSetIpSpaceSpecifierFactory}
+ * for non-null inputs, and defaults to {@link InferFromLocationIpSpaceSpecifier} for null input.
+ */
+@AutoService(IpSpaceSpecifierFactory.class)
+public class FlexibleIpSpaceSpecifierFactory implements IpSpaceSpecifierFactory {
+  public static final String NAME = FlexibleIpSpaceSpecifierFactory.class.getSimpleName();
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
+  public IpSpaceSpecifier buildIpSpaceSpecifier(Object input) {
+    if (input == null) {
+      return InferFromLocationIpSpaceSpecifier.INSTANCE;
+    }
+    checkArgument(input instanceof String, NAME + " requires String input");
+    String str = (String) input;
+    return new ConstantWildcardSetIpSpaceSpecifierFactory().buildIpSpaceSpecifier(str);
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/FlexibleIpSpaceSpecifierFactoryTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/FlexibleIpSpaceSpecifierFactoryTest.java
@@ -1,0 +1,35 @@
+package org.batfish.specifier;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.batfish.datamodel.IpWildcard;
+import org.batfish.datamodel.IpWildcardSetIpSpace;
+import org.junit.Test;
+
+public class FlexibleIpSpaceSpecifierFactoryTest {
+  @Test
+  public void testLoad() {
+    assertThat(
+        IpSpaceSpecifierFactory.load(FlexibleIpSpaceSpecifierFactory.NAME)
+            instanceof FlexibleIpSpaceSpecifierFactory,
+        is(true));
+  }
+
+  @Test
+  public void testNull() {
+    assertThat(
+        new FlexibleIpSpaceSpecifierFactory().buildIpSpaceSpecifier(null),
+        is(InferFromLocationIpSpaceSpecifier.INSTANCE));
+  }
+
+  @Test
+  public void testNonNull() {
+    assertThat(
+        new FlexibleIpSpaceSpecifierFactory().buildIpSpaceSpecifier("1.1.1.1"),
+        equalTo(
+            new ConstantIpSpaceSpecifier(
+                IpWildcardSetIpSpace.builder().including(new IpWildcard("1.1.1.1")).build())));
+  }
+}


### PR DESCRIPTION
Simple IpSpaceSpecifierFactory that delegates to ConstantIpWildcardSetIpSpaceSpecifierFactory except when input is null, in which case it defaults to InferFromLocation.