### PR TITLE
Add network configurations helper

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/NetworkConfigurations.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/NetworkConfigurations.java
@@ -14,7 +14,7 @@ public final class NetworkConfigurations {
   @Nonnull private final Map<String, Configuration> _configurations;
 
   /** Wrap a configurations map */
-  public NetworkConfigurations(@Nonnull Map<String, Configuration> configurations) {
+  private NetworkConfigurations(@Nonnull Map<String, Configuration> configurations) {
     _configurations = requireNonNull(configurations);
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/NetworkConfigurations.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/NetworkConfigurations.java
@@ -1,0 +1,44 @@
+package org.batfish.datamodel;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Represents a set of configurations in a network. Has helper methods to "walk the configuration
+ * tree" and extract specific objects based on their keys.
+ */
+public final class NetworkConfigurations {
+  @Nonnull private final Map<String, Configuration> _configurations;
+
+  /** Wrap a configurations map */
+  public NetworkConfigurations(@Nonnull Map<String, Configuration> configurations) {
+    _configurations = requireNonNull(configurations);
+  }
+
+  @Nonnull
+  public Map<String, Configuration> getMap() {
+    return _configurations;
+  }
+
+  @Nullable
+  public Configuration get(@Nonnull String hostname) {
+    return _configurations.get(hostname);
+  }
+
+  @Nullable
+  public Vrf getVrf(@Nonnull String hostname, @Nonnull String vrfName) {
+    Configuration c = _configurations.get(hostname);
+    if (c == null) {
+      return null;
+    }
+    return c.getVrfs().get(vrfName);
+  }
+
+  /** Wrap a configurations map */
+  public static NetworkConfigurations of(@Nonnull Map<String, Configuration> configurations) {
+    return new NetworkConfigurations(configurations);
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/NetworkConfigurationsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/NetworkConfigurationsTest.java
@@ -1,0 +1,35 @@
+package org.batfish.datamodel;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+
+/** Tests of {@link NetworkConfigurations} */
+public class NetworkConfigurationsTest {
+
+  @Test
+  public void testWrapConfigs() {
+    NetworkConfigurations nc = NetworkConfigurations.of(ImmutableMap.of());
+    assertThat(nc.getMap(), anEmptyMap());
+    assertThat(nc.get("foo"), nullValue());
+  }
+
+  @Test
+  public void testGetVrf() {
+    Configuration c = new Configuration("foo", ConfigurationFormat.CISCO_IOS);
+    c.getVrfs().put("fooVRF", new Vrf("fooVRF"));
+    NetworkConfigurations nc = NetworkConfigurations.of(ImmutableMap.of("foo", c));
+
+    // Missing values are null
+    assertThat(nc.getVrf("missingHostname", "missingVRF"), nullValue());
+    assertThat(nc.getVrf("missingHostname", "fooVRF"), nullValue());
+    assertThat(nc.getVrf("foo", "missingVRF"), nullValue());
+
+    // Actual get succeeds
+    assertThat(nc.getVrf("foo", "fooVRF"), notNullValue());
+  }
+}


### PR DESCRIPTION
*Purpose*:
Have a helper wrapper around `Map<String,Configuration>` that extracts desired objects from the configuration tree based on a key and simplifies a sequential null checks we do in a bunch of places.

First use case (coming soon): pass this around in the dataplane code and remove dependency on `Configuration` from `Node` class.

fyi @arifogel @anothermattbrown 