### PR TITLE
Add destination IpSpaceSpecifier to ReachabilityParameters

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/question/ReachabilityParameters.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/question/ReachabilityParameters.java
@@ -5,7 +5,9 @@ import java.util.SortedSet;
 import javax.annotation.Nonnull;
 import org.batfish.datamodel.ForwardingAction;
 import org.batfish.datamodel.HeaderSpace;
+import org.batfish.datamodel.UniverseIpSpace;
 import org.batfish.specifier.AllInterfacesLocationSpecifier;
+import org.batfish.specifier.ConstantIpSpaceSpecifier;
 import org.batfish.specifier.InferFromLocationIpSpaceSpecifier;
 import org.batfish.specifier.IpSpaceSpecifier;
 import org.batfish.specifier.LocationSpecifier;
@@ -20,6 +22,9 @@ public final class ReachabilityParameters {
 
   public static class Builder {
     private @Nonnull SortedSet<ForwardingAction> _actions = ImmutableSortedSet.of();
+
+    private @Nonnull IpSpaceSpecifier _destinationIpSpaceSpecifier =
+        new ConstantIpSpaceSpecifier(UniverseIpSpace.INSTANCE);
 
     private @Nonnull NodeSpecifier _finalNodesSpecifier = NoNodesNodeSpecifier.INSTANCE;
 
@@ -52,8 +57,9 @@ public final class ReachabilityParameters {
       return this;
     }
 
-    public Builder setSourceSpecifier(LocationSpecifier sourceLocationSpecifier) {
-      _sourceLocationSpecifier = sourceLocationSpecifier;
+    public Builder setDestinationIpSpaceSpecifier(
+        @Nonnull IpSpaceSpecifier destinationIpSpaceSpecifier) {
+      _destinationIpSpaceSpecifier = destinationIpSpaceSpecifier;
       return this;
     }
 
@@ -68,8 +74,13 @@ public final class ReachabilityParameters {
       return this;
     }
 
-    public Builder setSourceIpSpaceSpecifier(IpSpaceSpecifier sourceIpSpaceSpecifier) {
+    public Builder setSourceIpSpaceSpecifier(@Nonnull IpSpaceSpecifier sourceIpSpaceSpecifier) {
       _sourceIpSpaceSpecifier = sourceIpSpaceSpecifier;
+      return this;
+    }
+
+    public Builder setSourceLocationSpecifier(@Nonnull LocationSpecifier sourceLocationSpecifier) {
+      _sourceLocationSpecifier = sourceLocationSpecifier;
       return this;
     }
 
@@ -106,6 +117,9 @@ public final class ReachabilityParameters {
 
   private final SortedSet<ForwardingAction> _actions;
 
+  private @Nonnull IpSpaceSpecifier _destinationIpSpaceSpecifier =
+      new ConstantIpSpaceSpecifier(UniverseIpSpace.INSTANCE);
+
   private final NodeSpecifier _finalNodesSpecifier;
 
   private final @Nonnull NodeSpecifier _forbiddenTransitNodesSpecifier;
@@ -128,6 +142,7 @@ public final class ReachabilityParameters {
 
   private ReachabilityParameters(Builder builder) {
     _actions = builder._actions;
+    _destinationIpSpaceSpecifier = builder._destinationIpSpaceSpecifier;
     _finalNodesSpecifier = builder._finalNodesSpecifier;
     _forbiddenTransitNodesSpecifier = builder._forbiddenTransitNodesSpecifier;
     _headerSpace = builder._headerSpace;
@@ -146,6 +161,11 @@ public final class ReachabilityParameters {
 
   public SortedSet<ForwardingAction> getActions() {
     return _actions;
+  }
+
+  @Nonnull
+  public IpSpaceSpecifier getDestinationIpSpaceSpecifier() {
+    return _destinationIpSpaceSpecifier;
   }
 
   public NodeSpecifier getFinalNodesSpecifier() {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/question/ResolvedReachabilityParameters.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/question/ResolvedReachabilityParameters.java
@@ -11,7 +11,6 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.ForwardingAction;
 import org.batfish.datamodel.HeaderSpace;
-import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.questions.InvalidReachabilityParametersException;
 import org.batfish.specifier.IpSpaceAssignment;
 
@@ -27,8 +26,6 @@ public final class ResolvedReachabilityParameters {
     private Map<String, Configuration> _configurations;
 
     private DataPlane _dataPlane;
-
-    private IpSpace _destinationIpSpace;
 
     private Set<String> _finalNodes;
 
@@ -64,11 +61,6 @@ public final class ResolvedReachabilityParameters {
 
     public Builder setDataPlane(DataPlane dataPlane) {
       _dataPlane = dataPlane;
-      return this;
-    }
-
-    public Builder setDestinationIpSpace(IpSpace ipSpaceAssignment) {
-      _destinationIpSpace = ipSpaceAssignment;
       return this;
     }
 
@@ -124,8 +116,6 @@ public final class ResolvedReachabilityParameters {
 
   private final DataPlane _dataPlane;
 
-  private final IpSpace _destinationIpSpace;
-
   private final Set<String> _finalNodes;
 
   private Set<String> _forbiddenTransitNodes;
@@ -149,7 +139,6 @@ public final class ResolvedReachabilityParameters {
     _actions = builder._actions;
     _configurations = builder._configurations;
     _dataPlane = builder._dataPlane;
-    _destinationIpSpace = builder._destinationIpSpace;
     _finalNodes = builder._finalNodes;
     _forbiddenTransitNodes = builder._forbiddenTransitNodes;
     _headerSpace = builder._headerSpace;
@@ -196,10 +185,6 @@ public final class ResolvedReachabilityParameters {
 
   public DataPlane getDataPlane() {
     return _dataPlane;
-  }
-
-  public IpSpace getDestinationIpSpace() {
-    return _destinationIpSpace;
   }
 
   public Set<String> getFinalNodes() {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/question/ResolvedReachabilityParameters.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/question/ResolvedReachabilityParameters.java
@@ -11,6 +11,7 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.ForwardingAction;
 import org.batfish.datamodel.HeaderSpace;
+import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.questions.InvalidReachabilityParametersException;
 import org.batfish.specifier.IpSpaceAssignment;
 
@@ -26,6 +27,8 @@ public final class ResolvedReachabilityParameters {
     private Map<String, Configuration> _configurations;
 
     private DataPlane _dataPlane;
+
+    private IpSpace _destinationIpSpace;
 
     private Set<String> _finalNodes;
 
@@ -61,6 +64,11 @@ public final class ResolvedReachabilityParameters {
 
     public Builder setDataPlane(DataPlane dataPlane) {
       _dataPlane = dataPlane;
+      return this;
+    }
+
+    public Builder setDestinationIpSpace(IpSpace ipSpaceAssignment) {
+      _destinationIpSpace = ipSpaceAssignment;
       return this;
     }
 
@@ -116,6 +124,8 @@ public final class ResolvedReachabilityParameters {
 
   private final DataPlane _dataPlane;
 
+  private final IpSpace _destinationIpSpace;
+
   private final Set<String> _finalNodes;
 
   private Set<String> _forbiddenTransitNodes;
@@ -139,6 +149,7 @@ public final class ResolvedReachabilityParameters {
     _actions = builder._actions;
     _configurations = builder._configurations;
     _dataPlane = builder._dataPlane;
+    _destinationIpSpace = builder._destinationIpSpace;
     _finalNodes = builder._finalNodes;
     _forbiddenTransitNodes = builder._forbiddenTransitNodes;
     _headerSpace = builder._headerSpace;
@@ -185,6 +196,10 @@ public final class ResolvedReachabilityParameters {
 
   public DataPlane getDataPlane() {
     return _dataPlane;
+  }
+
+  public IpSpace getDestinationIpSpace() {
+    return _destinationIpSpace;
   }
 
   public Set<String> getFinalNodes() {

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -1857,7 +1857,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
     return _settings.getImmutableConfiguration();
   }
 
-  private NetworkSnapshot getNetworkSnapshot() {
+  NetworkSnapshot getNetworkSnapshot() {
     return new NetworkSnapshot(
         _settings.getContainer(),
         new Snapshot(

--- a/projects/batfish/src/main/java/org/batfish/main/ReachabilityParametersResolver.java
+++ b/projects/batfish/src/main/java/org/batfish/main/ReachabilityParametersResolver.java
@@ -51,7 +51,6 @@ final class ReachabilityParametersResolver {
 
     SpecifierContext context = new SpecifierContextImpl(batfish, resolver._configs);
 
-    HeaderSpace headerSpace = params.getHeaderSpace();
     IpSpace destinationIpSpace =
         AclIpSpace.union(
             params
@@ -61,7 +60,12 @@ final class ReachabilityParametersResolver {
                 .stream()
                 .map(Entry::getIpSpace)
                 .collect(ImmutableList.toImmutableList()));
-    headerSpace.setDstIps(destinationIpSpace);
+    HeaderSpace headerSpace = params.getHeaderSpace();
+    if (headerSpace == null) {
+      headerSpace = HeaderSpace.builder().setDstIps(destinationIpSpace).build();
+    } else {
+      headerSpace.setDstIps(destinationIpSpace);
+    }
 
     return ResolvedReachabilityParameters.builder()
         .setActions(params.getActions())

--- a/projects/batfish/src/main/java/org/batfish/main/ReachabilityParametersResolver.java
+++ b/projects/batfish/src/main/java/org/batfish/main/ReachabilityParametersResolver.java
@@ -1,14 +1,18 @@
 package org.batfish.main;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import java.util.Map;
 import org.batfish.common.BatfishException;
 import org.batfish.common.NetworkSnapshot;
+import org.batfish.datamodel.AclIpSpace;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.questions.InvalidReachabilityParametersException;
 import org.batfish.main.Batfish.CompressDataPlaneResult;
 import org.batfish.question.ReachabilityParameters;
 import org.batfish.question.ResolvedReachabilityParameters;
+import org.batfish.specifier.IpSpaceAssignment.Entry;
 import org.batfish.specifier.SpecifierContext;
 import org.batfish.specifier.SpecifierContextImpl;
 
@@ -48,6 +52,15 @@ final class ReachabilityParametersResolver {
         .setActions(params.getActions())
         .setConfigurations(resolver._configs)
         .setDataPlane(resolver._dataPlane)
+        .setDestinationIpSpace(
+            AclIpSpace.union(
+                params
+                    .getDestinationIpSpaceSpecifier()
+                    .resolve(ImmutableSet.of(), context)
+                    .getEntries()
+                    .stream()
+                    .map(Entry::getIpSpace)
+                    .collect(ImmutableList.toImmutableList())))
         .setFinalNodes(params.getFinalNodesSpecifier().resolve(context))
         .setForbiddenTransitNodes(params.getForbiddenTransitNodesSpecifier().resolve(context))
         .setHeaderSpace(params.getHeaderSpace())

--- a/projects/batfish/src/main/java/org/batfish/main/ReachabilityParametersResolver.java
+++ b/projects/batfish/src/main/java/org/batfish/main/ReachabilityParametersResolver.java
@@ -8,6 +8,8 @@ import org.batfish.common.NetworkSnapshot;
 import org.batfish.datamodel.AclIpSpace;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DataPlane;
+import org.batfish.datamodel.HeaderSpace;
+import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.questions.InvalidReachabilityParametersException;
 import org.batfish.main.Batfish.CompressDataPlaneResult;
 import org.batfish.question.ReachabilityParameters;
@@ -48,22 +50,26 @@ final class ReachabilityParametersResolver {
         new ReachabilityParametersResolver(batfish, params, snapshot);
 
     SpecifierContext context = new SpecifierContextImpl(batfish, resolver._configs);
+
+    HeaderSpace headerSpace = params.getHeaderSpace();
+    IpSpace destinationIpSpace =
+        AclIpSpace.union(
+            params
+                .getDestinationIpSpaceSpecifier()
+                .resolve(ImmutableSet.of(), context)
+                .getEntries()
+                .stream()
+                .map(Entry::getIpSpace)
+                .collect(ImmutableList.toImmutableList()));
+    headerSpace.setDstIps(destinationIpSpace);
+
     return ResolvedReachabilityParameters.builder()
         .setActions(params.getActions())
         .setConfigurations(resolver._configs)
         .setDataPlane(resolver._dataPlane)
-        .setDestinationIpSpace(
-            AclIpSpace.union(
-                params
-                    .getDestinationIpSpaceSpecifier()
-                    .resolve(ImmutableSet.of(), context)
-                    .getEntries()
-                    .stream()
-                    .map(Entry::getIpSpace)
-                    .collect(ImmutableList.toImmutableList())))
         .setFinalNodes(params.getFinalNodesSpecifier().resolve(context))
         .setForbiddenTransitNodes(params.getForbiddenTransitNodesSpecifier().resolve(context))
-        .setHeaderSpace(params.getHeaderSpace())
+        .setHeaderSpace(headerSpace)
         .setMaxChunkSize(params.getMaxChunkSize())
         .setSourceIpSpaceAssignment(
             params

--- a/projects/batfish/src/test/java/org/batfish/main/ReachabilityParametersResolverTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/ReachabilityParametersResolverTest.java
@@ -5,6 +5,7 @@ import static org.batfish.datamodel.ForwardingAction.ACCEPT;
 import static org.batfish.main.ReachabilityParametersResolver.resolveReachabilityParameters;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
@@ -57,8 +58,10 @@ public class ReachabilityParametersResolverTest {
     ReachabilityParameters reachabilityParameters = reachabilityParametersBuilder.build();
     ResolvedReachabilityParameters resolvedReachabilityParameters =
         resolveReachabilityParameters(_batfish, reachabilityParameters, _snapshot);
+    assertThat(resolvedReachabilityParameters.getHeaderSpace().getNotDstIps(), nullValue());
     assertThat(
-        resolvedReachabilityParameters.getDestinationIpSpace(), equalTo(UniverseIpSpace.INSTANCE));
+        resolvedReachabilityParameters.getHeaderSpace().getDstIps(),
+        equalTo(UniverseIpSpace.INSTANCE));
 
     // test setting destination IpSpace
     reachabilityParameters =
@@ -67,7 +70,9 @@ public class ReachabilityParametersResolverTest {
             .build();
     resolvedReachabilityParameters =
         resolveReachabilityParameters(_batfish, reachabilityParameters, _snapshot);
+    assertThat(resolvedReachabilityParameters.getHeaderSpace().getNotDstIps(), nullValue());
     assertThat(
-        resolvedReachabilityParameters.getDestinationIpSpace(), equalTo(EmptyIpSpace.INSTANCE));
+        resolvedReachabilityParameters.getHeaderSpace().getDstIps(),
+        equalTo(EmptyIpSpace.INSTANCE));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/main/ReachabilityParametersResolverTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/ReachabilityParametersResolverTest.java
@@ -1,0 +1,73 @@
+package org.batfish.main;
+
+import static org.batfish.datamodel.ConfigurationFormat.CISCO_IOS;
+import static org.batfish.datamodel.ForwardingAction.ACCEPT;
+import static org.batfish.main.ReachabilityParametersResolver.resolveReachabilityParameters;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.ImmutableSortedSet;
+import java.io.IOException;
+import java.util.SortedMap;
+import org.batfish.common.NetworkSnapshot;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.EmptyIpSpace;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.UniverseIpSpace;
+import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.questions.InvalidReachabilityParametersException;
+import org.batfish.question.ReachabilityParameters;
+import org.batfish.question.ReachabilityParameters.Builder;
+import org.batfish.question.ResolvedReachabilityParameters;
+import org.batfish.specifier.AllNodesNodeSpecifier;
+import org.batfish.specifier.ConstantIpSpaceSpecifier;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class ReachabilityParametersResolverTest {
+  @Rule public TemporaryFolder _tempFolder = new TemporaryFolder();
+
+  private Batfish _batfish;
+
+  private NetworkSnapshot _snapshot;
+
+  @Before
+  public void setup() throws IOException {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration config = nf.configurationBuilder().setConfigurationFormat(CISCO_IOS).build();
+    Vrf vrf = nf.vrfBuilder().setOwner(config).build();
+    nf.interfaceBuilder().setOwner(config).setVrf(vrf).build();
+    SortedMap<String, Configuration> configs = ImmutableSortedMap.of(config.getName(), config);
+    _batfish = BatfishTestUtils.getBatfish(configs, _tempFolder);
+    _batfish.computeDataPlane(false);
+    _snapshot = _batfish.getNetworkSnapshot();
+  }
+
+  @Test
+  public void testDestinationIpSpace() throws InvalidReachabilityParametersException {
+    Builder reachabilityParametersBuilder =
+        ReachabilityParameters.builder()
+            .setActions(ImmutableSortedSet.of(ACCEPT))
+            .setFinalNodesSpecifier(AllNodesNodeSpecifier.INSTANCE);
+
+    // test default destination IpSpace
+    ReachabilityParameters reachabilityParameters = reachabilityParametersBuilder.build();
+    ResolvedReachabilityParameters resolvedReachabilityParameters =
+        resolveReachabilityParameters(_batfish, reachabilityParameters, _snapshot);
+    assertThat(
+        resolvedReachabilityParameters.getDestinationIpSpace(), equalTo(UniverseIpSpace.INSTANCE));
+
+    // test setting destination IpSpace
+    reachabilityParameters =
+        reachabilityParametersBuilder
+            .setDestinationIpSpaceSpecifier(new ConstantIpSpaceSpecifier(EmptyIpSpace.INSTANCE))
+            .build();
+    resolvedReachabilityParameters =
+        resolveReachabilityParameters(_batfish, reachabilityParameters, _snapshot);
+    assertThat(
+        resolvedReachabilityParameters.getDestinationIpSpace(), equalTo(EmptyIpSpace.INSTANCE));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/z3/ReducedReachabilityTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/ReducedReachabilityTest.java
@@ -123,7 +123,7 @@ public class ReducedReachabilityTest {
                 .setFinalNodesSpecifier(new NameRegexNodeSpecifier(Pattern.compile(NODE2)))
                 .setHeaderSpace(
                     HeaderSpace.builder().setDstIps(NODE2_ALTERNATE_IP.toIpSpace()).build())
-                .setSourceSpecifier(
+                .setSourceLocationSpecifier(
                     /* Source = loopback0 on node1 */
                     new IntersectionLocationSpecifier(
                         new NodeNameRegexInterfaceLocationSpecifier(Pattern.compile(NODE1)),

--- a/projects/question/src/main/java/org/batfish/question/ReachabilitySettings.java
+++ b/projects/question/src/main/java/org/batfish/question/ReachabilitySettings.java
@@ -1,5 +1,7 @@
 package org.batfish.question;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+
 import com.google.common.collect.ImmutableSortedSet;
 import java.util.Objects;
 import java.util.SortedSet;
@@ -302,18 +304,11 @@ public final class ReachabilitySettings {
         _useCompression);
   }
 
-  IpSpaceSpecifier toIpSpaceSpecifier(IpSpace include, IpSpace exclude) {
-    if (include != null && exclude != null) {
-      return new ConstantIpSpaceSpecifier(AclIpSpace.difference(include, exclude));
-    }
-    if (include != null) {
-      return new ConstantIpSpaceSpecifier(include);
-    }
-    if (exclude != null) {
-      return new ConstantIpSpaceSpecifier(AclIpSpace.difference(UniverseIpSpace.INSTANCE, exclude));
-    }
-    return new ConstantIpSpaceSpecifier(UniverseIpSpace.INSTANCE);
+  private static IpSpaceSpecifier toIpSpaceSpecifier(IpSpace include, IpSpace exclude) {
+    return new ConstantIpSpaceSpecifier(
+        firstNonNull(AclIpSpace.difference(include, exclude), UniverseIpSpace.INSTANCE));
   }
+
   /**
    * Convert to a {@link ReachabilityParameters} object. Mostly this means converting user input
    * into {@link LocationSpecifier} and {@link IpSpaceSpecifier} objects. At some point, this class

--- a/projects/question/src/main/java/org/batfish/question/ReachabilitySettings.java
+++ b/projects/question/src/main/java/org/batfish/question/ReachabilitySettings.java
@@ -362,7 +362,7 @@ public final class ReachabilitySettings {
         .setMaxChunkSize(_maxChunkSize)
         .setRequiredTransitNodesSpecifier(NodeSpecifiers.from(_transitNodes))
         .setSourceIpSpaceSpecifier(sourceIpSpace)
-        .setSourceSpecifier(sourceLocations)
+        .setSourceLocationSpecifier(sourceLocations)
         .setSrcNatted(SrcNattedConstraint.fromBoolean(_srcNatted))
         .setSpecialize(_specialize)
         .setUseCompression(_useCompression)

--- a/projects/question/src/main/java/org/batfish/question/specifiers/SpecifiersReachabilityQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/specifiers/SpecifiersReachabilityQuestion.java
@@ -154,7 +154,7 @@ public final class SpecifiersReachabilityQuestion extends Question {
         .setForbiddenTransitNodesSpecifier(getForbiddenTransitNodesSpecifier())
         .setHeaderSpace(_headerSpace != null ? _headerSpace : HeaderSpace.builder().build())
         .setRequiredTransitNodesSpecifier(getRequiredTransitNodesSpecifier())
-        .setSourceSpecifier(getSourceLocationSpecifier())
+        .setSourceLocationSpecifier(getSourceLocationSpecifier())
         .setSourceIpSpaceSpecifier(getSourceIpSpaceSpecifier())
         .setSpecialize(true)
         .build();


### PR DESCRIPTION
Use an IpSpaceSpecifier to specify destination IPs in reachability parameters.
- We do resolution with an empty set of locations. This means IpSpaceSpecifiers that depend on locations (like InferFromLocationIpSpaceSpecifier) will fail. 
- After resolution, we union the IpSpaces from the IpSpaceAssignment and update the HeaderSpace with it.
- ReachabilitySettings constructs a ConstantIpSpaceSpecifier from its input HeaderSpace and then unsets the dstIps and notDstIps fields.
