### PR TITLE
Jax-RS: add @PreMatching to filters

### DIFF
--- a/projects/coordinator/src/main/java/org/batfish/coordinator/ApiKeyAuthenticationFilter.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/ApiKeyAuthenticationFilter.java
@@ -5,6 +5,7 @@ import static org.batfish.common.CoordConstsV2.HTTP_HEADER_BATFISH_APIKEY;
 
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.PreMatching;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
@@ -12,6 +13,7 @@ import javax.ws.rs.ext.Provider;
 import org.batfish.common.CoordConsts;
 
 /** This filter verifies the apiKey provided in request header is a valid work apikey. */
+@PreMatching
 @Provider
 public class ApiKeyAuthenticationFilter implements ContainerRequestFilter {
   @Override

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/CrossDomainFilter.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/CrossDomainFilter.java
@@ -6,13 +6,15 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.container.PreMatching;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.Provider;
 import org.batfish.common.CoordConstsV2;
 
 /** Allow the system to serve xhr level 2 from all cross domain site */
-@Provider
+@PreMatching
 @Priority(-1) /* Highest priority to set the CORS filter as the first one to run. */
+@Provider
 public class CrossDomainFilter implements ContainerRequestFilter, ContainerResponseFilter {
   /**
    * Recognizes a CORS preflight request, and return OK without any further downstream processing in

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/VersionCompatibilityFilter.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/VersionCompatibilityFilter.java
@@ -5,6 +5,7 @@ import static org.batfish.common.CoordConstsV2.HTTP_HEADER_BATFISH_VERSION;
 import com.google.common.base.Strings;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.PreMatching;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
@@ -14,6 +15,7 @@ import org.batfish.common.Version;
 /**
  * This filter verifies that the client's version is compatible with the version of Batfish service.
  */
+@PreMatching
 @Provider
 public class VersionCompatibilityFilter implements ContainerRequestFilter {
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/CrossDomainFilterTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/CrossDomainFilterTest.java
@@ -1,0 +1,71 @@
+package org.batfish.coordinator;
+
+import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static javax.ws.rs.core.Response.Status.OK;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import org.batfish.common.CoordConstsV2;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.TestProperties;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests of {@link CrossDomainFilter}. */
+@RunWith(JUnit4.class)
+public class CrossDomainFilterTest extends JerseyTest {
+
+  @Path("/test")
+  public static class TestService {
+    public TestService() {
+      throw new IllegalStateException("Should never reach here!");
+    }
+
+    @GET
+    public Response get() {
+      // Should be unreachable, as the test resource will crash on creation.
+      return Response.ok().build();
+    }
+  }
+
+  @Override
+  protected Application configure() {
+    forceSet(TestProperties.CONTAINER_PORT, "0");
+    return new ResourceConfig(TestService.class).register(CrossDomainFilter.class);
+  }
+
+  @Test
+  public void testGetRequestThrows() {
+    Response response = target("/test").request().get();
+    assertThat(response.getStatus(), equalTo(INTERNAL_SERVER_ERROR.getStatusCode()));
+  }
+
+  @Test
+  public void testOptionsRequestSucceeds() {
+    Response response = target("/test").request().options();
+
+    assertThat(response.getStatus(), equalTo(OK.getStatusCode()));
+
+    MultivaluedMap<String, String> headers = response.getStringHeaders();
+    assertThat(headers, hasEntry(equalTo("Access-Control-Allow-Origin"), contains("*")));
+    assertThat(
+        headers,
+        hasEntry(
+            equalTo("Access-Control-Allow-Headers"),
+            contains(
+                allOf(
+                    containsString(CoordConstsV2.HTTP_HEADER_BATFISH_APIKEY),
+                    containsString(CoordConstsV2.HTTP_HEADER_BATFISH_VERSION)))));
+  }
+}

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrServiceV2Test.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrServiceV2Test.java
@@ -3,6 +3,7 @@ package org.batfish.coordinator;
 import static javax.ws.rs.core.Response.Status.FORBIDDEN;
 import static javax.ws.rs.core.Response.Status.MOVED_PERMANENTLY;
 import static javax.ws.rs.core.Response.Status.OK;
+import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
 import static org.glassfish.jersey.client.ClientProperties.FOLLOW_REDIRECTS;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
@@ -77,13 +78,16 @@ public class WorkMgrServiceV2Test extends WorkMgrServiceV2TestBase {
 
   /** Test that the ApiKey is extracted from the correct header */
   @Test
-  public void correctApiKeyHeader() {
+  public void apiKeyValidationAndCorrectReturnCodes() {
     // Set up by making a call to authorize container
     String containerName = "someContainer";
+    String otherContainerName = "anotherContainer";
     String myKey = "ApiKey";
+    String otherKey = "AnotherApiKey";
     Authorizer auth = new MapAuthorizer();
     Main.setAuthorizer(auth);
     auth.authorizeContainer(myKey, containerName);
+    auth.authorizeContainer(otherKey, otherContainerName);
     Main.getWorkMgr().initContainer(containerName, null);
 
     // Test that subsequent calls return 200 with correct API key
@@ -99,17 +103,29 @@ public class WorkMgrServiceV2Test extends WorkMgrServiceV2TestBase {
         resp.readEntity(Container.class),
         equalTo(Container.of(containerName, Collections.emptySortedSet())));
 
-    // Test that subsequent calls return 403 forbidden with wrong API key
+    // Test that subsequent calls return 401 unauthorized with unknown API key
     resp =
         getContainersTarget()
             .path(containerName)
             .request()
             .header(CoordConstsV2.HTTP_HEADER_BATFISH_VERSION, Version.getVersion())
-            .header(CoordConstsV2.HTTP_HEADER_BATFISH_APIKEY, "wrongKey")
+            .header(CoordConstsV2.HTTP_HEADER_BATFISH_APIKEY, "unknownKey")
+            .get();
+    assertThat(resp.getStatus(), equalTo(UNAUTHORIZED.getStatusCode()));
+    assertThat(
+        resp.readEntity(String.class), equalTo("Authorizer: 'unknownKey' is NOT a valid key"));
+
+    // Test that subsequent calls return 403 forbidden with known API key and no access
+    resp =
+        getContainersTarget()
+            .path(containerName)
+            .request()
+            .header(CoordConstsV2.HTTP_HEADER_BATFISH_VERSION, Version.getVersion())
+            .header(CoordConstsV2.HTTP_HEADER_BATFISH_APIKEY, otherKey)
             .get();
     assertThat(resp.getStatus(), equalTo(FORBIDDEN.getStatusCode()));
     assertThat(
         resp.readEntity(String.class),
-        equalTo("container 'someContainer' is not accessible by the api key: wrongKey"));
+        equalTo("container 'someContainer' is not accessible by the api key: AnotherApiKey"));
   }
 }


### PR DESCRIPTION
These filters should run unconditionally before any resource expansion
happens.