### PR TITLE
Traceroute: crash with a meaningful error message on missing ingressNode

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/TracerouteEngineImplContext.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/TracerouteEngineImplContext.java
@@ -199,6 +199,11 @@ class TracerouteEngineImplContext {
       Flow transformedFlow) {
     Ip dstIp = transformedFlow.getDstIp();
     Configuration currentConfiguration = _configurations.get(currentNodeName);
+    if (currentConfiguration == null) {
+      throw new BatfishException(
+          String.format(
+              "Node %s is not in the network, cannot perform traceroute", currentNodeName));
+    }
     if (_dataPlane
         .getIpVrfOwners()
         .getOrDefault(dstIp, ImmutableMap.of())

--- a/projects/batfish/src/test/java/org/batfish/dataplane/TracerouteEngineTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/TracerouteEngineTest.java
@@ -344,4 +344,23 @@ public class TracerouteEngineTest {
     /* Flow should be blocked by ACL before ARP, which would otherwise result in unreachable neighbor */
     assertThat(trace.getDisposition(), equalTo(FlowDisposition.DENIED_OUT));
   }
+
+  /** When ingress node is non-existent, don't crash with null-pointer. */
+  @Test(expected = BatfishException.class)
+  public void testTracerouteOutsideNetwork() throws IOException {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration.Builder cb =
+        nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+    Configuration c1 = cb.build();
+    Batfish batfish =
+        BatfishTestUtils.getBatfish(ImmutableSortedMap.of(c1.getName(), c1), _tempFolder);
+    batfish.computeDataPlane(false);
+    DataPlane dp = batfish.loadDataPlane();
+    TracerouteEngineImpl.getInstance()
+        .processFlows(
+            dp,
+            ImmutableSet.of(Flow.builder().setTag("tag").setIngressNode("missingNode").build()),
+            dp.getFibs(),
+            false);
+  }
 }


### PR DESCRIPTION
*Issue*:
When traceroute is given `ingressNode` not in the network, NPE occurs.

*Fix*:
Still crash but at least with custom exception and a meaningful error message (since currently there is no way to "gracefully" return custom errors).