### PR TITLE
Add support for ASA network objects

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -2434,7 +2434,7 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   @Override
   public void exitOn_fqdn(On_fqdnContext ctx) {
     _currentNetworkObject.setIpSpace(EmptyIpSpace.INSTANCE);
-    _w.redFlag("Cannot convert fqdn to IpSpace: " + getFullText(ctx));
+    _w.redFlag("Unknown how to resolve domain name to IP address: " + getFullText(ctx));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -2291,11 +2291,11 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   public void enterO_network(O_networkContext ctx) {
     _currentNetworkObject =
         _configuration.getNetworkObjects().computeIfAbsent(ctx.name.getText(), NetworkObject::new);
+    defineStructure(NETWORK_OBJECT, ctx.name.getText(), ctx);
   }
 
   @Override
   public void exitO_network(O_networkContext ctx) {
-    defineStructure(NETWORK_OBJECT, ctx.name.getText(), ctx);
     _currentNetworkObject = null;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -2442,7 +2442,7 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
     if (ctx.address != null) {
       _currentNetworkObject.setIpSpace(new Ip(ctx.address.getText()).toIpSpace());
     } else {
-      // Warn about lack of support for IPv6
+      // IPv6
       _w.redFlag("Unimplemented network object line: " + getFullText(ctx));
     }
   }
@@ -2458,7 +2458,7 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
       _currentNetworkObject.setIpSpace(
           new Prefix(new Ip(ctx.address.getText()), new Ip(ctx.mask.getText())).toIpSpace());
     } else {
-      // Warn about lack of support for IPv6
+      // IPv6
       _w.redFlag("Unimplemented network object line: " + getFullText(ctx));
     }
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -386,6 +386,8 @@ public final class CiscoConfiguration extends VendorConfiguration {
 
   private final Map<String, NetworkObjectGroup> _networkObjectGroups;
 
+  private final Map<String, NetworkObject> _networkObjects;
+
   private String _ntpSourceInterface;
 
   private CiscoNxBgpGlobalConfiguration _nxBgpGlobalConfiguration;
@@ -462,6 +464,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
     _macAccessLists = new TreeMap<>();
     _natPools = new TreeMap<>();
     _networkObjectGroups = new TreeMap<>();
+    _networkObjects = new TreeMap<>();
     _nxBgpGlobalConfiguration = new CiscoNxBgpGlobalConfiguration();
     _objectGroups = new TreeMap<>();
     _prefixLists = new TreeMap<>();
@@ -3107,10 +3110,12 @@ public final class CiscoConfiguration extends VendorConfiguration {
       c.getIpAccessLists().put(ipaList.getName(), ipaList);
     }
 
-    // convert each NetworkObjectGroup to IpSpace
+    // convert each NetworkObject and NetworkObjectGroup to IpSpace
     _networkObjectGroups.forEach(
         (name, networkObjectGroup) ->
             c.getIpSpaces().put(name, CiscoConversions.toIpSpace(networkObjectGroup)));
+    _networkObjects.forEach(
+        (name, networkObject) -> c.getIpSpaces().put(name, networkObject.getIpSpace()));
 
     // convert each ProtocolObjectGroup to IpAccessList
     _protocolObjectGroups.forEach(
@@ -3506,13 +3511,16 @@ public final class CiscoConfiguration extends VendorConfiguration {
     markConcreteStructure(
         CiscoStructureType.NETWORK_OBJECT_GROUP,
         CiscoStructureUsage.EXTENDED_ACCESS_LIST_NETWORK_OBJECT_GROUP,
-        CiscoStructureUsage.NETWORK_OBJECT_GROUP_GROUP_OBJECT,
-        CiscoStructureUsage.NETWORK_OBJECT_GROUP_NETWORK_OBJECT);
+        CiscoStructureUsage.NETWORK_OBJECT_GROUP_GROUP_OBJECT);
     markAbstractStructure(
         CiscoStructureType.PROTOCOL_OR_SERVICE_OBJECT_GROUP,
         CiscoStructureUsage.EXTENDED_ACCESS_LIST_PROTOCOL_OR_SERVICE_OBJECT_GROUP,
         ImmutableList.of(
             CiscoStructureType.PROTOCOL_OBJECT_GROUP, CiscoStructureType.SERVICE_OBJECT_GROUP));
+
+    // objects
+    markConcreteStructure(
+        CiscoStructureType.NETWORK_OBJECT, CiscoStructureUsage.NETWORK_OBJECT_GROUP_NETWORK_OBJECT);
 
     // service template
     markConcreteStructure(
@@ -4083,6 +4091,10 @@ public final class CiscoConfiguration extends VendorConfiguration {
 
   public Map<String, NetworkObjectGroup> getNetworkObjectGroups() {
     return _networkObjectGroups;
+  }
+
+  public Map<String, NetworkObject> getNetworkObjects() {
+    return _networkObjects;
   }
 
   public Map<String, ObjectGroup> getObjectGroups() {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoStructureType.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoStructureType.java
@@ -40,6 +40,7 @@ public enum CiscoStructureType implements StructureType {
   L2TP_CLASS("l2tp-class"),
   MAC_ACCESS_LIST("mac acl"),
   NAT_POOL("nat pool"),
+  NETWORK_OBJECT("object network"),
   NETWORK_OBJECT_GROUP("object-group network"),
   POLICY_MAP("policy-map"),
   PREFIX_LIST("ipv4 prefix-list"),

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoStructureUsage.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoStructureUsage.java
@@ -94,7 +94,7 @@ public enum CiscoStructureUsage implements StructureUsage {
   MANAGEMENT_TELNET_ACCESS_GROUP("management telnet ip access-group"),
   MSDP_PEER_SA_LIST("msdp peer sa-list"),
   NETWORK_OBJECT_GROUP_GROUP_OBJECT("object-group network group-object"),
-  NETWORK_OBJECT_GROUP_NETWORK_OBJECT("object-group network network-object"),
+  NETWORK_OBJECT_GROUP_NETWORK_OBJECT("object-group network object"),
   NTP_ACCESS_GROUP("ntp access-group"),
   OSPF_AREA_FILTER_LIST("ospf area filter-list"),
   OSPF_DEFAULT_ORIGINATE_ROUTE_MAP("ospf default-originate route-map"),

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoStructureUsage.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoStructureUsage.java
@@ -94,7 +94,7 @@ public enum CiscoStructureUsage implements StructureUsage {
   MANAGEMENT_TELNET_ACCESS_GROUP("management telnet ip access-group"),
   MSDP_PEER_SA_LIST("msdp peer sa-list"),
   NETWORK_OBJECT_GROUP_GROUP_OBJECT("object-group network group-object"),
-  NETWORK_OBJECT_GROUP_NETWORK_OBJECT("object-group network object"),
+  NETWORK_OBJECT_GROUP_NETWORK_OBJECT("object-group network network-object object"),
   NTP_ACCESS_GROUP("ntp access-group"),
   OSPF_AREA_FILTER_LIST("ospf area filter-list"),
   OSPF_DEFAULT_ORIGINATE_ROUTE_MAP("ospf default-originate route-map"),

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/NetworkObject.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/NetworkObject.java
@@ -1,0 +1,33 @@
+package org.batfish.representation.cisco;
+
+import org.batfish.common.util.ComparableStructure;
+import org.batfish.datamodel.IpSpace;
+
+public final class NetworkObject extends ComparableStructure<String> {
+  /** */
+  private static final long serialVersionUID = 1L;
+
+  private String _description;
+
+  private IpSpace _ipSpace;
+
+  public NetworkObject(String name) {
+    super(name);
+  }
+
+  public String getDescription() {
+    return _description;
+  }
+
+  public IpSpace getIpSpace() {
+    return _ipSpace;
+  }
+
+  public void setDescription(String description) {
+    _description = description;
+  }
+
+  public void setIpSpace(IpSpace ipSpace) {
+    _ipSpace = ipSpace;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/NetworkObject.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/NetworkObject.java
@@ -1,22 +1,28 @@
 package org.batfish.representation.cisco;
 
-import org.batfish.common.util.ComparableStructure;
+import java.io.Serializable;
 import org.batfish.datamodel.IpSpace;
 
-public final class NetworkObject extends ComparableStructure<String> {
+public final class NetworkObject implements Serializable {
   /** */
   private static final long serialVersionUID = 1L;
 
   private String _description;
 
+  private String _name;
+
   private IpSpace _ipSpace;
 
   public NetworkObject(String name) {
-    super(name);
+    _name = name;
   }
 
   public String getDescription() {
     return _description;
+  }
+
+  public String getName() {
+    return _name;
   }
 
   public IpSpace getIpSpace() {

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -785,6 +785,34 @@ public class CiscoGrammarTest {
   }
 
   @Test
+  public void testNetworkObject() throws IOException {
+    String hostname = "network-object";
+    Configuration c = parseConfig(hostname);
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse();
+    Ip no1Ip = new Ip("1.2.3.4");
+    Ip no2IpStart = new Ip("2.2.2.0");
+    Ip no2IpEnd = new Ip("2.2.2.255");
+
+    /* Confirm network object IpSpaces cover the correct Ip addresses */
+    assertThat(c, hasIpSpace("NO1", containsIp(no1Ip)));
+    assertThat(c, hasIpSpace("NO1", not(containsIp(no2IpStart))));
+    assertThat(c, hasIpSpace("NO2", containsIp(no2IpStart)));
+    assertThat(c, hasIpSpace("NO2", containsIp(no2IpEnd)));
+    assertThat(c, hasIpSpace("NO2", not(containsIp(no1Ip))));
+    assertThat(c, hasIpSpace("OGN", containsIp(no1Ip, c.getIpSpaces())));
+    assertThat(c, hasIpSpace("OGN", not(containsIp(no2IpStart, c.getIpSpaces()))));
+
+    /* Confirm network objects have the correct number of referrers */
+    assertThat(ccae, hasNumReferrers(hostname, CiscoStructureType.NETWORK_OBJECT, "NO1", 1));
+    assertThat(ccae, hasNumReferrers(hostname, CiscoStructureType.NETWORK_OBJECT, "NO2", 0));
+    /* Confirm undefined reference shows up as such */
+    assertThat(
+        ccae, hasUndefinedReference(hostname, CiscoStructureType.NETWORK_OBJECT, "NO_UNDEFINED"));
+  }
+
+  @Test
   public void testIosObjectGroupNetwork() throws IOException {
     String hostname = "ios-object-group-network";
     Configuration c = parseConfig(hostname);
@@ -798,7 +826,7 @@ public class CiscoGrammarTest {
     String ognNameHost = "ogn_host";
     String ognNameIndirect = "ogn_indirect";
     String ognNameNetworkObject = "ogn_network_object";
-    String ognNameNetworkObjectIndirect = "ogn_network_object_indirect";
+    String ognNameNetworkObjectIndirect = "ogn_object_group_indirect";
     String ognNameUndef = "ogn_undef";
     String ognNameUnused = "ogn_unused";
     String ognNameWildcard = "ogn_wildcard";

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -785,34 +785,6 @@ public class CiscoGrammarTest {
   }
 
   @Test
-  public void testNetworkObject() throws IOException {
-    String hostname = "network-object";
-    Configuration c = parseConfig(hostname);
-    Batfish batfish = getBatfishForConfigurationNames(hostname);
-    ConvertConfigurationAnswerElement ccae =
-        batfish.loadConvertConfigurationAnswerElementOrReparse();
-    Ip no1Ip = new Ip("1.2.3.4");
-    Ip no2IpStart = new Ip("2.2.2.0");
-    Ip no2IpEnd = new Ip("2.2.2.255");
-
-    /* Confirm network object IpSpaces cover the correct Ip addresses */
-    assertThat(c, hasIpSpace("NO1", containsIp(no1Ip)));
-    assertThat(c, hasIpSpace("NO1", not(containsIp(no2IpStart))));
-    assertThat(c, hasIpSpace("NO2", containsIp(no2IpStart)));
-    assertThat(c, hasIpSpace("NO2", containsIp(no2IpEnd)));
-    assertThat(c, hasIpSpace("NO2", not(containsIp(no1Ip))));
-    assertThat(c, hasIpSpace("OGN", containsIp(no1Ip, c.getIpSpaces())));
-    assertThat(c, hasIpSpace("OGN", not(containsIp(no2IpStart, c.getIpSpaces()))));
-
-    /* Confirm network objects have the correct number of referrers */
-    assertThat(ccae, hasNumReferrers(hostname, CiscoStructureType.NETWORK_OBJECT, "NO1", 1));
-    assertThat(ccae, hasNumReferrers(hostname, CiscoStructureType.NETWORK_OBJECT, "NO2", 0));
-    /* Confirm undefined reference shows up as such */
-    assertThat(
-        ccae, hasUndefinedReference(hostname, CiscoStructureType.NETWORK_OBJECT, "NO_UNDEFINED"));
-  }
-
-  @Test
   public void testIosObjectGroupNetwork() throws IOException {
     String hostname = "ios-object-group-network";
     Configuration c = parseConfig(hostname);
@@ -1343,6 +1315,38 @@ public class CiscoGrammarTest {
     assertThat(c, hasZone("z1", hasMemberInterfaces(not(empty()))));
     assertThat(c, hasZone("z2", hasMemberInterfaces(not(empty()))));
     assertThat(c, hasZone("zempty", hasMemberInterfaces(empty())));
+  }
+
+  @Test
+  public void testNetworkObject() throws IOException {
+    String hostname = "network-object";
+    Configuration c = parseConfig(hostname);
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse();
+    Ip on1Ip = new Ip("1.2.3.4");
+    Ip on2IpStart = new Ip("2.2.2.0");
+    Ip on2IpEnd = new Ip("2.2.2.255");
+    Ip inlineIp = new Ip("3.3.3.3");
+
+    /* Confirm network object IpSpaces cover the correct Ip addresses */
+    assertThat(c, hasIpSpace("ON1", containsIp(on1Ip)));
+    assertThat(c, hasIpSpace("ON1", not(containsIp(on2IpStart))));
+    assertThat(c, hasIpSpace("ON2", containsIp(on2IpStart)));
+    assertThat(c, hasIpSpace("ON2", containsIp(on2IpEnd)));
+    assertThat(c, hasIpSpace("ON2", not(containsIp(on1Ip))));
+
+    /* Confirm object-group also covers the IpSpaces its network objects cover */
+    assertThat(c, hasIpSpace("OGN", containsIp(on1Ip, c.getIpSpaces())));
+    assertThat(c, hasIpSpace("OGN", containsIp(inlineIp, c.getIpSpaces())));
+    assertThat(c, hasIpSpace("OGN", not(containsIp(on2IpStart, c.getIpSpaces()))));
+
+    /* Confirm network objects have the correct number of referrers */
+    assertThat(ccae, hasNumReferrers(hostname, CiscoStructureType.NETWORK_OBJECT, "ON1", 1));
+    assertThat(ccae, hasNumReferrers(hostname, CiscoStructureType.NETWORK_OBJECT, "ON2", 0));
+    /* Confirm undefined reference shows up as such */
+    assertThat(
+        ccae, hasUndefinedReference(hostname, CiscoStructureType.NETWORK_OBJECT, "ON_UNDEFINED"));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-object-group-network
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-object-group-network
@@ -15,10 +15,10 @@ object-group network ogn_network_object
  network-object host 2.0.0.1
  network-object 1.0.0.0 255.0.0.0
 !
-object-group network ogn_network_object_indirect
- network-object object ogn_host
- network-object object ogn_indirect
- network-object object ogn_undef
+object-group network ogn_object_group_indirect
+ group-object ogn_host
+ group-object ogn_indirect
+ group-object ogn_undef
 !
 object-group network ogn_unused
 !

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/network-object
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/network-object
@@ -1,0 +1,14 @@
+!
+hostname network-object
+!
+object network NO1
+ description blah blah blah
+ host 1.2.3.4
+!
+object network NO2
+ subnet 2.2.2.0 255.255.255.0
+!
+object-group network OGN
+ network-object object NO1
+ network-object object NO_UNDEFINED
+!

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/network-object
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/network-object
@@ -1,14 +1,15 @@
 !
 hostname network-object
 !
-object network NO1
+object network ON1
  description blah blah blah
  host 1.2.3.4
 !
-object network NO2
+object network ON2
  subnet 2.2.2.0 255.255.255.0
 !
 object-group network OGN
- network-object object NO1
- network-object object NO_UNDEFINED
+ network-object object ON1
+ network-object 3.3.3.3 255.255.255.255
+ network-object object ON_UNDEFINED
 !

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -9039,6 +9039,10 @@
                 }
               }
             ]
+          },
+          "obj_any" : {
+            "class" : "org.batfish.datamodel.PrefixIpSpace",
+            "prefix" : "0.0.0.0/0"
           }
         },
         "vendorFamily" : {

--- a/tests/parsing-tests/unit-tests-unused.ref
+++ b/tests/parsing-tests/unit-tests-unused.ref
@@ -941,6 +941,15 @@
           ]
         }
       },
+      "unused:object network:obj_any" : {
+        "description" : "Unused structure of type: 'object network' with name: 'obj_any'",
+        "files" : {
+          "cisco_qos" : [
+            31,
+            32
+          ]
+        }
+      },
       "unused:object-group network:1.2.3.4-24" : {
         "description" : "Unused structure of type: 'object-group network' with name: '1.2.3.4-24'",
         "files" : {
@@ -1457,7 +1466,7 @@
     "summary" : {
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 140
+      "numResults" : 141
     },
     "unusedStructures" : {
       "aggAddress" : {
@@ -1927,6 +1936,12 @@
             23,
             24,
             25
+          ]
+        },
+        "object network" : {
+          "obj_any" : [
+            31,
+            32
           ]
         },
         "object-group network" : {

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -55776,6 +55776,15 @@
               "numReferrers" : 0
             }
           },
+          "object network" : {
+            "obj_any" : {
+              "definitionLines" : [
+                31,
+                32
+              ],
+              "numReferrers" : 0
+            }
+          },
           "object-group network" : {
             "1.2.3.4-24" : {
               "definitionLines" : [


### PR DESCRIPTION
Add Cisco ASA `network object` datamodel support and ref tracking.  Also fixed existing ref tracking using `network object-group` structure type instead of `network object`.
