### PR TITLE
InferFromLocationIpSpaceSpecifier: some locations should have no IpSpace.

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/InferFromLocationIpSpaceSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/InferFromLocationIpSpaceSpecifier.java
@@ -2,7 +2,9 @@ package org.batfish.specifier;
 
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.batfish.datamodel.AclIpSpace;
+import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.IpSpace;
 
@@ -29,13 +31,18 @@ public final class InferFromLocationIpSpaceSpecifier implements IpSpaceSpecifier
     public IpSpace visitInterfaceLinkLocation(InterfaceLinkLocation interfaceLinkLocation) {
       String node = interfaceLinkLocation.getNodeName();
       String iface = interfaceLinkLocation.getInterfaceName();
-      return AclIpSpace.difference(
+
+      @Nullable
+      IpSpace linkIpSpace =
           AclIpSpace.union(
               interfaceAddresses(node, iface)
                   .stream()
                   .map(address -> address.getPrefix().toIpSpace())
-                  .collect(Collectors.toList())),
-          _specifierContext.getInterfaceOwnedIps(node, iface));
+                  .collect(Collectors.toList()));
+
+      return linkIpSpace == null
+          ? EmptyIpSpace.INSTANCE
+          : AclIpSpace.difference(linkIpSpace, _specifierContext.getInterfaceOwnedIps(node, iface));
     }
 
     @Override

--- a/projects/batfish/src/test/java/org/batfish/specifier/IpSpaceSpecifierTest.java
+++ b/projects/batfish/src/test/java/org/batfish/specifier/IpSpaceSpecifierTest.java
@@ -4,6 +4,7 @@ import static org.batfish.datamodel.matchers.IpSpaceMatchers.containsIp;
 import static org.batfish.specifier.IpSpaceAssignmentMatchers.hasEntry;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
@@ -15,6 +16,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
@@ -31,6 +33,7 @@ public class IpSpaceSpecifierTest {
   private static final SpecifierContext _context;
 
   private static final Interface _i1;
+  private static final Interface _i2;
 
   static {
     NetworkFactory nf = new NetworkFactory();
@@ -42,6 +45,7 @@ public class IpSpaceSpecifierTest {
     ib.setOwner(n1);
 
     _i1 = ib.setAddress(new InterfaceAddress("1.0.0.0/24")).build();
+    _i2 = nf.interfaceBuilder().setOwner(n1).build();
 
     _configs = ImmutableMap.of(n1.getHostname(), n1);
     _context =
@@ -50,7 +54,11 @@ public class IpSpaceSpecifierTest {
             .setInterfaceOwnedIps(
                 ImmutableMap.of(
                     n1.getName(),
-                    ImmutableMap.of(_i1.getName(), _i1.getAddress().getIp().toIpSpace())))
+                    ImmutableMap.of(
+                        _i1.getName(),
+                        _i1.getAddress().getIp().toIpSpace(),
+                        _i2.getName(),
+                        EmptyIpSpace.INSTANCE)))
             .build();
     _allLocations =
         Sets.union(
@@ -78,7 +86,7 @@ public class IpSpaceSpecifierTest {
             .map(Entry::getLocations)
             .flatMap(Set::stream)
             .collect(Collectors.toSet());
-    assertThat(assignmentLocations, contains(_allLocations.toArray()));
+    assertThat(assignmentLocations, containsInAnyOrder(_allLocations.toArray()));
 
     assertThat(
         assignment,
@@ -91,5 +99,17 @@ public class IpSpaceSpecifierTest {
         hasEntry(
             allOf(containsIp(new Ip("1.0.0.1")), not(containsIp(new Ip("1.0.0.0")))),
             contains(new InterfaceLinkLocation(_i1.getOwner().getName(), _i1.getName()))));
+
+    // Locations that don't own any ipspace are assigned EmptyIpSpace.
+    assertThat(
+        assignment,
+        hasEntry(
+            equalTo(EmptyIpSpace.INSTANCE),
+            contains(new InterfaceLocation(_i2.getOwner().getName(), _i2.getName()))));
+    assertThat(
+        assignment,
+        hasEntry(
+            equalTo(EmptyIpSpace.INSTANCE),
+            contains(new InterfaceLinkLocation(_i2.getOwner().getName(), _i2.getName()))));
   }
 }


### PR DESCRIPTION
Locations that own no IPs should be assigned EmptyIpSpace (old behavior was to assign UniverseIpSpace).