### PR TITLE
compare OspfNeighbor IpLinks directly

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/VerboseOspfEdge.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/VerboseOspfEdge.java
@@ -51,11 +51,11 @@ public final class VerboseOspfEdge implements Serializable, Comparable<VerboseOs
     if (cmp != 0) {
       return cmp;
     }
-    cmp = _session1.compareTo(o._session1);
+    cmp = _session1.getIpLink().compareTo(o._session1.getIpLink());
     if (cmp != 0) {
       return cmp;
     }
-    cmp = _session2.compareTo(o._session2);
+    cmp = _session2.getIpLink().compareTo(o._session2.getIpLink());
     return cmp;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/VerboseOspfEdge.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/VerboseOspfEdge.java
@@ -3,6 +3,7 @@ package org.batfish.datamodel.collections;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
+import java.util.Comparator;
 import javax.annotation.Nonnull;
 import org.batfish.datamodel.ospf.OspfNeighbor;
 
@@ -46,16 +47,10 @@ public final class VerboseOspfEdge implements Serializable, Comparable<VerboseOs
   }
 
   @Override
-  public int compareTo(VerboseOspfEdge o) {
-    int cmp = _edgeSummary.compareTo(o._edgeSummary);
-    if (cmp != 0) {
-      return cmp;
-    }
-    cmp = _session1.getIpLink().compareTo(o._session1.getIpLink());
-    if (cmp != 0) {
-      return cmp;
-    }
-    cmp = _session2.getIpLink().compareTo(o._session2.getIpLink());
-    return cmp;
+  public int compareTo(@Nonnull VerboseOspfEdge o) {
+    return Comparator.comparing(VerboseOspfEdge::getEdgeSummary)
+        .thenComparing(edge -> edge.getSession1().getIpLink())
+        .thenComparing(edge -> edge.getSession2().getIpLink())
+        .compare(this, o);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfNeighbor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfNeighbor.java
@@ -90,6 +90,11 @@ public class OspfNeighbor extends ComparableStructure<IpLink> {
   }
 
   @JsonIgnore
+  public IpLink getIpLink() {
+    return _key;
+  }
+
+  @JsonIgnore
   public Ip getLocalIp() {
     return _key.getIp1();
   }


### PR DESCRIPTION
instead of using the compareTo implementation inherited from
ComparableStructure