### PR TITLE
Juniper Is-is: fix interface setting conversion

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import javax.annotation.Nonnull;
 import org.batfish.common.util.ComparableStructure;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
@@ -55,7 +56,7 @@ public class Interface extends ComparableStructure<String> {
 
   private transient boolean _inherited;
 
-  private final IsisInterfaceSettings _isisSettings;
+  @Nonnull private final IsisInterfaceSettings _isisSettings;
 
   private IsoAddress _isoAddress;
 
@@ -160,6 +161,7 @@ public class Interface extends ComparableStructure<String> {
     return _incomingFilter;
   }
 
+  @Nonnull
   public IsisInterfaceSettings getIsisSettings() {
     return _isisSettings;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -621,31 +621,23 @@ public final class JuniperConfiguration extends VendorConfiguration {
     if (level2) {
       newProc.setLevel2(toIsisLevelSettings(settings.getLevel2Settings()));
     }
-    processIsisInterfaceSettings(routingInstance, settings, netAddress, level1, level2);
+    processIsisInterfaceSettings(routingInstance, settings, level1, level2);
     newProc.setOverloadTimeout(settings.getOverloadTimeout());
     newProc.setReferenceBandwidth(settings.getReferenceBandwidth());
     return newProc.build();
   }
 
   private void processIsisInterfaceSettings(
-      RoutingInstance routingInstance,
-      IsisSettings settings,
-      IsoAddress procIsoAddress,
-      boolean level1,
-      boolean level2) {
+      RoutingInstance routingInstance, IsisSettings settings, boolean level1, boolean level2) {
     _c.getVrfs()
         .get(routingInstance.getName())
         .getInterfaces()
         .forEach(
             (ifaceName, newIface) -> {
               Interface iface = routingInstance.getInterfaces().get(ifaceName);
-              IsoAddress netAddress = iface.getIsoAddress();
-              if (netAddress == null) {
-                netAddress = procIsoAddress;
-              }
               newIface.setIsis(
                   toIsisInterfaceSettings(
-                      settings, iface.getIsisSettings(), netAddress, level1, level2));
+                      settings, iface.getIsisSettings(), iface.getIsoAddress(), level1, level2));
             });
   }
 
@@ -655,7 +647,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
       IsoAddress isoAddress,
       boolean level1,
       boolean level2) {
-    if (!interfaceSettings.getEnabled() || isoAddress == null) {
+    if (!interfaceSettings.getEnabled()) {
       return null;
     }
     org.batfish.datamodel.IsisInterfaceSettings.Builder newInterfaceSettingsBuilder =

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -22,6 +22,7 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.collections4.list.TreeList;
 import org.batfish.common.BatfishException;
@@ -620,33 +621,41 @@ public final class JuniperConfiguration extends VendorConfiguration {
     if (level2) {
       newProc.setLevel2(toIsisLevelSettings(settings.getLevel2Settings()));
     }
-    processIsisInterfaceSettings(routingInstance, settings, level1, level2);
+    processIsisInterfaceSettings(routingInstance, settings, netAddress, level1, level2);
     newProc.setOverloadTimeout(settings.getOverloadTimeout());
     newProc.setReferenceBandwidth(settings.getReferenceBandwidth());
     return newProc.build();
   }
 
   private void processIsisInterfaceSettings(
-      RoutingInstance routingInstance, IsisSettings settings, boolean level1, boolean level2) {
+      RoutingInstance routingInstance,
+      IsisSettings settings,
+      IsoAddress procIsoAddress,
+      boolean level1,
+      boolean level2) {
     _c.getVrfs()
         .get(routingInstance.getName())
         .getInterfaces()
         .forEach(
             (ifaceName, newIface) -> {
               Interface iface = routingInstance.getInterfaces().get(ifaceName);
+              IsoAddress netAddress = iface.getIsoAddress();
+              if (netAddress == null) {
+                netAddress = procIsoAddress;
+              }
               newIface.setIsis(
                   toIsisInterfaceSettings(
-                      settings, iface.getIsisSettings(), iface.getIsoAddress(), level1, level2));
+                      settings, iface.getIsisSettings(), netAddress, level1, level2));
             });
   }
 
   private org.batfish.datamodel.IsisInterfaceSettings toIsisInterfaceSettings(
       IsisSettings settings,
-      IsisInterfaceSettings interfaceSettings,
+      @Nonnull IsisInterfaceSettings interfaceSettings,
       IsoAddress isoAddress,
       boolean level1,
       boolean level2) {
-    if (interfaceSettings == null || isoAddress == null) {
+    if (!interfaceSettings.getEnabled() || isoAddress == null) {
       return null;
     }
     org.batfish.datamodel.IsisInterfaceSettings.Builder newInterfaceSettingsBuilder =

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -1706,6 +1706,13 @@ public class FlatJuniperGrammarTest {
         hasInterface(
             physical, hasIsis(hasLevel2(IsisInterfaceLevelSettingsMatchers.hasHelloInterval(1)))));
     assertThat(c, hasInterface(physical, hasIsis(hasLevel2(hasHoldTime(3)))));
+
+    // Assert non-ISIS interface has no ISIS, but has IP address
+    assertThat(c, hasInterface("ge-1/0/0.0", hasIsis(nullValue())));
+    assertThat(
+        c,
+        hasInterface(
+            "ge-1/0/0.0", hasAllAddresses(contains(new InterfaceAddress(new Ip("10.1.1.1"), 24)))));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-isis
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-isis
@@ -5,7 +5,7 @@ set interfaces lo0 unit 0 family inet address 1.1.1.1/32
 set interfaces lo0 unit 0 family iso address 12.1234.1234.1234.1234.00 
 #
 set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.0/24 
-set interfaces ge-0/0/0 unit 0 family iso address 12.1234.1234.1234.1234.01 
+set interfaces ge-0/0/0 unit 0 family iso address 12.1234.1234.1234.1234.01
 #
 set protocols isis interface ge-0/0/0.0 bfd-liveness-detection minimum-interval 250
 set protocols isis interface ge-0/0/0.0 bfd-liveness-detection multiplier 3
@@ -23,4 +23,9 @@ set protocols isis level 1 disable
 set protocols isis level 2 wide-metrics-only
 set protocols isis overload timeout 360
 set protocols isis reference-bandwidth 100g
+#
+#
+# NOT an ISIS interface
+set interfaces ge-1/0/0 unit 0 family inet address 10.1.1.1/24
+#
 #


### PR DESCRIPTION
*Issue*:
When converting to VI configs, no interfaces would come up unless an ISO address was explicitly configured.
Once fixes, **all** the inferfaces would be labeled ISIS because we were doing a null check on settings instead of `.getEnabled()`.

*Fix*:
- Fix if statement in `toIsisInterfaceSettings`
- Add annotations for clarity
- Expand existing test with negative example