### PR TITLE
Added support for marking structures in multiple namespaces

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -1,5 +1,15 @@
 package org.batfish.representation.palo_alto;
 
+import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Multiset;
+import com.google.common.collect.SortedMultiset;
+import com.google.common.collect.TreeMultiset;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NavigableMap;
 import java.util.NavigableSet;
@@ -7,12 +17,15 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import javax.annotation.Nullable;
 import org.batfish.common.VendorConversionException;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.DefinedStructureInfo;
 import org.batfish.datamodel.InterfaceType;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.Vrf;
+import org.batfish.vendor.StructureUsage;
 import org.batfish.vendor.VendorConfiguration;
 
 public final class PaloAltoConfiguration extends VendorConfiguration {
@@ -129,6 +142,12 @@ public final class PaloAltoConfiguration extends VendorConfiguration {
    */
   public static String computeObjectName(String vsysName, String objectName) {
     return String.format("%s~%s", vsysName, objectName);
+  }
+
+  /** Extract object name from a name with an embedded namespace */
+  private static String extractObjectName(String nameWithNamespace) {
+    String[] parts = nameWithNamespace.split("~", -1);
+    return parts[parts.length - 1];
   }
 
   // Visible for testing
@@ -255,11 +274,74 @@ public final class PaloAltoConfiguration extends VendorConfiguration {
     // Handle converting items within virtual systems
     convertVirtualSystems();
 
-    // Count and mark structure usages and identify undefined references
+    // Count and mark simple structure usages and identify undefined references
     markConcreteStructure(
         PaloAltoStructureType.INTERFACE,
         PaloAltoStructureUsage.VIRTUAL_ROUTER_INTERFACE,
         PaloAltoStructureUsage.ZONE_INTERFACE);
+
+    // Handle marking for structures that may exist in one of a couple namespaces
+    markAbstractStructureFromUnknownNamespace(
+        PaloAltoStructureType.SERVICE_OR_SERVICE_GROUP,
+        ImmutableList.of(PaloAltoStructureType.SERVICE, PaloAltoStructureType.SERVICE_GROUP),
+        PaloAltoStructureUsage.SERVICE_GROUP_MEMBER);
     return _c;
+  }
+
+  /**
+   * Helper method to return DefinedStructureInfo for the structure with the specified name that
+   * could be any of the specified structureTypesToCheck, return null if no match is found
+   */
+  private @Nullable DefinedStructureInfo findDefinedStructure(
+      String name, Collection<PaloAltoStructureType> structureTypesToCheck) {
+    for (PaloAltoStructureType typeToCheck : structureTypesToCheck) {
+      Map<String, DefinedStructureInfo> matchingDefinitions =
+          _structureDefinitions.get(typeToCheck.getDescription());
+      if (!matchingDefinitions.isEmpty()) {
+        DefinedStructureInfo definition = matchingDefinitions.get(name);
+        if (definition != null) {
+          return definition;
+        }
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Update referrers and/or warn for undefined structures based on references to an abstract
+   * structure type existing in either the reference's namespace or shared namespace
+   */
+  private void markAbstractStructureFromUnknownNamespace(
+      PaloAltoStructureType type,
+      Collection<PaloAltoStructureType> structureTypesToCheck,
+      PaloAltoStructureUsage usage) {
+    Map<String, SortedMap<StructureUsage, SortedMultiset<Integer>>> references =
+        firstNonNull(_structureReferences.get(type), Collections.emptyMap());
+    references.forEach(
+        (name, byUsage) -> {
+          Multiset<Integer> lines =
+              MoreObjects.firstNonNull(byUsage.get(usage), TreeMultiset.create());
+          // Check this namespace first
+          DefinedStructureInfo info = findDefinedStructure(name, structureTypesToCheck);
+          // Check shared namespace if there was no match
+          if (info == null) {
+            info =
+                findDefinedStructure(
+                    computeObjectName(SHARED_VSYS_NAME, extractObjectName(name)),
+                    structureTypesToCheck);
+          }
+
+          // Now update reference count if applicable
+          if (info != null) {
+            info.setNumReferrers(
+                info.getNumReferrers() == DefinedStructureInfo.UNKNOWN_NUM_REFERRERS
+                    ? DefinedStructureInfo.UNKNOWN_NUM_REFERRERS
+                    : info.getNumReferrers() + lines.size());
+          } else {
+            for (int line : lines) {
+              undefined(type, name, usage, line);
+            }
+          }
+        });
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -320,7 +320,7 @@ public final class PaloAltoConfiguration extends VendorConfiguration {
     references.forEach(
         (name, byUsage) -> {
           Multiset<Integer> lines =
-              MoreObjects.firstNonNull(byUsage.get(usage), TreeMultiset.create());
+              firstNonNull(byUsage.get(usage), TreeMultiset.create());
           // Check this namespace first
           DefinedStructureInfo info = findDefinedStructure(name, structureTypesToCheck);
           // Check shared namespace if there was no match

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -2,7 +2,6 @@ package org.batfish.representation.palo_alto;
 
 import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
 
-import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multiset;
 import com.google.common.collect.SortedMultiset;
@@ -319,8 +318,7 @@ public final class PaloAltoConfiguration extends VendorConfiguration {
         firstNonNull(_structureReferences.get(type), Collections.emptyMap());
     references.forEach(
         (name, byUsage) -> {
-          Multiset<Integer> lines =
-              firstNonNull(byUsage.get(usage), TreeMultiset.create());
+          Multiset<Integer> lines = firstNonNull(byUsage.get(usage), TreeMultiset.create());
           // Check this namespace first
           DefinedStructureInfo info = findDefinedStructure(name, structureTypesToCheck);
           // Check shared namespace if there was no match

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -143,7 +143,10 @@ public final class PaloAltoConfiguration extends VendorConfiguration {
     return String.format("%s~%s", vsysName, objectName);
   }
 
-  /** Extract object name from a name with an embedded namespace */
+  /**
+   * Extract object name from a name with an embedded namespace. For example: nameWithNamespace
+   * might be `vsys1~SERVICE1`, where `SERVICE1` is the object name extracted and returned.
+   */
   private static String extractObjectName(String nameWithNamespace) {
     String[] parts = nameWithNamespace.split("~", -1);
     return parts[parts.length - 1];
@@ -317,16 +320,17 @@ public final class PaloAltoConfiguration extends VendorConfiguration {
     Map<String, SortedMap<StructureUsage, SortedMultiset<Integer>>> references =
         firstNonNull(_structureReferences.get(type), Collections.emptyMap());
     references.forEach(
-        (name, byUsage) -> {
+        (nameWithNamespace, byUsage) -> {
+          String name = extractObjectName(nameWithNamespace);
           Multiset<Integer> lines = firstNonNull(byUsage.get(usage), TreeMultiset.create());
           // Check this namespace first
-          DefinedStructureInfo info = findDefinedStructure(name, structureTypesToCheck);
+          DefinedStructureInfo info =
+              findDefinedStructure(nameWithNamespace, structureTypesToCheck);
           // Check shared namespace if there was no match
           if (info == null) {
             info =
                 findDefinedStructure(
-                    computeObjectName(SHARED_VSYS_NAME, extractObjectName(name)),
-                    structureTypesToCheck);
+                    computeObjectName(SHARED_VSYS_NAME, name), structureTypesToCheck);
           }
 
           // Now update reference count if applicable

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -370,7 +370,6 @@ public class PaloAltoGrammarTest {
     String service4Name = computeObjectName(DEFAULT_VSYS_NAME, "SERVICE4");
     String serviceGroup1Name = computeObjectName(DEFAULT_VSYS_NAME, "SG1");
     String serviceGroup2Name = computeObjectName(DEFAULT_VSYS_NAME, "SG2");
-    String serviceUndefinedName = computeObjectName(DEFAULT_VSYS_NAME, "SERVICE_UNDEFINED");
 
     // Confirm structure definitions are tracked
     assertThat(ccae, hasDefinedStructure(hostname, PaloAltoStructureType.SERVICE, service1Name));
@@ -398,7 +397,7 @@ public class PaloAltoGrammarTest {
     assertThat(
         ccae,
         hasUndefinedReference(
-            hostname, PaloAltoStructureType.SERVICE_OR_SERVICE_GROUP, serviceUndefinedName));
+            hostname, PaloAltoStructureType.SERVICE_OR_SERVICE_GROUP, "SERVICE_UNDEFINED"));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -370,6 +370,7 @@ public class PaloAltoGrammarTest {
     String service4Name = computeObjectName(DEFAULT_VSYS_NAME, "SERVICE4");
     String serviceGroup1Name = computeObjectName(DEFAULT_VSYS_NAME, "SG1");
     String serviceGroup2Name = computeObjectName(DEFAULT_VSYS_NAME, "SG2");
+    String serviceUndefinedName = computeObjectName(DEFAULT_VSYS_NAME, "SERVICE_UNDEFINED");
 
     // Confirm structure definitions are tracked
     assertThat(ccae, hasDefinedStructure(hostname, PaloAltoStructureType.SERVICE, service1Name));
@@ -382,6 +383,22 @@ public class PaloAltoGrammarTest {
     assertThat(
         ccae,
         hasDefinedStructure(hostname, PaloAltoStructureType.SERVICE_GROUP, serviceGroup2Name));
+
+    // Confirm structure references are tracked
+    assertThat(ccae, hasNumReferrers(hostname, PaloAltoStructureType.SERVICE, service1Name, 1));
+    assertThat(ccae, hasNumReferrers(hostname, PaloAltoStructureType.SERVICE, service2Name, 1));
+    assertThat(ccae, hasNumReferrers(hostname, PaloAltoStructureType.SERVICE, service3Name, 0));
+    assertThat(ccae, hasNumReferrers(hostname, PaloAltoStructureType.SERVICE, service4Name, 0));
+    assertThat(
+        ccae, hasNumReferrers(hostname, PaloAltoStructureType.SERVICE_GROUP, serviceGroup1Name, 1));
+    assertThat(
+        ccae, hasNumReferrers(hostname, PaloAltoStructureType.SERVICE_GROUP, serviceGroup2Name, 0));
+
+    // Confirm undefined reference shows up as such
+    assertThat(
+        ccae,
+        hasUndefinedReference(
+            hostname, PaloAltoStructureType.SERVICE_OR_SERVICE_GROUP, serviceUndefinedName));
   }
 
   @Test
@@ -466,6 +483,14 @@ public class PaloAltoGrammarTest {
         ccae, hasDefinedStructure(hostname, PaloAltoStructureType.SERVICE, sharedServiceName));
     assertThat(
         ccae, hasDefinedStructure(hostname, PaloAltoStructureType.SERVICE, sharedOnlyServiceName));
+
+    // Confirm structure references are tracked separately for each vsys
+    assertThat(ccae, hasNumReferrers(hostname, PaloAltoStructureType.SERVICE, vsys1ServiceName, 1));
+    assertThat(ccae, hasNumReferrers(hostname, PaloAltoStructureType.SERVICE, vsys2ServiceName, 1));
+    assertThat(
+        ccae, hasNumReferrers(hostname, PaloAltoStructureType.SERVICE, sharedServiceName, 1));
+    assertThat(
+        ccae, hasNumReferrers(hostname, PaloAltoStructureType.SERVICE, sharedOnlyServiceName, 3));
   }
 
   @Test


### PR DESCRIPTION
PAN structure references may implicitly span multiple namespaces.

For example:  consider the config line:`set vsys vsys1 service-group GROUP members SERVICE1`.
Here, `GROUP` is an object inside the logical firewall `vsys1`, and it is made-up of a reference to `SERVICE1`.
`SERVICE1` may refer to a `service` or `service-group` defined in either `vsys1` or in the `shared` namespace.

This PR sets up infrastructure to handle marking these abstract structure types across multiple namespaces, and applies this to `service` and `service-group` marking.
