### PR TITLE
Add support for PAN virtual system

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
@@ -210,6 +210,11 @@ VIRTUAL_ROUTER
     'virtual-router'
 ;
 
+VSYS
+:
+    'vsys'
+;
+
 // Complex tokens
 
 DEC

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoParser.g4
@@ -2,7 +2,7 @@ parser grammar PaloAltoParser;
 
 /* This is only needed if parser grammar is spread across files */
 import
-PaloAlto_common, PaloAlto_deviceconfig, PaloAlto_network, PaloAlto_shared;
+PaloAlto_common, PaloAlto_deviceconfig, PaloAlto_network, PaloAlto_shared, PaloAlto_vsys;
 
 options {
     superClass = 'org.batfish.grammar.BatfishParser';
@@ -39,6 +39,7 @@ statement_config_devices
 :
     s_deviceconfig
     | s_network
+    | s_vsys
 ;
 
 /*

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_shared.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_shared.g4
@@ -10,8 +10,14 @@ s_shared
 :
     SHARED
     (
-        ss_log_settings
+        ss_common
     )
+;
+
+// Common syntax between set shared and set vsys
+ss_common
+:
+    ss_log_settings
 ;
 
 ss_log_settings

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_vsys.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_vsys.g4
@@ -1,6 +1,6 @@
 parser grammar PaloAlto_vsys;
 
-import PaloAlto_common, PaloAlto_shared;
+import PaloAlto_common, PaloAlto_shared, PaloAlto_zone;
 
 options {
     tokenVocab = PaloAltoLexer;
@@ -10,6 +10,7 @@ s_vsys
 :
     VSYS name = variable
     (
-        ss_common
+        s_zone
+        | ss_common
     )
 ;

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_vsys.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_vsys.g4
@@ -1,0 +1,15 @@
+parser grammar PaloAlto_vsys;
+
+import PaloAlto_common, PaloAlto_shared;
+
+options {
+    tokenVocab = PaloAltoLexer;
+}
+
+s_vsys
+:
+    VSYS name = variable
+    (
+        ss_common
+    )
+;

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -3,7 +3,7 @@ package org.batfish.grammar.palo_alto;
 import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.DEFAULT_VSYS_NAME;
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.SHARED_VSYS_NAME;
-import static org.batfish.representation.palo_alto.PaloAltoConfiguration.computeZoneName;
+import static org.batfish.representation.palo_alto.PaloAltoConfiguration.computeObjectName;
 import static org.batfish.representation.palo_alto.PaloAltoStructureType.INTERFACE;
 import static org.batfish.representation.palo_alto.PaloAltoStructureType.ZONE;
 import static org.batfish.representation.palo_alto.PaloAltoStructureUsage.VIRTUAL_ROUTER_INTERFACE;
@@ -174,10 +174,12 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
 
   @Override
   public void enterS_zone(S_zoneContext ctx) {
-    // Use constructed zone name so same-named zone defs and refs across vsys are unique
-    String name = computeZoneName(_currentVsys.getName(), ctx.name.getText());
+    String name = ctx.name.getText();
     _currentZone = _currentVsys.getZones().computeIfAbsent(name, Zone::new);
-    defineStructure(ZONE, name, ctx);
+
+    // Use constructed zone name so same-named zone defs across vsys are unique
+    String uniqueName = computeObjectName(_currentVsys.getName(), name);
+    defineStructure(ZONE, uniqueName, ctx);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -168,7 +168,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
   @Override
   public void enterPalo_alto_configuration(Palo_alto_configurationContext ctx) {
     _configuration = new PaloAltoConfiguration(_unimplementedFeatures);
-    _defaultVsys = _configuration.getVsys().computeIfAbsent(DEFAULT_VSYS_NAME, Vsys::new);
+    _defaultVsys = _configuration.getVirtualSystems().computeIfAbsent(DEFAULT_VSYS_NAME, Vsys::new);
     _currentVsys = _defaultVsys;
   }
 
@@ -339,7 +339,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
 
   @Override
   public void enterS_shared(S_sharedContext ctx) {
-    _currentVsys = _configuration.getVsys().computeIfAbsent(SHARED_VSYS_NAME, Vsys::new);
+    _currentVsys = _configuration.getVirtualSystems().computeIfAbsent(SHARED_VSYS_NAME, Vsys::new);
   }
 
   @Override
@@ -375,7 +375,8 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
 
   @Override
   public void enterS_vsys(S_vsysContext ctx) {
-    _currentVsys = _configuration.getVsys().computeIfAbsent(ctx.name.getText(), Vsys::new);
+    _currentVsys =
+        _configuration.getVirtualSystems().computeIfAbsent(ctx.name.getText(), Vsys::new);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -43,13 +43,13 @@ public final class PaloAltoConfiguration extends VendorConfiguration {
 
   private final SortedMap<String, VirtualRouter> _virtualRouters;
 
-  private final SortedMap<String, Vsys> _vsys;
+  private final SortedMap<String, Vsys> _virtualSystems;
 
   public PaloAltoConfiguration(Set<String> unimplementedFeatures) {
     _interfaces = new TreeMap<>();
     _unimplementedFeatures = unimplementedFeatures;
     _virtualRouters = new TreeMap<>();
-    _vsys = new TreeMap<>();
+    _virtualSystems = new TreeMap<>();
   }
 
   private NavigableSet<String> getDnsServers() {
@@ -92,8 +92,8 @@ public final class PaloAltoConfiguration extends VendorConfiguration {
     return _virtualRouters;
   }
 
-  public SortedMap<String, Vsys> getVsys() {
-    return _vsys;
+  public SortedMap<String, Vsys> getVirtualSystems() {
+    return _virtualSystems;
   }
 
   public void setDnsServerPrimary(String dnsServerPrimary) {
@@ -132,10 +132,10 @@ public final class PaloAltoConfiguration extends VendorConfiguration {
   }
 
   /** Convert vsys components to vendor independent model */
-  private void convertVsys() {
+  private void convertVirtualSystems() {
     NavigableSet<String> loggingServers = new TreeSet<>();
 
-    for (Vsys vsys : _vsys.values()) {
+    for (Vsys vsys : _virtualSystems.values()) {
       loggingServers.addAll(vsys.getSyslogServerAddresses());
       for (Entry<String, Zone> zoneEntry : vsys.getZones().entrySet()) {
         Zone zone = zoneEntry.getValue();
@@ -225,8 +225,8 @@ public final class PaloAltoConfiguration extends VendorConfiguration {
       _c.getVrfs().put(vr.getKey(), toVrf(vr.getValue()));
     }
 
-    // Handle converting items within vsys's
-    convertVsys();
+    // Handle converting items within virtual systems
+    convertVirtualSystems();
 
     // Count and mark structure usages and identify undefined references
     markConcreteStructure(

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -139,7 +139,7 @@ public final class PaloAltoConfiguration extends VendorConfiguration {
       loggingServers.addAll(vsys.getSyslogServerAddresses());
       for (Entry<String, Zone> zoneEntry : vsys.getZones().entrySet()) {
         Zone zone = zoneEntry.getValue();
-        String zoneName = zone.getName();
+        String zoneName = computeObjectName(vsys.getName(), zone.getName());
         _c.getZones().put(zoneName, toZone(zoneName, zone));
       }
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -123,8 +123,12 @@ public final class PaloAltoConfiguration extends VendorConfiguration {
   }
 
   // Visible for testing
-  public static String computeZoneName(String vsysName, String zoneName) {
-    return String.format("%s~%s", vsysName, zoneName);
+  /**
+   * Generate unique object name (no collision across vsys namespaces) given a vsys name and
+   * original object name
+   */
+  public static String computeObjectName(String vsysName, String objectName) {
+    return String.format("%s~%s", vsysName, objectName);
   }
 
   /** Convert vsys components to vendor independent model */

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/Vsys.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/Vsys.java
@@ -1,0 +1,42 @@
+package org.batfish.representation.palo_alto;
+
+import java.io.Serializable;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+public final class Vsys implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  private final String _name;
+
+  private final SortedMap<String, SortedMap<String, SyslogServer>> _syslogServerGroups;
+
+  public Vsys(String name) {
+    _name = name;
+    _syslogServerGroups = new TreeMap<>();
+  }
+
+  /** Returns the name of this vsys. */
+  public String getName() {
+    return _name;
+  }
+
+  /**
+   * Returns a syslog server with the specified name in the specified server group. If a matching
+   * server does not exist, one is created.
+   */
+  public SyslogServer getSyslogServer(String serverGroupName, String serverName) {
+    SortedMap<String, SyslogServer> serverGroup =
+        _syslogServerGroups.computeIfAbsent(serverGroupName, g -> new TreeMap<>());
+    return serverGroup.computeIfAbsent(serverName, SyslogServer::new);
+  }
+
+  /** Returns a list of all syslog server addresses. */
+  public SortedSet<String> getSyslogServerAddresses() {
+    SortedSet<String> servers = new TreeSet<>();
+    _syslogServerGroups.values().forEach(g -> g.values().forEach(s -> servers.add(s.getAddress())));
+    return servers;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/Vsys.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/Vsys.java
@@ -13,9 +13,12 @@ public final class Vsys implements Serializable {
 
   private final SortedMap<String, SortedMap<String, SyslogServer>> _syslogServerGroups;
 
+  private final SortedMap<String, Zone> _zones;
+
   public Vsys(String name) {
     _name = name;
     _syslogServerGroups = new TreeMap<>();
+    _zones = new TreeMap<>();
   }
 
   /** Returns the name of this vsys. */
@@ -34,9 +37,14 @@ public final class Vsys implements Serializable {
   }
 
   /** Returns a list of all syslog server addresses. */
-  public SortedSet<String> getSyslogServerAddresses() {
+  SortedSet<String> getSyslogServerAddresses() {
     SortedSet<String> servers = new TreeSet<>();
     _syslogServerGroups.values().forEach(g -> g.values().forEach(s -> servers.add(s.getAddress())));
     return servers;
+  }
+
+  /** Returns a map of zone name to zone for the zones in this vsys. */
+  public SortedMap<String, Zone> getZones() {
+    return _zones;
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -168,7 +168,8 @@ public class PaloAltoGrammarTest {
     Configuration c = parseConfig(hostname);
 
     // Confirm all the defined syslog servers show up in VI model
-    assertThat(c.getLoggingServers(), containsInAnyOrder("1.1.1.1", "2.2.2.2", "3.3.3.3"));
+    assertThat(
+        c.getLoggingServers(), containsInAnyOrder("1.1.1.1", "2.2.2.2", "3.3.3.3", "4.4.4.4"));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -21,7 +21,7 @@ import static org.batfish.datamodel.matchers.InterfaceMatchers.isActive;
 import static org.batfish.datamodel.matchers.VrfMatchers.hasInterfaces;
 import static org.batfish.datamodel.matchers.VrfMatchers.hasStaticRoutes;
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.DEFAULT_VSYS_NAME;
-import static org.batfish.representation.palo_alto.PaloAltoConfiguration.computeZoneName;
+import static org.batfish.representation.palo_alto.PaloAltoConfiguration.computeObjectName;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -314,8 +314,8 @@ public class PaloAltoGrammarTest {
     ConvertConfigurationAnswerElement ccae =
         batfish.loadConvertConfigurationAnswerElementOrReparse();
 
-    String zoneName = computeZoneName("vsys1", "z1");
-    String zoneEmptyName = computeZoneName("vsys11", "z1");
+    String zoneName = computeObjectName("vsys1", "z1");
+    String zoneEmptyName = computeObjectName("vsys11", "z1");
 
     // Confirm zone definitions are recorded properly
     assertThat(ccae, hasDefinedStructure(hostname, PaloAltoStructureType.ZONE, zoneName));
@@ -340,8 +340,8 @@ public class PaloAltoGrammarTest {
     ConvertConfigurationAnswerElement ccae =
         batfish.loadConvertConfigurationAnswerElementOrReparse();
 
-    String z1Name = computeZoneName(DEFAULT_VSYS_NAME, "z1");
-    String zEmptyName = computeZoneName(DEFAULT_VSYS_NAME, "zempty");
+    String z1Name = computeObjectName(DEFAULT_VSYS_NAME, "z1");
+    String zEmptyName = computeObjectName(DEFAULT_VSYS_NAME, "zempty");
 
     // Confirm zone definitions are recorded properly
     assertThat(ccae, hasDefinedStructure(hostname, PaloAltoStructureType.ZONE, z1Name));

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/log-settings-syslog
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/log-settings-syslog
@@ -2,3 +2,4 @@ set deviceconfig system hostname log-settings-syslog
 set shared log-settings syslog SLNAME1 server SNAME1 server 1.1.1.1
 set shared log-settings syslog SLNAME1 server SNAME2 server 2.2.2.2
 set shared log-settings syslog SLNAME2 server SNAME1 server 3.3.3.3
+set vsys vsys1 log-settings syslog SLNAME1 server SNAME1 server 4.4.4.4

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/vsys-zones
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/vsys-zones
@@ -1,0 +1,5 @@
+set deviceconfig system hostname vsys-zones
+set network interface ethernet ethernet1/1 layer3 ip 1.1.1.1/24
+set network interface ethernet ethernet1/2 layer3 ip 1.1.2.1/24
+set vsys vsys1 zone z1 network layer3 [ ethernet1/1 ethernet1/2 ]
+set vsys vsys11 zone z1 network layer3


### PR DESCRIPTION
Add support for PAN virtual systems (`vsys`)
* `vsys` shares some syntax with `shared` set commands, so those have been grouped into a `common` rule in `shared` grammar
* `syslog server` and `zones` moved from top-level of PAN configuration to `vsys`

