### PR TITLE
Juniper: parse and extract static route no-install

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractRoute.java
@@ -50,6 +50,8 @@ public abstract class AbstractRoute implements Serializable, Comparable<Abstract
 
   private boolean _nonRouting;
 
+  private boolean _nonForwarding;
+
   @Nullable private String _vrf;
 
   @JsonCreator
@@ -133,6 +135,11 @@ public abstract class AbstractRoute implements Serializable, Comparable<Abstract
   }
 
   @JsonIgnore
+  public final boolean getNonForwarding() {
+    return _nonForwarding;
+  }
+
+  @JsonIgnore
   public abstract RoutingProtocol getProtocol();
 
   @JsonIgnore
@@ -163,6 +170,11 @@ public abstract class AbstractRoute implements Serializable, Comparable<Abstract
   @JsonIgnore
   public final void setNonRouting(boolean nonRouting) {
     _nonRouting = nonRouting;
+  }
+
+  @JsonIgnore
+  public final void setNonForwarding(boolean nonForwarding) {
+    _nonForwarding = nonForwarding;
   }
 
   @JsonProperty(PROP_VRF)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibImpl.java
@@ -70,6 +70,11 @@ public class FibImpl implements Fib {
     }
     Ip nextHopIp = route.getNextHopIp();
 
+    // For non-forwarding routes, abort
+    if (route.getNonForwarding()) {
+      return;
+    }
+
     /* For BGP next-hop-discard routes, ignore next-hop-ip and exit early */
     if (route instanceof BgpRoute && ((BgpRoute) route).getDiscard()) {
       Map<Ip, Set<AbstractRoute>> nextHopInterfaceRoutesByFinalNextHopIp =

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/AbstractRouteMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/AbstractRouteMatchers.java
@@ -12,6 +12,7 @@ import org.batfish.datamodel.matchers.AbstractRouteMatchersImpl.HasNextHopInterf
 import org.batfish.datamodel.matchers.AbstractRouteMatchersImpl.HasNextHopIp;
 import org.batfish.datamodel.matchers.AbstractRouteMatchersImpl.HasPrefix;
 import org.batfish.datamodel.matchers.AbstractRouteMatchersImpl.HasProtocol;
+import org.batfish.datamodel.matchers.AbstractRouteMatchersImpl.IsNonForwarding;
 import org.hamcrest.Matcher;
 
 public final class AbstractRouteMatchers {
@@ -88,6 +89,14 @@ public final class AbstractRouteMatchers {
    */
   public static HasProtocol hasProtocol(RoutingProtocol expectedProtocol) {
     return new HasProtocol(equalTo(expectedProtocol));
+  }
+
+  /**
+   * Provides a matcher that matches when the supplied {@code nonForwarding} is equal to the {@link
+   * AbstractRoute}'s nonForwarding.
+   */
+  public static IsNonForwarding isNonForwarding(boolean nonForwarding) {
+    return new IsNonForwarding(equalTo(nonForwarding));
   }
 
   private AbstractRouteMatchers() {}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/AbstractRouteMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/AbstractRouteMatchersImpl.java
@@ -75,5 +75,16 @@ final class AbstractRouteMatchersImpl {
     }
   }
 
+  static final class IsNonForwarding extends FeatureMatcher<AbstractRoute, Boolean> {
+    IsNonForwarding(@Nonnull Matcher<? super Boolean> subMatcher) {
+      super(subMatcher, "An AbstractRoute with nonRouting:", "nonRouting");
+    }
+
+    @Override
+    protected Boolean featureValueOf(AbstractRoute actual) {
+      return actual.getNonForwarding();
+    }
+  }
+
   private AbstractRouteMatchersImpl() {}
 }

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_routing_instances.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_routing_instances.g4
@@ -481,6 +481,7 @@ rosr_common
    | rosr_community
    | rosr_discard
    | rosr_install
+   | rosr_no_install
    | rosr_metric
    | rosr_next_hop
    | rosr_next_table
@@ -531,6 +532,11 @@ rosr_next_hop
 rosr_next_table
 :
    NEXT_TABLE name = variable
+;
+
+rosr_no_install
+:
+   NO_INSTALL
 ;
 
 rosr_no_readvertise

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -337,6 +337,7 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ros_routeContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Rosr_discardContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Rosr_metricContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Rosr_next_hopContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Rosr_no_installContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Rosr_preferenceContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Rosr_rejectContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Rosr_tagContext;
@@ -4186,6 +4187,11 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
       initInterface(ctx.interface_id());
       _currentStaticRoute.setNextHopInterface(ctx.interface_id().getText());
     }
+  }
+
+  @Override
+  public void exitRosr_no_install(Rosr_no_installContext ctx) {
+    _currentStaticRoute.setNoInstall(ctx.NO_INSTALL() != null);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -1901,6 +1901,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
             .setTag(tag)
             .build();
 
+    newStaticRoute.setNonForwarding(firstNonNull(route.getNoInstall(), Boolean.FALSE));
     return newStaticRoute;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/StaticRoute.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/StaticRoute.java
@@ -3,6 +3,7 @@ package org.batfish.representation.juniper;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
 
@@ -30,6 +31,8 @@ public class StaticRoute implements Serializable {
 
   private Integer _tag;
 
+  private Boolean _noInstall;
+
   public StaticRoute(Prefix prefix) {
     _prefix = prefix;
     _policies = new ArrayList<>();
@@ -55,6 +58,11 @@ public class StaticRoute implements Serializable {
 
   public Ip getNextHopIp() {
     return _nextHopIp;
+  }
+
+  @Nullable
+  public Boolean getNoInstall() {
+    return _noInstall;
   }
 
   public List<String> getPolicies() {
@@ -87,6 +95,10 @@ public class StaticRoute implements Serializable {
 
   public void setNextHopIp(Ip nextHopIp) {
     _nextHopIp = nextHopIp;
+  }
+
+  public void setNoInstall(@Nullable Boolean noInstall) {
+    _noInstall = noInstall;
   }
 
   public void setTag(int tag) {

--- a/projects/batfish/src/test/java/org/batfish/dataplane/FibTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/FibTest.java
@@ -1,0 +1,44 @@
+package org.batfish.dataplane;
+
+import static org.batfish.datamodel.matchers.AbstractRouteMatchers.hasPrefix;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+
+import java.util.Set;
+import org.batfish.datamodel.AbstractRoute;
+import org.batfish.datamodel.Fib;
+import org.batfish.datamodel.FibImpl;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.StaticRoute;
+import org.batfish.dataplane.rib.Rib;
+import org.junit.Test;
+
+/** Test of {@link Fib} that depend on dataplane behavior. */
+public class FibTest {
+  @Test
+  public void testNonForwardingRouteNotInFib() {
+    Rib rib = new Rib();
+
+    StaticRoute nonForwardingRoute =
+        StaticRoute.builder()
+            .setNetwork(Prefix.parse("1.1.1.0/24"))
+            .setNextHopInterface("Eth1")
+            .build();
+    nonForwardingRoute.setNonForwarding(true);
+    StaticRoute forwardingRoute =
+        StaticRoute.builder()
+            .setNetwork(Prefix.parse("2.2.2.0/24"))
+            .setNextHopInterface("Eth1")
+            .build();
+
+    rib.mergeRoute(nonForwardingRoute);
+    rib.mergeRoute(forwardingRoute);
+
+    Fib fib = new FibImpl(rib);
+    Set<AbstractRoute> fibRoutes = fib.getRoutesByNextHopInterface().get("Eth1");
+
+    assertThat(fibRoutes, not(hasItem(hasPrefix(Prefix.parse("1.1.1.0/24")))));
+    assertThat(fibRoutes, hasItem(hasPrefix(Prefix.parse("2.2.2.0/24"))));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -1,6 +1,7 @@
 package org.batfish.grammar.flatjuniper;
 
 import static org.batfish.datamodel.matchers.AbstractRouteMatchers.hasPrefix;
+import static org.batfish.datamodel.matchers.AbstractRouteMatchers.isNonForwarding;
 import static org.batfish.datamodel.matchers.BgpNeighborMatchers.hasClusterId;
 import static org.batfish.datamodel.matchers.BgpNeighborMatchers.hasEnforceFirstAs;
 import static org.batfish.datamodel.matchers.BgpNeighborMatchers.hasLocalAs;
@@ -2520,6 +2521,11 @@ public class FlatJuniperGrammarTest {
 
     assertThat(c, hasDefaultVrf(hasStaticRoutes(hasItem(hasPrefix(Prefix.parse("1.0.0.0/8"))))));
     assertThat(c, hasVrf("ri2", hasStaticRoutes(hasItem(hasPrefix(Prefix.parse("2.0.0.0/8"))))));
+    assertThat(
+        c,
+        hasDefaultVrf(
+            hasStaticRoutes(
+                hasItem(allOf(hasPrefix(Prefix.parse("3.0.0.0/8")), isNonForwarding(true))))));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/static-routes
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/static-routes
@@ -3,4 +3,5 @@ set system host-name static-routes
 #
 set routing-options static route 1.0.0.0/8 next-hop 10.0.0.1
 set routing-instances ri2 routing-options static route 2.0.0.0/8 next-hop 10.0.0.2
+set routing-options static route 3.0.0.0/8 no-install
 #


### PR DESCRIPTION
Was generating a parse warning.
Parsed and extracted according to [this](https://www.juniper.net/documentation/en_US/junos/topics/reference/configuration-statement/install-edit-routing-options.html)