### PR TITLE
NodePropertySpecifier: remove default-vrf

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/NodePropertySpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/NodePropertySpecifier.java
@@ -49,7 +49,6 @@ public class NodePropertySpecifier extends PropertySpecifier {
           .put(
               "default-inbound-action",
               new PropertyDescriptor<>(Configuration::getDefaultInboundAction, Schema.STRING))
-          .put("default-vrf", new PropertyDescriptor<>(Configuration::getDefaultVrf, Schema.STRING))
           .put("device-type", new PropertyDescriptor<>(Configuration::getDeviceType, Schema.STRING))
           .put(
               "dns-servers",


### PR DESCRIPTION
This is really just an internal method, it's always equivalent to getVrf(default).