### PR TITLE
Add support for PAN services

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
@@ -40,6 +40,11 @@ CONFIG
     'config'
 ;
 
+DESCRIPTION
+:
+    'description'
+;
+
 DESTINATION
 :
     'destination'
@@ -140,6 +145,11 @@ OPEN_BRACKET
     '['
 ;
 
+PORT
+:
+    'port'
+;
+
 PRIMARY
 :
     'primary'
@@ -150,9 +160,19 @@ PRIMARY_NTP_SERVER
     'primary-ntp-server'
 ;
 
+PROTOCOL
+:
+    'protocol'
+;
+
 ROUTING_TABLE
 :
     'routing-table'
+;
+
+SCTP
+:
+    'sctp'
 ;
 
 SECONDARY
@@ -175,6 +195,11 @@ SERVERS
     'servers'
 ;
 
+SERVICE
+:
+    'service'
+;
+
 SET
 :
     'set'
@@ -183,6 +208,11 @@ SET
 SHARED
 :
     'shared'
+;
+
+SOURCE_PORT
+:
+    'source-port'
 ;
 
 STATIC_ROUTE
@@ -203,6 +233,16 @@ SYSTEM
 TAG
 :
     'tag'
+;
+
+TCP
+:
+    'tcp'
+;
+
+UDP
+:
+    'udp'
 ;
 
 UNITS
@@ -231,6 +271,11 @@ ZONE
 ;
 
 // Complex tokens
+
+COMMA
+:
+    ','
+;
 
 DEC
 :
@@ -352,7 +397,7 @@ F_Whitespace
 fragment
 F_Variable_VarChar
 :
-    ~[ \t\n\r;{}[\]&|()"']
+    ~[ \t\n\r;,{}[\]&|()"']
 ;
 
 // Modes

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoParser.g4
@@ -2,7 +2,7 @@ parser grammar PaloAltoParser;
 
 /* This is only needed if parser grammar is spread across files */
 import
-PaloAlto_common, PaloAlto_deviceconfig, PaloAlto_network, PaloAlto_shared, PaloAlto_vsys, PaloAlto_zone;
+PaloAlto_common, PaloAlto_deviceconfig, PaloAlto_network, PaloAlto_service, PaloAlto_shared, PaloAlto_vsys, PaloAlto_zone;
 
 options {
     superClass = 'org.batfish.grammar.BatfishParser';
@@ -38,6 +38,7 @@ set_line_config_general
 statement_config_devices
 :
     s_deviceconfig
+    | s_service
     | s_network
     | s_vsys
     | s_zone

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_common.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_common.g4
@@ -14,6 +14,14 @@ variable
     ~NEWLINE
 ;
 
+variable_comma_separated_dec
+:
+    DEC
+    (
+        COMMA DEC
+    )*
+;
+
 variable_list
 :
     (

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_service.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_service.g4
@@ -1,0 +1,43 @@
+parser grammar PaloAlto_service;
+
+import PaloAlto_common;
+
+options {
+    tokenVocab = PaloAltoLexer;
+}
+
+s_service
+:
+    SERVICE name = variable
+    (
+        sserv_description
+        | sserv_port
+        | sserv_protocol
+        | sserv_source_port
+    )+
+;
+
+sserv_description
+:
+    DESCRIPTION description = variable
+;
+
+sserv_port
+:
+    PORT variable_comma_separated_dec
+;
+
+sserv_protocol
+:
+    PROTOCOL
+    (
+        SCTP
+        | TCP
+        | UDP
+    )
+;
+
+sserv_source_port
+:
+    SOURCE_PORT variable_comma_separated_dec
+;

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_shared.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_shared.g4
@@ -1,6 +1,6 @@
 parser grammar PaloAlto_shared;
 
-import PaloAlto_common;
+import PaloAlto_common, PaloAlto_service;
 
 options {
     tokenVocab = PaloAltoLexer;
@@ -17,7 +17,8 @@ s_shared
 // Common syntax between set shared and set vsys
 ss_common
 :
-    ss_log_settings
+    s_service
+    | ss_log_settings
 ;
 
 ss_log_settings

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -20,8 +20,11 @@ import org.batfish.common.BatfishException;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.SubRange;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Palo_alto_configurationContext;
+import org.batfish.grammar.palo_alto.PaloAltoParser.S_serviceContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.S_sharedContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.S_vsysContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.S_zoneContext;
@@ -45,6 +48,10 @@ import org.batfish.grammar.palo_alto.PaloAltoParser.Snvrrt_destinationContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Snvrrt_interfaceContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Snvrrt_metricContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Snvrrt_nexthopContext;
+import org.batfish.grammar.palo_alto.PaloAltoParser.Sserv_descriptionContext;
+import org.batfish.grammar.palo_alto.PaloAltoParser.Sserv_portContext;
+import org.batfish.grammar.palo_alto.PaloAltoParser.Sserv_protocolContext;
+import org.batfish.grammar.palo_alto.PaloAltoParser.Sserv_source_portContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Ssl_syslogContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Ssls_serverContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sslss_serverContext;
@@ -52,6 +59,8 @@ import org.batfish.grammar.palo_alto.PaloAltoParser.Szn_layer3Context;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Variable_list_itemContext;
 import org.batfish.representation.palo_alto.Interface;
 import org.batfish.representation.palo_alto.PaloAltoConfiguration;
+import org.batfish.representation.palo_alto.PaloAltoStructureType;
+import org.batfish.representation.palo_alto.Service;
 import org.batfish.representation.palo_alto.StaticRoute;
 import org.batfish.representation.palo_alto.SyslogServer;
 import org.batfish.representation.palo_alto.VirtualRouter;
@@ -69,6 +78,8 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
   private boolean _currentNtpServerPrimary;
 
   private Interface _currentParentInterface;
+
+  private Service _currentService;
 
   private StaticRoute _currentStaticRoute;
 
@@ -143,6 +154,10 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
   /** Return token text with enclosing quotes removed, if applicable */
   private String getText(ParserRuleContext ctx) {
     return unquote(ctx.getText());
+  }
+
+  private static int toInteger(ParserRuleContext ctx) {
+    return Integer.parseInt(ctx.getText());
   }
 
   private static int toInteger(Token t) {
@@ -335,6 +350,46 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
   @Override
   public void exitSnvrrt_nexthop(Snvrrt_nexthopContext ctx) {
     _currentStaticRoute.setNextHopIp(new Ip(ctx.address.getText()));
+  }
+
+  @Override
+  public void enterS_service(S_serviceContext ctx) {
+    String name = ctx.name.getText();
+    _currentService = _currentVsys.getServices().computeIfAbsent(name, Service::new);
+
+    // Use constructed service name so same-named defs across vsys are unique
+    String uniqueName = computeObjectName(_currentVsys.getName(), name);
+    defineStructure(PaloAltoStructureType.SERVICE, uniqueName, ctx);
+  }
+
+  @Override
+  public void exitSserv_description(Sserv_descriptionContext ctx) {
+    _currentService.setDescription(getText(ctx.description));
+  }
+
+  @Override
+  public void exitSserv_port(Sserv_portContext ctx) {
+    for (TerminalNode item : ctx.variable_comma_separated_dec().DEC()) {
+      _currentService.getPorts().add(new SubRange(toInteger(item.getSymbol())));
+    }
+  }
+
+  @Override
+  public void exitSserv_protocol(Sserv_protocolContext ctx) {
+    if (ctx.SCTP() != null) {
+      _currentService.setProtocol(IpProtocol.SCTP);
+    } else if (ctx.TCP() != null) {
+      _currentService.setProtocol(IpProtocol.TCP);
+    } else if (ctx.UDP() != null) {
+      _currentService.setProtocol(IpProtocol.UDP);
+    }
+  }
+
+  @Override
+  public void exitSserv_source_port(Sserv_source_portContext ctx) {
+    for (TerminalNode item : ctx.variable_comma_separated_dec().DEC()) {
+      _currentService.getPorts().add(new SubRange(toInteger(item.getSymbol())));
+    }
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -359,6 +359,11 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
   }
 
   @Override
+  public void exitS_service(S_serviceContext ctx) {
+    _currentService = null;
+  }
+
+  @Override
   public void exitSserv_description(Sserv_descriptionContext ctx) {
     _currentService.setDescription(getText(ctx.description));
   }

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -156,10 +156,6 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
     return unquote(ctx.getText());
   }
 
-  private static int toInteger(ParserRuleContext ctx) {
-    return Integer.parseInt(ctx.getText());
-  }
-
   private static int toInteger(Token t) {
     return Integer.parseInt(t.getText());
   }
@@ -388,7 +384,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
   @Override
   public void exitSserv_source_port(Sserv_source_portContext ctx) {
     for (TerminalNode item : ctx.variable_comma_separated_dec().DEC()) {
-      _currentService.getPorts().add(new SubRange(toInteger(item.getSymbol())));
+      _currentService.getSourcePorts().add(new SubRange(toInteger(item.getSymbol())));
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoStructureType.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoStructureType.java
@@ -4,6 +4,7 @@ import org.batfish.vendor.StructureType;
 
 public enum PaloAltoStructureType implements StructureType {
   INTERFACE("interface"),
+  SERVICE("service"),
   ZONE("zone");
 
   private final String _description;

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/Service.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/Service.java
@@ -6,7 +6,7 @@ import java.util.TreeSet;
 import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.SubRange;
 
-public class Service implements Serializable {
+public final class Service implements Serializable {
   private static final long serialVersionUID = 1L;
 
   private String _description;

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/Service.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/Service.java
@@ -1,0 +1,55 @@
+package org.batfish.representation.palo_alto;
+
+import java.io.Serializable;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import org.batfish.datamodel.IpProtocol;
+import org.batfish.datamodel.SubRange;
+
+public class Service implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  private String _description;
+
+  private final String _name;
+
+  private final SortedSet<SubRange> _ports;
+
+  private IpProtocol _protocol;
+
+  private final SortedSet<SubRange> _sourcePorts;
+
+  public Service(String name) {
+    _name = name;
+    _ports = new TreeSet<>();
+    _sourcePorts = new TreeSet<>();
+  }
+
+  public String getDescription() {
+    return _description;
+  }
+
+  public String getName() {
+    return _name;
+  }
+
+  public SortedSet<SubRange> getPorts() {
+    return _ports;
+  }
+
+  public IpProtocol getProtocol() {
+    return _protocol;
+  }
+
+  public SortedSet<SubRange> getSourcePorts() {
+    return _sourcePorts;
+  }
+
+  public void setDescription(String description) {
+    _description = description;
+  }
+
+  public void setProtocol(IpProtocol protocol) {
+    _protocol = protocol;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/Vsys.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/Vsys.java
@@ -11,12 +11,15 @@ public final class Vsys implements Serializable {
 
   private final String _name;
 
+  private final SortedMap<String, Service> _services;
+
   private final SortedMap<String, SortedMap<String, SyslogServer>> _syslogServerGroups;
 
   private final SortedMap<String, Zone> _zones;
 
   public Vsys(String name) {
     _name = name;
+    _services = new TreeMap<>();
     _syslogServerGroups = new TreeMap<>();
     _zones = new TreeMap<>();
   }
@@ -24,6 +27,11 @@ public final class Vsys implements Serializable {
   /** Returns the name of this vsys. */
   public String getName() {
     return _name;
+  }
+
+  /** Returns a map of service name to services for the services in this vsys. */
+  public SortedMap<String, Service> getServices() {
+    return _services;
   }
 
   /**

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -21,6 +21,7 @@ import static org.batfish.datamodel.matchers.InterfaceMatchers.isActive;
 import static org.batfish.datamodel.matchers.VrfMatchers.hasInterfaces;
 import static org.batfish.datamodel.matchers.VrfMatchers.hasStaticRoutes;
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.DEFAULT_VSYS_NAME;
+import static org.batfish.representation.palo_alto.PaloAltoConfiguration.SHARED_VSYS_NAME;
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.computeObjectName;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
@@ -297,6 +298,20 @@ public class PaloAltoGrammarTest {
   }
 
   @Test
+  public void testService() throws IOException {
+    String hostname = "service";
+
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse();
+
+    // Confirm structure definitions are tracked
+    assertThat(ccae, hasDefinedStructure(hostname, PaloAltoStructureType.SERVICE, "SERVICE1"));
+    assertThat(ccae, hasDefinedStructure(hostname, PaloAltoStructureType.SERVICE, "SERVICE2"));
+    assertThat(ccae, hasDefinedStructure(hostname, PaloAltoStructureType.SERVICE, "SERVICE3"));
+  }
+
+  @Test
   public void testVirtualRouterInterfaces() throws IOException {
     String hostname = "virtual-router-interfaces";
     Configuration c = parseConfig(hostname);
@@ -304,6 +319,34 @@ public class PaloAltoGrammarTest {
     assertThat(c, hasVrf("default", hasInterfaces(hasItem("ethernet1/1"))));
     assertThat(c, hasVrf("somename", hasInterfaces(hasItems("ethernet1/2", "ethernet1/3"))));
     assertThat(c, hasVrf("someothername", hasInterfaces(emptyIterable())));
+  }
+
+  @Test
+  public void testVsysService() throws IOException {
+    String hostname = "vsys-service";
+    String vsys1Name = "vsys1";
+    String vsys2Name = "vsys2";
+    String serviceName = "SERVICE1";
+
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse();
+
+    // Confirm structure definitions are tracked separately for each vsys
+    assertThat(
+        ccae,
+        hasDefinedStructure(
+            hostname, PaloAltoStructureType.SERVICE, computeObjectName(vsys1Name, serviceName)));
+    assertThat(
+        ccae,
+        hasDefinedStructure(
+            hostname, PaloAltoStructureType.SERVICE, computeObjectName(vsys2Name, serviceName)));
+    assertThat(
+        ccae,
+        hasDefinedStructure(
+            hostname,
+            PaloAltoStructureType.SERVICE,
+            computeObjectName(SHARED_VSYS_NAME, serviceName)));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -306,9 +306,24 @@ public class PaloAltoGrammarTest {
         batfish.loadConvertConfigurationAnswerElementOrReparse();
 
     // Confirm structure definitions are tracked
-    assertThat(ccae, hasDefinedStructure(hostname, PaloAltoStructureType.SERVICE, "SERVICE1"));
-    assertThat(ccae, hasDefinedStructure(hostname, PaloAltoStructureType.SERVICE, "SERVICE2"));
-    assertThat(ccae, hasDefinedStructure(hostname, PaloAltoStructureType.SERVICE, "SERVICE3"));
+    assertThat(
+        ccae,
+        hasDefinedStructure(
+            hostname,
+            PaloAltoStructureType.SERVICE,
+            computeObjectName(DEFAULT_VSYS_NAME, "SERVICE1")));
+    assertThat(
+        ccae,
+        hasDefinedStructure(
+            hostname,
+            PaloAltoStructureType.SERVICE,
+            computeObjectName(DEFAULT_VSYS_NAME, "SERVICE2")));
+    assertThat(
+        ccae,
+        hasDefinedStructure(
+            hostname,
+            PaloAltoStructureType.SERVICE,
+            computeObjectName(DEFAULT_VSYS_NAME, "SERVICE3")));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/service
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/service
@@ -1,0 +1,5 @@
+set deviceconfig system hostname service
+set service SERVICE1 description "long description"
+set service SERVICE1 protocol tcp port 1 source-port 2
+set service SERVICE2 protocol udp port 3 source-port 4
+set service SERVICE3 protocol udp port 5,6,7 source-port 8,9,10

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/vsys-service
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/vsys-service
@@ -1,0 +1,4 @@
+set deviceconfig system hostname vsys-service
+set vsys vsys1 service SERVICE1 protocol tcp port 1
+set vsys vsys2 service SERVICE1 protocol udp source-port 2
+set shared service SERVICE1 protocol udp port 3


### PR DESCRIPTION
`Service`s are used to define protocol and ports for firewall rules (not yet implemented) on PAN devices.

Added parsing and vendor model extraction for `service`s.
