### PR TITLE
ComparableStructure: finish removing from vendor-specific representations

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatvyos/FlatVyosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatvyos/FlatVyosControlPlaneExtractor.java
@@ -222,7 +222,8 @@ public class FlatVyosControlPlaneExtractor extends FlatVyosParserBaseListener
   @Override
   public void enterEspt_proposal(Espt_proposalContext ctx) {
     int num = toInteger(ctx.num);
-    _currentEspProposal = _currentEspGroup.getProposals().computeIfAbsent(num, EspProposal::new);
+    _currentEspProposal =
+        _currentEspGroup.getProposals().computeIfAbsent(num, n -> new EspProposal());
   }
 
   @Override
@@ -234,7 +235,8 @@ public class FlatVyosControlPlaneExtractor extends FlatVyosParserBaseListener
   @Override
   public void enterIket_proposal(Iket_proposalContext ctx) {
     int num = toInteger(ctx.num);
-    _currentIkeProposal = _currentIkeGroup.getProposals().computeIfAbsent(num, IkeProposal::new);
+    _currentIkeProposal =
+        _currentIkeGroup.getProposals().computeIfAbsent(num, n -> new IkeProposal());
   }
 
   @Override
@@ -246,7 +248,7 @@ public class FlatVyosControlPlaneExtractor extends FlatVyosParserBaseListener
   @Override
   public void enterIvt_ike_group(Ivt_ike_groupContext ctx) {
     String name = ctx.name.getText();
-    _currentIkeGroup = _configuration.getIkeGroups().computeIfAbsent(name, IkeGroup::new);
+    _currentIkeGroup = _configuration.getIkeGroups().computeIfAbsent(name, n -> new IkeGroup());
   }
 
   @Override
@@ -259,7 +261,7 @@ public class FlatVyosControlPlaneExtractor extends FlatVyosParserBaseListener
   public void enterPlt_rule(Plt_ruleContext ctx) {
     int num = toInteger(ctx.num);
     _currentPrefixListRule =
-        _currentPrefixList.getRules().computeIfAbsent(num, PrefixListRule::new);
+        _currentPrefixList.getRules().computeIfAbsent(num, n -> new PrefixListRule());
   }
 
   @Override
@@ -277,7 +279,8 @@ public class FlatVyosControlPlaneExtractor extends FlatVyosParserBaseListener
   @Override
   public void enterRmt_rule(Rmt_ruleContext ctx) {
     int num = toInteger(ctx.num);
-    _currentRouteMapRule = _currentRouteMap.getRules().computeIfAbsent(num, RouteMapRule::new);
+    _currentRouteMapRule =
+        _currentRouteMap.getRules().computeIfAbsent(num, n -> new RouteMapRule());
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -300,7 +300,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
     String name = ctx.name.getText();
     _currentInterface = _configuration.getInterfaces().computeIfAbsent(name, Interface::new);
     _currentInterface.setParent(_currentParentInterface);
-    _currentParentInterface.getUnits().add(_currentInterface);
+    _currentParentInterface.getUnits().put(name, _currentInterface);
     defineStructure(INTERFACE, name, ctx);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
@@ -892,7 +892,7 @@ class CiscoConversions {
         org.batfish.datamodel.eigrp.EigrpProcess.builder();
     org.batfish.datamodel.Vrf vrf = c.getVrfs().get(vrfName);
 
-    newProcess.setAsNumber(proc.getAsNumber());
+    newProcess.setAsNumber(proc.getAsn());
     newProcess.setMode(proc.getMode());
 
     // Establish associated interfaces
@@ -905,7 +905,7 @@ class CiscoConversions {
       boolean match = proc.getNetworks().stream().anyMatch(interfaceAddress.getPrefix()::equals);
       if (match) {
         EigrpInterfaceSettings.Builder builder = EigrpInterfaceSettings.builder();
-        builder.setAsn(proc.getAsNumber());
+        builder.setAsn(proc.getAsn());
         if (iface.getEigrp() != null && iface.getEigrp().getDelay() != null) {
           builder.setDelay(iface.getEigrp().getDelay());
         } else {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/EigrpProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/EigrpProcess.java
@@ -1,20 +1,21 @@
 package org.batfish.representation.cisco;
 
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.Set;
 import java.util.TreeSet;
-import org.batfish.common.util.ComparableStructure;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.eigrp.EigrpProcessMode;
 
-public class EigrpProcess extends ComparableStructure<Long> {
+public class EigrpProcess implements Serializable {
 
   private static final String DEFAULT_ADDRESS_FAMILY = "ipv4-unicast";
   private static final long serialVersionUID = 1L;
   private String _addressFamily;
+  private long _asn;
   private boolean _autoSummary;
   private EigrpProcessMode _mode;
   private Ip _routerId;
@@ -22,8 +23,7 @@ public class EigrpProcess extends ComparableStructure<Long> {
   private Set<Prefix> _networks;
 
   public EigrpProcess(Long asn, EigrpProcessMode mode) {
-    super(asn);
-
+    _asn = asn;
     _addressFamily = DEFAULT_ADDRESS_FAMILY;
     _autoSummary = false;
     _mode = mode;
@@ -63,8 +63,8 @@ public class EigrpProcess extends ComparableStructure<Long> {
     _addressFamily = af;
   }
 
-  public long getAsNumber() {
-    return _key;
+  public long getAsn() {
+    return _asn;
   }
 
   public boolean getAutoSummary() {
@@ -96,6 +96,6 @@ public class EigrpProcess extends ComparableStructure<Long> {
   }
 
   public void setAsn(long asn) {
-    _key = asn;
+    _asn = asn;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/iptables/IptablesTable.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/iptables/IptablesTable.java
@@ -1,19 +1,21 @@
 package org.batfish.representation.iptables;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
-import org.batfish.common.util.ComparableStructure;
 import org.batfish.representation.iptables.IptablesChain.ChainPolicy;
 
-public class IptablesTable extends ComparableStructure<String> {
+public class IptablesTable implements Serializable {
 
   /** */
   private static final long serialVersionUID = 1L;
 
   private Map<String, IptablesChain> _chains;
 
+  private final String _name;
+
   public IptablesTable(String name) {
-    super(name);
+    _name = name;
     _chains = new HashMap<>();
   }
 
@@ -30,6 +32,10 @@ public class IptablesTable extends ComparableStructure<String> {
 
   public Map<String, IptablesChain> getChains() {
     return _chains;
+  }
+
+  public String getName() {
+    return _name;
   }
 
   public void setChainPolicy(String chainName, ChainPolicy policy) {

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/Interface.java
@@ -1,14 +1,14 @@
 package org.batfish.representation.palo_alto;
 
+import java.io.Serializable;
 import java.util.LinkedHashSet;
 import java.util.Set;
-import java.util.SortedSet;
-import java.util.TreeSet;
-import org.batfish.common.util.ComparableStructure;
+import java.util.SortedMap;
+import java.util.TreeMap;
 import org.batfish.datamodel.InterfaceAddress;
 
 /** PAN datamodel component containing interface configuration */
-public final class Interface extends ComparableStructure<String> {
+public final class Interface implements Serializable {
   public static final int DEFAULT_INTERFACE_MTU = 1500;
 
   private static final long serialVersionUID = 1L;
@@ -23,18 +23,20 @@ public final class Interface extends ComparableStructure<String> {
 
   private Integer _mtu;
 
+  private final String _name;
+
   private Interface _parent;
 
   private Integer _tag;
 
-  private final SortedSet<Interface> _units;
+  private final SortedMap<String, Interface> _units;
 
   public Interface(String name) {
-    super(name);
     _active = true;
     _allAddresses = new LinkedHashSet<>();
-    _units = new TreeSet<>();
     _mtu = DEFAULT_INTERFACE_MTU;
+    _name = name;
+    _units = new TreeMap<>();
   }
 
   public boolean getActive() {
@@ -57,6 +59,10 @@ public final class Interface extends ComparableStructure<String> {
     return _mtu;
   }
 
+  public String getName() {
+    return _name;
+  }
+
   public Interface getParent() {
     return _parent;
   }
@@ -65,7 +71,7 @@ public final class Interface extends ComparableStructure<String> {
     return _tag;
   }
 
-  public SortedSet<Interface> getUnits() {
+  public SortedMap<String, Interface> getUnits() {
     return _units;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/StaticRoute.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/StaticRoute.java
@@ -1,10 +1,10 @@
 package org.batfish.representation.palo_alto;
 
-import org.batfish.common.util.ComparableStructure;
+import java.io.Serializable;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
 
-public class StaticRoute extends ComparableStructure<String> {
+public class StaticRoute implements Serializable {
 
   /** */
   private static final long serialVersionUID = 1L;
@@ -17,30 +17,36 @@ public class StaticRoute extends ComparableStructure<String> {
 
   private int _adminDistance;
 
+  private Prefix _destination;
+
   private int _metric;
+
+  private final String _name;
 
   private String _nextHopInterface;
 
   private Ip _nextHopIp;
 
-  private Prefix _destination;
-
   public StaticRoute(String name) {
-    super(name);
+    _name = name;
     _adminDistance = DEFAULT_ADMIN_DISTANCE;
     _metric = DEFAULT_METRIC;
-  }
-
-  public Prefix getDestination() {
-    return _destination;
   }
 
   public int getAdminDistance() {
     return _adminDistance;
   }
 
+  public Prefix getDestination() {
+    return _destination;
+  }
+
   public int getMetric() {
     return _metric;
+  }
+
+  public String getName() {
+    return _name;
   }
 
   public String getNextHopInterface() {

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/SyslogServer.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/SyslogServer.java
@@ -1,19 +1,25 @@
 package org.batfish.representation.palo_alto;
 
-import org.batfish.common.util.ComparableStructure;
+import java.io.Serializable;
 
 /** PAN datamodel component containing server information for a syslog server */
-public final class SyslogServer extends ComparableStructure<String> {
+public final class SyslogServer implements Serializable {
   private static final long serialVersionUID = 1L;
 
   private String _address;
 
+  private final String _name;
+
   public SyslogServer(String name) {
-    super(name);
+    _name = name;
   }
 
   public String getAddress() {
     return _address;
+  }
+
+  public String getName() {
+    return _name;
   }
 
   public void setAddress(String address) {

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/VirtualRouter.java
@@ -1,27 +1,33 @@
 package org.batfish.representation.palo_alto;
 
+import java.io.Serializable;
 import java.util.Map;
 import java.util.NavigableSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import org.batfish.common.util.ComparableStructure;
 
-public class VirtualRouter extends ComparableStructure<String> {
+public class VirtualRouter implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
   private final NavigableSet<String> _interfaceNames;
 
+  private final String _name;
+
   private final Map<String, StaticRoute> _staticRoutes;
 
   public VirtualRouter(String name) {
-    super(name);
     _interfaceNames = new TreeSet<>();
+    _name = name;
     _staticRoutes = new TreeMap<>();
   }
 
   public NavigableSet<String> getInterfaceNames() {
     return _interfaceNames;
+  }
+
+  public String getName() {
+    return _name;
   }
 
   public Map<String, StaticRoute> getStaticRoutes() {

--- a/projects/batfish/src/main/java/org/batfish/representation/vyos/BgpNeighbor.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/vyos/BgpNeighbor.java
@@ -1,9 +1,9 @@
 package org.batfish.representation.vyos;
 
-import org.batfish.common.util.ComparableStructure;
+import java.io.Serializable;
 import org.batfish.datamodel.Ip;
 
-public class BgpNeighbor extends ComparableStructure<Ip> {
+public class BgpNeighbor implements Serializable {
 
   /** */
   private static final long serialVersionUID = 1L;
@@ -16,8 +16,10 @@ public class BgpNeighbor extends ComparableStructure<Ip> {
 
   private int _remoteAs;
 
+  private final Ip _remoteIp;
+
   public BgpNeighbor(Ip neighborIp) {
-    super(neighborIp);
+    _remoteIp = neighborIp;
   }
 
   public String getExportRouteMap() {
@@ -37,7 +39,7 @@ public class BgpNeighbor extends ComparableStructure<Ip> {
   }
 
   public Ip getRemoteIp() {
-    return _key;
+    return _remoteIp;
   }
 
   public void setExportRouteMap(String exportRouteMap) {

--- a/projects/batfish/src/main/java/org/batfish/representation/vyos/BgpProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/vyos/BgpProcess.java
@@ -1,24 +1,26 @@
 package org.batfish.representation.vyos;
 
+import java.io.Serializable;
 import java.util.Map;
 import java.util.TreeMap;
-import org.batfish.common.util.ComparableStructure;
 import org.batfish.datamodel.Ip;
 
-public class BgpProcess extends ComparableStructure<Integer> {
+public class BgpProcess implements Serializable {
 
   /** */
   private static final long serialVersionUID = 1L;
 
   private final Map<Ip, BgpNeighbor> _neighbors;
 
+  private final int _localAs;
+
   public BgpProcess(int localAs) {
-    super(localAs);
+    _localAs = localAs;
     _neighbors = new TreeMap<>();
   }
 
   public int getLocalAs() {
-    return _key;
+    return _localAs;
   }
 
   public Map<Ip, BgpNeighbor> getNeighbors() {

--- a/projects/batfish/src/main/java/org/batfish/representation/vyos/EspGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/vyos/EspGroup.java
@@ -1,11 +1,11 @@
 package org.batfish.representation.vyos;
 
+import java.io.Serializable;
 import java.util.Map;
 import java.util.TreeMap;
-import org.batfish.common.util.ComparableStructure;
 import org.batfish.datamodel.DiffieHellmanGroup;
 
-public class EspGroup extends ComparableStructure<String> {
+public class EspGroup implements Serializable {
 
   /** */
   private static final long serialVersionUID = 1L;
@@ -14,6 +14,8 @@ public class EspGroup extends ComparableStructure<String> {
 
   private int _lifetimeSeconds;
 
+  private final String _name;
+
   private DiffieHellmanGroup _pfsDhGroup;
 
   private PfsSource _pfsSource;
@@ -21,7 +23,7 @@ public class EspGroup extends ComparableStructure<String> {
   private final Map<Integer, EspProposal> _proposals;
 
   public EspGroup(String name) {
-    super(name);
+    _name = name;
     _proposals = new TreeMap<>();
   }
 
@@ -31,6 +33,10 @@ public class EspGroup extends ComparableStructure<String> {
 
   public int getLifetimeSeconds() {
     return _lifetimeSeconds;
+  }
+
+  public String getName() {
+    return _name;
   }
 
   public DiffieHellmanGroup getPfsDhGroup() {

--- a/projects/batfish/src/main/java/org/batfish/representation/vyos/EspProposal.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/vyos/EspProposal.java
@@ -1,9 +1,9 @@
 package org.batfish.representation.vyos;
 
-import org.batfish.common.util.ComparableStructure;
+import java.io.Serializable;
 import org.batfish.datamodel.EncryptionAlgorithm;
 
-public class EspProposal extends ComparableStructure<Integer> {
+public class EspProposal implements Serializable {
 
   /** */
   private static final long serialVersionUID = 1L;
@@ -11,10 +11,6 @@ public class EspProposal extends ComparableStructure<Integer> {
   private EncryptionAlgorithm _encryptionAlgorithm;
 
   private HashAlgorithm _hashAlgorithm;
-
-  public EspProposal(Integer name) {
-    super(name);
-  }
 
   public EncryptionAlgorithm getEncryptionAlgorithm() {
     return _encryptionAlgorithm;

--- a/projects/batfish/src/main/java/org/batfish/representation/vyos/IkeGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/vyos/IkeGroup.java
@@ -1,22 +1,17 @@
 package org.batfish.representation.vyos;
 
+import java.io.Serializable;
 import java.util.Map;
 import java.util.TreeMap;
-import org.batfish.common.util.ComparableStructure;
 
-public class IkeGroup extends ComparableStructure<String> {
+public class IkeGroup implements Serializable {
 
   /** */
   private static final long serialVersionUID = 1L;
 
   private int _lifetimeSeconds;
 
-  private final Map<Integer, IkeProposal> _proposals;
-
-  public IkeGroup(String name) {
-    super(name);
-    _proposals = new TreeMap<>();
-  }
+  private final Map<Integer, IkeProposal> _proposals = new TreeMap<>();
 
   public int getLifetimeSeconds() {
     return _lifetimeSeconds;

--- a/projects/batfish/src/main/java/org/batfish/representation/vyos/IkeProposal.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/vyos/IkeProposal.java
@@ -1,10 +1,10 @@
 package org.batfish.representation.vyos;
 
-import org.batfish.common.util.ComparableStructure;
+import java.io.Serializable;
 import org.batfish.datamodel.DiffieHellmanGroup;
 import org.batfish.datamodel.EncryptionAlgorithm;
 
-public class IkeProposal extends ComparableStructure<Integer> {
+public class IkeProposal implements Serializable {
 
   /** */
   private static final long serialVersionUID = 1L;
@@ -14,10 +14,6 @@ public class IkeProposal extends ComparableStructure<Integer> {
   private EncryptionAlgorithm _encryptionAlgorithm;
 
   private HashAlgorithm _hashAlgorithm;
-
-  public IkeProposal(Integer name) {
-    super(name);
-  }
 
   public DiffieHellmanGroup getDhGroup() {
     return _dhGroup;

--- a/projects/batfish/src/main/java/org/batfish/representation/vyos/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/vyos/Interface.java
@@ -1,12 +1,12 @@
 package org.batfish.representation.vyos;
 
+import java.io.Serializable;
 import java.util.Set;
 import java.util.TreeSet;
 import org.batfish.common.BatfishException;
-import org.batfish.common.util.ComparableStructure;
 import org.batfish.datamodel.InterfaceAddress;
 
-public class Interface extends ComparableStructure<String> {
+public class Interface implements Serializable {
 
   /** */
   private static final long serialVersionUID = 1L;
@@ -35,23 +35,29 @@ public class Interface extends ComparableStructure<String> {
     }
   }
 
+  private InterfaceAddress _address;
+
   private final Set<InterfaceAddress> _allAddresses;
 
   private double _bandwidth;
 
   private String _description;
 
-  private InterfaceAddress _address;
+  private final String _name;
 
   private InterfaceType _type;
 
   public Interface(String name) {
-    super(name);
     _allAddresses = new TreeSet<>();
+    _name = name;
   }
 
   public Set<InterfaceAddress> getAllAddresses() {
     return _allAddresses;
+  }
+
+  public InterfaceAddress getAddress() {
+    return _address;
   }
 
   public double getBandwidth() {
@@ -62,8 +68,8 @@ public class Interface extends ComparableStructure<String> {
     return _description;
   }
 
-  public InterfaceAddress getAddress() {
-    return _address;
+  public String getName() {
+    return _name;
   }
 
   public InterfaceType getType() {

--- a/projects/batfish/src/main/java/org/batfish/representation/vyos/IpsecPeer.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/vyos/IpsecPeer.java
@@ -1,10 +1,10 @@
 package org.batfish.representation.vyos;
 
-import org.batfish.common.util.ComparableStructure;
+import java.io.Serializable;
 import org.batfish.datamodel.IkeAuthenticationMethod;
 import org.batfish.datamodel.Ip;
 
-public class IpsecPeer extends ComparableStructure<Ip> {
+public class IpsecPeer implements Serializable {
 
   /** */
   private static final long serialVersionUID = 1L;
@@ -29,8 +29,10 @@ public class IpsecPeer extends ComparableStructure<Ip> {
 
   private Ip _localAddress;
 
+  private final Ip _name;
+
   public IpsecPeer(Ip name) {
-    super(name);
+    _name = name;
   }
 
   public String getAuthenticationId() {
@@ -111,5 +113,9 @@ public class IpsecPeer extends ComparableStructure<Ip> {
 
   public void setLocalAddress(Ip localAddress) {
     _localAddress = localAddress;
+  }
+
+  public Ip getName() {
+    return _name;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/vyos/PrefixList.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/vyos/PrefixList.java
@@ -1,25 +1,31 @@
 package org.batfish.representation.vyos;
 
+import java.io.Serializable;
 import java.util.Map;
 import java.util.TreeMap;
-import org.batfish.common.util.ComparableStructure;
 
-public class PrefixList extends ComparableStructure<String> {
+public class PrefixList implements Serializable {
 
   /** */
   private static final long serialVersionUID = 1L;
 
   private String _description;
 
+  private final String _name;
+
   private final Map<Integer, PrefixListRule> _rules;
 
   public PrefixList(String name) {
-    super(name);
+    _name = name;
     _rules = new TreeMap<>();
   }
 
   public String getDescription() {
     return _description;
+  }
+
+  public String getName() {
+    return _name;
   }
 
   public Map<Integer, PrefixListRule> getRules() {

--- a/projects/batfish/src/main/java/org/batfish/representation/vyos/PrefixListRule.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/vyos/PrefixListRule.java
@@ -1,12 +1,12 @@
 package org.batfish.representation.vyos;
 
+import java.io.Serializable;
 import org.batfish.common.BatfishException;
-import org.batfish.common.util.ComparableStructure;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.SubRange;
 
-public class PrefixListRule extends ComparableStructure<Integer> {
+public class PrefixListRule implements Serializable {
 
   /** */
   private static final long serialVersionUID = 1L;
@@ -21,8 +21,7 @@ public class PrefixListRule extends ComparableStructure<Integer> {
 
   private Prefix _prefix;
 
-  public PrefixListRule(int num) {
-    super(num);
+  public PrefixListRule() {
     _ge = 0;
     _le = 32;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/vyos/RouteMap.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/vyos/RouteMap.java
@@ -1,19 +1,25 @@
 package org.batfish.representation.vyos;
 
+import java.io.Serializable;
 import java.util.Map;
 import java.util.TreeMap;
-import org.batfish.common.util.ComparableStructure;
 
-public class RouteMap extends ComparableStructure<String> {
+public class RouteMap implements Serializable {
 
   /** */
   private static final long serialVersionUID = 1L;
 
+  private final String _name;
+
   private final Map<Integer, RouteMapRule> _rules;
 
   public RouteMap(String name) {
-    super(name);
+    _name = name;
     _rules = new TreeMap<>();
+  }
+
+  public String getName() {
+    return _name;
   }
 
   public Map<Integer, RouteMapRule> getRules() {

--- a/projects/batfish/src/main/java/org/batfish/representation/vyos/RouteMapRule.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/vyos/RouteMapRule.java
@@ -1,11 +1,11 @@
 package org.batfish.representation.vyos;
 
+import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
-import org.batfish.common.util.ComparableStructure;
 import org.batfish.datamodel.LineAction;
 
-public class RouteMapRule extends ComparableStructure<Integer> {
+public class RouteMapRule implements Serializable {
 
   /** */
   private static final long serialVersionUID = 1L;
@@ -14,12 +14,7 @@ public class RouteMapRule extends ComparableStructure<Integer> {
 
   private String _description;
 
-  private final Set<RouteMapMatch> _matches;
-
-  public RouteMapRule(int num) {
-    super(num);
-    _matches = new HashSet<>();
-  }
+  private final Set<RouteMapMatch> _matches = new HashSet<>();
 
   public LineAction getAction() {
     return _action;


### PR DESCRIPTION
Only one actual change from a Set to a Map where we were using the ComparableStructure-backed hack.