### PR TITLE
Cleanup RoutingPolicy

### DIFF
--- a/projects/question/src/main/java/org/batfish/question/BgpLoopbacksQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/BgpLoopbacksQuestionPlugin.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.service.AutoService;
 import com.google.common.collect.Iterables;
+import java.util.Comparator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -121,7 +122,8 @@ public class BgpLoopbacksQuestionPlugin extends QuestionPlugin {
             continue;
           }
           BgpProcess proc = vrf.getBgpProcess();
-          Set<RoutingPolicy> exportPolicies = new TreeSet<>();
+          Set<RoutingPolicy> exportPolicies =
+              new TreeSet<>(Comparator.comparing(RoutingPolicy::getName));
           for (BgpPeerConfig neighbor :
               Iterables.concat(
                   proc.getActiveNeighbors().values(), proc.getPassiveNeighbors().values())) {


### PR DESCRIPTION
- Remove comparable structure
- Better javadoc in places
- Had to keep overriding `equals` and `hashcode` in a weird way for compatibility (deferring proper fix for later).