### PR TITLE
ReachabilityParametersResolver: throw if the destination IpSpace is e…

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/question/ReachabilityParameters.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/question/ReachabilityParameters.java
@@ -3,6 +3,7 @@ package org.batfish.question;
 import com.google.common.collect.ImmutableSortedSet;
 import java.util.SortedSet;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.batfish.datamodel.ForwardingAction;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.UniverseIpSpace;
@@ -11,12 +12,15 @@ import org.batfish.specifier.ConstantIpSpaceSpecifier;
 import org.batfish.specifier.InferFromLocationIpSpaceSpecifier;
 import org.batfish.specifier.IpSpaceSpecifier;
 import org.batfish.specifier.LocationSpecifier;
-import org.batfish.specifier.NoNodesNodeSpecifier;
 import org.batfish.specifier.NodeSpecifier;
 
 /**
  * A set of parameters for reachability analysis that uses high-level specifiers. It is a good
  * choice for questions because relatively little work is needed to map user input into it.
+ *
+ * <p>Nullable parameters are interpreted as "no constraint". If a (Nonnull) constraint is supplied,
+ * then it must be satisfiable. For example, if a no nodes match a {@link NodeSpecifier}, it is
+ * unsatisfiable. This requirement is enforced during resolution.
  */
 public final class ReachabilityParameters {
 
@@ -26,15 +30,15 @@ public final class ReachabilityParameters {
     private @Nonnull IpSpaceSpecifier _destinationIpSpaceSpecifier =
         new ConstantIpSpaceSpecifier(UniverseIpSpace.INSTANCE);
 
-    private @Nonnull NodeSpecifier _finalNodesSpecifier = NoNodesNodeSpecifier.INSTANCE;
+    private @Nullable NodeSpecifier _finalNodesSpecifier = null;
 
-    private @Nonnull NodeSpecifier _forbiddenTransitNodesSpecifier = NoNodesNodeSpecifier.INSTANCE;
+    private @Nullable NodeSpecifier _forbiddenTransitNodesSpecifier = null;
 
-    private HeaderSpace _headerSpace;
+    private @Nullable HeaderSpace _headerSpace;
 
     private int _maxChunkSize;
 
-    private @Nonnull NodeSpecifier _requiredTransitNodesSpecifier = NoNodesNodeSpecifier.INSTANCE;
+    private @Nullable NodeSpecifier _requiredTransitNodesSpecifier = null;
 
     private @Nonnull LocationSpecifier _sourceLocationSpecifier =
         AllInterfacesLocationSpecifier.INSTANCE;
@@ -120,9 +124,9 @@ public final class ReachabilityParameters {
   private @Nonnull IpSpaceSpecifier _destinationIpSpaceSpecifier =
       new ConstantIpSpaceSpecifier(UniverseIpSpace.INSTANCE);
 
-  private final NodeSpecifier _finalNodesSpecifier;
+  private final @Nullable NodeSpecifier _finalNodesSpecifier;
 
-  private final @Nonnull NodeSpecifier _forbiddenTransitNodesSpecifier;
+  private final @Nullable NodeSpecifier _forbiddenTransitNodesSpecifier;
 
   private final HeaderSpace _headerSpace;
 
@@ -136,7 +140,7 @@ public final class ReachabilityParameters {
 
   private final boolean _specialize;
 
-  private final NodeSpecifier _requiredTransitNodesSpecifier;
+  private final @Nullable NodeSpecifier _requiredTransitNodesSpecifier;
 
   private final boolean _useCompression;
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/question/ResolvedReachabilityParameters.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/question/ResolvedReachabilityParameters.java
@@ -3,7 +3,6 @@ package org.batfish.question;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
-import com.google.common.collect.Sets;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
@@ -148,27 +147,6 @@ public final class ResolvedReachabilityParameters {
     _specialize = builder._specialize;
     _requiredTransitNodes = builder._requiredTransitNodes;
     _useCompression = builder._useCompression;
-
-    // validate actions
-    if (_actions.isEmpty()) {
-      throw new InvalidReachabilityParametersException("No actions");
-    }
-    // validate source IP assignment
-    if (_sourceIpSpaceByLocations.getEntries().isEmpty()) {
-      throw new InvalidReachabilityParametersException("No source locations");
-    }
-
-    // validate final nodes
-    if (_finalNodes.isEmpty()) {
-      throw new InvalidReachabilityParametersException("No final nodes");
-    }
-
-    // validate transit nodes
-    Set<String> commonNodes = Sets.intersection(_requiredTransitNodes, _forbiddenTransitNodes);
-    if (!commonNodes.isEmpty()) {
-      throw new InvalidReachabilityParametersException(
-          "Required and forbidden transit nodes overlap: " + commonNodes);
-    }
   }
 
   public static Builder builder() {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/IpSpaceAssignment.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/IpSpaceAssignment.java
@@ -62,7 +62,7 @@ public final class IpSpaceAssignment {
 
   private final List<Entry> _entries;
 
-  public IpSpaceAssignment(List<Entry> entries) {
+  private IpSpaceAssignment(List<Entry> entries) {
     _entries = ImmutableList.copyOf(entries);
   }
 
@@ -76,5 +76,9 @@ public final class IpSpaceAssignment {
 
   public Collection<Entry> getEntries() {
     return _entries;
+  }
+
+  public static IpSpaceAssignment of(List<Entry> entries) {
+    return new IpSpaceAssignment(entries);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/IpSpaceAssignment.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/IpSpaceAssignment.java
@@ -62,7 +62,7 @@ public final class IpSpaceAssignment {
 
   private final List<Entry> _entries;
 
-  private IpSpaceAssignment(List<Entry> entries) {
+  public IpSpaceAssignment(List<Entry> entries) {
     _entries = ImmutableList.copyOf(entries);
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/NodeSpecifiers.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/NodeSpecifiers.java
@@ -7,7 +7,7 @@ import org.batfish.datamodel.questions.NodesSpecifier;
 public class NodeSpecifiers {
 
   public static NodeSpecifier difference(
-      NodeSpecifier nodeSpecifier, NodeSpecifier notNodeSpecifier) {
+      @Nullable NodeSpecifier nodeSpecifier, @Nullable NodeSpecifier notNodeSpecifier) {
     if (nodeSpecifier != null && notNodeSpecifier != null) {
       return new DifferenceNodeSpecifier(nodeSpecifier, notNodeSpecifier);
     } else if (nodeSpecifier != null) {
@@ -15,13 +15,13 @@ public class NodeSpecifiers {
     } else if (notNodeSpecifier != null) {
       return new DifferenceNodeSpecifier(AllNodesNodeSpecifier.INSTANCE, notNodeSpecifier);
     } else {
-      return AllNodesNodeSpecifier.INSTANCE;
+      return null;
     }
   }
 
   public static NodeSpecifier from(@Nullable NodesSpecifier nodesSpecifier) {
     if (nodesSpecifier == null) {
-      return NoNodesNodeSpecifier.INSTANCE;
+      return null;
     }
 
     switch (nodesSpecifier.getType()) {

--- a/projects/batfish/src/main/java/org/batfish/main/ReachabilityParametersResolver.java
+++ b/projects/batfish/src/main/java/org/batfish/main/ReachabilityParametersResolver.java
@@ -160,7 +160,7 @@ final class ReachabilityParametersResolver {
 
     // resolve the IpSpaceSpecifier, and filter out entries with empty IpSpaces
     IpSpaceAssignment sourceIpSpaceAssignment =
-        new IpSpaceAssignment(
+        IpSpaceAssignment.of(
             _params
                 .getSourceIpSpaceSpecifier()
                 .resolve(sourceLocations, _context)

--- a/projects/batfish/src/main/java/org/batfish/main/ReachabilityParametersResolver.java
+++ b/projects/batfish/src/main/java/org/batfish/main/ReachabilityParametersResolver.java
@@ -11,6 +11,7 @@ import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.questions.InvalidReachabilityParametersException;
+import org.batfish.datamodel.visitors.IpSpaceRepresentativeImpl;
 import org.batfish.main.Batfish.CompressDataPlaneResult;
 import org.batfish.question.ReachabilityParameters;
 import org.batfish.question.ResolvedReachabilityParameters;
@@ -66,6 +67,15 @@ final class ReachabilityParametersResolver {
                 .stream()
                 .map(Entry::getIpSpace)
                 .collect(ImmutableList.toImmutableList()));
+
+    /*
+     * Make sure the destinationIpSpace is non-empty. Otherwise, we'll get no results and no
+     * explanation why.
+     */
+    if (!new IpSpaceRepresentativeImpl().getRepresentative(destinationIpSpace).isPresent()) {
+      throw new InvalidReachabilityParametersException("Empty destination IpSpace");
+    }
+
     HeaderSpace headerSpace = params.getHeaderSpace();
     if (headerSpace == null) {
       headerSpace = HeaderSpace.builder().setDstIps(destinationIpSpace).build();

--- a/projects/batfish/src/test/java/org/batfish/main/ReachabilityParametersResolverTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/ReachabilityParametersResolverTest.java
@@ -7,10 +7,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import java.io.IOException;
 import java.util.SortedMap;
+import java.util.regex.Pattern;
 import org.batfish.common.NetworkSnapshot;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.EmptyIpSpace;
@@ -25,6 +27,8 @@ import org.batfish.question.ReachabilityParameters.Builder;
 import org.batfish.question.ResolvedReachabilityParameters;
 import org.batfish.specifier.AllNodesNodeSpecifier;
 import org.batfish.specifier.ConstantIpSpaceSpecifier;
+import org.batfish.specifier.NoNodesNodeSpecifier;
+import org.batfish.specifier.NodeNameRegexInterfaceLinkLocationSpecifier;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -56,6 +60,7 @@ public class ReachabilityParametersResolverTest {
     Builder reachabilityParametersBuilder =
         ReachabilityParameters.builder()
             .setActions(ImmutableSortedSet.of(ACCEPT))
+            .setSourceIpSpaceSpecifier(new ConstantIpSpaceSpecifier(UniverseIpSpace.INSTANCE))
             .setFinalNodesSpecifier(AllNodesNodeSpecifier.INSTANCE);
 
     // test default destination IpSpace
@@ -80,7 +85,7 @@ public class ReachabilityParametersResolverTest {
   }
 
   @Test
-  public void testDestinationIpSpace_emptyDestIpSpace()
+  public void testResolveDestinationIpSpace_emptyDestIpSpace()
       throws InvalidReachabilityParametersException {
     ReachabilityParameters reachabilityParameters =
         ReachabilityParameters.builder()
@@ -91,6 +96,101 @@ public class ReachabilityParametersResolverTest {
 
     exception.expect(InvalidReachabilityParametersException.class);
     exception.expectMessage("Empty destination IpSpace");
+    new ReachabilityParametersResolver(_batfish, reachabilityParameters, _snapshot)
+        .resolveDestinationIpSpace();
+  }
+
+  @Test
+  public void testResolveNodes_null() throws InvalidReachabilityParametersException {
+    ReachabilityParameters reachabilityParameters =
+        ReachabilityParameters.builder()
+            .setActions(ImmutableSortedSet.of(ACCEPT))
+            .setFinalNodesSpecifier(null)
+            .setDestinationIpSpaceSpecifier(new ConstantIpSpaceSpecifier(EmptyIpSpace.INSTANCE))
+            .setSourceLocationSpecifier(
+                new NodeNameRegexInterfaceLinkLocationSpecifier(Pattern.compile("")))
+            .build();
+    ReachabilityParametersResolver resolver =
+        new ReachabilityParametersResolver(_batfish, reachabilityParameters, _snapshot);
+    assertThat(
+        resolver.resolveNodes("foo", reachabilityParameters.getFinalNodesSpecifier()),
+        equalTo(ImmutableSet.of()));
+  }
+
+  @Test
+  public void testResolveNodes_noMatch() throws InvalidReachabilityParametersException {
+    ReachabilityParameters reachabilityParameters =
+        ReachabilityParameters.builder()
+            .setActions(ImmutableSortedSet.of(ACCEPT))
+            .setFinalNodesSpecifier(NoNodesNodeSpecifier.INSTANCE)
+            .setDestinationIpSpaceSpecifier(new ConstantIpSpaceSpecifier(EmptyIpSpace.INSTANCE))
+            .setSourceLocationSpecifier(
+                new NodeNameRegexInterfaceLinkLocationSpecifier(Pattern.compile("")))
+            .build();
+    ReachabilityParametersResolver resolver =
+        new ReachabilityParametersResolver(_batfish, reachabilityParameters, _snapshot);
+    exception.expect(InvalidReachabilityParametersException.class);
+    exception.expectMessage("No nodes match foo specifier");
+    resolver.resolveNodes("foo", reachabilityParameters.getFinalNodesSpecifier());
+  }
+
+  @Test
+  public void testResolveSourceIpSpace_emptyLocations()
+      throws InvalidReachabilityParametersException {
+    ReachabilityParameters reachabilityParameters =
+        ReachabilityParameters.builder()
+            .setActions(ImmutableSortedSet.of(ACCEPT))
+            .setFinalNodesSpecifier(AllNodesNodeSpecifier.INSTANCE)
+            .setDestinationIpSpaceSpecifier(new ConstantIpSpaceSpecifier(EmptyIpSpace.INSTANCE))
+            .setSourceLocationSpecifier(
+                new NodeNameRegexInterfaceLinkLocationSpecifier(Pattern.compile("")))
+            .build();
+
+    ReachabilityParametersResolver resolver =
+        new ReachabilityParametersResolver(_batfish, reachabilityParameters, _snapshot);
+
+    exception.expect(InvalidReachabilityParametersException.class);
+    exception.expectMessage("No matching source locations");
+    resolver.resolveSourceIpSpaceAssignment();
+  }
+
+  @Test
+  public void testResolveSourceIpSpace_emptyIpSpace()
+      throws InvalidReachabilityParametersException {
+    ReachabilityParameters reachabilityParameters =
+        ReachabilityParameters.builder()
+            .setActions(ImmutableSortedSet.of(ACCEPT))
+            .setFinalNodesSpecifier(AllNodesNodeSpecifier.INSTANCE)
+            .setDestinationIpSpaceSpecifier(new ConstantIpSpaceSpecifier(EmptyIpSpace.INSTANCE))
+            .setSourceLocationSpecifier(
+                new NodeNameRegexInterfaceLinkLocationSpecifier(Pattern.compile(".*")))
+            .build();
+
+    ReachabilityParametersResolver reachabilityParametersResolver =
+        new ReachabilityParametersResolver(_batfish, reachabilityParameters, _snapshot);
+
+    exception.expect(InvalidReachabilityParametersException.class);
+    exception.expectMessage("All sources have empty source IpSpaces");
+    reachabilityParametersResolver.resolveSourceIpSpaceAssignment();
+  }
+
+  @Test
+  public void testResolveReachabilityParameters_conflictingTransitNodes()
+      throws InvalidReachabilityParametersException {
+    // all required transit nodes are also forbidden
+    ReachabilityParameters reachabilityParameters =
+        ReachabilityParameters.builder()
+            .setActions(ImmutableSortedSet.of(ACCEPT))
+            .setFinalNodesSpecifier(AllNodesNodeSpecifier.INSTANCE)
+            .setDestinationIpSpaceSpecifier(new ConstantIpSpaceSpecifier(UniverseIpSpace.INSTANCE))
+            .setRequiredTransitNodesSpecifier(AllNodesNodeSpecifier.INSTANCE)
+            .setForbiddenTransitNodesSpecifier(AllNodesNodeSpecifier.INSTANCE)
+            .setSourceLocationSpecifier(
+                new NodeNameRegexInterfaceLinkLocationSpecifier(Pattern.compile(".*")))
+            .build();
+
+    exception.expect(InvalidReachabilityParametersException.class);
+    exception.expectMessage("All required transit nodes are also forbidden");
     resolveReachabilityParameters(_batfish, reachabilityParameters, _snapshot);
   }
 }

--- a/projects/question/src/main/java/org/batfish/question/ReachabilityQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/ReachabilityQuestionPlugin.java
@@ -120,15 +120,15 @@ public class ReachabilityQuestionPlugin extends QuestionPlugin {
 
     private static final int DEFAULT_MAX_CHUNK_SIZE = 1;
 
-    private static final NodesSpecifier DEFAULT_NON_TRANSIT_NODES = NodesSpecifier.NONE;
+    private static final NodesSpecifier DEFAULT_NON_TRANSIT_NODES = null;
 
-    private static final NodesSpecifier DEFAULT_NOT_FINAL_NODE_REGEX = NodesSpecifier.NONE;
+    private static final NodesSpecifier DEFAULT_NOT_FINAL_NODE_REGEX = null;
 
-    private static final NodesSpecifier DEFAULT_NOT_INGRESS_NODE_REGEX = NodesSpecifier.NONE;
+    private static final NodesSpecifier DEFAULT_NOT_INGRESS_NODE_REGEX = null;
 
     private static final boolean DEFAULT_SPECIALIZE = true;
 
-    private static final NodesSpecifier DEFAULT_TRANSIT_NODES = NodesSpecifier.NONE;
+    private static final NodesSpecifier DEFAULT_TRANSIT_NODES = null;
 
     private static final boolean DEFAULT_USE_COMPRESSION = false;
 

--- a/projects/question/src/main/java/org/batfish/question/specifiers/SpecifiersReachabilityQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/specifiers/SpecifiersReachabilityQuestion.java
@@ -7,7 +7,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;
 import java.util.SortedSet;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.ForwardingAction;
 import org.batfish.datamodel.HeaderSpace;
@@ -23,7 +22,6 @@ import org.batfish.specifier.IpSpaceSpecifierFactory;
 import org.batfish.specifier.LocationSpecifier;
 import org.batfish.specifier.LocationSpecifierFactory;
 import org.batfish.specifier.NameRegexNodeSpecifierFactory;
-import org.batfish.specifier.NoNodesNodeSpecifier;
 import org.batfish.specifier.NodeNameRegexConnectedHostsIpSpaceSpecifierFactory;
 import org.batfish.specifier.NodeSpecifier;
 import org.batfish.specifier.NodeSpecifierFactory;
@@ -81,7 +79,7 @@ public final class SpecifiersReachabilityQuestion extends Question {
       "requiredTransitNodesNodeSpecifierInput";
 
   private static NodeSpecifier getNodeSpecifier(
-      @Nullable String factoryName, @Nullable String input, @Nonnull NodeSpecifier def) {
+      @Nullable String factoryName, @Nullable String input, @Nullable NodeSpecifier def) {
     if (factoryName == null && input == null) {
       return def;
     }
@@ -181,9 +179,7 @@ public final class SpecifiersReachabilityQuestion extends Question {
 
   NodeSpecifier getForbiddenTransitNodesSpecifier() {
     return getNodeSpecifier(
-        _forbiddenTransitNodesNodeSpecifierFactory,
-        _forbiddenTransitNodesNodeSpecifierInput,
-        NoNodesNodeSpecifier.INSTANCE);
+        _forbiddenTransitNodesNodeSpecifierFactory, _forbiddenTransitNodesNodeSpecifierInput, null);
   }
 
   @VisibleForTesting
@@ -215,9 +211,7 @@ public final class SpecifiersReachabilityQuestion extends Question {
 
   NodeSpecifier getRequiredTransitNodesSpecifier() {
     return getNodeSpecifier(
-        _requiredTransitNodesNodeSpecifierFactory,
-        _requiredTransitNodesNodeSpecifierInput,
-        NoNodesNodeSpecifier.INSTANCE);
+        _requiredTransitNodesNodeSpecifierFactory, _requiredTransitNodesNodeSpecifierInput, null);
   }
 
   IpSpaceSpecifier getSourceIpSpaceSpecifier() {

--- a/projects/question/src/main/java/org/batfish/question/specifiers/SpecifiersReachabilityQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/specifiers/SpecifiersReachabilityQuestion.java
@@ -78,7 +78,7 @@ public final class SpecifiersReachabilityQuestion extends Question {
   private static final String PROP_REQUIRED_TRANSIT_NODES_SPECIFIER_INPUT =
       "requiredTransitNodesNodeSpecifierInput";
 
-  private static NodeSpecifier getNodeSpecifier(
+  private static @Nullable NodeSpecifier getNodeSpecifier(
       @Nullable String factoryName, @Nullable String input, @Nullable NodeSpecifier def) {
     if (factoryName == null && input == null) {
       return def;

--- a/projects/question/src/test/java/org/batfish/question/specifiers/SpecifiersReachabilityQuestionTest.java
+++ b/projects/question/src/test/java/org/batfish/question/specifiers/SpecifiersReachabilityQuestionTest.java
@@ -2,6 +2,7 @@ package org.batfish.question.specifiers;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 
 import com.google.common.collect.ImmutableSortedSet;
 import java.util.regex.Pattern;
@@ -21,7 +22,6 @@ import org.batfish.specifier.ConstantWildcardSetIpSpaceSpecifierFactory;
 import org.batfish.specifier.InferFromLocationIpSpaceSpecifier;
 import org.batfish.specifier.NameRegexNodeSpecifier;
 import org.batfish.specifier.NameRegexNodeSpecifierFactory;
-import org.batfish.specifier.NoNodesNodeSpecifier;
 import org.batfish.specifier.NodeNameRegexConnectedHostsIpSpaceSpecifier;
 import org.batfish.specifier.NodeNameRegexInterfaceLinkLocationSpecifier;
 import org.junit.Rule;
@@ -176,9 +176,8 @@ public class SpecifiersReachabilityQuestionTest {
   @Test
   public void getTransitNodes_bothNull() {
     SpecifiersReachabilityQuestion question = new SpecifiersReachabilityQuestion();
-    assertThat(
-        question.getForbiddenTransitNodesSpecifier(), equalTo(NoNodesNodeSpecifier.INSTANCE));
-    assertThat(question.getRequiredTransitNodesSpecifier(), equalTo(NoNodesNodeSpecifier.INSTANCE));
+    assertThat(question.getForbiddenTransitNodesSpecifier(), nullValue());
+    assertThat(question.getRequiredTransitNodesSpecifier(), nullValue());
   }
 
   @Test


### PR DESCRIPTION
…mpty.

This can easily happen when using specifiers, and leads to zero results
from reachability. Can be quite confusing, so best to detect and report
an error.