### PR TITLE
Add delay parameter to interfaces

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -42,6 +42,8 @@ public final class Interface extends ComparableStructure<String> {
 
     private SortedSet<String> _declaredNames;
 
+    @Nullable private Double _delay;
+
     private IpAccessList _incomingFilter;
 
     private IsisInterfaceSettings _isis;
@@ -98,6 +100,7 @@ public final class Interface extends ComparableStructure<String> {
       iface.setBandwidth(_bandwidth);
       iface.setBlacklisted(_blacklisted);
       iface.setDeclaredNames(_declaredNames);
+      iface.setDelay(_delay);
       iface.setIncomingFilter(_incomingFilter);
       iface.setIsis(_isis);
       iface.setOspfArea(_ospfArea);
@@ -197,6 +200,11 @@ public final class Interface extends ComparableStructure<String> {
 
     public Builder setDeclaredNames(Iterable<String> declaredNames) {
       _declaredNames = ImmutableSortedSet.copyOf(declaredNames);
+      return this;
+    }
+
+    public Builder setDelay(@Nullable Double delay) {
+      _delay = delay;
       return this;
     }
 
@@ -317,6 +325,8 @@ public final class Interface extends ComparableStructure<String> {
   private static final String PROP_CRYPTO_MAP = "cryptoMap";
 
   private static final String PROP_DECLARED_NAMES = "declaredNames";
+
+  private static final String PROP_DELAY = "delay";
 
   private static final String PROP_DESCRIPTION = "description";
 
@@ -570,6 +580,8 @@ public final class Interface extends ComparableStructure<String> {
 
   private SortedSet<String> _declaredNames;
 
+  @Nullable private Double _delay;
+
   private String _description;
 
   private List<Ip> _dhcpRelayAddresses;
@@ -720,6 +732,9 @@ public final class Interface extends ComparableStructure<String> {
     if (!Objects.equals(_cryptoMap, other._cryptoMap)) {
       return false;
     }
+    if (!Objects.equals(_delay, other._delay)) {
+      return false;
+    }
     // we check ACLs for name match only -- full ACL diff can be done
     // elsewhere.
     if (!IpAccessList.bothNullOrSameName(this.getInboundFilter(), other.getInboundFilter())) {
@@ -829,6 +844,14 @@ public final class Interface extends ComparableStructure<String> {
   @JsonProperty(PROP_DECLARED_NAMES)
   public SortedSet<String> getDeclaredNames() {
     return _declaredNames;
+  }
+
+  @JsonProperty(PROP_DELAY)
+  @JsonPropertyDescription(
+      "The nominal delay of this interface in microseconds for use in protocol cost calculations")
+  @Nullable
+  public Double getDelay() {
+    return _delay;
   }
 
   @JsonProperty(PROP_DESCRIPTION)
@@ -1195,6 +1218,11 @@ public final class Interface extends ComparableStructure<String> {
   @JsonProperty(PROP_DECLARED_NAMES)
   public void setDeclaredNames(SortedSet<String> declaredNames) {
     _declaredNames = ImmutableSortedSet.copyOf(declaredNames);
+  }
+
+  @JsonProperty(PROP_DELAY)
+  public void setDelay(@Nullable Double delay) {
+    _delay = delay;
   }
 
   @JsonProperty(PROP_DESCRIPTION)

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/DataModelMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/DataModelMatchers.java
@@ -48,6 +48,7 @@ import org.batfish.datamodel.matchers.DeniedByIpAccessListLineMatchersImpl.IsDen
 import org.batfish.datamodel.matchers.DeniedByNamedIpSpaceMatchers.IsDeniedByNamedIpSpaceThat;
 import org.batfish.datamodel.matchers.HeaderSpaceMatchersImpl.HasSrcOrDstPorts;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasBandwidth;
+import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasDelay;
 import org.batfish.datamodel.matchers.OspfProcessMatchersImpl.HasReferenceBandwidth;
 import org.batfish.datamodel.matchers.PermittedByAclIpSpaceLineMatchersImpl.IsPermittedByAclIpSpaceLineThat;
 import org.batfish.datamodel.matchers.PermittedByIpAccessListLineMatchersImpl.IsPermittedByIpAccessListLineThat;
@@ -242,6 +243,21 @@ public final class DataModelMatchers {
           @Nonnull Matcher<? super Set<Integer>> subMatcher) {
     return new ConvertConfigurationAnswerElementMatchers.HasDefinedStructureWithDefinitionLines(
         hostname, type, structureName, subMatcher);
+  }
+
+  /**
+   * Provides a matcher that matches if the provided {@code delay} is that of the {@link Interface}.
+   */
+  public static @Nonnull Matcher<Interface> hasDelay(double delay) {
+    return hasDelay(equalTo(delay));
+  }
+
+  /**
+   * Provides a matcher that matches if the provided {@code subMatcher} matches the {@link
+   * Interface}'s bandwidth.
+   */
+  public static @Nonnull Matcher<Interface> hasDelay(Matcher<? super Double> subMatcher) {
+    return new HasDelay(subMatcher);
   }
 
   /**

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchersImpl.java
@@ -85,6 +85,17 @@ final class InterfaceMatchersImpl {
     }
   }
 
+  static final class HasDelay extends FeatureMatcher<Interface, Double> {
+    HasDelay(@Nonnull Matcher<? super Double> subMatcher) {
+      super(subMatcher, "an Interface with delay:", "delay");
+    }
+
+    @Override
+    protected Double featureValueOf(Interface actual) {
+      return actual.getDelay();
+    }
+  }
+
   static final class HasDescription extends FeatureMatcher<Interface, String> {
     HasDescription(@Nonnull Matcher<? super String> subMatcher) {
       super(subMatcher, "An Interface with description:", "description");

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_interface.g4
@@ -54,6 +54,11 @@ if_default_gw
    DEFAULT_GW IP_ADDRESS NEWLINE
 ;
 
+if_delay
+:
+   NO? DELAY DEC NEWLINE
+;
+
 if_description
 :
    description_line
@@ -1334,6 +1339,7 @@ if_inner
    | if_channel_group
    | if_crypto_map
    | if_default_gw
+   | if_delay
    | if_description
    | if_flow_sampler
    | if_hsrp

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -497,6 +497,7 @@ import org.batfish.grammar.cisco.CiscoParser.If_autostateContext;
 import org.batfish.grammar.cisco.CiscoParser.If_bandwidthContext;
 import org.batfish.grammar.cisco.CiscoParser.If_channel_groupContext;
 import org.batfish.grammar.cisco.CiscoParser.If_crypto_mapContext;
+import org.batfish.grammar.cisco.CiscoParser.If_delayContext;
 import org.batfish.grammar.cisco.CiscoParser.If_descriptionContext;
 import org.batfish.grammar.cisco.CiscoParser.If_ip_access_groupContext;
 import org.batfish.grammar.cisco.CiscoParser.If_ip_addressContext;
@@ -4969,6 +4970,17 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
     _currentInterfaces.forEach(i -> i.setCryptoMap(ctx.name.getText()));
   }
 
+  @Override
+  public void exitIf_delay(If_delayContext ctx) {
+    Double newDelayPs;
+    if (ctx.NO() != null) {
+      newDelayPs = null;
+    } else {
+      newDelayPs = toLong(ctx.DEC()) * 1E7;
+    }
+    _currentInterfaces.forEach(i -> i.setDelay(newDelayPs));
+  }
+
   private @Nullable String computeAggregatedInterfaceName(int num, ConfigurationFormat format) {
     switch (format) {
       case CISCO_ASA:
@@ -8280,8 +8292,10 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
             ? CiscoConfiguration.MANAGEMENT_VRF_NAME
             : Configuration.DEFAULT_VRF_NAME;
     double bandwidth = Interface.getDefaultBandwidth(canonicalNamePrefix, _format);
+    double delay = Interface.getDefaultDelay(canonicalNamePrefix, _format);
     int mtu = Interface.getDefaultMtu();
     iface.setBandwidth(bandwidth);
+    iface.setDelay(delay);
     iface.setVrf(vrf);
     initVrf(vrf);
     iface.setMtu(mtu);

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -2033,6 +2033,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
     newIface.setAutoState(iface.getAutoState());
     newIface.setVrf(c.getVrfs().get(vrfName));
     newIface.setBandwidth(iface.getBandwidth());
+    newIface.setDelay(iface.getDelay());
     if (iface.getDhcpRelayClient()) {
       newIface.getDhcpRelayAddresses().addAll(_dhcpRelayServers);
     } else {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/Interface.java
@@ -37,6 +37,8 @@ public class Interface extends ComparableStructure<String> {
   /** dirty hack: just chose a very large number */
   private static final double LOOPBACK_BANDWIDTH = 1E12;
 
+  private static final double LOOPBACK_DELAY = 5E9;
+
   /** NX-OS Ethernet 802.3z - may not apply for non-NX-OS */
   private static final double NXOS_ETHERNET_BANDWIDTH = 1E9;
 
@@ -105,6 +107,24 @@ public class Interface extends ComparableStructure<String> {
     return bandwidth;
   }
 
+  public static double getDefaultDelay(String name, ConfigurationFormat format) {
+    if (name.startsWith("Loopback")) {
+      return LOOPBACK_DELAY;
+    }
+    double bandwidth = getDefaultBandwidth(name, format);
+    if (bandwidth == 0D) {
+      return 0D;
+    }
+
+    /*
+     * This is not true for all cases, but it is true for all of the cases that are defined above.
+     * See https://tools.ietf.org/html/draft-savage-eigrp-00#section-5.5.1.2
+     *
+     * Delay is only relevant on routers that support EIGRP (Cisco).
+     */
+    return 1E13 / bandwidth;
+  }
+
   public static int getDefaultMtu() {
     return DEFAULT_INTERFACE_MTU;
   }
@@ -122,6 +142,8 @@ public class Interface extends ComparableStructure<String> {
   private String _channelGroup;
 
   private String _cryptoMap;
+
+  private Double _delay;
 
   private String _description;
 
@@ -278,6 +300,10 @@ public class Interface extends ComparableStructure<String> {
 
   public String getCryptoMap() {
     return _cryptoMap;
+  }
+
+  public Double getDelay() {
+    return _delay;
   }
 
   public String getDescription() {
@@ -445,6 +471,10 @@ public class Interface extends ComparableStructure<String> {
 
   public void setDescription(String description) {
     _description = description;
+  }
+
+  public void setDelay(Double delay) {
+    _delay = delay;
   }
 
   public void setDhcpRelayAddress(SortedSet<Ip> dhcpRelayAddress) {

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -44,6 +44,7 @@ import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasVendorFami
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasVrfs;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasAclName;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasBandwidth;
+import static org.batfish.datamodel.matchers.DataModelMatchers.hasDelay;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasIpProtocols;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasMemberInterfaces;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasName;
@@ -801,6 +802,16 @@ public class CiscoGrammarTest {
     assertThat(eth2Acl, rejects(deniedByBoth, eth1Name, c.getIpAccessLists(), c.getIpSpaces()));
     assertThat(eth3Acl, rejects(deniedByBoth, eth0Name, c.getIpAccessLists(), c.getIpSpaces()));
     assertThat(eth3Acl, rejects(deniedByBoth, eth1Name, c.getIpAccessLists(), c.getIpSpaces()));
+  }
+
+  @Test
+  public void testIosInterfaceDelay() throws IOException {
+    String hostname = "ios-interface-delay";
+    Configuration c = parseConfig(hostname);
+
+    assertThat(c, hasInterface("GigabitEthernet0/0", hasDelay(1E4)));
+    assertThat(c, hasInterface("GigabitEthernet0/1", hasDelay(1E10)));
+    assertThat(c, hasInterface("FastEthernet0/2", hasDelay(1E5)));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-interface-delay
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-interface-delay
@@ -1,0 +1,11 @@
+!
+hostname ios-interface-delay
+!
+interface GigabitEthernet0/0
+!
+interface GigabitEthernet0/1
+ delay 1000
+!
+interface FastEthernet0/2
+!
+!

--- a/test_rigs/unit-tests/configs/cisco_eigrp
+++ b/test_rigs/unit-tests/configs/cisco_eigrp
@@ -101,4 +101,6 @@ router eigrp 5
  no passive-interface GigabitEthernet2/5/3
  network 1.1.1.1
 !
+interface Ethernet0
+ delay 1000
 

--- a/tests/aws/nodes-example-aws.ref
+++ b/tests/aws/nodes-example-aws.ref
@@ -546,6 +546,7 @@
             "declaredNames" : [
               "Ethernet0/0"
             ],
+            "delay" : 1000000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -574,6 +575,7 @@
             "declaredNames" : [
               "Ethernet1/0"
             ],
+            "delay" : 1000000.0,
             "description" : "link to lhr-fw-01 e1/3",
             "mtu" : 1500,
             "nativeVlan" : 1,
@@ -606,6 +608,7 @@
             "declaredNames" : [
               "Ethernet1/1"
             ],
+            "delay" : 1000000.0,
             "description" : "link to lhr-fw-02 e1/3",
             "mtu" : 1500,
             "nativeVlan" : 1,
@@ -635,6 +638,7 @@
             "declaredNames" : [
               "Ethernet1/2"
             ],
+            "delay" : 1000000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -663,6 +667,7 @@
             "declaredNames" : [
               "Ethernet1/3"
             ],
+            "delay" : 1000000.0,
             "description" : "link to lix-peer-01 e1/1",
             "incomingFilter" : "LIMIT_PEER",
             "mtu" : 1500,
@@ -691,6 +696,7 @@
             "declaredNames" : [
               "Ethernet1/4"
             ],
+            "delay" : 1000000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -716,6 +722,7 @@
             "declaredNames" : [
               "Ethernet1/5"
             ],
+            "delay" : 1000000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -741,6 +748,7 @@
             "declaredNames" : [
               "Ethernet1/6"
             ],
+            "delay" : 1000000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -766,6 +774,7 @@
             "declaredNames" : [
               "Ethernet1/7"
             ],
+            "delay" : 1000000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -794,6 +803,7 @@
             "declaredNames" : [
               "GigabitEthernet0/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -823,6 +833,7 @@
             "declaredNames" : [
               "GigabitEthernet2/0"
             ],
+            "delay" : 10000.0,
             "description" : "Border Interface",
             "mtu" : 1500,
             "nativeVlan" : 1,
@@ -853,6 +864,7 @@
             "declaredNames" : [
               "Loopback0"
             ],
+            "delay" : 5.0E9,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 0,
@@ -884,6 +896,7 @@
             "declaredNames" : [
               "Tunnel1"
             ],
+            "delay" : 10.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -913,6 +926,7 @@
             "declaredNames" : [
               "Tunnel2"
             ],
+            "delay" : 10.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,

--- a/tests/basic/neighbors.ref
+++ b/tests/basic/neighbors.ref
@@ -2341,6 +2341,7 @@
           "declaredNames" : [
             "GigabitEthernet0/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -2372,6 +2373,7 @@
           "declaredNames" : [
             "GigabitEthernet1/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -2411,6 +2413,7 @@
           "declaredNames" : [
             "GigabitEthernet1/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfDeadInterval" : 0,
@@ -2440,6 +2443,7 @@
           "declaredNames" : [
             "GigabitEthernet0/0"
           ],
+          "delay" : 10000.0,
           "incomingFilter" : "OUTSIDE_TO_INSIDE",
           "mtu" : 1500,
           "nativeVlan" : 1,
@@ -2479,6 +2483,7 @@
           "declaredNames" : [
             "GigabitEthernet0/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfDeadInterval" : 0,
@@ -2508,6 +2513,7 @@
           "declaredNames" : [
             "GigabitEthernet0/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfDeadInterval" : 0,
@@ -2545,6 +2551,7 @@
           "declaredNames" : [
             "GigabitEthernet1/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -2576,6 +2583,7 @@
           "declaredNames" : [
             "GigabitEthernet0/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -2615,6 +2623,7 @@
           "declaredNames" : [
             "GigabitEthernet0/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -2646,6 +2655,7 @@
           "declaredNames" : [
             "GigabitEthernet1/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -2685,6 +2695,7 @@
           "declaredNames" : [
             "GigabitEthernet1/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -2716,6 +2727,7 @@
           "declaredNames" : [
             "GigabitEthernet0/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -2755,6 +2767,7 @@
           "declaredNames" : [
             "GigabitEthernet0/0"
           ],
+          "delay" : 10000.0,
           "incomingFilter" : "OUTSIDE_TO_INSIDE",
           "mtu" : 1500,
           "nativeVlan" : 1,
@@ -2786,6 +2799,7 @@
           "declaredNames" : [
             "GigabitEthernet1/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfDeadInterval" : 0,
@@ -2823,6 +2837,7 @@
           "declaredNames" : [
             "GigabitEthernet1/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -2854,6 +2869,7 @@
           "declaredNames" : [
             "GigabitEthernet0/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -2893,6 +2909,7 @@
           "declaredNames" : [
             "GigabitEthernet2/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -2924,6 +2941,7 @@
           "declaredNames" : [
             "GigabitEthernet1/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1600,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -2963,6 +2981,7 @@
           "declaredNames" : [
             "GigabitEthernet0/0"
           ],
+          "delay" : 10000.0,
           "incomingFilter" : "OUTSIDE_TO_INSIDE",
           "mtu" : 1500,
           "nativeVlan" : 1,
@@ -2994,6 +3013,7 @@
           "declaredNames" : [
             "GigabitEthernet1/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfDeadInterval" : 0,
@@ -3031,6 +3051,7 @@
           "declaredNames" : [
             "GigabitEthernet1/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -3062,6 +3083,7 @@
           "declaredNames" : [
             "GigabitEthernet0/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1800,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -3101,6 +3123,7 @@
           "declaredNames" : [
             "GigabitEthernet2/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -3132,6 +3155,7 @@
           "declaredNames" : [
             "GigabitEthernet1/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -3171,6 +3195,7 @@
           "declaredNames" : [
             "GigabitEthernet0/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -3202,6 +3227,7 @@
           "declaredNames" : [
             "GigabitEthernet1/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -3241,6 +3267,7 @@
           "declaredNames" : [
             "GigabitEthernet1/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -3272,6 +3299,7 @@
           "declaredNames" : [
             "GigabitEthernet2/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -3311,6 +3339,7 @@
           "declaredNames" : [
             "GigabitEthernet2/0"
           ],
+          "delay" : 10000.0,
           "incomingFilter" : "blocktelnet",
           "mtu" : 1500,
           "nativeVlan" : 1,
@@ -3343,6 +3372,7 @@
           "declaredNames" : [
             "GigabitEthernet0/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -3382,6 +3412,7 @@
           "declaredNames" : [
             "GigabitEthernet3/0"
           ],
+          "delay" : 10000.0,
           "incomingFilter" : "blocktelnet",
           "mtu" : 1500,
           "nativeVlan" : 1,
@@ -3414,6 +3445,7 @@
           "declaredNames" : [
             "GigabitEthernet1/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -3453,6 +3485,7 @@
           "declaredNames" : [
             "GigabitEthernet0/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1800,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -3484,6 +3517,7 @@
           "declaredNames" : [
             "GigabitEthernet1/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -3523,6 +3557,7 @@
           "declaredNames" : [
             "GigabitEthernet1/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1600,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -3554,6 +3589,7 @@
           "declaredNames" : [
             "GigabitEthernet2/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -3593,6 +3629,7 @@
           "declaredNames" : [
             "GigabitEthernet2/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1700,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -3624,6 +3661,7 @@
           "declaredNames" : [
             "GigabitEthernet0/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -3663,6 +3701,7 @@
           "declaredNames" : [
             "GigabitEthernet3/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -3694,6 +3733,7 @@
           "declaredNames" : [
             "GigabitEthernet1/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -3733,6 +3773,7 @@
           "declaredNames" : [
             "GigabitEthernet0/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfDeadInterval" : 0,
@@ -3762,6 +3803,7 @@
           "declaredNames" : [
             "GigabitEthernet2/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfDeadInterval" : 0,
@@ -3799,6 +3841,7 @@
           "declaredNames" : [
             "GigabitEthernet1/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfDeadInterval" : 0,
@@ -3828,6 +3871,7 @@
           "declaredNames" : [
             "GigabitEthernet2/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfDeadInterval" : 0,
@@ -3865,6 +3909,7 @@
           "declaredNames" : [
             "GigabitEthernet2/0"
           ],
+          "delay" : 10000.0,
           "incomingFilter" : "RESTRICT_HOST_TRAFFIC_IN",
           "mtu" : 1500,
           "nativeVlan" : 1,
@@ -3934,6 +3979,7 @@
           "declaredNames" : [
             "GigabitEthernet3/0"
           ],
+          "delay" : 10000.0,
           "incomingFilter" : "RESTRICT_HOST_TRAFFIC_IN",
           "mtu" : 1500,
           "nativeVlan" : 1,
@@ -4003,6 +4049,7 @@
           "declaredNames" : [
             "GigabitEthernet0/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -4034,6 +4081,7 @@
           "declaredNames" : [
             "GigabitEthernet2/0"
           ],
+          "delay" : 10000.0,
           "incomingFilter" : "blocktelnet",
           "mtu" : 1500,
           "nativeVlan" : 1,
@@ -4074,6 +4122,7 @@
           "declaredNames" : [
             "GigabitEthernet1/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -4105,6 +4154,7 @@
           "declaredNames" : [
             "GigabitEthernet3/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -4144,6 +4194,7 @@
           "declaredNames" : [
             "GigabitEthernet2/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfDeadInterval" : 0,
@@ -4173,6 +4224,7 @@
           "declaredNames" : [
             "GigabitEthernet0/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfDeadInterval" : 0,
@@ -4210,6 +4262,7 @@
           "declaredNames" : [
             "GigabitEthernet0/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -4241,6 +4294,7 @@
           "declaredNames" : [
             "GigabitEthernet2/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1700,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -4280,6 +4334,7 @@
           "declaredNames" : [
             "GigabitEthernet1/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -4311,6 +4366,7 @@
           "declaredNames" : [
             "GigabitEthernet3/0"
           ],
+          "delay" : 10000.0,
           "incomingFilter" : "blocktelnet",
           "mtu" : 1500,
           "nativeVlan" : 1,
@@ -4351,6 +4407,7 @@
           "declaredNames" : [
             "GigabitEthernet2/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfDeadInterval" : 0,
@@ -4380,6 +4437,7 @@
           "declaredNames" : [
             "GigabitEthernet1/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfDeadInterval" : 0,
@@ -4417,6 +4475,7 @@
           "declaredNames" : [
             "GigabitEthernet0/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -4448,6 +4507,7 @@
           "declaredNames" : [
             "GigabitEthernet1/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -4487,6 +4547,7 @@
           "declaredNames" : [
             "GigabitEthernet1/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfDeadInterval" : 0,
@@ -4516,6 +4577,7 @@
           "declaredNames" : [
             "GigabitEthernet0/0"
           ],
+          "delay" : 10000.0,
           "incomingFilter" : "OUTSIDE_TO_INSIDE",
           "mtu" : 1500,
           "nativeVlan" : 1,
@@ -4555,6 +4617,7 @@
           "declaredNames" : [
             "GigabitEthernet0/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfDeadInterval" : 0,
@@ -4584,6 +4647,7 @@
           "declaredNames" : [
             "GigabitEthernet0/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfDeadInterval" : 0,
@@ -4621,6 +4685,7 @@
           "declaredNames" : [
             "GigabitEthernet1/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -4652,6 +4717,7 @@
           "declaredNames" : [
             "GigabitEthernet0/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -4691,6 +4757,7 @@
           "declaredNames" : [
             "GigabitEthernet0/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -4722,6 +4789,7 @@
           "declaredNames" : [
             "GigabitEthernet1/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -4761,6 +4829,7 @@
           "declaredNames" : [
             "GigabitEthernet1/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -4792,6 +4861,7 @@
           "declaredNames" : [
             "GigabitEthernet0/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -4831,6 +4901,7 @@
           "declaredNames" : [
             "GigabitEthernet2/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfDeadInterval" : 0,
@@ -4860,6 +4931,7 @@
           "declaredNames" : [
             "GigabitEthernet3/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfDeadInterval" : 0,
@@ -4897,6 +4969,7 @@
           "declaredNames" : [
             "GigabitEthernet3/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfDeadInterval" : 0,
@@ -4926,6 +4999,7 @@
           "declaredNames" : [
             "GigabitEthernet2/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfDeadInterval" : 0,
@@ -4994,6 +5068,7 @@
           "declaredNames" : [
             "GigabitEthernet2/0"
           ],
+          "delay" : 10000.0,
           "incomingFilter" : "RESTRICT_HOST_TRAFFIC_IN",
           "mtu" : 1500,
           "nativeVlan" : 1,
@@ -5063,6 +5138,7 @@
           "declaredNames" : [
             "GigabitEthernet3/0"
           ],
+          "delay" : 10000.0,
           "incomingFilter" : "RESTRICT_HOST_TRAFFIC_IN",
           "mtu" : 1500,
           "nativeVlan" : 1,
@@ -5109,6 +5185,7 @@
             "declaredNames" : [
               "GigabitEthernet0/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -5148,6 +5225,7 @@
             "declaredNames" : [
               "GigabitEthernet1/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -5195,6 +5273,7 @@
             "declaredNames" : [
               "GigabitEthernet1/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -5234,6 +5313,7 @@
             "declaredNames" : [
               "GigabitEthernet0/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -5281,6 +5361,7 @@
             "declaredNames" : [
               "GigabitEthernet1/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -5320,6 +5401,7 @@
             "declaredNames" : [
               "GigabitEthernet0/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -5367,6 +5449,7 @@
             "declaredNames" : [
               "GigabitEthernet0/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -5406,6 +5489,7 @@
             "declaredNames" : [
               "GigabitEthernet1/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -5453,6 +5537,7 @@
             "declaredNames" : [
               "GigabitEthernet1/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -5492,6 +5577,7 @@
             "declaredNames" : [
               "GigabitEthernet0/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -5539,6 +5625,7 @@
             "declaredNames" : [
               "GigabitEthernet2/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -5578,6 +5665,7 @@
             "declaredNames" : [
               "GigabitEthernet1/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1600,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -5625,6 +5713,7 @@
             "declaredNames" : [
               "GigabitEthernet2/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -5664,6 +5753,7 @@
             "declaredNames" : [
               "GigabitEthernet1/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -5711,6 +5801,7 @@
             "declaredNames" : [
               "GigabitEthernet1/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -5750,6 +5841,7 @@
             "declaredNames" : [
               "GigabitEthernet0/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1800,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -5797,6 +5889,7 @@
             "declaredNames" : [
               "GigabitEthernet0/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -5836,6 +5929,7 @@
             "declaredNames" : [
               "GigabitEthernet1/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -5883,6 +5977,7 @@
             "declaredNames" : [
               "GigabitEthernet1/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -5922,6 +6017,7 @@
             "declaredNames" : [
               "GigabitEthernet2/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -5969,6 +6065,7 @@
             "declaredNames" : [
               "GigabitEthernet2/0"
             ],
+            "delay" : 10000.0,
             "incomingFilter" : "blocktelnet",
             "mtu" : 1500,
             "nativeVlan" : 1,
@@ -6009,6 +6106,7 @@
             "declaredNames" : [
               "GigabitEthernet0/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -6056,6 +6154,7 @@
             "declaredNames" : [
               "GigabitEthernet3/0"
             ],
+            "delay" : 10000.0,
             "incomingFilter" : "blocktelnet",
             "mtu" : 1500,
             "nativeVlan" : 1,
@@ -6096,6 +6195,7 @@
             "declaredNames" : [
               "GigabitEthernet1/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -6143,6 +6243,7 @@
             "declaredNames" : [
               "GigabitEthernet1/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1600,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -6182,6 +6283,7 @@
             "declaredNames" : [
               "GigabitEthernet2/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -6229,6 +6331,7 @@
             "declaredNames" : [
               "GigabitEthernet0/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1800,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -6268,6 +6371,7 @@
             "declaredNames" : [
               "GigabitEthernet1/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -6315,6 +6419,7 @@
             "declaredNames" : [
               "GigabitEthernet3/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -6354,6 +6459,7 @@
             "declaredNames" : [
               "GigabitEthernet1/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -6401,6 +6507,7 @@
             "declaredNames" : [
               "GigabitEthernet2/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1700,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -6440,6 +6547,7 @@
             "declaredNames" : [
               "GigabitEthernet0/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -6487,6 +6595,7 @@
             "declaredNames" : [
               "GigabitEthernet0/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -6526,6 +6635,7 @@
             "declaredNames" : [
               "GigabitEthernet2/0"
             ],
+            "delay" : 10000.0,
             "incomingFilter" : "blocktelnet",
             "mtu" : 1500,
             "nativeVlan" : 1,
@@ -6574,6 +6684,7 @@
             "declaredNames" : [
               "GigabitEthernet1/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -6613,6 +6724,7 @@
             "declaredNames" : [
               "GigabitEthernet3/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -6660,6 +6772,7 @@
             "declaredNames" : [
               "GigabitEthernet1/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -6699,6 +6812,7 @@
             "declaredNames" : [
               "GigabitEthernet3/0"
             ],
+            "delay" : 10000.0,
             "incomingFilter" : "blocktelnet",
             "mtu" : 1500,
             "nativeVlan" : 1,
@@ -6747,6 +6861,7 @@
             "declaredNames" : [
               "GigabitEthernet0/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -6786,6 +6901,7 @@
             "declaredNames" : [
               "GigabitEthernet2/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1700,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -6833,6 +6949,7 @@
             "declaredNames" : [
               "GigabitEthernet0/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -6872,6 +6989,7 @@
             "declaredNames" : [
               "GigabitEthernet1/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -6919,6 +7037,7 @@
             "declaredNames" : [
               "GigabitEthernet1/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -6958,6 +7077,7 @@
             "declaredNames" : [
               "GigabitEthernet0/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -7005,6 +7125,7 @@
             "declaredNames" : [
               "GigabitEthernet1/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -7044,6 +7165,7 @@
             "declaredNames" : [
               "GigabitEthernet0/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -7091,6 +7213,7 @@
             "declaredNames" : [
               "GigabitEthernet0/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -7130,6 +7253,7 @@
             "declaredNames" : [
               "GigabitEthernet1/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,

--- a/tests/basic/nodes.ref
+++ b/tests/basic/nodes.ref
@@ -51,6 +51,7 @@
             "declaredNames" : [
               "Ethernet0/0"
             ],
+            "delay" : 1000000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -79,6 +80,7 @@
             "declaredNames" : [
               "GigabitEthernet0/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -110,6 +112,7 @@
             "declaredNames" : [
               "GigabitEthernet1/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -139,6 +142,7 @@
             "declaredNames" : [
               "Loopback0"
             ],
+            "delay" : 5.0E9,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -1289,6 +1293,7 @@
             "declaredNames" : [
               "Ethernet0/0"
             ],
+            "delay" : 1000000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -1317,6 +1322,7 @@
             "declaredNames" : [
               "GigabitEthernet0/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -1346,6 +1352,7 @@
             "declaredNames" : [
               "GigabitEthernet1/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -1377,6 +1384,7 @@
             "declaredNames" : [
               "GigabitEthernet2/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -1406,6 +1414,7 @@
             "declaredNames" : [
               "Loopback0"
             ],
+            "delay" : 5.0E9,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -2514,6 +2523,7 @@
             "declaredNames" : [
               "Ethernet0/0"
             ],
+            "delay" : 1000000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -2542,6 +2552,7 @@
             "declaredNames" : [
               "GigabitEthernet0/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -2573,6 +2584,7 @@
             "declaredNames" : [
               "GigabitEthernet1/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -2604,6 +2616,7 @@
             "declaredNames" : [
               "Loopback0"
             ],
+            "delay" : 5.0E9,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -2941,6 +2954,7 @@
             "declaredNames" : [
               "Ethernet0/0"
             ],
+            "delay" : 1000000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -2969,6 +2983,7 @@
             "declaredNames" : [
               "GigabitEthernet0/0"
             ],
+            "delay" : 10000.0,
             "incomingFilter" : "OUTSIDE_TO_INSIDE",
             "mtu" : 1500,
             "nativeVlan" : 1,
@@ -3000,6 +3015,7 @@
             "declaredNames" : [
               "GigabitEthernet1/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -3031,6 +3047,7 @@
             "declaredNames" : [
               "GigabitEthernet2/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -3062,6 +3079,7 @@
             "declaredNames" : [
               "Loopback0"
             ],
+            "delay" : 5.0E9,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -4240,6 +4258,7 @@
             "declaredNames" : [
               "Ethernet0/0"
             ],
+            "delay" : 1000000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -4268,6 +4287,7 @@
             "declaredNames" : [
               "GigabitEthernet0/0"
             ],
+            "delay" : 10000.0,
             "incomingFilter" : "OUTSIDE_TO_INSIDE",
             "mtu" : 1500,
             "nativeVlan" : 1,
@@ -4299,6 +4319,7 @@
             "declaredNames" : [
               "GigabitEthernet1/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -4330,6 +4351,7 @@
             "declaredNames" : [
               "GigabitEthernet2/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -4361,6 +4383,7 @@
             "declaredNames" : [
               "Loopback0"
             ],
+            "delay" : 5.0E9,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -5450,6 +5473,7 @@
             "declaredNames" : [
               "Ethernet0/0"
             ],
+            "delay" : 1000000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -5478,6 +5502,7 @@
             "declaredNames" : [
               "GigabitEthernet0/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -5509,6 +5534,7 @@
             "declaredNames" : [
               "GigabitEthernet1/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -5540,6 +5566,7 @@
             "declaredNames" : [
               "GigabitEthernet2/0"
             ],
+            "delay" : 10000.0,
             "incomingFilter" : "blocktelnet",
             "mtu" : 1500,
             "nativeVlan" : 1,
@@ -5572,6 +5599,7 @@
             "declaredNames" : [
               "GigabitEthernet3/0"
             ],
+            "delay" : 10000.0,
             "incomingFilter" : "blocktelnet",
             "mtu" : 1500,
             "nativeVlan" : 1,
@@ -5604,6 +5632,7 @@
             "declaredNames" : [
               "Loopback0"
             ],
+            "delay" : 5.0E9,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -6056,6 +6085,7 @@
             "declaredNames" : [
               "Ethernet0/0"
             ],
+            "delay" : 1000000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -6084,6 +6114,7 @@
             "declaredNames" : [
               "GigabitEthernet0/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1800,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -6115,6 +6146,7 @@
             "declaredNames" : [
               "GigabitEthernet1/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1600,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -6146,6 +6178,7 @@
             "declaredNames" : [
               "GigabitEthernet2/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1700,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -6177,6 +6210,7 @@
             "declaredNames" : [
               "GigabitEthernet3/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -6208,6 +6242,7 @@
             "declaredNames" : [
               "Loopback0"
             ],
+            "delay" : 5.0E9,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -6623,6 +6658,7 @@
             "declaredNames" : [
               "Ethernet0/0"
             ],
+            "delay" : 1000000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -6651,6 +6687,7 @@
             "declaredNames" : [
               "GigabitEthernet0/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -6680,6 +6717,7 @@
             "declaredNames" : [
               "GigabitEthernet1/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -6709,6 +6747,7 @@
             "declaredNames" : [
               "GigabitEthernet2/0"
             ],
+            "delay" : 10000.0,
             "incomingFilter" : "RESTRICT_HOST_TRAFFIC_IN",
             "mtu" : 1500,
             "nativeVlan" : 1,
@@ -6739,6 +6778,7 @@
             "declaredNames" : [
               "GigabitEthernet3/0"
             ],
+            "delay" : 10000.0,
             "incomingFilter" : "RESTRICT_HOST_TRAFFIC_IN",
             "mtu" : 1500,
             "nativeVlan" : 1,
@@ -6769,6 +6809,7 @@
             "declaredNames" : [
               "Loopback0"
             ],
+            "delay" : 5.0E9,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -7575,6 +7616,7 @@
             "declaredNames" : [
               "Ethernet0/0"
             ],
+            "delay" : 1000000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -7603,6 +7645,7 @@
             "declaredNames" : [
               "GigabitEthernet0/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -7634,6 +7677,7 @@
             "declaredNames" : [
               "GigabitEthernet1/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -7665,6 +7709,7 @@
             "declaredNames" : [
               "GigabitEthernet2/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -7694,6 +7739,7 @@
             "declaredNames" : [
               "Loopback0"
             ],
+            "delay" : 5.0E9,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -8331,6 +8377,7 @@
             "declaredNames" : [
               "Ethernet0/0"
             ],
+            "delay" : 1000000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -8359,6 +8406,7 @@
             "declaredNames" : [
               "GigabitEthernet0/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -8390,6 +8438,7 @@
             "declaredNames" : [
               "GigabitEthernet1/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -8421,6 +8470,7 @@
             "declaredNames" : [
               "GigabitEthernet2/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -8450,6 +8500,7 @@
             "declaredNames" : [
               "Loopback0"
             ],
+            "delay" : 5.0E9,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -9107,6 +9158,7 @@
             "declaredNames" : [
               "Ethernet0/0"
             ],
+            "delay" : 1000000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -9135,6 +9187,7 @@
             "declaredNames" : [
               "GigabitEthernet0/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -9166,6 +9219,7 @@
             "declaredNames" : [
               "GigabitEthernet1/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -9195,6 +9249,7 @@
             "declaredNames" : [
               "Loopback0"
             ],
+            "delay" : 5.0E9,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -10257,6 +10312,7 @@
             "declaredNames" : [
               "Ethernet0/0"
             ],
+            "delay" : 1000000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -10285,6 +10341,7 @@
             "declaredNames" : [
               "GigabitEthernet0/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -10314,6 +10371,7 @@
             "declaredNames" : [
               "GigabitEthernet1/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -10345,6 +10403,7 @@
             "declaredNames" : [
               "Loopback0"
             ],
+            "delay" : 5.0E9,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -11318,6 +11377,7 @@
             "declaredNames" : [
               "Ethernet0/0"
             ],
+            "delay" : 1000000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -11346,6 +11406,7 @@
             "declaredNames" : [
               "GigabitEthernet0/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -11377,6 +11438,7 @@
             "declaredNames" : [
               "GigabitEthernet1/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,
@@ -11408,6 +11470,7 @@
             "declaredNames" : [
               "GigabitEthernet2/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -11437,6 +11500,7 @@
             "declaredNames" : [
               "GigabitEthernet3/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -11466,6 +11530,7 @@
             "declaredNames" : [
               "Loopback0"
             ],
+            "delay" : 5.0E9,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 1,

--- a/tests/basic/outliers-verbose.ref
+++ b/tests/basic/outliers-verbose.ref
@@ -29,6 +29,7 @@
           "declaredNames" : [
             "Ethernet0/0"
           ],
+          "delay" : 1000000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfDeadInterval" : 0,
@@ -2119,6 +2120,7 @@
           "declaredNames" : [
             "GigabitEthernet3/0"
           ],
+          "delay" : 10000.0,
           "incomingFilter" : "blocktelnet",
           "mtu" : 1500,
           "nativeVlan" : 1,
@@ -2169,6 +2171,7 @@
           "declaredNames" : [
             "GigabitEthernet2/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfDeadInterval" : 0,
@@ -2220,6 +2223,7 @@
           "declaredNames" : [
             "GigabitEthernet0/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -2273,6 +2277,7 @@
           "declaredNames" : [
             "GigabitEthernet1/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfDeadInterval" : 0,
@@ -2324,6 +2329,7 @@
           "declaredNames" : [
             "Loopback0"
           ],
+          "delay" : 5.0E9,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,

--- a/tests/basic/outliers2.ref
+++ b/tests/basic/outliers2.ref
@@ -33,6 +33,7 @@
           "declaredNames" : [
             "Ethernet0/0"
           ],
+          "delay" : 1000000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfDeadInterval" : 0,
@@ -85,6 +86,7 @@
           "declaredNames" : [
             "GigabitEthernet0/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,
@@ -140,6 +142,7 @@
           "declaredNames" : [
             "GigabitEthernet1/0"
           ],
+          "delay" : 10000.0,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfDeadInterval" : 0,
@@ -193,6 +196,7 @@
           "declaredNames" : [
             "Loopback0"
           ],
+          "delay" : 5.0E9,
           "mtu" : 1500,
           "nativeVlan" : 1,
           "ospfArea" : 1,

--- a/tests/jsonpath-addons/jsonpath-display-hints-prefixofsuffix.ref
+++ b/tests/jsonpath-addons/jsonpath-display-hints-prefixofsuffix.ref
@@ -70,6 +70,7 @@
                   "declaredNames" : [
                     "Ethernet0/0"
                   ],
+                  "delay" : 1000000.0,
                   "mtu" : 1500,
                   "nativeVlan" : 1,
                   "ospfDeadInterval" : 0,
@@ -98,6 +99,7 @@
                   "declaredNames" : [
                     "GigabitEthernet0/0"
                   ],
+                  "delay" : 10000.0,
                   "incomingFilter" : "OUTSIDE_TO_INSIDE",
                   "mtu" : 1500,
                   "nativeVlan" : 1,
@@ -129,6 +131,7 @@
                   "declaredNames" : [
                     "GigabitEthernet1/0"
                   ],
+                  "delay" : 10000.0,
                   "mtu" : 1500,
                   "nativeVlan" : 1,
                   "ospfArea" : 1,
@@ -160,6 +163,7 @@
                   "declaredNames" : [
                     "GigabitEthernet2/0"
                   ],
+                  "delay" : 10000.0,
                   "mtu" : 1500,
                   "nativeVlan" : 1,
                   "ospfArea" : 1,
@@ -191,6 +195,7 @@
                   "declaredNames" : [
                     "Loopback0"
                   ],
+                  "delay" : 5.0E9,
                   "mtu" : 1500,
                   "nativeVlan" : 1,
                   "ospfArea" : 1,

--- a/tests/jsonpath-addons/jsonpath-display-hints-suffixofsuffix.ref
+++ b/tests/jsonpath-addons/jsonpath-display-hints-suffixofsuffix.ref
@@ -70,6 +70,7 @@
                   "declaredNames" : [
                     "Ethernet0/0"
                   ],
+                  "delay" : 1000000.0,
                   "mtu" : 1500,
                   "nativeVlan" : 1,
                   "ospfDeadInterval" : 0,
@@ -98,6 +99,7 @@
                   "declaredNames" : [
                     "GigabitEthernet0/0"
                   ],
+                  "delay" : 10000.0,
                   "incomingFilter" : "OUTSIDE_TO_INSIDE",
                   "mtu" : 1500,
                   "nativeVlan" : 1,
@@ -129,6 +131,7 @@
                   "declaredNames" : [
                     "GigabitEthernet1/0"
                   ],
+                  "delay" : 10000.0,
                   "mtu" : 1500,
                   "nativeVlan" : 1,
                   "ospfArea" : 1,
@@ -160,6 +163,7 @@
                   "declaredNames" : [
                     "GigabitEthernet2/0"
                   ],
+                  "delay" : 10000.0,
                   "mtu" : 1500,
                   "nativeVlan" : 1,
                   "ospfArea" : 1,
@@ -191,6 +195,7 @@
                   "declaredNames" : [
                     "Loopback0"
                   ],
+                  "delay" : 5.0E9,
                   "mtu" : 1500,
                   "nativeVlan" : 1,
                   "ospfArea" : 1,

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -802,6 +802,7 @@
             "declaredNames" : [
               "Ethernet0"
             ],
+            "delay" : 1000000.0,
             "dhcpRelayAddresses" : [
               "1.2.3.4",
               "2.3.4.5"
@@ -831,6 +832,7 @@
             "declaredNames" : [
               "Ethernet1"
             ],
+            "delay" : 1000000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -886,6 +888,7 @@
             "declaredNames" : [
               "Vlan1"
             ],
+            "delay" : 10.0,
             "dhcpRelayAddresses" : [
               "5.5.5.5"
             ],
@@ -1294,6 +1297,7 @@
             "declaredNames" : [
               "gigabitethernet0/0/0"
             ],
+            "delay" : 10000.0,
             "description" : "\"blah\"",
             "dhcpRelayAddresses" : [
               "2.3.4.5"
@@ -1730,6 +1734,7 @@
             "declaredNames" : [
               "Ethernet0/0"
             ],
+            "delay" : 1000000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfArea" : 0,
@@ -3467,6 +3472,7 @@
             "declaredNames" : [
               "ethernet6/0.0"
             ],
+            "delay" : 1000000.0,
             "description" : "\"squeee\"",
             "mtu" : 1500,
             "nativeVlan" : 1,
@@ -3497,6 +3503,7 @@
             "declaredNames" : [
               "ethernet6/0.48"
             ],
+            "delay" : 1000000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -3523,6 +3530,7 @@
             "declaredNames" : [
               "ethernet6/1"
             ],
+            "delay" : 1000000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -3548,6 +3556,7 @@
             "declaredNames" : [
               "cable-downstream1/2"
             ],
+            "delay" : 10.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -3573,6 +3582,7 @@
             "declaredNames" : [
               "cable-downstream1/2/3"
             ],
+            "delay" : 10.0,
             "description" : "\"blah\"",
             "mtu" : 1500,
             "nativeVlan" : 1,
@@ -3599,6 +3609,7 @@
             "declaredNames" : [
               "cable-downstream5/0/0"
             ],
+            "delay" : 10.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -3624,6 +3635,7 @@
             "declaredNames" : [
               "cable-mac1"
             ],
+            "delay" : 10.0,
             "description" : "\"cable-mac 1\"",
             "mtu" : 1500,
             "nativeVlan" : 1,
@@ -3653,6 +3665,7 @@
             "declaredNames" : [
               "cable-mac1.1"
             ],
+            "delay" : 10.0,
             "description" : "\"foobar\"",
             "mtu" : 1500,
             "nativeVlan" : 1,
@@ -3686,6 +3699,7 @@
             "declaredNames" : [
               "cable-mac1.2"
             ],
+            "delay" : 10.0,
             "description" : "\"bleep\"",
             "mtu" : 1500,
             "nativeVlan" : 1,
@@ -3713,6 +3727,7 @@
             "declaredNames" : [
               "cable-mac2"
             ],
+            "delay" : 10.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -3738,6 +3753,7 @@
             "declaredNames" : [
               "cable-mac3"
             ],
+            "delay" : 10.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -3763,6 +3779,7 @@
             "declaredNames" : [
               "cable-upstream1/0/0"
             ],
+            "delay" : 10.0,
             "description" : "\"bleh\"",
             "mtu" : 1500,
             "nativeVlan" : 1,
@@ -3789,6 +3806,7 @@
             "declaredNames" : [
               "cable-upstream1/0/0.0"
             ],
+            "delay" : 10.0,
             "description" : "\"blarp\"",
             "mtu" : 1500,
             "nativeVlan" : 1,
@@ -3815,6 +3833,7 @@
             "declaredNames" : [
               "cable-upstream1/0/10"
             ],
+            "delay" : 10.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -3840,6 +3859,7 @@
             "declaredNames" : [
               "mgmt6/0"
             ],
+            "delay" : 10.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -5655,6 +5675,7 @@
             "declaredNames" : [
               "Cable1/2/3"
             ],
+            "delay" : 10.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -6119,6 +6140,34 @@
         "defaultCrossZoneAction" : "ACCEPT",
         "defaultInboundAction" : "ACCEPT",
         "deviceType" : "SWITCH",
+        "interfaces" : {
+          "Ethernet0" : {
+            "name" : "Ethernet0",
+            "accessVlan" : 0,
+            "active" : true,
+            "autostate" : true,
+            "bandwidth" : 1.0E7,
+            "declaredNames" : [
+              "Ethernet0"
+            ],
+            "delay" : 1.0E10,
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
         "ipAccessLists" : {
           "bippety" : {
             "name" : "bippety",
@@ -6285,7 +6334,10 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default"
+            "name" : "default",
+            "interfaces" : [
+              "Ethernet0"
+            ]
           }
         }
       },
@@ -6326,6 +6378,7 @@
             "declaredNames" : [
               "GigabitEthernet0/1"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -6396,6 +6449,7 @@
             "declaredNames" : [
               "TenGigE0/0/2/2"
             ],
+            "delay" : 1000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -6446,6 +6500,7 @@
             "declaredNames" : [
               "Async1"
             ],
+            "delay" : 10.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -6471,6 +6526,7 @@
             "declaredNames" : [
               "Cable1/2/3:4"
             ],
+            "delay" : 10.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -6496,6 +6552,7 @@
             "declaredNames" : [
               "Crypto-Engine1/2/3"
             ],
+            "delay" : 10.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -6521,6 +6578,7 @@
             "declaredNames" : [
               "Dot11Radio0"
             ],
+            "delay" : 10.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -6550,6 +6608,7 @@
             "declaredNames" : [
               "Ethernet0"
             ],
+            "delay" : 1.0E7,
             "description" : "description-goes-here",
             "dhcpRelayAddresses" : [
               "1.2.3.4",
@@ -6585,6 +6644,7 @@
             "declaredNames" : [
               "ethernet1/11"
             ],
+            "delay" : 1000000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -6610,6 +6670,7 @@
             "declaredNames" : [
               "ethernet1/12"
             ],
+            "delay" : 1000000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -6638,6 +6699,7 @@
             "declaredNames" : [
               "GigabitEthernet0/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfCost" : 60,
@@ -6665,6 +6727,7 @@
             "declaredNames" : [
               "Loopback0"
             ],
+            "delay" : 5.0E9,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -6690,6 +6753,7 @@
             "declaredNames" : [
               "Modular-Cable1/2/3:4"
             ],
+            "delay" : 10.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -6715,6 +6779,7 @@
             "declaredNames" : [
               "Null0"
             ],
+            "delay" : 10.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -6740,6 +6805,7 @@
             "declaredNames" : [
               "vlan1"
             ],
+            "delay" : 10.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -6765,6 +6831,7 @@
             "declaredNames" : [
               "vlan1005"
             ],
+            "delay" : 10.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -6790,6 +6857,7 @@
             "declaredNames" : [
               "vlan1006"
             ],
+            "delay" : 10.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -6815,6 +6883,7 @@
             "declaredNames" : [
               "Vlan111"
             ],
+            "delay" : 10.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -6840,6 +6909,7 @@
             "declaredNames" : [
               "vlan1234"
             ],
+            "delay" : 10.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -6865,6 +6935,7 @@
             "declaredNames" : [
               "vlan2"
             ],
+            "delay" : 10.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -6890,6 +6961,7 @@
             "declaredNames" : [
               "vlan3"
             ],
+            "delay" : 10.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -6915,6 +6987,7 @@
             "declaredNames" : [
               "vlan4094"
             ],
+            "delay" : 10.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -6940,6 +7013,7 @@
             "declaredNames" : [
               "Vxlan1"
             ],
+            "delay" : 10.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -6965,6 +7039,7 @@
             "declaredNames" : [
               "Wideband-Cable1/2/3:4"
             ],
+            "delay" : 10.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -6990,6 +7065,7 @@
             "declaredNames" : [
               "tunnel-ip6"
             ],
+            "delay" : 10.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -7563,6 +7639,7 @@
             "declaredNames" : [
               "GigabitEthernet0/0"
             ],
+            "delay" : 10000.0,
             "isis" : {
               "level1" : {
                 "mode" : "passive"
@@ -7600,6 +7677,7 @@
             "declaredNames" : [
               "GigabitEthernet0/0/1"
             ],
+            "delay" : 10000.0,
             "isis" : {
               "level1" : {
                 "cost" : 15,
@@ -7637,6 +7715,7 @@
             "declaredNames" : [
               "GigabitEthernet0/1"
             ],
+            "delay" : 10000.0,
             "isis" : {
               "level1" : {
                 "mode" : "active"
@@ -7671,6 +7750,7 @@
             "declaredNames" : [
               "HundredGigE0/0/0/0.2302"
             ],
+            "delay" : 10.0,
             "isis" : {
               "level1" : {
                 "mode" : "active"
@@ -7705,6 +7785,7 @@
             "declaredNames" : [
               "Loopback0"
             ],
+            "delay" : 5.0E9,
             "isis" : {
               "level1" : {
                 "mode" : "passive"
@@ -7739,6 +7820,7 @@
             "declaredNames" : [
               "Serial4/0"
             ],
+            "delay" : 10.0,
             "isis" : {
               "level1" : {
                 "mode" : "active"
@@ -8896,6 +8978,7 @@
             "declaredNames" : [
               "ethernet0/0"
             ],
+            "delay" : 1000000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -8925,6 +9008,7 @@
             "declaredNames" : [
               "loopback0"
             ],
+            "delay" : 5.0E9,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -10121,6 +10205,7 @@
             "declaredNames" : [
               "Ethernet0"
             ],
+            "delay" : 1000000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -10824,6 +10909,7 @@
             "declaredNames" : [
               "ethernet1/15"
             ],
+            "delay" : 1000000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -11207,6 +11293,7 @@
             "declaredNames" : [
               "eth0"
             ],
+            "delay" : 1000000.0,
             "incomingFilter" : "iptables_Ethernet0_ingress",
             "mtu" : 1500,
             "nativeVlan" : 1,
@@ -11239,6 +11326,7 @@
             "declaredNames" : [
               "eth1"
             ],
+            "delay" : 1000000.0,
             "incomingFilter" : "iptables_Ethernet1_ingress",
             "mtu" : 1500,
             "nativeVlan" : 1,
@@ -11649,6 +11737,7 @@
             "declaredNames" : [
               "Vlan303"
             ],
+            "delay" : 10.0,
             "mtu" : 9100,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -11678,6 +11767,7 @@
             "declaredNames" : [
               "Vlan803"
             ],
+            "delay" : 10.0,
             "dhcpRelayAddresses" : [
               "10.22.33.111",
               "10.22.33.112"
@@ -11734,6 +11824,7 @@
             "declaredNames" : [
               "FastEthernet12/13"
             ],
+            "delay" : 100000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -11759,6 +11850,7 @@
             "declaredNames" : [
               "HundredGigE0/6/0/8"
             ],
+            "delay" : 10.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -11784,6 +11876,7 @@
             "declaredNames" : [
               "Port-channel1"
             ],
+            "delay" : 0.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -11809,6 +11902,7 @@
             "declaredNames" : [
               "Vlan100"
             ],
+            "delay" : 10.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -11862,6 +11956,7 @@
             "declaredNames" : [
               "Loopback0"
             ],
+            "delay" : 5.0E9,
             "description" : "SLO-AGG1 lo0 (Loopback0 Address)",
             "mtu" : 1500,
             "nativeVlan" : 1,
@@ -11974,6 +12069,7 @@
             "declaredNames" : [
               "GigabitEthernet1/0/1"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -12506,6 +12602,7 @@
             "declaredNames" : [
               "GigabitEthernet0/2/1/6"
             ],
+            "delay" : 10000.0,
             "isis" : {
               "level1" : {
                 "mode" : "active"
@@ -12652,6 +12749,7 @@
             "declaredNames" : [
               "Bundle-Ether101"
             ],
+            "delay" : 0.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -12677,6 +12775,7 @@
             "declaredNames" : [
               "Bundle-Ether103"
             ],
+            "delay" : 0.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -12702,6 +12801,7 @@
             "declaredNames" : [
               "Bundle-Ether201"
             ],
+            "delay" : 0.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfCost" : 1,
@@ -12728,6 +12828,7 @@
             "declaredNames" : [
               "HundredGigE0/2/0/0.292"
             ],
+            "delay" : 10.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -12753,6 +12854,7 @@
             "declaredNames" : [
               "HundredGigE0/2/0/3"
             ],
+            "delay" : 10.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -12778,6 +12880,7 @@
             "declaredNames" : [
               "Loopback0"
             ],
+            "delay" : 5.0E9,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -12803,6 +12906,7 @@
             "declaredNames" : [
               "TenGigE0/0/0/2"
             ],
+            "delay" : 1000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -12828,6 +12932,7 @@
             "declaredNames" : [
               "TenGigE0/0/0/4"
             ],
+            "delay" : 1000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -12853,6 +12958,7 @@
             "declaredNames" : [
               "TenGigE0/0/0/5"
             ],
+            "delay" : 1000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -15555,6 +15661,7 @@
             "declaredNames" : [
               "et1"
             ],
+            "delay" : 1000000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -15580,6 +15687,7 @@
             "declaredNames" : [
               "et2"
             ],
+            "delay" : 1000000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -15605,6 +15713,7 @@
             "declaredNames" : [
               "ma1"
             ],
+            "delay" : 10.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -15630,6 +15739,7 @@
             "declaredNames" : [
               "ap1"
             ],
+            "delay" : 10.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -16852,6 +16962,7 @@
             "declaredNames" : [
               "GigabitEthernet1"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -17211,6 +17322,7 @@
             "declaredNames" : [
               "Ethernet0/0"
             ],
+            "delay" : 10000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -17236,6 +17348,7 @@
             "declaredNames" : [
               "nve1"
             ],
+            "delay" : 10.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -19230,6 +19343,7 @@
             "declaredNames" : [
               "loopback1"
             ],
+            "delay" : 5.0E9,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -22756,6 +22870,7 @@
             "declaredNames" : [
               "FastEthernet0/1"
             ],
+            "delay" : 100000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -23255,6 +23370,7 @@
             "declaredNames" : [
               "FastEthernet0/0"
             ],
+            "delay" : 100000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,
@@ -23305,6 +23421,7 @@
             "declaredNames" : [
               "FastEthernet0/0"
             ],
+            "delay" : 100000.0,
             "mtu" : 1500,
             "nativeVlan" : 1,
             "ospfDeadInterval" : 0,

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -20974,6 +20974,20 @@
             "          NETWORK:'network'  <== mode:DEFAULT_MODE",
             "          address = IP_ADDRESS:'1.1.1.1'  <== mode:DEFAULT_MODE",
             "          NEWLINE:'\\n'  <== mode:DEFAULT_MODE))))",
+            "  (stanza",
+            "    (s_interface",
+            "      INTERFACE:'interface'  <== mode:DEFAULT_MODE",
+            "      iname = (interface_name",
+            "        name_prefix_alpha = M_Interface_PREFIX:'Ethernet'  <== mode:M_Interface",
+            "        (range",
+            "          (subrange",
+            "            low = DEC:'0'  <== mode:M_Interface)))",
+            "      NEWLINE:'\\n'  <== mode:M_Interface",
+            "      (if_inner",
+            "        (if_delay",
+            "          DELAY:'delay'  <== mode:DEFAULT_MODE",
+            "          DEC:'1000'  <== mode:DEFAULT_MODE",
+            "          NEWLINE:'\\n\\n\\n'  <== mode:DEFAULT_MODE))))",
             "  EOF:<EOF>  <== mode:DEFAULT_MODE)"
           ]
         },
@@ -21848,7 +21862,7 @@
             "          PASSIVE:'passive'  <== mode:DEFAULT_MODE",
             "          NEWLINE:'\\n'  <== mode:DEFAULT_MODE))",
             "      (if_inner",
-            "        (if_null_block",
+            "        (if_delay",
             "          DELAY:'delay'  <== mode:DEFAULT_MODE",
             "          DEC:'1'  <== mode:DEFAULT_MODE",
             "          NEWLINE:'\\n'  <== mode:DEFAULT_MODE))",
@@ -56379,6 +56393,15 @@
                 91
               ],
               "numReferrers" : 0
+            }
+          },
+          "interface" : {
+            "Ethernet0" : {
+              "definitionLines" : [
+                104,
+                105
+              ],
+              "numReferrers" : 1
             }
           }
         },

--- a/tests/roles/perRoleOutliers.ref
+++ b/tests/roles/perRoleOutliers.ref
@@ -25,6 +25,7 @@
           "declaredNames" : [
             "GigabitEthernet2/0"
           ],
+          "delay" : 10000.0,
           "incomingFilter" : "blocktelnet",
           "mtu" : 1500,
           "nativeVlan" : 1,
@@ -71,6 +72,7 @@
           "declaredNames" : [
             "GigabitEthernet3/0"
           ],
+          "delay" : 10000.0,
           "incomingFilter" : "blocktelnet",
           "mtu" : 1500,
           "nativeVlan" : 1,


### PR DESCRIPTION
For EIGRP, routers have a delay parameter which is roughly inversely proportional to bandwidth. Only used on Cisco routers as far as I know. This is step 0 in the EIGRP implementation.