### PR TITLE
Sanitize references in And, Not, and Or expressions

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/CircularReferenceException.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/CircularReferenceException.java
@@ -1,0 +1,12 @@
+package org.batfish.datamodel.acl;
+
+import org.batfish.common.BatfishException;
+
+/** TODO */
+public class CircularReferenceException extends BatfishException {
+  private static final long serialVersionUID = 1L;
+
+  public CircularReferenceException(String msg) {
+    super(msg);
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/CircularReferenceException.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/CircularReferenceException.java
@@ -2,7 +2,10 @@ package org.batfish.datamodel.acl;
 
 import org.batfish.common.BatfishException;
 
-/** TODO */
+/**
+ * Raised when attempting to use a reference that is part of a circular chain of references. For
+ * example, two named IP spaces can reference each other, rendering both invalid.
+ */
 public class CircularReferenceException extends BatfishException {
   private static final long serialVersionUID = 1L;
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/UndefinedReferenceException.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/UndefinedReferenceException.java
@@ -2,7 +2,10 @@ package org.batfish.datamodel.acl;
 
 import org.batfish.common.BatfishException;
 
-/** TODO */
+/**
+ * Raised when attempting to use an undefined reference. For example, an ACL can reference a named
+ * IP space that is never defined.
+ */
 public class UndefinedReferenceException extends BatfishException {
   private static final long serialVersionUID = 1L;
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/UndefinedReferenceException.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/UndefinedReferenceException.java
@@ -1,0 +1,12 @@
+package org.batfish.datamodel.acl;
+
+import org.batfish.common.BatfishException;
+
+/** TODO */
+public class UndefinedReferenceException extends BatfishException {
+  private static final long serialVersionUID = 1L;
+
+  public UndefinedReferenceException(String msg) {
+    super(msg);
+  }
+}

--- a/projects/question/src/main/java/org/batfish/question/aclreachability2/AclReachabilityAnswererUtils.java
+++ b/projects/question/src/main/java/org/batfish/question/aclreachability2/AclReachabilityAnswererUtils.java
@@ -217,12 +217,8 @@ public final class AclReachabilityAnswererUtils {
           if (!matchExpr.equals(sanitizedForIpSpaces)) {
             node.sanitizeLine(index, sanitizedForIpSpaces);
           }
-        } catch (CircularReferenceException e) {
-          // Line contains an IpSpaceReference that is part of a circular chain of references.
-          node.addUndefinedRef(index);
-          lineMarkedUnmatchable = true;
-        } catch (UndefinedReferenceException e) {
-          // Line contains an IpSpaceReference that refers to an undefined IpSpace.
+        } catch (CircularReferenceException | UndefinedReferenceException e) {
+          // Line contains invalid IpSpaceReference: undefined or part of a circular reference chain
           node.addUndefinedRef(index);
           lineMarkedUnmatchable = true;
         }

--- a/projects/question/src/main/java/org/batfish/question/aclreachability2/AclReachabilityAnswererUtils.java
+++ b/projects/question/src/main/java/org/batfish/question/aclreachability2/AclReachabilityAnswererUtils.java
@@ -21,10 +21,13 @@ import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.IpAccessListLine;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.acl.AndMatchExpr;
 import org.batfish.datamodel.acl.CanonicalAcl;
 import org.batfish.datamodel.acl.FalseExpr;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.datamodel.acl.MatchSrcInterface;
+import org.batfish.datamodel.acl.NotMatchExpr;
+import org.batfish.datamodel.acl.OrMatchExpr;
 import org.batfish.datamodel.acl.PermittedByAcl;
 import org.batfish.datamodel.answers.AclLinesAnswerElementInterface;
 import org.batfish.datamodel.answers.AclLinesAnswerElementInterface.AclSpecs;
@@ -125,20 +128,66 @@ public final class AclReachabilityAnswererUtils {
       _interfaces.addAll(newInterfaces);
     }
 
-    public void sanitizeHeaderSpace(
-        int lineNum, HeaderSpace headerSpace, Map<String, IpSpace> namedIpSpaces) {
-      try {
-        // Try dereferencing all IpSpace fields in header space. If that results in a header space
-        // different from the original, sanitize the line.
-        HeaderSpace dereferenced =
-            IpSpaceDereferencer.dereferenceHeaderSpace(headerSpace, namedIpSpaces);
-        if (!dereferenced.equals(headerSpace)) {
-          sanitizeLine(lineNum, new MatchHeaderSpace(dereferenced));
-        }
-      } catch (BatfishException e) {
-        // If dereferencing causes an error, one of the IpSpaces was a cycle or undefined ref.
+    // Dereferences any IpSpace references in the match expression.
+    // Returns true if all went well, false if it found an undefined reference.
+    public boolean sanitizeHeaderSpaces(
+        int lineNum, AclLineMatchExpr matchExpr, Map<String, IpSpace> namedIpSpaces) {
+      AclLineMatchExpr sanitizedMatchExpr = sanitizeHeaderSpacesHelper(matchExpr, namedIpSpaces);
+      if (sanitizedMatchExpr == null) {
+        // One of the IpSpaces was a cycle or undefined ref.
         addUndefinedRef(lineNum);
+        return false;
+      } else if (!matchExpr.equals(sanitizedMatchExpr)) {
+        // There were IpSpaces that got dereferenced. Sanitize the line.
+        sanitizeLine(lineNum, sanitizedMatchExpr);
       }
+      return true;
+    }
+
+    // Returns a version of the given match expression with any IpSpace references dereferenced. If
+    // there is any undefined IpSpace reference, returns null instead.
+    private static AclLineMatchExpr sanitizeHeaderSpacesHelper(
+        AclLineMatchExpr matchExpr, Map<String, IpSpace> namedIpSpaces) {
+      if (matchExpr instanceof MatchHeaderSpace) {
+        try {
+          // Try dereferencing all IpSpace fields in header space. If that results in a header space
+          // different from the original, sanitize the line.
+          HeaderSpace headerSpace = ((MatchHeaderSpace) matchExpr).getHeaderspace();
+          return new MatchHeaderSpace(
+              IpSpaceDereferencer.dereferenceHeaderSpace(headerSpace, namedIpSpaces));
+        } catch (BatfishException e) {
+          // If dereferencing causes an error, one of the IpSpaces was a cycle or undefined ref.
+          return null;
+        }
+      } else if (matchExpr instanceof AndMatchExpr) {
+        List<AclLineMatchExpr> newConjuncts = new ArrayList<>();
+        for (AclLineMatchExpr conjunct : ((AndMatchExpr) matchExpr).getConjuncts()) {
+          AclLineMatchExpr sanitizedConjunct = sanitizeHeaderSpacesHelper(conjunct, namedIpSpaces);
+          if (sanitizedConjunct == null) {
+            return null;
+          }
+          newConjuncts.add(sanitizedConjunct);
+        }
+        return new AndMatchExpr(newConjuncts);
+      } else if (matchExpr instanceof OrMatchExpr) {
+        List<AclLineMatchExpr> newDisjuncts = new ArrayList<>();
+        for (AclLineMatchExpr disjunct : ((OrMatchExpr) matchExpr).getDisjuncts()) {
+          AclLineMatchExpr sanitizedDisjunct = sanitizeHeaderSpacesHelper(disjunct, namedIpSpaces);
+          if (sanitizedDisjunct == null) {
+            return null;
+          }
+          newDisjuncts.add(sanitizedDisjunct);
+        }
+        return new OrMatchExpr(newDisjuncts);
+      } else if (matchExpr instanceof NotMatchExpr) {
+        AclLineMatchExpr sanitizedOperand =
+            sanitizeHeaderSpacesHelper(((NotMatchExpr) matchExpr).getOperand(), namedIpSpaces);
+        if (sanitizedOperand == null) {
+          return null;
+        }
+        return new NotMatchExpr(sanitizedOperand);
+      }
+      return matchExpr;
     }
 
     public void addUndefinedRef(int lineNum) {
@@ -189,39 +238,86 @@ public final class AclReachabilityAnswererUtils {
     // Go through lines and add dependencies
     int index = 0;
     for (IpAccessListLine line : acl.getLines()) {
-      AclLineMatchExpr matchCondition = line.getMatchCondition();
-      if (matchCondition instanceof PermittedByAcl) {
-        String referencedAclName = ((PermittedByAcl) matchCondition).getAclName();
-        IpAccessList referencedAcl = acls.get(referencedAclName);
-        if (referencedAcl == null) {
-          // Referenced ACL doesn't exist. Mark line as unmatchable.
+      AclLineMatchExpr matchExpr = line.getMatchCondition();
+      boolean lineMarkedUnmatchable = false;
+
+      // Find all references to other ACLs and record them
+      List<PermittedByAcl> permittedByAclExprs =
+          findMatchExprsOfType(PermittedByAcl.class, matchExpr);
+      if (!permittedByAclExprs.isEmpty()) {
+        Set<String> referencedAcls =
+            permittedByAclExprs
+                .stream()
+                .map(PermittedByAcl::getAclName)
+                .collect(Collectors.toSet());
+        if (!acls.keySet().containsAll(referencedAcls)) {
+          // Not all referenced ACLs exist. Mark line as unmatchable.
           node.addUndefinedRef(index);
+          lineMarkedUnmatchable = true;
         } else {
-          AclNode referencedAclNode = aclNodeMap.get(referencedAclName);
-          if (referencedAclNode == null) {
-            // Referenced ACL not yet recorded; recurse on it
-            createAclNode(referencedAcl, aclNodeMap, acls, namedIpSpaces, nodeInterfaces);
-            referencedAclNode = aclNodeMap.get(referencedAclName);
+          for (String referencedAclName : referencedAcls) {
+            AclNode referencedAclNode = aclNodeMap.get(referencedAclName);
+            if (referencedAclNode == null) {
+              // Referenced ACL not yet recorded; recurse on it
+              createAclNode(
+                  acls.get(referencedAclName), aclNodeMap, acls, namedIpSpaces, nodeInterfaces);
+              referencedAclNode = aclNodeMap.get(referencedAclName);
+            }
+            // Referenced ACL has now been recorded; add dependency
+            node.addDependency(referencedAclNode, index);
           }
-          // Referenced ACL has now been recorded; add dependency
-          node.addDependency(referencedAclNode, index);
         }
-      } else if (matchCondition instanceof MatchHeaderSpace) {
-        // Sanitize IP space references, or mark the line unmatchable if it has invalid references
-        HeaderSpace headerSpace = ((MatchHeaderSpace) matchCondition).getHeaderspace();
-        node.sanitizeHeaderSpace(index, headerSpace, namedIpSpaces);
-      } else if (matchCondition instanceof MatchSrcInterface) {
-        Set<String> referencedInterfaces = ((MatchSrcInterface) matchCondition).getSrcInterfaces();
+      }
+
+      // Dereference all IpSpace references, or mark line unmatchable if it has invalid references
+      if (!lineMarkedUnmatchable && !node.sanitizeHeaderSpaces(index, matchExpr, namedIpSpaces)) {
+        // Header space contained an undefined reference; line is unmatchable
+        lineMarkedUnmatchable = true;
+      }
+
+      // Find all references to interfaces and ensure they exist
+      if (!lineMarkedUnmatchable) {
+        List<MatchSrcInterface> matchSrcInterfaceExprs =
+            findMatchExprsOfType(MatchSrcInterface.class, matchExpr);
+        Set<String> referencedInterfaces =
+            matchSrcInterfaceExprs
+                .stream()
+                .flatMap(expr -> expr.getSrcInterfaces().stream())
+                .collect(Collectors.toSet());
         if (!nodeInterfaces.containsAll(referencedInterfaces)) {
           // Line references an undefined source interface. Report undefined ref.
           node.addUndefinedRef(index);
         } else {
-          // Line interfaces are valid. Record.
           node.addInterfaces(referencedInterfaces);
         }
       }
+
       index++;
     }
+  }
+
+  private static <T extends AclLineMatchExpr> List<T> findMatchExprsOfType(
+      Class<T> tClass, AclLineMatchExpr matchExpr) {
+    if (matchExpr.getClass().equals(tClass)) {
+      return ImmutableList.of((T) matchExpr);
+    } else if (matchExpr instanceof NotMatchExpr) {
+      return findMatchExprsOfType(tClass, ((NotMatchExpr) matchExpr).getOperand());
+    } else if (matchExpr instanceof AndMatchExpr) {
+      List<T> matchExprs = new ArrayList<>();
+      ((AndMatchExpr) matchExpr)
+          .getConjuncts()
+          .parallelStream()
+          .forEach(conjunct -> matchExprs.addAll(findMatchExprsOfType(tClass, conjunct)));
+      return matchExprs;
+    } else if (matchExpr instanceof OrMatchExpr) {
+      List<T> matchExprs = new ArrayList<>();
+      ((OrMatchExpr) matchExpr)
+          .getDisjuncts()
+          .parallelStream()
+          .forEach(disjunct -> matchExprs.addAll(findMatchExprsOfType(tClass, disjunct)));
+      return matchExprs;
+    }
+    return ImmutableList.of();
   }
 
   private static List<ImmutableList<String>> sanitizeNode(

--- a/projects/question/src/main/java/org/batfish/question/aclreachability2/HeaderSpaceSanitizer.java
+++ b/projects/question/src/main/java/org/batfish/question/aclreachability2/HeaderSpaceSanitizer.java
@@ -38,7 +38,7 @@ public class HeaderSpaceSanitizer implements GenericAclLineMatchExprVisitor<AclL
   public AclLineMatchExpr visitAndMatchExpr(AndMatchExpr andMatchExpr)
       throws CircularReferenceException, UndefinedReferenceException {
     return new AndMatchExpr(
-        andMatchExpr.getConjuncts().stream().map(c -> c.accept(this)).collect(Collectors.toList()));
+        andMatchExpr.getConjuncts().stream().map(this::visit).collect(Collectors.toList()));
   }
 
   @Override
@@ -62,7 +62,7 @@ public class HeaderSpaceSanitizer implements GenericAclLineMatchExprVisitor<AclL
   @Override
   public AclLineMatchExpr visitNotMatchExpr(NotMatchExpr notMatchExpr)
       throws CircularReferenceException, UndefinedReferenceException {
-    return new NotMatchExpr(notMatchExpr.getOperand().accept(this));
+    return new NotMatchExpr(visit(notMatchExpr.getOperand()));
   }
 
   @Override
@@ -74,7 +74,7 @@ public class HeaderSpaceSanitizer implements GenericAclLineMatchExprVisitor<AclL
   public AclLineMatchExpr visitOrMatchExpr(OrMatchExpr orMatchExpr)
       throws CircularReferenceException, UndefinedReferenceException {
     return new OrMatchExpr(
-        orMatchExpr.getDisjuncts().stream().map(d -> d.accept(this)).collect(Collectors.toList()));
+        orMatchExpr.getDisjuncts().stream().map(this::visit).collect(Collectors.toList()));
   }
 
   @Override

--- a/projects/question/src/main/java/org/batfish/question/aclreachability2/HeaderSpaceSanitizer.java
+++ b/projects/question/src/main/java/org/batfish/question/aclreachability2/HeaderSpaceSanitizer.java
@@ -1,0 +1,103 @@
+package org.batfish.question.aclreachability2;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.batfish.common.BatfishException;
+import org.batfish.datamodel.HeaderSpace;
+import org.batfish.datamodel.IpSpace;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.acl.AndMatchExpr;
+import org.batfish.datamodel.acl.FalseExpr;
+import org.batfish.datamodel.acl.GenericAclLineMatchExprVisitor;
+import org.batfish.datamodel.acl.MatchHeaderSpace;
+import org.batfish.datamodel.acl.MatchSrcInterface;
+import org.batfish.datamodel.acl.NotMatchExpr;
+import org.batfish.datamodel.acl.OrMatchExpr;
+import org.batfish.datamodel.acl.OriginatingFromDevice;
+import org.batfish.datamodel.acl.PermittedByAcl;
+import org.batfish.datamodel.acl.TrueExpr;
+import org.batfish.datamodel.visitors.IpSpaceDereferencer;
+
+public class HeaderSpaceSanitizer implements GenericAclLineMatchExprVisitor<AclLineMatchExpr> {
+
+  private final Map<String, IpSpace> _namedIpSpaces;
+
+  public HeaderSpaceSanitizer(Map<String, IpSpace> namedIpSpaces) {
+    _namedIpSpaces = namedIpSpaces;
+  }
+
+  @Override
+  public AclLineMatchExpr visitAndMatchExpr(AndMatchExpr andMatchExpr) {
+    List<AclLineMatchExpr> newConjuncts = new ArrayList<>();
+    for (AclLineMatchExpr conjunct : andMatchExpr.getConjuncts()) {
+      AclLineMatchExpr sanitizedConjunct = conjunct.accept(this);
+      if (sanitizedConjunct == null) {
+        return null;
+      }
+      newConjuncts.add(sanitizedConjunct);
+    }
+    return new AndMatchExpr(newConjuncts);
+  }
+
+  @Override
+  public AclLineMatchExpr visitFalseExpr(FalseExpr falseExpr) {
+    return falseExpr;
+  }
+
+  @Override
+  public AclLineMatchExpr visitMatchHeaderSpace(MatchHeaderSpace matchHeaderSpace) {
+    try {
+      // Try dereferencing all IpSpace fields in header space. If that results in a header space
+      // different from the original, sanitize the line.
+      HeaderSpace headerSpace = matchHeaderSpace.getHeaderspace();
+      return new MatchHeaderSpace(
+          IpSpaceDereferencer.dereferenceHeaderSpace(headerSpace, _namedIpSpaces));
+    } catch (BatfishException e) {
+      // If dereferencing causes an error, one of the IpSpaces was a cycle or undefined ref.
+      return null;
+    }
+  }
+
+  @Override
+  public AclLineMatchExpr visitMatchSrcInterface(MatchSrcInterface matchSrcInterface) {
+    return matchSrcInterface;
+  }
+
+  @Override
+  public AclLineMatchExpr visitNotMatchExpr(NotMatchExpr notMatchExpr) {
+    AclLineMatchExpr sanitizedOperand = notMatchExpr.getOperand().accept(this);
+    if (sanitizedOperand == null) {
+      return null;
+    }
+    return new NotMatchExpr(sanitizedOperand);
+  }
+
+  @Override
+  public AclLineMatchExpr visitOriginatingFromDevice(OriginatingFromDevice originatingFromDevice) {
+    return originatingFromDevice;
+  }
+
+  @Override
+  public AclLineMatchExpr visitOrMatchExpr(OrMatchExpr orMatchExpr) {
+    List<AclLineMatchExpr> newDisjuncts = new ArrayList<>();
+    for (AclLineMatchExpr disjunct : orMatchExpr.getDisjuncts()) {
+      AclLineMatchExpr sanitizedDisjunct = disjunct.accept(this);
+      if (sanitizedDisjunct == null) {
+        return null;
+      }
+      newDisjuncts.add(sanitizedDisjunct);
+    }
+    return new OrMatchExpr(newDisjuncts);
+  }
+
+  @Override
+  public AclLineMatchExpr visitPermittedByAcl(PermittedByAcl permittedByAcl) {
+    return permittedByAcl;
+  }
+
+  @Override
+  public AclLineMatchExpr visitTrueExpr(TrueExpr trueExpr) {
+    return trueExpr;
+  }
+}

--- a/projects/question/src/main/java/org/batfish/question/aclreachability2/HeaderSpaceSanitizer.java
+++ b/projects/question/src/main/java/org/batfish/question/aclreachability2/HeaderSpaceSanitizer.java
@@ -19,6 +19,13 @@ import org.batfish.datamodel.acl.PermittedByAcl;
 import org.batfish.datamodel.acl.TrueExpr;
 import org.batfish.datamodel.visitors.IpSpaceDereferencer;
 
+/**
+ * Visits an {@link AclLineMatchExpr} and replaces any named IP space references with the
+ * dereferenced {@link IpSpace}. An {@link AclLineMatchExpr} may contain multiple IP space
+ * references if it is of type {@link AndMatchExpr}, {@link OrMatchExpr}, or {@link NotMatchExpr}.
+ * Returns a version of the original {@link AclLineMatchExpr} with all IP spaces dereferenced, or
+ * {@code null} if any undefined IP space is referenced.
+ */
 public class HeaderSpaceSanitizer implements GenericAclLineMatchExprVisitor<AclLineMatchExpr> {
 
   private final Map<String, IpSpace> _namedIpSpaces;

--- a/projects/question/src/main/java/org/batfish/question/aclreachability2/TypeMatchExprsCollector.java
+++ b/projects/question/src/main/java/org/batfish/question/aclreachability2/TypeMatchExprsCollector.java
@@ -24,6 +24,7 @@ import org.batfish.datamodel.acl.TrueExpr;
  *
  * @param <T> Type of {@link AclLineMatchExpr} to collect from the visited expression.
  */
+@SuppressWarnings("unchecked")
 public class TypeMatchExprsCollector<T extends AclLineMatchExpr>
     implements GenericAclLineMatchExprVisitor<List<T>> {
 

--- a/projects/question/src/main/java/org/batfish/question/aclreachability2/TypeMatchExprsCollector.java
+++ b/projects/question/src/main/java/org/batfish/question/aclreachability2/TypeMatchExprsCollector.java
@@ -1,0 +1,101 @@
+package org.batfish.question.aclreachability2;
+
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.List;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.acl.AndMatchExpr;
+import org.batfish.datamodel.acl.FalseExpr;
+import org.batfish.datamodel.acl.GenericAclLineMatchExprVisitor;
+import org.batfish.datamodel.acl.MatchHeaderSpace;
+import org.batfish.datamodel.acl.MatchSrcInterface;
+import org.batfish.datamodel.acl.NotMatchExpr;
+import org.batfish.datamodel.acl.OrMatchExpr;
+import org.batfish.datamodel.acl.OriginatingFromDevice;
+import org.batfish.datamodel.acl.PermittedByAcl;
+import org.batfish.datamodel.acl.TrueExpr;
+
+public class TypeMatchExprsCollector<T> implements GenericAclLineMatchExprVisitor<List<T>> {
+
+  private final Class<T> _type;
+
+  public TypeMatchExprsCollector(Class<T> type) {
+    _type = type;
+  }
+
+  @Override
+  public List<T> visitAndMatchExpr(AndMatchExpr andMatchExpr) {
+    List<T> matchingExprs = new ArrayList<>();
+    if (_type.isAssignableFrom(AndMatchExpr.class)) {
+      matchingExprs.add((T) andMatchExpr);
+    }
+    for (AclLineMatchExpr conjunct : andMatchExpr.getConjuncts()) {
+      matchingExprs.addAll(conjunct.accept(this));
+    }
+    return matchingExprs;
+  }
+
+  @Override
+  public List<T> visitFalseExpr(FalseExpr falseExpr) {
+    return _type.isAssignableFrom(FalseExpr.class)
+        ? ImmutableList.of((T) falseExpr)
+        : ImmutableList.of();
+  }
+
+  @Override
+  public List<T> visitMatchHeaderSpace(MatchHeaderSpace matchHeaderSpace) {
+    return _type.isAssignableFrom(MatchHeaderSpace.class)
+        ? ImmutableList.of((T) matchHeaderSpace)
+        : ImmutableList.of();
+  }
+
+  @Override
+  public List<T> visitMatchSrcInterface(MatchSrcInterface matchSrcInterface) {
+    return _type.isAssignableFrom(MatchSrcInterface.class)
+        ? ImmutableList.of((T) matchSrcInterface)
+        : ImmutableList.of();
+  }
+
+  @Override
+  public List<T> visitNotMatchExpr(NotMatchExpr notMatchExpr) {
+    List<T> matchingExprs = new ArrayList<>();
+    if (_type.isAssignableFrom(NotMatchExpr.class)) {
+      matchingExprs.add((T) notMatchExpr);
+    }
+    matchingExprs.addAll(notMatchExpr.getOperand().accept(this));
+    return matchingExprs;
+  }
+
+  @Override
+  public List<T> visitOriginatingFromDevice(OriginatingFromDevice originatingFromDevice) {
+    return _type.isAssignableFrom(OriginatingFromDevice.class)
+        ? ImmutableList.of((T) originatingFromDevice)
+        : ImmutableList.of();
+  }
+
+  @Override
+  public List<T> visitOrMatchExpr(OrMatchExpr orMatchExpr) {
+    List<T> matchingExprs = new ArrayList<>();
+    if (_type.isAssignableFrom(OrMatchExpr.class)) {
+      matchingExprs.add((T) orMatchExpr);
+    }
+    for (AclLineMatchExpr disjunct : orMatchExpr.getDisjuncts()) {
+      matchingExprs.addAll(disjunct.accept(this));
+    }
+    return matchingExprs;
+  }
+
+  @Override
+  public List<T> visitPermittedByAcl(PermittedByAcl permittedByAcl) {
+    return _type.isAssignableFrom(PermittedByAcl.class)
+        ? ImmutableList.of((T) permittedByAcl)
+        : ImmutableList.of();
+  }
+
+  @Override
+  public List<T> visitTrueExpr(TrueExpr trueExpr) {
+    return _type.isAssignableFrom(TrueExpr.class)
+        ? ImmutableList.of((T) trueExpr)
+        : ImmutableList.of();
+  }
+}

--- a/projects/question/src/main/java/org/batfish/question/aclreachability2/TypeMatchExprsCollector.java
+++ b/projects/question/src/main/java/org/batfish/question/aclreachability2/TypeMatchExprsCollector.java
@@ -24,7 +24,6 @@ import org.batfish.datamodel.acl.TrueExpr;
  *
  * @param <T> Type of {@link AclLineMatchExpr} to collect from the visited expression.
  */
-@SuppressWarnings("unchecked")
 public class TypeMatchExprsCollector<T extends AclLineMatchExpr>
     implements GenericAclLineMatchExprVisitor<List<T>> {
 
@@ -38,7 +37,7 @@ public class TypeMatchExprsCollector<T extends AclLineMatchExpr>
   public List<T> visitAndMatchExpr(AndMatchExpr andMatchExpr) {
     List<T> matchingExprs = new ArrayList<>();
     if (_type.isAssignableFrom(AndMatchExpr.class)) {
-      matchingExprs.add((T) andMatchExpr);
+      matchingExprs.add(_type.cast(andMatchExpr));
     }
     for (AclLineMatchExpr conjunct : andMatchExpr.getConjuncts()) {
       matchingExprs.addAll(conjunct.accept(this));
@@ -49,21 +48,21 @@ public class TypeMatchExprsCollector<T extends AclLineMatchExpr>
   @Override
   public List<T> visitFalseExpr(FalseExpr falseExpr) {
     return _type.isAssignableFrom(FalseExpr.class)
-        ? ImmutableList.of((T) falseExpr)
+        ? ImmutableList.of(_type.cast(falseExpr))
         : ImmutableList.of();
   }
 
   @Override
   public List<T> visitMatchHeaderSpace(MatchHeaderSpace matchHeaderSpace) {
     return _type.isAssignableFrom(MatchHeaderSpace.class)
-        ? ImmutableList.of((T) matchHeaderSpace)
+        ? ImmutableList.of(_type.cast(matchHeaderSpace))
         : ImmutableList.of();
   }
 
   @Override
   public List<T> visitMatchSrcInterface(MatchSrcInterface matchSrcInterface) {
     return _type.isAssignableFrom(MatchSrcInterface.class)
-        ? ImmutableList.of((T) matchSrcInterface)
+        ? ImmutableList.of(_type.cast(matchSrcInterface))
         : ImmutableList.of();
   }
 
@@ -71,7 +70,7 @@ public class TypeMatchExprsCollector<T extends AclLineMatchExpr>
   public List<T> visitNotMatchExpr(NotMatchExpr notMatchExpr) {
     List<T> matchingExprs = new ArrayList<>();
     if (_type.isAssignableFrom(NotMatchExpr.class)) {
-      matchingExprs.add((T) notMatchExpr);
+      matchingExprs.add(_type.cast(notMatchExpr));
     }
     matchingExprs.addAll(notMatchExpr.getOperand().accept(this));
     return matchingExprs;
@@ -80,7 +79,7 @@ public class TypeMatchExprsCollector<T extends AclLineMatchExpr>
   @Override
   public List<T> visitOriginatingFromDevice(OriginatingFromDevice originatingFromDevice) {
     return _type.isAssignableFrom(OriginatingFromDevice.class)
-        ? ImmutableList.of((T) originatingFromDevice)
+        ? ImmutableList.of(_type.cast(originatingFromDevice))
         : ImmutableList.of();
   }
 
@@ -88,7 +87,7 @@ public class TypeMatchExprsCollector<T extends AclLineMatchExpr>
   public List<T> visitOrMatchExpr(OrMatchExpr orMatchExpr) {
     List<T> matchingExprs = new ArrayList<>();
     if (_type.isAssignableFrom(OrMatchExpr.class)) {
-      matchingExprs.add((T) orMatchExpr);
+      matchingExprs.add(_type.cast(orMatchExpr));
     }
     for (AclLineMatchExpr disjunct : orMatchExpr.getDisjuncts()) {
       matchingExprs.addAll(disjunct.accept(this));
@@ -99,14 +98,14 @@ public class TypeMatchExprsCollector<T extends AclLineMatchExpr>
   @Override
   public List<T> visitPermittedByAcl(PermittedByAcl permittedByAcl) {
     return _type.isAssignableFrom(PermittedByAcl.class)
-        ? ImmutableList.of((T) permittedByAcl)
+        ? ImmutableList.of(_type.cast(permittedByAcl))
         : ImmutableList.of();
   }
 
   @Override
   public List<T> visitTrueExpr(TrueExpr trueExpr) {
     return _type.isAssignableFrom(TrueExpr.class)
-        ? ImmutableList.of((T) trueExpr)
+        ? ImmutableList.of(_type.cast(trueExpr))
         : ImmutableList.of();
   }
 }

--- a/projects/question/src/main/java/org/batfish/question/aclreachability2/TypeMatchExprsCollector.java
+++ b/projects/question/src/main/java/org/batfish/question/aclreachability2/TypeMatchExprsCollector.java
@@ -15,7 +15,17 @@ import org.batfish.datamodel.acl.OriginatingFromDevice;
 import org.batfish.datamodel.acl.PermittedByAcl;
 import org.batfish.datamodel.acl.TrueExpr;
 
-public class TypeMatchExprsCollector<T> implements GenericAclLineMatchExprVisitor<List<T>> {
+/**
+ * Collects all {@link AclLineMatchExpr}s of the given type built into the visited expression.
+ * Multiple expressions of the given type may be built into the visited expression if the visited
+ * expression is of type {@link AndMatchExpr}, {@link OrMatchExpr}, or {@link NotMatchExpr}. This
+ * visitor is therefore useful for finding all ACLs referenced or all header spaces contained within
+ * a single ACL line.
+ *
+ * @param <T> Type of {@link AclLineMatchExpr} to collect from the visited expression.
+ */
+public class TypeMatchExprsCollector<T extends AclLineMatchExpr>
+    implements GenericAclLineMatchExprVisitor<List<T>> {
 
   private final Class<T> _type;
 

--- a/projects/question/src/main/java/org/batfish/question/aclreachability2/TypeMatchExprsCollector.java
+++ b/projects/question/src/main/java/org/batfish/question/aclreachability2/TypeMatchExprsCollector.java
@@ -40,7 +40,7 @@ public class TypeMatchExprsCollector<T extends AclLineMatchExpr>
       matchingExprs.add(_type.cast(andMatchExpr));
     }
     for (AclLineMatchExpr conjunct : andMatchExpr.getConjuncts()) {
-      matchingExprs.addAll(conjunct.accept(this));
+      matchingExprs.addAll(visit(conjunct));
     }
     return matchingExprs;
   }
@@ -72,7 +72,7 @@ public class TypeMatchExprsCollector<T extends AclLineMatchExpr>
     if (_type.isAssignableFrom(NotMatchExpr.class)) {
       matchingExprs.add(_type.cast(notMatchExpr));
     }
-    matchingExprs.addAll(notMatchExpr.getOperand().accept(this));
+    matchingExprs.addAll(visit(notMatchExpr.getOperand()));
     return matchingExprs;
   }
 
@@ -90,7 +90,7 @@ public class TypeMatchExprsCollector<T extends AclLineMatchExpr>
       matchingExprs.add(_type.cast(orMatchExpr));
     }
     for (AclLineMatchExpr disjunct : orMatchExpr.getDisjuncts()) {
-      matchingExprs.addAll(disjunct.accept(this));
+      matchingExprs.addAll(visit(disjunct));
     }
     return matchingExprs;
   }


### PR DESCRIPTION
Fixes an issue where references to ACLs, IpSpaces, and interfaces could go unnoticed during ACL sanitization if they were hidden inside And, Or, or Not match expressions.