### PR TITLE
new IpSpaceSpecifier that specifies an IpSpace by locations

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/FlexibleLocationIpSpaceSpecifierFactory.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/FlexibleLocationIpSpaceSpecifierFactory.java
@@ -1,0 +1,24 @@
+package org.batfish.specifier;
+
+import com.google.auto.service.AutoService;
+import javax.annotation.Nullable;
+
+/**
+ * Builds a {@link LocationIpSpaceSpecifier} using {@link FlexibleLocationSpecifierFactory} to build
+ * its {@link LocationSpecifier} input.
+ */
+@AutoService(IpSpaceSpecifierFactory.class)
+public final class FlexibleLocationIpSpaceSpecifierFactory implements IpSpaceSpecifierFactory {
+  public static final String NAME = FlexibleLocationIpSpaceSpecifierFactory.class.getSimpleName();
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
+  public IpSpaceSpecifier buildIpSpaceSpecifier(@Nullable Object input) {
+    return new LocationIpSpaceSpecifier(
+        new FlexibleLocationSpecifierFactory().buildLocationSpecifier(input));
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/LocationIpSpaceSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/LocationIpSpaceSpecifier.java
@@ -1,0 +1,57 @@
+package org.batfish.specifier;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import org.batfish.datamodel.AclIpSpace;
+import org.batfish.datamodel.EmptyIpSpace;
+import org.batfish.datamodel.IpSpace;
+import org.batfish.specifier.IpSpaceAssignment.Entry;
+
+/**
+ * Specify the {@lnk IpSpace} inferred from a set of {@link Location locations} (specified by a
+ * {@link LocationSpecifier}.
+ */
+public final class LocationIpSpaceSpecifier implements IpSpaceSpecifier {
+  private final @Nonnull LocationSpecifier _locationSpecifier;
+
+  LocationIpSpaceSpecifier(@Nonnull LocationSpecifier locationSpecifier) {
+    _locationSpecifier = locationSpecifier;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof LocationIpSpaceSpecifier)) {
+      return false;
+    }
+    LocationIpSpaceSpecifier that = (LocationIpSpaceSpecifier) o;
+    return Objects.equals(_locationSpecifier, that._locationSpecifier);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_locationSpecifier);
+  }
+
+  @Override
+  public IpSpaceAssignment resolve(Set<Location> key, SpecifierContext ctxt) {
+    Set<Location> locations = _locationSpecifier.resolve(ctxt);
+    IpSpace ipSpace =
+        AclIpSpace.union(
+            InferFromLocationIpSpaceSpecifier.INSTANCE
+                .resolve(locations, ctxt)
+                .getEntries()
+                .stream()
+                .map(Entry::getIpSpace)
+                .collect(Collectors.toList()));
+    return IpSpaceAssignment.builder()
+        .assign(key, firstNonNull(ipSpace, EmptyIpSpace.INSTANCE))
+        .build();
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/LocationIpSpaceSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/LocationIpSpaceSpecifier.java
@@ -12,8 +12,16 @@ import org.batfish.datamodel.IpSpace;
 import org.batfish.specifier.IpSpaceAssignment.Entry;
 
 /**
- * Specify the {@lnk IpSpace} inferred from a set of {@link Location locations} (specified by a
- * {@link LocationSpecifier}.
+ * Specify the {@link IpSpace} inferred from a set of {@link Location locations} (specified by a
+ * {@link LocationSpecifier}). This set of "{@link IpSpace} locations" is independent of the set of
+ * locations that are to be assigned {@link IpSpace IpSpaces}, which input via the {@link #resolve}
+ * method (we could call these the "assignment locations"). All the inferred {@link IpSpace
+ * IpSpaces} are unioned together into a single large space, which is then assigned to each
+ * assignment location.
+ *
+ * <p>Example: We want to analyze the behavior of a set of packets starting at a core router, where
+ * the packets look like they were sent from some set of hosts. Here, the {@link IpSpace} locations
+ * are the host locations, and the assignment locations are the core router locations.
  */
 public final class LocationIpSpaceSpecifier implements IpSpaceSpecifier {
   private final @Nonnull LocationSpecifier _locationSpecifier;

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/IpSpaceSpecifierFactoryTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/IpSpaceSpecifierFactoryTest.java
@@ -35,6 +35,18 @@ public class IpSpaceSpecifierFactoryTest {
   }
 
   @Test
+  public void testFlexibleLocationIpSpaceSpecifierFactory() {
+    assertThat(
+        load(FlexibleLocationIpSpaceSpecifierFactory.NAME),
+        instanceOf(FlexibleLocationIpSpaceSpecifierFactory.class));
+    assertThat(
+        new FlexibleLocationIpSpaceSpecifierFactory().buildIpSpaceSpecifier("vrf=foo"),
+        equalTo(
+            new LocationIpSpaceSpecifier(
+                new VrfNameRegexInterfaceLinkLocationSpecifier(Pattern.compile("foo")))));
+  }
+
+  @Test
   public void testNodeNameRegexConnecgtedHostsIpSpaceSpecifierFactory() {
     assertThat(
         load(NodeNameRegexConnectedHostsIpSpaceSpecifierFactory.NAME),

--- a/projects/batfish/src/test/java/org/batfish/specifier/IpSpaceSpecifierTest.java
+++ b/projects/batfish/src/test/java/org/batfish/specifier/IpSpaceSpecifierTest.java
@@ -11,6 +11,7 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import java.util.Map;
 import java.util.Set;
@@ -137,6 +138,14 @@ public class IpSpaceSpecifierTest {
         hasEntry(
             equalTo(EmptyIpSpace.INSTANCE),
             contains(new InterfaceLinkLocation(_i2.getOwner().getName(), _i2.getName()))));
+  }
+
+  @Test
+  public void testLocationIpSpaceSpecifier() {
+    IpSpaceAssignment assignment =
+        new LocationIpSpaceSpecifier(AllInterfacesLocationSpecifier.INSTANCE)
+            .resolve(ImmutableSet.of(), _context);
+    assertThat(assignment, hasEntry(containsIp(new Ip("1.0.0.0")), equalTo(ImmutableSet.of())));
   }
 
   @Test


### PR DESCRIPTION
Given a LocationSpecifier, it infers an IpSpace for each location, and
then unions them into a single IpSpace. This is useful for specifying
destination IpSpaces by location. In the future this will probably
replace InferFromLocationIpSpaceSpecifier so we can simplify the
IpSpaceSpecifier API. At that point, we will no longer union all the
spaces into a single IpSpace, but instead construct a separate
assignment entry for each.