### PR TITLE
factor out IpAccessListSpecializer as an abstract class

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclLineMatchExprs.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclLineMatchExprs.java
@@ -1,0 +1,40 @@
+package org.batfish.datamodel.acl;
+
+import java.util.Arrays;
+import java.util.List;
+import org.batfish.datamodel.HeaderSpace;
+
+public final class AclLineMatchExprs {
+  private AclLineMatchExprs() {}
+
+  public static final FalseExpr FALSE = FalseExpr.INSTANCE;
+
+  public static final OriginatingFromDevice ORIGINATING_FROM_DEVICE =
+      OriginatingFromDevice.INSTANCE;
+
+  public static final TrueExpr TRUE = TrueExpr.INSTANCE;
+
+  public static AclLineMatchExpr and(AclLineMatchExpr... exprs) {
+    return and(Arrays.asList(exprs));
+  }
+
+  public static AclLineMatchExpr and(List<AclLineMatchExpr> exprs) {
+    return new AndMatchExpr(exprs);
+  }
+
+  public static AclLineMatchExpr match(HeaderSpace headerSpace) {
+    return new MatchHeaderSpace(headerSpace);
+  }
+
+  public static AclLineMatchExpr not(AclLineMatchExpr expr) {
+    return new NotMatchExpr(expr);
+  }
+
+  public static AclLineMatchExpr or(AclLineMatchExpr... exprs) {
+    return or(Arrays.asList(exprs));
+  }
+
+  public static AclLineMatchExpr or(List<AclLineMatchExpr> exprs) {
+    return new OrMatchExpr(exprs);
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/z3/IpSpaceIpAccessListSpecializer.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/IpSpaceIpAccessListSpecializer.java
@@ -1,0 +1,74 @@
+package org.batfish.z3;
+
+import static org.batfish.datamodel.AclIpSpace.difference;
+import static org.batfish.datamodel.AclIpSpace.union;
+
+import java.util.Map;
+import org.batfish.datamodel.HeaderSpace;
+import org.batfish.datamodel.IpSpace;
+
+public final class IpSpaceIpAccessListSpecializer extends IpAccessListSpecializer {
+  private final boolean _canSpecialize;
+  private final IpSpaceSpecializer _dstIpSpaceSpecializer;
+  private final IpSpaceSpecializer _srcIpSpaceSpecializer;
+  private final IpSpaceSpecializer _srcOrDstIpSpaceSpecializer;
+
+  IpSpaceIpAccessListSpecializer(HeaderSpace headerSpace, Map<String, IpSpace> namedIpSpaces) {
+    IpSpace dstIps = headerSpace.getDstIps();
+    IpSpace srcIps = headerSpace.getSrcIps();
+    IpSpace srcOrDstIps = headerSpace.getSrcOrDstIps();
+
+    IpSpace notDstIps = headerSpace.getNotDstIps();
+    IpSpace notSrcIps = headerSpace.getNotSrcIps();
+
+    _dstIpSpaceSpecializer =
+        (dstIps == null && srcOrDstIps == null && notDstIps == null)
+            ? null
+            : new IpSpaceIpSpaceSpecializer(
+                difference(union(dstIps, srcOrDstIps), notDstIps), namedIpSpaces);
+    _srcIpSpaceSpecializer =
+        (srcIps == null && srcOrDstIps == null && notSrcIps == null)
+            ? null
+            : new IpSpaceIpSpaceSpecializer(
+                difference(union(srcIps, srcOrDstIps), notSrcIps), namedIpSpaces);
+    _srcOrDstIpSpaceSpecializer =
+        (srcIps == null
+                && dstIps == null
+                && srcOrDstIps == null
+                && notSrcIps == null
+                && notDstIps == null)
+            ? null
+            : new IpSpaceIpSpaceSpecializer(
+                difference(union(srcIps, dstIps, srcOrDstIps), union(notSrcIps, notDstIps)),
+                namedIpSpaces);
+
+    /*
+     * Currently, specialization is based on srcIp and dstIp only. We can specialize only
+     * if we have at least one IpSpace specializer.
+     */
+    _canSpecialize = _dstIpSpaceSpecializer != null || _srcIpSpaceSpecializer != null;
+  }
+
+  @Override
+  protected boolean canSpecialize() {
+    return _canSpecialize;
+  }
+
+  private static IpSpace specializeWith(IpSpace dstIpSpace, IpSpaceSpecializer specializer) {
+    return dstIpSpace != null && specializer != null
+        ? specializer.specialize(dstIpSpace)
+        : dstIpSpace;
+  }
+
+  @Override
+  protected HeaderSpace specialize(HeaderSpace headerSpace) {
+    return headerSpace
+        .toBuilder()
+        .setDstIps(specializeWith(headerSpace.getDstIps(), _dstIpSpaceSpecializer))
+        .setNotDstIps(specializeWith(headerSpace.getNotDstIps(), _dstIpSpaceSpecializer))
+        .setNotSrcIps(specializeWith(headerSpace.getNotSrcIps(), _srcIpSpaceSpecializer))
+        .setSrcIps(specializeWith(headerSpace.getSrcIps(), _srcIpSpaceSpecializer))
+        .setSrcOrDstIps(specializeWith(headerSpace.getSrcOrDstIps(), _srcOrDstIpSpaceSpecializer))
+        .build();
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/z3/SynthesizerInputImpl.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/SynthesizerInputImpl.java
@@ -267,7 +267,7 @@ public final class SynthesizerInputImpl implements SynthesizerInput {
                 _namedIpSpaces,
                 Entry::getKey,
                 namedIpSpacesEntry ->
-                    new IpAccessListSpecializer(headerSpace, namedIpSpacesEntry.getValue()))
+                    new IpSpaceIpAccessListSpecializer(headerSpace, namedIpSpacesEntry.getValue()))
             : ImmutableMap.of();
     _disabledInterfaces = ImmutableMap.copyOf(builder._disabledInterfaces);
     _disabledNodes = ImmutableSet.copyOf(builder._disabledNodes);

--- a/projects/batfish/src/test/java/org/batfish/z3/IpSpaceIpAccessListSpecializerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/IpSpaceIpAccessListSpecializerTest.java
@@ -1,0 +1,120 @@
+package org.batfish.z3;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import java.util.Optional;
+import org.batfish.datamodel.HeaderSpace;
+import org.batfish.datamodel.IpAccessListLine;
+import org.batfish.datamodel.IpWildcard;
+import org.batfish.datamodel.acl.MatchHeaderSpace;
+import org.batfish.datamodel.acl.TrueExpr;
+import org.junit.Test;
+
+public class IpSpaceIpAccessListSpecializerTest {
+  private static final IpAccessListSpecializer TRIVIAL_SPECIALIZER =
+      new IpSpaceIpAccessListSpecializer(new HeaderSpace(), ImmutableMap.of());
+
+  private static final IpAccessListSpecializer BLACKLIST_ANY_DST_SPECIALIZER =
+      new IpSpaceIpAccessListSpecializer(
+          HeaderSpace.builder().setNotDstIps(ImmutableSet.of(IpWildcard.ANY)).build(),
+          ImmutableMap.of());
+
+  private static final IpAccessListSpecializer BLACKLIST_ANY_SRC_SPECIALIZER =
+      new IpSpaceIpAccessListSpecializer(
+          HeaderSpace.builder().setNotSrcIps(ImmutableSet.of(IpWildcard.ANY)).build(),
+          ImmutableMap.of());
+
+  private static final IpAccessListSpecializer WHITELIST_ANY_DST_SPECIALIZER =
+      new IpSpaceIpAccessListSpecializer(
+          HeaderSpace.builder().setDstIps(ImmutableSet.of(IpWildcard.ANY)).build(),
+          ImmutableMap.of());
+
+  private static final IpAccessListSpecializer WHITELIST_ANY_SRC_SPECIALIZER =
+      new IpSpaceIpAccessListSpecializer(
+          HeaderSpace.builder().setSrcIps(ImmutableSet.of(IpWildcard.ANY)).build(),
+          ImmutableMap.of());
+
+  @Test
+  public void testSpecializeIpAccessListLine_singleDst() {
+    IpAccessListLine ipAccessListLine =
+        IpAccessListLine.accepting()
+            .setMatchCondition(
+                new MatchHeaderSpace(
+                    HeaderSpace.builder()
+                        .setDstIps(new IpWildcard("1.2.3.0/24").toIpSpace())
+                        .build()))
+            .build();
+
+    assertThat(
+        TRIVIAL_SPECIALIZER.specialize(ipAccessListLine), equalTo(Optional.of(ipAccessListLine)));
+    assertThat(
+        BLACKLIST_ANY_DST_SPECIALIZER.specialize(ipAccessListLine), equalTo(Optional.empty()));
+    assertThat(
+        WHITELIST_ANY_DST_SPECIALIZER.specialize(ipAccessListLine),
+        equalTo(Optional.of(ipAccessListLine)));
+    assertThat(
+        BLACKLIST_ANY_SRC_SPECIALIZER.specialize(ipAccessListLine),
+        equalTo(Optional.of(ipAccessListLine)));
+    assertThat(
+        WHITELIST_ANY_SRC_SPECIALIZER.specialize(ipAccessListLine),
+        equalTo(Optional.of(ipAccessListLine)));
+
+    // specialize to a headerspace that whitelists part of the dstIp
+    IpAccessListSpecializer specializer =
+        new IpSpaceIpAccessListSpecializer(
+            HeaderSpace.builder().setDstIps(ImmutableSet.of(new IpWildcard("1.2.3.4"))).build(),
+            ImmutableMap.of());
+    assertThat(
+        specializer.specialize(ipAccessListLine),
+        equalTo(
+            Optional.of(
+                IpAccessListLine.accepting().setMatchCondition(TrueExpr.INSTANCE).build())));
+
+    // specialize to a headerspace that blacklists part of the dstIp
+    specializer =
+        new IpSpaceIpAccessListSpecializer(
+            HeaderSpace.builder().setNotDstIps(new IpWildcard("1.2.3.4").toIpSpace()).build(),
+            ImmutableMap.of());
+    assertThat(specializer.specialize(ipAccessListLine), equalTo(Optional.of(ipAccessListLine)));
+  }
+
+  @Test
+  public void testSpecializeIpAccessListLine_singleSrc() {
+    IpAccessListLine ipAccessListLine =
+        IpAccessListLine.acceptingHeaderSpace(
+            HeaderSpace.builder().setSrcIps(new IpWildcard("1.2.3.0/24").toIpSpace()).build());
+
+    assertThat(
+        TRIVIAL_SPECIALIZER.specialize(ipAccessListLine), equalTo(Optional.of(ipAccessListLine)));
+    assertThat(
+        BLACKLIST_ANY_DST_SPECIALIZER.specialize(ipAccessListLine),
+        equalTo(Optional.of(ipAccessListLine)));
+    assertThat(
+        WHITELIST_ANY_DST_SPECIALIZER.specialize(ipAccessListLine),
+        equalTo(Optional.of(ipAccessListLine)));
+    assertThat(
+        BLACKLIST_ANY_SRC_SPECIALIZER.specialize(ipAccessListLine), equalTo(Optional.empty()));
+    assertThat(
+        WHITELIST_ANY_SRC_SPECIALIZER.specialize(ipAccessListLine),
+        equalTo(Optional.of(ipAccessListLine)));
+
+    // specialize to a headerspace that whitelists part of the srcIp
+    IpAccessListSpecializer specializer =
+        new IpSpaceIpAccessListSpecializer(
+            HeaderSpace.builder().setSrcIps(ImmutableSet.of(new IpWildcard("1.2.3.4"))).build(),
+            ImmutableMap.of());
+    assertThat(
+        specializer.specialize(ipAccessListLine),
+        equalTo(Optional.of(IpAccessListLine.ACCEPT_ALL)));
+
+    // specialize to a headerspace that blacklists part of the srcIp
+    specializer =
+        new IpSpaceIpAccessListSpecializer(
+            HeaderSpace.builder().setNotSrcIps(ImmutableSet.of(new IpWildcard("1.2.3.4"))).build(),
+            ImmutableMap.of());
+    assertThat(specializer.specialize(ipAccessListLine), equalTo(Optional.of(ipAccessListLine)));
+  }
+}


### PR DESCRIPTION
Move everything specific to how we are representing the header space
we're specializing the ACL to into a subclass.