### PR TITLE
bazel: fix recovery grammar dependency

### DIFF
--- a/projects/batfish-common-protocol/BUILD
+++ b/projects/batfish-common-protocol/BUILD
@@ -148,7 +148,7 @@ java_library(
         ":RecoveryParserListener.java",
     ],
     deps = [
-        ":common",
+        ":parser_common",
         "@antlr4_runtime//:compile",
     ],
 )


### PR DESCRIPTION
Missed this one when I simplified parser deps