### PR TITLE
Update terminology in WorkMgrService javadocs

### DIFF
--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrServiceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrServiceTest.java
@@ -169,7 +169,7 @@ public class WorkMgrServiceTest {
             "testrig",
             "config1.cfg");
     String actualMessage = response.getEntity().toString();
-    assertThat(actualMessage, equalTo("Container 'nonExistContainer' not found"));
+    assertThat(actualMessage, equalTo("Network 'nonExistContainer' not found"));
   }
 
   @Test


### PR DESCRIPTION
Replaces `container` with `network` and `testrig` with `snapshot` in Javadocs, including in names of parameters. Skipped deprecated methods and methods that still need to be changed more fundamentally.