### PR TITLE
Allow length constraints on longest prefix match in a RIB

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/GenericRib.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/GenericRib.java
@@ -31,9 +31,26 @@ public interface GenericRib<R extends AbstractRoute> extends Serializable {
   /** Return a set of routes this RIB contains. */
   Set<R> getRoutes();
 
+  /**
+   * Execute the longest prefix match for a given IP address.
+   *
+   * @param address the IP address to match
+   * @return a set of routes with the maximum allowable prefix length that match the {@code address}
+   */
   Set<R> longestPrefixMatch(Ip address);
 
-  boolean mergeRoute(R route);
+  /**
+   * Execute a constrained longest prefix match for a given IP address.
+   *
+   * <p>To be used when the longest prefix match is unsatisfactory and less specific route(s) is
+   * required.
+   *
+   * @param address the IP address to match
+   * @param maxPrefixLength the maximum prefix length allowed (i.e., do not match more specific
+   *     routes). This is a less than or equal constraint.
+   * @return a set of routes that match the {@code address} given the constraint.
+   */
+  Set<R> longestPrefixMatch(Ip address, int maxPrefixLength);
 
-  Map<Prefix, Set<Ip>> nextHopIpsByPrefix();
+  boolean mergeRoute(R route);
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockRib.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockRib.java
@@ -148,12 +148,12 @@ public class MockRib implements GenericRib<AbstractRoute> {
   }
 
   @Override
-  public boolean mergeRoute(AbstractRoute route) {
-    return _mergeRouteTrues.contains(route);
+  public Set<AbstractRoute> longestPrefixMatch(Ip address, int maxPrefixLength) {
+    throw new UnsupportedOperationException();
   }
 
   @Override
-  public Map<Prefix, Set<Ip>> nextHopIpsByPrefix() {
-    return _nextHopIpsByPrefix;
+  public boolean mergeRoute(AbstractRoute route) {
+    return _mergeRouteTrues.contains(route);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/AbstractRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/AbstractRib.java
@@ -8,7 +8,6 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
 import java.util.SortedSet;
-import java.util.TreeMap;
 import java.util.TreeSet;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.AbstractRoute;
@@ -110,7 +109,12 @@ public abstract class AbstractRib<R extends AbstractRoute> implements GenericRib
 
   @Override
   public Set<R> longestPrefixMatch(Ip address) {
-    return _tree.getLongestPrefixMatch(address);
+    return longestPrefixMatch(address, Prefix.MAX_PREFIX_LENGTH);
+  }
+
+  @Override
+  public Set<R> longestPrefixMatch(Ip address, int maxPrefixLength) {
+    return _tree.getLongestPrefixMatch(address, maxPrefixLength);
   }
 
   /**
@@ -201,18 +205,6 @@ public abstract class AbstractRib<R extends AbstractRoute> implements GenericRib
       _allRoutes = null;
     }
     return d;
-  }
-
-  @Override
-  public final Map<Prefix, Set<Ip>> nextHopIpsByPrefix() {
-    Map<Prefix, Set<Ip>> map = new TreeMap<>();
-    for (AbstractRoute route : getRoutes()) {
-      Prefix prefix = route.getNetwork();
-      Ip nextHopIp = route.getNextHopIp();
-      Set<Ip> nextHopIps = map.computeIfAbsent(prefix, k -> new TreeSet<>());
-      nextHopIps.add(nextHopIp);
-    }
-    return map;
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/RibTree.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/RibTree.java
@@ -57,9 +57,9 @@ class RibTree<R extends AbstractRoute> implements Serializable {
     return _root.containsRoute(route, bits, prefixLength);
   }
 
-  Set<R> getLongestPrefixMatch(Ip address) {
+  Set<R> getLongestPrefixMatch(Ip address, int maxPrefixLength) {
     long addressBits = address.asLong();
-    return _root.getLongestPrefixMatch(address, addressBits, 0);
+    return _root.getLongestPrefixMatch(address, addressBits, 0, maxPrefixLength);
   }
 
   /**

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/AbstractRibTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/AbstractRibTest.java
@@ -153,7 +153,10 @@ public class AbstractRibTest {
     assertThat(_rib.longestPrefixMatch(new Ip("0.0.0.0")), is(emptyIterableOf(StaticRoute.class)));
   }
 
-  /** Ensure that longestPrefixMatch() returns correct routes when the RIB is non-empty */
+  /**
+   * Ensure that {@link AbstractRib#longestPrefixMatch(Ip)} returns correct routes when the RIB is
+   * non-empty
+   */
   @Test
   public void testLongestPrefixMatch() {
     List<StaticRoute> routes = setupOverlappingRoutes();
@@ -169,6 +172,20 @@ public class AbstractRibTest {
 
     match = _rib.longestPrefixMatch(new Ip("11.1.1.1"));
     assertThat(match, is(emptyIterableOf(StaticRoute.class)));
+  }
+
+  /**
+   * Ensure that {@link AbstractRib#longestPrefixMatch(Ip, int)} returns correct routes when the RIB
+   * is non-empty
+   */
+  @Test
+  public void testLongestPrefixMatchConstrained() {
+    List<StaticRoute> routes = setupOverlappingRoutes();
+
+    // Only the first route matches with prefix len of <= 8
+    Set<StaticRoute> match = _rib.longestPrefixMatch(new Ip("10.1.1.1"), 8);
+    assertThat(match, hasSize(1));
+    assertThat(match, contains(routes.get(0)));
   }
 
   /** Ensure that a RIB is equal to itself */

--- a/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
@@ -392,12 +392,12 @@ public class RoutesAnswererTest {
     }
 
     @Override
-    public boolean mergeRoute(R route) {
+    public Set<R> longestPrefixMatch(Ip address, int maxPrefixLength) {
       throw new UnsupportedOperationException();
     }
 
     @Override
-    public Map<Prefix, Set<Ip>> nextHopIpsByPrefix() {
+    public boolean mergeRoute(R route) {
       throw new UnsupportedOperationException();
     }
   }


### PR DESCRIPTION
*Issue*:
In some cases when constructing FIBs we need a less specific route to match (e.g., in case of non-forwarding routes). Currently that's not possible.

*Fix*:
Add ability to constrain the max number of bits matched when long `longestPrefixMatch`