### PR TITLE
Delete flaky assertions

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
@@ -1205,8 +1205,6 @@ public class VirtualRouterTest {
      * Old best path is gone. Now must choose best path from the multipath RIB.
      * new routes should exist for the new prefix
      */
-    Entry<RibDelta<BgpRoute>, RibDelta<BgpRoute>> e =
-        VirtualRouter.syncBgpDeltaPropagation(bestPathRib, multipathRib, staging);
 
     // One route only, taken from the multipathRib
     assertThat(bestPathRib.getRoutes(), contains(oldRoute2));

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
@@ -1212,14 +1212,5 @@ public class VirtualRouterTest {
     assertThat(bestPathRib.getRoutes(), contains(oldRoute2));
     // Both good routes
     assertThat(multipathRib.getRoutes(), containsInAnyOrder(oldRoute2, oldRoute3));
-
-    RibDelta<BgpRoute> bpDelta = e.getKey();
-    RibDelta<BgpRoute> mpDelta = e.getValue();
-    assert bpDelta != null;
-    assert mpDelta != null;
-    // 2 operations for best path rib, one withdraw, one add
-    assertThat(bpDelta.getActions(), hasSize(2));
-    // 1 operations for multipath rib, one withdraw
-    assertThat(mpDelta.getActions(), hasSize(1));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
@@ -1205,6 +1205,7 @@ public class VirtualRouterTest {
      * Old best path is gone. Now must choose best path from the multipath RIB.
      * new routes should exist for the new prefix
      */
+    VirtualRouter.syncBgpDeltaPropagation(bestPathRib, multipathRib, staging);
 
     // One route only, taken from the multipathRib
     assertThat(bestPathRib.getRoutes(), contains(oldRoute2));


### PR DESCRIPTION
The number of actions in a delta can vary based on route ordering which is not deterministic (simple `Set`). 
Delete flaky assertions; really important assertions are still preserved (`contains`, etc.)