### PR TITLE
Routes2: Add metric column to all main RIB routes

### DIFF
--- a/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswerer.java
@@ -50,13 +50,13 @@ public class RoutesAnswerer extends Answerer {
   // Present sometimes
   static final String COL_NEXT_HOP = "NextHop";
   static final String COL_PROTOCOL = "Protocol";
+  static final String COL_METRIC = "Metric";
 
   // Main RIB
   static final String COL_ADMIN_DISTANCE = "AdminDistance";
 
   // BGP only
   static final String COL_AS_PATH = "AsPath";
-  static final String COL_METRIC = "Metric";
   static final String COL_LOCAL_PREF = "LocalPref";
   static final String COL_COMMUNITIES = "Communities";
   static final String COL_ORIGIN_PROTOCOL = "OriginProtocol";
@@ -159,6 +159,7 @@ public class RoutesAnswerer extends Answerer {
                     .put(COL_PROTOCOL, route.getProtocol())
                     .put(COL_TAG, route.getTag())
                     .put(COL_ADMIN_DISTANCE, route.getAdministrativeCost())
+                    .put(COL_METRIC, route.getMetric())
                     .build())
         .collect(toImmutableList());
   }
@@ -260,6 +261,9 @@ public class RoutesAnswerer extends Answerer {
                 "Route's admin distance",
                 Boolean.FALSE,
                 Boolean.TRUE));
+        columnBuilder.add(
+            new ColumnMetadata(
+                COL_METRIC, Schema.INTEGER, "Route's metric", Boolean.FALSE, Boolean.TRUE));
     }
     DisplayHints dh = new DisplayHints();
     dh.setTextDesc("Display RIB routes");

--- a/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
@@ -147,6 +147,26 @@ public class RoutesAnswererTest {
   }
 
   @Test
+  public void testHasMetric() {
+    SortedMap<String, SortedMap<String, GenericRib<AbstractRoute>>> ribs =
+        ImmutableSortedMap.of(
+            "n1",
+            ImmutableSortedMap.of(
+                Configuration.DEFAULT_VRF_NAME,
+                new MockRib<>(
+                    ImmutableSet.of(
+                        StaticRoute.builder()
+                            .setNetwork(Prefix.parse("1.1.1.0/24"))
+                            .setNextHopInterface("Null")
+                            .setMetric(111)
+                            .build()))));
+
+    Multiset<Row> actual = getMainRibRoutes(ribs, ImmutableSet.of("n1"), ".*", null);
+
+    assertThat(actual.iterator().next().get(COL_METRIC, Schema.INTEGER), equalTo(111));
+  }
+
+  @Test
   public void testGetTableMetadataProtocolAll() {
     List<ColumnMetadata> columnMetadata = getTableMetadata(RibProtocol.ALL).getColumnMetadata();
 
@@ -163,7 +183,8 @@ public class RoutesAnswererTest {
             COL_TAG,
             COL_NEXT_HOP_IP,
             COL_NEXT_HOP,
-            COL_ADMIN_DISTANCE));
+            COL_ADMIN_DISTANCE,
+            COL_METRIC));
 
     assertThat(
         columnMetadata
@@ -178,6 +199,7 @@ public class RoutesAnswererTest {
             Schema.INTEGER,
             Schema.IP,
             Schema.STRING,
+            Schema.INTEGER,
             Schema.INTEGER));
   }
 


### PR DESCRIPTION
While it doesn't make sense for all route types, the field is so common for learned routes that decided to just include it for all routes in the main RIB.