### PR TITLE
Handle zips missing directory entries

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/UnzipUtility.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/UnzipUtility.java
@@ -82,6 +82,13 @@ public final class UnzipUtility {
               throw new IOException("Unable to make directory " + outputPath);
             }
           } else {
+            // Make sure parent directories exist, in case the zip does not contain dir entries
+            File parentDir = outputPath.toFile().getParentFile();
+            if (!parentDir.exists()) {
+              if (!parentDir.mkdirs()) {
+                throw new IOException("Unable to make directory " + parentDir.getPath());
+              }
+            }
             // Extract the file.
             extractFile(zipIn, outputPath);
           }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/UnzipUtilityTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/UnzipUtilityTest.java
@@ -46,7 +46,6 @@ public class UnzipUtilityTest {
     File directoriesMissing = _folder.newFile("directories_missing");
     try (FileOutputStream fos = new FileOutputStream(directoriesMissing);
         ZipOutputStream out = new ZipOutputStream(fos)) {
-      out.putNextEntry(new ZipEntry("missing_dir/child_dir/"));
       out.putNextEntry(new ZipEntry("missing_dir/child_dir/file.txt"));
       out.write(contents);
     }


### PR DESCRIPTION
Update unzip utility to create parent directories when unzipping files.

Fixes #1864 
