### PR TITLE
javadoc: don't warn on missing tags

### DIFF
--- a/projects/pom.xml
+++ b/projects/pom.xml
@@ -192,6 +192,7 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>${maven-javadoc-plugin.version}</version>
           <configuration>
+            <doclint>all,-missing</doclint>
             <failOnError>false</failOnError>
           </configuration>
         </plugin>


### PR DESCRIPTION
No need for @param, @throws