### PR TITLE
improve simplification and clean up IpAccessListSpecializer

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/z3/IpAccessListSpecializer.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/IpAccessListSpecializer.java
@@ -1,7 +1,11 @@
 package org.batfish.z3;
 
+import static org.batfish.datamodel.acl.AclLineMatchExprs.FALSE;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.TRUE;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -31,23 +35,22 @@ import org.batfish.datamodel.acl.TrueExpr;
  */
 public abstract class IpAccessListSpecializer
     implements GenericAclLineMatchExprVisitor<AclLineMatchExpr> {
+
+  private static <T> boolean emptyDisjuction(Collection<T> orig, Collection<T> specialized) {
+    return orig != null && !orig.isEmpty() && specialized.isEmpty();
+  }
+
   private static IpSpace simplifyNegativeIpConstraint(IpSpace ipSpace) {
-    if (ipSpace == EmptyIpSpace.INSTANCE) {
-      return null;
-    }
-    return ipSpace;
+    return ipSpace == EmptyIpSpace.INSTANCE ? null : ipSpace;
   }
 
   private static IpSpace simplifyPositiveIpConstraint(IpSpace ipSpace) {
-    if (ipSpace == UniverseIpSpace.INSTANCE) {
-      return null;
-    }
-    return ipSpace;
+    return ipSpace == UniverseIpSpace.INSTANCE ? null : ipSpace;
   }
 
-  protected abstract boolean canSpecialize();
+  abstract boolean canSpecialize();
 
-  protected abstract HeaderSpace specialize(HeaderSpace headerSpace);
+  abstract HeaderSpace specialize(HeaderSpace headerSpace);
 
   public final IpAccessList specialize(IpAccessList ipAccessList) {
     if (!canSpecialize()) {
@@ -71,12 +74,9 @@ public abstract class IpAccessListSpecializer
 
   public final Optional<IpAccessListLine> specialize(IpAccessListLine ipAccessListLine) {
     AclLineMatchExpr aclLineMatchExpr = ipAccessListLine.getMatchCondition().accept(this);
-
-    if (aclLineMatchExpr == FalseExpr.INSTANCE) {
-      return Optional.empty();
-    }
-
-    return Optional.of(ipAccessListLine.toBuilder().setMatchCondition(aclLineMatchExpr).build());
+    return aclLineMatchExpr == FALSE
+        ? Optional.empty()
+        : Optional.of(ipAccessListLine.toBuilder().setMatchCondition(aclLineMatchExpr).build());
   }
 
   @Override
@@ -104,25 +104,51 @@ public abstract class IpAccessListSpecializer
 
   @Override
   public final AclLineMatchExpr visitMatchHeaderSpace(MatchHeaderSpace matchHeaderSpace) {
-    HeaderSpace headerSpace = specialize(matchHeaderSpace.getHeaderspace());
+    HeaderSpace originalHeaderSpace = matchHeaderSpace.getHeaderspace();
+    HeaderSpace headerSpace = specialize(originalHeaderSpace);
     IpSpace dstIps = headerSpace.getDstIps();
     IpSpace notDstIps = headerSpace.getNotDstIps();
     IpSpace notSrcIps = headerSpace.getNotSrcIps();
     IpSpace srcIps = headerSpace.getSrcIps();
     IpSpace srcOrDstIps = headerSpace.getSrcOrDstIps();
 
-    boolean empty =
+    boolean emptyIpSpace =
         dstIps == EmptyIpSpace.INSTANCE
             || srcIps == EmptyIpSpace.INSTANCE
             || srcOrDstIps == EmptyIpSpace.INSTANCE
             || notDstIps == UniverseIpSpace.INSTANCE
             || notSrcIps == UniverseIpSpace.INSTANCE;
 
-    if (empty) {
-      return FalseExpr.INSTANCE;
+    if (emptyIpSpace) {
+      return FALSE;
     }
 
-    HeaderSpace specializedHeaderSpace =
+    /*
+     * if any field has an empty list of required values (i.e. it must be one of zero choices), then
+     * false. Exclude empty lists of forbidden values (that part of the constraint has become true).
+     */
+    boolean emptyDisjunction =
+        emptyDisjuction(originalHeaderSpace.getDscps(), headerSpace.getDscps())
+            || emptyDisjuction(originalHeaderSpace.getEcns(), headerSpace.getEcns())
+            || emptyDisjuction(originalHeaderSpace.getDstPorts(), headerSpace.getDstPorts())
+            || emptyDisjuction(
+                originalHeaderSpace.getFragmentOffsets(), headerSpace.getFragmentOffsets())
+            || emptyDisjuction(originalHeaderSpace.getIcmpCodes(), headerSpace.getIcmpCodes())
+            || emptyDisjuction(originalHeaderSpace.getIcmpTypes(), headerSpace.getIcmpTypes())
+            || emptyDisjuction(originalHeaderSpace.getIpProtocols(), headerSpace.getIpProtocols())
+            || emptyDisjuction(originalHeaderSpace.getSrcPorts(), headerSpace.getSrcPorts())
+            || emptyDisjuction(
+                originalHeaderSpace.getSrcOrDstPorts(), headerSpace.getSrcOrDstPorts())
+            || emptyDisjuction(
+                originalHeaderSpace.getSrcOrDstProtocols(), headerSpace.getSrcOrDstProtocols())
+            || emptyDisjuction(originalHeaderSpace.getStates(), headerSpace.getStates())
+            || emptyDisjuction(originalHeaderSpace.getTcpFlags(), headerSpace.getTcpFlags());
+
+    if (emptyDisjunction) {
+      return FALSE;
+    }
+
+    HeaderSpace simplifiedHeaderSpace =
         headerSpace
             .toBuilder()
             .setDstIps(simplifyPositiveIpConstraint(dstIps))
@@ -132,11 +158,12 @@ public abstract class IpAccessListSpecializer
             .setSrcOrDstIps(simplifyPositiveIpConstraint(srcOrDstIps))
             .build();
 
-    if (specializedHeaderSpace.equals(HeaderSpace.builder().build())) {
-      return TrueExpr.INSTANCE;
+    if (simplifiedHeaderSpace.equals(HeaderSpace.builder().build())) {
+      // unconstrained: the input headerspace contains the space we're specializing to
+      return TRUE;
     }
 
-    return new MatchHeaderSpace(specializedHeaderSpace);
+    return new MatchHeaderSpace(simplifiedHeaderSpace);
   }
 
   @Override

--- a/projects/batfish/src/test/java/org/batfish/z3/IpAccessListSpecializerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/IpAccessListSpecializerTest.java
@@ -11,9 +11,15 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
+import java.util.List;
 import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpProtocol;
+import org.batfish.datamodel.Protocol;
+import org.batfish.datamodel.State;
+import org.batfish.datamodel.SubRange;
+import org.batfish.datamodel.TcpFlags;
 import org.batfish.datamodel.UniverseIpSpace;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.datamodel.acl.MatchSrcInterface;
@@ -21,7 +27,20 @@ import org.batfish.datamodel.acl.PermittedByAcl;
 import org.junit.Test;
 
 public final class IpAccessListSpecializerTest {
-  private static final IpAccessListSpecializer specializer =
+  private static final IpAccessListSpecializer CONSTANT_SPECIALIZER =
+      new IpAccessListSpecializer() {
+        @Override
+        boolean canSpecialize() {
+          return true;
+        }
+
+        @Override
+        HeaderSpace specialize(HeaderSpace headerSpace) {
+          return HeaderSpace.builder().build();
+        }
+      };
+
+  private static final IpAccessListSpecializer IDENTITY_SPECIALIZER =
       new IpAccessListSpecializer() {
         @Override
         protected boolean canSpecialize() {
@@ -34,24 +53,28 @@ public final class IpAccessListSpecializerTest {
         }
       };
 
-  private static AclLineMatchExpr specialize(AclLineMatchExpr expr) {
-    return specializer.visit(expr);
+  private static AclLineMatchExpr constantSpecialize(AclLineMatchExpr expr) {
+    return CONSTANT_SPECIALIZER.visit(expr);
+  }
+
+  private static AclLineMatchExpr identitySpecialize(AclLineMatchExpr expr) {
+    return IDENTITY_SPECIALIZER.visit(expr);
   }
 
   @Test
   public void visitAndMatchExpr() {
-    assertThat(specialize(and()), equalTo(TRUE));
-    assertThat(specialize(and(TRUE, TRUE, TRUE)), equalTo(TRUE));
-    assertThat(specialize(and(TRUE, TRUE, FALSE)), equalTo(FALSE));
+    assertThat(identitySpecialize(and()), equalTo(TRUE));
+    assertThat(identitySpecialize(and(TRUE, TRUE, TRUE)), equalTo(TRUE));
+    assertThat(identitySpecialize(and(TRUE, TRUE, FALSE)), equalTo(FALSE));
   }
 
   @Test
   public void visitFalseExpr() {
-    assertThat(specialize(FALSE), equalTo(FALSE));
+    assertThat(identitySpecialize(FALSE), equalTo(FALSE));
   }
 
   @Test
-  public void visitMatchHeaderSpace_False() {
+  public void visitMatchHeaderSpace_EmptyIpSpace() {
     HeaderSpace dstEmpty = HeaderSpace.builder().setDstIps(EmptyIpSpace.INSTANCE).build();
     HeaderSpace notDstUniverse =
         HeaderSpace.builder().setNotDstIps(UniverseIpSpace.INSTANCE).build();
@@ -60,54 +83,101 @@ public final class IpAccessListSpecializerTest {
         HeaderSpace.builder().setNotSrcIps(UniverseIpSpace.INSTANCE).build();
     HeaderSpace srcOrDstEmpty = HeaderSpace.builder().setSrcOrDstIps(EmptyIpSpace.INSTANCE).build();
 
-    assertThat(specialize(match(dstEmpty)), equalTo(FALSE));
-    assertThat(specialize(match(notDstUniverse)), equalTo(FALSE));
-    assertThat(specialize(match(srcEmpty)), equalTo(FALSE));
-    assertThat(specialize(match(notSrcUniverse)), equalTo(FALSE));
-    assertThat(specialize(match(srcOrDstEmpty)), equalTo(FALSE));
+    assertThat(identitySpecialize(match(dstEmpty)), equalTo(FALSE));
+    assertThat(identitySpecialize(match(notDstUniverse)), equalTo(FALSE));
+    assertThat(identitySpecialize(match(srcEmpty)), equalTo(FALSE));
+    assertThat(identitySpecialize(match(notSrcUniverse)), equalTo(FALSE));
+    assertThat(identitySpecialize(match(srcOrDstEmpty)), equalTo(FALSE));
+  }
+
+  @Test
+  public void visitMatchHeaderSpace_EmptyDisjunction() {
+    List<Integer> integerList = ImmutableList.of(0);
+    List<IpProtocol> ipProtocolList = ImmutableList.of(IpProtocol.ICMP);
+    List<Protocol> protocolList = ImmutableList.of(Protocol.TCP);
+    List<State> stateList = ImmutableList.of(State.NEW);
+    List<SubRange> subRangeList = ImmutableList.of(new SubRange(0, 0));
+    List<TcpFlags> tcpFlagsList = ImmutableList.of(TcpFlags.ACK_TCP_FLAG);
+    assertThat(
+        constantSpecialize(match(HeaderSpace.builder().setDscps(integerList).build())),
+        equalTo(FALSE));
+    assertThat(
+        constantSpecialize(match(HeaderSpace.builder().setEcns(integerList).build())),
+        equalTo(FALSE));
+    assertThat(
+        constantSpecialize(match(HeaderSpace.builder().setDstPorts(subRangeList).build())),
+        equalTo(FALSE));
+    assertThat(
+        constantSpecialize(match(HeaderSpace.builder().setFragmentOffsets(subRangeList).build())),
+        equalTo(FALSE));
+    assertThat(
+        constantSpecialize(match(HeaderSpace.builder().setIcmpCodes(subRangeList).build())),
+        equalTo(FALSE));
+    assertThat(
+        constantSpecialize(match(HeaderSpace.builder().setIcmpTypes(subRangeList).build())),
+        equalTo(FALSE));
+    assertThat(
+        constantSpecialize(match(HeaderSpace.builder().setIpProtocols(ipProtocolList).build())),
+        equalTo(FALSE));
+    assertThat(
+        constantSpecialize(match(HeaderSpace.builder().setSrcPorts(subRangeList).build())),
+        equalTo(FALSE));
+    assertThat(
+        constantSpecialize(match(HeaderSpace.builder().setSrcOrDstPorts(subRangeList).build())),
+        equalTo(FALSE));
+    assertThat(
+        constantSpecialize(match(HeaderSpace.builder().setSrcOrDstProtocols(protocolList).build())),
+        equalTo(FALSE));
+    assertThat(
+        constantSpecialize(match(HeaderSpace.builder().setStates(stateList).build())),
+        equalTo(FALSE));
+    assertThat(
+        constantSpecialize(match(HeaderSpace.builder().setTcpFlags(tcpFlagsList).build())),
+        equalTo(FALSE));
   }
 
   @Test
   public void visitMatchHeaderSpace() {
     HeaderSpace headerSpace =
         HeaderSpace.builder().setDstIps(new Ip("1.1.1.1").toIpSpace()).build();
-    assertThat(specialize(match(headerSpace)), equalTo(match(headerSpace)));
+    assertThat(identitySpecialize(match(headerSpace)), equalTo(match(headerSpace)));
   }
 
   @Test
   public void visitMatchSrcInterface() {
     AclLineMatchExpr expr = new MatchSrcInterface(ImmutableList.of("foo"));
-    assertThat(specialize(expr), equalTo(expr));
+    assertThat(identitySpecialize(expr), equalTo(expr));
   }
 
   @Test
   public void visitNotMatchExpr() {
-    assertThat(specialize(not(TRUE)), equalTo(FALSE));
-    assertThat(specialize(not(FALSE)), equalTo(TRUE));
-    assertThat(specialize(not(not(TRUE))), equalTo(TRUE));
-    assertThat(specialize(not(ORIGINATING_FROM_DEVICE)), equalTo(not(ORIGINATING_FROM_DEVICE)));
+    assertThat(identitySpecialize(not(TRUE)), equalTo(FALSE));
+    assertThat(identitySpecialize(not(FALSE)), equalTo(TRUE));
+    assertThat(identitySpecialize(not(not(TRUE))), equalTo(TRUE));
+    assertThat(
+        identitySpecialize(not(ORIGINATING_FROM_DEVICE)), equalTo(not(ORIGINATING_FROM_DEVICE)));
   }
 
   @Test
   public void visitOriginatingFromDevice() {
-    assertThat(specialize(ORIGINATING_FROM_DEVICE), equalTo(ORIGINATING_FROM_DEVICE));
+    assertThat(identitySpecialize(ORIGINATING_FROM_DEVICE), equalTo(ORIGINATING_FROM_DEVICE));
   }
 
   @Test
   public void visitOrMatchExpr() {
-    assertThat(specialize(or()), equalTo(FALSE));
-    assertThat(specialize(or(FALSE, FALSE, FALSE)), equalTo(FALSE));
-    assertThat(specialize(or(FALSE, TRUE, FALSE)), equalTo(TRUE));
+    assertThat(identitySpecialize(or()), equalTo(FALSE));
+    assertThat(identitySpecialize(or(FALSE, FALSE, FALSE)), equalTo(FALSE));
+    assertThat(identitySpecialize(or(FALSE, TRUE, FALSE)), equalTo(TRUE));
   }
 
   @Test
   public void visitPermittedByAcl() {
     PermittedByAcl permittedByAcl = new PermittedByAcl("foo");
-    assertThat(specialize(permittedByAcl), equalTo(permittedByAcl));
+    assertThat(identitySpecialize(permittedByAcl), equalTo(permittedByAcl));
   }
 
   @Test
   public void visitTrueExpr() {
-    assertThat(specialize(TRUE), equalTo(TRUE));
+    assertThat(identitySpecialize(TRUE), equalTo(TRUE));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/z3/IpAccessListSpecializerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/IpAccessListSpecializerTest.java
@@ -98,6 +98,9 @@ public final class IpAccessListSpecializerTest {
     List<State> stateList = ImmutableList.of(State.NEW);
     List<SubRange> subRangeList = ImmutableList.of(new SubRange(0, 0));
     List<TcpFlags> tcpFlagsList = ImmutableList.of(TcpFlags.ACK_TCP_FLAG);
+    /* If the initial headerspace has non-empty disjunctions that become empty after specialization,
+     * the entire match expression is FALSE.
+     */
     assertThat(
         constantSpecialize(match(HeaderSpace.builder().setDscps(integerList).build())),
         equalTo(FALSE));
@@ -134,6 +137,8 @@ public final class IpAccessListSpecializerTest {
     assertThat(
         constantSpecialize(match(HeaderSpace.builder().setTcpFlags(tcpFlagsList).build())),
         equalTo(FALSE));
+    // if we started with empty disjunctions, they are interpreted as "unconstrained", i.e. TRUE
+    assertThat(constantSpecialize(match(HeaderSpace.builder().build())), equalTo(TRUE));
   }
 
   @Test


### PR DESCRIPTION
After specializing a HeaderSpace, check for empty disjunctions of
required header field values (i.e. a field was required to be equal to
one of some number of choices, but specialization ruled out all of them)