### PR TITLE
Add support for exploring BGP RIBs with the routes2 question

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/DataPlane.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/DataPlane.java
@@ -1,5 +1,6 @@
 package org.batfish.datamodel;
 
+import com.google.common.collect.Table;
 import com.google.common.graph.Network;
 import java.io.Serializable;
 import java.util.Map;
@@ -8,6 +9,8 @@ import java.util.SortedMap;
 import java.util.SortedSet;
 
 public interface DataPlane extends Serializable {
+
+  Table<String, String, Set<BgpRoute>> getBgpRoutes(boolean multipath);
 
   Network<BgpPeerConfig, BgpSession> getBgpTopology();
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockDataPlane.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockDataPlane.java
@@ -3,6 +3,7 @@ package org.batfish.datamodel;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Table;
 import com.google.common.graph.Network;
 import com.google.common.graph.NetworkBuilder;
 import java.util.Map;
@@ -14,6 +15,8 @@ import javax.annotation.Nullable;
 public class MockDataPlane implements DataPlane {
 
   public static class Builder {
+
+    private Table<String, String, Set<BgpRoute>> _bgpRoutes;
 
     private Network<BgpPeerConfig, BgpSession> _bgpTopology;
 
@@ -44,6 +47,10 @@ public class MockDataPlane implements DataPlane {
 
     public MockDataPlane build() {
       return new MockDataPlane(this);
+    }
+
+    public void setBgpRoutes(Table<String, String, Set<BgpRoute>> bgpRoutes) {
+      this._bgpRoutes = bgpRoutes;
     }
 
     public Builder setBgpTopology(Network<BgpPeerConfig, BgpSession> bgpTopology) {
@@ -83,6 +90,8 @@ public class MockDataPlane implements DataPlane {
     return new Builder();
   }
 
+  private Table<String, String, Set<BgpRoute>> _bgpRoutes;
+
   private final Network<BgpPeerConfig, BgpSession> _bgpTopology;
 
   private final Map<String, Configuration> _configurations;
@@ -111,6 +120,16 @@ public class MockDataPlane implements DataPlane {
     _ribs = ImmutableSortedMap.copyOf(builder._ribs);
     _topology = builder._topology;
     _topologyEdges = ImmutableSortedSet.copyOf(builder._topologyEdges);
+  }
+
+  @Override
+  public Table<String, String, Set<BgpRoute>> getBgpRoutes(boolean multipath) {
+    return _bgpRoutes;
+  }
+
+  @Override
+  public Network<BgpPeerConfig, BgpSession> getBgpTopology() {
+    return _bgpTopology;
   }
 
   @Override
@@ -147,11 +166,6 @@ public class MockDataPlane implements DataPlane {
   @Override
   public SortedSet<Edge> getTopologyEdges() {
     return _topologyEdges;
-  }
-
-  @Override
-  public Network<BgpPeerConfig, BgpSession> getBgpTopology() {
-    return _bgpTopology;
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -126,7 +126,7 @@ public class VirtualRouter extends ComparableStructure<String> {
       new RouteDependencyTracker<>();
 
   /** Best-path BGP RIB */
-  transient BgpBestPathRib _bgpBestPathRib;
+  BgpBestPathRib _bgpBestPathRib;
 
   /** Builder for constructing {@link RibDelta} as pertains to the best-path BGP RIB */
   private transient RibDelta.Builder<BgpRoute> _bgpBestPathDeltaBuilder;
@@ -135,7 +135,7 @@ public class VirtualRouter extends ComparableStructure<String> {
   transient SortedMap<UndirectedBgpSession, Queue<RouteAdvertisement<BgpRoute>>> _bgpIncomingRoutes;
 
   /** BGP multipath RIB */
-  transient BgpMultipathRib _bgpMultipathRib;
+  BgpMultipathRib _bgpMultipathRib;
 
   /** Builder for constructing {@link RibDelta} as pertains to the multipath BGP RIB */
   private transient RibDelta.Builder<BgpRoute> _bgpMultiPathDeltaBuilder;
@@ -3016,5 +3016,9 @@ public class VirtualRouter extends ComparableStructure<String> {
 
   Set<BgpAdvertisement> getSentBgpAdvertisements() {
     return _sentBgpAdvertisements;
+  }
+
+  public BgpMultipathRib getBgpMultipathRib() {
+    return _bgpMultipathRib;
   }
 }

--- a/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswerer.java
@@ -6,14 +6,17 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.HashMultiset;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multiset;
+import com.google.common.collect.Table;
 import java.util.List;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.regex.Pattern;
+import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.common.Answerer;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.datamodel.AbstractRoute;
+import org.batfish.datamodel.BgpRoute;
 import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.GenericRib;
 import org.batfish.datamodel.answers.AnswerElement;
@@ -30,12 +33,23 @@ import org.batfish.question.routes.RoutesQuestion.RibProtocol;
 /** Answerer for {@link RoutesQuestion} */
 @ParametersAreNonnullByDefault
 public class RoutesAnswerer extends Answerer {
+  // Global (always present) columns
   static final String COL_NODE = "Node";
   static final String COL_VRF_NAME = "VRF";
   static final String COL_NETWORK = "Network";
-  static final String COL_NEXT_HOP = "NextHop";
   static final String COL_NEXT_HOP_IP = "NextHopIp";
+
+  // Present sometimes
+  static final String COL_NEXT_HOP = "NextHop";
   static final String COL_PROTOCOL = "Protocol";
+
+  // BGP only
+  static final String COL_AS_PATH = "AsPath";
+  static final String COL_METRIC = "Metric";
+  static final String COL_LOCAL_PREF = "LocalPref";
+  static final String COL_COMMUNITIES = "Communities";
+  static final String COL_ORIGIN_PROTOCOL = "OriginProtocol";
+  static final String VALUE_NA = "N/A";
 
   RoutesAnswerer(Question question, IBatfish batfish) {
     super(question, batfish);
@@ -59,10 +73,31 @@ public class RoutesAnswerer extends Answerer {
   private static Multiset<Row> generateRows(
       DataPlane dp, RibProtocol protocol, Set<String> matchingNodes, String vrfRegex) {
     switch (protocol) {
+      case BGP:
+        return getBgpRibRoutes(dp.getBgpRoutes(false), matchingNodes, vrfRegex);
+      case BGPMP:
+        return getBgpRibRoutes(dp.getBgpRoutes(true), matchingNodes, vrfRegex);
       case ALL:
       default:
         return getMainRibRoutes(dp.getRibs(), matchingNodes, vrfRegex);
     }
+  }
+
+  private static Multiset<Row> getBgpRibRoutes(
+      Table<String, String, Set<BgpRoute>> bgpRoutes, Set<String> matchingNodes, String vrfRegex) {
+    HashMultiset<Row> rows = HashMultiset.create();
+    Pattern compiledVrfRegex = Pattern.compile(vrfRegex);
+    matchingNodes.forEach(
+        hostname ->
+            bgpRoutes
+                .row(hostname)
+                .forEach(
+                    (vrfName, routes) -> {
+                      if (compiledVrfRegex.matcher(vrfName).matches()) {
+                        rows.addAll(getRowsForBgpRoutes(hostname, vrfName, routes));
+                      }
+                    }));
+    return rows;
   }
 
   /** Get the rows for MainRib routes. */
@@ -88,6 +123,7 @@ public class RoutesAnswerer extends Answerer {
   }
 
   /** Convert a {@link Set} of {@link AbstractRoute} into a list of rows. */
+  @Nonnull
   private static List<Row> getRowsForAbstractRoutes(
       String node, String vrfName, Set<AbstractRoute> routes) {
     Node nodeObj = new Node(node);
@@ -100,8 +136,32 @@ public class RoutesAnswerer extends Answerer {
                     .put(COL_VRF_NAME, vrfName)
                     .put(COL_NETWORK, route.getNetwork())
                     .put(COL_NEXT_HOP_IP, route.getNextHopIp())
-                    .put(COL_NEXT_HOP, firstNonNull(route.getNextHop(), "N/A"))
+                    .put(COL_NEXT_HOP, firstNonNull(route.getNextHop(), VALUE_NA))
                     .put(COL_PROTOCOL, route.getProtocol())
+                    .build())
+        .collect(ImmutableList.toImmutableList());
+  }
+
+  /** Convert a set of {@link BgpRoute} into a list of rows. */
+  @Nonnull
+  private static List<Row> getRowsForBgpRoutes(
+      String hostname, String vrfName, Set<BgpRoute> routes) {
+    Node nodeObj = new Node(hostname);
+    return routes
+        .stream()
+        .map(
+            route ->
+                Row.builder()
+                    .put(COL_NODE, nodeObj)
+                    .put(COL_VRF_NAME, vrfName)
+                    .put(COL_NETWORK, route.getNetwork())
+                    .put(COL_NEXT_HOP_IP, route.getNextHopIp())
+                    .put(COL_PROTOCOL, route.getProtocol())
+                    .put(COL_AS_PATH, route.getAsPath().getAsPathString())
+                    .put(COL_METRIC, route.getMetric())
+                    .put(COL_LOCAL_PREF, route.getLocalPreference())
+                    .put(COL_COMMUNITIES, route.getCommunities())
+                    .put(COL_ORIGIN_PROTOCOL, firstNonNull(route.getSrcProtocol(), VALUE_NA))
                     .build())
         .collect(ImmutableList.toImmutableList());
   }
@@ -109,18 +169,33 @@ public class RoutesAnswerer extends Answerer {
   /** Generate the table metadata based on the protocol for which we are examining the RIBs */
   @VisibleForTesting
   static TableMetadata getTableMetadata(RibProtocol protocol) {
+    ImmutableList.Builder<ColumnMetadata> columnBuilder = ImmutableList.builder();
+    addCommonTableColumns(columnBuilder);
     switch (protocol) {
+      case BGP:
+        columnBuilder.add(new ColumnMetadata(COL_NEXT_HOP_IP, Schema.IP, "Route's next hop IP"));
+        columnBuilder.add(new ColumnMetadata(COL_AS_PATH, Schema.STRING, "AS path"));
+        columnBuilder.add(new ColumnMetadata(COL_METRIC, Schema.INTEGER, "Metric"));
+        columnBuilder.add(new ColumnMetadata(COL_LOCAL_PREF, Schema.INTEGER, "Local Preference"));
+        columnBuilder.add(
+            new ColumnMetadata(COL_COMMUNITIES, Schema.list(Schema.INTEGER), "BGP communities"));
+        columnBuilder.add(
+            new ColumnMetadata(COL_ORIGIN_PROTOCOL, Schema.STRING, "Origin protocol"));
+        break;
       case ALL:
       default:
-        ImmutableList.Builder<ColumnMetadata> columnBuilder = ImmutableList.builder();
-        columnBuilder.add(new ColumnMetadata(COL_NODE, Schema.NODE, "Node"));
-        columnBuilder.add(new ColumnMetadata(COL_VRF_NAME, Schema.STRING, "VRF name"));
-        columnBuilder.add(new ColumnMetadata(COL_NETWORK, Schema.PREFIX, "Route network (prefix)"));
-        columnBuilder.add(new ColumnMetadata(COL_PROTOCOL, Schema.STRING, "Route protocol"));
         columnBuilder.add(
             new ColumnMetadata(COL_NEXT_HOP, Schema.STRING, "Route's next hop (as node hostname)"));
         columnBuilder.add(new ColumnMetadata(COL_NEXT_HOP_IP, Schema.IP, "Route's next hop IP"));
-        return new TableMetadata(columnBuilder.build(), new DisplayHints());
     }
+    return new TableMetadata(columnBuilder.build(), new DisplayHints());
+  }
+
+  /** Generate table columns that should be always present, at the start of table. */
+  private static void addCommonTableColumns(ImmutableList.Builder<ColumnMetadata> columnBuilder) {
+    columnBuilder.add(new ColumnMetadata(COL_NODE, Schema.NODE, "Node"));
+    columnBuilder.add(new ColumnMetadata(COL_VRF_NAME, Schema.STRING, "VRF name"));
+    columnBuilder.add(new ColumnMetadata(COL_NETWORK, Schema.PREFIX, "Route network (prefix)"));
+    columnBuilder.add(new ColumnMetadata(COL_PROTOCOL, Schema.STRING, "Route protocol"));
   }
 }

--- a/projects/question/src/main/java/org/batfish/question/routes/RoutesQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RoutesQuestion.java
@@ -23,7 +23,8 @@ public class RoutesQuestion extends Question {
   /** RIBs of these protocols are available for examining routes using {@link RoutesQuestion}. */
   public enum RibProtocol {
     ALL("all"),
-    BGP("bgp");
+    BGP("bgp"),
+    BGPMP("bgpmp"); // BGP multi path
 
     private final String _protocolName;
 

--- a/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
@@ -1,9 +1,14 @@
 package org.batfish.question.routes;
 
+import static org.batfish.question.routes.RoutesAnswerer.COL_AS_PATH;
+import static org.batfish.question.routes.RoutesAnswerer.COL_COMMUNITIES;
+import static org.batfish.question.routes.RoutesAnswerer.COL_LOCAL_PREF;
+import static org.batfish.question.routes.RoutesAnswerer.COL_METRIC;
 import static org.batfish.question.routes.RoutesAnswerer.COL_NETWORK;
 import static org.batfish.question.routes.RoutesAnswerer.COL_NEXT_HOP;
 import static org.batfish.question.routes.RoutesAnswerer.COL_NEXT_HOP_IP;
 import static org.batfish.question.routes.RoutesAnswerer.COL_NODE;
+import static org.batfish.question.routes.RoutesAnswerer.COL_ORIGIN_PROTOCOL;
 import static org.batfish.question.routes.RoutesAnswerer.COL_PROTOCOL;
 import static org.batfish.question.routes.RoutesAnswerer.COL_VRF_NAME;
 import static org.batfish.question.routes.RoutesAnswerer.getMainRibRoutes;
@@ -108,5 +113,31 @@ public class RoutesAnswererTest {
             .collect(ImmutableList.toImmutableList()),
         contains(
             Schema.NODE, Schema.STRING, Schema.PREFIX, Schema.STRING, Schema.STRING, Schema.IP));
+  }
+
+  @Test
+  public void testGetTableMetadataBGP() {
+    List<ColumnMetadata> columnMetadata = getTableMetadata(RibProtocol.BGP).getColumnMetadata();
+    ImmutableList.Builder<String> expectedBuilder = ImmutableList.builder();
+    expectedBuilder.add(
+        COL_NODE,
+        COL_VRF_NAME,
+        COL_NETWORK,
+        COL_PROTOCOL,
+        COL_NEXT_HOP_IP,
+        // BGP attributes
+        COL_AS_PATH,
+        COL_METRIC,
+        COL_LOCAL_PREF,
+        COL_COMMUNITIES,
+        COL_ORIGIN_PROTOCOL);
+    List<String> expected = expectedBuilder.build();
+
+    assertThat(
+        columnMetadata
+            .stream()
+            .map(ColumnMetadata::getName)
+            .collect(ImmutableList.toImmutableList()),
+        equalTo(expected));
   }
 }


### PR DESCRIPTION
- Ability to inspect BGP ribs with the new routes question.
- Make BGP ribs non-transient (breaking change).
Minor: Trying out Guavas table interface