### PR TITLE
BGP neighbors, edges: remove comparable structure

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpPeerConfig.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpPeerConfig.java
@@ -5,18 +5,18 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDescription;
+import java.io.Serializable;
 import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import javax.annotation.Nullable;
-import org.batfish.common.util.ComparableStructure;
 import org.batfish.datamodel.NetworkFactory.NetworkFactoryBuilder;
 
 /** Represents a configured BGP peering, at the control plane level */
 @JsonSchemaDescription("A configured e/iBGP peering relationship")
-public final class BgpPeerConfig extends ComparableStructure<Prefix> {
+public final class BgpPeerConfig implements Serializable {
 
   public static class Builder extends NetworkFactoryBuilder<BgpPeerConfig> {
     private Configuration _owner;
@@ -205,8 +205,6 @@ public final class BgpPeerConfig extends ComparableStructure<Prefix> {
 
   private static final String PROP_LOCAL_IP = "localIp";
 
-  private static final String PROP_NAME = "name";
-
   private static final String PROP_OWNER = "owner";
 
   private static final String PROP_REMOTE_AS = "remoteAs";
@@ -277,6 +275,8 @@ public final class BgpPeerConfig extends ComparableStructure<Prefix> {
   /** Whether this session is passive/dynamic (e.g., listens for incoming connections only) */
   private boolean _dynamic;
 
+  @Nullable private Prefix _prefix;
+
   /** The autonomous system number that the containing BGP process considers this peer to have. */
   private Long _remoteAs;
 
@@ -310,8 +310,8 @@ public final class BgpPeerConfig extends ComparableStructure<Prefix> {
   }
 
   @JsonCreator
-  public BgpPeerConfig(@JsonProperty(PROP_NAME) Prefix prefix) {
-    super(prefix);
+  public BgpPeerConfig(@Nullable @JsonProperty(PROP_REMOTE_PREFIX) Prefix prefix) {
+    _prefix = prefix;
     _exportPolicySources = new TreeSet<>();
     _generatedRoutes = new LinkedHashSet<>();
     _importPolicySources = new TreeSet<>();
@@ -395,6 +395,37 @@ public final class BgpPeerConfig extends ComparableStructure<Prefix> {
         && this._dynamic == other._dynamic;
   }
 
+  @Override
+  public int hashCode() {
+    // SKIPS: description, generated routes, owner to be consistent with equals
+    return Objects.hash(
+        _additionalPathsReceive,
+        _additionalPathsSelectAll,
+        _additionalPathsSend,
+        _advertiseExternal,
+        _advertiseInactive,
+        _allowLocalAsIn,
+        _allowRemoteAsOut,
+        _authenticationSettings,
+        _clusterId,
+        _defaultMetric,
+        _ebgpMultihop,
+        _enforceFirstAs,
+        _exportPolicy,
+        _exportPolicySources,
+        _group,
+        _importPolicy,
+        _importPolicySources,
+        _localAs,
+        _localIp,
+        _dynamic,
+        _prefix,
+        _remoteAs,
+        _routeReflectorClient,
+        _sendCommunity,
+        _vrf);
+  }
+
   @JsonProperty(PROP_ADDITIONAL_PATHS_RECEIVE)
   public boolean getAdditionalPathsReceive() {
     return _additionalPathsReceive;
@@ -414,8 +445,8 @@ public final class BgpPeerConfig extends ComparableStructure<Prefix> {
   @JsonProperty(PROP_ADDRESS)
   @JsonPropertyDescription("The IPV4 address of the remote peer if not dynamic (passive)")
   public Ip getAddress() {
-    if (_key != null && _key.getPrefixLength() == Prefix.MAX_PREFIX_LENGTH) {
-      return _key.getStartIp();
+    if (_prefix != null && _prefix.getPrefixLength() == Prefix.MAX_PREFIX_LENGTH) {
+      return _prefix.getStartIp();
     } else {
       return null;
     }
@@ -559,7 +590,7 @@ public final class BgpPeerConfig extends ComparableStructure<Prefix> {
       "The remote (destination) IPV4 address of this peering (when not-dynamic), or the "
           + "network of peers allowed to connect on this peering (otherwise)")
   public Prefix getPrefix() {
-    return _key;
+    return _prefix;
   }
 
   @JsonProperty(PROP_REMOTE_AS)
@@ -736,6 +767,6 @@ public final class BgpPeerConfig extends ComparableStructure<Prefix> {
 
   @Override
   public String toString() {
-    return "BgpPeerConfig<Prefix:" + _key + ", AS:" + _remoteAs + ">";
+    return "BgpPeerConfig<Prefix:" + _prefix + ", AS:" + _remoteAs + ">";
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/VerboseBgpEdge.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/VerboseBgpEdge.java
@@ -6,7 +6,7 @@ import java.io.Serializable;
 import javax.annotation.Nonnull;
 import org.batfish.datamodel.BgpPeerConfig;
 
-public final class VerboseBgpEdge implements Serializable, Comparable<VerboseBgpEdge> {
+public final class VerboseBgpEdge implements Serializable {
 
   private static final String PROP_EDGE_SUMMARY = "edgeSummary";
 
@@ -43,19 +43,5 @@ public final class VerboseBgpEdge implements Serializable, Comparable<VerboseBgp
   @JsonProperty(PROP_NODE2_SESSION)
   public BgpPeerConfig getNode2Session() {
     return _session2;
-  }
-
-  @Override
-  public int compareTo(VerboseBgpEdge o) {
-    int cmp = _edgeSummary.compareTo(o._edgeSummary);
-    if (cmp != 0) {
-      return cmp;
-    }
-    cmp = _session1.compareTo(o._session1);
-    if (cmp != 0) {
-      return cmp;
-    }
-    cmp = _session2.compareTo(o._session2);
-    return cmp;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/symbolic/abstraction/AbstractionBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/abstraction/AbstractionBuilder.java
@@ -2,6 +2,7 @@ package org.batfish.symbolic.abstraction;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -470,7 +471,8 @@ class AbstractionBuilder {
 
     SortedSet<Interface> toRetain = new TreeSet<>();
     SortedSet<IpLink> ipNeighbors = new TreeSet<>();
-    SortedSet<BgpPeerConfig> bgpPeerConfigs = new TreeSet<>();
+    SortedSet<BgpPeerConfig> bgpPeerConfigs =
+        new TreeSet<>(Comparator.comparing(BgpPeerConfig::getPrefix));
 
     List<GraphEdge> edges = _graph.getEdgeMap().get(conf.getName());
     for (GraphEdge ge : edges) {

--- a/tests/aws/nodes-example-aws.ref
+++ b/tests/aws/nodes-example-aws.ref
@@ -1662,7 +1662,7 @@
               "multipathIbgp" : false,
               "neighbors" : {
                 "10.10.10.37/32" : {
-                  "name" : "10.10.10.37/32",
+                  "remotePrefix" : "10.10.10.37/32",
                   "additionalPathsReceive" : false,
                   "additionalPathsSelectAll" : false,
                   "additionalPathsSend" : false,
@@ -1685,13 +1685,12 @@
                   "localAs" : 65301,
                   "localIp" : "10.10.10.38",
                   "remoteAs" : 65201,
-                  "remotePrefix" : "10.10.10.37/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : false,
                   "vrf" : "default"
                 },
                 "10.10.10.45/32" : {
-                  "name" : "10.10.10.45/32",
+                  "remotePrefix" : "10.10.10.45/32",
                   "additionalPathsReceive" : false,
                   "additionalPathsSelectAll" : false,
                   "additionalPathsSend" : false,
@@ -1710,13 +1709,12 @@
                   "localAs" : 65301,
                   "localIp" : "10.10.10.46",
                   "remoteAs" : 65202,
-                  "remotePrefix" : "10.10.10.45/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : false,
                   "vrf" : "default"
                 },
                 "10.10.30.2/32" : {
-                  "name" : "10.10.30.2/32",
+                  "remotePrefix" : "10.10.30.2/32",
                   "additionalPathsReceive" : false,
                   "additionalPathsSelectAll" : false,
                   "additionalPathsSend" : false,
@@ -1738,13 +1736,12 @@
                   "localAs" : 65301,
                   "localIp" : "10.10.30.1",
                   "remoteAs" : 65331,
-                  "remotePrefix" : "10.10.30.2/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : false,
                   "vrf" : "default"
                 },
                 "10.10.255.7/32" : {
-                  "name" : "10.10.255.7/32",
+                  "remotePrefix" : "10.10.255.7/32",
                   "additionalPathsReceive" : false,
                   "additionalPathsSelectAll" : false,
                   "additionalPathsSend" : false,
@@ -1762,13 +1759,12 @@
                   "localAs" : 65301,
                   "localIp" : "10.10.255.8",
                   "remoteAs" : 65301,
-                  "remotePrefix" : "10.10.255.7/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : false,
                   "vrf" : "default"
                 },
                 "169.254.13.237/32" : {
-                  "name" : "169.254.13.237/32",
+                  "remotePrefix" : "169.254.13.237/32",
                   "additionalPathsReceive" : false,
                   "additionalPathsSelectAll" : false,
                   "additionalPathsSend" : false,
@@ -1802,13 +1798,12 @@
                   "localAs" : 65301,
                   "localIp" : "169.254.13.238",
                   "remoteAs" : 65401,
-                  "remotePrefix" : "169.254.13.237/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : false,
                   "vrf" : "default"
                 },
                 "169.254.15.193/32" : {
-                  "name" : "169.254.15.193/32",
+                  "remotePrefix" : "169.254.15.193/32",
                   "additionalPathsReceive" : false,
                   "additionalPathsSelectAll" : false,
                   "additionalPathsSend" : false,
@@ -1842,7 +1837,6 @@
                   "localAs" : 65301,
                   "localIp" : "169.254.15.194",
                   "remoteAs" : 65401,
-                  "remotePrefix" : "169.254.15.193/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : false,
                   "vrf" : "default"
@@ -3978,7 +3972,7 @@
               "multipathIbgp" : false,
               "neighbors" : {
                 "169.254.13.238/32" : {
-                  "name" : "169.254.13.238/32",
+                  "remotePrefix" : "169.254.13.238/32",
                   "additionalPathsReceive" : false,
                   "additionalPathsSelectAll" : false,
                   "additionalPathsSend" : false,
@@ -3995,13 +3989,12 @@
                   "localAs" : 65401,
                   "localIp" : "169.254.13.237",
                   "remoteAs" : 65301,
-                  "remotePrefix" : "169.254.13.238/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : false,
                   "vrf" : "default"
                 },
                 "169.254.15.194/32" : {
-                  "name" : "169.254.15.194/32",
+                  "remotePrefix" : "169.254.15.194/32",
                   "additionalPathsReceive" : false,
                   "additionalPathsSelectAll" : false,
                   "additionalPathsSend" : false,
@@ -4018,13 +4011,12 @@
                   "localAs" : 65401,
                   "localIp" : "169.254.15.193",
                   "remoteAs" : 65301,
-                  "remotePrefix" : "169.254.15.194/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : false,
                   "vrf" : "default"
                 },
                 "240.0.0.7/32" : {
-                  "name" : "240.0.0.7/32",
+                  "remotePrefix" : "240.0.0.7/32",
                   "additionalPathsReceive" : false,
                   "additionalPathsSelectAll" : false,
                   "additionalPathsSend" : false,
@@ -4042,7 +4034,6 @@
                   "localAs" : 65401,
                   "localIp" : "240.0.0.6",
                   "remoteAs" : 65401,
-                  "remotePrefix" : "240.0.0.7/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : true,
                   "vrf" : "default"
@@ -4136,7 +4127,7 @@
               "multipathIbgp" : false,
               "neighbors" : {
                 "240.0.0.6/32" : {
-                  "name" : "240.0.0.6/32",
+                  "remotePrefix" : "240.0.0.6/32",
                   "additionalPathsReceive" : false,
                   "additionalPathsSelectAll" : false,
                   "additionalPathsSend" : false,
@@ -4154,7 +4145,6 @@
                   "localAs" : 65401,
                   "localIp" : "240.0.0.7",
                   "remoteAs" : 65401,
-                  "remotePrefix" : "240.0.0.6/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : true,
                   "vrf" : "default"

--- a/tests/basic/neighbors.ref
+++ b/tests/basic/neighbors.ref
@@ -10,7 +10,7 @@
           "node2" : "as2border1"
         },
         "node1Session" : {
-          "name" : "10.12.11.2/32",
+          "remotePrefix" : "10.12.11.2/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -36,13 +36,12 @@
           "localAs" : 1,
           "localIp" : "10.12.11.1",
           "remoteAs" : 2,
-          "remotePrefix" : "10.12.11.2/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
         },
         "node2Session" : {
-          "name" : "10.12.11.1/32",
+          "remotePrefix" : "10.12.11.1/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -68,7 +67,6 @@
           "localAs" : 2,
           "localIp" : "10.12.11.2",
           "remoteAs" : 1,
-          "remotePrefix" : "10.12.11.1/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
@@ -82,7 +80,7 @@
           "node2" : "as3border2"
         },
         "node1Session" : {
-          "name" : "10.13.22.3/32",
+          "remotePrefix" : "10.13.22.3/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -108,13 +106,12 @@
           "localAs" : 1,
           "localIp" : "10.13.22.1",
           "remoteAs" : 3,
-          "remotePrefix" : "10.13.22.3/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
         },
         "node2Session" : {
-          "name" : "10.13.22.1/32",
+          "remotePrefix" : "10.13.22.1/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -140,7 +137,6 @@
           "localAs" : 3,
           "localIp" : "10.13.22.3",
           "remoteAs" : 1,
-          "remotePrefix" : "10.13.22.1/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
@@ -154,7 +150,7 @@
           "node2" : "as1border1"
         },
         "node1Session" : {
-          "name" : "10.12.11.1/32",
+          "remotePrefix" : "10.12.11.1/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -180,13 +176,12 @@
           "localAs" : 2,
           "localIp" : "10.12.11.2",
           "remoteAs" : 1,
-          "remotePrefix" : "10.12.11.1/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
         },
         "node2Session" : {
-          "name" : "10.12.11.2/32",
+          "remotePrefix" : "10.12.11.2/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -212,7 +207,6 @@
           "localAs" : 1,
           "localIp" : "10.12.11.1",
           "remoteAs" : 2,
-          "remotePrefix" : "10.12.11.2/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
@@ -226,7 +220,7 @@
           "node2" : "as3border1"
         },
         "node1Session" : {
-          "name" : "10.23.21.3/32",
+          "remotePrefix" : "10.23.21.3/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -252,13 +246,12 @@
           "localAs" : 2,
           "localIp" : "10.23.21.2",
           "remoteAs" : 3,
-          "remotePrefix" : "10.23.21.3/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
         },
         "node2Session" : {
-          "name" : "10.23.21.2/32",
+          "remotePrefix" : "10.23.21.2/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -284,7 +277,6 @@
           "localAs" : 3,
           "localIp" : "10.23.21.3",
           "remoteAs" : 2,
-          "remotePrefix" : "10.23.21.2/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
@@ -298,7 +290,7 @@
           "node2" : "as2dist1"
         },
         "node1Session" : {
-          "name" : "2.34.101.3/32",
+          "remotePrefix" : "2.34.101.3/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -324,13 +316,12 @@
           "localAs" : 65001,
           "localIp" : "2.34.101.4",
           "remoteAs" : 2,
-          "remotePrefix" : "2.34.101.3/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
         },
         "node2Session" : {
-          "name" : "2.34.101.4/32",
+          "remotePrefix" : "2.34.101.4/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -356,7 +347,6 @@
           "localAs" : 2,
           "localIp" : "2.34.101.3",
           "remoteAs" : 65001,
-          "remotePrefix" : "2.34.101.4/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
@@ -370,7 +360,7 @@
           "node2" : "as2dist2"
         },
         "node1Session" : {
-          "name" : "2.34.201.3/32",
+          "remotePrefix" : "2.34.201.3/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -396,13 +386,12 @@
           "localAs" : 65001,
           "localIp" : "2.34.201.4",
           "remoteAs" : 2,
-          "remotePrefix" : "2.34.201.3/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
         },
         "node2Session" : {
-          "name" : "2.34.201.4/32",
+          "remotePrefix" : "2.34.201.4/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -428,7 +417,6 @@
           "localAs" : 2,
           "localIp" : "2.34.201.3",
           "remoteAs" : 65001,
-          "remotePrefix" : "2.34.201.4/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
@@ -442,7 +430,7 @@
           "node2" : "as2dept1"
         },
         "node1Session" : {
-          "name" : "2.34.101.4/32",
+          "remotePrefix" : "2.34.101.4/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -468,13 +456,12 @@
           "localAs" : 2,
           "localIp" : "2.34.101.3",
           "remoteAs" : 65001,
-          "remotePrefix" : "2.34.101.4/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
         },
         "node2Session" : {
-          "name" : "2.34.101.3/32",
+          "remotePrefix" : "2.34.101.3/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -500,7 +487,6 @@
           "localAs" : 65001,
           "localIp" : "2.34.101.4",
           "remoteAs" : 2,
-          "remotePrefix" : "2.34.101.3/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
@@ -514,7 +500,7 @@
           "node2" : "as2dept1"
         },
         "node1Session" : {
-          "name" : "2.34.201.4/32",
+          "remotePrefix" : "2.34.201.4/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -540,13 +526,12 @@
           "localAs" : 2,
           "localIp" : "2.34.201.3",
           "remoteAs" : 65001,
-          "remotePrefix" : "2.34.201.4/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
         },
         "node2Session" : {
-          "name" : "2.34.201.3/32",
+          "remotePrefix" : "2.34.201.3/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -572,7 +557,6 @@
           "localAs" : 65001,
           "localIp" : "2.34.201.4",
           "remoteAs" : 2,
-          "remotePrefix" : "2.34.201.3/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
@@ -586,7 +570,7 @@
           "node2" : "as2border2"
         },
         "node1Session" : {
-          "name" : "10.23.21.2/32",
+          "remotePrefix" : "10.23.21.2/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -612,13 +596,12 @@
           "localAs" : 3,
           "localIp" : "10.23.21.3",
           "remoteAs" : 2,
-          "remotePrefix" : "10.23.21.2/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
         },
         "node2Session" : {
-          "name" : "10.23.21.3/32",
+          "remotePrefix" : "10.23.21.3/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -644,7 +627,6 @@
           "localAs" : 2,
           "localIp" : "10.23.21.2",
           "remoteAs" : 3,
-          "remotePrefix" : "10.23.21.3/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
@@ -658,7 +640,7 @@
           "node2" : "as1border2"
         },
         "node1Session" : {
-          "name" : "10.13.22.1/32",
+          "remotePrefix" : "10.13.22.1/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -684,13 +666,12 @@
           "localAs" : 3,
           "localIp" : "10.13.22.3",
           "remoteAs" : 1,
-          "remotePrefix" : "10.13.22.1/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
         },
         "node2Session" : {
-          "name" : "10.13.22.3/32",
+          "remotePrefix" : "10.13.22.3/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -716,7 +697,6 @@
           "localAs" : 1,
           "localIp" : "10.13.22.1",
           "remoteAs" : 3,
-          "remotePrefix" : "10.13.22.3/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
@@ -732,7 +712,7 @@
           "node2" : "as1core1"
         },
         "node1Session" : {
-          "name" : "1.10.1.1/32",
+          "remotePrefix" : "1.10.1.1/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -751,13 +731,12 @@
           "localAs" : 1,
           "localIp" : "1.1.1.1",
           "remoteAs" : 1,
-          "remotePrefix" : "1.10.1.1/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
         },
         "node2Session" : {
-          "name" : "1.1.1.1/32",
+          "remotePrefix" : "1.1.1.1/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -776,7 +755,6 @@
           "localAs" : 1,
           "localIp" : "1.10.1.1",
           "remoteAs" : 1,
-          "remotePrefix" : "1.1.1.1/32",
           "routeReflectorClient" : true,
           "sendCommunity" : true,
           "vrf" : "default"
@@ -790,7 +768,7 @@
           "node2" : "as1core1"
         },
         "node1Session" : {
-          "name" : "1.10.1.1/32",
+          "remotePrefix" : "1.10.1.1/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -809,13 +787,12 @@
           "localAs" : 1,
           "localIp" : "1.2.2.2",
           "remoteAs" : 1,
-          "remotePrefix" : "1.10.1.1/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
         },
         "node2Session" : {
-          "name" : "1.2.2.2/32",
+          "remotePrefix" : "1.2.2.2/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -834,7 +811,6 @@
           "localAs" : 1,
           "localIp" : "1.10.1.1",
           "remoteAs" : 1,
-          "remotePrefix" : "1.2.2.2/32",
           "routeReflectorClient" : true,
           "sendCommunity" : true,
           "vrf" : "default"
@@ -848,7 +824,7 @@
           "node2" : "as1border1"
         },
         "node1Session" : {
-          "name" : "1.1.1.1/32",
+          "remotePrefix" : "1.1.1.1/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -867,13 +843,12 @@
           "localAs" : 1,
           "localIp" : "1.10.1.1",
           "remoteAs" : 1,
-          "remotePrefix" : "1.1.1.1/32",
           "routeReflectorClient" : true,
           "sendCommunity" : true,
           "vrf" : "default"
         },
         "node2Session" : {
-          "name" : "1.10.1.1/32",
+          "remotePrefix" : "1.10.1.1/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -892,7 +867,6 @@
           "localAs" : 1,
           "localIp" : "1.1.1.1",
           "remoteAs" : 1,
-          "remotePrefix" : "1.10.1.1/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
@@ -906,7 +880,7 @@
           "node2" : "as1border2"
         },
         "node1Session" : {
-          "name" : "1.2.2.2/32",
+          "remotePrefix" : "1.2.2.2/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -925,13 +899,12 @@
           "localAs" : 1,
           "localIp" : "1.10.1.1",
           "remoteAs" : 1,
-          "remotePrefix" : "1.2.2.2/32",
           "routeReflectorClient" : true,
           "sendCommunity" : true,
           "vrf" : "default"
         },
         "node2Session" : {
-          "name" : "1.10.1.1/32",
+          "remotePrefix" : "1.10.1.1/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -950,7 +923,6 @@
           "localAs" : 1,
           "localIp" : "1.2.2.2",
           "remoteAs" : 1,
-          "remotePrefix" : "1.10.1.1/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
@@ -964,7 +936,7 @@
           "node2" : "as2core1"
         },
         "node1Session" : {
-          "name" : "2.1.2.1/32",
+          "remotePrefix" : "2.1.2.1/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -983,13 +955,12 @@
           "localAs" : 2,
           "localIp" : "2.1.1.1",
           "remoteAs" : 2,
-          "remotePrefix" : "2.1.2.1/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
         },
         "node2Session" : {
-          "name" : "2.1.1.1/32",
+          "remotePrefix" : "2.1.1.1/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -1008,7 +979,6 @@
           "localAs" : 2,
           "localIp" : "2.1.2.1",
           "remoteAs" : 2,
-          "remotePrefix" : "2.1.1.1/32",
           "routeReflectorClient" : true,
           "sendCommunity" : true,
           "vrf" : "default"
@@ -1022,7 +992,7 @@
           "node2" : "as2core2"
         },
         "node1Session" : {
-          "name" : "2.1.2.2/32",
+          "remotePrefix" : "2.1.2.2/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -1041,13 +1011,12 @@
           "localAs" : 2,
           "localIp" : "2.1.1.1",
           "remoteAs" : 2,
-          "remotePrefix" : "2.1.2.2/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
         },
         "node2Session" : {
-          "name" : "2.1.1.1/32",
+          "remotePrefix" : "2.1.1.1/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -1066,7 +1035,6 @@
           "localAs" : 2,
           "localIp" : "2.1.2.2",
           "remoteAs" : 2,
-          "remotePrefix" : "2.1.1.1/32",
           "routeReflectorClient" : true,
           "sendCommunity" : true,
           "vrf" : "default"
@@ -1080,7 +1048,7 @@
           "node2" : "as2core1"
         },
         "node1Session" : {
-          "name" : "2.1.2.1/32",
+          "remotePrefix" : "2.1.2.1/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -1099,13 +1067,12 @@
           "localAs" : 2,
           "localIp" : "2.1.1.2",
           "remoteAs" : 2,
-          "remotePrefix" : "2.1.2.1/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
         },
         "node2Session" : {
-          "name" : "2.1.1.2/32",
+          "remotePrefix" : "2.1.1.2/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -1124,7 +1091,6 @@
           "localAs" : 2,
           "localIp" : "2.1.2.1",
           "remoteAs" : 2,
-          "remotePrefix" : "2.1.1.2/32",
           "routeReflectorClient" : true,
           "sendCommunity" : true,
           "vrf" : "default"
@@ -1138,7 +1104,7 @@
           "node2" : "as2core2"
         },
         "node1Session" : {
-          "name" : "2.1.2.2/32",
+          "remotePrefix" : "2.1.2.2/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -1157,13 +1123,12 @@
           "localAs" : 2,
           "localIp" : "2.1.1.2",
           "remoteAs" : 2,
-          "remotePrefix" : "2.1.2.2/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
         },
         "node2Session" : {
-          "name" : "2.1.1.2/32",
+          "remotePrefix" : "2.1.1.2/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -1182,7 +1147,6 @@
           "localAs" : 2,
           "localIp" : "2.1.2.2",
           "remoteAs" : 2,
-          "remotePrefix" : "2.1.1.2/32",
           "routeReflectorClient" : true,
           "sendCommunity" : true,
           "vrf" : "default"
@@ -1196,7 +1160,7 @@
           "node2" : "as2border1"
         },
         "node1Session" : {
-          "name" : "2.1.1.1/32",
+          "remotePrefix" : "2.1.1.1/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -1215,13 +1179,12 @@
           "localAs" : 2,
           "localIp" : "2.1.2.1",
           "remoteAs" : 2,
-          "remotePrefix" : "2.1.1.1/32",
           "routeReflectorClient" : true,
           "sendCommunity" : true,
           "vrf" : "default"
         },
         "node2Session" : {
-          "name" : "2.1.2.1/32",
+          "remotePrefix" : "2.1.2.1/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -1240,7 +1203,6 @@
           "localAs" : 2,
           "localIp" : "2.1.1.1",
           "remoteAs" : 2,
-          "remotePrefix" : "2.1.2.1/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
@@ -1254,7 +1216,7 @@
           "node2" : "as2border2"
         },
         "node1Session" : {
-          "name" : "2.1.1.2/32",
+          "remotePrefix" : "2.1.1.2/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -1273,13 +1235,12 @@
           "localAs" : 2,
           "localIp" : "2.1.2.1",
           "remoteAs" : 2,
-          "remotePrefix" : "2.1.1.2/32",
           "routeReflectorClient" : true,
           "sendCommunity" : true,
           "vrf" : "default"
         },
         "node2Session" : {
-          "name" : "2.1.2.1/32",
+          "remotePrefix" : "2.1.2.1/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -1298,7 +1259,6 @@
           "localAs" : 2,
           "localIp" : "2.1.1.2",
           "remoteAs" : 2,
-          "remotePrefix" : "2.1.2.1/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
@@ -1312,7 +1272,7 @@
           "node2" : "as2dist1"
         },
         "node1Session" : {
-          "name" : "2.1.3.1/32",
+          "remotePrefix" : "2.1.3.1/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -1331,13 +1291,12 @@
           "localAs" : 2,
           "localIp" : "2.1.2.1",
           "remoteAs" : 2,
-          "remotePrefix" : "2.1.3.1/32",
           "routeReflectorClient" : true,
           "sendCommunity" : true,
           "vrf" : "default"
         },
         "node2Session" : {
-          "name" : "2.1.2.1/32",
+          "remotePrefix" : "2.1.2.1/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -1356,7 +1315,6 @@
           "localAs" : 2,
           "localIp" : "2.1.3.1",
           "remoteAs" : 2,
-          "remotePrefix" : "2.1.2.1/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
@@ -1370,7 +1328,7 @@
           "node2" : "as2dist2"
         },
         "node1Session" : {
-          "name" : "2.1.3.2/32",
+          "remotePrefix" : "2.1.3.2/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -1389,13 +1347,12 @@
           "localAs" : 2,
           "localIp" : "2.1.2.1",
           "remoteAs" : 2,
-          "remotePrefix" : "2.1.3.2/32",
           "routeReflectorClient" : true,
           "sendCommunity" : true,
           "vrf" : "default"
         },
         "node2Session" : {
-          "name" : "2.1.2.1/32",
+          "remotePrefix" : "2.1.2.1/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -1414,7 +1371,6 @@
           "localAs" : 2,
           "localIp" : "2.1.3.2",
           "remoteAs" : 2,
-          "remotePrefix" : "2.1.2.1/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
@@ -1428,7 +1384,7 @@
           "node2" : "as2border1"
         },
         "node1Session" : {
-          "name" : "2.1.1.1/32",
+          "remotePrefix" : "2.1.1.1/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -1447,13 +1403,12 @@
           "localAs" : 2,
           "localIp" : "2.1.2.2",
           "remoteAs" : 2,
-          "remotePrefix" : "2.1.1.1/32",
           "routeReflectorClient" : true,
           "sendCommunity" : true,
           "vrf" : "default"
         },
         "node2Session" : {
-          "name" : "2.1.2.2/32",
+          "remotePrefix" : "2.1.2.2/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -1472,7 +1427,6 @@
           "localAs" : 2,
           "localIp" : "2.1.1.1",
           "remoteAs" : 2,
-          "remotePrefix" : "2.1.2.2/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
@@ -1486,7 +1440,7 @@
           "node2" : "as2border2"
         },
         "node1Session" : {
-          "name" : "2.1.1.2/32",
+          "remotePrefix" : "2.1.1.2/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -1505,13 +1459,12 @@
           "localAs" : 2,
           "localIp" : "2.1.2.2",
           "remoteAs" : 2,
-          "remotePrefix" : "2.1.1.2/32",
           "routeReflectorClient" : true,
           "sendCommunity" : true,
           "vrf" : "default"
         },
         "node2Session" : {
-          "name" : "2.1.2.2/32",
+          "remotePrefix" : "2.1.2.2/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -1530,7 +1483,6 @@
           "localAs" : 2,
           "localIp" : "2.1.1.2",
           "remoteAs" : 2,
-          "remotePrefix" : "2.1.2.2/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
@@ -1544,7 +1496,7 @@
           "node2" : "as2dist1"
         },
         "node1Session" : {
-          "name" : "2.1.3.1/32",
+          "remotePrefix" : "2.1.3.1/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -1563,13 +1515,12 @@
           "localAs" : 2,
           "localIp" : "2.1.2.2",
           "remoteAs" : 2,
-          "remotePrefix" : "2.1.3.1/32",
           "routeReflectorClient" : true,
           "sendCommunity" : true,
           "vrf" : "default"
         },
         "node2Session" : {
-          "name" : "2.1.2.2/32",
+          "remotePrefix" : "2.1.2.2/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -1588,7 +1539,6 @@
           "localAs" : 2,
           "localIp" : "2.1.3.1",
           "remoteAs" : 2,
-          "remotePrefix" : "2.1.2.2/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
@@ -1602,7 +1552,7 @@
           "node2" : "as2dist2"
         },
         "node1Session" : {
-          "name" : "2.1.3.2/32",
+          "remotePrefix" : "2.1.3.2/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -1621,13 +1571,12 @@
           "localAs" : 2,
           "localIp" : "2.1.2.2",
           "remoteAs" : 2,
-          "remotePrefix" : "2.1.3.2/32",
           "routeReflectorClient" : true,
           "sendCommunity" : true,
           "vrf" : "default"
         },
         "node2Session" : {
-          "name" : "2.1.2.2/32",
+          "remotePrefix" : "2.1.2.2/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -1646,7 +1595,6 @@
           "localAs" : 2,
           "localIp" : "2.1.3.2",
           "remoteAs" : 2,
-          "remotePrefix" : "2.1.2.2/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
@@ -1660,7 +1608,7 @@
           "node2" : "as2core1"
         },
         "node1Session" : {
-          "name" : "2.1.2.1/32",
+          "remotePrefix" : "2.1.2.1/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -1679,13 +1627,12 @@
           "localAs" : 2,
           "localIp" : "2.1.3.1",
           "remoteAs" : 2,
-          "remotePrefix" : "2.1.2.1/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
         },
         "node2Session" : {
-          "name" : "2.1.3.1/32",
+          "remotePrefix" : "2.1.3.1/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -1704,7 +1651,6 @@
           "localAs" : 2,
           "localIp" : "2.1.2.1",
           "remoteAs" : 2,
-          "remotePrefix" : "2.1.3.1/32",
           "routeReflectorClient" : true,
           "sendCommunity" : true,
           "vrf" : "default"
@@ -1718,7 +1664,7 @@
           "node2" : "as2core2"
         },
         "node1Session" : {
-          "name" : "2.1.2.2/32",
+          "remotePrefix" : "2.1.2.2/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -1737,13 +1683,12 @@
           "localAs" : 2,
           "localIp" : "2.1.3.1",
           "remoteAs" : 2,
-          "remotePrefix" : "2.1.2.2/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
         },
         "node2Session" : {
-          "name" : "2.1.3.1/32",
+          "remotePrefix" : "2.1.3.1/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -1762,7 +1707,6 @@
           "localAs" : 2,
           "localIp" : "2.1.2.2",
           "remoteAs" : 2,
-          "remotePrefix" : "2.1.3.1/32",
           "routeReflectorClient" : true,
           "sendCommunity" : true,
           "vrf" : "default"
@@ -1776,7 +1720,7 @@
           "node2" : "as2core1"
         },
         "node1Session" : {
-          "name" : "2.1.2.1/32",
+          "remotePrefix" : "2.1.2.1/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -1795,13 +1739,12 @@
           "localAs" : 2,
           "localIp" : "2.1.3.2",
           "remoteAs" : 2,
-          "remotePrefix" : "2.1.2.1/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
         },
         "node2Session" : {
-          "name" : "2.1.3.2/32",
+          "remotePrefix" : "2.1.3.2/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -1820,7 +1763,6 @@
           "localAs" : 2,
           "localIp" : "2.1.2.1",
           "remoteAs" : 2,
-          "remotePrefix" : "2.1.3.2/32",
           "routeReflectorClient" : true,
           "sendCommunity" : true,
           "vrf" : "default"
@@ -1834,7 +1776,7 @@
           "node2" : "as2core2"
         },
         "node1Session" : {
-          "name" : "2.1.2.2/32",
+          "remotePrefix" : "2.1.2.2/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -1853,13 +1795,12 @@
           "localAs" : 2,
           "localIp" : "2.1.3.2",
           "remoteAs" : 2,
-          "remotePrefix" : "2.1.2.2/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
         },
         "node2Session" : {
-          "name" : "2.1.3.2/32",
+          "remotePrefix" : "2.1.3.2/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -1878,7 +1819,6 @@
           "localAs" : 2,
           "localIp" : "2.1.2.2",
           "remoteAs" : 2,
-          "remotePrefix" : "2.1.3.2/32",
           "routeReflectorClient" : true,
           "sendCommunity" : true,
           "vrf" : "default"
@@ -1892,7 +1832,7 @@
           "node2" : "as3core1"
         },
         "node1Session" : {
-          "name" : "3.10.1.1/32",
+          "remotePrefix" : "3.10.1.1/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -1911,13 +1851,12 @@
           "localAs" : 3,
           "localIp" : "3.1.1.1",
           "remoteAs" : 3,
-          "remotePrefix" : "3.10.1.1/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
         },
         "node2Session" : {
-          "name" : "3.1.1.1/32",
+          "remotePrefix" : "3.1.1.1/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -1936,7 +1875,6 @@
           "localAs" : 3,
           "localIp" : "3.10.1.1",
           "remoteAs" : 3,
-          "remotePrefix" : "3.1.1.1/32",
           "routeReflectorClient" : true,
           "sendCommunity" : true,
           "vrf" : "default"
@@ -1950,7 +1888,7 @@
           "node2" : "as3core1"
         },
         "node1Session" : {
-          "name" : "3.10.1.1/32",
+          "remotePrefix" : "3.10.1.1/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -1969,13 +1907,12 @@
           "localAs" : 3,
           "localIp" : "3.2.2.2",
           "remoteAs" : 3,
-          "remotePrefix" : "3.10.1.1/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
         },
         "node2Session" : {
-          "name" : "3.2.2.2/32",
+          "remotePrefix" : "3.2.2.2/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -1994,7 +1931,6 @@
           "localAs" : 3,
           "localIp" : "3.10.1.1",
           "remoteAs" : 3,
-          "remotePrefix" : "3.2.2.2/32",
           "routeReflectorClient" : true,
           "sendCommunity" : true,
           "vrf" : "default"
@@ -2008,7 +1944,7 @@
           "node2" : "as3border1"
         },
         "node1Session" : {
-          "name" : "3.1.1.1/32",
+          "remotePrefix" : "3.1.1.1/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -2027,13 +1963,12 @@
           "localAs" : 3,
           "localIp" : "3.10.1.1",
           "remoteAs" : 3,
-          "remotePrefix" : "3.1.1.1/32",
           "routeReflectorClient" : true,
           "sendCommunity" : true,
           "vrf" : "default"
         },
         "node2Session" : {
-          "name" : "3.10.1.1/32",
+          "remotePrefix" : "3.10.1.1/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -2052,7 +1987,6 @@
           "localAs" : 3,
           "localIp" : "3.1.1.1",
           "remoteAs" : 3,
-          "remotePrefix" : "3.10.1.1/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"
@@ -2066,7 +2000,7 @@
           "node2" : "as3border2"
         },
         "node1Session" : {
-          "name" : "3.2.2.2/32",
+          "remotePrefix" : "3.2.2.2/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -2085,13 +2019,12 @@
           "localAs" : 3,
           "localIp" : "3.10.1.1",
           "remoteAs" : 3,
-          "remotePrefix" : "3.2.2.2/32",
           "routeReflectorClient" : true,
           "sendCommunity" : true,
           "vrf" : "default"
         },
         "node2Session" : {
-          "name" : "3.10.1.1/32",
+          "remotePrefix" : "3.10.1.1/32",
           "additionalPathsReceive" : true,
           "additionalPathsSelectAll" : true,
           "additionalPathsSend" : true,
@@ -2110,7 +2043,6 @@
           "localAs" : 3,
           "localIp" : "3.2.2.2",
           "remoteAs" : 3,
-          "remotePrefix" : "3.10.1.1/32",
           "routeReflectorClient" : false,
           "sendCommunity" : true,
           "vrf" : "default"

--- a/tests/basic/nodes.ref
+++ b/tests/basic/nodes.ref
@@ -1109,7 +1109,7 @@
               "multipathIbgp" : true,
               "neighbors" : {
                 "1.10.1.1/32" : {
-                  "name" : "1.10.1.1/32",
+                  "remotePrefix" : "1.10.1.1/32",
                   "additionalPathsReceive" : true,
                   "additionalPathsSelectAll" : true,
                   "additionalPathsSend" : true,
@@ -1128,13 +1128,12 @@
                   "localAs" : 1,
                   "localIp" : "1.1.1.1",
                   "remoteAs" : 1,
-                  "remotePrefix" : "1.10.1.1/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : true,
                   "vrf" : "default"
                 },
                 "3.2.2.2/32" : {
-                  "name" : "3.2.2.2/32",
+                  "remotePrefix" : "3.2.2.2/32",
                   "additionalPathsReceive" : true,
                   "additionalPathsSelectAll" : true,
                   "additionalPathsSend" : true,
@@ -1152,13 +1151,12 @@
                   "group" : "bad-ebgp",
                   "localAs" : 1,
                   "remoteAs" : 666,
-                  "remotePrefix" : "3.2.2.2/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : false,
                   "vrf" : "default"
                 },
                 "5.6.7.8/32" : {
-                  "name" : "5.6.7.8/32",
+                  "remotePrefix" : "5.6.7.8/32",
                   "additionalPathsReceive" : true,
                   "additionalPathsSelectAll" : true,
                   "additionalPathsSend" : true,
@@ -1176,13 +1174,12 @@
                   "group" : "xanadu",
                   "localAs" : 1,
                   "remoteAs" : 555,
-                  "remotePrefix" : "5.6.7.8/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : false,
                   "vrf" : "default"
                 },
                 "10.12.11.2/32" : {
-                  "name" : "10.12.11.2/32",
+                  "remotePrefix" : "10.12.11.2/32",
                   "additionalPathsReceive" : true,
                   "additionalPathsSelectAll" : true,
                   "additionalPathsSend" : true,
@@ -1208,7 +1205,6 @@
                   "localAs" : 1,
                   "localIp" : "10.12.11.1",
                   "remoteAs" : 2,
-                  "remotePrefix" : "10.12.11.2/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : true,
                   "vrf" : "default"
@@ -2400,7 +2396,7 @@
               "multipathIbgp" : true,
               "neighbors" : {
                 "1.10.1.1/32" : {
-                  "name" : "1.10.1.1/32",
+                  "remotePrefix" : "1.10.1.1/32",
                   "additionalPathsReceive" : true,
                   "additionalPathsSelectAll" : true,
                   "additionalPathsSend" : true,
@@ -2419,13 +2415,12 @@
                   "localAs" : 1,
                   "localIp" : "1.2.2.2",
                   "remoteAs" : 1,
-                  "remotePrefix" : "1.10.1.1/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : true,
                   "vrf" : "default"
                 },
                 "10.13.22.3/32" : {
-                  "name" : "10.13.22.3/32",
+                  "remotePrefix" : "10.13.22.3/32",
                   "additionalPathsReceive" : true,
                   "additionalPathsSelectAll" : true,
                   "additionalPathsSend" : true,
@@ -2451,13 +2446,12 @@
                   "localAs" : 1,
                   "localIp" : "10.13.22.1",
                   "remoteAs" : 3,
-                  "remotePrefix" : "10.13.22.3/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : true,
                   "vrf" : "default"
                 },
                 "10.14.22.4/32" : {
-                  "name" : "10.14.22.4/32",
+                  "remotePrefix" : "10.14.22.4/32",
                   "additionalPathsReceive" : true,
                   "additionalPathsSelectAll" : true,
                   "additionalPathsSend" : true,
@@ -2483,7 +2477,6 @@
                   "localAs" : 1,
                   "localIp" : "10.14.22.1",
                   "remoteAs" : 4,
-                  "remotePrefix" : "10.14.22.4/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : false,
                   "vrf" : "default"
@@ -2840,7 +2833,7 @@
               "multipathIbgp" : true,
               "neighbors" : {
                 "1.1.1.1/32" : {
-                  "name" : "1.1.1.1/32",
+                  "remotePrefix" : "1.1.1.1/32",
                   "additionalPathsReceive" : true,
                   "additionalPathsSelectAll" : true,
                   "additionalPathsSend" : true,
@@ -2859,13 +2852,12 @@
                   "localAs" : 1,
                   "localIp" : "1.10.1.1",
                   "remoteAs" : 1,
-                  "remotePrefix" : "1.1.1.1/32",
                   "routeReflectorClient" : true,
                   "sendCommunity" : true,
                   "vrf" : "default"
                 },
                 "1.2.2.2/32" : {
-                  "name" : "1.2.2.2/32",
+                  "remotePrefix" : "1.2.2.2/32",
                   "additionalPathsReceive" : true,
                   "additionalPathsSelectAll" : true,
                   "additionalPathsSend" : true,
@@ -2884,7 +2876,6 @@
                   "localAs" : 1,
                   "localIp" : "1.10.1.1",
                   "remoteAs" : 1,
-                  "remotePrefix" : "1.2.2.2/32",
                   "routeReflectorClient" : true,
                   "sendCommunity" : true,
                   "vrf" : "default"
@@ -4111,7 +4102,7 @@
               "multipathIbgp" : true,
               "neighbors" : {
                 "2.1.2.1/32" : {
-                  "name" : "2.1.2.1/32",
+                  "remotePrefix" : "2.1.2.1/32",
                   "additionalPathsReceive" : true,
                   "additionalPathsSelectAll" : true,
                   "additionalPathsSend" : true,
@@ -4130,13 +4121,12 @@
                   "localAs" : 2,
                   "localIp" : "2.1.1.1",
                   "remoteAs" : 2,
-                  "remotePrefix" : "2.1.2.1/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : true,
                   "vrf" : "default"
                 },
                 "2.1.2.2/32" : {
-                  "name" : "2.1.2.2/32",
+                  "remotePrefix" : "2.1.2.2/32",
                   "additionalPathsReceive" : true,
                   "additionalPathsSelectAll" : true,
                   "additionalPathsSend" : true,
@@ -4155,13 +4145,12 @@
                   "localAs" : 2,
                   "localIp" : "2.1.1.1",
                   "remoteAs" : 2,
-                  "remotePrefix" : "2.1.2.2/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : true,
                   "vrf" : "default"
                 },
                 "10.12.11.1/32" : {
-                  "name" : "10.12.11.1/32",
+                  "remotePrefix" : "10.12.11.1/32",
                   "additionalPathsReceive" : true,
                   "additionalPathsSelectAll" : true,
                   "additionalPathsSend" : true,
@@ -4187,7 +4176,6 @@
                   "localAs" : 2,
                   "localIp" : "10.12.11.2",
                   "remoteAs" : 1,
-                  "remotePrefix" : "10.12.11.1/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : true,
                   "vrf" : "default"
@@ -5362,7 +5350,7 @@
               "multipathIbgp" : true,
               "neighbors" : {
                 "2.1.2.1/32" : {
-                  "name" : "2.1.2.1/32",
+                  "remotePrefix" : "2.1.2.1/32",
                   "additionalPathsReceive" : true,
                   "additionalPathsSelectAll" : true,
                   "additionalPathsSend" : true,
@@ -5381,13 +5369,12 @@
                   "localAs" : 2,
                   "localIp" : "2.1.1.2",
                   "remoteAs" : 2,
-                  "remotePrefix" : "2.1.2.1/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : true,
                   "vrf" : "default"
                 },
                 "2.1.2.2/32" : {
-                  "name" : "2.1.2.2/32",
+                  "remotePrefix" : "2.1.2.2/32",
                   "additionalPathsReceive" : true,
                   "additionalPathsSelectAll" : true,
                   "additionalPathsSend" : true,
@@ -5406,13 +5393,12 @@
                   "localAs" : 2,
                   "localIp" : "2.1.1.2",
                   "remoteAs" : 2,
-                  "remotePrefix" : "2.1.2.2/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : true,
                   "vrf" : "default"
                 },
                 "10.23.21.3/32" : {
-                  "name" : "10.23.21.3/32",
+                  "remotePrefix" : "10.23.21.3/32",
                   "additionalPathsReceive" : true,
                   "additionalPathsSelectAll" : true,
                   "additionalPathsSend" : true,
@@ -5438,7 +5424,6 @@
                   "localAs" : 2,
                   "localIp" : "10.23.21.2",
                   "remoteAs" : 3,
-                  "remotePrefix" : "10.23.21.3/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : true,
                   "vrf" : "default"
@@ -5959,7 +5944,7 @@
               "multipathIbgp" : true,
               "neighbors" : {
                 "2.1.1.1/32" : {
-                  "name" : "2.1.1.1/32",
+                  "remotePrefix" : "2.1.1.1/32",
                   "additionalPathsReceive" : true,
                   "additionalPathsSelectAll" : true,
                   "additionalPathsSend" : true,
@@ -5978,13 +5963,12 @@
                   "localAs" : 2,
                   "localIp" : "2.1.2.1",
                   "remoteAs" : 2,
-                  "remotePrefix" : "2.1.1.1/32",
                   "routeReflectorClient" : true,
                   "sendCommunity" : true,
                   "vrf" : "default"
                 },
                 "2.1.1.2/32" : {
-                  "name" : "2.1.1.2/32",
+                  "remotePrefix" : "2.1.1.2/32",
                   "additionalPathsReceive" : true,
                   "additionalPathsSelectAll" : true,
                   "additionalPathsSend" : true,
@@ -6003,13 +5987,12 @@
                   "localAs" : 2,
                   "localIp" : "2.1.2.1",
                   "remoteAs" : 2,
-                  "remotePrefix" : "2.1.1.2/32",
                   "routeReflectorClient" : true,
                   "sendCommunity" : true,
                   "vrf" : "default"
                 },
                 "2.1.3.1/32" : {
-                  "name" : "2.1.3.1/32",
+                  "remotePrefix" : "2.1.3.1/32",
                   "additionalPathsReceive" : true,
                   "additionalPathsSelectAll" : true,
                   "additionalPathsSend" : true,
@@ -6028,13 +6011,12 @@
                   "localAs" : 2,
                   "localIp" : "2.1.2.1",
                   "remoteAs" : 2,
-                  "remotePrefix" : "2.1.3.1/32",
                   "routeReflectorClient" : true,
                   "sendCommunity" : true,
                   "vrf" : "default"
                 },
                 "2.1.3.2/32" : {
-                  "name" : "2.1.3.2/32",
+                  "remotePrefix" : "2.1.3.2/32",
                   "additionalPathsReceive" : true,
                   "additionalPathsSelectAll" : true,
                   "additionalPathsSend" : true,
@@ -6053,7 +6035,6 @@
                   "localAs" : 2,
                   "localIp" : "2.1.2.1",
                   "remoteAs" : 2,
-                  "remotePrefix" : "2.1.3.2/32",
                   "routeReflectorClient" : true,
                   "sendCommunity" : true,
                   "vrf" : "default"
@@ -6526,7 +6507,7 @@
               "multipathIbgp" : true,
               "neighbors" : {
                 "2.1.1.1/32" : {
-                  "name" : "2.1.1.1/32",
+                  "remotePrefix" : "2.1.1.1/32",
                   "additionalPathsReceive" : true,
                   "additionalPathsSelectAll" : true,
                   "additionalPathsSend" : true,
@@ -6545,13 +6526,12 @@
                   "localAs" : 2,
                   "localIp" : "2.1.2.2",
                   "remoteAs" : 2,
-                  "remotePrefix" : "2.1.1.1/32",
                   "routeReflectorClient" : true,
                   "sendCommunity" : true,
                   "vrf" : "default"
                 },
                 "2.1.1.2/32" : {
-                  "name" : "2.1.1.2/32",
+                  "remotePrefix" : "2.1.1.2/32",
                   "additionalPathsReceive" : true,
                   "additionalPathsSelectAll" : true,
                   "additionalPathsSend" : true,
@@ -6570,13 +6550,12 @@
                   "localAs" : 2,
                   "localIp" : "2.1.2.2",
                   "remoteAs" : 2,
-                  "remotePrefix" : "2.1.1.2/32",
                   "routeReflectorClient" : true,
                   "sendCommunity" : true,
                   "vrf" : "default"
                 },
                 "2.1.3.1/32" : {
-                  "name" : "2.1.3.1/32",
+                  "remotePrefix" : "2.1.3.1/32",
                   "additionalPathsReceive" : true,
                   "additionalPathsSelectAll" : true,
                   "additionalPathsSend" : true,
@@ -6595,13 +6574,12 @@
                   "localAs" : 2,
                   "localIp" : "2.1.2.2",
                   "remoteAs" : 2,
-                  "remotePrefix" : "2.1.3.1/32",
                   "routeReflectorClient" : true,
                   "sendCommunity" : true,
                   "vrf" : "default"
                 },
                 "2.1.3.2/32" : {
-                  "name" : "2.1.3.2/32",
+                  "remotePrefix" : "2.1.3.2/32",
                   "additionalPathsReceive" : true,
                   "additionalPathsSelectAll" : true,
                   "additionalPathsSend" : true,
@@ -6620,7 +6598,6 @@
                   "localAs" : 2,
                   "localIp" : "2.1.2.2",
                   "remoteAs" : 2,
-                  "remotePrefix" : "2.1.3.2/32",
                   "routeReflectorClient" : true,
                   "sendCommunity" : true,
                   "vrf" : "default"
@@ -7539,7 +7516,7 @@
               "multipathIbgp" : true,
               "neighbors" : {
                 "2.34.101.3/32" : {
-                  "name" : "2.34.101.3/32",
+                  "remotePrefix" : "2.34.101.3/32",
                   "additionalPathsReceive" : true,
                   "additionalPathsSelectAll" : true,
                   "additionalPathsSend" : true,
@@ -7565,13 +7542,12 @@
                   "localAs" : 65001,
                   "localIp" : "2.34.101.4",
                   "remoteAs" : 2,
-                  "remotePrefix" : "2.34.101.3/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : true,
                   "vrf" : "default"
                 },
                 "2.34.201.3/32" : {
-                  "name" : "2.34.201.3/32",
+                  "remotePrefix" : "2.34.201.3/32",
                   "additionalPathsReceive" : true,
                   "additionalPathsSelectAll" : true,
                   "additionalPathsSend" : true,
@@ -7597,7 +7573,6 @@
                   "localAs" : 65001,
                   "localIp" : "2.34.201.4",
                   "remoteAs" : 2,
-                  "remotePrefix" : "2.34.201.3/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : true,
                   "vrf" : "default"
@@ -8270,7 +8245,7 @@
               "multipathIbgp" : true,
               "neighbors" : {
                 "2.1.2.1/32" : {
-                  "name" : "2.1.2.1/32",
+                  "remotePrefix" : "2.1.2.1/32",
                   "additionalPathsReceive" : true,
                   "additionalPathsSelectAll" : true,
                   "additionalPathsSend" : true,
@@ -8289,13 +8264,12 @@
                   "localAs" : 2,
                   "localIp" : "2.1.3.1",
                   "remoteAs" : 2,
-                  "remotePrefix" : "2.1.2.1/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : true,
                   "vrf" : "default"
                 },
                 "2.1.2.2/32" : {
-                  "name" : "2.1.2.2/32",
+                  "remotePrefix" : "2.1.2.2/32",
                   "additionalPathsReceive" : true,
                   "additionalPathsSelectAll" : true,
                   "additionalPathsSend" : true,
@@ -8314,13 +8288,12 @@
                   "localAs" : 2,
                   "localIp" : "2.1.3.1",
                   "remoteAs" : 2,
-                  "remotePrefix" : "2.1.2.2/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : true,
                   "vrf" : "default"
                 },
                 "2.34.101.4/32" : {
-                  "name" : "2.34.101.4/32",
+                  "remotePrefix" : "2.34.101.4/32",
                   "additionalPathsReceive" : true,
                   "additionalPathsSelectAll" : true,
                   "additionalPathsSend" : true,
@@ -8346,7 +8319,6 @@
                   "localAs" : 2,
                   "localIp" : "2.34.101.3",
                   "remoteAs" : 65001,
-                  "remotePrefix" : "2.34.101.4/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : true,
                   "vrf" : "default"
@@ -9035,7 +9007,7 @@
               "multipathIbgp" : true,
               "neighbors" : {
                 "2.1.2.1/32" : {
-                  "name" : "2.1.2.1/32",
+                  "remotePrefix" : "2.1.2.1/32",
                   "additionalPathsReceive" : true,
                   "additionalPathsSelectAll" : true,
                   "additionalPathsSend" : true,
@@ -9054,13 +9026,12 @@
                   "localAs" : 2,
                   "localIp" : "2.1.3.2",
                   "remoteAs" : 2,
-                  "remotePrefix" : "2.1.2.1/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : true,
                   "vrf" : "default"
                 },
                 "2.1.2.2/32" : {
-                  "name" : "2.1.2.2/32",
+                  "remotePrefix" : "2.1.2.2/32",
                   "additionalPathsReceive" : true,
                   "additionalPathsSelectAll" : true,
                   "additionalPathsSend" : true,
@@ -9079,13 +9050,12 @@
                   "localAs" : 2,
                   "localIp" : "2.1.3.2",
                   "remoteAs" : 2,
-                  "remotePrefix" : "2.1.2.2/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : true,
                   "vrf" : "default"
                 },
                 "2.34.201.4/32" : {
-                  "name" : "2.34.201.4/32",
+                  "remotePrefix" : "2.34.201.4/32",
                   "additionalPathsReceive" : true,
                   "additionalPathsSelectAll" : true,
                   "additionalPathsSend" : true,
@@ -9111,7 +9081,6 @@
                   "localAs" : 2,
                   "localIp" : "2.34.201.3",
                   "remoteAs" : 65001,
-                  "remotePrefix" : "2.34.201.4/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : true,
                   "vrf" : "default"
@@ -10218,7 +10187,7 @@
               "multipathIbgp" : true,
               "neighbors" : {
                 "3.10.1.1/32" : {
-                  "name" : "3.10.1.1/32",
+                  "remotePrefix" : "3.10.1.1/32",
                   "additionalPathsReceive" : true,
                   "additionalPathsSelectAll" : true,
                   "additionalPathsSend" : true,
@@ -10237,13 +10206,12 @@
                   "localAs" : 3,
                   "localIp" : "3.1.1.1",
                   "remoteAs" : 3,
-                  "remotePrefix" : "3.10.1.1/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : true,
                   "vrf" : "default"
                 },
                 "10.23.21.2/32" : {
-                  "name" : "10.23.21.2/32",
+                  "remotePrefix" : "10.23.21.2/32",
                   "additionalPathsReceive" : true,
                   "additionalPathsSelectAll" : true,
                   "additionalPathsSend" : true,
@@ -10269,7 +10237,6 @@
                   "localAs" : 3,
                   "localIp" : "10.23.21.3",
                   "remoteAs" : 2,
-                  "remotePrefix" : "10.23.21.2/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : true,
                   "vrf" : "default"
@@ -11317,7 +11284,7 @@
               "multipathIbgp" : true,
               "neighbors" : {
                 "3.10.1.1/32" : {
-                  "name" : "3.10.1.1/32",
+                  "remotePrefix" : "3.10.1.1/32",
                   "additionalPathsReceive" : true,
                   "additionalPathsSelectAll" : true,
                   "additionalPathsSend" : true,
@@ -11336,13 +11303,12 @@
                   "localAs" : 3,
                   "localIp" : "3.2.2.2",
                   "remoteAs" : 3,
-                  "remotePrefix" : "3.10.1.1/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : true,
                   "vrf" : "default"
                 },
                 "10.13.22.1/32" : {
-                  "name" : "10.13.22.1/32",
+                  "remotePrefix" : "10.13.22.1/32",
                   "additionalPathsReceive" : true,
                   "additionalPathsSelectAll" : true,
                   "additionalPathsSend" : true,
@@ -11368,7 +11334,6 @@
                   "localAs" : 3,
                   "localIp" : "10.13.22.3",
                   "remoteAs" : 1,
-                  "remotePrefix" : "10.13.22.1/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : true,
                   "vrf" : "default"
@@ -11922,7 +11887,7 @@
               "multipathIbgp" : true,
               "neighbors" : {
                 "3.1.1.1/32" : {
-                  "name" : "3.1.1.1/32",
+                  "remotePrefix" : "3.1.1.1/32",
                   "additionalPathsReceive" : true,
                   "additionalPathsSelectAll" : true,
                   "additionalPathsSend" : true,
@@ -11941,13 +11906,12 @@
                   "localAs" : 3,
                   "localIp" : "3.10.1.1",
                   "remoteAs" : 3,
-                  "remotePrefix" : "3.1.1.1/32",
                   "routeReflectorClient" : true,
                   "sendCommunity" : true,
                   "vrf" : "default"
                 },
                 "3.2.2.2/32" : {
-                  "name" : "3.2.2.2/32",
+                  "remotePrefix" : "3.2.2.2/32",
                   "additionalPathsReceive" : true,
                   "additionalPathsSelectAll" : true,
                   "additionalPathsSend" : true,
@@ -11966,7 +11930,6 @@
                   "localAs" : 3,
                   "localIp" : "3.10.1.1",
                   "remoteAs" : 3,
-                  "remotePrefix" : "3.2.2.2/32",
                   "routeReflectorClient" : true,
                   "sendCommunity" : true,
                   "vrf" : "default"

--- a/tests/basic/outliers-verbose.ref
+++ b/tests/basic/outliers-verbose.ref
@@ -2375,7 +2375,7 @@
             "multipathIbgp" : true,
             "neighbors" : {
               "1.10.1.1/32" : {
-                "name" : "1.10.1.1/32",
+                "remotePrefix" : "1.10.1.1/32",
                 "additionalPathsReceive" : true,
                 "additionalPathsSelectAll" : true,
                 "additionalPathsSend" : true,
@@ -2394,13 +2394,12 @@
                 "localAs" : 1,
                 "localIp" : "1.1.1.1",
                 "remoteAs" : 1,
-                "remotePrefix" : "1.10.1.1/32",
                 "routeReflectorClient" : false,
                 "sendCommunity" : true,
                 "vrf" : "default"
               },
               "3.2.2.2/32" : {
-                "name" : "3.2.2.2/32",
+                "remotePrefix" : "3.2.2.2/32",
                 "additionalPathsReceive" : true,
                 "additionalPathsSelectAll" : true,
                 "additionalPathsSend" : true,
@@ -2418,13 +2417,12 @@
                 "group" : "bad-ebgp",
                 "localAs" : 1,
                 "remoteAs" : 666,
-                "remotePrefix" : "3.2.2.2/32",
                 "routeReflectorClient" : false,
                 "sendCommunity" : false,
                 "vrf" : "default"
               },
               "5.6.7.8/32" : {
-                "name" : "5.6.7.8/32",
+                "remotePrefix" : "5.6.7.8/32",
                 "additionalPathsReceive" : true,
                 "additionalPathsSelectAll" : true,
                 "additionalPathsSend" : true,
@@ -2442,13 +2440,12 @@
                 "group" : "xanadu",
                 "localAs" : 1,
                 "remoteAs" : 555,
-                "remotePrefix" : "5.6.7.8/32",
                 "routeReflectorClient" : false,
                 "sendCommunity" : false,
                 "vrf" : "default"
               },
               "10.12.11.2/32" : {
-                "name" : "10.12.11.2/32",
+                "remotePrefix" : "10.12.11.2/32",
                 "additionalPathsReceive" : true,
                 "additionalPathsSelectAll" : true,
                 "additionalPathsSend" : true,
@@ -2474,7 +2471,6 @@
                 "localAs" : 1,
                 "localIp" : "10.12.11.1",
                 "remoteAs" : 2,
-                "remotePrefix" : "10.12.11.2/32",
                 "routeReflectorClient" : false,
                 "sendCommunity" : true,
                 "vrf" : "default"

--- a/tests/jsonpath-addons/jsonpath-display-hints-prefixofsuffix.ref
+++ b/tests/jsonpath-addons/jsonpath-display-hints-prefixofsuffix.ref
@@ -1217,7 +1217,7 @@
                     "multipathIbgp" : true,
                     "neighbors" : {
                       "2.1.2.1/32" : {
-                        "name" : "2.1.2.1/32",
+                        "remotePrefix" : "2.1.2.1/32",
                         "additionalPathsReceive" : true,
                         "additionalPathsSelectAll" : true,
                         "additionalPathsSend" : true,
@@ -1236,13 +1236,12 @@
                         "localAs" : 2,
                         "localIp" : "2.1.1.1",
                         "remoteAs" : 2,
-                        "remotePrefix" : "2.1.2.1/32",
                         "routeReflectorClient" : false,
                         "sendCommunity" : true,
                         "vrf" : "default"
                       },
                       "2.1.2.2/32" : {
-                        "name" : "2.1.2.2/32",
+                        "remotePrefix" : "2.1.2.2/32",
                         "additionalPathsReceive" : true,
                         "additionalPathsSelectAll" : true,
                         "additionalPathsSend" : true,
@@ -1261,13 +1260,12 @@
                         "localAs" : 2,
                         "localIp" : "2.1.1.1",
                         "remoteAs" : 2,
-                        "remotePrefix" : "2.1.2.2/32",
                         "routeReflectorClient" : false,
                         "sendCommunity" : true,
                         "vrf" : "default"
                       },
                       "10.12.11.1/32" : {
-                        "name" : "10.12.11.1/32",
+                        "remotePrefix" : "10.12.11.1/32",
                         "additionalPathsReceive" : true,
                         "additionalPathsSelectAll" : true,
                         "additionalPathsSend" : true,
@@ -1293,7 +1291,6 @@
                         "localAs" : 2,
                         "localIp" : "10.12.11.2",
                         "remoteAs" : 1,
-                        "remotePrefix" : "10.12.11.1/32",
                         "routeReflectorClient" : false,
                         "sendCommunity" : true,
                         "vrf" : "default"

--- a/tests/jsonpath-addons/jsonpath-display-hints-suffixofsuffix.ref
+++ b/tests/jsonpath-addons/jsonpath-display-hints-suffixofsuffix.ref
@@ -1217,7 +1217,7 @@
                     "multipathIbgp" : true,
                     "neighbors" : {
                       "2.1.2.1/32" : {
-                        "name" : "2.1.2.1/32",
+                        "remotePrefix" : "2.1.2.1/32",
                         "additionalPathsReceive" : true,
                         "additionalPathsSelectAll" : true,
                         "additionalPathsSend" : true,
@@ -1236,13 +1236,12 @@
                         "localAs" : 2,
                         "localIp" : "2.1.1.1",
                         "remoteAs" : 2,
-                        "remotePrefix" : "2.1.2.1/32",
                         "routeReflectorClient" : false,
                         "sendCommunity" : true,
                         "vrf" : "default"
                       },
                       "2.1.2.2/32" : {
-                        "name" : "2.1.2.2/32",
+                        "remotePrefix" : "2.1.2.2/32",
                         "additionalPathsReceive" : true,
                         "additionalPathsSelectAll" : true,
                         "additionalPathsSend" : true,
@@ -1261,13 +1260,12 @@
                         "localAs" : 2,
                         "localIp" : "2.1.1.1",
                         "remoteAs" : 2,
-                        "remotePrefix" : "2.1.2.2/32",
                         "routeReflectorClient" : false,
                         "sendCommunity" : true,
                         "vrf" : "default"
                       },
                       "10.12.11.1/32" : {
-                        "name" : "10.12.11.1/32",
+                        "remotePrefix" : "10.12.11.1/32",
                         "additionalPathsReceive" : true,
                         "additionalPathsSelectAll" : true,
                         "additionalPathsSend" : true,
@@ -1293,7 +1291,6 @@
                         "localAs" : 2,
                         "localIp" : "10.12.11.2",
                         "remoteAs" : 1,
-                        "remotePrefix" : "10.12.11.1/32",
                         "routeReflectorClient" : false,
                         "sendCommunity" : true,
                         "vrf" : "default"

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -235,7 +235,7 @@
               "multipathIbgp" : false,
               "neighbors" : {
                 "1.2.3.4/32" : {
-                  "name" : "1.2.3.4/32",
+                  "remotePrefix" : "1.2.3.4/32",
                   "additionalPathsReceive" : false,
                   "additionalPathsSelectAll" : false,
                   "additionalPathsSend" : false,
@@ -252,7 +252,6 @@
                   "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:1.2.3.4~",
                   "localAs" : 1,
                   "remoteAs" : 1,
-                  "remotePrefix" : "1.2.3.4/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : false,
                   "vrf" : "default"
@@ -2049,7 +2048,7 @@
               "multipathIbgp" : false,
               "neighbors" : {
                 "10.1.1.0/24" : {
-                  "name" : "10.1.1.0/24",
+                  "remotePrefix" : "10.1.1.0/24",
                   "additionalPathsReceive" : false,
                   "additionalPathsSelectAll" : false,
                   "additionalPathsSend" : false,
@@ -2071,7 +2070,6 @@
                   "localAs" : 1,
                   "localIp" : "1.1.1.1",
                   "remoteAs" : 2,
-                  "remotePrefix" : "10.1.1.0/24",
                   "routeReflectorClient" : false,
                   "sendCommunity" : true,
                   "vrf" : "default"
@@ -2286,7 +2284,7 @@
               "multipathIbgp" : false,
               "neighbors" : {
                 "1.1.1.1/32" : {
-                  "name" : "1.1.1.1/32",
+                  "remotePrefix" : "1.1.1.1/32",
                   "additionalPathsReceive" : false,
                   "additionalPathsSelectAll" : false,
                   "additionalPathsSend" : false,
@@ -2308,7 +2306,6 @@
                   "importPolicy" : "~PEER_IMPORT_POLICY:1.1.1.1/32~",
                   "localAs" : 1,
                   "remoteAs" : 2,
-                  "remotePrefix" : "1.1.1.1/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : true,
                   "vrf" : "default"
@@ -2566,7 +2563,7 @@
               "multipathIbgp" : true,
               "neighbors" : {
                 "1.10.1.1/32" : {
-                  "name" : "1.10.1.1/32",
+                  "remotePrefix" : "1.10.1.1/32",
                   "additionalPathsReceive" : false,
                   "additionalPathsSelectAll" : false,
                   "additionalPathsSend" : false,
@@ -2584,13 +2581,12 @@
                   "group" : "as1",
                   "localAs" : 1,
                   "remoteAs" : 1,
-                  "remotePrefix" : "1.10.1.1/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : true,
                   "vrf" : "default"
                 },
                 "10.12.11.2/32" : {
-                  "name" : "10.12.11.2/32",
+                  "remotePrefix" : "10.12.11.2/32",
                   "additionalPathsReceive" : false,
                   "additionalPathsSelectAll" : false,
                   "additionalPathsSend" : false,
@@ -2608,7 +2604,6 @@
                   "group" : "as2",
                   "localAs" : 1,
                   "remoteAs" : 2,
-                  "remotePrefix" : "10.12.11.2/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : true,
                   "vrf" : "default"
@@ -3040,7 +3035,7 @@
               "multipathIbgp" : false,
               "neighbors" : {
                 "64.57.21.1/32" : {
-                  "name" : "64.57.21.1/32",
+                  "remotePrefix" : "64.57.21.1/32",
                   "additionalPathsReceive" : false,
                   "additionalPathsSelectAll" : false,
                   "additionalPathsSend" : false,
@@ -3059,7 +3054,6 @@
                   "group" : "EBGP-PEER-SVL-PNI",
                   "localAs" : 2152,
                   "remoteAs" : 11164,
-                  "remotePrefix" : "64.57.21.1/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : false,
                   "vrf" : "default"
@@ -5496,7 +5490,7 @@
               "multipathIbgp" : false,
               "neighbors" : {
                 "10.0.1.2/32" : {
-                  "name" : "10.0.1.2/32",
+                  "remotePrefix" : "10.0.1.2/32",
                   "additionalPathsReceive" : false,
                   "additionalPathsSelectAll" : false,
                   "additionalPathsSend" : false,
@@ -5517,7 +5511,6 @@
                   ],
                   "localAs" : 1,
                   "remoteAs" : 65001,
-                  "remotePrefix" : "10.0.1.2/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : false,
                   "vrf" : "aVrfWithInnerStatements"
@@ -8702,7 +8695,7 @@
               "multipathIbgp" : false,
               "neighbors" : {
                 "2.2.2.2/32" : {
-                  "name" : "2.2.2.2/32",
+                  "remotePrefix" : "2.2.2.2/32",
                   "additionalPathsReceive" : false,
                   "additionalPathsSelectAll" : false,
                   "additionalPathsSend" : false,
@@ -8719,7 +8712,6 @@
                   "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.2.2.2~",
                   "localAs" : 65500,
                   "remoteAs" : 6600,
-                  "remotePrefix" : "2.2.2.2/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : false,
                   "vrf" : "default"
@@ -12016,7 +12008,7 @@
               "multipathIbgp" : false,
               "neighbors" : {
                 "1.2.1.1/32" : {
-                  "name" : "1.2.1.1/32",
+                  "remotePrefix" : "1.2.1.1/32",
                   "additionalPathsReceive" : false,
                   "additionalPathsSelectAll" : false,
                   "additionalPathsSend" : false,
@@ -12035,13 +12027,12 @@
                   "group" : "foobar-iBGP_ipv4",
                   "localAs" : 5555,
                   "remoteAs" : 5555,
-                  "remotePrefix" : "1.2.1.1/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : false,
                   "vrf" : "default"
                 },
                 "1.2.1.2/32" : {
-                  "name" : "1.2.1.2/32",
+                  "remotePrefix" : "1.2.1.2/32",
                   "additionalPathsReceive" : false,
                   "additionalPathsSelectAll" : false,
                   "additionalPathsSend" : false,
@@ -12060,13 +12051,12 @@
                   "group" : "foobar-iBGP_ipv4",
                   "localAs" : 5555,
                   "remoteAs" : 5555,
-                  "remotePrefix" : "1.2.1.2/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : false,
                   "vrf" : "default"
                 },
                 "1.2.1.3/32" : {
-                  "name" : "1.2.1.3/32",
+                  "remotePrefix" : "1.2.1.3/32",
                   "additionalPathsReceive" : false,
                   "additionalPathsSelectAll" : false,
                   "additionalPathsSend" : false,
@@ -12085,7 +12075,6 @@
                   "group" : "foobar-iBGP_border_ipv4",
                   "localAs" : 5555,
                   "remoteAs" : 5555,
-                  "remotePrefix" : "1.2.1.3/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : false,
                   "vrf" : "default"
@@ -13590,7 +13579,7 @@
               "multipathIbgp" : false,
               "neighbors" : {
                 "172.16.2.1/32" : {
-                  "name" : "172.16.2.1/32",
+                  "remotePrefix" : "172.16.2.1/32",
                   "additionalPathsReceive" : false,
                   "additionalPathsSelectAll" : false,
                   "additionalPathsSend" : false,
@@ -13614,13 +13603,12 @@
                   "importPolicy" : "~PEER_IMPORT_POLICY:172.16.2.1/32~",
                   "localAs" : 65533,
                   "remoteAs" : 65530,
-                  "remotePrefix" : "172.16.2.1/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : true,
                   "vrf" : "default"
                 },
                 "172.16.2.2/32" : {
-                  "name" : "172.16.2.2/32",
+                  "remotePrefix" : "172.16.2.2/32",
                   "additionalPathsReceive" : false,
                   "additionalPathsSelectAll" : false,
                   "additionalPathsSend" : false,
@@ -13643,7 +13631,6 @@
                   "importPolicy" : "~PEER_IMPORT_POLICY:172.16.2.2/32~",
                   "localAs" : 65533,
                   "remoteAs" : 65530,
-                  "remotePrefix" : "172.16.2.2/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : true,
                   "vrf" : "default"
@@ -15258,7 +15245,7 @@
               "multipathIbgp" : false,
               "neighbors" : {
                 "123.123.123.123/32" : {
-                  "name" : "123.123.123.123/32",
+                  "remotePrefix" : "123.123.123.123/32",
                   "additionalPathsReceive" : false,
                   "additionalPathsSelectAll" : false,
                   "additionalPathsSend" : false,
@@ -15275,7 +15262,6 @@
                   "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:123.123.123.123~",
                   "localAs" : 1,
                   "remoteAs" : 1,
-                  "remotePrefix" : "123.123.123.123/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : false,
                   "vrf" : "default"
@@ -15428,7 +15414,7 @@
               "multipathIbgp" : false,
               "neighbors" : {
                 "123.123.123.123/32" : {
-                  "name" : "123.123.123.123/32",
+                  "remotePrefix" : "123.123.123.123/32",
                   "additionalPathsReceive" : false,
                   "additionalPathsSelectAll" : false,
                   "additionalPathsSend" : false,
@@ -15445,7 +15431,6 @@
                   "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:123.123.123.123~",
                   "localAs" : 1,
                   "remoteAs" : 1,
-                  "remotePrefix" : "123.123.123.123/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : false,
                   "vrf" : "default"
@@ -15658,7 +15643,7 @@
               "multipathIbgp" : false,
               "neighbors" : {
                 "1.1.1.1/32" : {
-                  "name" : "1.1.1.1/32",
+                  "remotePrefix" : "1.1.1.1/32",
                   "additionalPathsReceive" : false,
                   "additionalPathsSelectAll" : false,
                   "additionalPathsSend" : false,
@@ -15676,13 +15661,12 @@
                   "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:1.1.1.1~",
                   "localAs" : 1,
                   "remoteAs" : 1,
-                  "remotePrefix" : "1.1.1.1/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : false,
                   "vrf" : "default"
                 },
                 "3.3.3.3/32" : {
-                  "name" : "3.3.3.3/32",
+                  "remotePrefix" : "3.3.3.3/32",
                   "additionalPathsReceive" : false,
                   "additionalPathsSelectAll" : false,
                   "additionalPathsSend" : false,
@@ -15700,13 +15684,12 @@
                   "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:3.3.3.3~",
                   "localAs" : 1,
                   "remoteAs" : 3,
-                  "remotePrefix" : "3.3.3.3/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : false,
                   "vrf" : "default"
                 },
                 "4.4.4.4/32" : {
-                  "name" : "4.4.4.4/32",
+                  "remotePrefix" : "4.4.4.4/32",
                   "additionalPathsReceive" : false,
                   "additionalPathsSelectAll" : false,
                   "additionalPathsSend" : false,
@@ -15724,7 +15707,6 @@
                   "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:4.4.4.4~",
                   "localAs" : 1,
                   "remoteAs" : 4,
-                  "remotePrefix" : "4.4.4.4/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : false,
                   "vrf" : "default"
@@ -16361,7 +16343,7 @@
               "multipathIbgp" : false,
               "neighbors" : {
                 "10.0.0.0/32" : {
-                  "name" : "10.0.0.0/32",
+                  "remotePrefix" : "10.0.0.0/32",
                   "additionalPathsReceive" : false,
                   "additionalPathsSelectAll" : false,
                   "additionalPathsSend" : false,
@@ -16378,7 +16360,6 @@
                   "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.0.0.0~",
                   "localAs" : 2,
                   "remoteAs" : 1,
-                  "remotePrefix" : "10.0.0.0/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : false,
                   "vrf" : "default"
@@ -18463,7 +18444,7 @@
               "multipathIbgp" : true,
               "neighbors" : {
                 "10.98.25.0/25" : {
-                  "name" : "10.98.25.0/25",
+                  "remotePrefix" : "10.98.25.0/25",
                   "additionalPathsReceive" : false,
                   "additionalPathsSelectAll" : false,
                   "additionalPathsSend" : false,
@@ -18481,13 +18462,12 @@
                   "group" : "RAAS",
                   "localAs" : 64601,
                   "remoteAs" : 65511,
-                  "remotePrefix" : "10.98.25.0/25",
                   "routeReflectorClient" : false,
                   "sendCommunity" : false,
                   "vrf" : "default"
                 },
                 "100.93.100.16/32" : {
-                  "name" : "100.93.100.16/32",
+                  "remotePrefix" : "100.93.100.16/32",
                   "additionalPathsReceive" : false,
                   "additionalPathsSelectAll" : false,
                   "additionalPathsSend" : false,
@@ -18506,7 +18486,6 @@
                   "group" : "SPINE",
                   "localAs" : 64601,
                   "remoteAs" : 64802,
-                  "remotePrefix" : "100.93.100.16/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : false,
                   "vrf" : "default"
@@ -20813,7 +20792,7 @@
               "multipathIbgp" : false,
               "neighbors" : {
                 "1.1.1.1/32" : {
-                  "name" : "1.1.1.1/32",
+                  "remotePrefix" : "1.1.1.1/32",
                   "additionalPathsReceive" : false,
                   "additionalPathsSelectAll" : false,
                   "additionalPathsSend" : false,
@@ -20835,7 +20814,6 @@
                   ],
                   "localAs" : 1,
                   "remoteAs" : 2,
-                  "remotePrefix" : "1.1.1.1/32",
                   "routeReflectorClient" : false,
                   "sendCommunity" : true,
                   "vrf" : "default"


### PR DESCRIPTION
For both `BgpPeerConfig` and `VerboseBgpEdge` remove the dependency and comparable implementation. Use custom comparators where necessary.
Refs changed because Bgp neighbors don't have `name` json property anymore.
