### PR TITLE
Renaming in TracerouteQuestion and FlexibleLocationSpecifierFactory

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/FlexibleLocationSpecifierFactory.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/FlexibleLocationSpecifierFactory.java
@@ -45,8 +45,8 @@ import javax.annotation.Nullable;
 public final class FlexibleLocationSpecifierFactory implements LocationSpecifierFactory {
   public static final String NAME = FlexibleLocationSpecifierFactory.class.getSimpleName();
 
-  private static final String LOCATION_TYPE_INTERFACE = "interface";
-  private static final String LOCATION_TYPE_INTERFACE_LINK = "interfaceLink";
+  static final String LOCATION_TYPE_INTERFACE = "source";
+  static final String LOCATION_TYPE_INTERFACE_LINK = "intermediate";
   private static final String DEFAULT_LOCATION_TYPE = LOCATION_TYPE_INTERFACE_LINK;
 
   private static final String PROPERTY_TYPE_INTERFACE_NAME = "interface";

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/FlexibleLocationSpecifierFactoryTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/FlexibleLocationSpecifierFactoryTest.java
@@ -1,5 +1,7 @@
 package org.batfish.specifier;
 
+import static org.batfish.specifier.FlexibleLocationSpecifierFactory.LOCATION_TYPE_INTERFACE;
+import static org.batfish.specifier.FlexibleLocationSpecifierFactory.LOCATION_TYPE_INTERFACE_LINK;
 import static org.batfish.specifier.FlexibleLocationSpecifierFactory.parseSpecifier;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -115,8 +117,8 @@ public class FlexibleLocationSpecifierFactoryTest {
   public void testParseSpecifier_type() {
     LocationSpecifier iface = new NodeNameRegexInterfaceLocationSpecifier(_foo);
     LocationSpecifier ifaceLink = new NodeNameRegexInterfaceLinkLocationSpecifier(_foo);
-    assertThat(parseSpecifier("interfaceLink:foo"), equalTo(ifaceLink));
-    assertThat(parseSpecifier("interface:foo"), equalTo(iface));
+    assertThat(parseSpecifier(LOCATION_TYPE_INTERFACE_LINK + ":foo"), equalTo(ifaceLink));
+    assertThat(parseSpecifier(LOCATION_TYPE_INTERFACE + ":foo"), equalTo(iface));
     assertThat(parseSpecifier("foo"), equalTo(ifaceLink));
   }
 }

--- a/projects/question/src/main/java/org/batfish/question/traceroute/TracerouteQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/traceroute/TracerouteQuestion.java
@@ -37,10 +37,9 @@ public final class TracerouteQuestion extends IPacketTraceQuestion {
 
   private static final String PROP_SOURCE_LOCATION_SPECIFIER_INPUT = "traceStart";
 
-  private static final String PROP_SOURCE_IP_SPACE_SPECIFIER_FACTORY =
-      "sourceIpSpaceSpecifierFactory";
+  private static final String PROP_SOURCE_IP_SPACE_SPECIFIER_FACTORY = "srcIpSpaceSpecifierFactory";
 
-  private static final String PROP_SOURCE_IP_SPACE_SPECIFIER_INPUT = "sourceIpSpace";
+  private static final String PROP_SOURCE_IP_SPACE_SPECIFIER_INPUT = "srcIpSpace";
 
   private boolean _ignoreAcls = false;
 

--- a/projects/question/src/main/java/org/batfish/question/traceroute/TracerouteQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/traceroute/TracerouteQuestion.java
@@ -33,9 +33,9 @@ public final class TracerouteQuestion extends IPacketTraceQuestion {
   private static final String PROP_IGNORE_ACLS = "ignoreAcls";
 
   private static final String PROP_SOURCE_LOCATION_SPECIFIER_FACTORY =
-      "sourceLocationSpecifierFactory";
+      "traceStartLocationSpecifierFactory";
 
-  private static final String PROP_SOURCE_LOCATION_SPECIFIER_INPUT = "sourceLocation";
+  private static final String PROP_SOURCE_LOCATION_SPECIFIER_INPUT = "traceStart";
 
   private static final String PROP_SOURCE_IP_SPACE_SPECIFIER_FACTORY =
       "sourceIpSpaceSpecifierFactory";

--- a/tests/basic/commands
+++ b/tests/basic/commands
@@ -35,8 +35,8 @@ test tests/basic/selfAdjacencies.ref get selfAdjacencies
 test tests/basic/traceroute-1-2.ref get traceroute ingressNode="as1core1", dst="host1"
 test tests/basic/traceroute-1-2-ignoreAcls.ref get traceroute ingressNode="as1core1", dst="host1", ignoreAcls=true
 test tests/basic/traceroute-2-1.ref get traceroute ingressNode="host2", dst="1.0.1.1"
-test tests/basic/traceroute2-1-2.ref get traceroute2 sourceLocation="node=as1core1", dst="host1"
-test tests/basic/traceroute2-2-1.ref get traceroute2 sourceLocationSpecifierFactory="NodeNameRegexInterfaceLocationSpecifierFactory", sourceLocation="host2", dst="1.0.1.1"
+test tests/basic/traceroute2-1-2.ref get traceroute2 traceStart="node=as1core1", dst="host1"
+test tests/basic/traceroute2-2-1.ref get traceroute2 traceStartLocationSpecifierFactory="NodeNameRegexInterfaceLocationSpecifierFactory", traceStart="host2", dst="1.0.1.1"
 test tests/basic/tracefilters.ref get tracefilters dst="1.1.1.1", nodeRegex="host.*", filterRegex="filter.*"
 test tests/basic/multipath-host1.ref get reachability type="multipath", ingressNodeRegex="host1", srcIps=["2.128.0.0"], dstIps=["3.0.1.2"], ipProtocols=["TCP"], srcPorts=[0], dstPorts=[0]
 test tests/basic/multipath-host2.ref get reachability type="multipath", ingressNodeRegex="host2", srcIps=["2.128.0.0"], dstIps=["1.0.1.1"], ipProtocols=["UDP"], srcPorts=[0], dstPorts=[0]


### PR DESCRIPTION
- traceroute2: source is now traceStart
- FlexibleLocationSpecifierFactory:
  - LocationType "interface" is now "source"
  - LocationType "interfaceLink" is now "intermediate"