### PR TITLE
OSPF: do not propagate default route to other ABRs within an area

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -2100,7 +2100,7 @@ public class VirtualRouter extends ComparableStructure<String> {
       int adminCost,
       long linkAreaNum) {
     return OspfProtocolHelper.isOspfInterAreaDefaultOriginationAllowed(
-            neighborProc, neighborInterface.getOspfArea())
+            _vrf.getOspfProcess(), neighborProc, neighborInterface.getOspfArea())
         && _ospfInterAreaStagingRib.mergeRoute(
             new OspfInterAreaRoute(
                 Prefix.ZERO,

--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/OspfProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/OspfProtocolHelper.java
@@ -56,13 +56,15 @@ public class OspfProtocolHelper {
   /**
    * Decide whether a default inter-area OSPF route should be originated by neighbor
    *
+   * @param process the receiving node's {@link OspfProcess}
    * @param neighborProc The adjacent {@link OspfProcess}
    * @param neighborArea The propagator's OSPF area configuration
    * @return {@code true} iff the route should be considered for installation into the OSPF RIB
    */
   public static boolean isOspfInterAreaDefaultOriginationAllowed(
-      OspfProcess neighborProc, OspfArea neighborArea) {
+      OspfProcess process, OspfProcess neighborProc, OspfArea neighborArea) {
     return neighborProc.isAreaBorderRouter()
+        && !process.isAreaBorderRouter()
         && (neighborArea.getStubType() == StubType.STUB
             || (neighborArea.getStubType() == StubType.NSSA
                 && neighborArea.getNssa().getDefaultOriginateType()


### PR DESCRIPTION
*Problem*:
If a stub area contains multiple ABRs, all ABRs would inject default route to other ABRs and they would be installed.

*Fix*: 
Check if both neighbors are ABRs before allowing default route propagation.