### PR TITLE
questions: remove unnecessary testrig initialization

### DIFF
--- a/tests/questions/experimental/commands
+++ b/tests/questions/experimental/commands
@@ -1,5 +1,4 @@
 load-questions questions/experimental
-init-testrig test_rigs/example tr-example
 
 # validate aclReachability
 test -raw tests/questions/experimental/aclReachability.ref validate-template aclReachability aclNameRegex=".*", nodeRegex=".*"

--- a/tests/questions/stable/commands
+++ b/tests/questions/stable/commands
@@ -1,5 +1,4 @@
 load-questions questions/stable
-init-testrig test_rigs/example tr-example
 
 # validate ipOwners
 test -raw tests/questions/stable/ipOwners.ref validate-template ipOwners duplicatesOnly=false


### PR DESCRIPTION
Template validation does not require testrigs to be initialized.