### PR TITLE
Juniper: extract OSPF point to point interface type

### DIFF
--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchers.java
@@ -28,6 +28,7 @@ import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasName;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasOspfArea;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasOspfAreaName;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasOspfCost;
+import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasOspfPointToPoint;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasSourceNats;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasSwitchPortMode;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasVrf;
@@ -178,6 +179,15 @@ public final class InterfaceMatchers {
    */
   public static HasOspfCost hasOspfCost(Matcher<Integer> subMatcher) {
     return new HasOspfCost(subMatcher);
+  }
+
+  /**
+   * Provides a matcher that matches if the provided {@code subMatcher} matches the interface's OSPF
+   * point to point.
+   */
+  public static @Nonnull Matcher<Interface> hasOspfPointToPoint(
+      @Nonnull Matcher<? super Boolean> subMatcher) {
+    return new HasOspfPointToPoint(subMatcher);
   }
 
   /**

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchersImpl.java
@@ -162,6 +162,17 @@ final class InterfaceMatchersImpl {
     }
   }
 
+  static final class HasOspfPointToPoint extends FeatureMatcher<Interface, Boolean> {
+    HasOspfPointToPoint(@Nonnull Matcher<? super Boolean> subMatcher) {
+      super(subMatcher, "an Interface with ospfPointToPoint:", "ospfPointToPoint");
+    }
+
+    @Override
+    protected Boolean featureValueOf(Interface actual) {
+      return actual.getOspfPointToPoint();
+    }
+  }
+
   static final class HasOutgoingFilter extends FeatureMatcher<Interface, IpAccessList> {
     HasOutgoingFilter(@Nonnull Matcher<? super IpAccessList> subMatcher) {
       super(subMatcher, "an Interface with outgoingFilter:", "outgoingFilter");

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -252,6 +252,7 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.O_reference_bandwidthCo
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Oa_interfaceContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Oa_nssaContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Oa_stubContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Oai_interface_typeContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Oai_passiveContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Oan_default_lsaContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Oan_no_summariesContext;
@@ -3656,6 +3657,13 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   @Override
   public void exitOaa_restrict(FlatJuniperParser.Oaa_restrictContext ctx) {
     _currentAreaRangeRestrict = true;
+  }
+
+  @Override
+  public void exitOai_interface_type(Oai_interface_typeContext ctx) {
+    if (ctx.P2P() != null) {
+      _currentOspfInterface.setOspfPointToPoint(true);
+    }
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
@@ -73,6 +73,8 @@ public class Interface extends ComparableStructure<String> {
 
   private boolean _ospfPassive;
 
+  private boolean _ospfPointToPoint;
+
   private String _outgoingFilter;
 
   private Interface _parent;
@@ -194,6 +196,10 @@ public class Interface extends ComparableStructure<String> {
     return _ospfPassive;
   }
 
+  public boolean getOspfPointToPoint() {
+    return _ospfPointToPoint;
+  }
+
   public String getOutgoingFilter() {
     return _outgoingFilter;
   }
@@ -304,6 +310,10 @@ public class Interface extends ComparableStructure<String> {
 
   public void setOspfPassive(boolean ospfPassive) {
     _ospfPassive = true;
+  }
+
+  public void setOspfPointToPoint(boolean opsfPointToPoint) {
+    _ospfPointToPoint = opsfPointToPoint;
   }
 
   public void setOutgoingFilter(String accessListName) {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -1322,6 +1322,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
     }
     newIface.setSwitchportTrunkEncapsulation(swe);
     newIface.setBandwidth(iface.getBandwidth());
+    newIface.setOspfPointToPoint(iface.getOspfPointToPoint());
     return newIface;
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -43,6 +43,7 @@ import static org.batfish.datamodel.matchers.InterfaceMatchers.hasIsis;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasMtu;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasOspfAreaName;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasOspfCost;
+import static org.batfish.datamodel.matchers.InterfaceMatchers.hasOspfPointToPoint;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasSwitchPortMode;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasZoneName;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.isOspfPassive;
@@ -1368,6 +1369,13 @@ public class FlatJuniperGrammarTest {
     /* Properly configured interfaces should be present in respective areas. */
     assertThat(c.getInterfaces().keySet(), equalTo(Collections.singleton("xe-0/0/0:0.0")));
     assertThat(c, hasInterface("xe-0/0/0:0.0", hasMtu(9000)));
+  }
+
+  @Test
+  public void testInteraceOspfPointToPoint() throws IOException {
+    String hostname = "ospf-interface-point-to-point";
+    Configuration c = parseConfig(hostname);
+    assertThat(c, hasInterface("ge-0/0/0.0", hasOspfPointToPoint(equalTo(true))));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/ospf-interface-point-to-point
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/ospf-interface-point-to-point
@@ -1,0 +1,8 @@
+#
+set system host-name ospf-interface-point-to-point
+#
+set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.0/31
+#
+set protocols ospf area 0.0.0.0 interface ge-0/0/0.0
+set protocols ospf area 0.0.0.0 interface ge-0/0/0.0 interface-type p2p
+#


### PR DESCRIPTION
Currently we were parsing but not extracting this property. 

See https://www.juniper.net/documentation/en_US/junos/topics/reference/configuration-statement/interface-type-edit-protocols-ospf.html

*Note*: this does not include additional parsing/extraction support for `nbma | p2mp | p2mp-over-lan`