### PR TITLE
New BDDOps methods andNull, orNull

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/symbolic/bdd/BDDOps.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/bdd/BDDOps.java
@@ -1,10 +1,12 @@
 package org.batfish.symbolic.bdd;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+
 import java.util.Arrays;
 import net.sf.javabdd.BDD;
 import net.sf.javabdd.BDDFactory;
 
-public class BDDOps {
+public final class BDDOps {
   private final BDDFactory _factory;
 
   public BDDOps(BDDFactory factory) {
@@ -16,10 +18,19 @@ public class BDDOps {
   }
 
   public BDD and(Iterable<BDD> conjuncts) {
-    BDD result = _factory.one();
+    return firstNonNull(andNull(conjuncts), _factory.one());
+  }
+
+  /** A variant of {@link #and(BDD...)} that returns {@code null} when all conjuncts are null. */
+  public static BDD andNull(BDD... conjuncts) {
+    return andNull(Arrays.asList(conjuncts));
+  }
+
+  public static BDD andNull(Iterable<BDD> conjuncts) {
+    BDD result = null;
     for (BDD conjunct : conjuncts) {
       if (conjunct != null) {
-        result = result.and(conjunct);
+        result = result == null ? conjunct : result.and(conjunct);
       }
     }
     return result;
@@ -30,10 +41,19 @@ public class BDDOps {
   }
 
   public BDD or(Iterable<BDD> disjuncts) {
-    BDD result = _factory.zero();
+    return firstNonNull(orNull(disjuncts), _factory.zero());
+  }
+
+  /** A variant of {@link #or(BDD...)} that returns {@code null} when all disjuncts are null. */
+  public static BDD orNull(BDD... disjuncts) {
+    return orNull(Arrays.asList(disjuncts));
+  }
+
+  public static BDD orNull(Iterable<BDD> disjuncts) {
+    BDD result = null;
     for (BDD disjunct : disjuncts) {
       if (disjunct != null) {
-        result = result.or(disjunct);
+        result = result == null ? disjunct : result.or(disjunct);
       }
     }
     return result;

--- a/projects/batfish/src/test/java/org/batfish/symbolic/bdd/BDDOpsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/symbolic/bdd/BDDOpsTest.java
@@ -2,6 +2,7 @@ package org.batfish.symbolic.bdd;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 
 import net.sf.javabdd.BDD;
 import net.sf.javabdd.BDDFactory;
@@ -49,6 +50,27 @@ public class BDDOpsTest {
   }
 
   @Test
+  public void testAndNull_null() {
+    assertThat(BDDOps.andNull(), nullValue());
+    assertThat(BDDOps.andNull(null, null), nullValue());
+  }
+
+  @Test
+  public void testAndNull_one() {
+    _factory.setVarNum(1);
+    BDD var = _factory.ithVar(0);
+    assertThat(BDDOps.andNull(var, null), equalTo(var));
+  }
+
+  @Test
+  public void testAndNull_two() {
+    _factory.setVarNum(2);
+    BDD var1 = _factory.ithVar(0);
+    BDD var2 = _factory.ithVar(1);
+    assertThat(BDDOps.andNull(var1, var2, null), equalTo(var1.and(var2)));
+  }
+
+  @Test
   public void testOr_one() {
     _factory.setVarNum(1);
     BDD var = _factory.ithVar(0);
@@ -73,5 +95,26 @@ public class BDDOpsTest {
     _factory.setVarNum(1);
     BDD var = _factory.ithVar(0);
     assertThat(_bddOps.or(var, _factory.zero()), equalTo(var));
+  }
+
+  @Test
+  public void testOrNull_null() {
+    assertThat(BDDOps.orNull(), nullValue());
+    assertThat(BDDOps.orNull(null, null), nullValue());
+  }
+
+  @Test
+  public void testOrNull_one() {
+    _factory.setVarNum(1);
+    BDD var = _factory.ithVar(0);
+    assertThat(BDDOps.orNull(var, null), equalTo(var));
+  }
+
+  @Test
+  public void testOrNull_two() {
+    _factory.setVarNum(2);
+    BDD var1 = _factory.ithVar(0);
+    BDD var2 = _factory.ithVar(1);
+    assertThat(BDDOps.orNull(null, var1, var2), equalTo(var1.or(var2)));
   }
 }


### PR DESCRIPTION
Factor out variants of and and or that return null when all inputs are null. The idea is that null means "unconstrained", which is different than the identity elements true and false. 