### PR TITLE
Batfish: update and flesh out definition of BGP well-known communities

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/WellKnownCommunity.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/WellKnownCommunity.java
@@ -1,19 +1,27 @@
 package org.batfish.common;
 
-public enum WellKnownCommunity {
-  INTERNET(0L),
-  GSHUT(0xFFFFFF04L),
-  LOCAL_AS(0xFFFFFF03L),
-  NO_ADVERTISE(0xFFFFFF02L),
-  NO_EXPORT(0xFFFFFF01L);
+/**
+ * BGP Well-known Communities
+ *
+ * <p>See IANA page:
+ * https://www.iana.org/assignments/bgp-well-known-communities/bgp-well-known-communities.xml
+ */
+public final class WellKnownCommunity {
+  public static final long INTERNET = 0L;
+  public static final long GRACEFUL_SHUTDOWN = 0xFFFF_0000L;
+  public static final long ACCEPT_OWN = 0xFFFF_0001L;
+  public static final long ROUTE_FILTER_TRANSLATED_V4 = 0xFFFF_0002L;
+  public static final long ROUTE_FILTER_V4 = 0xFFFF_0003L;
+  public static final long ROUTE_FILTER_TRANSLATED_V6 = 0xFFFF_0004L;
+  public static final long ROUTE_FILTER_V6 = 0xFFFF_0005L;
+  public static final long LLGR_STALE = 0xFFFF_0006;
+  public static final long NO_LLGR = 0xFFFF_0007L;
+  public static final long ACCEPT_OWN_NEXTHOP = 0xFFFF_0008L;
+  public static final long BLACKHOLE = 0xFFFF_029AL;
+  public static final long NO_EXPORT = 0xFFFF_FF01L;
+  public static final long NO_ADVERTISE = 0xFFFF_FF02L;
+  public static final long NO_EXPORT_SUBCONFED = 0xFFFF_FF03L;
+  public static final long NO_PEER = 0xFFFF_FF04L;
 
-  private final long _value;
-
-  WellKnownCommunity(long value) {
-    this._value = value;
-  }
-
-  public long getValue() {
-    return this._value;
-  }
+  private WellKnownCommunity() {} // prevent instantiation
 }

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -8677,15 +8677,16 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
     } else if (ctx.DEC() != null) {
       return toLong(ctx.com);
     } else if (ctx.INTERNET() != null) {
-      return WellKnownCommunity.INTERNET.getValue();
+      return WellKnownCommunity.INTERNET;
     } else if (ctx.GSHUT() != null) {
-      return WellKnownCommunity.GSHUT.getValue();
+      return WellKnownCommunity.GRACEFUL_SHUTDOWN;
     } else if (ctx.LOCAL_AS() != null) {
-      return WellKnownCommunity.LOCAL_AS.getValue();
+      // Cisco LOCAL_AS is interpreted as RFC1997 NO_EXPORT_SUBCONFED: internet forums.
+      return WellKnownCommunity.NO_EXPORT_SUBCONFED;
     } else if (ctx.NO_ADVERTISE() != null) {
-      return WellKnownCommunity.NO_ADVERTISE.getValue();
+      return WellKnownCommunity.NO_ADVERTISE;
     } else if (ctx.NO_EXPORT() != null) {
-      return WellKnownCommunity.NO_EXPORT.getValue();
+      return WellKnownCommunity.NO_EXPORT;
     } else {
       throw convError(Long.class, ctx);
     }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -1714,15 +1714,13 @@ public class CiscoGrammarTest {
     String nxosRegexExpMulti = getCLRegex(nxosCommunityLists, "nxos_exp_multi");
 
     // Check well known community regexes are generated properly
-    String regexInternet =
-        "^" + CommonUtil.longToCommunity(WellKnownCommunity.INTERNET.getValue()) + "$";
-    String regexNoAdv =
-        "^" + CommonUtil.longToCommunity(WellKnownCommunity.NO_ADVERTISE.getValue()) + "$";
-    String regexNoExport =
-        "^" + CommonUtil.longToCommunity(WellKnownCommunity.NO_EXPORT.getValue()) + "$";
-    String regexGshut = "^" + CommonUtil.longToCommunity(WellKnownCommunity.GSHUT.getValue()) + "$";
+    String regexInternet = "^" + CommonUtil.longToCommunity(WellKnownCommunity.INTERNET) + "$";
+    String regexNoAdv = "^" + CommonUtil.longToCommunity(WellKnownCommunity.NO_ADVERTISE) + "$";
+    String regexNoExport = "^" + CommonUtil.longToCommunity(WellKnownCommunity.NO_EXPORT) + "$";
+    String regexGshut =
+        "^" + CommonUtil.longToCommunity(WellKnownCommunity.GRACEFUL_SHUTDOWN) + "$";
     String regexLocalAs =
-        "^" + CommonUtil.longToCommunity(WellKnownCommunity.LOCAL_AS.getValue()) + "$";
+        "^" + CommonUtil.longToCommunity(WellKnownCommunity.NO_EXPORT_SUBCONFED) + "$";
     assertThat(iosRegexStdInternet, equalTo(regexInternet));
     assertThat(iosRegexStdNoAdv, equalTo(regexNoAdv));
     assertThat(iosRegexStdNoExport, equalTo(regexNoExport));


### PR DESCRIPTION
* Use the standard names, not the cisco names
* add link to the reference defining the constants
* use constants, not enums where we always then do `.longValue()`

Main changes to scrutinize:
* gshut had the wrong number before (verify?)
