### PR TITLE
IpSpaceRepresentative fixes

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/datamodel/visitors/IpSpaceRepresentativeImpl.java
+++ b/projects/batfish/src/main/java/org/batfish/datamodel/visitors/IpSpaceRepresentativeImpl.java
@@ -20,13 +20,15 @@ public final class IpSpaceRepresentativeImpl implements IpSpaceRepresentative {
   /** Returns some representative element of an {@link IpSpace ip space}, if any exists. */
   @Override
   public Optional<Ip> getRepresentative(IpSpace ipSpace) {
-    if (factory.varNum() < Prefix.MAX_PREFIX_LENGTH) {
-      factory.setVarNum(Prefix.MAX_PREFIX_LENGTH);
-    }
+    synchronized (factory) {
+      if (factory.varNum() < Prefix.MAX_PREFIX_LENGTH) {
+        factory.setVarNum(Prefix.MAX_PREFIX_LENGTH);
+      }
 
-    BDDInteger ipAddrBdd = BDDInteger.makeFromIndex(factory, Prefix.MAX_PREFIX_LENGTH, 0, false);
-    IpSpaceToBDD ipSpaceToBDD = new IpSpaceToBDD(factory, ipAddrBdd);
-    BDD ipSpaceBDD = ipSpace.accept(ipSpaceToBDD);
-    return ipSpaceToBDD.getBDDInteger().getValueSatisfying(ipSpaceBDD).map(Ip::new);
+      BDDInteger ipAddrBdd = BDDInteger.makeFromIndex(factory, Prefix.MAX_PREFIX_LENGTH, 0, true);
+      IpSpaceToBDD ipSpaceToBDD = new IpSpaceToBDD(factory, ipAddrBdd);
+      BDD ipSpaceBDD = ipSpace.accept(ipSpaceToBDD);
+      return ipSpaceToBDD.getBDDInteger().getValueSatisfying(ipSpaceBDD).map(Ip::new);
+    }
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/datamodel/visitors/IpSpaceRepresentativeTest.java
+++ b/projects/batfish/src/test/java/org/batfish/datamodel/visitors/IpSpaceRepresentativeTest.java
@@ -12,6 +12,8 @@ import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.IpWildcardSetIpSpace;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.UniverseIpSpace;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -62,7 +64,9 @@ public class IpSpaceRepresentativeTest {
             .thenPermitting(ip3.toIpSpace())
             .thenPermitting(ip4.toIpSpace())
             .build();
-    assertThat(_ipSpaceRepresentative.getRepresentative(ipSpace), equalTo(Optional.of(ip4)));
+    Optional<Ip> representative = _ipSpaceRepresentative.getRepresentative(ipSpace);
+    MatcherAssert.assertThat("no representative", representative.isPresent());
+    assertThat(representative.get(), Matchers.oneOf(ip1, ip2, ip3, ip4));
   }
 
   @Test


### PR DESCRIPTION
- synchronize on the BDDFactory, since it's not thread-safe
- reverse the bit order of the BDDInteger created to represent an Ip.
- relax a test