### PR TITLE
Warnings remove

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
@@ -57,11 +57,9 @@ public class BfConsts {
   public static final String ARG_IGNORE_FILES_WITH_STRINGS = "ignorefileswithstrings";
   public static final String ARG_LOG_LEVEL = "loglevel";
   public static final String ARG_OUTPUT_ENV = "outputenv";
-  public static final String ARG_PEDANTIC_AS_ERROR = "pedanticerror";
   public static final String ARG_PEDANTIC_SUPPRESS = "pedanticsuppress";
   public static final String ARG_PRETTY_PRINT_ANSWER = "ppa";
   public static final String ARG_QUESTION_NAME = "questionname";
-  public static final String ARG_RED_FLAG_AS_ERROR = "redflagerror";
   public static final String ARG_RED_FLAG_SUPPRESS = "redflagsuppress";
   public static final String ARG_SSL_DISABLE = "ssldisable";
   public static final String ARG_SSL_KEYSTORE_FILE = "sslkeystorefile";
@@ -74,7 +72,6 @@ public class BfConsts {
   public static final String ARG_SYNTHESIZE_TOPOLOGY = "synthesizetopology";
   public static final String ARG_TASK_PLUGIN = "taskplugin";
   public static final String ARG_TESTRIG = "testrig";
-  public static final String ARG_UNIMPLEMENTED_AS_ERROR = "unimplementederror";
   public static final String ARG_UNIMPLEMENTED_SUPPRESS = "unimplementedsuppress";
   public static final String ARG_UNRECOGNIZED_AS_RED_FLAG = "urf";
   public static final String ARG_VERBOSE_PARSE = "verboseparse";

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/Warnings.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/Warnings.java
@@ -226,7 +226,6 @@ public class Warnings implements Serializable {
         sb.append(parseTreePrefix + parseTreeLine + "\n");
       }
     }
-    String warning = sb.toString();
     _unimplementedWarnings.add(new Warning(sb.toString(), "UNIMPLEMENTED"));
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/Warnings.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/Warnings.java
@@ -163,40 +163,12 @@ public class Warnings implements Serializable {
     _unimplementedRecord = unimplementedRecord;
   }
 
-  public boolean getPedanticAsError() {
-    return _pedanticAsError;
-  }
-
-  public boolean getPedanticRecord() {
-    return _pedanticRecord;
-  }
-
   public List<Warning> getPedanticWarnings() {
     return _pedanticWarnings;
   }
 
-  public boolean getPrintParseTree() {
-    return _printParseTree;
-  }
-
-  public boolean getRedFlagAsError() {
-    return _redFlagAsError;
-  }
-
-  public boolean getRedFlagRecord() {
-    return _redFlagRecord;
-  }
-
   public List<Warning> getRedFlagWarnings() {
     return _redFlagWarnings;
-  }
-
-  public boolean getUnimplementedAsError() {
-    return _unimplementedAsError;
-  }
-
-  public boolean getUnimplementedRecord() {
-    return _unimplementedRecord;
   }
 
   public List<Warning> getUnimplementedWarnings() {
@@ -232,34 +204,6 @@ public class Warnings implements Serializable {
     } else if (_redFlagRecord) {
       _redFlagWarnings.add(new Warning(msg, tag));
     }
-  }
-
-  public void setPedanticAsError(boolean pedanticAsError) {
-    _pedanticAsError = pedanticAsError;
-  }
-
-  public void setPedanticRecord(boolean pedanticRecord) {
-    _pedanticRecord = pedanticRecord;
-  }
-
-  public void setPrintParseTree(boolean printParseTree) {
-    _printParseTree = printParseTree;
-  }
-
-  public void setRedFlagAsError(boolean redFlagAsError) {
-    _redFlagAsError = redFlagAsError;
-  }
-
-  public void setRedFlagRecord(boolean redFlagRecord) {
-    _redFlagRecord = redFlagRecord;
-  }
-
-  public void setUnimplementedAsError(boolean unimplementedAsError) {
-    _unimplementedAsError = unimplementedAsError;
-  }
-
-  public void setUnimplementedRecord(boolean unimplementedRecord) {
-    _unimplementedRecord = unimplementedRecord;
   }
 
   public void todo(

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/Warnings.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/Warnings.java
@@ -119,21 +119,15 @@ public class Warnings implements Serializable {
 
   private static final String UNIMPLEMENTED_VAR = "Unimplemented features";
 
-  private transient boolean _pedanticAsError;
-
   private transient boolean _pedanticRecord;
 
   protected final List<Warning> _pedanticWarnings;
 
   private transient boolean _printParseTree;
 
-  private transient boolean _redFlagAsError;
-
   private transient boolean _redFlagRecord;
 
   protected final List<Warning> _redFlagWarnings;
-
-  private transient boolean _unimplementedAsError;
 
   private transient boolean _unimplementedRecord;
 
@@ -146,20 +140,14 @@ public class Warnings implements Serializable {
   }
 
   public Warnings(
-      boolean pedanticAsError,
       boolean pedanticRecord,
-      boolean redFlagAsError,
       boolean redFlagRecord,
-      boolean unimplementedAsError,
       boolean unimplementedRecord,
       boolean printParseTree) {
     this();
-    _pedanticAsError = pedanticAsError;
     _pedanticRecord = pedanticRecord;
     _printParseTree = printParseTree;
-    _redFlagAsError = redFlagAsError;
     _redFlagRecord = redFlagRecord;
-    _unimplementedAsError = unimplementedAsError;
     _unimplementedRecord = unimplementedRecord;
   }
 
@@ -183,15 +171,14 @@ public class Warnings implements Serializable {
   }
 
   public void pedantic(String msg) {
+    if (!_pedanticRecord) {
+      return;
+    }
     pedantic(msg, MISCELLANEOUS);
   }
 
   public void pedantic(String msg, String tag) {
-    if (_pedanticAsError) {
-      throw new PedanticBatfishException(msg);
-    } else if (_pedanticRecord) {
-      _pedanticWarnings.add(new Warning(msg, tag));
-    }
+    _pedanticWarnings.add(new Warning(msg, tag));
   }
 
   public void redFlag(String msg) {
@@ -199,16 +186,15 @@ public class Warnings implements Serializable {
   }
 
   public void redFlag(String msg, String tag) {
-    if (_redFlagAsError) {
-      throw new RedFlagBatfishException(msg);
-    } else if (_redFlagRecord) {
-      _redFlagWarnings.add(new Warning(msg, tag));
+    if (!_redFlagRecord) {
+      return;
     }
+    _redFlagWarnings.add(new Warning(msg, tag));
   }
 
   public void todo(
       ParserRuleContext ctx, String feature, BatfishCombinedParser<?, ?> parser, String text) {
-    if (!_unimplementedRecord && !_unimplementedAsError) {
+    if (!_unimplementedRecord) {
       return;
     }
     String prefix = "WARNING: UNIMPLEMENTED: " + (_unimplementedWarnings.size() + 1) + ": ";
@@ -241,11 +227,7 @@ public class Warnings implements Serializable {
       }
     }
     String warning = sb.toString();
-    if (_unimplementedAsError) {
-      throw new UnimplementedBatfishException(warning);
-    } else {
-      _unimplementedWarnings.add(new Warning(sb.toString(), "UNIMPLEMENTED"));
-    }
+    _unimplementedWarnings.add(new Warning(sb.toString(), "UNIMPLEMENTED"));
   }
 
   public void unimplemented(String msg) {
@@ -253,10 +235,9 @@ public class Warnings implements Serializable {
   }
 
   public void unimplemented(String msg, String tag) {
-    if (_unimplementedAsError) {
-      throw new UnimplementedBatfishException(msg);
-    } else if (_unimplementedRecord) {
-      _unimplementedWarnings.add(new Warning(msg, tag));
+    if (!_unimplementedRecord) {
+      return;
     }
+    _unimplementedWarnings.add(new Warning(msg, tag));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/RoutingPolicyTests.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/RoutingPolicyTests.java
@@ -37,8 +37,7 @@ public class RoutingPolicyTests {
     NetworkFactory nf = new NetworkFactory();
     _c = nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS).build();
     _rpb = nf.routingPolicyBuilder().setOwner(_c);
-    _w = new Warnings();
-    _w.setRedFlagRecord(true);
+    _w = new Warnings(false, true, false, true, false, true, false);
   }
 
   /** Policy with actual circular reference as statement */

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/RoutingPolicyTests.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/RoutingPolicyTests.java
@@ -37,7 +37,7 @@ public class RoutingPolicyTests {
     NetworkFactory nf = new NetworkFactory();
     _c = nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS).build();
     _rpb = nf.routingPolicyBuilder().setOwner(_c);
-    _w = new Warnings(false, true, false, true, false, true, false);
+    _w = new Warnings(true, true, true, false);
   }
 
   /** Policy with actual circular reference as statement */

--- a/projects/batfish/src/main/java/org/batfish/config/Settings.java
+++ b/projects/batfish/src/main/java/org/batfish/config/Settings.java
@@ -11,9 +11,6 @@ import org.batfish.common.BaseSettings;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.BfConsts;
 import org.batfish.common.CoordConsts;
-import org.batfish.common.PedanticBatfishException;
-import org.batfish.common.RedFlagBatfishException;
-import org.batfish.common.UnimplementedBatfishException;
 import org.batfish.common.Version;
 import org.batfish.common.util.CommonUtil;
 import org.batfish.datamodel.Ip;
@@ -793,10 +790,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     return _config.getString(BfConsts.ARG_OUTPUT_ENV);
   }
 
-  public boolean getPedanticAsError() {
-    return _config.getBoolean(BfConsts.ARG_PEDANTIC_AS_ERROR);
-  }
-
   public boolean getPedanticRecord() {
     return !_config.getBoolean(BfConsts.ARG_PEDANTIC_SUPPRESS);
   }
@@ -826,10 +819,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
   @Nullable
   public Path getQuestionPath() {
     return nullablePath(_config.getString(QUESTION_PATH));
-  }
-
-  public boolean getRedFlagAsError() {
-    return _config.getBoolean(BfConsts.ARG_RED_FLAG_AS_ERROR);
   }
 
   public boolean getRedFlagRecord() {
@@ -956,10 +945,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     return _config.getBoolean(ARG_TRACING_ENABLE);
   }
 
-  public boolean getUnimplementedAsError() {
-    return _config.getBoolean(BfConsts.ARG_UNIMPLEMENTED_AS_ERROR);
-  }
-
   public boolean getUnimplementedRecord() {
     return !_config.getBoolean(BfConsts.ARG_UNIMPLEMENTED_SUPPRESS);
   }
@@ -1046,7 +1031,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     setDefaultProperty(ARG_CHECK_BGP_REACHABILITY, true);
     setDefaultProperty(ARG_NO_SHUFFLE, false);
     setDefaultProperty(BfConsts.ARG_OUTPUT_ENV, null);
-    setDefaultProperty(BfConsts.ARG_PEDANTIC_AS_ERROR, false);
     setDefaultProperty(BfConsts.ARG_PEDANTIC_SUPPRESS, false);
     setDefaultProperty(BfConsts.ARG_PRETTY_PRINT_ANSWER, false);
     setDefaultProperty(ARG_PARENT_PID, -1);
@@ -1054,7 +1038,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     setDefaultProperty(ARG_PRINT_PARSE_TREE_LINE_NUMS, false);
     setDefaultProperty(ARG_PRINT_SYMMETRIC_EDGES, false);
     setDefaultProperty(BfConsts.ARG_QUESTION_NAME, null);
-    setDefaultProperty(BfConsts.ARG_RED_FLAG_AS_ERROR, false);
     setDefaultProperty(BfConsts.ARG_RED_FLAG_SUPPRESS, false);
     setDefaultProperty(ARG_RUN_MODE, RunMode.WORKER.toString());
     setDefaultProperty(ARG_SEQUENTIAL, false);
@@ -1079,7 +1062,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     setDefaultProperty(ARG_TRACING_AGENT_PORT, 5775);
     setDefaultProperty(ARG_TRACING_ENABLE, false);
     setDefaultProperty(BfConsts.ARG_UNRECOGNIZED_AS_RED_FLAG, true);
-    setDefaultProperty(BfConsts.ARG_UNIMPLEMENTED_AS_ERROR, false);
     setDefaultProperty(BfConsts.ARG_UNIMPLEMENTED_SUPPRESS, true);
     setDefaultProperty(BfConsts.ARG_VERBOSE_PARSE, false);
     setDefaultProperty(ARG_VERSION, false);
@@ -1261,13 +1243,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
 
     addOption(ARG_PARENT_PID, "name of parent PID", ARGNAME_NUMBER);
 
-    addBooleanOption(
-        BfConsts.ARG_PEDANTIC_AS_ERROR,
-        "throws "
-            + PedanticBatfishException.class.getSimpleName()
-            + " for likely harmless warnings (e.g. deviation from good configuration style), "
-            + "instead of emitting warning and continuing");
-
     addBooleanOption(BfConsts.ARG_PEDANTIC_SUPPRESS, "suppresses pedantic warnings");
 
     addBooleanOption(BfConsts.ARG_PRETTY_PRINT_ANSWER, "pretty print answer");
@@ -1281,13 +1256,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
         ARG_PRINT_SYMMETRIC_EDGES, "print topology with symmetric edges adjacent in listing");
 
     addOption(BfConsts.ARG_QUESTION_NAME, "name of question", ARGNAME_NAME);
-
-    addBooleanOption(
-        BfConsts.ARG_RED_FLAG_AS_ERROR,
-        "throws "
-            + RedFlagBatfishException.class.getSimpleName()
-            + " on some recoverable errors (e.g. bad config lines), instead of emitting warning "
-            + "and attempting to recover");
 
     addBooleanOption(BfConsts.ARG_RED_FLAG_SUPPRESS, "suppresses red-flag warnings");
 
@@ -1343,13 +1311,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     addOption(ARG_TRACING_AGENT_PORT, "jaeger agent port", "jaeger_agent_port");
 
     addBooleanOption(ARG_TRACING_ENABLE, "enable tracing");
-
-    addBooleanOption(
-        BfConsts.ARG_UNIMPLEMENTED_AS_ERROR,
-        "throws "
-            + UnimplementedBatfishException.class.getSimpleName()
-            + " when encountering unimplemented configuration directives, instead of emitting "
-            + "warning and ignoring");
 
     addBooleanOption(
         BfConsts.ARG_UNIMPLEMENTED_SUPPRESS,
@@ -1458,14 +1419,12 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     getIntOptionValue(ARG_MAX_RUNTIME_MS);
     getStringOptionValue(BfConsts.ARG_OUTPUT_ENV);
     getIntOptionValue(ARG_PARENT_PID);
-    getBooleanOptionValue(BfConsts.ARG_PEDANTIC_AS_ERROR);
     getBooleanOptionValue(BfConsts.ARG_PEDANTIC_SUPPRESS);
     getBooleanOptionValue(BfConsts.ARG_PRETTY_PRINT_ANSWER);
     getBooleanOptionValue(ARG_PRINT_PARSE_TREES);
     getBooleanOptionValue(ARG_PRINT_PARSE_TREE_LINE_NUMS);
     getBooleanOptionValue(ARG_PRINT_SYMMETRIC_EDGES);
     getStringOptionValue(BfConsts.ARG_QUESTION_NAME);
-    getBooleanOptionValue(BfConsts.ARG_RED_FLAG_AS_ERROR);
     getBooleanOptionValue(BfConsts.ARG_RED_FLAG_SUPPRESS);
     getBooleanOptionValue(BfConsts.COMMAND_REPORT);
     getStringOptionValue(ARG_RUN_MODE);
@@ -1495,7 +1454,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     getStringOptionValue(ARG_TRACING_AGENT_HOST);
     getIntegerOptionValue(ARG_TRACING_AGENT_PORT);
     getBooleanOptionValue(ARG_TRACING_ENABLE);
-    getBooleanOptionValue(BfConsts.ARG_UNIMPLEMENTED_AS_ERROR);
     getBooleanOptionValue(BfConsts.ARG_UNIMPLEMENTED_SUPPRESS);
     getBooleanOptionValue(BfConsts.ARG_UNRECOGNIZED_AS_RED_FLAG);
     getBooleanOptionValue(BfConsts.COMMAND_VALIDATE_ENVIRONMENT);

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -923,11 +923,8 @@ public class Batfish extends PluginConsumer implements IBatfish {
 
   public static Warnings buildWarnings(Settings settings) {
     return new Warnings(
-        settings.getPedanticAsError(),
         settings.getPedanticRecord() && settings.getLogger().isActive(BatfishLogger.LEVEL_PEDANTIC),
-        settings.getRedFlagAsError(),
         settings.getRedFlagRecord() && settings.getLogger().isActive(BatfishLogger.LEVEL_REDFLAG),
-        settings.getUnimplementedAsError(),
         settings.getUnimplementedRecord()
             && settings.getLogger().isActive(BatfishLogger.LEVEL_UNIMPLEMENTED),
         settings.getPrintParseTree());

--- a/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoConversionsTest.java
@@ -38,8 +38,7 @@ public class CiscoConversionsTest {
 
   @Before
   public void before() {
-    _warnings = new Warnings();
-    _warnings.setRedFlagRecord(true);
+    _warnings = new Warnings(false, true, false, true, false, true, false);
     _nf = new NetworkFactory();
   }
 

--- a/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoConversionsTest.java
@@ -38,7 +38,7 @@ public class CiscoConversionsTest {
 
   @Before
   public void before() {
-    _warnings = new Warnings(false, true, false, true, false, true, false);
+    _warnings = new Warnings(true, true, true, false);
     _nf = new NetworkFactory();
   }
 


### PR DESCRIPTION
* delete a bunch of unused code from Warnings
* remove the ability to make Warnings throw when logging. We've changed philosophy fundamentally, and now believe that logging and making progress is a significantly better strategy.