### PR TITLE
Deprecate "container" in java client

### DIFF
--- a/projects/batfish-client/src/main/java/org/batfish/client/BfCoordWorkHelper.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/BfCoordWorkHelper.java
@@ -246,13 +246,13 @@ public class BfCoordWorkHelper {
               .delete();
 
       if (response.getStatus() != Status.NO_CONTENT.getStatusCode()) {
-        _logger.errorf("delContainer: Did not get OK response. Got: %s\n", response.getStatus());
+        _logger.errorf("delNetwork: Did not get OK response. Got: %s\n", response.getStatus());
         _logger.error(response.readEntity(String.class) + "\n");
         return false;
       }
       return true;
     } catch (Exception e) {
-      _logger.errorf("Exception in delContainer from %s for %s\n", _coordWorkMgrV2, containerName);
+      _logger.errorf("Exception in delNetwork from %s for %s\n", _coordWorkMgrV2, containerName);
       _logger.error(Throwables.getStackTraceAsString(e) + "\n");
       return false;
     }

--- a/projects/batfish-client/src/main/java/org/batfish/client/Client.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/Client.java
@@ -2437,7 +2437,15 @@ public class Client extends AbstractClient implements IClient {
 
   private void printUsage(Command command) {
     Pair<String, String> usage = Command.getUsageMap().get(command);
-    _logger.outputf("%s %s\n\t%s\n\n", command.commandName(), usage.getFirst(), usage.getSecond());
+    String deprecationReason = Command.getDeprecatedMap().get(command);
+    if (deprecationReason == null) {
+      _logger.outputf(
+          "%s %s\n\t%s\n\n", command.commandName(), usage.getFirst(), usage.getSecond());
+    } else {
+      _logger.outputf(
+          "(deprecated) %s %s\n\t%s\n\t%s\n\n",
+          command.commandName(), usage.getFirst(), usage.getSecond(), deprecationReason);
+    }
   }
 
   private void printWorkStatusResponse(

--- a/projects/batfish-client/src/main/java/org/batfish/client/Client.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/Client.java
@@ -2511,7 +2511,7 @@ public class Client extends AbstractClient implements IClient {
     String deprecationReason = Command.getDeprecatedMap().get(command);
     if (deprecationReason != null) {
       _logger.outputf(
-          "WARNING: Command %s has been deprecated and may be removed. %s\n\n",
+          "WARNING: Command %s has been deprecated and may be removed. %s\n",
           command.commandName(), deprecationReason);
     }
 

--- a/projects/batfish-client/src/main/java/org/batfish/client/Client.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/Client.java
@@ -934,8 +934,8 @@ public class Client extends AbstractClient implements IClient {
     return true;
   }
 
-  private boolean delContainer(List<String> options, List<String> parameters) {
-    if (!isValidArgument(options, parameters, 0, 1, 1, Command.DEL_CONTAINER)) {
+  private boolean delNetwork(List<String> options, List<String> parameters) {
+    if (!isValidArgument(options, parameters, 0, 1, 1, Command.DEL_NETWORK)) {
       return false;
     }
     String containerName = parameters.get(0);
@@ -1333,8 +1333,8 @@ public class Client extends AbstractClient implements IClient {
    *
    * <p>Returns {@code true} if successfully get container information, {@code false} otherwise
    */
-  private boolean getContainer(List<String> options, List<String> parameters) {
-    if (!isValidArgument(options, parameters, 0, 1, 1, Command.GET_CONTAINER)) {
+  private boolean getNetwork(List<String> options, List<String> parameters) {
+    if (!isValidArgument(options, parameters, 0, 1, 1, Command.GET_NETWORK)) {
       return false;
     }
     String containerName = parameters.get(0);
@@ -1522,14 +1522,14 @@ public class Client extends AbstractClient implements IClient {
     return true;
   }
 
-  private boolean initContainer(List<String> options, List<String> parameters) {
+  private boolean initNetwork(List<String> options, List<String> parameters) {
     if (options.contains("-setname")) {
-      if (!isValidArgument(options, parameters, 1, 1, 1, Command.INIT_CONTAINER)) {
+      if (!isValidArgument(options, parameters, 1, 1, 1, Command.INIT_NETWORK)) {
         return false;
       }
       _currContainerName = _workHelper.initContainer(parameters.get(0), null);
     } else {
-      if (!isValidArgument(options, parameters, 0, 0, 1, Command.INIT_CONTAINER)) {
+      if (!isValidArgument(options, parameters, 0, 0, 1, Command.INIT_NETWORK)) {
         return false;
       }
       String containerPrefix = parameters.isEmpty() ? DEFAULT_CONTAINER_PREFIX : parameters.get(0);
@@ -1801,10 +1801,10 @@ public class Client extends AbstractClient implements IClient {
     if (!isSetContainer(false)) {
       _currContainerName = _workHelper.initContainer(null, DEFAULT_CONTAINER_PREFIX);
       if (_currContainerName == null) {
-        _logger.errorf("Could not init container\n");
+        _logger.errorf("Could not init network\n");
         return false;
       }
-      _logger.output("Init'ed and set active container");
+      _logger.output("Init'ed and set active network");
       _logger.infof(" to %s\n", _currContainerName);
       _logger.output("\n");
     }
@@ -1859,7 +1859,7 @@ public class Client extends AbstractClient implements IClient {
 
     if (_currContainerName == null) {
       if (printError) {
-        _logger.errorf("Active container is not set\n");
+        _logger.errorf("Active network is not set\n");
       }
       return false;
     }
@@ -1973,8 +1973,8 @@ public class Client extends AbstractClient implements IClient {
     return true;
   }
 
-  private boolean listContainers(List<String> options, List<String> parameters) {
-    if (!isValidArgument(options, parameters, 0, 0, 0, Command.LIST_CONTAINERS)) {
+  private boolean listNetworks(List<String> options, List<String> parameters) {
+    if (!isValidArgument(options, parameters, 0, 0, 0, Command.LIST_NETWORKS)) {
       return false;
     }
     String[] containerList = _workHelper.listContainers();
@@ -2560,11 +2560,11 @@ public class Client extends AbstractClient implements IClient {
       case DEL_BATFISH_OPTION:
         return delBatfishOption(options, parameters);
       case DEL_CONTAINER:
-        return delContainer(options, parameters);
+        return delNetwork(options, parameters);
       case DEL_ENVIRONMENT:
         return delEnvironment(options, parameters);
       case DEL_NETWORK:
-        return delContainer(options, parameters);
+        return delNetwork(options, parameters);
       case DEL_QUESTION:
         return delQuestion(options, parameters);
       case DEL_TESTRIG:
@@ -2582,7 +2582,7 @@ public class Client extends AbstractClient implements IClient {
       case GET_CONFIGURATION:
         return getConfiguration(options, parameters);
       case GET_CONTAINER:
-        return getContainer(options, parameters);
+        return getNetwork(options, parameters);
       case GET_DELTA:
         return get(words, outWriter, options, parameters, true);
       case GET_ANALYSIS_ANSWERS:
@@ -2598,7 +2598,7 @@ public class Client extends AbstractClient implements IClient {
       case GET_ANSWER_DIFFERENTIAL:
         return getAnswer(outWriter, options, parameters, false, true);
       case GET_NETWORK:
-        return getContainer(options, parameters);
+        return getNetwork(options, parameters);
       case GET_OBJECT:
         return getObject(outWriter, options, parameters, false);
       case GET_OBJECT_DELTA:
@@ -2614,13 +2614,13 @@ public class Client extends AbstractClient implements IClient {
       case INIT_ANALYSIS:
         return initOrAddAnalysis(outWriter, options, parameters, true);
       case INIT_CONTAINER:
-        return initContainer(options, parameters);
+        return initNetwork(options, parameters);
       case INIT_DELTA_TESTRIG:
         return initTestrig(outWriter, options, parameters, true);
       case INIT_ENVIRONMENT:
         return initEnvironment(words, outWriter, options, parameters);
       case INIT_NETWORK:
-        return initContainer(options, parameters);
+        return initNetwork(options, parameters);
       case INIT_TESTRIG:
         return initTestrig(outWriter, options, parameters, false);
       case KILL_WORK:
@@ -2628,13 +2628,13 @@ public class Client extends AbstractClient implements IClient {
       case LIST_ANALYSES:
         return listAnalyses(outWriter, options, parameters);
       case LIST_CONTAINERS:
-        return listContainers(options, parameters);
+        return listNetworks(options, parameters);
       case LIST_ENVIRONMENTS:
         return listEnvironments(options, parameters);
       case LIST_INCOMPLETE_WORK:
         return listIncompleteWork(options, parameters);
       case LIST_NETWORKS:
-        return listContainers(options, parameters);
+        return listNetworks(options, parameters);
       case LIST_QUESTIONS:
         return listQuestions(options, parameters);
       case LIST_TESTRIGS:
@@ -2662,7 +2662,7 @@ public class Client extends AbstractClient implements IClient {
       case SET_BATFISH_LOGLEVEL:
         return setBatfishLogLevel(options, parameters);
       case SET_CONTAINER:
-        return setContainer(options, parameters);
+        return setNetwork(options, parameters);
       case SET_DELTA_ENV:
         return setDeltaEnv(options, parameters);
       case SET_ENV:
@@ -2674,7 +2674,7 @@ public class Client extends AbstractClient implements IClient {
       case SET_LOGLEVEL:
         return setLogLevel(options, parameters);
       case SET_NETWORK:
-        return setContainer(options, parameters);
+        return setNetwork(options, parameters);
       case SET_PRETTY_PRINT:
         return setPrettyPrint(options, parameters);
       case SET_TESTRIG:
@@ -2686,7 +2686,7 @@ public class Client extends AbstractClient implements IClient {
       case SHOW_BATFISH_OPTIONS:
         return showBatfishOptions(options, parameters);
       case SHOW_CONTAINER:
-        return showContainer(options, parameters);
+        return showNetwork(options, parameters);
       case SHOW_COORDINATOR_HOST:
         return showCoordinatorHost(options, parameters);
       case SHOW_DELTA_TESTRIG:
@@ -2694,7 +2694,7 @@ public class Client extends AbstractClient implements IClient {
       case SHOW_LOGLEVEL:
         return showLogLevel(options, parameters);
       case SHOW_NETWORK:
-        return showContainer(options, parameters);
+        return showNetwork(options, parameters);
       case SHOW_TESTRIG:
         return showTestrig(options, parameters);
       case SHOW_VERSION:
@@ -2956,8 +2956,8 @@ public class Client extends AbstractClient implements IClient {
     return true;
   }
 
-  private boolean setContainer(List<String> options, List<String> parameters) {
-    if (!isValidArgument(options, parameters, 0, 1, 1, Command.SET_CONTAINER)) {
+  private boolean setNetwork(List<String> options, List<String> parameters) {
+    if (!isValidArgument(options, parameters, 0, 1, 1, Command.SET_NETWORK)) {
       return false;
     }
     _currContainerName = parameters.get(0);
@@ -3077,8 +3077,8 @@ public class Client extends AbstractClient implements IClient {
     return true;
   }
 
-  private boolean showContainer(List<String> options, List<String> parameters) {
-    if (!isValidArgument(options, parameters, 0, 0, 0, Command.SHOW_CONTAINER)) {
+  private boolean showNetwork(List<String> options, List<String> parameters) {
+    if (!isValidArgument(options, parameters, 0, 0, 0, Command.SHOW_NETWORK)) {
       return false;
     }
     _logger.outputf("Current network is %s\n", _currContainerName);

--- a/projects/batfish-client/src/main/java/org/batfish/client/Client.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/Client.java
@@ -940,7 +940,7 @@ public class Client extends AbstractClient implements IClient {
     }
     String containerName = parameters.get(0);
     boolean result = _workHelper.delContainer(containerName);
-    _logger.outputf("Result of deleting container: %s\n", result);
+    _logger.outputf("Result of deleting network: %s\n", result);
     return true;
   }
 
@@ -1536,10 +1536,10 @@ public class Client extends AbstractClient implements IClient {
       _currContainerName = _workHelper.initContainer(null, containerPrefix);
     }
     if (_currContainerName == null) {
-      _logger.errorf("Could not init container\n");
+      _logger.errorf("Could not init network\n");
       return false;
     }
-    _logger.output("Active container is set");
+    _logger.output("Active network is set");
     _logger.infof(" to  %s\n", _currContainerName);
     _logger.output("\n");
     return true;
@@ -1978,7 +1978,7 @@ public class Client extends AbstractClient implements IClient {
       return false;
     }
     String[] containerList = _workHelper.listContainers();
-    _logger.outputf("Containers: %s\n", Arrays.toString(containerList));
+    _logger.outputf("Networks: %s\n", Arrays.toString(containerList));
     return true;
   }
 
@@ -2507,6 +2507,14 @@ public class Client extends AbstractClient implements IClient {
       return false;
     }
 
+    // If command is deprecated, encourage user to use alternative.
+    String deprecationReason = Command.getDeprecatedMap().get(command);
+    if (deprecationReason != null) {
+      _logger.outputf(
+          "WARNING: Command %s has been deprecated and may be removed. %s\n\n",
+          command.commandName(), deprecationReason);
+    }
+
     List<String> options = getCommandOptions(words);
     List<String> parameters = getCommandParameters(words, options.size());
 
@@ -2555,6 +2563,8 @@ public class Client extends AbstractClient implements IClient {
         return delContainer(options, parameters);
       case DEL_ENVIRONMENT:
         return delEnvironment(options, parameters);
+      case DEL_NETWORK:
+        return delContainer(options, parameters);
       case DEL_QUESTION:
         return delQuestion(options, parameters);
       case DEL_TESTRIG:
@@ -2587,6 +2597,8 @@ public class Client extends AbstractClient implements IClient {
         return getAnswer(outWriter, options, parameters, true, false);
       case GET_ANSWER_DIFFERENTIAL:
         return getAnswer(outWriter, options, parameters, false, true);
+      case GET_NETWORK:
+        return getContainer(options, parameters);
       case GET_OBJECT:
         return getObject(outWriter, options, parameters, false);
       case GET_OBJECT_DELTA:
@@ -2607,6 +2619,8 @@ public class Client extends AbstractClient implements IClient {
         return initTestrig(outWriter, options, parameters, true);
       case INIT_ENVIRONMENT:
         return initEnvironment(words, outWriter, options, parameters);
+      case INIT_NETWORK:
+        return initContainer(options, parameters);
       case INIT_TESTRIG:
         return initTestrig(outWriter, options, parameters, false);
       case KILL_WORK:
@@ -2619,6 +2633,8 @@ public class Client extends AbstractClient implements IClient {
         return listEnvironments(options, parameters);
       case LIST_INCOMPLETE_WORK:
         return listIncompleteWork(options, parameters);
+      case LIST_NETWORKS:
+        return listContainers(options, parameters);
       case LIST_QUESTIONS:
         return listQuestions(options, parameters);
       case LIST_TESTRIGS:
@@ -2657,6 +2673,8 @@ public class Client extends AbstractClient implements IClient {
         return setDeltaTestrig(options, parameters);
       case SET_LOGLEVEL:
         return setLogLevel(options, parameters);
+      case SET_NETWORK:
+        return setContainer(options, parameters);
       case SET_PRETTY_PRINT:
         return setPrettyPrint(options, parameters);
       case SET_TESTRIG:
@@ -2675,6 +2693,8 @@ public class Client extends AbstractClient implements IClient {
         return showDeltaTestrig(options, parameters);
       case SHOW_LOGLEVEL:
         return showLogLevel(options, parameters);
+      case SHOW_NETWORK:
+        return showContainer(options, parameters);
       case SHOW_TESTRIG:
         return showTestrig(options, parameters);
       case SHOW_VERSION:
@@ -2941,7 +2961,7 @@ public class Client extends AbstractClient implements IClient {
       return false;
     }
     _currContainerName = parameters.get(0);
-    _logger.outputf("Active container is now set to %s\n", _currContainerName);
+    _logger.outputf("Active network is now set to %s\n", _currContainerName);
     return true;
   }
 
@@ -3061,7 +3081,7 @@ public class Client extends AbstractClient implements IClient {
     if (!isValidArgument(options, parameters, 0, 0, 0, Command.SHOW_CONTAINER)) {
       return false;
     }
-    _logger.outputf("Current container is %s\n", _currContainerName);
+    _logger.outputf("Current network is %s\n", _currContainerName);
     return true;
   }
 

--- a/projects/batfish-client/src/main/java/org/batfish/client/Command.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/Command.java
@@ -224,7 +224,7 @@ public enum Command {
     descs.put(
         GET_CONFIGURATION,
         new Pair<>(
-            "<container-name> <testrig-name> <configuration-name>",
+            "<network-name> <testrig-name> <configuration-name>",
             "Get the file content of the configuration file"));
     descs.put(GET_CONTAINER, new Pair<>("<network-name>", "Get the information of the network"));
     descs.put(
@@ -242,7 +242,7 @@ public enum Command {
     descs.put(
         INIT_ANALYSIS,
         new Pair<>(
-            "<analysis-name> <question-directory>", "Initialize a new analysis for the container"));
+            "<analysis-name> <question-directory>", "Initialize a new analysis for the network"));
     descs.put(
         INIT_CONTAINER,
         new Pair<>(
@@ -320,16 +320,15 @@ public enum Command {
     descs.put(LIST_ANALYSES, new Pair<>("", "List the analyses and their configuration"));
     descs.put(LIST_CONTAINERS, new Pair<>("", "List the networks to which you have access"));
     descs.put(
-        LIST_INCOMPLETE_WORK, new Pair<>("", "List all incomplete works for the active container"));
+        LIST_INCOMPLETE_WORK, new Pair<>("", "List all incomplete works for the active network"));
     descs.put(
         LIST_ENVIRONMENTS,
-        new Pair<>("", "List the environments under current container and testrig"));
+        new Pair<>("", "List the environments under current network and testrig"));
     descs.put(LIST_NETWORKS, new Pair<>("", "List the networks to which you have access"));
     descs.put(
-        LIST_QUESTIONS, new Pair<>("", "List the questions under current container and testrig"));
+        LIST_QUESTIONS, new Pair<>("", "List the questions under current network and testrig"));
     descs.put(
-        LIST_TESTRIGS,
-        new Pair<>("[-nometadata]", "List the testrigs within the current container"));
+        LIST_TESTRIGS, new Pair<>("[-nometadata]", "List the testrigs within the current network"));
     descs.put(
         LOAD_QUESTIONS,
         new Pair<>(

--- a/projects/batfish-client/src/main/java/org/batfish/client/Command.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/Command.java
@@ -128,32 +128,32 @@ public enum Command {
         DEL_CONTAINER,
         String.format(
             "The term \"container\" has been replaced with \"network\". Use %s instead.",
-            DEL_NETWORK));
+            DEL_NETWORK.commandName()));
     map.put(
         GET_CONTAINER,
         String.format(
             "The term \"container\" has been replaced with \"network\". Use %s instead.",
-            GET_NETWORK));
+            GET_NETWORK.commandName()));
     map.put(
         INIT_CONTAINER,
         String.format(
             "The term \"container\" has been replaced with \"network\". Use %s instead.",
-            INIT_NETWORK));
+            INIT_NETWORK.commandName()));
     map.put(
         LIST_CONTAINERS,
         String.format(
             "The term \"container\" has been replaced with \"network\". Use %s instead.",
-            LIST_NETWORKS));
+            LIST_NETWORKS.commandName()));
     map.put(
         SET_CONTAINER,
         String.format(
             "The term \"container\" has been replaced with \"network\". Use %s instead.",
-            SET_NETWORK));
+            SET_NETWORK.commandName()));
     map.put(
         SHOW_CONTAINER,
         String.format(
             "The term \"container\" has been replaced with \"network\". Use %s instead.",
-            SHOW_NETWORK));
+            SHOW_NETWORK.commandName()));
     return map.build();
   }
 
@@ -417,6 +417,10 @@ public enum Command {
 
   public static Map<String, Command> getNameMap() {
     return _nameMap;
+  }
+
+  public static Map<Command, String> getDeprecatedMap() {
+    return _deprecatedMap;
   }
 
   public static Map<Command, Pair<String, String>> getUsageMap() {

--- a/projects/batfish-client/src/main/java/org/batfish/client/Command.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/Command.java
@@ -23,6 +23,7 @@ public enum Command {
   DEL_BATFISH_OPTION("del-batfish-option"),
   DEL_CONTAINER("del-container"),
   DEL_ENVIRONMENT("del-environment"),
+  DEL_NETWORK("del-network"),
   DEL_QUESTION("del-question"),
   DEL_TESTRIG("del-testrig"),
   DIR("dir"),
@@ -40,6 +41,7 @@ public enum Command {
   GET_CONFIGURATION("get-configuration"),
   GET_CONTAINER("get-container"),
   GET_DELTA("get-delta"),
+  GET_NETWORK("get-network"),
   GET_OBJECT("get-object"),
   GET_OBJECT_DELTA("get-delta-object"),
   GET_QUESTION("get-question"),
@@ -50,12 +52,14 @@ public enum Command {
   INIT_CONTAINER("init-container"),
   INIT_DELTA_TESTRIG("init-delta-testrig"),
   INIT_ENVIRONMENT("init-environment"),
+  INIT_NETWORK("init-network"),
   INIT_TESTRIG("init-testrig"),
   KILL_WORK("kill-work"),
   LIST_ANALYSES("list-analyses"),
   LIST_CONTAINERS("list-containers"),
   LIST_ENVIRONMENTS("list-environments"),
   LIST_INCOMPLETE_WORK("list-incomplete-work"),
+  LIST_NETWORKS("list-networks"),
   LIST_QUESTIONS("list-questions"),
   LIST_TESTRIGS("list-testrigs"),
   LOAD_QUESTIONS("load-questions"),
@@ -76,6 +80,7 @@ public enum Command {
   SET_ENV("set-environment"),
   SET_FIXED_WORKITEM_ID("set-fixed-workitem-id"),
   SET_LOGLEVEL("set-loglevel"),
+  SET_NETWORK("set-network"),
   SET_PRETTY_PRINT("set-pretty-print"),
   SET_TESTRIG("set-testrig"),
   SHOW_API_KEY("show-api-key"),
@@ -85,6 +90,7 @@ public enum Command {
   SHOW_COORDINATOR_HOST("show-coordinator-host"),
   SHOW_DELTA_TESTRIG("show-delta-testrig"),
   SHOW_LOGLEVEL("show-loglevel"),
+  SHOW_NETWORK("show-network"),
   SHOW_TESTRIG("show-testrig"),
   SHOW_VERSION("show-version"),
   SYNC_TESTRIGS_SYNC_NOW("sync-testrigs-sync-now"),
@@ -103,6 +109,8 @@ public enum Command {
 
   private static final Map<String, Command> _nameMap = buildNameMap();
 
+  private static final Map<Command, String> _deprecatedMap = buildDeprecatedMap();
+
   private static final Map<Command, Pair<String, String>> _usageMap = buildUsageMap();
 
   private static Map<String, Command> buildNameMap() {
@@ -111,6 +119,41 @@ public enum Command {
       String name = value._name;
       map.put(name, value);
     }
+    return map.build();
+  }
+
+  private static Map<Command, String> buildDeprecatedMap() {
+    ImmutableMap.Builder<Command, String> map = ImmutableMap.builder();
+    map.put(
+        DEL_CONTAINER,
+        String.format(
+            "The term \"container\" has been replaced with \"network\". Use %s instead.",
+            DEL_NETWORK));
+    map.put(
+        GET_CONTAINER,
+        String.format(
+            "The term \"container\" has been replaced with \"network\". Use %s instead.",
+            GET_NETWORK));
+    map.put(
+        INIT_CONTAINER,
+        String.format(
+            "The term \"container\" has been replaced with \"network\". Use %s instead.",
+            INIT_NETWORK));
+    map.put(
+        LIST_CONTAINERS,
+        String.format(
+            "The term \"container\" has been replaced with \"network\". Use %s instead.",
+            LIST_NETWORKS));
+    map.put(
+        SET_CONTAINER,
+        String.format(
+            "The term \"container\" has been replaced with \"network\". Use %s instead.",
+            SET_NETWORK));
+    map.put(
+        SHOW_CONTAINER,
+        String.format(
+            "The term \"container\" has been replaced with \"network\". Use %s instead.",
+            SHOW_NETWORK));
     return map.build();
   }
 
@@ -156,9 +199,10 @@ public enum Command {
             "<analysis-name> qname1 [qname2 [qname3] ...]", "Delete questions from the analysis"));
     descs.put(
         DEL_BATFISH_OPTION, new Pair<>("<option-key>", "Stop passing this option to Batfish"));
-    descs.put(DEL_CONTAINER, new Pair<>("<container-name>", "Delete the specified container"));
+    descs.put(DEL_CONTAINER, new Pair<>("<network-name>", "Delete the specified network"));
     descs.put(
         DEL_ENVIRONMENT, new Pair<>("<environment-name>", "Delete the specified environment"));
+    descs.put(DEL_NETWORK, new Pair<>("<network-name>", "Delete the specified network"));
     descs.put(DEL_QUESTION, new Pair<>("<question-name>", "Delete the specified question"));
     descs.put(DEL_TESTRIG, new Pair<>("<testrig-name>", "Delete the specified testrig"));
     descs.put(DIR, new Pair<>("<dir>", "List directory contents"));
@@ -182,13 +226,13 @@ public enum Command {
         new Pair<>(
             "<container-name> <testrig-name> <configuration-name>",
             "Get the file content of the configuration file"));
-    descs.put(
-        GET_CONTAINER, new Pair<>("<container-name>", "Get the information of the container"));
+    descs.put(GET_CONTAINER, new Pair<>("<network-name>", "Get the information of the network"));
     descs.put(
         GET_DELTA,
         new Pair<>(
             "<question-file>  [param1=value1 [param2=value2] ...]",
             "Answer the question by type for the delta environment"));
+    descs.put(GET_NETWORK, new Pair<>("<network-name>", "Get the information of the network"));
     descs.put(GET_OBJECT, new Pair<>("<object path>", "Get the object"));
     descs.put(GET_OBJECT_DELTA, new Pair<>("<object path>", "Get the object from delta testrig"));
     descs.put(GET_QUESTION, new Pair<>("<question-name>", "Get the question and parameter files"));
@@ -202,7 +246,7 @@ public enum Command {
     descs.put(
         INIT_CONTAINER,
         new Pair<>(
-            "[-setname <container-name> | <container-name-prefix>]", "Initialize a new container"));
+            "[-setname <network-name> | <network-name-prefix>]", "Initialize a new network"));
     descs.put(
         INIT_DELTA_TESTRIG,
         new Pair<>(
@@ -264,18 +308,23 @@ public enum Command {
     + "newly-created\n"
     + "        environment.\n"));*/
     descs.put(
+        INIT_NETWORK,
+        new Pair<>(
+            "[-setname <network-name> | <network-name-prefix>]", "Initialize a new network"));
+    descs.put(
         INIT_TESTRIG,
         new Pair<>(
             "[-autoanalyze] <testrig zipfile or directory> [<testrig-name>]",
             "Initialize the testrig with default environment"));
     descs.put(KILL_WORK, new Pair<>("<guid>", "Kill work with the given GUID"));
     descs.put(LIST_ANALYSES, new Pair<>("", "List the analyses and their configuration"));
-    descs.put(LIST_CONTAINERS, new Pair<>("", "List the containers to which you have access"));
+    descs.put(LIST_CONTAINERS, new Pair<>("", "List the networks to which you have access"));
     descs.put(
         LIST_INCOMPLETE_WORK, new Pair<>("", "List all incomplete works for the active container"));
     descs.put(
         LIST_ENVIRONMENTS,
         new Pair<>("", "List the environments under current container and testrig"));
+    descs.put(LIST_NETWORKS, new Pair<>("", "List the networks to which you have access"));
     descs.put(
         LIST_QUESTIONS, new Pair<>("", "List the questions under current container and testrig"));
     descs.put(
@@ -304,7 +353,7 @@ public enum Command {
     descs.put(
         SET_BATFISH_LOGLEVEL,
         new Pair<>("<debug|info|output|warn|error>", "Set the batfish loglevel. Default is warn"));
-    descs.put(SET_CONTAINER, new Pair<>("<container-name>", "Set the current container"));
+    descs.put(SET_CONTAINER, new Pair<>("<network-name>", "Set the current network"));
     descs.put(SET_DELTA_ENV, new Pair<>("<environment-name>", "Set the delta environment"));
     descs.put(
         SET_DELTA_TESTRIG,
@@ -316,6 +365,7 @@ public enum Command {
     descs.put(
         SET_LOGLEVEL,
         new Pair<>("<debug|info|output|warn|error>", "Set the client loglevel. Default is output"));
+    descs.put(SET_NETWORK, new Pair<>("<network-name>", "Set the current network"));
     descs.put(SET_PRETTY_PRINT, new Pair<>("<true|false>", "Whether to pretty print answers"));
     descs.put(SET_TESTRIG, new Pair<>("<testrig-name> [environment name]", "Set the base testrig"));
     descs.put(SHOW_API_KEY, new Pair<>("", "Show API Key"));
@@ -323,10 +373,11 @@ public enum Command {
     descs.put(
         SHOW_BATFISH_OPTIONS,
         new Pair<>("", "Show the additional options that will be sent to batfish"));
-    descs.put(SHOW_CONTAINER, new Pair<>("", "Show active container"));
+    descs.put(SHOW_CONTAINER, new Pair<>("", "Show active network"));
     descs.put(SHOW_COORDINATOR_HOST, new Pair<>("", "Show coordinator host"));
-    descs.put(SHOW_LOGLEVEL, new Pair<>("", "Show current client loglevel"));
     descs.put(SHOW_DELTA_TESTRIG, new Pair<>("", "Show delta testrig and environment"));
+    descs.put(SHOW_LOGLEVEL, new Pair<>("", "Show current client loglevel"));
+    descs.put(SHOW_NETWORK, new Pair<>("", "Show active network"));
     descs.put(SHOW_TESTRIG, new Pair<>("", "Show base testrig and environment"));
     descs.put(SHOW_VERSION, new Pair<>("", "Show the version of Client and Service"));
     descs.put(

--- a/projects/batfish-client/src/test/java/org/batfish/client/ClientTest.java
+++ b/projects/batfish-client/src/test/java/org/batfish/client/ClientTest.java
@@ -10,8 +10,8 @@ import static org.batfish.client.Command.CLEAR_SCREEN;
 import static org.batfish.client.Command.DEL_ANALYSIS;
 import static org.batfish.client.Command.DEL_ANALYSIS_QUESTIONS;
 import static org.batfish.client.Command.DEL_BATFISH_OPTION;
-import static org.batfish.client.Command.DEL_CONTAINER;
 import static org.batfish.client.Command.DEL_ENVIRONMENT;
+import static org.batfish.client.Command.DEL_NETWORK;
 import static org.batfish.client.Command.DEL_QUESTION;
 import static org.batfish.client.Command.DEL_TESTRIG;
 import static org.batfish.client.Command.DIR;
@@ -30,13 +30,13 @@ import static org.batfish.client.Command.GET_DELTA;
 import static org.batfish.client.Command.GET_QUESTION;
 import static org.batfish.client.Command.HELP;
 import static org.batfish.client.Command.INIT_ANALYSIS;
-import static org.batfish.client.Command.INIT_CONTAINER;
 import static org.batfish.client.Command.INIT_DELTA_TESTRIG;
 import static org.batfish.client.Command.INIT_ENVIRONMENT;
+import static org.batfish.client.Command.INIT_NETWORK;
 import static org.batfish.client.Command.INIT_TESTRIG;
 import static org.batfish.client.Command.LIST_ANALYSES;
-import static org.batfish.client.Command.LIST_CONTAINERS;
 import static org.batfish.client.Command.LIST_ENVIRONMENTS;
+import static org.batfish.client.Command.LIST_NETWORKS;
 import static org.batfish.client.Command.LIST_QUESTIONS;
 import static org.batfish.client.Command.LIST_TESTRIGS;
 import static org.batfish.client.Command.LOAD_QUESTIONS;
@@ -48,20 +48,20 @@ import static org.batfish.client.Command.RUN_ANALYSIS;
 import static org.batfish.client.Command.RUN_ANALYSIS_DELTA;
 import static org.batfish.client.Command.RUN_ANALYSIS_DIFFERENTIAL;
 import static org.batfish.client.Command.SET_BATFISH_LOGLEVEL;
-import static org.batfish.client.Command.SET_CONTAINER;
 import static org.batfish.client.Command.SET_DELTA_ENV;
 import static org.batfish.client.Command.SET_DELTA_TESTRIG;
 import static org.batfish.client.Command.SET_ENV;
 import static org.batfish.client.Command.SET_LOGLEVEL;
+import static org.batfish.client.Command.SET_NETWORK;
 import static org.batfish.client.Command.SET_PRETTY_PRINT;
 import static org.batfish.client.Command.SET_TESTRIG;
 import static org.batfish.client.Command.SHOW_API_KEY;
 import static org.batfish.client.Command.SHOW_BATFISH_LOGLEVEL;
 import static org.batfish.client.Command.SHOW_BATFISH_OPTIONS;
-import static org.batfish.client.Command.SHOW_CONTAINER;
 import static org.batfish.client.Command.SHOW_COORDINATOR_HOST;
 import static org.batfish.client.Command.SHOW_DELTA_TESTRIG;
 import static org.batfish.client.Command.SHOW_LOGLEVEL;
+import static org.batfish.client.Command.SHOW_NETWORK;
 import static org.batfish.client.Command.SHOW_TESTRIG;
 import static org.batfish.client.Command.TEST;
 import static org.batfish.client.Command.UPLOAD_CUSTOM_OBJECT;
@@ -127,7 +127,7 @@ import org.junit.rules.TemporaryFolder;
 /** Tests for {@link org.batfish.client.Client}. */
 public class ClientTest {
 
-  private static final String CONTAINER_NOT_SET = "Active container is not set\n";
+  private static final String NETWORK_NOT_SET = "Active network is not set\n";
 
   private static final String TESTRIG_NOT_SET =
       "Active testrig is not set.\nSpecify testrig on"
@@ -249,13 +249,13 @@ public class ClientTest {
   @Test
   public void testDelAnalysisQuestionValidParas() throws Exception {
     String[] parameters = new String[] {"parameter1", "parameter2"};
-    checkProcessCommandErrorMessage(DEL_ANALYSIS_QUESTIONS, parameters, CONTAINER_NOT_SET);
+    checkProcessCommandErrorMessage(DEL_ANALYSIS_QUESTIONS, parameters, NETWORK_NOT_SET);
   }
 
   @Test
   public void testDelAnalysisValidParas() throws Exception {
     String[] parameters = new String[] {"parameter1"};
-    checkProcessCommandErrorMessage(DEL_ANALYSIS, parameters, CONTAINER_NOT_SET);
+    checkProcessCommandErrorMessage(DEL_ANALYSIS, parameters, NETWORK_NOT_SET);
   }
 
   @Test
@@ -271,8 +271,8 @@ public class ClientTest {
   }
 
   @Test
-  public void testDelContainerInvalidParas() throws Exception {
-    testInvalidInput(DEL_CONTAINER, new String[] {}, new String[] {});
+  public void testDelNetworkInvalidParas() throws Exception {
+    testInvalidInput(DEL_NETWORK, new String[] {}, new String[] {});
   }
 
   @Test
@@ -305,7 +305,7 @@ public class ClientTest {
   @Test
   public void testDelTestrigValidParas() throws Exception {
     String[] parameters = new String[] {"parameter1"};
-    checkProcessCommandErrorMessage(DEL_TESTRIG, parameters, CONTAINER_NOT_SET);
+    checkProcessCommandErrorMessage(DEL_TESTRIG, parameters, NETWORK_NOT_SET);
   }
 
   @Test
@@ -516,8 +516,8 @@ public class ClientTest {
   }
 
   @Test
-  public void testInitContainerEmptyParasWithOption() throws Exception {
-    Command command = INIT_CONTAINER;
+  public void testInitNetworkEmptyParasWithOption() throws Exception {
+    Command command = INIT_NETWORK;
     String[] args = new String[] {"-setname"};
     Pair<String, String> usage = Command.getUsageMap().get(command);
     String expected =
@@ -528,15 +528,15 @@ public class ClientTest {
   }
 
   @Test
-  public void testInitContainerInvalidOptions() throws Exception {
-    Command command = INIT_CONTAINER;
-    String invalidOption = "-setcontainer";
+  public void testInitNetworkInvalidOptions() throws Exception {
+    Command command = INIT_NETWORK;
+    String invalidOption = "-setnetwork";
     String[] args = new String[] {invalidOption, "parameter1"};
     Pair<String, String> usage = Command.getUsageMap().get(command);
     String expected =
         String.format(
             "Invalid arguments: %s %s\n%s %s\n\t%s\n\n",
-            "[-setcontainer]",
+            "[-setnetwork]",
             "[parameter1]",
             command.commandName(),
             usage.getFirst(),
@@ -545,9 +545,9 @@ public class ClientTest {
   }
 
   @Test
-  public void testInitContainerInvalidParas() throws Exception {
+  public void testInitNetworkInvalidParas() throws Exception {
     String[] parameters = new String[] {"parameter1", "parameter2", "parameter3"};
-    testInvalidInput(INIT_CONTAINER, new String[] {}, parameters);
+    testInvalidInput(INIT_NETWORK, new String[] {}, parameters);
   }
 
   @Test
@@ -762,13 +762,13 @@ public class ClientTest {
   @Test
   public void testListAnalysisValidParas() throws Exception {
     String[] parameters = new String[] {};
-    checkProcessCommandErrorMessage(LIST_ANALYSES, parameters, CONTAINER_NOT_SET);
+    checkProcessCommandErrorMessage(LIST_ANALYSES, parameters, NETWORK_NOT_SET);
   }
 
   @Test
-  public void testListContainersInvalidParas() throws Exception {
+  public void testListNetworksInvalidParas() throws Exception {
     String[] parameters = new String[] {"parameter1"};
-    testInvalidInput(LIST_CONTAINERS, new String[] {}, parameters);
+    testInvalidInput(LIST_NETWORKS, new String[] {}, parameters);
   }
 
   @Test
@@ -1203,13 +1203,13 @@ public class ClientTest {
   @Test
   public void testRunAnalysisDeltaValidParas() throws Exception {
     String[] parameters = new String[] {"parameter1"};
-    checkProcessCommandErrorMessage(RUN_ANALYSIS_DELTA, parameters, CONTAINER_NOT_SET);
+    checkProcessCommandErrorMessage(RUN_ANALYSIS_DELTA, parameters, NETWORK_NOT_SET);
   }
 
   @Test
   public void testRunAnalysisDifferentialValidParas() throws Exception {
     String[] parameters = new String[] {"parameter1"};
-    checkProcessCommandErrorMessage(RUN_ANALYSIS_DIFFERENTIAL, parameters, CONTAINER_NOT_SET);
+    checkProcessCommandErrorMessage(RUN_ANALYSIS_DIFFERENTIAL, parameters, NETWORK_NOT_SET);
   }
 
   @Test
@@ -1220,7 +1220,7 @@ public class ClientTest {
   @Test
   public void testRunAnalysisValidParas() throws Exception {
     String[] parameters = new String[] {"parameter1"};
-    checkProcessCommandErrorMessage(RUN_ANALYSIS, parameters, CONTAINER_NOT_SET);
+    checkProcessCommandErrorMessage(RUN_ANALYSIS, parameters, NETWORK_NOT_SET);
   }
 
   @Test
@@ -1259,17 +1259,15 @@ public class ClientTest {
   }
 
   @Test
-  public void testSetContainerInvalidParas() throws Exception {
-    testInvalidInput(SET_CONTAINER, new String[] {}, new String[] {});
+  public void testSetNetworkInvalidParas() throws Exception {
+    testInvalidInput(SET_NETWORK, new String[] {}, new String[] {});
   }
 
   @Test
-  public void testSetContainerValidParas() throws Exception {
+  public void testSetNetworkValidParas() throws Exception {
     String[] parameters = new String[] {"parameter1"};
     testProcessCommandWithValidInput(
-        SET_CONTAINER,
-        parameters,
-        String.format("Active container is now set to %s\n", parameters[0]));
+        SET_NETWORK, parameters, String.format("Active network is now set to %s\n", parameters[0]));
   }
 
   @Test
@@ -1343,7 +1341,7 @@ public class ClientTest {
   @Test
   public void testSetTestrigValidParas() throws Exception {
     String[] parameters = new String[] {"parameter1"};
-    checkProcessCommandErrorMessage(SET_TESTRIG, parameters, CONTAINER_NOT_SET);
+    checkProcessCommandErrorMessage(SET_TESTRIG, parameters, NETWORK_NOT_SET);
   }
 
   @Test
@@ -1383,15 +1381,14 @@ public class ClientTest {
   }
 
   @Test
-  public void testShowConrainerValidParas() throws Exception {
-    testProcessCommandWithValidInput(
-        SHOW_CONTAINER, new String[] {}, "Current container is null\n");
+  public void testShowNetworkValidParas() throws Exception {
+    testProcessCommandWithValidInput(SHOW_NETWORK, new String[] {}, "Current network is null\n");
   }
 
   @Test
-  public void testShowContainerInvalidParas() throws Exception {
+  public void testShowNetworkInvalidParas() throws Exception {
     String[] parameters = new String[] {"parameter1"};
-    testInvalidInput(SHOW_CONTAINER, new String[] {}, parameters);
+    testInvalidInput(SHOW_NETWORK, new String[] {}, parameters);
   }
 
   @Test

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/resources/ContainerResource.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/resources/ContainerResource.java
@@ -39,7 +39,7 @@ public class ContainerResource {
   /** Returns information about the given {@link Container}, provided this user can access it. */
   @GET
   public Response getContainer() {
-    _logger.infof("WMS2: getContainer '%s'\n", _name);
+    _logger.infof("WMS2: getNetwork '%s'\n", _name);
     Container container = Main.getWorkMgr().getContainer(_name);
     return Response.ok(container).build();
   }
@@ -53,7 +53,7 @@ public class ContainerResource {
   /** Delete a specified container with name: {@link #_name}. */
   @DELETE
   public Response deleteContainer() {
-    _logger.infof("WMS2: delContainer '%s'\n", _name);
+    _logger.infof("WMS2: delNetwork '%s'\n", _name);
     if (Main.getWorkMgr().delContainer(_name)) {
       return Response.noContent().build();
     } else {
@@ -64,12 +64,12 @@ public class ContainerResource {
   /** Check if {@code container} exists and {@code apiKey} has access to it. */
   private static void checkAccessToContainer(String apiKey, String container) {
     if (!Main.getWorkMgr().checkContainerExists(container)) {
-      throw new NotFoundException(String.format("Container '%s' does not exist", container));
+      throw new NotFoundException(String.format("Network '%s' does not exist", container));
     }
 
     if (!Main.getAuthorizer().isAccessibleContainer(apiKey, container, false)) {
       throw new ForbiddenException(
-          String.format("container '%s' is not accessible by the api key: %s", container, apiKey));
+          String.format("network '%s' is not accessible by the api key: %s", container, apiKey));
     }
   }
 }

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrServiceV2Test.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrServiceV2Test.java
@@ -126,6 +126,6 @@ public class WorkMgrServiceV2Test extends WorkMgrServiceV2TestBase {
     assertThat(resp.getStatus(), equalTo(FORBIDDEN.getStatusCode()));
     assertThat(
         resp.readEntity(String.class),
-        equalTo("container 'someContainer' is not accessible by the api key: AnotherApiKey"));
+        equalTo("network 'someContainer' is not accessible by the api key: AnotherApiKey"));
   }
 }


### PR DESCRIPTION
Example interaction with java client:
```
batfish> list-containers
WARNING: Command list-containers has been deprecated and may be removed. The term "container" has been replaced with "network". Use list-networks instead.
Networks: [LHR, aclContainer]
batfish> init-container abc
WARNING: Command init-container has been deprecated and may be removed. The term "container" has been replaced with "network". Use init-network instead.
Active network is set
batfish> list-networks
Networks: [LHR, abc_81777451-945e-432a-8c87-a12c0eef999b, aclContainer]
batfish> del-container abc_81777451-945e-432a-8c87-a12c0eef999b
WARNING: Command del-container has been deprecated and may be removed. The term "container" has been replaced with "network". Use del-network instead.
Result of deleting network: true
batfish> del-network xyz
delNetwork: Did not get OK response. Got: 404
Network 'xyz' does not exist
Result of deleting network: false
batfish> help set-container
(deprecated) set-container <network-name>
	Set the current network
	The term "container" has been replaced with "network". Use set-network instead.
```