### PR TITLE
Delete misleading EIGRP redflag

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -2098,13 +2098,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
         builder.setDelay(iface.getDelay());
       }
       newIface.setEigrp(builder.build());
-    } else {
-      if (iface.getDelay() != null) {
-        _w.redFlag(
-            "Interface: '"
-                + iface.getName()
-                + "' contains EIGRP settings, but there is no EIGRP process");
-      }
     }
 
     boolean level1 = false;

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -60935,8 +60935,7 @@
         },
         "cisco_interface" : {
           "Red flags" : {
-            "1" : "MISCELLANEOUS: Interface: 'Ethernet0' contains OSPF settings, but there is no OSPF process",
-            "2" : "MISCELLANEOUS: Interface: 'Ethernet0' contains EIGRP settings, but there is no EIGRP process"
+            "1" : "MISCELLANEOUS: Interface: 'Ethernet0' contains OSPF settings, but there is no OSPF process"
           }
         },
         "cisco_nxos_bgp" : {


### PR DESCRIPTION
The redflag was generating false positives.

After some digging around looks like it's perfectly valid to have delay defined even if its not used, L3 protocols can choose to use it, but don't have to ([docs](https://www.cisco.com/c/en/us/td/docs/switches/datacenter/sw/5_x/nx-os/interfaces/configuration/guide/if_cli/if_basic.html#74566))