### PR TITLE
Cisco: remove all extenders of ComparableStructure

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco/DepiClass.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco/DepiClass.java
@@ -2,15 +2,24 @@ package org.batfish.datamodel.vendor_family.cisco;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.batfish.common.util.ComparableStructure;
+import java.io.Serializable;
 
-public class DepiClass extends ComparableStructure<String> {
+public class DepiClass implements Serializable {
 
   /** */
   private static final long serialVersionUID = 1L;
 
+  private static final String PROP_NAME = "name";
+
+  private final String _name;
+
   @JsonCreator
   public DepiClass(@JsonProperty(PROP_NAME) String name) {
-    super(name);
+    _name = name;
+  }
+
+  @JsonProperty(PROP_NAME)
+  public String getName() {
+    return _name;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco/DepiTunnel.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco/DepiTunnel.java
@@ -2,15 +2,24 @@ package org.batfish.datamodel.vendor_family.cisco;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.batfish.common.util.ComparableStructure;
+import java.io.Serializable;
 
-public class DepiTunnel extends ComparableStructure<String> {
+public class DepiTunnel implements Serializable {
 
   /** */
   private static final long serialVersionUID = 1L;
 
+  private static final String PROP_NAME = "name";
+
+  private final String _name;
+
   @JsonCreator
   public DepiTunnel(@JsonProperty(PROP_NAME) String name) {
-    super(name);
+    _name = name;
+  }
+
+  @JsonProperty(PROP_NAME)
+  public String getName() {
+    return _name;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco/DocsisPolicy.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco/DocsisPolicy.java
@@ -2,21 +2,30 @@ package org.batfish.datamodel.vendor_family.cisco;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import org.batfish.common.util.ComparableStructure;
 
-public class DocsisPolicy extends ComparableStructure<String> {
+public class DocsisPolicy implements Serializable {
 
   /** */
   private static final long serialVersionUID = 1L;
+
+  private static final String PROP_NAME = "name";
+
+  private final String _name;
 
   private List<String> _rules;
 
   @JsonCreator
   public DocsisPolicy(@JsonProperty(PROP_NAME) String number) {
-    super(number);
+    _name = number;
     _rules = new ArrayList<>();
+  }
+
+  @JsonProperty(PROP_NAME)
+  public String getName() {
+    return _name;
   }
 
   public List<String> getRules() {

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -3762,7 +3762,6 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   @Override
   public void enterViaf_vrrp(Viaf_vrrpContext ctx) {
     int groupNum = toInteger(ctx.groupnum);
-    final int line = ctx.getStart().getLine();
     _currentVrrpGroup =
         _configuration
             .getVrrpGroups()
@@ -5516,7 +5515,6 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   public void exitIfvrrp_authentication(Ifvrrp_authenticationContext ctx) {
     String hashedAuthenticationText =
         CommonUtil.sha256Digest(ctx.text.getText() + CommonUtil.salt());
-    final int line = ctx.getStart().getLine();
     for (Interface iface : _currentInterfaces) {
       String ifaceName = iface.getName();
       VrrpGroup vrrpGroup =
@@ -5532,7 +5530,6 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   @Override
   public void exitIfvrrp_ip(Ifvrrp_ipContext ctx) {
     Ip ip = toIp(ctx.ip);
-    final int line = ctx.getStart().getLine();
     for (Interface iface : _currentInterfaces) {
       String ifaceName = iface.getName();
       VrrpGroup vrrpGroup =
@@ -5547,7 +5544,6 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
 
   @Override
   public void exitIfvrrp_preempt(Ifvrrp_preemptContext ctx) {
-    final int line = ctx.getStart().getLine();
     for (Interface iface : _currentInterfaces) {
       String ifaceName = iface.getName();
       VrrpGroup vrrpGroup =
@@ -5563,7 +5559,6 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   @Override
   public void exitIfvrrp_priority(Ifvrrp_priorityContext ctx) {
     int priority = toInteger(ctx.priority);
-    final int line = ctx.getStart().getLine();
     for (Interface iface : _currentInterfaces) {
       String ifaceName = iface.getName();
       VrrpGroup vrrpGroup =

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -1935,7 +1935,7 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
     CryptoMapSet cryptoMapSet = _configuration.getCryptoMapSets().get(name);
     // if this is the first crypto map entry in the crypto map set
     if (cryptoMapSet == null) {
-      cryptoMapSet = new CryptoMapSet(name);
+      cryptoMapSet = new CryptoMapSet();
       cryptoMapSet.setDynamic(true);
       _configuration.getCryptoMapSets().put(name, cryptoMapSet);
       defineStructure(CRYPTO_DYNAMIC_MAP_SET, name, ctx);
@@ -1955,7 +1955,7 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
     CryptoMapSet cryptoMapSet = _configuration.getCryptoMapSets().get(_currentCryptoMapName);
     // if this is the first crypto map entry in the crypto map set
     if (cryptoMapSet == null) {
-      cryptoMapSet = new CryptoMapSet(_currentCryptoMapName);
+      cryptoMapSet = new CryptoMapSet();
       _configuration.getCryptoMapSets().put(_currentCryptoMapName, cryptoMapSet);
       defineStructure(CRYPTO_MAP_SET, _currentCryptoMapName, ctx);
     } else if (cryptoMapSet.getDynamic()) {
@@ -2116,7 +2116,7 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   @Override
   public void enterIp_nat_pool(Ip_nat_poolContext ctx) {
     String name = ctx.name.getText();
-    NatPool natPool = new NatPool(name);
+    NatPool natPool = new NatPool();
     _configuration.getNatPools().put(name, natPool);
     _currentNatPool = natPool;
     defineStructure(NAT_POOL, name, ctx);
@@ -3766,7 +3766,7 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
     _currentVrrpGroup =
         _configuration
             .getVrrpGroups()
-            .computeIfAbsent(_currentVrrpInterface, name -> new VrrpInterface(name, line))
+            .computeIfAbsent(_currentVrrpInterface, name -> new VrrpInterface())
             .getVrrpGroups()
             .computeIfAbsent(groupNum, VrrpGroup::new);
   }
@@ -5522,7 +5522,7 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
       VrrpGroup vrrpGroup =
           _configuration
               .getVrrpGroups()
-              .computeIfAbsent(ifaceName, n -> new VrrpInterface(ifaceName, line))
+              .computeIfAbsent(ifaceName, n -> new VrrpInterface())
               .getVrrpGroups()
               .computeIfAbsent(_currentVrrpGroupNum, VrrpGroup::new);
       vrrpGroup.setAuthenticationTextHash(hashedAuthenticationText);
@@ -5538,7 +5538,7 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
       VrrpGroup vrrpGroup =
           _configuration
               .getVrrpGroups()
-              .computeIfAbsent(ifaceName, n -> new VrrpInterface(ifaceName, line))
+              .computeIfAbsent(ifaceName, n -> new VrrpInterface())
               .getVrrpGroups()
               .computeIfAbsent(_currentVrrpGroupNum, VrrpGroup::new);
       vrrpGroup.setVirtualAddress(ip);
@@ -5553,7 +5553,7 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
       VrrpGroup vrrpGroup =
           _configuration
               .getVrrpGroups()
-              .computeIfAbsent(ifaceName, n -> new VrrpInterface(ifaceName, line))
+              .computeIfAbsent(ifaceName, n -> new VrrpInterface())
               .getVrrpGroups()
               .computeIfAbsent(_currentVrrpGroupNum, VrrpGroup::new);
       vrrpGroup.setPreempt(true);
@@ -5569,7 +5569,7 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
       VrrpGroup vrrpGroup =
           _configuration
               .getVrrpGroups()
-              .computeIfAbsent(ifaceName, n -> new VrrpInterface(ifaceName, line))
+              .computeIfAbsent(ifaceName, n -> new VrrpInterface())
               .getVrrpGroups()
               .computeIfAbsent(_currentVrrpGroupNum, VrrpGroup::new);
       vrrpGroup.setPriority(priority);
@@ -6249,7 +6249,7 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
       mapLine = ctx.mapname.getStart().getLine();
       _configuration.referenceStructure(ROUTE_MAP, map, BGP_NETWORK_ORIGINATION_ROUTE_MAP, mapLine);
     }
-    BgpNetwork bgpNetwork = new BgpNetwork(prefix, map, mapLine);
+    BgpNetwork bgpNetwork = new BgpNetwork(map, mapLine);
     BgpProcess proc = currentVrf().getBgpProcess();
     proc.getIpNetworks().put(prefix, bgpNetwork);
   }
@@ -6266,7 +6266,7 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
           ROUTE_MAP, map, BGP_NETWORK6_ORIGINATION_ROUTE_MAP, mapLine);
     }
     BgpProcess proc = currentVrf().getBgpProcess();
-    BgpNetwork6 bgpNetwork6 = new BgpNetwork6(prefix6, map, mapLine);
+    BgpNetwork6 bgpNetwork6 = new BgpNetwork6(map, mapLine);
     proc.getIpv6Networks().put(prefix6, bgpNetwork6);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -3775,7 +3775,7 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   public void enterVrf_block_rb_stanza(Vrf_block_rb_stanzaContext ctx) {
     _currentVrf = ctx.name.getText();
     int procNum =
-        _configuration.getVrfs().get(Configuration.DEFAULT_VRF_NAME).getBgpProcess().getName();
+        _configuration.getVrfs().get(Configuration.DEFAULT_VRF_NAME).getBgpProcess().getProcnum();
     BgpProcess proc = new BgpProcess(_format, procNum);
     currentVrf().setBgpProcess(proc);
     pushPeer(proc.getMasterBgpPeerGroup());

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/AsPathSet.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/AsPathSet.java
@@ -1,23 +1,28 @@
 package org.batfish.representation.cisco;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import org.batfish.common.util.ComparableStructure;
 import org.batfish.datamodel.routing_policy.expr.AsPathSetElem;
 
-public class AsPathSet extends ComparableStructure<String> {
+public class AsPathSet implements Serializable {
 
   /** */
   private static final long serialVersionUID = 1L;
 
   private final List<AsPathSetElem> _elements;
+  private final String _name;
 
   public AsPathSet(String name) {
-    super(name);
+    _name = name;
     _elements = new ArrayList<>();
   }
 
   public List<AsPathSetElem> getElements() {
     return _elements;
+  }
+
+  public String getName() {
+    return _name;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/BgpNetwork.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/BgpNetwork.java
@@ -1,19 +1,21 @@
 package org.batfish.representation.cisco;
 
-import org.batfish.common.util.ComparableStructure;
+import java.io.Serializable;
 import org.batfish.datamodel.Prefix;
 
-public class BgpNetwork extends ComparableStructure<Prefix> {
+public class BgpNetwork implements Serializable {
 
   /** */
   private static final long serialVersionUID = 1L;
+
+  private final Prefix _prefix;
 
   private final Integer _routeMapLine;
 
   private final String _routeMapName;
 
-  public BgpNetwork(Prefix name, String routeMapName, Integer routeMapLine) {
-    super(name);
+  public BgpNetwork(Prefix prefix, String routeMapName, Integer routeMapLine) {
+    _prefix = prefix;
     _routeMapName = routeMapName;
     _routeMapLine = routeMapLine;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/BgpNetwork.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/BgpNetwork.java
@@ -1,21 +1,17 @@
 package org.batfish.representation.cisco;
 
 import java.io.Serializable;
-import org.batfish.datamodel.Prefix;
 
 public class BgpNetwork implements Serializable {
 
   /** */
   private static final long serialVersionUID = 1L;
 
-  private final Prefix _prefix;
-
   private final Integer _routeMapLine;
 
   private final String _routeMapName;
 
-  public BgpNetwork(Prefix prefix, String routeMapName, Integer routeMapLine) {
-    _prefix = prefix;
+  public BgpNetwork(String routeMapName, Integer routeMapLine) {
     _routeMapName = routeMapName;
     _routeMapLine = routeMapLine;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/BgpNetwork6.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/BgpNetwork6.java
@@ -1,19 +1,21 @@
 package org.batfish.representation.cisco;
 
-import org.batfish.common.util.ComparableStructure;
+import java.io.Serializable;
 import org.batfish.datamodel.Prefix6;
 
-public class BgpNetwork6 extends ComparableStructure<Prefix6> {
+public class BgpNetwork6 implements Serializable {
 
   /** */
   private static final long serialVersionUID = 1L;
+
+  private final Prefix6 _prefix6;
 
   private final Integer _routeMapLine;
 
   private final String _routeMapName;
 
-  public BgpNetwork6(Prefix6 name, String routeMapName, Integer routeMapLine) {
-    super(name);
+  public BgpNetwork6(Prefix6 prefix6, String routeMapName, Integer routeMapLine) {
+    _prefix6 = prefix6;
     _routeMapName = routeMapName;
     _routeMapLine = routeMapLine;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/BgpNetwork6.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/BgpNetwork6.java
@@ -1,21 +1,17 @@
 package org.batfish.representation.cisco;
 
 import java.io.Serializable;
-import org.batfish.datamodel.Prefix6;
 
 public class BgpNetwork6 implements Serializable {
 
   /** */
   private static final long serialVersionUID = 1L;
 
-  private final Prefix6 _prefix6;
-
   private final Integer _routeMapLine;
 
   private final String _routeMapName;
 
-  public BgpNetwork6(Prefix6 prefix6, String routeMapName, Integer routeMapLine) {
-    _prefix6 = prefix6;
+  public BgpNetwork6(String routeMapName, Integer routeMapLine) {
     _routeMapName = routeMapName;
     _routeMapLine = routeMapLine;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/BgpProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/BgpProcess.java
@@ -1,12 +1,12 @@
 package org.batfish.representation.cisco;
 
+import java.io.Serializable;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
-import org.batfish.common.util.ComparableStructure;
 import org.batfish.datamodel.BgpTieBreaker;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Ip;
@@ -15,7 +15,7 @@ import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Prefix6;
 import org.batfish.datamodel.RoutingProtocol;
 
-public class BgpProcess extends ComparableStructure<Integer> {
+public class BgpProcess implements Serializable {
 
   private static final int DEFAULT_BGP_DEFAULT_METRIC = 0;
 
@@ -65,6 +65,8 @@ public class BgpProcess extends ComparableStructure<Integer> {
 
   private Map<String, NamedBgpPeerGroup> _peerSessions;
 
+  private final int _procnum;
+
   private final Map<RoutingProtocol, BgpRedistributionPolicy> _redistributionPolicies;
 
   private Ip _routerId;
@@ -72,7 +74,6 @@ public class BgpProcess extends ComparableStructure<Integer> {
   private BgpTieBreaker _tieBreaker;
 
   public BgpProcess(ConfigurationFormat format, int procnum) {
-    super(procnum);
     _afGroups = new HashMap<>();
     _aggregateNetworks = new HashMap<>();
     _aggregateIpv6Networks = new HashMap<>();
@@ -86,6 +87,7 @@ public class BgpProcess extends ComparableStructure<Integer> {
     _ipv6Networks = new LinkedHashMap<>();
     _ipv6PeerGroups = new HashMap<>();
     _peerSessions = new HashMap<>();
+    _procnum = procnum;
     _redistributionPolicies = new EnumMap<>(RoutingProtocol.class);
     _masterBgpPeerGroup = new MasterBgpPeerGroup();
     if (format == ConfigurationFormat.ARISTA) {
@@ -237,6 +239,10 @@ public class BgpProcess extends ComparableStructure<Integer> {
 
   public Map<String, NamedBgpPeerGroup> getPeerSessions() {
     return _peerSessions;
+  }
+
+  public int getProcnum() {
+    return _procnum;
   }
 
   public Map<RoutingProtocol, BgpRedistributionPolicy> getRedistributionPolicies() {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -1890,7 +1890,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
           continue;
         }
         Long pgLocalAs = lpg.getLocalAs();
-        long localAs = pgLocalAs != null ? pgLocalAs : proc.getName();
+        long localAs = pgLocalAs != null ? pgLocalAs : proc.getProcnum();
 
         BgpPeerConfig.Builder<?, ?> newNeighborBuilder;
         if (lpg instanceof IpBgpPeerGroup) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CryptoMapEntry.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CryptoMapEntry.java
@@ -1,13 +1,13 @@
 package org.batfish.representation.cisco;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
-import org.batfish.common.util.ComparableStructure;
 import org.batfish.datamodel.DiffieHellmanGroup;
 import org.batfish.datamodel.Ip;
 
-public class CryptoMapEntry extends ComparableStructure<String> {
+public class CryptoMapEntry implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
@@ -27,8 +27,10 @@ public class CryptoMapEntry extends ComparableStructure<String> {
 
   private int _sequenceNumber;
 
+  private final String _name;
+
   public CryptoMapEntry(String name, int sequenceNumber) {
-    super(name);
+    _name = name;
     _transforms = new ArrayList<>(); /* transforms or IPSec proposals are applied in order */
     _sequenceNumber = sequenceNumber;
   }
@@ -43,6 +45,10 @@ public class CryptoMapEntry extends ComparableStructure<String> {
 
   public @Nullable String getIsakmpProfile() {
     return _isakmpProfile;
+  }
+
+  public String getName() {
+    return _name;
   }
 
   public @Nullable Ip getPeer() {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CryptoMapSet.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CryptoMapSet.java
@@ -1,11 +1,11 @@
 package org.batfish.representation.cisco;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.batfish.common.util.ComparableStructure;
 
-public class CryptoMapSet extends ComparableStructure<String> {
+public class CryptoMapSet implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
@@ -13,9 +13,11 @@ public class CryptoMapSet extends ComparableStructure<String> {
 
   private List<CryptoMapEntry> _cryptoMapEntries;
 
+  private final String _name;
+
   public CryptoMapSet(String name) {
-    super(name);
     _cryptoMapEntries = new ArrayList<>();
+    _name = name;
   }
 
   public boolean getDynamic() {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CryptoMapSet.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CryptoMapSet.java
@@ -13,11 +13,8 @@ public class CryptoMapSet implements Serializable {
 
   private List<CryptoMapEntry> _cryptoMapEntries;
 
-  private final String _name;
-
-  public CryptoMapSet(String name) {
+  public CryptoMapSet() {
     _cryptoMapEntries = new ArrayList<>();
-    _name = name;
   }
 
   public boolean getDynamic() {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/ExpandedCommunityList.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/ExpandedCommunityList.java
@@ -1,17 +1,19 @@
 package org.batfish.representation.cisco;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import org.batfish.common.util.ComparableStructure;
 
-public class ExpandedCommunityList extends ComparableStructure<String> {
+public class ExpandedCommunityList implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
   private List<ExpandedCommunityListLine> _lines;
 
+  private final String _name;
+
   public ExpandedCommunityList(String name) {
-    super(name);
+    _name = name;
     _lines = new ArrayList<>();
   }
 
@@ -21,5 +23,9 @@ public class ExpandedCommunityList extends ComparableStructure<String> {
 
   public List<ExpandedCommunityListLine> getLines() {
     return _lines;
+  }
+
+  public String getName() {
+    return _name;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/ExtendedAccessList.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/ExtendedAccessList.java
@@ -1,19 +1,21 @@
 package org.batfish.representation.cisco;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import org.batfish.common.util.ComparableStructure;
 
-public class ExtendedAccessList extends ComparableStructure<String> {
+public class ExtendedAccessList implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
   private List<ExtendedAccessListLine> _lines;
 
+  private final String _name;
+
   private StandardAccessList _parent;
 
   public ExtendedAccessList(String id) {
-    super(id);
+    _name = id;
     _lines = new ArrayList<>();
   }
 
@@ -23,6 +25,10 @@ public class ExtendedAccessList extends ComparableStructure<String> {
 
   public List<ExtendedAccessListLine> getLines() {
     return _lines;
+  }
+
+  public String getName() {
+    return _name;
   }
 
   public StandardAccessList getParent() {
@@ -35,7 +41,7 @@ public class ExtendedAccessList extends ComparableStructure<String> {
 
   @Override
   public String toString() {
-    StringBuilder output = new StringBuilder(super.toString() + "\n" + "Identifier: " + _key);
+    StringBuilder output = new StringBuilder(super.toString() + "\n" + "Identifier: " + _name);
     for (ExtendedAccessListLine line : _lines) {
       output.append("\n").append(line);
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/ExtendedIpv6AccessList.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/ExtendedIpv6AccessList.java
@@ -1,19 +1,21 @@
 package org.batfish.representation.cisco;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import org.batfish.common.util.ComparableStructure;
 
-public class ExtendedIpv6AccessList extends ComparableStructure<String> {
+public class ExtendedIpv6AccessList implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
   private List<ExtendedIpv6AccessListLine> _lines;
 
+  private final String _name;
+
   private StandardIpv6AccessList _parent;
 
   public ExtendedIpv6AccessList(String id) {
-    super(id);
+    _name = id;
     _lines = new ArrayList<>();
   }
 
@@ -23,6 +25,10 @@ public class ExtendedIpv6AccessList extends ComparableStructure<String> {
 
   public List<ExtendedIpv6AccessListLine> getLines() {
     return _lines;
+  }
+
+  public String getName() {
+    return _name;
   }
 
   public StandardIpv6AccessList getParent() {
@@ -35,7 +41,7 @@ public class ExtendedIpv6AccessList extends ComparableStructure<String> {
 
   @Override
   public String toString() {
-    StringBuilder output = new StringBuilder(super.toString() + "\n" + "Identifier: " + _key);
+    StringBuilder output = new StringBuilder(super.toString() + "\n" + "Identifier: " + _name);
     for (ExtendedIpv6AccessListLine line : _lines) {
       output.append("\n").append(line);
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/InspectClassMap.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/InspectClassMap.java
@@ -1,10 +1,10 @@
 package org.batfish.representation.cisco;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import org.batfish.common.util.ComparableStructure;
 
-public class InspectClassMap extends ComparableStructure<String> {
+public class InspectClassMap implements Serializable {
 
   /** */
   private static final long serialVersionUID = 1L;
@@ -13,9 +13,11 @@ public class InspectClassMap extends ComparableStructure<String> {
 
   private MatchSemantics _matchSemantics;
 
+  private final String _name;
+
   public InspectClassMap(String name) {
-    super(name);
     _matches = new ArrayList<>();
+    _name = name;
   }
 
   public List<InspectClassMapMatch> getMatches() {
@@ -24,6 +26,10 @@ public class InspectClassMap extends ComparableStructure<String> {
 
   public MatchSemantics getMatchSemantics() {
     return _matchSemantics;
+  }
+
+  public String getName() {
+    return _name;
   }
 
   public void setMatchSemantics(MatchSemantics matchSemantics) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/InspectPolicyMap.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/InspectPolicyMap.java
@@ -1,11 +1,11 @@
 package org.batfish.representation.cisco;
 
+import java.io.Serializable;
 import java.util.Map;
 import java.util.TreeMap;
-import org.batfish.common.util.ComparableStructure;
 import org.batfish.datamodel.LineAction;
 
-public class InspectPolicyMap extends ComparableStructure<String> {
+public class InspectPolicyMap implements Serializable {
 
   /** */
   private static final long serialVersionUID = 1L;
@@ -14,8 +14,10 @@ public class InspectPolicyMap extends ComparableStructure<String> {
 
   private Map<String, InspectPolicyMapInspectClass> _inspectClasses;
 
+  private final String _name;
+
   public InspectPolicyMap(String name) {
-    super(name);
+    _name = name;
     _classDefaultAction = LineAction.REJECT;
     _inspectClasses = new TreeMap<>();
   }
@@ -26,6 +28,10 @@ public class InspectPolicyMap extends ComparableStructure<String> {
 
   public Map<String, InspectPolicyMapInspectClass> getInspectClasses() {
     return _inspectClasses;
+  }
+
+  public String getName() {
+    return _name;
   }
 
   public void setClassDefaultAction(LineAction classDefaultAction) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/Interface.java
@@ -1,6 +1,7 @@
 package org.batfish.representation.cisco;
 
 import com.google.common.collect.ImmutableSortedSet;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -9,7 +10,6 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import javax.annotation.Nullable;
 import org.batfish.common.BatfishException;
-import org.batfish.common.util.ComparableStructure;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
@@ -18,7 +18,7 @@ import org.batfish.datamodel.SwitchportEncapsulationType;
 import org.batfish.datamodel.SwitchportMode;
 import org.batfish.datamodel.isis.IsisInterfaceMode;
 
-public class Interface extends ComparableStructure<String> {
+public class Interface implements Serializable {
 
   private static final double ARISTA_ETHERNET_BANDWIDTH = 1E9;
 
@@ -139,6 +139,8 @@ public class Interface extends ComparableStructure<String> {
 
   private int _mtu;
 
+  private final String _name;
+
   private int _nativeVlan;
 
   private boolean _ospfActive;
@@ -198,13 +200,13 @@ public class Interface extends ComparableStructure<String> {
   }
 
   public Interface(String name, CiscoConfiguration c) {
-    super(name);
     _active = true;
     _autoState = true;
     _allowedVlans = new ArrayList<>();
     _declaredNames = ImmutableSortedSet.of();
     _dhcpRelayAddresses = new TreeSet<>();
     _isisInterfaceMode = IsisInterfaceMode.UNSET;
+    _name = name;
     _nativeVlan = 1;
     _secondaryAddresses = new LinkedHashSet<>();
     SwitchportMode defaultSwitchportMode = c.getCf().getDefaultSwitchportMode();
@@ -310,6 +312,10 @@ public class Interface extends ComparableStructure<String> {
 
   public int getMtu() {
     return _mtu;
+  }
+
+  public String getName() {
+    return _name;
   }
 
   public int getNativeVlan() {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/IpAsPathAccessList.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/IpAsPathAccessList.java
@@ -1,17 +1,19 @@
 package org.batfish.representation.cisco;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import org.batfish.common.util.ComparableStructure;
 
-public class IpAsPathAccessList extends ComparableStructure<String> {
+public class IpAsPathAccessList implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
   private List<IpAsPathAccessListLine> _lines;
 
+  private final String _name;
+
   public IpAsPathAccessList(String name) {
-    super(name);
+    _name = name;
     _lines = new ArrayList<>();
   }
 
@@ -21,5 +23,9 @@ public class IpAsPathAccessList extends ComparableStructure<String> {
 
   public List<IpAsPathAccessListLine> getLines() {
     return _lines;
+  }
+
+  public String getName() {
+    return _name;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/IpsecProfile.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/IpsecProfile.java
@@ -1,27 +1,33 @@
 package org.batfish.representation.cisco;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import org.batfish.common.util.ComparableStructure;
 import org.batfish.datamodel.DiffieHellmanGroup;
 
-public class IpsecProfile extends ComparableStructure<String> {
+public class IpsecProfile implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
   private String _isakmpProfile;
+
+  private final String _name;
 
   private DiffieHellmanGroup _pfsGroup;
 
   private List<String> _transformSets;
 
   public IpsecProfile(String name) {
-    super(name);
+    _name = name;
     _transformSets = new ArrayList<>();
   }
 
   public String getIsakmpProfile() {
     return _isakmpProfile;
+  }
+
+  public String getName() {
+    return _name;
   }
 
   public DiffieHellmanGroup getPfsGroup() {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/IpsecTransformSet.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/IpsecTransformSet.java
@@ -2,17 +2,17 @@ package org.batfish.representation.cisco;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 
+import java.io.Serializable;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.batfish.common.util.ComparableStructure;
 import org.batfish.datamodel.EncryptionAlgorithm;
 import org.batfish.datamodel.IpsecAuthenticationAlgorithm;
 import org.batfish.datamodel.IpsecEncapsulationMode;
 import org.batfish.datamodel.IpsecProtocol;
 
-public class IpsecTransformSet extends ComparableStructure<String> {
+public class IpsecTransformSet implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
@@ -22,12 +22,14 @@ public class IpsecTransformSet extends ComparableStructure<String> {
 
   @Nonnull private IpsecEncapsulationMode _ipsecEncapsulationMode;
 
+  private final String _name;
+
   @Nonnull private SortedSet<IpsecProtocol> _protocols;
 
   public IpsecTransformSet(String name) {
-    super(name);
-    _protocols = new TreeSet<>();
     _ipsecEncapsulationMode = IpsecEncapsulationMode.TUNNEL;
+    _name = name;
+    _protocols = new TreeSet<>();
   }
 
   public IpsecAuthenticationAlgorithm getAuthenticationAlgorithm() {
@@ -40,6 +42,10 @@ public class IpsecTransformSet extends ComparableStructure<String> {
 
   public IpsecEncapsulationMode getIpsecEncapsulationMode() {
     return _ipsecEncapsulationMode;
+  }
+
+  public String getName() {
+    return _name;
   }
 
   public SortedSet<IpsecProtocol> getProtocols() {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/IsakmpPolicy.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/IsakmpPolicy.java
@@ -1,12 +1,12 @@
 package org.batfish.representation.cisco;
 
-import org.batfish.common.util.ComparableStructure;
+import java.io.Serializable;
 import org.batfish.datamodel.DiffieHellmanGroup;
 import org.batfish.datamodel.EncryptionAlgorithm;
 import org.batfish.datamodel.IkeAuthenticationMethod;
 import org.batfish.datamodel.IkeHashingAlgorithm;
 
-public class IsakmpPolicy extends ComparableStructure<Integer> {
+public class IsakmpPolicy implements Serializable {
 
   /** */
   private static final long serialVersionUID = 1L;
@@ -21,8 +21,10 @@ public class IsakmpPolicy extends ComparableStructure<Integer> {
 
   private Integer _lifetimeSeconds;
 
+  private final Integer _name;
+
   public IsakmpPolicy(Integer name) {
-    super(name);
+    _name = name;
   }
 
   public IkeAuthenticationMethod getAuthenticationMethod() {
@@ -43,6 +45,10 @@ public class IsakmpPolicy extends ComparableStructure<Integer> {
 
   public Integer getLifetimeSeconds() {
     return _lifetimeSeconds;
+  }
+
+  public Integer getName() {
+    return _name;
   }
 
   public void setAuthenticationMethod(IkeAuthenticationMethod authenticationMethod) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/IsakmpProfile.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/IsakmpProfile.java
@@ -2,13 +2,13 @@ package org.batfish.representation.cisco;
 
 import static org.batfish.datamodel.Interface.UNSET_LOCAL_INTERFACE;
 
+import java.io.Serializable;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.batfish.common.util.ComparableStructure;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpWildcard;
 
-public class IsakmpProfile extends ComparableStructure<String> {
+public class IsakmpProfile implements Serializable {
 
   /** */
   private static final long serialVersionUID = 1L;
@@ -21,10 +21,12 @@ public class IsakmpProfile extends ComparableStructure<String> {
 
   private IpWildcard _matchIdentity;
 
+  private final String _name;
+
   @Nullable private Ip _selfIdentity;
 
   public IsakmpProfile(String name) {
-    super(name);
+    _name = name;
     _localInterfaceName = UNSET_LOCAL_INTERFACE;
   }
 
@@ -44,6 +46,10 @@ public class IsakmpProfile extends ComparableStructure<String> {
 
   public IpWildcard getMatchIdentity() {
     return _matchIdentity;
+  }
+
+  public String getName() {
+    return _name;
   }
 
   public Ip getSelfIdentity() {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/Keyring.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/Keyring.java
@@ -2,14 +2,14 @@ package org.batfish.representation.cisco;
 
 import static org.batfish.datamodel.Interface.UNSET_LOCAL_INTERFACE;
 
+import java.io.Serializable;
 import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.batfish.common.util.ComparableStructure;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpWildcard;
 
-public class Keyring extends ComparableStructure<String> {
+public class Keyring implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
@@ -21,8 +21,10 @@ public class Keyring extends ComparableStructure<String> {
 
   private String _key;
 
+  private final String _name;
+
   public Keyring(String name) {
-    super(name);
+    _name = name;
     _localInterfaceName = UNSET_LOCAL_INTERFACE;
   }
 
@@ -37,6 +39,10 @@ public class Keyring extends ComparableStructure<String> {
 
   public String getLocalInterfaceName() {
     return _localInterfaceName;
+  }
+
+  public String getName() {
+    return _name;
   }
 
   public IpWildcard getRemoteIdentity() {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/MacAccessList.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/MacAccessList.java
@@ -1,18 +1,20 @@
 package org.batfish.representation.cisco;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import org.batfish.common.util.ComparableStructure;
 
-public class MacAccessList extends ComparableStructure<String> {
+public class MacAccessList implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
   private List<MacAccessListLine> _lines;
 
+  private final String _name;
+
   public MacAccessList(String name) {
-    super(name);
     _lines = new ArrayList<>();
+    _name = name;
   }
 
   public List<MacAccessListLine> getLines() {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/MacAccessList.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/MacAccessList.java
@@ -20,4 +20,8 @@ public class MacAccessList implements Serializable {
   public List<MacAccessListLine> getLines() {
     return _lines;
   }
+
+  public String getName() {
+    return _name;
+  }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/NatPool.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/NatPool.java
@@ -1,9 +1,9 @@
 package org.batfish.representation.cisco;
 
-import org.batfish.common.util.ComparableStructure;
+import java.io.Serializable;
 import org.batfish.datamodel.Ip;
 
-public class NatPool extends ComparableStructure<String> {
+public class NatPool implements Serializable {
 
   /** */
   private static final long serialVersionUID = 1L;
@@ -12,8 +12,10 @@ public class NatPool extends ComparableStructure<String> {
 
   private Ip _last;
 
+  private final String _name;
+
   public NatPool(String name) {
-    super(name);
+    _name = name;
   }
 
   public Ip getFirst() {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/NatPool.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/NatPool.java
@@ -12,12 +12,6 @@ public class NatPool implements Serializable {
 
   private Ip _last;
 
-  private final String _name;
-
-  public NatPool(String name) {
-    _name = name;
-  }
-
   public Ip getFirst() {
     return _first;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/ObjectGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/ObjectGroup.java
@@ -1,13 +1,19 @@
 package org.batfish.representation.cisco;
 
-import org.batfish.common.util.ComparableStructure;
+import java.io.Serializable;
 
-abstract class ObjectGroup extends ComparableStructure<String> {
+abstract class ObjectGroup implements Serializable {
 
   /** */
   private static final long serialVersionUID = 1L;
 
+  private final String _name;
+
   ObjectGroup(String name) {
-    super(name);
+    _name = name;
+  }
+
+  public final String getName() {
+    return _name;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/OspfProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/OspfProcess.java
@@ -1,5 +1,6 @@
 package org.batfish.representation.cisco;
 
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.EnumMap;
 import java.util.HashMap;
@@ -10,7 +11,6 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import javax.annotation.Nullable;
 import org.batfish.common.BatfishException;
-import org.batfish.common.util.ComparableStructure;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
@@ -19,7 +19,7 @@ import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.ospf.OspfAreaSummary;
 import org.batfish.datamodel.ospf.OspfMetricType;
 
-public class OspfProcess extends ComparableStructure<String> {
+public class OspfProcess implements Serializable {
 
   private static final long DEFAULT_DEFAULT_INFORMATION_METRIC = 1L;
 
@@ -64,6 +64,8 @@ public class OspfProcess extends ComparableStructure<String> {
   private boolean _maxMetricRouterLsa;
 
   private Long _maxMetricSummaryLsa;
+
+  private final String _name;
 
   private Set<OspfNetwork> _networks;
 
@@ -140,7 +142,7 @@ public class OspfProcess extends ComparableStructure<String> {
   }
 
   public OspfProcess(String name, ConfigurationFormat format) {
-    super(name);
+    _name = name;
     _referenceBandwidth = getReferenceOspfBandwidth(format);
     _networks = new TreeSet<>();
     _defaultInformationMetric = DEFAULT_DEFAULT_INFORMATION_METRIC;
@@ -225,6 +227,10 @@ public class OspfProcess extends ComparableStructure<String> {
 
   public Long getMaxMetricSummaryLsa() {
     return _maxMetricSummaryLsa;
+  }
+
+  public String getName() {
+    return _name;
   }
 
   public Set<OspfNetwork> getNetworks() {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/Prefix6List.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/Prefix6List.java
@@ -1,17 +1,19 @@
 package org.batfish.representation.cisco;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import org.batfish.common.util.ComparableStructure;
 
-public class Prefix6List extends ComparableStructure<String> {
+public class Prefix6List implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
   private List<Prefix6ListLine> _lines;
 
+  private final String _name;
+
   public Prefix6List(String name) {
-    super(name);
+    _name = name;
     _lines = new ArrayList<>();
   }
 
@@ -25,5 +27,9 @@ public class Prefix6List extends ComparableStructure<String> {
 
   public List<Prefix6ListLine> getLines() {
     return _lines;
+  }
+
+  public String getName() {
+    return _name;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/PrefixList.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/PrefixList.java
@@ -1,18 +1,20 @@
 package org.batfish.representation.cisco;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import org.batfish.common.util.ComparableStructure;
 
-public class PrefixList extends ComparableStructure<String> {
+public class PrefixList implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
   private List<PrefixListLine> _lines;
 
+  private final String _name;
+
   public PrefixList(String name) {
-    super(name);
     _lines = new ArrayList<>();
+    _name = name;
   }
 
   public void addLine(PrefixListLine r) {
@@ -25,5 +27,9 @@ public class PrefixList extends ComparableStructure<String> {
 
   public List<PrefixListLine> getLines() {
     return _lines;
+  }
+
+  public String getName() {
+    return _name;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/RouteMap.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/RouteMap.java
@@ -1,21 +1,27 @@
 package org.batfish.representation.cisco;
 
+import java.io.Serializable;
 import java.util.NavigableMap;
 import java.util.TreeMap;
-import org.batfish.common.util.ComparableStructure;
 
-public class RouteMap extends ComparableStructure<String> {
+public class RouteMap implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
   private NavigableMap<Integer, RouteMapClause> _clauses;
 
+  private final String _name;
+
   public RouteMap(String name) {
-    super(name);
+    _name = name;
     _clauses = new TreeMap<>();
   }
 
   public NavigableMap<Integer, RouteMapClause> getClauses() {
     return _clauses;
+  }
+
+  public String getName() {
+    return _name;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/RoutePolicy.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/RoutePolicy.java
@@ -1,18 +1,24 @@
 package org.batfish.representation.cisco;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import org.batfish.common.util.ComparableStructure;
 
-public class RoutePolicy extends ComparableStructure<String> {
+public class RoutePolicy implements Serializable {
 
   private static final long serialVersionUID = 1L;
+
+  private final String _name;
 
   private List<RoutePolicyStatement> _stmtList;
 
   public RoutePolicy(String name) {
-    super(name);
+    _name = name;
     _stmtList = new ArrayList<>();
+  }
+
+  public String getName() {
+    return _name;
   }
 
   public List<RoutePolicyStatement> getStatements() {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/SecurityZone.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/SecurityZone.java
@@ -1,13 +1,15 @@
 package org.batfish.representation.cisco;
 
-import org.batfish.common.util.ComparableStructure;
+import java.io.Serializable;
 
-public class SecurityZone extends ComparableStructure<String> {
+public class SecurityZone implements Serializable {
 
   /** */
   private static final long serialVersionUID = 1L;
 
+  private final String _name;
+
   public SecurityZone(String name) {
-    super(name);
+    _name = name;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/SecurityZone.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/SecurityZone.java
@@ -12,4 +12,8 @@ public class SecurityZone implements Serializable {
   public SecurityZone(String name) {
     _name = name;
   }
+
+  public String getName() {
+    return _name;
+  }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/SecurityZonePair.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/SecurityZonePair.java
@@ -1,8 +1,8 @@
 package org.batfish.representation.cisco;
 
-import org.batfish.common.util.ComparableStructure;
+import java.io.Serializable;
 
-public class SecurityZonePair extends ComparableStructure<String> {
+public class SecurityZonePair implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
@@ -10,10 +10,12 @@ public class SecurityZonePair extends ComparableStructure<String> {
 
   private String _inspectPolicyMap;
 
+  private final String _name;
+
   private final String _srcZone;
 
   public SecurityZonePair(String name, String srcZone, String dstZone) {
-    super(name);
+    _name = name;
     _srcZone = srcZone;
     _dstZone = dstZone;
   }
@@ -24,6 +26,10 @@ public class SecurityZonePair extends ComparableStructure<String> {
 
   public String getInspectPolicyMap() {
     return _inspectPolicyMap;
+  }
+
+  public String getName() {
+    return _name;
   }
 
   public String getSrcZone() {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/StandardAccessList.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/StandardAccessList.java
@@ -1,17 +1,19 @@
 package org.batfish.representation.cisco;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import org.batfish.common.util.ComparableStructure;
 
-public class StandardAccessList extends ComparableStructure<String> {
+public class StandardAccessList implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
   private List<StandardAccessListLine> _lines;
 
+  private final String _name;
+
   public StandardAccessList(String id) {
-    super(id);
+    _name = id;
     _lines = new ArrayList<>();
   }
 
@@ -24,7 +26,7 @@ public class StandardAccessList extends ComparableStructure<String> {
   }
 
   public ExtendedAccessList toExtendedAccessList() {
-    ExtendedAccessList eal = new ExtendedAccessList(_key);
+    ExtendedAccessList eal = new ExtendedAccessList(_name);
     eal.setParent(this);
     eal.getLines().clear();
     for (StandardAccessListLine sall : _lines) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/StandardIpv6AccessList.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/StandardIpv6AccessList.java
@@ -1,17 +1,19 @@
 package org.batfish.representation.cisco;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import org.batfish.common.util.ComparableStructure;
 
-public class StandardIpv6AccessList extends ComparableStructure<String> {
+public class StandardIpv6AccessList implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
   private List<StandardIpv6AccessListLine> _lines;
 
+  private final String _name;
+
   public StandardIpv6AccessList(String id) {
-    super(id);
+    _name = id;
     _lines = new ArrayList<>();
   }
 
@@ -24,7 +26,7 @@ public class StandardIpv6AccessList extends ComparableStructure<String> {
   }
 
   public ExtendedIpv6AccessList toExtendedIpv6AccessList() {
-    ExtendedIpv6AccessList eal = new ExtendedIpv6AccessList(_key);
+    ExtendedIpv6AccessList eal = new ExtendedIpv6AccessList(_name);
     eal.setParent(this);
     eal.getLines().clear();
     for (StandardIpv6AccessListLine sall : _lines) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/Vrf.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/Vrf.java
@@ -1,11 +1,11 @@
 package org.batfish.representation.cisco;
 
+import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
-import org.batfish.common.util.ComparableStructure;
 import org.batfish.representation.cisco.nx.CiscoNxBgpVrfConfiguration;
 
-public final class Vrf extends ComparableStructure<String> {
+public final class Vrf implements Serializable {
 
   /** */
   private static final long serialVersionUID = 1L;
@@ -18,6 +18,8 @@ public final class Vrf extends ComparableStructure<String> {
 
   private IsisProcess _isisProcess;
 
+  private final String _name;
+
   private OspfProcess _ospfProcess;
 
   private RipProcess _ripProcess;
@@ -25,7 +27,7 @@ public final class Vrf extends ComparableStructure<String> {
   private final Set<StaticRoute> _staticRoutes;
 
   public Vrf(String name) {
-    super(name);
+    _name = name;
     _staticRoutes = new HashSet<>();
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/Vrf.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/Vrf.java
@@ -47,6 +47,10 @@ public final class Vrf implements Serializable {
     return _isisProcess;
   }
 
+  public String getName() {
+    return _name;
+  }
+
   public OspfProcess getOspfProcess() {
     return _ospfProcess;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/VrrpGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/VrrpGroup.java
@@ -28,6 +28,10 @@ public class VrrpGroup implements Serializable {
     return _authenticationTextHash;
   }
 
+  public Integer getName() {
+    return _name;
+  }
+
   public boolean getPreempt() {
     return _preempt;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/VrrpGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/VrrpGroup.java
@@ -1,14 +1,16 @@
 package org.batfish.representation.cisco;
 
-import org.batfish.common.util.ComparableStructure;
+import java.io.Serializable;
 import org.batfish.datamodel.Ip;
 
-public class VrrpGroup extends ComparableStructure<Integer> {
+public class VrrpGroup implements Serializable {
 
   /** */
   private static final long serialVersionUID = 1L;
 
   private String _authenticationTextHash;
+
+  private final Integer _name;
 
   private boolean _preempt;
 
@@ -17,7 +19,7 @@ public class VrrpGroup extends ComparableStructure<Integer> {
   private Ip _virtualAddress;
 
   public VrrpGroup(Integer name) {
-    super(name);
+    _name = name;
     _preempt = CiscoConfiguration.DEFAULT_VRRP_PREEMPT;
     _priority = CiscoConfiguration.DEFAULT_VRRP_PRIORITY;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/VrrpInterface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/VrrpInterface.java
@@ -9,20 +9,10 @@ public class VrrpInterface implements Serializable {
   /** */
   private static final long serialVersionUID = 1L;
 
-  private final int _definitionLine;
-
-  private final String _name;
-
   private final SortedMap<Integer, VrrpGroup> _vrrpGroups;
 
-  public VrrpInterface(String name, int definitionLine) {
-    _name = name;
-    _definitionLine = definitionLine;
+  public VrrpInterface() {
     _vrrpGroups = new TreeMap<>();
-  }
-
-  public int getDefinitionLine() {
-    return _definitionLine;
   }
 
   public SortedMap<Integer, VrrpGroup> getVrrpGroups() {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/VrrpInterface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/VrrpInterface.java
@@ -1,20 +1,22 @@
 package org.batfish.representation.cisco;
 
+import java.io.Serializable;
 import java.util.SortedMap;
 import java.util.TreeMap;
-import org.batfish.common.util.ComparableStructure;
 
-public class VrrpInterface extends ComparableStructure<String> {
+public class VrrpInterface implements Serializable {
 
   /** */
   private static final long serialVersionUID = 1L;
 
   private final int _definitionLine;
 
+  private final String _name;
+
   private final SortedMap<Integer, VrrpGroup> _vrrpGroups;
 
   public VrrpInterface(String name, int definitionLine) {
-    super(name);
+    _name = name;
     _definitionLine = definitionLine;
     _vrrpGroups = new TreeMap<>();
   }

--- a/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoConfigurationTest.java
@@ -40,7 +40,7 @@ public class CiscoConfigurationTest {
     CiscoSourceNat nat = new CiscoSourceNat();
     nat.setAclName(ACL);
     nat.setNatPool(POOL);
-    NatPool pool = new NatPool(POOL);
+    NatPool pool = new NatPool();
     pool.setFirst(IP);
     pool.setLast(IP);
     _config.getNatPools().put(POOL, pool);


### PR DESCRIPTION
In zero of the cases was the `ComparableStructure` nature of the object used.

For the ones that were `ComparableStructure<String>`, I left the local variable as name.

For the ones that were `ComparableStructure<Other>`, I changed the local variable to `_foo` and, for vendor-specific (non-JSON-ified) structures I renamed the getters. (BgpProcess, for example).