### PR TITLE
new IpSpace specifier by node host subnets

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/NodeNameRegexConnectedHostsIpSpaceSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/NodeNameRegexConnectedHostsIpSpaceSpecifier.java
@@ -1,0 +1,59 @@
+package org.batfish.specifier;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Pattern;
+import org.batfish.datamodel.AclIpSpace;
+import org.batfish.datamodel.IpSpace;
+
+/**
+ * An {@link IpSpaceSpecifier} that represents the {@link IpSpace} of host subnets (less than 30-bit
+ * prefixes) connected to nodes with names matching an input {@link Pattern regex}.
+ */
+public final class NodeNameRegexConnectedHostsIpSpaceSpecifier implements IpSpaceSpecifier {
+  private static final int MAX_PREFIX_LENGTH = 29;
+
+  private final Pattern _pattern;
+
+  NodeNameRegexConnectedHostsIpSpaceSpecifier(Pattern pattern) {
+    _pattern = pattern;
+  }
+
+  @Override
+  public IpSpaceAssignment resolve(Set<Location> locations, SpecifierContext ctxt) {
+    IpSpace ipSpace =
+        AclIpSpace.union(
+            ctxt.getConfigs()
+                .values()
+                .stream()
+                .filter(node -> _pattern.matcher(node.getName()).matches())
+                .flatMap(node -> node.getInterfaces().values().stream())
+                .flatMap(iface -> iface.getAllAddresses().stream())
+                .filter(ifaceAddr -> ifaceAddr.getPrefix().getPrefixLength() <= MAX_PREFIX_LENGTH)
+                .map(
+                    ifaceAddr ->
+                        AclIpSpace.difference(
+                            ifaceAddr.getPrefix().toIpSpace(), ifaceAddr.getIp().toIpSpace()))
+                .collect(ImmutableList.toImmutableList()));
+    return IpSpaceAssignment.builder().assign(locations, ipSpace).build();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof NodeNameRegexConnectedHostsIpSpaceSpecifier)) {
+      return false;
+    }
+    NodeNameRegexConnectedHostsIpSpaceSpecifier that =
+        (NodeNameRegexConnectedHostsIpSpaceSpecifier) o;
+    return Objects.equals(_pattern.pattern(), that._pattern.pattern());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_pattern);
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/NodeNameRegexConnectedHostsIpSpaceSpecifierFactory.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/NodeNameRegexConnectedHostsIpSpaceSpecifierFactory.java
@@ -1,0 +1,26 @@
+package org.batfish.specifier;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.auto.service.AutoService;
+import java.util.regex.Pattern;
+import javax.annotation.Nullable;
+
+@AutoService(IpSpaceSpecifierFactory.class)
+public final class NodeNameRegexConnectedHostsIpSpaceSpecifierFactory
+    implements IpSpaceSpecifierFactory {
+  public static final String NAME =
+      NodeNameRegexConnectedHostsIpSpaceSpecifierFactory.class.getSimpleName();
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
+  public IpSpaceSpecifier buildIpSpaceSpecifier(@Nullable Object input) {
+    checkArgument(input instanceof String, getName() + " requires input of type String");
+    return new NodeNameRegexConnectedHostsIpSpaceSpecifier(
+        Pattern.compile((String) input, Pattern.CASE_INSENSITIVE));
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/IpSpaceSpecifierFactoryTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/IpSpaceSpecifierFactoryTest.java
@@ -5,7 +5,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
+import java.util.regex.Pattern;
 import org.batfish.datamodel.UniverseIpSpace;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
 public class IpSpaceSpecifierFactoryTest {
@@ -28,5 +30,15 @@ public class IpSpaceSpecifierFactoryTest {
     assertThat(
         new InferFromLocationIpSpaceSpecifierFactory().buildIpSpaceSpecifier(null),
         is(InferFromLocationIpSpaceSpecifier.INSTANCE));
+  }
+
+  @Test
+  public void testNodeNameRegexConnecgtedHostsIpSpaceSpecifierFactory() {
+    assertThat(
+        IpSpaceSpecifierFactory.load(NodeNameRegexConnectedHostsIpSpaceSpecifierFactory.NAME),
+        Matchers.instanceOf(NodeNameRegexConnectedHostsIpSpaceSpecifierFactory.class));
+    assertThat(
+        new NodeNameRegexConnectedHostsIpSpaceSpecifierFactory().buildIpSpaceSpecifier("foo"),
+        equalTo(new NodeNameRegexConnectedHostsIpSpaceSpecifier(Pattern.compile("foo"))));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/specifier/IpSpaceSpecifierTest.java
+++ b/projects/batfish/src/test/java/org/batfish/specifier/IpSpaceSpecifierTest.java
@@ -38,7 +38,6 @@ public class IpSpaceSpecifierTest {
 
   private static final Interface _i1;
   private static final Interface _i2;
-  private static final Interface _i3;
 
   static {
     NetworkFactory nf = new NetworkFactory();
@@ -50,7 +49,10 @@ public class IpSpaceSpecifierTest {
     ib.setOwner(_c1);
 
     _i1 = ib.setAddress(new InterfaceAddress("1.0.0.0/24")).build();
-    _i3 = ib.setAddress(new InterfaceAddress("1.0.0.3/24")).build();
+
+    // another interface on _i1's subnet
+    ib.setAddress(new InterfaceAddress("1.0.0.3/24")).build();
+
     _i2 = nf.interfaceBuilder().setOwner(_c1).build();
 
     _configs = ImmutableMap.of(_c1.getHostname(), _c1);
@@ -132,7 +134,7 @@ public class IpSpaceSpecifierTest {
                 containsIp(new Ip("1.0.0.1")),
                 // does not include _i1's IP.
                 not(containsIp(new Ip("1.0.0.0"))),
-                // does not include _i3's IP.
+                // does not include the IP of the other interface on _i1's subnet
                 not(containsIp(new Ip("1.0.0.3")))),
             equalTo(_allLocations)));
   }

--- a/projects/batfish/src/test/java/org/batfish/specifier/IpSpaceSpecifierTest.java
+++ b/projects/batfish/src/test/java/org/batfish/specifier/IpSpaceSpecifierTest.java
@@ -38,6 +38,7 @@ public class IpSpaceSpecifierTest {
 
   private static final Interface _i1;
   private static final Interface _i2;
+  private static final Interface _i3;
 
   static {
     NetworkFactory nf = new NetworkFactory();
@@ -49,6 +50,7 @@ public class IpSpaceSpecifierTest {
     ib.setOwner(_c1);
 
     _i1 = ib.setAddress(new InterfaceAddress("1.0.0.0/24")).build();
+    _i3 = ib.setAddress(new InterfaceAddress("1.0.0.3/24")).build();
     _i2 = nf.interfaceBuilder().setOwner(_c1).build();
 
     _configs = ImmutableMap.of(_c1.getHostname(), _c1);
@@ -126,7 +128,12 @@ public class IpSpaceSpecifierTest {
     assertThat(
         assignment,
         hasEntry(
-            allOf(containsIp(new Ip("1.0.0.1")), not(containsIp(new Ip("1.0.0.0")))),
+            allOf(
+                containsIp(new Ip("1.0.0.1")),
+                // does not include _i1's IP.
+                not(containsIp(new Ip("1.0.0.0"))),
+                // does not include _i3's IP.
+                not(containsIp(new Ip("1.0.0.3")))),
             equalTo(_allLocations)));
   }
 }


### PR DESCRIPTION
A new IpSpace specifier for sane mode. The input is a regex, which matches on node names. Specifiers the union of host subnets (/29 or shorter prefixes) on those nodes, excluding the IPs owned by the nodes themselves.