### PR TITLE
Better parallelization, 1 query per unreachable line job

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
@@ -55,6 +55,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.NavigableMap;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -1657,7 +1658,7 @@ public class CommonUtil {
         Comparator.naturalOrder(), keyFunction, valueFunction);
   }
 
-  public static <E, K extends Comparable<? super K>, V> SortedMap<K, V> toImmutableSortedMap(
+  public static <E, K extends Comparable<? super K>, V> NavigableMap<K, V> toImmutableSortedMap(
       Collection<E> set, Function<E, K> keyFunction, Function<E, V> valueFunction) {
     return set.stream()
         .collect(

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AclLinesAnswerElement.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AclLinesAnswerElement.java
@@ -9,7 +9,6 @@ import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import org.batfish.common.Pair;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.IpAccessListLine;
 
@@ -181,10 +180,9 @@ public class AclLinesAnswerElement extends AnswerElement implements AclLinesAnsw
       entry.setDifferentAction(!line.getAction().equals(blockingLine.getAction()));
     }
 
-    Pair<String, String> hostnameAndAcl = aclSpecs.getRepresentativeHostnameAclPair();
     _unreachableLines
-        .computeIfAbsent(hostnameAndAcl.getFirst(), k -> new TreeMap<>())
-        .computeIfAbsent(hostnameAndAcl.getSecond(), k -> new TreeSet<>())
+        .computeIfAbsent(aclSpecs.reprHostname, k -> new TreeMap<>())
+        .computeIfAbsent(aclSpecs.acl.getAclName(), k -> new TreeSet<>())
         .add(entry);
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AclLinesAnswerElementInterface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AclLinesAnswerElementInterface.java
@@ -8,7 +8,6 @@ import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import javax.annotation.ParametersAreNonnullByDefault;
-import org.batfish.common.Pair;
 import org.batfish.datamodel.acl.CanonicalAcl;
 
 /** Interface for representing answers to aclReachability and aclReachability2. */
@@ -24,12 +23,16 @@ public interface AclLinesAnswerElementInterface {
     public static class Builder {
       private CanonicalAcl _acl;
       private Map<String, Set<String>> _sources = new TreeMap<>();
+      private String _reprHostname;
 
       public AclSpecs build() {
-        return new AclSpecs(_acl, _sources);
+        return new AclSpecs(_acl, _reprHostname, _sources);
       }
 
       public Builder addSource(String hostname, String aclName) {
+        if (_sources.isEmpty()) {
+          _reprHostname = hostname;
+        }
         _sources.computeIfAbsent(hostname, h -> new TreeSet<>()).add(aclName);
         return this;
       }
@@ -45,21 +48,23 @@ public interface AclLinesAnswerElementInterface {
     }
 
     public final CanonicalAcl acl;
+
+    /**
+     * The hostname of the first node where this ACL was found; as a result, this host contains the
+     * ACL under the name {@code acl.getAclName()}.
+     */
+    public final String reprHostname;
+
     public final Map<String, Set<String>> sources;
 
-    public AclSpecs(CanonicalAcl acl, Map<String, Set<String>> sources) {
+    public AclSpecs(CanonicalAcl acl, String hostname, Map<String, Set<String>> sources) {
       this.acl = acl;
+      this.reprHostname = hostname;
       this.sources = ImmutableMap.copyOf(sources);
     }
 
     public static Builder builder() {
       return new Builder();
-    }
-
-    /** @return hostname-aclName pair where the host contains this ACL with the given ACL name */
-    public Pair<String, String> getRepresentativeHostnameAclPair() {
-      String hostname = sources.keySet().iterator().next();
-      return new Pair<>(hostname, sources.get(hostname).iterator().next());
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -749,7 +749,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
 
     // For all unreachable lines, see if they are unmatchable
     List<NodSatJob<AclLine>> lineMatchabilityJobs =
-        generateAllUnmatchableLineJobs(aclSpecsMap, configs, unreachableLines);
+        generateAllUnmatchableLineJobs(configs, unreachableLines);
     Map<AclLine, Boolean> lineMatchabilityMap = new TreeMap<>();
     computeNodSatOutput(lineMatchabilityJobs, lineMatchabilityMap);
 
@@ -828,17 +828,15 @@ public class Batfish extends PluginConsumer implements IBatfish {
   }
 
   private List<NodSatJob<AclLine>> generateAllUnmatchableLineJobs(
-      Map<AclIdentifier, AclSpecs> aclSpecsMap,
       Map<AclIdentifier, Configuration> configs,
       Map<AclIdentifier, Set<Integer>> unreachableLines) {
     List<NodSatJob<AclLine>> lineMatchabilityJobs = new ArrayList<>();
-    for (Entry<AclIdentifier, AclSpecs> e : aclSpecsMap.entrySet()) {
-      String aclName = e.getValue().acl.getAclName();
+    for (Entry<AclIdentifier, Set<Integer>> e : unreachableLines.entrySet()) {
+      String aclName = e.getKey().getAclName();
       Configuration c = configs.get(e.getKey());
-      Set<Integer> unreachableLinesSet = unreachableLines.get(e.getKey());
 
       // Create jobs to see if each unreachable line is unmatchable
-      lineMatchabilityJobs.addAll(generateUnmatchableAclLineJobs(c, aclName, unreachableLinesSet));
+      lineMatchabilityJobs.addAll(generateUnmatchableAclLineJobs(c, aclName, e.getValue()));
     }
     return lineMatchabilityJobs;
   }

--- a/projects/batfish/src/main/java/org/batfish/z3/AclIdentifier.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/AclIdentifier.java
@@ -1,0 +1,20 @@
+package org.batfish.z3;
+
+import org.batfish.common.Pair;
+
+public class AclIdentifier extends Pair<String, String> {
+
+  private static final long serialVersionUID = 1L;
+
+  public AclIdentifier(String hostname, String aclName) {
+    super(hostname, aclName);
+  }
+
+  public String getAclName() {
+    return _second;
+  }
+
+  public String getHostname() {
+    return _first;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/z3/AclLine.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/AclLine.java
@@ -22,4 +22,9 @@ public class AclLine extends Pair<String, Pair<String, Integer>> {
   public int getLine() {
     return _second.getSecond();
   }
+
+  public boolean matchesAcl(Pair<String, String> hostnameAndAclName) {
+    return hostnameAndAclName.getFirst().equals(getHostname())
+        && hostnameAndAclName.getSecond().equals(getAclName());
+  }
 }

--- a/projects/batfish/src/main/java/org/batfish/z3/AclLine.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/AclLine.java
@@ -22,9 +22,4 @@ public class AclLine extends Pair<String, Pair<String, Integer>> {
   public int getLine() {
     return _second.getSecond();
   }
-
-  public boolean matchesAcl(Pair<String, String> hostnameAndAclName) {
-    return hostnameAndAclName.getFirst().equals(getHostname())
-        && hostnameAndAclName.getSecond().equals(getAclName());
-  }
 }

--- a/projects/batfish/src/main/java/org/batfish/z3/AclReachabilityQuerySynthesizer.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/AclReachabilityQuerySynthesizer.java
@@ -1,43 +1,30 @@
 package org.batfish.z3;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import org.batfish.z3.expr.BasicRuleStatement;
+import java.util.List;
 import org.batfish.z3.expr.QueryStatement;
 import org.batfish.z3.expr.RuleStatement;
-import org.batfish.z3.expr.TrueExpr;
-import org.batfish.z3.state.AclLineMatch;
 import org.batfish.z3.state.NumberedQuery;
 
 public final class AclReachabilityQuerySynthesizer extends SatQuerySynthesizer<AclLine> {
 
-  private final String _aclName;
+  private final int _lineNum;
 
-  private final String _hostname;
+  private final List<RuleStatement> _rules;
 
-  private final int _numLines;
-
-  public AclReachabilityQuerySynthesizer(String hostname, String aclName, int numLines) {
-    _hostname = hostname;
-    _aclName = aclName;
-    _numLines = numLines;
+  public AclReachabilityQuerySynthesizer(
+      List<RuleStatement> rules, String hostname, String aclName, int lineNum) {
+    _rules = rules;
+    _lineNum = lineNum;
+    _keys.add(new AclLine(hostname, aclName, lineNum));
   }
 
   @Override
   public ReachabilityProgram getReachabilityProgram(SynthesizerInput input) {
-    ReachabilityProgram.Builder builder = ReachabilityProgram.builder().setInput(input);
-    ImmutableList.Builder<QueryStatement> queries = ImmutableList.builder();
-    ImmutableList.Builder<RuleStatement> rules = ImmutableList.builder();
-    for (int line = 0; line < _numLines; line++) {
-      NumberedQuery query = new NumberedQuery(line);
-      rules.add(
-          new BasicRuleStatement(
-              TrueExpr.INSTANCE,
-              ImmutableSet.of(new AclLineMatch(_hostname, _aclName, line)),
-              new NumberedQuery(line)));
-      queries.add(new QueryStatement(query));
-      _keys.add(new AclLine(_hostname, _aclName, line));
-    }
-    return builder.setInput(input).setQueries(queries.build()).setRules(rules.build()).build();
+    return ReachabilityProgram.builder()
+        .setInput(input)
+        .setQueries(ImmutableList.of(new QueryStatement(new NumberedQuery(_lineNum))))
+        .setRules(_rules)
+        .build();
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/z3/AclReachabilityQuerySynthesizer.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/AclReachabilityQuerySynthesizer.java
@@ -14,7 +14,7 @@ public final class AclReachabilityQuerySynthesizer extends SatQuerySynthesizer<A
 
   public AclReachabilityQuerySynthesizer(
       List<RuleStatement> rules, String hostname, String aclName, int lineNum) {
-    _rules = rules;
+    _rules = ImmutableList.copyOf(rules);
     _lineNum = lineNum;
     _keys.add(new AclLine(hostname, aclName, lineNum));
   }


### PR DESCRIPTION
- Refactored back to the version where all the jobs for each phase are submitted in one big batch
    - needed for parallelization, until Batfish can run one z3 job with low overhead
- Changed AclReachabilityQuerySynthesizer to generate 1 query per job
- Changed the way AclSpecs provides a representative hostname and ACL name, because I was concerned that it might have been possible to conflate the previous "representative" aclName with `aclSpec.acl.getAclName()`.