### PR TITLE
Not using V.I. datamodel for IKE proposal in V.D. representations

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -1688,18 +1688,16 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
     /* Pad priority number with zeros, so string sorting sorts in numerical order too */
     String priority = String.format("%03d", toInteger(ctx.priority));
     _currentIsakmpPolicy = new IsakmpPolicy(priority);
-    _currentIsakmpPolicy.getProposal().setAuthenticationAlgorithm(IkeHashingAlgorithm.SHA1);
-    _currentIsakmpPolicy.getProposal().setEncryptionAlgorithm(EncryptionAlgorithm.THREEDES_CBC);
-    _currentIsakmpPolicy
-        .getProposal()
-        .setAuthenticationMethod(IkeAuthenticationMethod.PRE_SHARED_KEYS);
+    _currentIsakmpPolicy.setHashAlgorithm(IkeHashingAlgorithm.SHA1);
+    _currentIsakmpPolicy.setEncryptionAlgorithm(EncryptionAlgorithm.THREEDES_CBC);
+    _currentIsakmpPolicy.setAuthenticationMethod(IkeAuthenticationMethod.PRE_SHARED_KEYS);
     if (_format == ARUBAOS) {
-      _currentIsakmpPolicy.getProposal().setDiffieHellmanGroup(DiffieHellmanGroup.GROUP1);
+      _currentIsakmpPolicy.setDiffieHellmanGroup(DiffieHellmanGroup.GROUP1);
     } else {
-      _currentIsakmpPolicy.getProposal().setDiffieHellmanGroup(DiffieHellmanGroup.GROUP2);
+      _currentIsakmpPolicy.setDiffieHellmanGroup(DiffieHellmanGroup.GROUP2);
     }
 
-    _currentIsakmpPolicy.getProposal().setLifetimeSeconds(86400);
+    _currentIsakmpPolicy.setLifetimeSeconds(86400);
     defineStructure(ISAKMP_POLICY, priority, ctx);
     /* Isakmp policies are checked in order not explicitly referenced, so add a self-reference
     here */
@@ -1736,13 +1734,9 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   @Override
   public void exitCispol_authentication(Cispol_authenticationContext ctx) {
     if (ctx.PRE_SHARE() != null) {
-      _currentIsakmpPolicy
-          .getProposal()
-          .setAuthenticationMethod(IkeAuthenticationMethod.PRE_SHARED_KEYS);
+      _currentIsakmpPolicy.setAuthenticationMethod(IkeAuthenticationMethod.PRE_SHARED_KEYS);
     } else if (ctx.RSA_SIG() != null) {
-      _currentIsakmpPolicy
-          .getProposal()
-          .setAuthenticationMethod(IkeAuthenticationMethod.RSA_SIGNATURES);
+      _currentIsakmpPolicy.setAuthenticationMethod(IkeAuthenticationMethod.RSA_SIGNATURES);
     } else {
       throw new BatfishException("Unsupported authentication method in " + ctx.getText());
     }
@@ -1750,34 +1744,28 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
 
   @Override
   public void exitCispol_encr(Cispol_encrContext ctx) {
-    _currentIsakmpPolicy
-        .getProposal()
-        .setEncryptionAlgorithm(toEncryptionAlgorithm(ctx.ike_encryption()));
+    _currentIsakmpPolicy.setEncryptionAlgorithm(toEncryptionAlgorithm(ctx.ike_encryption()));
   }
 
   @Override
   public void exitCispol_encryption(Cispol_encryptionContext ctx) {
-    _currentIsakmpPolicy
-        .getProposal()
-        .setEncryptionAlgorithm(toEncryptionAlgorithm(ctx.ike_encryption_aruba()));
+    _currentIsakmpPolicy.setEncryptionAlgorithm(toEncryptionAlgorithm(ctx.ike_encryption_aruba()));
   }
 
   @Override
   public void exitCispol_group(Cispol_groupContext ctx) {
     int group = Integer.parseInt(ctx.DEC().getText());
-    _currentIsakmpPolicy
-        .getProposal()
-        .setDiffieHellmanGroup(DiffieHellmanGroup.fromGroupNumber(group));
+    _currentIsakmpPolicy.setDiffieHellmanGroup(DiffieHellmanGroup.fromGroupNumber(group));
   }
 
   @Override
   public void exitCispol_hash(Cispol_hashContext ctx) {
     if (ctx.MD5() != null) {
-      _currentIsakmpPolicy.getProposal().setAuthenticationAlgorithm(IkeHashingAlgorithm.MD5);
+      _currentIsakmpPolicy.setHashAlgorithm(IkeHashingAlgorithm.MD5);
     } else if (ctx.SHA() != null) {
-      _currentIsakmpPolicy.getProposal().setAuthenticationAlgorithm(IkeHashingAlgorithm.SHA1);
+      _currentIsakmpPolicy.setHashAlgorithm(IkeHashingAlgorithm.SHA1);
     } else if (ctx.SHA2_256_128() != null) {
-      _currentIsakmpPolicy.getProposal().setAuthenticationAlgorithm(IkeHashingAlgorithm.SHA_256);
+      _currentIsakmpPolicy.setHashAlgorithm(IkeHashingAlgorithm.SHA_256);
     } else {
       throw new BatfishException("Unsupported authentication method in " + ctx.getText());
     }
@@ -1785,7 +1773,7 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
 
   @Override
   public void exitCispol_lifetime(Cispol_lifetimeContext ctx) {
-    _currentIsakmpPolicy.getProposal().setLifetimeSeconds(Integer.parseInt(ctx.DEC().getText()));
+    _currentIsakmpPolicy.setLifetimeSeconds(Integer.parseInt(ctx.DEC().getText()));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -84,7 +84,6 @@ import org.batfish.datamodel.IcmpCode;
 import org.batfish.datamodel.IcmpType;
 import org.batfish.datamodel.IkeAuthenticationMethod;
 import org.batfish.datamodel.IkeHashingAlgorithm;
-import org.batfish.datamodel.IkeProposal;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Ip6;
@@ -490,6 +489,7 @@ import org.batfish.representation.juniper.HostProtocol;
 import org.batfish.representation.juniper.HostSystemService;
 import org.batfish.representation.juniper.IkeGateway;
 import org.batfish.representation.juniper.IkePolicy;
+import org.batfish.representation.juniper.IkeProposal;
 import org.batfish.representation.juniper.Interface;
 import org.batfish.representation.juniper.IpBgpGroup;
 import org.batfish.representation.juniper.IpsecPolicy;
@@ -4801,15 +4801,68 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   private Set<String> initIkeProposalSet(Proposal_set_typeContext ctx) {
     Set<String> proposals = new HashSet<>();
     if (ctx.BASIC() != null) {
-      proposals.add(initIkeProposal(IkeProposal.PSK_DES_DH1_SHA1));
-      proposals.add(initIkeProposal(IkeProposal.PSK_DES_DH1_MD5));
+      IkeProposal.Builder ikeProposalBuilder =
+          org.batfish.representation.juniper.IkeProposal.builder()
+              .setEncryptionAlgorithm(EncryptionAlgorithm.DES_CBC)
+              .setAuthenticationMethod(IkeAuthenticationMethod.PRE_SHARED_KEYS)
+              .setDiffieHellmanGroup(DiffieHellmanGroup.GROUP1);
+      proposals.add(
+          initIkeProposal(
+              ikeProposalBuilder
+                  .setName("PSK_DES_DH1_SHA1")
+                  .setAuthenticationAlgorithm(IkeHashingAlgorithm.SHA1)
+                  .build()));
+      proposals.add(
+          initIkeProposal(
+              ikeProposalBuilder
+                  .setName("PSK_DES_DH1_MD5")
+                  .setAuthenticationAlgorithm(IkeHashingAlgorithm.MD5)
+                  .build()));
     } else if (ctx.COMPATIBLE() != null) {
-      proposals.add(initIkeProposal(IkeProposal.PSK_3DES_DH2_MD5));
-      proposals.add(initIkeProposal(IkeProposal.PSK_DES_DH2_SHA1));
-      proposals.add(initIkeProposal(IkeProposal.PSK_DES_DH2_MD5));
+      IkeProposal.Builder ikeProposalBuilder =
+          org.batfish.representation.juniper.IkeProposal.builder()
+              .setAuthenticationMethod(IkeAuthenticationMethod.PRE_SHARED_KEYS)
+              .setDiffieHellmanGroup(DiffieHellmanGroup.GROUP2);
+      proposals.add(
+          initIkeProposal(
+              ikeProposalBuilder
+                  .setName("PSK_3DES_DH2_MD5")
+                  .setEncryptionAlgorithm(EncryptionAlgorithm.THREEDES_CBC)
+                  .setAuthenticationAlgorithm(IkeHashingAlgorithm.MD5)
+                  .build()));
+      proposals.add(
+          initIkeProposal(
+              ikeProposalBuilder
+                  .setName("PSK_DES_DH2_SHA1")
+                  .setEncryptionAlgorithm(EncryptionAlgorithm.DES_CBC)
+                  .setAuthenticationAlgorithm(IkeHashingAlgorithm.SHA1)
+                  .build()));
+      proposals.add(
+          initIkeProposal(
+              ikeProposalBuilder
+                  .setName("PSK_DES_DH2_MD5")
+                  .setEncryptionAlgorithm(EncryptionAlgorithm.DES_CBC)
+                  .setAuthenticationAlgorithm(IkeHashingAlgorithm.MD5)
+                  .build()));
     } else if (ctx.STANDARD() != null) {
-      proposals.add(initIkeProposal(IkeProposal.PSK_3DES_DH2_SHA1));
-      proposals.add(initIkeProposal(IkeProposal.PSK_AES128_DH2_SHA1));
+      IkeProposal.Builder ikeProposalBuilder =
+          org.batfish.representation.juniper.IkeProposal.builder()
+              .setAuthenticationMethod(IkeAuthenticationMethod.PRE_SHARED_KEYS)
+              .setDiffieHellmanGroup(DiffieHellmanGroup.GROUP2);
+      proposals.add(
+          initIkeProposal(
+              ikeProposalBuilder
+                  .setName("PSK_3DES_DH2_SHA1")
+                  .setEncryptionAlgorithm(EncryptionAlgorithm.THREEDES_CBC)
+                  .setAuthenticationAlgorithm(IkeHashingAlgorithm.SHA1)
+                  .build()));
+      proposals.add(
+          initIkeProposal(
+              ikeProposalBuilder
+                  .setName("PSK_AES128_DH2_SHA1")
+                  .setEncryptionAlgorithm(EncryptionAlgorithm.AES_128_CBC)
+                  .setAuthenticationAlgorithm(IkeHashingAlgorithm.SHA1)
+                  .build()));
     }
     return proposals;
   }

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -4800,69 +4800,72 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
 
   private Set<String> initIkeProposalSet(Proposal_set_typeContext ctx) {
     Set<String> proposals = new HashSet<>();
+
+    // the proposal-sets have been defined as per the specifications in the link:
+    // https://www.juniper.net/documentation/en_US/junos/topics/reference/configuration-statement/security-edit-proposal-set-ike.html
     if (ctx.BASIC() != null) {
-      IkeProposal.Builder ikeProposalBuilder =
-          org.batfish.representation.juniper.IkeProposal.builder()
-              .setEncryptionAlgorithm(EncryptionAlgorithm.DES_CBC)
-              .setAuthenticationMethod(IkeAuthenticationMethod.PRE_SHARED_KEYS)
-              .setDiffieHellmanGroup(DiffieHellmanGroup.GROUP1);
+      IkeProposal proposal1 = new IkeProposal("PSK_DES_DH1_SHA1");
+      IkeProposal proposal2 = new IkeProposal("PSK_DES_DH1_MD5");
+
       proposals.add(
           initIkeProposal(
-              ikeProposalBuilder
-                  .setName("PSK_DES_DH1_SHA1")
-                  .setAuthenticationAlgorithm(IkeHashingAlgorithm.SHA1)
-                  .build()));
+              proposal1
+                  .setEncryptionAlgorithm(EncryptionAlgorithm.DES_CBC)
+                  .setAuthenticationMethod(IkeAuthenticationMethod.PRE_SHARED_KEYS)
+                  .setDiffieHellmanGroup(DiffieHellmanGroup.GROUP1)
+                  .setAuthenticationAlgorithm(IkeHashingAlgorithm.SHA1)));
       proposals.add(
           initIkeProposal(
-              ikeProposalBuilder
-                  .setName("PSK_DES_DH1_MD5")
-                  .setAuthenticationAlgorithm(IkeHashingAlgorithm.MD5)
-                  .build()));
+              proposal2
+                  .setEncryptionAlgorithm(EncryptionAlgorithm.DES_CBC)
+                  .setAuthenticationMethod(IkeAuthenticationMethod.PRE_SHARED_KEYS)
+                  .setDiffieHellmanGroup(DiffieHellmanGroup.GROUP1)
+                  .setAuthenticationAlgorithm(IkeHashingAlgorithm.MD5)));
     } else if (ctx.COMPATIBLE() != null) {
-      IkeProposal.Builder ikeProposalBuilder =
-          org.batfish.representation.juniper.IkeProposal.builder()
-              .setAuthenticationMethod(IkeAuthenticationMethod.PRE_SHARED_KEYS)
-              .setDiffieHellmanGroup(DiffieHellmanGroup.GROUP2);
+      IkeProposal proposal1 = new IkeProposal("PSK_3DES_DH2_MD5");
+      IkeProposal proposal2 = new IkeProposal("PSK_DES_DH2_SHA1");
+      IkeProposal proposal3 = new IkeProposal("PSK_DES_DH2_MD5");
+
       proposals.add(
           initIkeProposal(
-              ikeProposalBuilder
-                  .setName("PSK_3DES_DH2_MD5")
+              proposal1
+                  .setAuthenticationMethod(IkeAuthenticationMethod.PRE_SHARED_KEYS)
+                  .setDiffieHellmanGroup(DiffieHellmanGroup.GROUP2)
                   .setEncryptionAlgorithm(EncryptionAlgorithm.THREEDES_CBC)
-                  .setAuthenticationAlgorithm(IkeHashingAlgorithm.MD5)
-                  .build()));
+                  .setAuthenticationAlgorithm(IkeHashingAlgorithm.MD5)));
       proposals.add(
           initIkeProposal(
-              ikeProposalBuilder
-                  .setName("PSK_DES_DH2_SHA1")
+              proposal2
+                  .setAuthenticationMethod(IkeAuthenticationMethod.PRE_SHARED_KEYS)
+                  .setDiffieHellmanGroup(DiffieHellmanGroup.GROUP2)
                   .setEncryptionAlgorithm(EncryptionAlgorithm.DES_CBC)
-                  .setAuthenticationAlgorithm(IkeHashingAlgorithm.SHA1)
-                  .build()));
+                  .setAuthenticationAlgorithm(IkeHashingAlgorithm.SHA1)));
       proposals.add(
           initIkeProposal(
-              ikeProposalBuilder
-                  .setName("PSK_DES_DH2_MD5")
+              proposal3
+                  .setAuthenticationMethod(IkeAuthenticationMethod.PRE_SHARED_KEYS)
+                  .setDiffieHellmanGroup(DiffieHellmanGroup.GROUP2)
                   .setEncryptionAlgorithm(EncryptionAlgorithm.DES_CBC)
-                  .setAuthenticationAlgorithm(IkeHashingAlgorithm.MD5)
-                  .build()));
+                  .setAuthenticationAlgorithm(IkeHashingAlgorithm.MD5)));
+
     } else if (ctx.STANDARD() != null) {
-      IkeProposal.Builder ikeProposalBuilder =
-          org.batfish.representation.juniper.IkeProposal.builder()
-              .setAuthenticationMethod(IkeAuthenticationMethod.PRE_SHARED_KEYS)
-              .setDiffieHellmanGroup(DiffieHellmanGroup.GROUP2);
+      IkeProposal proposal1 = new IkeProposal("PSK_3DES_DH2_SHA1");
+      IkeProposal proposal2 = new IkeProposal("PSK_AES128_DH2_SHA1");
+
       proposals.add(
           initIkeProposal(
-              ikeProposalBuilder
-                  .setName("PSK_3DES_DH2_SHA1")
+              proposal1
+                  .setAuthenticationMethod(IkeAuthenticationMethod.PRE_SHARED_KEYS)
+                  .setDiffieHellmanGroup(DiffieHellmanGroup.GROUP2)
                   .setEncryptionAlgorithm(EncryptionAlgorithm.THREEDES_CBC)
-                  .setAuthenticationAlgorithm(IkeHashingAlgorithm.SHA1)
-                  .build()));
+                  .setAuthenticationAlgorithm(IkeHashingAlgorithm.SHA1)));
       proposals.add(
           initIkeProposal(
-              ikeProposalBuilder
-                  .setName("PSK_AES128_DH2_SHA1")
+              proposal2
+                  .setAuthenticationMethod(IkeAuthenticationMethod.PRE_SHARED_KEYS)
+                  .setDiffieHellmanGroup(DiffieHellmanGroup.GROUP2)
                   .setEncryptionAlgorithm(EncryptionAlgorithm.AES_128_CBC)
-                  .setAuthenticationAlgorithm(IkeHashingAlgorithm.SHA1)
-                  .build()));
+                  .setAuthenticationAlgorithm(IkeHashingAlgorithm.SHA1)));
     }
     return proposals;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -50,6 +50,7 @@ import org.batfish.datamodel.GeneratedRoute6;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.IkeGateway;
 import org.batfish.datamodel.IkePolicy;
+import org.batfish.datamodel.IkeProposal;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Ip6AccessList;
@@ -2159,6 +2160,16 @@ public final class CiscoConfiguration extends VendorConfiguration {
     return iface.getMtu();
   }
 
+  private static IkeProposal toIkeProposal(IsakmpPolicy isakmpPolicy) {
+    IkeProposal ikeProposal = new IkeProposal(isakmpPolicy.getName());
+    ikeProposal.setDiffieHellmanGroup(isakmpPolicy.getDiffieHellmanGroup());
+    ikeProposal.setAuthenticationMethod(isakmpPolicy.getAuthenticationMethod());
+    ikeProposal.setEncryptionAlgorithm(isakmpPolicy.getEncryptionAlgorithm());
+    ikeProposal.setLifetimeSeconds(isakmpPolicy.getLifetimeSeconds());
+    ikeProposal.setAuthenticationAlgorithm(isakmpPolicy.getHashAlgorithm());
+    return ikeProposal;
+  }
+
   private org.batfish.datamodel.Interface toInterface(
       Interface iface, Map<String, IpAccessList> ipAccessLists, Configuration c) {
     String name = iface.getName();
@@ -3204,9 +3215,9 @@ public final class CiscoConfiguration extends VendorConfiguration {
     // apply vrrp settings to interfaces
     applyVrrp(c);
 
-    // get IKE proposals
+    // ISAKMP policies to IKE proposals
     for (Entry<String, IsakmpPolicy> e : _isakmpPolicies.entrySet()) {
-      c.getIkeProposals().put(e.getKey(), e.getValue().getProposal());
+      c.getIkeProposals().put(e.getKey(), toIkeProposal(e.getValue()));
     }
     resolveKeyringIsakmpProfileAddresses();
     resolveTunnelSourceInterfaces();

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/IsakmpPolicy.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/IsakmpPolicy.java
@@ -1,25 +1,67 @@
 package org.batfish.representation.cisco;
 
 import org.batfish.common.util.ComparableStructure;
-import org.batfish.datamodel.IkeProposal;
+import org.batfish.datamodel.DiffieHellmanGroup;
+import org.batfish.datamodel.EncryptionAlgorithm;
+import org.batfish.datamodel.IkeAuthenticationMethod;
+import org.batfish.datamodel.IkeHashingAlgorithm;
 
 public class IsakmpPolicy extends ComparableStructure<String> {
 
   /** */
   private static final long serialVersionUID = 1L;
 
-  private IkeProposal _proposal;
+  private IkeAuthenticationMethod _authenticationMethod;
+
+  private DiffieHellmanGroup _diffieHellmanGroup;
+
+  private EncryptionAlgorithm _encryptionAlgorithm;
+
+  private IkeHashingAlgorithm _hashAlgorithm;
+
+  private Integer _lifetimeSeconds;
 
   public IsakmpPolicy(String name) {
     super(name);
-    _proposal = new IkeProposal(name);
   }
 
-  public IkeProposal getProposal() {
-    return _proposal;
+  public IkeAuthenticationMethod getAuthenticationMethod() {
+    return _authenticationMethod;
   }
 
-  public void setProposal(IkeProposal proposal) {
-    _proposal = proposal;
+  public DiffieHellmanGroup getDiffieHellmanGroup() {
+    return _diffieHellmanGroup;
+  }
+
+  public EncryptionAlgorithm getEncryptionAlgorithm() {
+    return _encryptionAlgorithm;
+  }
+
+  public IkeHashingAlgorithm getHashAlgorithm() {
+    return _hashAlgorithm;
+  }
+
+  public Integer getLifetimeSeconds() {
+    return _lifetimeSeconds;
+  }
+
+  public void setAuthenticationMethod(IkeAuthenticationMethod authenticationMethod) {
+    _authenticationMethod = authenticationMethod;
+  }
+
+  public void setDiffieHellmanGroup(DiffieHellmanGroup diffieHellmanGroup) {
+    _diffieHellmanGroup = diffieHellmanGroup;
+  }
+
+  public void setEncryptionAlgorithm(EncryptionAlgorithm encryptionAlgorithm) {
+    _encryptionAlgorithm = encryptionAlgorithm;
+  }
+
+  public void setHashAlgorithm(IkeHashingAlgorithm hashingAlgorithm) {
+    _hashAlgorithm = hashingAlgorithm;
+  }
+
+  public void setLifetimeSeconds(Integer lifetimeSeconds) {
+    _lifetimeSeconds = lifetimeSeconds;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/IkeProposal.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/IkeProposal.java
@@ -1,0 +1,130 @@
+package org.batfish.representation.juniper;
+
+import org.batfish.common.BatfishException;
+import org.batfish.common.util.ComparableStructure;
+import org.batfish.datamodel.DiffieHellmanGroup;
+import org.batfish.datamodel.EncryptionAlgorithm;
+import org.batfish.datamodel.IkeAuthenticationMethod;
+import org.batfish.datamodel.IkeHashingAlgorithm;
+
+public class IkeProposal extends ComparableStructure<String> {
+
+  /** */
+  private static final long serialVersionUID = 1L;
+
+  public static class Builder {
+
+    private IkeHashingAlgorithm _authenticationAlgorithm;
+
+    private IkeAuthenticationMethod _authenticationMethod;
+
+    private DiffieHellmanGroup _diffieHellmanGroup;
+
+    private EncryptionAlgorithm _encryptionAlgorithm;
+
+    private Integer _lifetimeSeconds;
+
+    private String _name;
+
+    public IkeProposal build() {
+      if (_name == null) {
+        throw new BatfishException("Cannot create an IKE proposal with no name");
+      }
+      IkeProposal ikeProposal = new IkeProposal(_name);
+      ikeProposal.setAuthenticationMethod(_authenticationMethod);
+      ikeProposal.setDiffieHellmanGroup(_diffieHellmanGroup);
+      ikeProposal.setEncryptionAlgorithm(_encryptionAlgorithm);
+      ikeProposal.setAuthenticationAlgorithm(_authenticationAlgorithm);
+      ikeProposal.setLifetimeSeconds(_lifetimeSeconds);
+      return ikeProposal;
+    }
+
+    public Builder setAuthenticationAlgorithm(IkeHashingAlgorithm authenticationAlgorithm) {
+      _authenticationAlgorithm = authenticationAlgorithm;
+      return this;
+    }
+
+    public Builder setAuthenticationMethod(IkeAuthenticationMethod authenticationMethod) {
+      _authenticationMethod = authenticationMethod;
+      return this;
+    }
+
+    public Builder setDiffieHellmanGroup(DiffieHellmanGroup diffieHellmanGroup) {
+      _diffieHellmanGroup = diffieHellmanGroup;
+      return this;
+    }
+
+    public Builder setEncryptionAlgorithm(EncryptionAlgorithm encryptionAlgorithm) {
+      _encryptionAlgorithm = encryptionAlgorithm;
+      return this;
+    }
+
+    public Builder setLifetimeSeconds(Integer lifetimeSeconds) {
+      _lifetimeSeconds = lifetimeSeconds;
+      return this;
+    }
+
+    public Builder setName(String name) {
+      _name = name;
+      return this;
+    }
+  }
+
+  private IkeHashingAlgorithm _authenticationAlgorithm;
+
+  private IkeAuthenticationMethod _authenticationMethod;
+
+  private DiffieHellmanGroup _diffieHellmanGroup;
+
+  private EncryptionAlgorithm _encryptionAlgorithm;
+
+  private Integer _lifetimeSeconds;
+
+  public IkeProposal(String name) {
+    super(name);
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public IkeAuthenticationMethod getAuthenticationMethod() {
+    return _authenticationMethod;
+  }
+
+  public DiffieHellmanGroup getDiffieHellmanGroup() {
+    return _diffieHellmanGroup;
+  }
+
+  public EncryptionAlgorithm getEncryptionAlgorithm() {
+    return _encryptionAlgorithm;
+  }
+
+  public IkeHashingAlgorithm getAuthenticationAlgorithm() {
+    return _authenticationAlgorithm;
+  }
+
+  public Integer getLifetimeSeconds() {
+    return _lifetimeSeconds;
+  }
+
+  public void setAuthenticationMethod(IkeAuthenticationMethod authenticationMethod) {
+    _authenticationMethod = authenticationMethod;
+  }
+
+  public void setDiffieHellmanGroup(DiffieHellmanGroup diffieHellmanGroup) {
+    _diffieHellmanGroup = diffieHellmanGroup;
+  }
+
+  public void setEncryptionAlgorithm(EncryptionAlgorithm encryptionAlgorithm) {
+    _encryptionAlgorithm = encryptionAlgorithm;
+  }
+
+  public void setAuthenticationAlgorithm(IkeHashingAlgorithm hashingAlgorithm) {
+    _authenticationAlgorithm = hashingAlgorithm;
+  }
+
+  public void setLifetimeSeconds(Integer lifetimeSeconds) {
+    _lifetimeSeconds = lifetimeSeconds;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/IkeProposal.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/IkeProposal.java
@@ -1,6 +1,5 @@
 package org.batfish.representation.juniper;
 
-import org.batfish.common.BatfishException;
 import org.batfish.common.util.ComparableStructure;
 import org.batfish.datamodel.DiffieHellmanGroup;
 import org.batfish.datamodel.EncryptionAlgorithm;
@@ -12,63 +11,8 @@ public class IkeProposal extends ComparableStructure<String> {
   /** */
   private static final long serialVersionUID = 1L;
 
-  public static class Builder {
-
-    private IkeHashingAlgorithm _authenticationAlgorithm;
-
-    private IkeAuthenticationMethod _authenticationMethod;
-
-    private DiffieHellmanGroup _diffieHellmanGroup;
-
-    private EncryptionAlgorithm _encryptionAlgorithm;
-
-    private Integer _lifetimeSeconds;
-
-    private String _name;
-
-    public IkeProposal build() {
-      if (_name == null) {
-        throw new BatfishException("Cannot create an IKE proposal with no name");
-      }
-      IkeProposal ikeProposal = new IkeProposal(_name);
-      ikeProposal.setAuthenticationMethod(_authenticationMethod);
-      ikeProposal.setDiffieHellmanGroup(_diffieHellmanGroup);
-      ikeProposal.setEncryptionAlgorithm(_encryptionAlgorithm);
-      ikeProposal.setAuthenticationAlgorithm(_authenticationAlgorithm);
-      ikeProposal.setLifetimeSeconds(_lifetimeSeconds);
-      return ikeProposal;
-    }
-
-    public Builder setAuthenticationAlgorithm(IkeHashingAlgorithm authenticationAlgorithm) {
-      _authenticationAlgorithm = authenticationAlgorithm;
-      return this;
-    }
-
-    public Builder setAuthenticationMethod(IkeAuthenticationMethod authenticationMethod) {
-      _authenticationMethod = authenticationMethod;
-      return this;
-    }
-
-    public Builder setDiffieHellmanGroup(DiffieHellmanGroup diffieHellmanGroup) {
-      _diffieHellmanGroup = diffieHellmanGroup;
-      return this;
-    }
-
-    public Builder setEncryptionAlgorithm(EncryptionAlgorithm encryptionAlgorithm) {
-      _encryptionAlgorithm = encryptionAlgorithm;
-      return this;
-    }
-
-    public Builder setLifetimeSeconds(Integer lifetimeSeconds) {
-      _lifetimeSeconds = lifetimeSeconds;
-      return this;
-    }
-
-    public Builder setName(String name) {
-      _name = name;
-      return this;
-    }
-  }
+  // https://www.juniper.net/documentation/en_US/junos/topics/reference/configuration-statement/security-edit-lifetime-seconds-ike.html
+  private static final Integer DEFAULT_LIFETIME_SECONDS = 28800;
 
   private IkeHashingAlgorithm _authenticationAlgorithm;
 
@@ -82,10 +26,7 @@ public class IkeProposal extends ComparableStructure<String> {
 
   public IkeProposal(String name) {
     super(name);
-  }
-
-  public static Builder builder() {
-    return new Builder();
+    _lifetimeSeconds = DEFAULT_LIFETIME_SECONDS;
   }
 
   public IkeAuthenticationMethod getAuthenticationMethod() {
@@ -108,23 +49,28 @@ public class IkeProposal extends ComparableStructure<String> {
     return _lifetimeSeconds;
   }
 
-  public void setAuthenticationMethod(IkeAuthenticationMethod authenticationMethod) {
+  public IkeProposal setAuthenticationMethod(IkeAuthenticationMethod authenticationMethod) {
     _authenticationMethod = authenticationMethod;
+    return this;
   }
 
-  public void setDiffieHellmanGroup(DiffieHellmanGroup diffieHellmanGroup) {
+  public IkeProposal setDiffieHellmanGroup(DiffieHellmanGroup diffieHellmanGroup) {
     _diffieHellmanGroup = diffieHellmanGroup;
+    return this;
   }
 
-  public void setEncryptionAlgorithm(EncryptionAlgorithm encryptionAlgorithm) {
+  public IkeProposal setEncryptionAlgorithm(EncryptionAlgorithm encryptionAlgorithm) {
     _encryptionAlgorithm = encryptionAlgorithm;
+    return this;
   }
 
-  public void setAuthenticationAlgorithm(IkeHashingAlgorithm hashingAlgorithm) {
+  public IkeProposal setAuthenticationAlgorithm(IkeHashingAlgorithm hashingAlgorithm) {
     _authenticationAlgorithm = hashingAlgorithm;
+    return this;
   }
 
-  public void setLifetimeSeconds(Integer lifetimeSeconds) {
+  public IkeProposal setLifetimeSeconds(Integer lifetimeSeconds) {
     _lifetimeSeconds = lifetimeSeconds;
+    return this;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -1177,8 +1177,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
     newIkeProposal.setDiffieHellmanGroup(ikeProposal.getDiffieHellmanGroup());
     newIkeProposal.setAuthenticationMethod(ikeProposal.getAuthenticationMethod());
     newIkeProposal.setEncryptionAlgorithm(ikeProposal.getEncryptionAlgorithm());
-    // https://www.juniper.net/documentation/en_US/junos/topics/reference/configuration-statement/security-edit-lifetime-seconds-ike.html
-    newIkeProposal.setLifetimeSeconds(firstNonNull(ikeProposal.getLifetimeSeconds(), 28800));
+    newIkeProposal.setLifetimeSeconds(ikeProposal.getLifetimeSeconds());
     newIkeProposal.setAuthenticationAlgorithm(ikeProposal.getAuthenticationAlgorithm());
     return newIkeProposal;
   }

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -8,6 +8,7 @@ import static org.batfish.datamodel.matchers.BgpProcessMatchers.hasNeighbor;
 import static org.batfish.datamodel.matchers.BgpProcessMatchers.hasNeighbors;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasDefaultVrf;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasHostname;
+import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasIkeProposal;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasInterface;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasInterfaces;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasIpAccessList;
@@ -23,6 +24,11 @@ import static org.batfish.datamodel.matchers.DataModelMatchers.hasRouteFilterLis
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasRouteFilterLists;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasUndefinedReference;
 import static org.batfish.datamodel.matchers.DataModelMatchers.isDynamic;
+import static org.batfish.datamodel.matchers.IkeProposalMatchers.hasAuthenticationAlgorithm;
+import static org.batfish.datamodel.matchers.IkeProposalMatchers.hasAuthenticationMethod;
+import static org.batfish.datamodel.matchers.IkeProposalMatchers.hasDiffieHellmanGroup;
+import static org.batfish.datamodel.matchers.IkeProposalMatchers.hasEncryptionAlgorithm;
+import static org.batfish.datamodel.matchers.IkeProposalMatchers.hasLifeTimeSeconds;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasAccessVlan;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasAdditionalArpIps;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasAllAddresses;
@@ -113,6 +119,8 @@ import org.batfish.datamodel.DiffieHellmanGroup;
 import org.batfish.datamodel.EncryptionAlgorithm;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.HeaderSpace;
+import org.batfish.datamodel.IkeAuthenticationMethod;
+import org.batfish.datamodel.IkeHashingAlgorithm;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpAccessList;
@@ -1221,6 +1229,71 @@ public class FlatJuniperGrammarTest {
   public void testTacplusPsk() throws IOException {
     /* allow both encrypted and unencrypted key */
     parseConfig("tacplus-psk");
+  }
+
+  @Test
+  public void testIkeProposal() throws IOException {
+    Configuration c = parseConfig("ike-proposal");
+
+    assertThat(
+        c,
+        hasIkeProposal(
+            "proposal1",
+            allOf(
+                hasEncryptionAlgorithm(EncryptionAlgorithm.THREEDES_CBC),
+                hasAuthenticationMethod(IkeAuthenticationMethod.PRE_SHARED_KEYS),
+                hasAuthenticationAlgorithm(IkeHashingAlgorithm.MD5),
+                hasDiffieHellmanGroup(DiffieHellmanGroup.GROUP14),
+                hasLifeTimeSeconds(50000))));
+  }
+
+  @Test
+  public void testIkeProposalSet() throws IOException {
+    Configuration c = parseConfig("ike-proposal");
+
+    // ike proposals added as part of the `basic` proposal set
+    assertThat(
+        c,
+        hasIkeProposal(
+            "PSK_DES_DH1_SHA1",
+            allOf(
+                hasEncryptionAlgorithm(EncryptionAlgorithm.DES_CBC),
+                hasAuthenticationMethod(IkeAuthenticationMethod.PRE_SHARED_KEYS),
+                hasAuthenticationAlgorithm(IkeHashingAlgorithm.SHA1),
+                hasDiffieHellmanGroup(DiffieHellmanGroup.GROUP1),
+                hasLifeTimeSeconds(28800))));
+    assertThat(
+        c,
+        hasIkeProposal(
+            "PSK_DES_DH1_MD5",
+            allOf(
+                hasEncryptionAlgorithm(EncryptionAlgorithm.DES_CBC),
+                hasAuthenticationMethod(IkeAuthenticationMethod.PRE_SHARED_KEYS),
+                hasAuthenticationAlgorithm(IkeHashingAlgorithm.MD5),
+                hasDiffieHellmanGroup(DiffieHellmanGroup.GROUP1),
+                hasLifeTimeSeconds(28800))));
+
+    // ike proposals added as part of `standard` proposal set
+    assertThat(
+        c,
+        hasIkeProposal(
+            "PSK_3DES_DH2_SHA1",
+            allOf(
+                hasEncryptionAlgorithm(EncryptionAlgorithm.THREEDES_CBC),
+                hasAuthenticationMethod(IkeAuthenticationMethod.PRE_SHARED_KEYS),
+                hasAuthenticationAlgorithm(IkeHashingAlgorithm.SHA1),
+                hasDiffieHellmanGroup(DiffieHellmanGroup.GROUP2),
+                hasLifeTimeSeconds(28800))));
+    assertThat(
+        c,
+        hasIkeProposal(
+            "PSK_AES128_DH2_SHA1",
+            allOf(
+                hasEncryptionAlgorithm(EncryptionAlgorithm.AES_128_CBC),
+                hasAuthenticationMethod(IkeAuthenticationMethod.PRE_SHARED_KEYS),
+                hasAuthenticationAlgorithm(IkeHashingAlgorithm.SHA1),
+                hasDiffieHellmanGroup(DiffieHellmanGroup.GROUP2),
+                hasLifeTimeSeconds(28800))));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/ike-proposal
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/ike-proposal
@@ -1,0 +1,17 @@
+#
+set system host-name ike-proposal
+#
+set security ike proposal proposal1 authentication-algorithm md5
+set security ike proposal proposal1 authentication-method pre-shared-keys
+set security ike proposal proposal1 dh-group group14
+set security ike proposal proposal1 encryption-algorithm 3des-cbc
+set security ike proposal proposal1 lifetime-seconds 50000
+#
+set security ike policy policy1 proposal-set standard
+#
+set security ike policy policy2 proposal-set basic
+
+
+
+
+

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -14664,7 +14664,8 @@
         },
         "ikeProposals" : {
           "PROPOSAL" : {
-            "name" : "PROPOSAL"
+            "name" : "PROPOSAL",
+            "lifetimeSeconds" : 28800
           }
         },
         "ipAccessLists" : {


### PR DESCRIPTION
- this will help in minimizing changes if data-model changes(only toVendorIndependent() method will change)
- makes the code cleaner and consistent with the rest of vendor dependent data-models

- Also added tests for Juniper to make sure nothing broke

- Default value for Juniper ike proposal's lifetime added([link](https://www.juniper.net/documentation/en_US/junos/topics/reference/configuration-statement/security-edit-lifetime-seconds-ike.html))