### PR TITLE
Not throwing exception on duplicate question template instance names

### DIFF
--- a/projects/coordinator/src/main/java/org/batfish/coordinator/Main.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/Main.java
@@ -108,8 +108,8 @@ public class Main {
         String key = name.toLowerCase();
         if (templates.containsKey(key) && _logger != null) {
           _logger.warnf(
-              "Found duplicate template having instance name %s, only %s will be loaded",
-              name, file);
+              "Found duplicate template having instance name %s, only the last one in the list of templatedirs will be loaded",
+              name);
         }
 
         templates.put(key, questionText);

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/Main.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/Main.java
@@ -105,17 +105,17 @@ public class Main {
         Question.InstanceData instanceData =
             BatfishObjectMapper.mapper().readValue(instanceDataStr, Question.InstanceData.class);
         String name = instanceData.getInstanceName();
-
-        if (templates.containsKey(name.toLowerCase()) && _logger != null) {
+        String key = name.toLowerCase();
+        if (templates.containsKey(key) && _logger != null) {
           _logger.warnf(
-              "Found duplicate template having instance name %s, only one of them will be loaded",
-              name);
+              "Found duplicate template having instance name %s, only %s will be loaded",
+              name, file);
         }
 
-        templates.put(name.toLowerCase(), questionText);
+        templates.put(key, questionText);
         return name;
       } else {
-        throw new BatfishException("Question in file: '" + file + "' has no instance name");
+        throw new BatfishException(String.format("Question in file:%s has no instance name", file));
       }
     } catch (JSONException | IOException e) {
       throw new BatfishException("Failed to process question", e);

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/Main.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/Main.java
@@ -3,6 +3,7 @@ package org.batfish.coordinator;
 import static com.google.common.base.Preconditions.checkState;
 import static java.nio.file.FileVisitOption.FOLLOW_LINKS;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.uber.jaeger.Configuration;
@@ -93,7 +94,8 @@ public class Main {
     return questionTemplates;
   }
 
-  private static String readQuestionTemplate(Path file, Map<String, String> templates) {
+  @VisibleForTesting
+  static String readQuestionTemplate(Path file, Map<String, String> templates) {
     String questionText = CommonUtil.readFile(file);
     try {
       JSONObject questionObj = new JSONObject(questionText);
@@ -104,8 +106,10 @@ public class Main {
             BatfishObjectMapper.mapper().readValue(instanceDataStr, Question.InstanceData.class);
         String name = instanceData.getInstanceName();
 
-        if (templates.containsKey(name)) {
-          throw new BatfishException("Duplicate template name " + name);
+        if (templates.containsKey(name.toLowerCase()) && _logger != null) {
+          _logger.warnf(
+              "Found duplicate template having instance name %s, only one of them will be loaded",
+              name);
         }
 
         templates.put(name.toLowerCase(), questionText);

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/MainTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/MainTest.java
@@ -22,7 +22,6 @@ import org.junit.runners.JUnit4;
 public class MainTest {
 
   private static final String DUPLICATE_TEMPLATE_NAME = "duplicate_template";
-  private static final String DUPLICATE_TEMPLATE_NAME_CAPS = "DUPLICATE_TEMPLATE";
   private static final String NEW_TEMPLATE_NAME = "new_template";
 
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
@@ -62,7 +61,7 @@ public class MainTest {
     testQuestion.put(
         "instance",
         new JSONObject()
-            .put("instanceName", DUPLICATE_TEMPLATE_NAME_CAPS)
+            .put("instanceName", DUPLICATE_TEMPLATE_NAME.toUpperCase())
             .put("description", "test question description"));
     Path questionJsonPath = _folder.newFile("testquestion.json").toPath();
     CommonUtil.writeFile(questionJsonPath, testQuestion.toString());

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/MainTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/MainTest.java
@@ -1,0 +1,51 @@
+package org.batfish.coordinator;
+
+import static org.batfish.coordinator.Main.readQuestionTemplate;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.hasSize;
+
+import com.google.common.collect.Maps;
+import java.nio.file.Path;
+import java.util.Map;
+import org.batfish.common.util.CommonUtil;
+import org.codehaus.jettison.json.JSONObject;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests of {@link Main}. */
+@RunWith(JUnit4.class)
+public class MainTest {
+
+  private static final String DUPLICATE_TEMPLATE_NAME = "duplicate_template";
+
+  @Rule public TemporaryFolder _folder = new TemporaryFolder();
+
+  @Test
+  public void testDuplicateNameReadQuestionTemplates() throws Exception {
+    Map<String, String> questionTemplates = Maps.newHashMap();
+    questionTemplates.put(DUPLICATE_TEMPLATE_NAME, "template_body");
+
+    JSONObject testQuestion = new JSONObject();
+    testQuestion.put(
+        "instance",
+        new JSONObject()
+            .put("instanceName", DUPLICATE_TEMPLATE_NAME)
+            .put("description", "test question description"));
+    Path questionJsonPath = _folder.newFile("testquestion.json").toPath();
+    CommonUtil.writeFile(questionJsonPath, testQuestion.toString());
+
+    readQuestionTemplate(questionJsonPath, questionTemplates);
+
+    assertThat(questionTemplates.keySet(), hasSize(1));
+    assertThat(questionTemplates, hasKey(DUPLICATE_TEMPLATE_NAME));
+    assertThat(
+        questionTemplates.get(DUPLICATE_TEMPLATE_NAME),
+        equalTo(
+            "{\"instance\":{\"instanceName\":\"duplicate_template\",\"description\":\"test question description\"}}"));
+  }
+}


### PR DESCRIPTION
- last template in the list of `templatedirs` will be retained in the map of question templates