### PR TITLE
make AclReachabilty2 metadata generation accessible to clients

### DIFF
--- a/projects/question/src/main/java/org/batfish/question/aclreachability2/AclReachability2Answerer.java
+++ b/projects/question/src/main/java/org/batfish/question/aclreachability2/AclReachability2Answerer.java
@@ -59,7 +59,7 @@ public class AclReachability2Answerer extends Answerer {
    * @param question The question
    * @return The resulting {@link TableMetadata} object
    */
-  private static TableMetadata createMetadata(AclReachability2Question question) {
+  public static TableMetadata createMetadata(Question question) {
     List<ColumnMetadata> columnMetadata =
         new ImmutableList.Builder<ColumnMetadata>()
             .add(


### PR DESCRIPTION
- relax question parameter so client can pass alternate question type