### PR TITLE
specifiers: tighten signatures

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/CaseInsensitiveRegexLocationSpecifierFactory.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/CaseInsensitiveRegexLocationSpecifierFactory.java
@@ -8,7 +8,7 @@ import javax.annotation.Nullable;
 public abstract class CaseInsensitiveRegexLocationSpecifierFactory
     implements LocationSpecifierFactory {
   @Override
-  public LocationSpecifier buildLocationSpecifier(@Nullable Object input) {
+  public final LocationSpecifier buildLocationSpecifier(@Nullable Object input) {
     checkArgument(input instanceof String, getName() + " requires input of type String");
     return buildLocationSpecifier(Pattern.compile((String) input, Pattern.CASE_INSENSITIVE));
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/FlexibleLocationSpecifierFactory.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/FlexibleLocationSpecifierFactory.java
@@ -42,18 +42,18 @@ import javax.annotation.Nullable;
  * ("nodeRole:[Dimension]"), VRF name ("vrf"), or interface name ("interface").
  */
 @AutoService(LocationSpecifierFactory.class)
-public class FlexibleLocationSpecifierFactory implements LocationSpecifierFactory {
+public final class FlexibleLocationSpecifierFactory implements LocationSpecifierFactory {
   public static final String NAME = FlexibleLocationSpecifierFactory.class.getSimpleName();
 
-  static final String LOCATION_TYPE_INTERFACE = "interface";
-  static final String LOCATION_TYPE_INTERFACE_LINK = "interfaceLink";
-  static final String DEFAULT_LOCATION_TYPE = LOCATION_TYPE_INTERFACE_LINK;
+  private static final String LOCATION_TYPE_INTERFACE = "interface";
+  private static final String LOCATION_TYPE_INTERFACE_LINK = "interfaceLink";
+  private static final String DEFAULT_LOCATION_TYPE = LOCATION_TYPE_INTERFACE_LINK;
 
-  static final String PROPERTY_TYPE_INTERFACE_NAME = "interface";
-  static final String PROPERTY_TYPE_NODE_NAME = "node";
-  static final String PROPERTY_TYPE_NODE_ROLE_PREFIX = "nodeRole:";
-  static final String PROPERTY_TYPE_VRF_NAME = "vrf";
-  static final String DEFAULT_PROPERTY_TYPE = PROPERTY_TYPE_NODE_NAME;
+  private static final String PROPERTY_TYPE_INTERFACE_NAME = "interface";
+  private static final String PROPERTY_TYPE_NODE_NAME = "node";
+  private static final String PROPERTY_TYPE_NODE_ROLE_PREFIX = "nodeRole:";
+  private static final String PROPERTY_TYPE_VRF_NAME = "vrf";
+  private static final String DEFAULT_PROPERTY_TYPE = PROPERTY_TYPE_NODE_NAME;
 
   private static final Map<String, ClauseParser> CLAUSE_PARSERS =
       ImmutableMap.of(

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/NodeRoleRegexLocationSpecifierFactory.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/NodeRoleRegexLocationSpecifierFactory.java
@@ -10,12 +10,12 @@ public abstract class NodeRoleRegexLocationSpecifierFactory
     extends TypedLocationSpecifierFactory<String> {
 
   @Override
-  protected Class<String> getInputClass() {
+  protected final Class<String> getInputClass() {
     return String.class;
   }
 
   @Override
-  public LocationSpecifier buildLocationSpecifierTyped(String input) {
+  public final LocationSpecifier buildLocationSpecifierTyped(String input) {
     String[] parts = input.split(":");
 
     if (parts.length != 2) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/TypedLocationSpecifierFactory.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/TypedLocationSpecifierFactory.java
@@ -15,7 +15,7 @@ public abstract class TypedLocationSpecifierFactory<T> implements LocationSpecif
   protected abstract Class<T> getInputClass();
 
   @Override
-  public LocationSpecifier buildLocationSpecifier(@Nullable Object input) {
+  public final LocationSpecifier buildLocationSpecifier(@Nullable Object input) {
     Class<T> inputClass = getInputClass();
     if (!getInputClass().isInstance(input)) {
       throw new BatfishException(


### PR DESCRIPTION
* Don't let children override functions in intermediate abstract
  classes.

* Make private variables that can be.