### PR TITLE
Some beginners work removing ComparableStructure from datamodel

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsPathAccessList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsPathAccessList.java
@@ -1,46 +1,48 @@
 package org.batfish.datamodel;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.google.common.collect.ImmutableList;
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDescription;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.batfish.common.util.ComparableStructure;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 @JsonSchemaDescription(
     "An AsPathAccessList is used to filter e/iBGP routes according to their AS-path attribute.")
-public final class AsPathAccessList extends ComparableStructure<String> implements Serializable {
+public final class AsPathAccessList implements Serializable {
 
   private static final String PROP_LINES = "lines";
+
+  private static final String PROP_NAME = "name";
 
   private static final long serialVersionUID = 1L;
 
   private transient Set<AsPath> _deniedCache;
 
-  private final List<AsPathAccessListLine> _lines;
+  @Nonnull private final List<AsPathAccessListLine> _lines;
+
+  private final String _name;
 
   private transient Set<AsPath> _permittedCache;
 
-  public AsPathAccessList(String name) {
-    super(name);
-    _lines = new ArrayList<>();
-  }
-
   @JsonCreator
   public AsPathAccessList(
-      @JsonProperty(PROP_NAME) String name,
-      @JsonProperty(PROP_LINES) List<AsPathAccessListLine> lines) {
-    super(name);
-    _lines = lines;
+      @Nullable @JsonProperty(PROP_NAME) String name,
+      @Nullable @JsonProperty(PROP_LINES) List<AsPathAccessListLine> lines) {
+    _lines = firstNonNull(lines, ImmutableList.of());
+    _name = name;
   }
 
   @Override
@@ -57,8 +59,15 @@ public final class AsPathAccessList extends ComparableStructure<String> implemen
   @JsonProperty(PROP_LINES)
   @JsonPropertyDescription(
       "The list of lines against which a route's AS-path will be checked in order.")
+  @Nonnull
   public List<AsPathAccessListLine> getLines() {
     return _lines;
+  }
+
+  @JsonProperty(PROP_NAME)
+  @Nonnull
+  public String getName() {
+    return _name;
   }
 
   private boolean newPermits(AsPath asPath) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsPathAccessList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsPathAccessList.java
@@ -12,6 +12,7 @@ import java.io.ObjectInputStream;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
@@ -53,7 +54,12 @@ public final class AsPathAccessList implements Serializable {
       return false;
     }
     AsPathAccessList other = (AsPathAccessList) o;
-    return other._lines.equals(_lines);
+    return Objects.equals(_name, other._name) && Objects.equals(_lines, other._lines);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_name, _lines);
   }
 
   @JsonProperty(PROP_LINES)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AuthenticationKey.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AuthenticationKey.java
@@ -2,17 +2,19 @@ package org.batfish.datamodel;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.batfish.common.util.ComparableStructure;
+import java.io.Serializable;
 import org.batfish.datamodel.isis.IsisAuthenticationAlgorithm;
 import org.batfish.datamodel.isis.IsisOption;
 
-public class AuthenticationKey extends ComparableStructure<String> {
+public class AuthenticationKey implements Serializable {
 
   private static final String PROP_BGP_AUTHENTICATION_ALGORITHM = "bgpAuthenticationAlgorithm";
 
   private static final String PROP_ISIS_AUTHENTICATION_ALGORITHM = "isisAuthenticationAlgorithm";
 
   private static final String PROP_ISIS_OPTION = "isisOption";
+
+  private static final String PROP_NAME = "name";
 
   private static final String PROP_SECRET = "secret";
 
@@ -31,13 +33,15 @@ public class AuthenticationKey extends ComparableStructure<String> {
 
   private IsisOption _isisOption;
 
+  private final String _name;
+
   private String _secret;
 
   private String _startTime;
 
   @JsonCreator
   public AuthenticationKey(@JsonProperty(PROP_NAME) String name) {
-    super(name);
+    _name = name;
     _isisAuthenticationAlgorithm = DEFAULT_ISIS_AUTHENTICATION_ALGORITHM;
     _isisOption = DEFAULT_ISIS_OPTION;
   }
@@ -55,6 +59,11 @@ public class AuthenticationKey extends ComparableStructure<String> {
   @JsonProperty(PROP_ISIS_OPTION)
   public IsisOption getIsisOption() {
     return _isisOption;
+  }
+
+  @JsonProperty(PROP_NAME)
+  public String getName() {
+    return _name;
   }
 
   @JsonProperty(PROP_SECRET)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AuthenticationKeyChain.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AuthenticationKeyChain.java
@@ -2,11 +2,11 @@ package org.batfish.datamodel;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.Serializable;
 import java.util.Map;
 import java.util.TreeMap;
-import org.batfish.common.util.ComparableStructure;
 
-public class AuthenticationKeyChain extends ComparableStructure<String> {
+public class AuthenticationKeyChain implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
@@ -14,18 +14,22 @@ public class AuthenticationKeyChain extends ComparableStructure<String> {
 
   private static final String PROP_KEYS = "keys";
 
+  private static final String PROP_NAME = "name";
+
   private static final String PROP_TOLERANCE = "tolerance";
 
   private String _description;
 
   private Map<String, AuthenticationKey> _keys;
 
+  private final String _name;
+
   private int _tolerance;
 
   @JsonCreator
   public AuthenticationKeyChain(@JsonProperty(PROP_NAME) String name) {
-    super(name);
     _keys = new TreeMap<>();
+    _name = name;
   }
 
   @JsonProperty(PROP_DESCRIPTION)
@@ -36,6 +40,11 @@ public class AuthenticationKeyChain extends ComparableStructure<String> {
   @JsonProperty(PROP_KEYS)
   public Map<String, AuthenticationKey> getKeys() {
     return _keys;
+  }
+
+  @JsonProperty(PROP_NAME)
+  public String getName() {
+    return _name;
   }
 
   @JsonProperty(PROP_TOLERANCE)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IkeGateway.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IkeGateway.java
@@ -4,15 +4,17 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
-import org.batfish.common.util.ComparableStructure;
+import java.io.Serializable;
 
-public class IkeGateway extends ComparableStructure<String> {
+public class IkeGateway implements Serializable {
 
   private static final String PROP_EXTERNAL_INTERFACE = "externalInterface";
 
   private static final String PROP_IKE_POLICY = "ikePolicy";
 
   private static final String PROP_LOCAL_ADDRESS = "localAddress";
+
+  private static final String PROP_NAME = "name";
 
   /** */
   private static final long serialVersionUID = 1L;
@@ -31,11 +33,13 @@ public class IkeGateway extends ComparableStructure<String> {
 
   private String _localId;
 
+  private final String _name;
+
   private String _remoteId;
 
   @JsonCreator
   public IkeGateway(@JsonProperty(PROP_NAME) String name) {
-    super(name);
+    _name = name;
   }
 
   @Override
@@ -114,6 +118,11 @@ public class IkeGateway extends ComparableStructure<String> {
   @JsonPropertyDescription("Local IKE ID used in connection to IKE gateway.")
   public String getLocalId() {
     return _localId;
+  }
+
+  @JsonProperty(PROP_NAME)
+  public String getName() {
+    return _name;
   }
 
   @JsonPropertyDescription("Remote IKE ID of IKE gateway.")

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IkeGateway.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IkeGateway.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import java.io.Serializable;
+import java.util.Objects;
 
 public class IkeGateway implements Serializable {
 
@@ -29,9 +30,9 @@ public class IkeGateway implements Serializable {
 
   private transient String _ikePolicyName;
 
-  private Ip _localIp;
-
   private String _localId;
+
+  private Ip _localIp;
 
   private final String _name;
 
@@ -50,25 +51,19 @@ public class IkeGateway implements Serializable {
       return false;
     }
     IkeGateway other = (IkeGateway) o;
-    if (!other._address.equals(_address)) {
-      return false;
-    }
-    if (!other._externalInterface.equals(_externalInterface)) {
-      return false;
-    }
-    if (!other._ikePolicy.equals(_ikePolicy)) {
-      return false;
-    }
-    if (!other._localIp.equals(_localIp)) {
-      return false;
-    }
-    if (!other._localId.equals(_localId)) {
-      return false;
-    }
-    if (!other._remoteId.equals(_remoteId)) {
-      return false;
-    }
-    return true;
+    return Objects.equals(_address, other._address)
+        && Objects.equals(_externalInterface, other._externalInterface)
+        && Objects.equals(_ikePolicy, other._ikePolicy)
+        && Objects.equals(_localId, other._localId)
+        && Objects.equals(_localIp, other._localIp)
+        && Objects.equals(_name, other._name)
+        && Objects.equals(_remoteId, other._remoteId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        _address, _externalInterface, _ikePolicy, _localId, _localIp, _name, _remoteId);
   }
 
   @JsonPropertyDescription("Remote IP address of IKE gateway")
@@ -108,16 +103,16 @@ public class IkeGateway implements Serializable {
     }
   }
 
+  @JsonPropertyDescription("Local IKE ID used in connection to IKE gateway.")
+  public String getLocalId() {
+    return _localId;
+  }
+
   @JsonProperty(PROP_LOCAL_ADDRESS)
   @JsonPropertyDescription(
       "Local IP address from which to connect to IKE gateway. Used instead of external interface.")
   public Ip getLocalIp() {
     return _localIp;
-  }
-
-  @JsonPropertyDescription("Local IKE ID used in connection to IKE gateway.")
-  public String getLocalId() {
-    return _localId;
   }
 
   @JsonProperty(PROP_NAME)
@@ -163,13 +158,13 @@ public class IkeGateway implements Serializable {
     _ikePolicyName = ikePolicyName;
   }
 
+  public void setLocalId(String localId) {
+    _localId = localId;
+  }
+
   @JsonProperty(PROP_LOCAL_ADDRESS)
   public void setLocalIp(Ip localIp) {
     _localIp = localIp;
-  }
-
-  public void setLocalId(String localId) {
-    _localId = localId;
   }
 
   public void setRemoteId(String remoteId) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IkePolicy.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IkePolicy.java
@@ -4,18 +4,22 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import java.io.Serializable;
 import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import org.batfish.common.util.ComparableStructure;
 
-public final class IkePolicy extends ComparableStructure<String> {
+public final class IkePolicy implements Serializable {
+
+  private static final String PROP_NAME = "name";
 
   private static final String PROP_PROPOSALS = "proposals";
 
   /** */
   private static final long serialVersionUID = 1L;
+
+  private final String _name;
 
   private String _preSharedKeyHash;
 
@@ -25,7 +29,7 @@ public final class IkePolicy extends ComparableStructure<String> {
 
   @JsonCreator
   public IkePolicy(@JsonProperty(PROP_NAME) String name) {
-    super(name);
+    _name = name;
     _proposals = new TreeMap<>();
   }
 
@@ -33,6 +37,11 @@ public final class IkePolicy extends ComparableStructure<String> {
       "SHA-256 hash of salted version of pre-shared-key stored in original configuration")
   public String getPreSharedKeyHash() {
     return _preSharedKeyHash;
+  }
+
+  @JsonProperty(PROP_NAME)
+  public String getName() {
+    return _name;
   }
 
   @JsonProperty(PROP_PROPOSALS)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco/DocsisPolicyRule.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco/DocsisPolicyRule.java
@@ -2,15 +2,24 @@ package org.batfish.datamodel.vendor_family.cisco;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.batfish.common.util.ComparableStructure;
+import java.io.Serializable;
 
-public class DocsisPolicyRule extends ComparableStructure<String> {
+public final class DocsisPolicyRule implements Serializable {
+
+  private static final String PROP_NAME = "name";
 
   /** */
   private static final long serialVersionUID = 1L;
 
+  private final String _name;
+
   @JsonCreator
   public DocsisPolicyRule(@JsonProperty(PROP_NAME) String number) {
-    super(number);
+    _name = number;
+  }
+
+  @JsonProperty(PROP_NAME)
+  public String getName() {
+    return _name;
   }
 }


### PR DESCRIPTION
Most were easy.

Did not add equals, hashCode, or toString to any class, except as needed to make tests pass or compiler warnings succeed.

These two were affected by the latter (and have commits with good messages explaining why).

* Configuration
* AsPathAccessList

Thoughts?