### PR TITLE
Fix bazel build

### DIFF
--- a/projects/batfish/BUILD
+++ b/projects/batfish/BUILD
@@ -77,6 +77,7 @@ java_library(
         "//projects/batfish-common-protocol:common",
         "//projects/batfish-common-protocol:common_testlib",
         "//projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper",
+        "//projects/lib/bdd",
         "//projects/lib/z3",
         "@antlr4_runtime//:compile",
         "@commons_collections4//:compile",

--- a/projects/question/BUILD
+++ b/projects/question/BUILD
@@ -24,22 +24,6 @@ java_library(
     ],
 )
 
-java_library(
-    name = "question_testlib",
-    testonly = True,
-    srcs = glob(
-        [
-            "src/test/**/*.java",
-        ],
-        exclude = ["src/test/**/*Test.java"],
-    ),
-    deps = [
-        ":question",
-        "//projects/batfish-common-protocol:common",
-        "@guava//:compile",
-    ],
-)
-
 junit_tests(
     name = "question_tests",
     size = "small",
@@ -57,8 +41,8 @@ junit_tests(
     ],
     deps = [
         ":question",
-        ":question_testlib",
         "//projects/batfish-common-protocol:common",
+        "//projects/batfish-common-protocol:common_testlib",
         "//projects/lib/jsonpath",
         "@auto_service//:compile",
         "@guava//:compile",


### PR DESCRIPTION
Add/remove dependencies as needed after changes to question tests, bdd work, and new topology tests.

*Note*: Not sure why topology tests use empty batches (perhaps as a "log statement"?) so had to suppress a couple of warnings.
