### PR TITLE
Deprecate upload testrig and add upload snapshot API

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
@@ -155,6 +155,7 @@ public class BfConsts {
   public static final String RELPATH_ORIGINAL_DIR = "original";
   public static final String RELPATH_PARSE_ANSWER_PATH = "parse_answer";
   public static final String RELPATH_REFERENCE_LIBRARY_PATH = "address_library.json";
+  public static final String RELPATH_SNAPSHOT_ZIP_FILE = "snapshot.zip";
   public static final String RELPATH_TESTRIG_POJO_TOPOLOGY_PATH = "testrig_pojo_topology";
   public static final String RELPATH_TESTRIG_ZIP_FILE = "testrig.zip";
   public static final String RELPATH_PRECOMPUTED_ROUTES = "precomputedroutes";

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/CoordConsts.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/CoordConsts.java
@@ -70,6 +70,7 @@ public class CoordConsts {
   public static final String SVC_KEY_ANSWERS = "answers";
   public static final String SVC_KEY_API_KEY = "apikey";
   public static final String SVC_KEY_ASSERTION = "assertion";
+  public static final String SVC_KEY_AUTO_ANALYZE = "autoanalyze";
   public static final String SVC_KEY_AUTO_ANALYZE_TESTRIG = "autoanalyzetestrig";
   public static final String SVC_KEY_BASE_ENV_NAME = "baseenvname";
   public static final String SVC_KEY_COMPLETION_TYPE = "completiontype";
@@ -171,5 +172,6 @@ public class CoordConsts {
   public static final String SVC_RSC_SYNC_TESTRIGS_UPDATE_SETTINGS = "synctestrigsupdatesettings";
   public static final String SVC_RSC_UPLOAD_ENV = "uploadenvironment";
   public static final String SVC_RSC_UPLOAD_QUESTION = "uploadquestion";
+  public static final String SVC_RSC_UPLOAD_SNAPSHOT = "uploadsnapshot";
   public static final String SVC_RSC_UPLOAD_TESTRIG = "uploadtestrig";
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/ICoordinator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/ICoordinator.java
@@ -6,15 +6,15 @@ import org.batfish.common.BatfishLogger;
 
 public interface ICoordinator {
 
-  Path getdirContainer(String containerName);
+  Path getdirNetwork(String networkName);
 
-  Path getdirTestrigs(String containerName);
+  Path getdirSnapshots(String networkName);
 
   BatfishLogger getLogger();
 
-  Set<String> getContainerNames();
+  Set<String> getNetworkNames();
 
-  void initTestrig(String containerName, String testrigName, Path srcDir, boolean autoAnalyze);
+  void initSnapshot(String networkName, String snapshotName, Path srcDir, boolean autoAnalyze);
 
   void registerTestrigSyncer(String name, SyncTestrigsPlugin plugin);
 }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -496,7 +496,7 @@ public class WorkMgr extends AbstractCoordinator {
       Map<String, String> questionsToAdd,
       List<String> questionsToDelete,
       @Nullable Boolean suggested) {
-    Path containerDir = getdirContainer(containerName);
+    Path containerDir = getdirNetwork(containerName);
     Path aDir = containerDir.resolve(BfConsts.RELPATH_ANALYSES_DIR).resolve(aName);
 
     this.configureAnalysisValidityCheck(
@@ -770,7 +770,7 @@ public class WorkMgr extends AbstractCoordinator {
 
   /** Return a {@link Container container} contains all testrigs directories inside it. */
   public Container getContainer(String containerName) {
-    return getContainer(getdirContainer(containerName));
+    return getContainer(getdirNetwork(containerName));
   }
 
   /** Return a {@link Container container} contains all testrigs directories inside it */
@@ -794,8 +794,8 @@ public class WorkMgr extends AbstractCoordinator {
   }
 
   @Override
-  public Path getdirContainer(String containerName) {
-    return getdirContainer(containerName, true);
+  public Path getdirNetwork(String networkName) {
+    return getdirContainer(networkName, true);
   }
 
   @Override
@@ -804,7 +804,7 @@ public class WorkMgr extends AbstractCoordinator {
   }
 
   @Override
-  public Set<String> getContainerNames() {
+  public Set<String> getNetworkNames() {
     Path containersDir = Main.getSettings().getContainersLocation();
     if (!Files.exists(containersDir)) {
       containersDir.toFile().mkdirs();
@@ -827,7 +827,7 @@ public class WorkMgr extends AbstractCoordinator {
   }
 
   private Path getdirContainerAnalysis(String containerName, String analysisName) {
-    Path containerDir = getdirContainer(containerName);
+    Path containerDir = getdirNetwork(containerName);
     Path aDir = containerDir.resolve(Paths.get(BfConsts.RELPATH_ANALYSES_DIR, analysisName));
     if (!Files.exists(aDir)) {
       throw new BatfishException(
@@ -837,7 +837,7 @@ public class WorkMgr extends AbstractCoordinator {
   }
 
   private Path getdirContainerQuestion(String containerName, String qName) {
-    Path containerDir = getdirContainer(containerName);
+    Path containerDir = getdirNetwork(containerName);
     Path qDir = containerDir.resolve(Paths.get(BfConsts.RELPATH_QUESTIONS_DIR, qName));
     if (!Files.exists(qDir)) {
       throw new BatfishException("Question '" + qName + "' does not exist");
@@ -855,16 +855,16 @@ public class WorkMgr extends AbstractCoordinator {
   }
 
   public Path getdirTestrig(String containerName, String testrigName) {
-    Path testrigDir = getdirTestrigs(containerName).resolve(Paths.get(testrigName));
-    if (!Files.exists(testrigDir)) {
+    Path snapshotDir = getdirSnapshots(containerName).resolve(Paths.get(testrigName));
+    if (!Files.exists(snapshotDir)) {
       throw new BatfishException("Testrig '" + testrigName + "' does not exist");
     }
-    return testrigDir;
+    return snapshotDir;
   }
 
   @Override
-  public Path getdirTestrigs(String containerName) {
-    return getdirContainer(containerName).resolve(Paths.get(BfConsts.RELPATH_TESTRIGS_DIR));
+  public Path getdirSnapshots(String networkName) {
+    return getdirNetwork(networkName).resolve(Paths.get(BfConsts.RELPATH_TESTRIGS_DIR));
   }
 
   /**
@@ -896,7 +896,7 @@ public class WorkMgr extends AbstractCoordinator {
 
   /** Gets the path of the node roles file */
   public Path getNodeRolesPath(String container) {
-    return getdirContainer(container).resolve(BfConsts.RELPATH_NODE_ROLES_PATH);
+    return getdirNetwork(container).resolve(BfConsts.RELPATH_NODE_ROLES_PATH);
   }
 
   /**
@@ -978,7 +978,7 @@ public class WorkMgr extends AbstractCoordinator {
 
   /** Gets the path of the reference library file */
   public Path getReferenceLibraryPath(String container) {
-    return getdirContainer(container).resolve(BfConsts.RELPATH_REFERENCE_LIBRARY_PATH);
+    return getdirNetwork(container).resolve(BfConsts.RELPATH_REFERENCE_LIBRARY_PATH);
   }
 
   public JSONObject getStatusJson() throws JSONException {
@@ -1104,8 +1104,8 @@ public class WorkMgr extends AbstractCoordinator {
   }
 
   @Override
-  public void initTestrig(
-      String containerName, String testrigName, Path srcDir, boolean autoAnalyze) {
+  public void initSnapshot(
+      String networkName, String snapshotName, Path srcDir, boolean autoAnalyze) {
     /*
      * Sanity check what we got:
      *    There should be just one top-level folder.
@@ -1119,8 +1119,8 @@ public class WorkMgr extends AbstractCoordinator {
     Path srcSubdir = srcDirEntries.iterator().next();
     SortedSet<Path> subFileList = CommonUtil.getEntries(srcSubdir);
 
-    Path containerDir = getdirContainer(containerName);
-    Path testrigDir = containerDir.resolve(Paths.get(BfConsts.RELPATH_TESTRIGS_DIR, testrigName));
+    Path containerDir = getdirNetwork(networkName);
+    Path testrigDir = containerDir.resolve(Paths.get(BfConsts.RELPATH_TESTRIGS_DIR, snapshotName));
 
     if (!testrigDir.toFile().mkdirs()) {
       throw new BatfishException("Failed to create directory: '" + testrigDir + "'");
@@ -1205,10 +1205,10 @@ public class WorkMgr extends AbstractCoordinator {
     }
     _logger.infof(
         "Environment data for testrig:%s; bgpTables:%s, routingTables:%s, nodeRoles:%s referenceBooks:%s\n",
-        testrigName, bgpTables, routingTables, roleData, referenceLibraryData);
+        snapshotName, bgpTables, routingTables, roleData, referenceLibraryData);
 
     if (autoAnalyze) {
-      for (WorkItem workItem : getAutoWorkQueue(containerName, testrigName)) {
+      for (WorkItem workItem : getAutoWorkQueue(networkName, snapshotName)) {
         boolean queued = queueWork(workItem);
         if (!queued) {
           _logger.errorf("Unable to queue work while auto processing: %s", workItem);
@@ -1347,7 +1347,7 @@ public class WorkMgr extends AbstractCoordinator {
    * @return {@link Set} of container names
    */
   public SortedSet<String> listAnalyses(String containerName, AnalysisType analysisType) {
-    Path containerDir = getdirContainer(containerName);
+    Path containerDir = getdirNetwork(containerName);
     Path analysesDir = containerDir.resolve(BfConsts.RELPATH_ANALYSES_DIR);
     if (!Files.exists(analysesDir)) {
       return ImmutableSortedSet.of();
@@ -1425,7 +1425,7 @@ public class WorkMgr extends AbstractCoordinator {
   }
 
   public SortedSet<String> listQuestions(String containerName, boolean verbose) {
-    Path containerDir = getdirContainer(containerName);
+    Path containerDir = getdirNetwork(containerName);
     Path questionsDir = containerDir.resolve(BfConsts.RELPATH_QUESTIONS_DIR);
     if (!Files.exists(questionsDir)) {
       return new TreeSet<>();
@@ -1442,7 +1442,7 @@ public class WorkMgr extends AbstractCoordinator {
   }
 
   public List<String> listTestrigs(String containerName) {
-    Path containerDir = getdirContainer(containerName);
+    Path containerDir = getdirNetwork(containerName);
     Path testrigsDir = containerDir.resolve(BfConsts.RELPATH_TESTRIGS_DIR);
     if (!Files.exists(testrigsDir)) {
       return new ArrayList<>();
@@ -1650,7 +1650,7 @@ public class WorkMgr extends AbstractCoordinator {
           String.format("Invalid question %s/%s: %s", containerName, qName, e.getMessage()), e);
     }
 
-    Path containerDir = getdirContainer(containerName);
+    Path containerDir = getdirNetwork(containerName);
     Path qDir = containerDir.resolve(Paths.get(BfConsts.RELPATH_QUESTIONS_DIR, qName));
     if (Files.exists(qDir)) {
       throw new BatfishException(
@@ -1686,7 +1686,7 @@ public class WorkMgr extends AbstractCoordinator {
    */
   public void uploadSnapshot(
       String networkName, String snapshotName, InputStream fileStream, boolean autoAnalyze) {
-    Path networkDir = getdirContainer(networkName);
+    Path networkDir = getdirNetwork(networkName);
 
     // Fail early if the snapshot already exists
     if (Files.exists(networkDir.resolve(Paths.get(BfConsts.RELPATH_TESTRIGS_DIR, snapshotName)))) {
@@ -1707,17 +1707,12 @@ public class WorkMgr extends AbstractCoordinator {
     UnzipUtility.unzip(snapshotZipFile, unzipDir);
 
     try {
-      initTestrig(networkName, snapshotName, unzipDir, autoAnalyze);
+      initSnapshot(networkName, snapshotName, unzipDir, autoAnalyze);
     } catch (Exception e) {
       throw new BatfishException("Error initializing snapshot", e);
     } finally {
       CommonUtil.deleteDirectory(unzipDir);
     }
-  }
-
-  public void uploadTestrig(
-      String containerName, String testrigName, InputStream fileStream, boolean autoAnalyze) {
-    uploadSnapshot(containerName, testrigName, fileStream, autoAnalyze);
   }
 
   /** Returns true if the container {@code containerName} exists, false otherwise. */

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -1681,7 +1681,7 @@ public class WorkMgr extends AbstractCoordinator {
    *
    * @param networkName Name of the network to upload the snapshot to.
    * @param snapshotName Name of the new snapshot.
-   * @param fileStream Filestream of the snapshot zip.
+   * @param fileStream {@link InputStream} of the snapshot zip.
    * @param autoAnalyze Boolean determining if the snapshot analysis should be triggered on upload.
    */
   public void uploadSnapshot(

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
@@ -1972,7 +1972,7 @@ public class WorkMgrService {
    * @param clientVersion The version of the client
    * @param networkName The name of the network under which to upload the new snapshot
    * @param snapshotName The name of the new snapshot to create
-   * @param fileStream The stream from which the new snapshot is read
+   * @param fileStream The {@link InputStream} from which the new snapshot is read
    * @return TODO: document JSON response
    */
   @POST

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
@@ -2051,44 +2051,7 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String testrigName,
       @FormDataParam(CoordConsts.SVC_KEY_ZIPFILE) InputStream fileStream,
       @FormDataParam(CoordConsts.SVC_KEY_AUTO_ANALYZE_TESTRIG) String autoAnalyzeStr) {
-    try {
-      _logger.infof("WMS:uploadTestrig %s %s %s\n", apiKey, containerName, testrigName);
-
-      checkStringParam(apiKey, "API key");
-      checkStringParam(clientVersion, "Client version");
-      checkStringParam(containerName, "Container name");
-      checkStringParam(testrigName, "Testrig name");
-
-      checkApiKeyValidity(apiKey);
-      checkClientVersion(clientVersion);
-      checkNetworkAccessibility(apiKey, containerName);
-
-      boolean autoAnalyze = false;
-      if (!Strings.isNullOrEmpty(autoAnalyzeStr)) {
-        autoAnalyze = Boolean.parseBoolean(autoAnalyzeStr);
-      }
-
-      if (GlobalTracer.get().activeSpan() != null) {
-        GlobalTracer.get()
-            .activeSpan()
-            .setTag("container-name", containerName)
-            .setTag("testrig-name", testrigName);
-      }
-
-      Main.getWorkMgr().uploadSnapshot(containerName, testrigName, fileStream, autoAnalyze);
-      _logger.infof(
-          "Uploaded testrig:%s for container:%s using api-key:%s\n",
-          testrigName, containerName, apiKey);
-      return successResponse(new JSONObject().put("result", "successfully uploaded testrig"));
-    } catch (IllegalArgumentException | AccessControlException e) {
-      _logger.errorf("WMS:uploadTestrig exception: %s\n", e.getMessage());
-      return failureResponse(e.getMessage());
-    } catch (Exception e) {
-      String stackTrace = Throwables.getStackTraceAsString(e);
-      _logger.errorf(
-          "WMS:uploadTestrig exception for apikey:%s in container:%s, testrig:%s; exception:%s",
-          apiKey, containerName, testrigName, stackTrace);
-      return failureResponse(e.getMessage());
-    }
+    return uploadSnapshot(
+        apiKey, clientVersion, containerName, testrigName, fileStream, autoAnalyzeStr);
   }
 }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
@@ -1966,6 +1966,68 @@ public class WorkMgrService {
   }
 
   /**
+   * Uploads a new snapshot under the specified network
+   *
+   * @param apiKey The API key of the client
+   * @param clientVersion The version of the client
+   * @param networkName The name of the network under which to upload the new snapshot
+   * @param snapshotName The name of the new snapshot to create
+   * @param fileStream The stream from which the new snapshot is read
+   * @return TODO: document JSON response
+   */
+  @POST
+  @Path(CoordConsts.SVC_RSC_UPLOAD_SNAPSHOT)
+  @Consumes(MediaType.MULTIPART_FORM_DATA)
+  @Produces(MediaType.APPLICATION_JSON)
+  public JSONArray uploadSnapshot(
+      @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
+      @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
+      @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
+      @FormDataParam(CoordConsts.SVC_KEY_SNAPSHOT_NAME) String snapshotName,
+      @FormDataParam(CoordConsts.SVC_KEY_ZIPFILE) InputStream fileStream,
+      @FormDataParam(CoordConsts.SVC_KEY_AUTO_ANALYZE) String autoAnalyzeStr) {
+    try {
+      _logger.infof("WMS:uploadSnapshot %s %s %s\n", apiKey, networkName, snapshotName);
+
+      checkStringParam(apiKey, "API key");
+      checkStringParam(clientVersion, "Client version");
+      checkStringParam(networkName, "Network name");
+      checkStringParam(snapshotName, "Snapshot name");
+
+      checkApiKeyValidity(apiKey);
+      checkClientVersion(clientVersion);
+      checkNetworkAccessibility(apiKey, networkName);
+
+      boolean autoAnalyze = false;
+      if (!Strings.isNullOrEmpty(autoAnalyzeStr)) {
+        autoAnalyze = Boolean.parseBoolean(autoAnalyzeStr);
+      }
+
+      if (GlobalTracer.get().activeSpan() != null) {
+        GlobalTracer.get()
+            .activeSpan()
+            .setTag("network-name", networkName)
+            .setTag("snapshot-name", snapshotName);
+      }
+
+      Main.getWorkMgr().uploadSnapshot(networkName, snapshotName, fileStream, autoAnalyze);
+      _logger.infof(
+          "Uploaded snapshot:%s for network:%s using api-key:%s\n",
+          snapshotName, networkName, apiKey);
+      return successResponse(new JSONObject().put("result", "successfully uploaded snapshot"));
+    } catch (IllegalArgumentException | AccessControlException e) {
+      _logger.errorf("WMS:uploadSnapshot exception: %s\n", e.getMessage());
+      return failureResponse(e.getMessage());
+    } catch (Exception e) {
+      String stackTrace = Throwables.getStackTraceAsString(e);
+      _logger.errorf(
+          "WMS:uploadSnapshot exception for apikey:%s in network:%s, snapshot:%s; exception:%s",
+          apiKey, networkName, snapshotName, stackTrace);
+      return failureResponse(e.getMessage());
+    }
+  }
+
+  /**
    * Uploads a new testrig under the specified container
    *
    * @param apiKey The API key of the client
@@ -1974,11 +2036,14 @@ public class WorkMgrService {
    * @param testrigName The name of the new testrig to create
    * @param fileStream The stream from which the new testrig is read
    * @return TODO: document JSON response
+   * @deprecated because testrigs were renamed to snapshots. Use {@link #uploadSnapshot(String,
+   *     String, String, String, InputStream, InputStream, String)} instead.
    */
   @POST
   @Path(CoordConsts.SVC_RSC_UPLOAD_TESTRIG)
   @Consumes(MediaType.MULTIPART_FORM_DATA)
   @Produces(MediaType.APPLICATION_JSON)
+  @Deprecated
   public JSONArray uploadTestrig(
       @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
@@ -2037,7 +2037,7 @@ public class WorkMgrService {
    * @param fileStream The stream from which the new testrig is read
    * @return TODO: document JSON response
    * @deprecated because testrigs were renamed to snapshots. Use {@link #uploadSnapshot(String,
-   *     String, String, String, InputStream, InputStream, String)} instead.
+   *     String, String, String, InputStream, String)} instead.
    */
   @POST
   @Path(CoordConsts.SVC_RSC_UPLOAD_TESTRIG)
@@ -2075,7 +2075,7 @@ public class WorkMgrService {
             .setTag("testrig-name", testrigName);
       }
 
-      Main.getWorkMgr().uploadTestrig(containerName, testrigName, fileStream, autoAnalyze);
+      Main.getWorkMgr().uploadSnapshot(containerName, testrigName, fileStream, autoAnalyze);
       _logger.infof(
           "Uploaded testrig:%s for container:%s using api-key:%s\n",
           testrigName, containerName, apiKey);

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/NodeRoleDimensionBeanTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/NodeRoleDimensionBeanTest.java
@@ -44,7 +44,7 @@ public class NodeRoleDimensionBeanTest extends WorkMgrServiceV2TestBase {
             "dimension2", ImmutableSortedSet.of(new NodeRole("role2", "a.*")), null, null);
     NodeRolesData.write(
         new NodeRolesData(null, null, ImmutableSortedSet.of(dimension1, dimension2)),
-        Main.getWorkMgr().getdirContainer(container).resolve(BfConsts.RELPATH_NODE_ROLES_PATH));
+        Main.getWorkMgr().getdirNetwork(container).resolve(BfConsts.RELPATH_NODE_ROLES_PATH));
 
     // we should the expected bean for dimension2
     assertThat(

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/NodeRoleDimensionResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/NodeRoleDimensionResourceTest.java
@@ -60,7 +60,7 @@ public class NodeRoleDimensionResourceTest extends WorkMgrServiceV2TestBase {
                 new NodeRoleDimension("dimension1", ImmutableSortedSet.of(), null, null)));
     NodeRolesData.write(
         data,
-        Main.getWorkMgr().getdirContainer(container).resolve(BfConsts.RELPATH_NODE_ROLES_PATH));
+        Main.getWorkMgr().getdirNetwork(container).resolve(BfConsts.RELPATH_NODE_ROLES_PATH));
 
     Response response = getNodeRoleDimensionTarget(container, "dimension1").delete();
 
@@ -88,7 +88,7 @@ public class NodeRoleDimensionResourceTest extends WorkMgrServiceV2TestBase {
         new NodeRoleDimension("dimension1", ImmutableSortedSet.of(), null, null);
     NodeRolesData.write(
         new NodeRolesData(null, null, ImmutableSortedSet.of(dimension1)),
-        Main.getWorkMgr().getdirContainer(container).resolve(BfConsts.RELPATH_NODE_ROLES_PATH));
+        Main.getWorkMgr().getdirNetwork(container).resolve(BfConsts.RELPATH_NODE_ROLES_PATH));
 
     // we only check that the right type of object is returned at the expected URL target
     // we rely on NodeRolesDataBean to have created the object with the right content

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/NodeRoleDimensionResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/NodeRoleDimensionResourceTest.java
@@ -59,8 +59,7 @@ public class NodeRoleDimensionResourceTest extends WorkMgrServiceV2TestBase {
             ImmutableSortedSet.of(
                 new NodeRoleDimension("dimension1", ImmutableSortedSet.of(), null, null)));
     NodeRolesData.write(
-        data,
-        Main.getWorkMgr().getdirNetwork(container).resolve(BfConsts.RELPATH_NODE_ROLES_PATH));
+        data, Main.getWorkMgr().getdirNetwork(container).resolve(BfConsts.RELPATH_NODE_ROLES_PATH));
 
     Response response = getNodeRoleDimensionTarget(container, "dimension1").delete();
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/NodeRolesDataBeanTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/NodeRolesDataBeanTest.java
@@ -47,8 +47,7 @@ public class NodeRolesDataBeanTest extends WorkMgrServiceV2TestBase {
                     null,
                     null)));
     NodeRolesData.write(
-        data,
-        Main.getWorkMgr().getdirNetwork(container).resolve(BfConsts.RELPATH_NODE_ROLES_PATH));
+        data, Main.getWorkMgr().getdirNetwork(container).resolve(BfConsts.RELPATH_NODE_ROLES_PATH));
 
     // we should get OK and the expected bean
     assertThat(

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/NodeRolesDataBeanTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/NodeRolesDataBeanTest.java
@@ -48,7 +48,7 @@ public class NodeRolesDataBeanTest extends WorkMgrServiceV2TestBase {
                     null)));
     NodeRolesData.write(
         data,
-        Main.getWorkMgr().getdirContainer(container).resolve(BfConsts.RELPATH_NODE_ROLES_PATH));
+        Main.getWorkMgr().getdirNetwork(container).resolve(BfConsts.RELPATH_NODE_ROLES_PATH));
 
     // we should get OK and the expected bean
     assertThat(


### PR DESCRIPTION
Continuation of the migration from container/testrig to network/snapshot terminology.
* Added `uploadSnapshot` and deprecated `uploadTestrig` REST API
* Update `ICoordinator` interface to use new terminology
