### PR TITLE
Juniper ISIS: ISO address can be configured on any interface

### DIFF
--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/IsisProcessMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/IsisProcessMatchers.java
@@ -6,8 +6,10 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.IsisLevelSettings;
 import org.batfish.datamodel.IsisProcess;
+import org.batfish.datamodel.IsoAddress;
 import org.batfish.datamodel.matchers.IsisProcessMatchersImpl.HasLevel1;
 import org.batfish.datamodel.matchers.IsisProcessMatchersImpl.HasLevel2;
+import org.batfish.datamodel.matchers.IsisProcessMatchersImpl.HasNetAddress;
 import org.batfish.datamodel.matchers.IsisProcessMatchersImpl.HasOverloadTimeout;
 import org.batfish.datamodel.matchers.IsisProcessMatchersImpl.HasReferenceBandwidth;
 import org.hamcrest.Matcher;
@@ -65,6 +67,15 @@ public final class IsisProcessMatchers {
   public static @Nonnull Matcher<IsisProcess> hasReferenceBandwidth(
       @Nonnull Matcher<? super Double> subMatcher) {
     return new HasReferenceBandwidth(subMatcher);
+  }
+
+  /**
+   * Provides a matcher that matches if the provided {@code subMatcher} matches the {@link
+   * IsisProcess}'s netAddress.
+   */
+  public static @Nonnull Matcher<IsisProcess> hasNetAddress(
+      @Nonnull Matcher<? super IsoAddress> subMatcher) {
+    return new HasNetAddress(subMatcher);
   }
 
   private IsisProcessMatchers() {}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/IsisProcessMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/IsisProcessMatchersImpl.java
@@ -3,6 +3,7 @@ package org.batfish.datamodel.matchers;
 import javax.annotation.Nonnull;
 import org.batfish.datamodel.IsisLevelSettings;
 import org.batfish.datamodel.IsisProcess;
+import org.batfish.datamodel.IsoAddress;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 
@@ -27,6 +28,17 @@ final class IsisProcessMatchersImpl {
     @Override
     protected IsisLevelSettings featureValueOf(IsisProcess actual) {
       return actual.getLevel2();
+    }
+  }
+
+  static final class HasNetAddress extends FeatureMatcher<IsisProcess, IsoAddress> {
+    HasNetAddress(@Nonnull Matcher<? super IsoAddress> subMatcher) {
+      super(subMatcher, "An IsisProcess with netAddress:", "netAddress");
+    }
+
+    @Override
+    protected IsoAddress featureValueOf(IsisProcess actual) {
+      return actual.getNetAddress();
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -17,6 +17,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NavigableMap;
 import java.util.NavigableSet;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -2122,16 +2124,19 @@ public final class JuniperConfiguration extends VendorConfiguration {
       }
 
       // create is-is process
-      // is-is runs only if iso address is configured on lo0 unit 0
-      Interface loopback0 =
-          _defaultRoutingInstance.getInterfaces().get(FIRST_LOOPBACK_INTERFACE_NAME + ".0");
-      if (loopback0 != null) {
-        IsoAddress isisNet = loopback0.getIsoAddress();
-        if (isisNet != null) {
-          // now we should create is-is process
-          IsisProcess proc = createIsisProcess(ri, isisNet);
-          vrf.setIsisProcess(proc);
-        }
+      // is-is runs only if at least one interface is an ISO address
+      Optional<IsoAddress> isoAddress =
+          _defaultRoutingInstance
+              .getInterfaces()
+              .values()
+              .stream()
+              .map(Interface::getIsoAddress)
+              .filter(Objects::nonNull)
+              .findFirst();
+      if (isoAddress.isPresent()) {
+        // now we should create is-is process
+        IsisProcess proc = createIsisProcess(ri, isoAddress.get());
+        vrf.setIsisProcess(proc);
       }
 
       // create bgp process

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -61,6 +61,7 @@ import static org.batfish.datamodel.matchers.IsisInterfaceSettingsMatchers.hasIs
 import static org.batfish.datamodel.matchers.IsisInterfaceSettingsMatchers.hasLevel1;
 import static org.batfish.datamodel.matchers.IsisInterfaceSettingsMatchers.hasLevel2;
 import static org.batfish.datamodel.matchers.IsisLevelSettingsMatchers.hasWideMetricsOnly;
+import static org.batfish.datamodel.matchers.IsisProcessMatchers.hasNetAddress;
 import static org.batfish.datamodel.matchers.IsisProcessMatchers.hasOverloadTimeout;
 import static org.batfish.datamodel.matchers.LiteralIntMatcher.hasVal;
 import static org.batfish.datamodel.matchers.LiteralIntMatcher.isLiteralIntThat;
@@ -1706,6 +1707,23 @@ public class FlatJuniperGrammarTest {
         hasInterface(
             physical, hasIsis(hasLevel2(IsisInterfaceLevelSettingsMatchers.hasHelloInterval(1)))));
     assertThat(c, hasInterface(physical, hasIsis(hasLevel2(hasHoldTime(3)))));
+  }
+
+  @Test
+  public void testJuniperIsisNoIsoAddress() throws IOException {
+    Configuration c = parseConfig("juniper-isis-no-iso");
+
+    assertThat(c, hasDefaultVrf(hasIsisProcess(nullValue())));
+  }
+
+  @Test
+  public void testJuniperIsisNonLoopbackIsoAddress() throws IOException {
+    Configuration c = parseConfig("juniper-isis-iso-non-loopback");
+
+    assertThat(
+        c,
+        hasDefaultVrf(
+            hasIsisProcess(hasNetAddress(equalTo(new IsoAddress("12.1234.1234.1234.1234.01"))))));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-isis-iso-non-loopback
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-isis-iso-non-loopback
@@ -1,0 +1,25 @@
+#
+set system host-name juniper-isis-iso-non-loopback
+#
+set interfaces lo0 unit 0 family inet address 1.1.1.1/32 
+#
+set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.0/24 
+set interfaces ge-0/0/0 unit 0 family iso address 12.1234.1234.1234.1234.01
+#
+set protocols isis interface ge-0/0/0.0 bfd-liveness-detection minimum-interval 250
+set protocols isis interface ge-0/0/0.0 bfd-liveness-detection multiplier 3
+# "hello there"
+set protocols isis interface ge-0/0/0.0 level 2 hello-authentication-key "$9$tc4xpORrlMxNbhSdsY2oan/CAu1SyKWX-tu"
+set protocols isis interface ge-0/0/0.0 level 2 hello-authentication-type md5
+set protocols isis interface ge-0/0/0.0 level 2 hello-interval 1
+set protocols isis interface ge-0/0/0.0 level 2 hold-time 3
+set protocols isis interface ge-0/0/0.0 level 2 metric 5
+set protocols isis interface ge-0/0/0.0 point-to-point
+#
+set protocols isis interface lo0.0 passive
+#
+set protocols isis level 1 disable
+set protocols isis level 2 wide-metrics-only
+set protocols isis overload timeout 360
+set protocols isis reference-bandwidth 100g
+#

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-isis-no-iso
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-isis-no-iso
@@ -1,0 +1,24 @@
+#
+set system host-name juniper-isis-no-iso
+#
+set interfaces lo0 unit 0 family inet address 1.1.1.1/32 
+#
+set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.0/24 
+#
+set protocols isis interface ge-0/0/0.0 bfd-liveness-detection minimum-interval 250
+set protocols isis interface ge-0/0/0.0 bfd-liveness-detection multiplier 3
+# "hello there"
+set protocols isis interface ge-0/0/0.0 level 2 hello-authentication-key "$9$tc4xpORrlMxNbhSdsY2oan/CAu1SyKWX-tu"
+set protocols isis interface ge-0/0/0.0 level 2 hello-authentication-type md5
+set protocols isis interface ge-0/0/0.0 level 2 hello-interval 1
+set protocols isis interface ge-0/0/0.0 level 2 hold-time 3
+set protocols isis interface ge-0/0/0.0 level 2 metric 5
+set protocols isis interface ge-0/0/0.0 point-to-point
+#
+set protocols isis interface lo0.0 passive
+#
+set protocols isis level 1 disable
+set protocols isis level 2 wide-metrics-only
+set protocols isis overload timeout 360
+set protocols isis reference-bandwidth 100g
+#


### PR DESCRIPTION
As specified [here](https://www.juniper.net/documentation/en_US/junos/topics/task/configuration/isis-network-configuring.html#id-10095177)
loopback is preferred, but not required.