### PR TITLE
Add BGP session status indicating remote AS is not configured

### DIFF
--- a/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionInfo.java
+++ b/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionInfo.java
@@ -21,6 +21,7 @@ public class BgpSessionInfo implements Comparable<BgpSessionInfo> {
     DYNAMIC_LISTEN,
     LOCAL_IP_UNKNOWN_STATICALLY,
     NO_LOCAL_IP,
+    NO_REMOTE_AS,
     INVALID_LOCAL_IP,
     UNKNOWN_REMOTE,
     HALF_OPEN,

--- a/projects/question/src/test/java/org/batfish/question/bgpsessionstatus/BgpSessionStatusAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/bgpsessionstatus/BgpSessionStatusAnswererTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 import org.batfish.datamodel.BgpActivePeerConfig.Builder;
 import org.batfish.datamodel.BgpSessionProperties;
+import org.batfish.datamodel.BgpSessionProperties.SessionType;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.question.bgpsessionstatus.BgpSessionInfo.SessionStatus;
@@ -32,5 +33,16 @@ public class BgpSessionStatusAnswererTest {
         getLocallyBrokenStatus(
             bgpb.setPeerAddress(new Ip("1.1.1.1")).build(), BgpSessionProperties.SessionType.IBGP),
         equalTo(SessionStatus.LOCAL_IP_UNKNOWN_STATICALLY));
+  }
+
+  @Test
+  public void testNoRemoteAs() {
+    NetworkFactory nf = new NetworkFactory();
+    Builder bgpb = nf.bgpNeighborBuilder();
+    assertThat(
+        getLocallyBrokenStatus(
+            bgpb.setPeerAddress(new Ip("1.1.1.1")).setLocalIp(new Ip("2.2.2.2")).build(),
+            SessionType.UNSET),
+        equalTo(SessionStatus.NO_REMOTE_AS));
   }
 }


### PR DESCRIPTION
If the local BGP configuration has no remote AS specified, flag it as a separate kind of bug.