### PR TITLE
Juniper: fix handling of "bgp group type internal"

### DIFF
--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpNeighborMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpNeighborMatchersImpl.java
@@ -1,7 +1,9 @@
 package org.batfish.datamodel.matchers;
 
+import java.util.List;
 import javax.annotation.Nonnull;
 import org.batfish.datamodel.BgpActivePeerConfig;
+import org.batfish.datamodel.BgpPassivePeerConfig;
 import org.batfish.datamodel.BgpPeerConfig;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
@@ -48,6 +50,17 @@ final class BgpNeighborMatchersImpl {
 
     @Override
     protected Long featureValueOf(BgpActivePeerConfig actual) {
+      return actual.getRemoteAs();
+    }
+  }
+
+  static final class HasRemoteAses extends FeatureMatcher<BgpPassivePeerConfig, List<Long>> {
+    HasRemoteAses(@Nonnull Matcher<? super List<Long>> subMatcher) {
+      super(subMatcher, "A BgpPeerConfig with remoteAs:", "remoteAs");
+    }
+
+    @Override
+    protected List<Long> featureValueOf(BgpPassivePeerConfig actual) {
       return actual.getRemoteAs();
     }
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -326,16 +326,15 @@ public final class JuniperConfiguration extends VendorConfiguration {
       Prefix prefix = e.getKey();
       IpBgpGroup ig = e.getValue();
       BgpPeerConfig.Builder<?, ?> neighbor;
+      Long remoteAs = ig.getType() == BgpGroupType.INTERNAL ? ig.getLocalAs() : ig.getPeerAs();
       if (ig.getDynamic()) {
         neighbor =
             BgpPassivePeerConfig.builder()
                 .setPeerPrefix(prefix)
-                .setRemoteAs(ImmutableList.of(ig.getLocalAs()));
+                .setRemoteAs(ImmutableList.of(remoteAs));
       } else {
         neighbor =
-            BgpActivePeerConfig.builder()
-                .setPeerAddress(prefix.getStartIp())
-                .setRemoteAs(ig.getPeerAs());
+            BgpActivePeerConfig.builder().setPeerAddress(prefix.getStartIp()).setRemoteAs(remoteAs);
       }
 
       // route reflection

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -4,6 +4,7 @@ import static org.batfish.datamodel.matchers.AbstractRouteMatchers.hasPrefix;
 import static org.batfish.datamodel.matchers.BgpNeighborMatchers.hasClusterId;
 import static org.batfish.datamodel.matchers.BgpNeighborMatchers.hasEnforceFirstAs;
 import static org.batfish.datamodel.matchers.BgpNeighborMatchers.hasLocalAs;
+import static org.batfish.datamodel.matchers.BgpNeighborMatchers.hasRemoteAs;
 import static org.batfish.datamodel.matchers.BgpProcessMatchers.hasActiveNeighbor;
 import static org.batfish.datamodel.matchers.BgpProcessMatchers.hasNeighbors;
 import static org.batfish.datamodel.matchers.BgpProcessMatchers.hasPassiveNeighbor;
@@ -582,6 +583,17 @@ public class FlatJuniperGrammarTest {
     assertThat(multipleAsDisabled, equalTo(MultipathEquivalentAsPathMatchMode.FIRST_AS));
     assertThat(multipleAsEnabled, equalTo(MultipathEquivalentAsPathMatchMode.PATH_LENGTH));
     assertThat(multipleAsMixed, equalTo(MultipathEquivalentAsPathMatchMode.FIRST_AS));
+  }
+
+  /** Make sure bgp type internal properly sets remote as when non explicitly specified */
+  @Test
+  public void testBgpTypeInternalPeerAs() throws IOException {
+    String hostname = "bgp-type-internal";
+    Configuration c = parseConfig(hostname);
+    assertThat(
+        c,
+        hasDefaultVrf(
+            hasBgpProcess(hasActiveNeighbor(Prefix.parse("1.1.1.1/32"), hasRemoteAs(1L)))));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/bgp-type-internal
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/bgp-type-internal
@@ -1,0 +1,7 @@
+#
+set system host-name bgp-type-internal
+#
+set protocols bgp group MYGROUP family inet unicast
+set protocols bgp group MYGROUP type internal
+set protocols bgp group MYGROUP neighbor 1.1.1.1
+set protocols bgp group MYGROUP local-as 1

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -2094,7 +2094,7 @@
                   "localIp" : "1.1.1.1",
                   "peerPrefix" : "10.1.1.0/24",
                   "remoteAs" : [
-                    1
+                    2
                   ],
                   "routeReflectorClient" : false,
                   "sendCommunity" : true


### PR DESCRIPTION
I accidentally broke this in #1812, fixing + test.