### PR TITLE
Deprecate & replace testrig-related commands in client

### DIFF
--- a/projects/allinone/src/main/java/org/batfish/allinone/AllInOne.java
+++ b/projects/allinone/src/main/java/org/batfish/allinone/AllInOne.java
@@ -69,11 +69,11 @@ public class AllInOne {
               org.batfish.client.config.Settings.ARG_COMMAND_FILE, _settings.getCommandFile());
     }
 
-    if (_settings.getTestrigDir() != null) {
+    if (_settings.getSnapshotDir() != null) {
       argString +=
           String.format(
               " -%s %s",
-              org.batfish.client.config.Settings.ARG_TESTRIG_DIR, _settings.getTestrigDir());
+              org.batfish.client.config.Settings.ARG_SNAPSHOT_DIR, _settings.getSnapshotDir());
     }
 
     if (_settings.getTracingEnable() && !GlobalTracer.isRegistered()) {

--- a/projects/allinone/src/main/java/org/batfish/allinone/config/Settings.java
+++ b/projects/allinone/src/main/java/org/batfish/allinone/config/Settings.java
@@ -24,7 +24,8 @@ public class Settings extends BaseSettings {
   private static final String ARG_RUN_CLIENT = "runclient";
   private static final String ARG_RUN_MODE = org.batfish.client.config.Settings.ARG_RUN_MODE;
   public static final String ARG_SERVICE_NAME = "servicename";
-  private static final String ARG_TESTRIG_DIR = org.batfish.client.config.Settings.ARG_TESTRIG_DIR;
+  private static final String ARG_SNAPSHOT_DIR =
+      org.batfish.client.config.Settings.ARG_SNAPSHOT_DIR;
   private static final String ARG_TRACING_AGENT_HOST = "tracingagenthost";
   private static final String ARG_TRACING_AGENT_PORT = "tracingagentport";
   private static final String ARG_TRACING_ENABLE = "tracingenable";
@@ -42,7 +43,7 @@ public class Settings extends BaseSettings {
   private boolean _runClient;
   private String _runMode;
   private String _serviceName;
-  private String _testrigDir;
+  private String _snapshotDir;
   private String _tracingAgentHost;
   private Integer _tracingAgentPort;
   private boolean _tracingEnable;
@@ -100,8 +101,8 @@ public class Settings extends BaseSettings {
     return _serviceName;
   }
 
-  public String getTestrigDir() {
-    return _testrigDir;
+  public String getSnapshotDir() {
+    return _snapshotDir;
   }
 
   public Integer getTracingAgentPort() {
@@ -168,7 +169,7 @@ public class Settings extends BaseSettings {
 
     addOption(ARG_SERVICE_NAME, "service name", "service_name");
 
-    addOption(ARG_TESTRIG_DIR, "where the testrig sits", "testrig_dir");
+    addOption(ARG_SNAPSHOT_DIR, "where the snapshot sits", "snapshot_dir");
 
     addOption(ARG_TRACING_AGENT_HOST, "jaeger agent host", "jaeger_agent_host");
 
@@ -205,7 +206,7 @@ public class Settings extends BaseSettings {
     _runClient = getBooleanOptionValue(ARG_RUN_CLIENT);
     _runMode = getStringOptionValue(ARG_RUN_MODE);
     _serviceName = getStringOptionValue(ARG_SERVICE_NAME);
-    _testrigDir = getStringOptionValue(ARG_TESTRIG_DIR);
+    _snapshotDir = getStringOptionValue(ARG_SNAPSHOT_DIR);
     _tracingAgentHost = getStringOptionValue(ARG_TRACING_AGENT_HOST);
     _tracingAgentPort = getIntegerOptionValue(ARG_TRACING_AGENT_PORT);
     _tracingEnable = getBooleanOptionValue(ARG_TRACING_ENABLE);

--- a/projects/batfish-client/src/main/java/org/batfish/client/BfCoordWorkHelper.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/BfCoordWorkHelper.java
@@ -314,7 +314,7 @@ public class BfCoordWorkHelper {
       JSONObject jObj = postData(webTarget, multiPart);
       return jObj != null;
     } catch (Exception e) {
-      _logger.errorf("exception: ");
+      _logger.errorf("Exception in delSnapshot for network %s:\n", containerName);
       _logger.error(Throwables.getStackTraceAsString(e) + "\n");
       return false;
     }
@@ -505,7 +505,7 @@ public class BfCoordWorkHelper {
       return response.readEntity(String.class);
     } catch (Exception e) {
       _logger.errorf(
-          "Exception in getConfiguration from %s for container %s, testrig %s, configuration %s\n",
+          "Exception in getConfiguration from %s for network %s, snapshot %s, configuration %s\n",
           _coordWorkMgr, containerName, testrigName, configName);
       _logger.error(Throwables.getStackTraceAsString(e) + "\n");
       return null;
@@ -513,15 +513,15 @@ public class BfCoordWorkHelper {
   }
 
   /**
-   * Returns a {@link Container Container} that contains information of '{@code containerName}',
-   * returns null if container '{@code containerName}' does not exist or the api key that is using
-   * has no access to the container
+   * Returns a {@link Container Container} that contains information of '{@code networkName}',
+   * returns null if network '{@code networkName}' does not exist or the api key that is using has
+   * no access to the network
    */
   @Nullable
-  Container getContainer(String containerName) {
+  Container getNetwork(String networkName) {
     try {
       WebTarget webTarget =
-          getTargetV2(Lists.newArrayList(CoordConstsV2.RSC_CONTAINERS, containerName));
+          getTargetV2(Lists.newArrayList(CoordConstsV2.RSC_CONTAINERS, networkName));
 
       Response response =
           webTarget
@@ -533,7 +533,7 @@ public class BfCoordWorkHelper {
       _logger.debug(response.getStatus() + " " + response.getStatusInfo() + " " + response + "\n");
 
       if (response.getStatus() != Response.Status.OK.getStatusCode()) {
-        _logger.errorf("GetContainer: Did not get OK response. Got: %s\n", response.getStatus());
+        _logger.errorf("getNetwork: Did not get OK response. Got: %s\n", response.getStatus());
         _logger.error(response.readEntity(String.class) + "\n");
         return null;
       }
@@ -541,7 +541,7 @@ public class BfCoordWorkHelper {
       String containerStr = response.readEntity(String.class);
       return BatfishObjectMapper.mapper().readValue(containerStr, Container.class);
     } catch (Exception e) {
-      _logger.errorf("Exception in getContainer from %s for %s\n", _coordWorkMgrV2, containerName);
+      _logger.errorf("Exception in getNetwork from %s for %s\n", _coordWorkMgrV2, networkName);
       _logger.error(Throwables.getStackTraceAsString(e) + "\n");
       return null;
     }
@@ -1039,7 +1039,7 @@ public class BfCoordWorkHelper {
 
       return jObj.getJSONArray(CoordConsts.SVC_KEY_TESTRIG_LIST);
     } catch (Exception e) {
-      _logger.errorf("exception: ");
+      _logger.errorf("Exception in listSnapshots for network %s:\n", containerName);
       _logger.error(Throwables.getStackTraceAsString(e) + "\n");
       return null;
     }
@@ -1129,7 +1129,7 @@ public class BfCoordWorkHelper {
       JSONObject jObj = postData(webTarget, multiPart);
       return jObj != null;
     } catch (Exception e) {
-      _logger.errorf("exception: ");
+      _logger.errorf("Exception syncing snapshots in network %s:\n", containerName);
       _logger.error(Throwables.getStackTraceAsString(e) + "\n");
       return false;
     }
@@ -1154,7 +1154,7 @@ public class BfCoordWorkHelper {
       JSONObject jObj = postData(webTarget, multiPart);
       return jObj != null;
     } catch (Exception e) {
-      _logger.errorf("exception: ");
+      _logger.errorf("Exception syncing snapshots in network %s:\n", containerName);
       _logger.error(Throwables.getStackTraceAsString(e) + "\n");
       return false;
     }
@@ -1263,7 +1263,7 @@ public class BfCoordWorkHelper {
         _logger.errorf("File not found: %s\n", zipfileName);
       } else {
         _logger.errorf(
-            "Exception when uploading test rig to %s using (%s, %s, %s): %s\n",
+            "Exception when uploading snapshot to %s using (%s, %s, %s): %s\n",
             _coordWorkMgr,
             containerName,
             testrigName,

--- a/projects/batfish-client/src/main/java/org/batfish/client/Client.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/Client.java
@@ -125,7 +125,7 @@ public class Client extends AbstractClient implements IClient {
   private static final Set<String> COMPARATORS =
       new HashSet<>(Arrays.asList(">", ">=", "==", "!=", "<", "<="));
 
-  private static final String DEFAULT_CONTAINER_PREFIX = "cp";
+  private static final String DEFAULT_NETWORK_PREFIX = "np";
 
   private static final String DEFAULT_DELTA_ENV_PREFIX = "env_";
 
@@ -133,7 +133,7 @@ public class Client extends AbstractClient implements IClient {
 
   private static final String DEFAULT_QUESTION_PREFIX = "q";
 
-  private static final String DEFAULT_TESTRIG_PREFIX = "tr_";
+  private static final String DEFAULT_SNAPSHOT_PREFIX = "ss_";
 
   private static final String DIFF_NOT_READY_MSG =
       "Cannot ask differential question without first setting delta testrig/environment\n";
@@ -972,9 +972,9 @@ public class Client extends AbstractClient implements IClient {
     return true;
   }
 
-  private boolean delTestrig(
+  private boolean delSnapshot(
       @Nullable FileWriter outWriter, List<String> options, List<String> parameters) {
-    if (!isValidArgument(options, parameters, 0, 1, 1, Command.DEL_TESTRIG)) {
+    if (!isValidArgument(options, parameters, 0, 1, 1, Command.DEL_SNAPSHOT)) {
       return false;
     }
     if (!isSetContainer(true)) {
@@ -983,7 +983,7 @@ public class Client extends AbstractClient implements IClient {
 
     String testrigName = parameters.get(0);
     boolean result = _workHelper.delTestrig(_currContainerName, testrigName);
-    logOutput(outWriter, "Result of deleting testrig: " + result + "\n");
+    logOutput(outWriter, "Result of deleting snapshot: " + result + "\n");
     return true;
   }
 
@@ -1338,7 +1338,7 @@ public class Client extends AbstractClient implements IClient {
       return false;
     }
     String containerName = parameters.get(0);
-    Container container = _workHelper.getContainer(containerName);
+    Container container = _workHelper.getNetwork(containerName);
     if (container != null) {
       _logger.output(container.getTestrigs() + "\n");
       return true;
@@ -1532,7 +1532,7 @@ public class Client extends AbstractClient implements IClient {
       if (!isValidArgument(options, parameters, 0, 0, 1, Command.INIT_NETWORK)) {
         return false;
       }
-      String containerPrefix = parameters.isEmpty() ? DEFAULT_CONTAINER_PREFIX : parameters.get(0);
+      String containerPrefix = parameters.isEmpty() ? DEFAULT_NETWORK_PREFIX : parameters.get(0);
       _currContainerName = _workHelper.initContainer(null, containerPrefix);
     }
     if (_currContainerName == null) {
@@ -1638,7 +1638,7 @@ public class Client extends AbstractClient implements IClient {
     _currDeltaEnv = newEnvName;
     _currDeltaTestrig = _currTestrig;
 
-    _logger.output("Active delta testrig->environment is set");
+    _logger.output("Active delta snapshot->environment is set");
     _logger.infof("to %s->%s\n", _currDeltaTestrig, _currDeltaEnv);
     _logger.output("\n");
 
@@ -1772,12 +1772,12 @@ public class Client extends AbstractClient implements IClient {
     return result;
   }
 
-  private boolean initTestrig(
+  private boolean initSnapshot(
       @Nullable FileWriter outWriter,
       List<String> options,
       List<String> parameters,
       boolean delta) {
-    Command command = delta ? Command.INIT_DELTA_TESTRIG : Command.INIT_TESTRIG;
+    Command command = delta ? Command.INIT_DELTA_SNAPSHOT : Command.INIT_SNAPSHOT;
     if (!isValidArgument(options, parameters, 1, 1, 2, command)) {
       return false;
     }
@@ -1795,11 +1795,11 @@ public class Client extends AbstractClient implements IClient {
 
     String testrigLocation = parameters.get(0);
     String testrigName =
-        (parameters.size() > 1) ? parameters.get(1) : DEFAULT_TESTRIG_PREFIX + UUID.randomUUID();
+        (parameters.size() > 1) ? parameters.get(1) : DEFAULT_SNAPSHOT_PREFIX + UUID.randomUUID();
 
     // initialize the container if it hasn't been init'd before
     if (!isSetContainer(false)) {
-      _currContainerName = _workHelper.initContainer(null, DEFAULT_CONTAINER_PREFIX);
+      _currContainerName = _workHelper.initContainer(null, DEFAULT_NETWORK_PREFIX);
       if (_currContainerName == null) {
         _logger.errorf("Could not init network\n");
         return false;
@@ -1813,7 +1813,7 @@ public class Client extends AbstractClient implements IClient {
       unsetTestrig(delta);
       return false;
     }
-    _logger.output("Uploaded testrig.\n");
+    _logger.output("Uploaded snapshot.\n");
 
     if (!autoAnalyze) {
       _logger.output("Parsing now.\n");
@@ -1828,11 +1828,11 @@ public class Client extends AbstractClient implements IClient {
     if (!delta) {
       _currTestrig = testrigName;
       _currEnv = DEFAULT_ENV_NAME;
-      _logger.infof("Base testrig is now %s\n", _currTestrig);
+      _logger.infof("Base snapshot is now %s\n", _currTestrig);
     } else {
       _currDeltaTestrig = testrigName;
       _currDeltaEnv = DEFAULT_ENV_NAME;
-      _logger.infof("Delta testrig is now %s\n", _currDeltaTestrig);
+      _logger.infof("Delta snapshot is now %s\n", _currDeltaTestrig);
     }
 
     return true;
@@ -1873,7 +1873,7 @@ public class Client extends AbstractClient implements IClient {
     }
 
     if (_currDeltaTestrig == null) {
-      _logger.errorf("Active delta testrig is not set\n");
+      _logger.errorf("Active delta snapshot is not set\n");
       return false;
     }
 
@@ -1890,10 +1890,10 @@ public class Client extends AbstractClient implements IClient {
     }
 
     if (_currTestrig == null) {
-      _logger.errorf("Active testrig is not set.\n");
+      _logger.errorf("Active snapshot is not set.\n");
       _logger.errorf(
-          "Specify testrig on command line (-%s <testrigdir>) or use command (%s <testrigdir>)\n",
-          Settings.ARG_TESTRIG_DIR, Command.INIT_TESTRIG);
+          "Specify snapshot on command line (-%s <snapshotdir>) or use command (%s <snapshotdir>)\n",
+          Settings.ARG_SNAPSHOT_DIR, Command.INIT_SNAPSHOT.commandName());
       return false;
     }
     return true;
@@ -2020,9 +2020,9 @@ public class Client extends AbstractClient implements IClient {
     return true;
   }
 
-  private boolean listTestrigs(
+  private boolean listSnapshots(
       @Nullable FileWriter outWriter, List<String> options, List<String> parameters) {
-    if (!isValidArgument(options, parameters, 1, 0, 0, Command.LIST_TESTRIGS)) {
+    if (!isValidArgument(options, parameters, 1, 0, 0, Command.LIST_SNAPSHOTS)) {
       return false;
     }
 
@@ -2032,7 +2032,7 @@ public class Client extends AbstractClient implements IClient {
         showMetadata = false;
       } else {
         _logger.errorf("Unknown option: %s\n", options.get(0));
-        printUsage(Command.LIST_TESTRIGS);
+        printUsage(Command.LIST_SNAPSHOTS);
         return false;
       }
     }
@@ -2563,8 +2563,10 @@ public class Client extends AbstractClient implements IClient {
         return delNetwork(options, parameters);
       case DEL_QUESTION:
         return delQuestion(options, parameters);
+      case DEL_SNAPSHOT:
+        return delSnapshot(outWriter, options, parameters);
       case DEL_TESTRIG:
-        return delTestrig(outWriter, options, parameters);
+        return delSnapshot(outWriter, options, parameters);
       case DIR:
         return dir(options, parameters);
       case ECHO:
@@ -2611,14 +2613,18 @@ public class Client extends AbstractClient implements IClient {
         return initOrAddAnalysis(outWriter, options, parameters, true);
       case INIT_CONTAINER:
         return initNetwork(options, parameters);
+      case INIT_DELTA_SNAPSHOT:
+        return initSnapshot(outWriter, options, parameters, true);
       case INIT_DELTA_TESTRIG:
-        return initTestrig(outWriter, options, parameters, true);
+        return initSnapshot(outWriter, options, parameters, true);
       case INIT_ENVIRONMENT:
         return initEnvironment(words, outWriter, options, parameters);
       case INIT_NETWORK:
         return initNetwork(options, parameters);
+      case INIT_SNAPSHOT:
+        return initSnapshot(outWriter, options, parameters, false);
       case INIT_TESTRIG:
-        return initTestrig(outWriter, options, parameters, false);
+        return initSnapshot(outWriter, options, parameters, false);
       case KILL_WORK:
         return killWork(options, parameters);
       case LIST_ANALYSES:
@@ -2633,8 +2639,10 @@ public class Client extends AbstractClient implements IClient {
         return listNetworks(options, parameters);
       case LIST_QUESTIONS:
         return listQuestions(options, parameters);
+      case LIST_SNAPSHOTS:
+        return listSnapshots(outWriter, options, parameters);
       case LIST_TESTRIGS:
-        return listTestrigs(outWriter, options, parameters);
+        return listSnapshots(outWriter, options, parameters);
       case LOAD_QUESTIONS:
         return loadQuestions(outWriter, options, parameters, _bfq);
       case POLL_WORK:
@@ -2643,6 +2651,8 @@ public class Client extends AbstractClient implements IClient {
         return prompt(options, parameters);
       case PWD:
         return pwd(options, parameters);
+      case REINIT_DELTA_SNAPSHOT:
+        return reinitTestrig(outWriter, options, parameters, true);
       case REINIT_DELTA_TESTRIG:
         return reinitTestrig(outWriter, options, parameters, true);
       case RUN_ANALYSIS:
@@ -2651,6 +2661,8 @@ public class Client extends AbstractClient implements IClient {
         return runAnalysis(outWriter, options, parameters, true, false);
       case RUN_ANALYSIS_DIFFERENTIAL:
         return runAnalysis(outWriter, options, parameters, false, true);
+      case REINIT_SNAPSHOT:
+        return reinitTestrig(outWriter, options, parameters, false);
       case REINIT_TESTRIG:
         return reinitTestrig(outWriter, options, parameters, false);
       case SET_BACKGROUND_EXECUCTION:
@@ -2665,16 +2677,20 @@ public class Client extends AbstractClient implements IClient {
         return setEnv(options, parameters);
       case SET_FIXED_WORKITEM_ID:
         return setFixedWorkItemId(options, parameters);
+      case SET_DELTA_SNAPSHOT:
+        return setDeltaSnapshot(options, parameters);
       case SET_DELTA_TESTRIG:
-        return setDeltaTestrig(options, parameters);
+        return setDeltaSnapshot(options, parameters);
       case SET_LOGLEVEL:
         return setLogLevel(options, parameters);
       case SET_NETWORK:
         return setNetwork(options, parameters);
       case SET_PRETTY_PRINT:
         return setPrettyPrint(options, parameters);
+      case SET_SNAPSHOT:
+        return setSnapshot(options, parameters);
       case SET_TESTRIG:
-        return setTestrig(options, parameters);
+        return setSnapshot(options, parameters);
       case SHOW_API_KEY:
         return showApiKey(options, parameters);
       case SHOW_BATFISH_LOGLEVEL:
@@ -2685,20 +2701,28 @@ public class Client extends AbstractClient implements IClient {
         return showNetwork(options, parameters);
       case SHOW_COORDINATOR_HOST:
         return showCoordinatorHost(options, parameters);
+      case SHOW_DELTA_SNAPSHOT:
+        return showDeltaSnapshot(options, parameters);
       case SHOW_DELTA_TESTRIG:
-        return showDeltaTestrig(options, parameters);
+        return showDeltaSnapshot(options, parameters);
       case SHOW_LOGLEVEL:
         return showLogLevel(options, parameters);
       case SHOW_NETWORK:
         return showNetwork(options, parameters);
+      case SHOW_SNAPSHOT:
+        return showSnapshot(options, parameters);
       case SHOW_TESTRIG:
-        return showTestrig(options, parameters);
+        return showSnapshot(options, parameters);
       case SHOW_VERSION:
         return showVersion(options, parameters);
+      case SYNC_SNAPSHOTS_SYNC_NOW:
+        return syncSnapshotsSyncNow(options, parameters);
       case SYNC_TESTRIGS_SYNC_NOW:
-        return syncTestrigsSyncNow(options, parameters);
+        return syncSnapshotsSyncNow(options, parameters);
+      case SYNC_SNAPSHOTS_UPDATE_SETTINGS:
+        return syncSnapshotsUpdateSettings(words, options, parameters);
       case SYNC_TESTRIGS_UPDATE_SETTINGS:
-        return syncTestrigsUpdateSettings(words, options, parameters);
+        return syncSnapshotsUpdateSettings(words, options, parameters);
       case TEST:
         return test(options, parameters);
       case UPLOAD_CUSTOM_OBJECT:
@@ -2765,16 +2789,16 @@ public class Client extends AbstractClient implements IClient {
       List<String> options,
       List<String> parameters,
       boolean delta) {
-    Command command = delta ? Command.REINIT_DELTA_TESTRIG : Command.REINIT_TESTRIG;
+    Command command = delta ? Command.REINIT_DELTA_SNAPSHOT : Command.REINIT_SNAPSHOT;
     if (!isValidArgument(options, parameters, 0, 0, 0, command)) {
       return false;
     }
     String testrig;
     if (!delta) {
-      _logger.output("Reinitializing testrig. Parsing now.\n");
+      _logger.output("Reinitializing snapshot. Parsing now.\n");
       testrig = _currTestrig;
     } else {
-      _logger.output("Reinitializing delta testrig. Parsing now.\n");
+      _logger.output("Reinitializing delta snapshot. Parsing now.\n");
       testrig = _currDeltaTestrig;
     }
 
@@ -2799,23 +2823,22 @@ public class Client extends AbstractClient implements IClient {
 
     // set container if specified
     if (_settings.getContainerId() != null
-        && !processCommand(
-            Command.SET_CONTAINER.commandName() + "  " + _settings.getContainerId())) {
+        && !processCommand(Command.SET_NETWORK.commandName() + "  " + _settings.getContainerId())) {
       return;
     }
 
     // set testrig if dir or id is specified
-    if (_settings.getTestrigDir() != null) {
-      if (_settings.getTestrigId() != null) {
-        System.err.println("org.batfish.client: Cannot supply both testrigDir and testrigId.");
+    if (_settings.getSnapshotDir() != null) {
+      if (_settings.getSnapshotId() != null) {
+        System.err.println("org.batfish.client: Cannot supply both snapshotDir and snapshotId.");
         System.exit(1);
       }
-      if (!processCommand(Command.INIT_TESTRIG.commandName() + " " + _settings.getTestrigDir())) {
+      if (!processCommand(Command.INIT_TESTRIG.commandName() + " " + _settings.getSnapshotDir())) {
         return;
       }
     }
-    if (_settings.getTestrigId() != null
-        && !processCommand(Command.SET_TESTRIG.commandName() + "  " + _settings.getTestrigId())) {
+    if (_settings.getSnapshotId() != null
+        && !processCommand(Command.SET_TESTRIG.commandName() + "  " + _settings.getSnapshotId())) {
       return;
     }
 
@@ -2970,17 +2993,17 @@ public class Client extends AbstractClient implements IClient {
       _currDeltaTestrig = _currTestrig;
     }
     _logger.outputf(
-        "Active delta testrig->environment is now %s->%s\n", _currDeltaTestrig, _currDeltaEnv);
+        "Active delta snapshot->environment is now %s->%s\n", _currDeltaTestrig, _currDeltaEnv);
     return true;
   }
 
-  private boolean setDeltaTestrig(List<String> options, List<String> parameters) {
-    if (!isValidArgument(options, parameters, 0, 1, 2, Command.SET_DELTA_TESTRIG)) {
+  private boolean setDeltaSnapshot(List<String> options, List<String> parameters) {
+    if (!isValidArgument(options, parameters, 0, 1, 2, Command.SET_DELTA_SNAPSHOT)) {
       return false;
     }
     _currDeltaTestrig = parameters.get(0);
     _currDeltaEnv = (parameters.size() > 1) ? parameters.get(1) : DEFAULT_ENV_NAME;
-    _logger.outputf("Delta testrig->env is now %s->%s\n", _currDeltaTestrig, _currDeltaEnv);
+    _logger.outputf("Delta snapshot->env is now %s->%s\n", _currDeltaTestrig, _currDeltaEnv);
     return true;
   }
 
@@ -2992,7 +3015,7 @@ public class Client extends AbstractClient implements IClient {
       return false;
     }
     _currEnv = parameters.get(0);
-    _logger.outputf("Base testrig->env is now %s->%s\n", _currTestrig, _currEnv);
+    _logger.outputf("Base snapshot->env is now %s->%s\n", _currTestrig, _currEnv);
     return true;
   }
 
@@ -3032,8 +3055,8 @@ public class Client extends AbstractClient implements IClient {
     return true;
   }
 
-  private boolean setTestrig(List<String> options, List<String> parameters) {
-    if (!isValidArgument(options, parameters, 0, 1, 2, Command.SET_TESTRIG)) {
+  private boolean setSnapshot(List<String> options, List<String> parameters) {
+    if (!isValidArgument(options, parameters, 0, 1, 2, Command.SET_SNAPSHOT)) {
       return false;
     }
     if (!isSetContainer(true)) {
@@ -3042,7 +3065,7 @@ public class Client extends AbstractClient implements IClient {
 
     _currTestrig = parameters.get(0);
     _currEnv = (parameters.size() > 1) ? parameters.get(1) : DEFAULT_ENV_NAME;
-    _logger.outputf("Base testrig->env is now %s->%s\n", _currTestrig, _currEnv);
+    _logger.outputf("Base snapshot->env is now %s->%s\n", _currTestrig, _currEnv);
     return true;
   }
 
@@ -3089,14 +3112,14 @@ public class Client extends AbstractClient implements IClient {
     return true;
   }
 
-  private boolean showDeltaTestrig(List<String> options, List<String> parameters) {
-    if (!isValidArgument(options, parameters, 0, 0, 0, Command.SHOW_DELTA_TESTRIG)) {
+  private boolean showDeltaSnapshot(List<String> options, List<String> parameters) {
+    if (!isValidArgument(options, parameters, 0, 0, 0, Command.SHOW_DELTA_SNAPSHOT)) {
       return false;
     }
     if (!isSetDeltaEnvironment()) {
       return false;
     }
-    _logger.outputf("Delta testrig->environment is %s->%s\n", _currDeltaTestrig, _currDeltaEnv);
+    _logger.outputf("Delta snapshot->environment is %s->%s\n", _currDeltaTestrig, _currDeltaEnv);
     return true;
   }
 
@@ -3108,14 +3131,14 @@ public class Client extends AbstractClient implements IClient {
     return true;
   }
 
-  private boolean showTestrig(List<String> options, List<String> parameters) {
-    if (!isValidArgument(options, parameters, 0, 0, 0, Command.SHOW_TESTRIG)) {
+  private boolean showSnapshot(List<String> options, List<String> parameters) {
+    if (!isValidArgument(options, parameters, 0, 0, 0, Command.SHOW_SNAPSHOT)) {
       return false;
     }
     if (!isSetTestrig()) {
       return false;
     }
-    _logger.outputf("Base testrig->environment is %s->%s\n", _currTestrig, _currEnv);
+    _logger.outputf("Base snapshot->environment is %s->%s\n", _currTestrig, _currEnv);
     return true;
   }
 
@@ -3137,8 +3160,8 @@ public class Client extends AbstractClient implements IClient {
     return true;
   }
 
-  private boolean syncTestrigsSyncNow(List<String> options, List<String> parameters) {
-    if (!isValidArgument(options, parameters, 1, 1, 1, Command.SYNC_TESTRIGS_SYNC_NOW)) {
+  private boolean syncSnapshotsSyncNow(List<String> options, List<String> parameters) {
+    if (!isValidArgument(options, parameters, 1, 1, 1, Command.SYNC_SNAPSHOTS_SYNC_NOW)) {
       return false;
     }
     if (!isSetContainer(true)) {
@@ -3152,7 +3175,7 @@ public class Client extends AbstractClient implements IClient {
         force = true;
       } else {
         _logger.errorf("Unknown option: %s\n", options.get(0));
-        printUsage(Command.SYNC_TESTRIGS_SYNC_NOW);
+        printUsage(Command.SYNC_SNAPSHOTS_SYNC_NOW);
         return false;
       }
     }
@@ -3162,10 +3185,10 @@ public class Client extends AbstractClient implements IClient {
     return _workHelper.syncTestrigsSyncNow(pluginId, _currContainerName, force);
   }
 
-  private boolean syncTestrigsUpdateSettings(
+  private boolean syncSnapshotsUpdateSettings(
       String[] words, List<String> options, List<String> parameters) {
     if (!isValidArgument(
-        options, parameters, 0, 1, Integer.MAX_VALUE, Command.SYNC_TESTRIGS_UPDATE_SETTINGS)) {
+        options, parameters, 0, 1, Integer.MAX_VALUE, Command.SYNC_SNAPSHOTS_UPDATE_SETTINGS)) {
       return false;
     }
     if (!isSetContainer(true)) {

--- a/projects/batfish-client/src/main/java/org/batfish/client/Command.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/Command.java
@@ -25,6 +25,7 @@ public enum Command {
   DEL_ENVIRONMENT("del-environment"),
   DEL_NETWORK("del-network"),
   DEL_QUESTION("del-question"),
+  DEL_SNAPSHOT("del-snapshot"),
   DEL_TESTRIG("del-testrig"),
   DIR("dir"),
   ECHO("echo"),
@@ -50,9 +51,11 @@ public enum Command {
   HELP("help"),
   INIT_ANALYSIS("init-analysis"),
   INIT_CONTAINER("init-container"),
+  INIT_DELTA_SNAPSHOT("init-delta-snapshot"),
   INIT_DELTA_TESTRIG("init-delta-testrig"),
   INIT_ENVIRONMENT("init-environment"),
   INIT_NETWORK("init-network"),
+  INIT_SNAPSHOT("init-snapshot"),
   INIT_TESTRIG("init-testrig"),
   KILL_WORK("kill-work"),
   LIST_ANALYSES("list-analyses"),
@@ -61,13 +64,16 @@ public enum Command {
   LIST_INCOMPLETE_WORK("list-incomplete-work"),
   LIST_NETWORKS("list-networks"),
   LIST_QUESTIONS("list-questions"),
+  LIST_SNAPSHOTS("list-snapshots"),
   LIST_TESTRIGS("list-testrigs"),
   LOAD_QUESTIONS("load-questions"),
   POLL_WORK("poll-work"),
   PROMPT("prompt"),
   PWD("pwd"),
   QUIT("quit"),
+  REINIT_DELTA_SNAPSHOT("reinit-delta-snapshot"),
   REINIT_DELTA_TESTRIG("reinit-delta-testrig"),
+  REINIT_SNAPSHOT("reinit-snapshot"),
   REINIT_TESTRIG("reinit-testrig"),
   RUN_ANALYSIS("run-analysis"),
   RUN_ANALYSIS_DELTA("run-analysis-delta"),
@@ -76,24 +82,30 @@ public enum Command {
   SET_BATFISH_LOGLEVEL("set-batfish-loglevel"),
   SET_CONTAINER("set-container"),
   SET_DELTA_ENV("set-delta-environment"),
+  SET_DELTA_SNAPSHOT("set-delta-snapshot"),
   SET_DELTA_TESTRIG("set-delta-testrig"),
   SET_ENV("set-environment"),
   SET_FIXED_WORKITEM_ID("set-fixed-workitem-id"),
   SET_LOGLEVEL("set-loglevel"),
   SET_NETWORK("set-network"),
   SET_PRETTY_PRINT("set-pretty-print"),
+  SET_SNAPSHOT("set-snapshot"),
   SET_TESTRIG("set-testrig"),
   SHOW_API_KEY("show-api-key"),
   SHOW_BATFISH_LOGLEVEL("show-batfish-loglevel"),
   SHOW_BATFISH_OPTIONS("show-batfish-options"),
   SHOW_CONTAINER("show-container"),
   SHOW_COORDINATOR_HOST("show-coordinator-host"),
+  SHOW_DELTA_SNAPSHOT("show-delta-snapshot"),
   SHOW_DELTA_TESTRIG("show-delta-testrig"),
   SHOW_LOGLEVEL("show-loglevel"),
   SHOW_NETWORK("show-network"),
+  SHOW_SNAPSHOT("show-snapshot"),
   SHOW_TESTRIG("show-testrig"),
   SHOW_VERSION("show-version"),
+  SYNC_SNAPSHOTS_SYNC_NOW("sync-snapshots-sync-now"),
   SYNC_TESTRIGS_SYNC_NOW("sync-testrigs-sync-now"),
+  SYNC_SNAPSHOTS_UPDATE_SETTINGS("sync-snapshots-update-settings"),
   SYNC_TESTRIGS_UPDATE_SETTINGS("sync-testrigs-update-settings"),
   TEST("test"),
   UPLOAD_CUSTOM_OBJECT("upload-custom"),
@@ -124,37 +136,35 @@ public enum Command {
 
   private static Map<Command, String> buildDeprecatedMap() {
     ImmutableMap.Builder<Command, String> map = ImmutableMap.builder();
+
+    String containerMsg = "The term \"container\" has been replaced with \"network\".";
+    String testrigMsg = "The term \"testrig\" has been replaced with \"snapshot\".";
+
+    map.put(DEL_CONTAINER, getDeprecatedMsg(containerMsg, DEL_NETWORK));
+    map.put(DEL_TESTRIG, getDeprecatedMsg(testrigMsg, DEL_SNAPSHOT));
+    map.put(GET_CONTAINER, getDeprecatedMsg(containerMsg, GET_NETWORK));
+    map.put(INIT_CONTAINER, getDeprecatedMsg(containerMsg, INIT_NETWORK));
+    map.put(INIT_DELTA_TESTRIG, getDeprecatedMsg(testrigMsg, INIT_DELTA_SNAPSHOT));
+    map.put(INIT_TESTRIG, getDeprecatedMsg(testrigMsg, INIT_SNAPSHOT));
+    map.put(LIST_CONTAINERS, getDeprecatedMsg(containerMsg, LIST_NETWORKS));
+    map.put(LIST_TESTRIGS, getDeprecatedMsg(testrigMsg, LIST_SNAPSHOTS));
+    map.put(REINIT_DELTA_TESTRIG, getDeprecatedMsg(testrigMsg, REINIT_DELTA_SNAPSHOT));
+    map.put(REINIT_TESTRIG, getDeprecatedMsg(testrigMsg, REINIT_SNAPSHOT));
+    map.put(SET_CONTAINER, getDeprecatedMsg(containerMsg, SET_NETWORK));
+    map.put(SET_DELTA_TESTRIG, getDeprecatedMsg(testrigMsg, SET_DELTA_SNAPSHOT));
+    map.put(SET_TESTRIG, getDeprecatedMsg(testrigMsg, SET_SNAPSHOT));
+    map.put(SHOW_CONTAINER, getDeprecatedMsg(containerMsg, SHOW_NETWORK));
+    map.put(SHOW_DELTA_TESTRIG, getDeprecatedMsg(testrigMsg, SHOW_DELTA_SNAPSHOT));
+    map.put(SHOW_TESTRIG, getDeprecatedMsg(testrigMsg, SHOW_SNAPSHOT));
+    map.put(SYNC_TESTRIGS_SYNC_NOW, getDeprecatedMsg(testrigMsg, SYNC_SNAPSHOTS_SYNC_NOW));
     map.put(
-        DEL_CONTAINER,
-        String.format(
-            "The term \"container\" has been replaced with \"network\". Use %s instead.",
-            DEL_NETWORK.commandName()));
-    map.put(
-        GET_CONTAINER,
-        String.format(
-            "The term \"container\" has been replaced with \"network\". Use %s instead.",
-            GET_NETWORK.commandName()));
-    map.put(
-        INIT_CONTAINER,
-        String.format(
-            "The term \"container\" has been replaced with \"network\". Use %s instead.",
-            INIT_NETWORK.commandName()));
-    map.put(
-        LIST_CONTAINERS,
-        String.format(
-            "The term \"container\" has been replaced with \"network\". Use %s instead.",
-            LIST_NETWORKS.commandName()));
-    map.put(
-        SET_CONTAINER,
-        String.format(
-            "The term \"container\" has been replaced with \"network\". Use %s instead.",
-            SET_NETWORK.commandName()));
-    map.put(
-        SHOW_CONTAINER,
-        String.format(
-            "The term \"container\" has been replaced with \"network\". Use %s instead.",
-            SHOW_NETWORK.commandName()));
+        SYNC_TESTRIGS_UPDATE_SETTINGS,
+        getDeprecatedMsg(testrigMsg, SYNC_SNAPSHOTS_UPDATE_SETTINGS));
     return map.build();
+  }
+
+  private static String getDeprecatedMsg(String reason, Command replacement) {
+    return String.format("%s Use %s instead.", reason, replacement.commandName());
   }
 
   private static Map<Command, Pair<String, String>> buildUsageMap() {
@@ -204,7 +214,8 @@ public enum Command {
         DEL_ENVIRONMENT, new Pair<>("<environment-name>", "Delete the specified environment"));
     descs.put(DEL_NETWORK, new Pair<>("<network-name>", "Delete the specified network"));
     descs.put(DEL_QUESTION, new Pair<>("<question-name>", "Delete the specified question"));
-    descs.put(DEL_TESTRIG, new Pair<>("<testrig-name>", "Delete the specified testrig"));
+    descs.put(DEL_SNAPSHOT, new Pair<>("<snapshot-name>", "Delete the specified snapshot"));
+    descs.put(DEL_TESTRIG, new Pair<>("<snapshot-name>", "Delete the specified snapshot"));
     descs.put(DIR, new Pair<>("<dir>", "List directory contents"));
     descs.put(ECHO, new Pair<>("<message>", "Echo the message"));
     descs.put(EXIT, new Pair<>("", "Terminate interactive client session"));
@@ -224,7 +235,7 @@ public enum Command {
     descs.put(
         GET_CONFIGURATION,
         new Pair<>(
-            "<network-name> <testrig-name> <configuration-name>",
+            "<network-name> <snapshot-name> <configuration-name>",
             "Get the file content of the configuration file"));
     descs.put(GET_CONTAINER, new Pair<>("<network-name>", "Get the information of the network"));
     descs.put(
@@ -234,7 +245,7 @@ public enum Command {
             "Answer the question by type for the delta environment"));
     descs.put(GET_NETWORK, new Pair<>("<network-name>", "Get the information of the network"));
     descs.put(GET_OBJECT, new Pair<>("<object path>", "Get the object"));
-    descs.put(GET_OBJECT_DELTA, new Pair<>("<object path>", "Get the object from delta testrig"));
+    descs.put(GET_OBJECT_DELTA, new Pair<>("<object path>", "Get the object from delta snapshot"));
     descs.put(GET_QUESTION, new Pair<>("<question-name>", "Get the question and parameter files"));
     descs.put(GET_QUESTION_TEMPLATES, new Pair<>("", "Get question templates from coordinator"));
     descs.put(GET_WORK_STATUS, new Pair<>("<work-id>", "Get the status of the specified work id"));
@@ -248,10 +259,15 @@ public enum Command {
         new Pair<>(
             "[-setname <network-name> | <network-name-prefix>]", "Initialize a new network"));
     descs.put(
+        INIT_DELTA_SNAPSHOT,
+        new Pair<>(
+            "[-autoanalyze] <snapshot zipfile or directory> [<snapshot-name>]",
+            "Initialize the delta snapshot with default environment"));
+    descs.put(
         INIT_DELTA_TESTRIG,
         new Pair<>(
-            "[-autoanalyze] <testrig zipfile or directory> [<testrig-name>]",
-            "Initialize the delta testrig with default environment"));
+            "[-autoanalyze] <snapshot zipfile or directory> [<snapshot-name>]",
+            "Initialize the delta snapshot with default environment"));
     descs.put(
         INIT_ENVIRONMENT,
         new Pair<>(
@@ -273,7 +289,7 @@ public enum Command {
                 + "generated.\n"
                 + "\n"
                 + "    sourceEnvironmentName\n"
-                + "        The name of an environment in the current testrig from which to clone "
+                + "        The name of an environment in the current snapshot from which to clone "
                 + "a new environment.\n"
                 + "        Files in the source environment are overriden by those in envDirOrZip "
                 + "(if specified),\n"
@@ -297,7 +313,7 @@ public enum Command {
                 + "    doDelta\n"
                 + "        Whether the sourceEnvironment and newEnvironment should be chosen "
                 + "from/created in the\n"
-                + "        current base(false) or delta(true) testrig. Defaults to false.\n"
+                + "        current base(false) or delta(true) snapshot. Defaults to false.\n"
                 + "\n"));
     /*                + "    update\n"
     + "        Whether to update the current base(doDelta=false)/delta(doDelta=true) "
@@ -312,10 +328,15 @@ public enum Command {
         new Pair<>(
             "[-setname <network-name> | <network-name-prefix>]", "Initialize a new network"));
     descs.put(
+        INIT_SNAPSHOT,
+        new Pair<>(
+            "[-autoanalyze] <snapshot zipfile or directory> [<snapshot-name>]",
+            "Initialize the snapshot with default environment"));
+    descs.put(
         INIT_TESTRIG,
         new Pair<>(
-            "[-autoanalyze] <testrig zipfile or directory> [<testrig-name>]",
-            "Initialize the testrig with default environment"));
+            "[-autoanalyze] <snapshot zipfile or directory> [<snapshot-name>]",
+            "Initialize the snapshot with default environment"));
     descs.put(KILL_WORK, new Pair<>("<guid>", "Kill work with the given GUID"));
     descs.put(LIST_ANALYSES, new Pair<>("", "List the analyses and their configuration"));
     descs.put(LIST_CONTAINERS, new Pair<>("", "List the networks to which you have access"));
@@ -323,12 +344,16 @@ public enum Command {
         LIST_INCOMPLETE_WORK, new Pair<>("", "List all incomplete works for the active network"));
     descs.put(
         LIST_ENVIRONMENTS,
-        new Pair<>("", "List the environments under current network and testrig"));
+        new Pair<>("", "List the environments under current network and snapshot"));
     descs.put(LIST_NETWORKS, new Pair<>("", "List the networks to which you have access"));
     descs.put(
-        LIST_QUESTIONS, new Pair<>("", "List the questions under current network and testrig"));
+        LIST_QUESTIONS, new Pair<>("", "List the questions under current network and snapshot"));
     descs.put(
-        LIST_TESTRIGS, new Pair<>("[-nometadata]", "List the testrigs within the current network"));
+        LIST_SNAPSHOTS,
+        new Pair<>("[-nometadata]", "List the snapshots within the current network"));
+    descs.put(
+        LIST_TESTRIGS,
+        new Pair<>("[-nometadata]", "List the snapshots within the current network"));
     descs.put(
         LOAD_QUESTIONS,
         new Pair<>(
@@ -341,9 +366,14 @@ public enum Command {
     descs.put(PWD, new Pair<>("", "Prints the working directory"));
     descs.put(QUIT, new Pair<>("", "Terminate interactive client session"));
     descs.put(
+        REINIT_DELTA_SNAPSHOT,
+        new Pair<>("", "Reinitialize the delta snapshot with default environment"));
+    descs.put(
         REINIT_DELTA_TESTRIG,
-        new Pair<>("", "Reinitialize the delta testrig with default environment"));
-    descs.put(REINIT_TESTRIG, new Pair<>("", "Reinitialize the testrig with default environment"));
+        new Pair<>("", "Reinitialize the delta snapshot with default environment"));
+    descs.put(
+        REINIT_SNAPSHOT, new Pair<>("", "Reinitialize the snapshot with default environment"));
+    descs.put(REINIT_TESTRIG, new Pair<>("", "Reinitialize the snapshot with default environment"));
     descs.put(
         RUN_ANALYSIS, new Pair<>("<analysis-name>", "Run the (previously configured) analysis"));
     descs.put(
@@ -355,8 +385,11 @@ public enum Command {
     descs.put(SET_CONTAINER, new Pair<>("<network-name>", "Set the current network"));
     descs.put(SET_DELTA_ENV, new Pair<>("<environment-name>", "Set the delta environment"));
     descs.put(
+        SET_DELTA_SNAPSHOT,
+        new Pair<>("<snapshot-name> [environment name]", "Set the delta snapshot"));
+    descs.put(
         SET_DELTA_TESTRIG,
-        new Pair<>("<testrig-name> [environment name]", "Set the delta testrig"));
+        new Pair<>("<snapshot-name> [environment name]", "Set the delta snapshot"));
     descs.put(SET_ENV, new Pair<>("<environment-name>", "Set the current base environment"));
     descs.put(
         SET_FIXED_WORKITEM_ID,
@@ -366,7 +399,10 @@ public enum Command {
         new Pair<>("<debug|info|output|warn|error>", "Set the client loglevel. Default is output"));
     descs.put(SET_NETWORK, new Pair<>("<network-name>", "Set the current network"));
     descs.put(SET_PRETTY_PRINT, new Pair<>("<true|false>", "Whether to pretty print answers"));
-    descs.put(SET_TESTRIG, new Pair<>("<testrig-name> [environment name]", "Set the base testrig"));
+    descs.put(
+        SET_SNAPSHOT, new Pair<>("<snapshot-name> [environment name]", "Set the base snapshot"));
+    descs.put(
+        SET_TESTRIG, new Pair<>("<snapshot-name> [environment name]", "Set the base snapshot"));
     descs.put(SHOW_API_KEY, new Pair<>("", "Show API Key"));
     descs.put(SHOW_BATFISH_LOGLEVEL, new Pair<>("", "Show current batfish loglevel"));
     descs.put(
@@ -374,21 +410,33 @@ public enum Command {
         new Pair<>("", "Show the additional options that will be sent to batfish"));
     descs.put(SHOW_CONTAINER, new Pair<>("", "Show active network"));
     descs.put(SHOW_COORDINATOR_HOST, new Pair<>("", "Show coordinator host"));
-    descs.put(SHOW_DELTA_TESTRIG, new Pair<>("", "Show delta testrig and environment"));
+    descs.put(SHOW_DELTA_SNAPSHOT, new Pair<>("", "Show delta snapshot and environment"));
+    descs.put(SHOW_DELTA_TESTRIG, new Pair<>("", "Show delta snapshot and environment"));
     descs.put(SHOW_LOGLEVEL, new Pair<>("", "Show current client loglevel"));
     descs.put(SHOW_NETWORK, new Pair<>("", "Show active network"));
-    descs.put(SHOW_TESTRIG, new Pair<>("", "Show base testrig and environment"));
+    descs.put(SHOW_SNAPSHOT, new Pair<>("", "Show base snapshot and environment"));
+    descs.put(SHOW_TESTRIG, new Pair<>("", "Show base snapshot and environment"));
     descs.put(SHOW_VERSION, new Pair<>("", "Show the version of Client and Service"));
+    descs.put(
+        SYNC_SNAPSHOTS_SYNC_NOW,
+        new Pair<>(
+            "[-force] <plugin-id>",
+            "Sync snapshots now (settings must have been configured before)"));
     descs.put(
         SYNC_TESTRIGS_SYNC_NOW,
         new Pair<>(
             "[-force] <plugin-id>",
-            "Sync testrigs now (settings must have been configured before)"));
+            "Sync snapshots now (settings must have been configured before)"));
+    descs.put(
+        SYNC_SNAPSHOTS_UPDATE_SETTINGS,
+        new Pair<>(
+            "<plugin-id> [key1=value1, [key2=value2], ...], ",
+            "Update the settings for sync snapshots plugin"));
     descs.put(
         SYNC_TESTRIGS_UPDATE_SETTINGS,
         new Pair<>(
             "<plugin-id> [key1=value1, [key2=value2], ...], ",
-            "Update the settings for sync testrigs plugin"));
+            "Update the settings for sync snapshots plugin"));
     descs.put(
         TEST,
         new Pair<>(

--- a/projects/batfish-client/src/main/java/org/batfish/client/config/Settings.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/config/Settings.java
@@ -33,8 +33,8 @@ public class Settings extends BaseSettings {
   public static final String ARG_SERVICE_NAME = "servicename";
   private static final String ARG_SERVICE_WORK_PORT = "coordinatorworkport";
   private static final String ARG_SERVICE_WORK_V2_PORT = "coordinatorworkv2port";
-  public static final String ARG_TESTRIG_DIR = "testrigdir";
-  public static final String ARG_TESTRIG_ID = "testrigid";
+  public static final String ARG_SNAPSHOT_DIR = "snapshotdir";
+  public static final String ARG_SNAPSHOT_ID = "snapshotid";
   private static final String ARG_TRACING_AGENT_HOST = "tracingagenthost";
   private static final String ARG_TRACING_AGENT_PORT = "tracingagentport";
   public static final String ARG_TRACING_ENABLE = "tracingenable";
@@ -57,14 +57,14 @@ public class Settings extends BaseSettings {
   private RunMode _runMode;
   private boolean _sanityCheck;
   private String _serviceName;
+  private String _snapshotDir;
+  private String _snapshotId;
   private boolean _sslDisable;
   private Path _sslKeystoreFile;
   private String _sslKeystorePassword;
   private boolean _sslTrustAllCerts;
   private Path _sslTruststoreFile;
   private String _sslTruststorePassword;
-  private String _testrigDir;
-  private String _testrigId;
   private String _tracingAgentHost;
   private Integer _tracingAgentPort;
   private boolean _tracingEnable;
@@ -146,6 +146,14 @@ public class Settings extends BaseSettings {
     return _serviceName;
   }
 
+  public String getSnapshotDir() {
+    return _snapshotDir;
+  }
+
+  public String getSnapshotId() {
+    return _snapshotId;
+  }
+
   public boolean getSslDisable() {
     return _sslDisable;
   }
@@ -168,14 +176,6 @@ public class Settings extends BaseSettings {
 
   public String getSslTruststorePassword() {
     return _sslTruststorePassword;
-  }
-
-  public String getTestrigDir() {
-    return _testrigDir;
-  }
-
-  public String getTestrigId() {
-    return _testrigId;
   }
 
   public Integer getTracingAgentPort() {
@@ -228,7 +228,7 @@ public class Settings extends BaseSettings {
 
     addOption(ARG_BATFISH_LOG_LEVEL, "log level for batfish", "batfish_loglevel");
 
-    addOption(ARG_CONTAINER_ID, "container to attach to", "container_id");
+    addOption(ARG_CONTAINER_ID, "network to attach to", "network_id");
 
     addOption(ARG_DATAMODEL_DIR, "directory where datamodel should be dumped", "datamodel_dir");
 
@@ -239,7 +239,7 @@ public class Settings extends BaseSettings {
     addOption(ARG_LOG_LEVEL, "log level", "loglevel");
 
     addBooleanOption(
-        ARG_NO_SANITY_CHECK, "do not check if container, testrig etc. are set. (helps debugging.)");
+        ARG_NO_SANITY_CHECK, "do not check if network, snapshot etc. are set. (helps debugging.)");
 
     addOption(
         ARG_PERIOD_CHECK_WORK, "period with which to check work (ms)", "period_check_work_ms");
@@ -255,16 +255,16 @@ public class Settings extends BaseSettings {
     addOption(
         ARG_SERVICE_WORK_PORT, "port for work management service", "port_number_work_service");
 
+    addOption(ARG_SNAPSHOT_DIR, "where the snapshot sits", "snapshot_dir");
+
+    addOption(ARG_SNAPSHOT_ID, "snapshot to attach to", "snapshot_id");
+
     addBooleanOption(
         BfConsts.ARG_SSL_DISABLE, "whether to disable SSL during communication with coordinator");
 
     addBooleanOption(
         BfConsts.ARG_SSL_TRUST_ALL_CERTS,
         "whether to trust all SSL certificates during communication with coordinator");
-
-    addOption(ARG_TESTRIG_DIR, "where the testrig sits", "testrig_dir");
-
-    addOption(ARG_TESTRIG_ID, "testrig to attach to", "testrig_id");
 
     addOption(ARG_TRACING_AGENT_HOST, "jaeger agent host", "jaeger_agent_host");
 
@@ -304,8 +304,8 @@ public class Settings extends BaseSettings {
     _tracingAgentPort = getIntegerOptionValue(ARG_TRACING_AGENT_PORT);
     _tracingEnable = getBooleanOptionValue(ARG_TRACING_ENABLE);
 
-    _testrigDir = getStringOptionValue(ARG_TESTRIG_DIR);
-    _testrigId = getStringOptionValue(ARG_TESTRIG_ID);
+    _snapshotDir = getStringOptionValue(ARG_SNAPSHOT_DIR);
+    _snapshotId = getStringOptionValue(ARG_SNAPSHOT_ID);
 
     _coordinatorHost = getStringOptionValue(ARG_COORDINATOR_HOST);
     _coordinatorWorkPort = getIntegerOptionValue(ARG_SERVICE_WORK_PORT);

--- a/projects/batfish-client/src/test/java/org/batfish/client/ClientTest.java
+++ b/projects/batfish-client/src/test/java/org/batfish/client/ClientTest.java
@@ -13,7 +13,7 @@ import static org.batfish.client.Command.DEL_BATFISH_OPTION;
 import static org.batfish.client.Command.DEL_ENVIRONMENT;
 import static org.batfish.client.Command.DEL_NETWORK;
 import static org.batfish.client.Command.DEL_QUESTION;
-import static org.batfish.client.Command.DEL_TESTRIG;
+import static org.batfish.client.Command.DEL_SNAPSHOT;
 import static org.batfish.client.Command.DIR;
 import static org.batfish.client.Command.EXIT;
 import static org.batfish.client.Command.GEN_DELTA_DP;
@@ -30,39 +30,39 @@ import static org.batfish.client.Command.GET_DELTA;
 import static org.batfish.client.Command.GET_QUESTION;
 import static org.batfish.client.Command.HELP;
 import static org.batfish.client.Command.INIT_ANALYSIS;
-import static org.batfish.client.Command.INIT_DELTA_TESTRIG;
+import static org.batfish.client.Command.INIT_DELTA_SNAPSHOT;
 import static org.batfish.client.Command.INIT_ENVIRONMENT;
 import static org.batfish.client.Command.INIT_NETWORK;
-import static org.batfish.client.Command.INIT_TESTRIG;
+import static org.batfish.client.Command.INIT_SNAPSHOT;
 import static org.batfish.client.Command.LIST_ANALYSES;
 import static org.batfish.client.Command.LIST_ENVIRONMENTS;
 import static org.batfish.client.Command.LIST_NETWORKS;
 import static org.batfish.client.Command.LIST_QUESTIONS;
-import static org.batfish.client.Command.LIST_TESTRIGS;
+import static org.batfish.client.Command.LIST_SNAPSHOTS;
 import static org.batfish.client.Command.LOAD_QUESTIONS;
 import static org.batfish.client.Command.PROMPT;
 import static org.batfish.client.Command.PWD;
-import static org.batfish.client.Command.REINIT_DELTA_TESTRIG;
-import static org.batfish.client.Command.REINIT_TESTRIG;
+import static org.batfish.client.Command.REINIT_DELTA_SNAPSHOT;
+import static org.batfish.client.Command.REINIT_SNAPSHOT;
 import static org.batfish.client.Command.RUN_ANALYSIS;
 import static org.batfish.client.Command.RUN_ANALYSIS_DELTA;
 import static org.batfish.client.Command.RUN_ANALYSIS_DIFFERENTIAL;
 import static org.batfish.client.Command.SET_BATFISH_LOGLEVEL;
 import static org.batfish.client.Command.SET_DELTA_ENV;
-import static org.batfish.client.Command.SET_DELTA_TESTRIG;
+import static org.batfish.client.Command.SET_DELTA_SNAPSHOT;
 import static org.batfish.client.Command.SET_ENV;
 import static org.batfish.client.Command.SET_LOGLEVEL;
 import static org.batfish.client.Command.SET_NETWORK;
 import static org.batfish.client.Command.SET_PRETTY_PRINT;
-import static org.batfish.client.Command.SET_TESTRIG;
+import static org.batfish.client.Command.SET_SNAPSHOT;
 import static org.batfish.client.Command.SHOW_API_KEY;
 import static org.batfish.client.Command.SHOW_BATFISH_LOGLEVEL;
 import static org.batfish.client.Command.SHOW_BATFISH_OPTIONS;
 import static org.batfish.client.Command.SHOW_COORDINATOR_HOST;
-import static org.batfish.client.Command.SHOW_DELTA_TESTRIG;
+import static org.batfish.client.Command.SHOW_DELTA_SNAPSHOT;
 import static org.batfish.client.Command.SHOW_LOGLEVEL;
 import static org.batfish.client.Command.SHOW_NETWORK;
-import static org.batfish.client.Command.SHOW_TESTRIG;
+import static org.batfish.client.Command.SHOW_SNAPSHOT;
 import static org.batfish.client.Command.TEST;
 import static org.batfish.client.Command.UPLOAD_CUSTOM_OBJECT;
 import static org.batfish.common.CoordConsts.DEFAULT_API_KEY;
@@ -129,9 +129,9 @@ public class ClientTest {
 
   private static final String NETWORK_NOT_SET = "Active network is not set\n";
 
-  private static final String TESTRIG_NOT_SET =
-      "Active testrig is not set.\nSpecify testrig on"
-          + " command line (-testrigdir <testrigdir>) or use command (INIT_TESTRIG <testrigdir>)\n";
+  private static final String SNAPSHOT_NOT_SET =
+      "Active snapshot is not set.\nSpecify snapshot on"
+          + " command line (-snapshotdir <snapshotdir>) or use command (init-snapshot <snapshotdir>)\n";
 
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
   @Rule public ExpectedException _thrown = ExpectedException.none();
@@ -179,7 +179,7 @@ public class ClientTest {
   @Test
   public void testAnswerDeltaValidParas() throws Exception {
     String[] parameters = new String[] {"parameter1"};
-    checkProcessCommandErrorMessage(ANSWER_DELTA, parameters, TESTRIG_NOT_SET);
+    checkProcessCommandErrorMessage(ANSWER_DELTA, parameters, SNAPSHOT_NOT_SET);
   }
 
   @Test
@@ -190,7 +190,7 @@ public class ClientTest {
   @Test
   public void testAnswerValidParas() throws Exception {
     String[] parameters = new String[] {"parameter1"};
-    checkProcessCommandErrorMessage(ANSWER, parameters, TESTRIG_NOT_SET);
+    checkProcessCommandErrorMessage(ANSWER, parameters, SNAPSHOT_NOT_SET);
   }
 
   @Test
@@ -283,7 +283,7 @@ public class ClientTest {
   @Test
   public void testDelEnvironmentValidParas() throws Exception {
     String[] parameters = new String[] {"parameter1"};
-    checkProcessCommandErrorMessage(DEL_ENVIRONMENT, parameters, TESTRIG_NOT_SET);
+    checkProcessCommandErrorMessage(DEL_ENVIRONMENT, parameters, SNAPSHOT_NOT_SET);
   }
 
   @Test
@@ -294,18 +294,18 @@ public class ClientTest {
   @Test
   public void testDelQuestionValidParas() throws Exception {
     String[] parameters = new String[] {"parameter1"};
-    checkProcessCommandErrorMessage(DEL_QUESTION, parameters, TESTRIG_NOT_SET);
+    checkProcessCommandErrorMessage(DEL_QUESTION, parameters, SNAPSHOT_NOT_SET);
   }
 
   @Test
-  public void testDelTestrigInvalidParas() throws Exception {
-    testInvalidInput(DEL_TESTRIG, new String[] {}, new String[] {});
+  public void testDelSnapshotInvalidParas() throws Exception {
+    testInvalidInput(DEL_SNAPSHOT, new String[] {}, new String[] {});
   }
 
   @Test
-  public void testDelTestrigValidParas() throws Exception {
+  public void testDelSnapshotValidParas() throws Exception {
     String[] parameters = new String[] {"parameter1"};
-    checkProcessCommandErrorMessage(DEL_TESTRIG, parameters, NETWORK_NOT_SET);
+    checkProcessCommandErrorMessage(DEL_SNAPSHOT, parameters, NETWORK_NOT_SET);
   }
 
   @Test
@@ -359,7 +359,7 @@ public class ClientTest {
   @Test
   public void testGenerateDataplaneDeltaValidParas() throws Exception {
     checkProcessCommandErrorMessage(
-        GEN_DELTA_DP, new String[] {}, "Active delta testrig is not set\n");
+        GEN_DELTA_DP, new String[] {}, "Active delta snapshot is not set\n");
   }
 
   @Test
@@ -370,19 +370,20 @@ public class ClientTest {
 
   @Test
   public void testGenerateDataplaneValidParas() throws Exception {
-    checkProcessCommandErrorMessage(GEN_DP, new String[] {}, TESTRIG_NOT_SET);
+    checkProcessCommandErrorMessage(GEN_DP, new String[] {}, SNAPSHOT_NOT_SET);
   }
 
   @Test
   public void testGetAnalysisAnswersDeltaValidParas() throws Exception {
     String[] parameters = new String[] {"parameter1"};
-    checkProcessCommandErrorMessage(GET_ANALYSIS_ANSWERS_DELTA, parameters, TESTRIG_NOT_SET);
+    checkProcessCommandErrorMessage(GET_ANALYSIS_ANSWERS_DELTA, parameters, SNAPSHOT_NOT_SET);
   }
 
   @Test
   public void testGetAnalysisAnswersDifferentialValidParas() throws Exception {
     String[] parameters = new String[] {"parameter1"};
-    checkProcessCommandErrorMessage(GET_ANALYSIS_ANSWERS_DIFFERENTIAL, parameters, TESTRIG_NOT_SET);
+    checkProcessCommandErrorMessage(
+        GET_ANALYSIS_ANSWERS_DIFFERENTIAL, parameters, SNAPSHOT_NOT_SET);
   }
 
   @Test
@@ -393,19 +394,19 @@ public class ClientTest {
   @Test
   public void testGetAnalysisAnswersValidParas() throws Exception {
     String[] parameters = new String[] {"parameter1"};
-    checkProcessCommandErrorMessage(GET_ANALYSIS_ANSWERS, parameters, TESTRIG_NOT_SET);
+    checkProcessCommandErrorMessage(GET_ANALYSIS_ANSWERS, parameters, SNAPSHOT_NOT_SET);
   }
 
   @Test
   public void testGetAnswersDeltaValidParas() throws Exception {
     String[] parameters = new String[] {"parameter1"};
-    checkProcessCommandErrorMessage(GET_ANSWER_DELTA, parameters, TESTRIG_NOT_SET);
+    checkProcessCommandErrorMessage(GET_ANSWER_DELTA, parameters, SNAPSHOT_NOT_SET);
   }
 
   @Test
   public void testGetAnswersDifferentialValidParas() throws Exception {
     String[] parameters = new String[] {"parameter1"};
-    checkProcessCommandErrorMessage(GET_ANSWER_DIFFERENTIAL, parameters, TESTRIG_NOT_SET);
+    checkProcessCommandErrorMessage(GET_ANSWER_DIFFERENTIAL, parameters, SNAPSHOT_NOT_SET);
   }
 
   @Test
@@ -416,7 +417,7 @@ public class ClientTest {
   @Test
   public void testGetAnswersValidParas() throws Exception {
     String[] parameters = new String[] {"parameter1"};
-    checkProcessCommandErrorMessage(GET_ANSWER, parameters, TESTRIG_NOT_SET);
+    checkProcessCommandErrorMessage(GET_ANSWER, parameters, SNAPSHOT_NOT_SET);
   }
 
   @Test
@@ -427,7 +428,7 @@ public class ClientTest {
   @Test
   public void testGetDeltaValidParas() throws Exception {
     String[] parameters = new String[] {"parameter1"};
-    checkProcessCommandErrorMessage(GET_DELTA, parameters, TESTRIG_NOT_SET);
+    checkProcessCommandErrorMessage(GET_DELTA, parameters, SNAPSHOT_NOT_SET);
   }
 
   @Test
@@ -477,13 +478,13 @@ public class ClientTest {
   @Test
   public void testGetQuestionValidParas() throws Exception {
     String[] parameters = new String[] {"parameter1"};
-    checkProcessCommandErrorMessage(GET_QUESTION, parameters, TESTRIG_NOT_SET);
+    checkProcessCommandErrorMessage(GET_QUESTION, parameters, SNAPSHOT_NOT_SET);
   }
 
   @Test
   public void testGetValidParas() throws Exception {
     String[] parameters = new String[] {"parameter1"};
-    checkProcessCommandErrorMessage(GET, parameters, TESTRIG_NOT_SET);
+    checkProcessCommandErrorMessage(GET, parameters, SNAPSHOT_NOT_SET);
   }
 
   @Test
@@ -558,17 +559,17 @@ public class ClientTest {
   @Test
   public void testInitEnvValidParas() throws Exception {
     String[] parameters = new String[] {"parameter1"};
-    checkProcessCommandErrorMessage(INIT_ENVIRONMENT, parameters, TESTRIG_NOT_SET);
+    checkProcessCommandErrorMessage(INIT_ENVIRONMENT, parameters, SNAPSHOT_NOT_SET);
   }
 
   @Test
-  public void testInitTestrigDeltaInvalidParas() throws Exception {
-    testInvalidInput(INIT_DELTA_TESTRIG, new String[] {}, new String[] {});
+  public void testInitSnapshotDeltaInvalidParas() throws Exception {
+    testInvalidInput(INIT_DELTA_SNAPSHOT, new String[] {}, new String[] {});
   }
 
   @Test
-  public void testInitTestrigInvalidParas() throws Exception {
-    testInvalidInput(INIT_TESTRIG, new String[] {}, new String[] {});
+  public void testInitSnapshotInvalidParas() throws Exception {
+    testInvalidInput(INIT_SNAPSHOT, new String[] {}, new String[] {});
   }
 
   @Test
@@ -779,7 +780,7 @@ public class ClientTest {
 
   @Test
   public void testListEnvironmentsValidParas() throws Exception {
-    checkProcessCommandErrorMessage(LIST_ENVIRONMENTS, new String[] {}, TESTRIG_NOT_SET);
+    checkProcessCommandErrorMessage(LIST_ENVIRONMENTS, new String[] {}, SNAPSHOT_NOT_SET);
   }
 
   @Test
@@ -790,13 +791,13 @@ public class ClientTest {
 
   @Test
   public void testListQuestionsValidParas() throws Exception {
-    checkProcessCommandErrorMessage(LIST_QUESTIONS, new String[] {}, TESTRIG_NOT_SET);
+    checkProcessCommandErrorMessage(LIST_QUESTIONS, new String[] {}, SNAPSHOT_NOT_SET);
   }
 
   @Test
-  public void testListTestrigsInvalidParas() throws Exception {
+  public void testListSnapshotsInvalidParas() throws Exception {
     String[] parameters = new String[] {"parameter1"};
-    testInvalidInput(LIST_TESTRIGS, new String[] {}, parameters);
+    testInvalidInput(LIST_SNAPSHOTS, new String[] {}, parameters);
   }
 
   @Test
@@ -1189,15 +1190,15 @@ public class ClientTest {
   }
 
   @Test
-  public void testReinitTestrigDeltaInvalidParas() throws Exception {
+  public void testReinitSnapshotDeltaInvalidParas() throws Exception {
     String[] parameters = new String[] {"parameter1"};
-    testInvalidInput(REINIT_DELTA_TESTRIG, new String[] {}, parameters);
+    testInvalidInput(REINIT_DELTA_SNAPSHOT, new String[] {}, parameters);
   }
 
   @Test
-  public void testReinitTestrigInvalidParas() throws Exception {
+  public void testReinitSnapshotInvalidParas() throws Exception {
     String[] parameters = new String[] {"parameter1"};
-    testInvalidInput(REINIT_TESTRIG, new String[] {}, parameters);
+    testInvalidInput(REINIT_SNAPSHOT, new String[] {}, parameters);
   }
 
   @Test
@@ -1281,21 +1282,21 @@ public class ClientTest {
     testProcessCommandWithValidInput(
         SET_DELTA_ENV,
         parameters,
-        String.format("Active delta testrig->environment is now null->%s\n", parameters[0]));
+        String.format("Active delta snapshot->environment is now null->%s\n", parameters[0]));
   }
 
   @Test
-  public void testSetDeltaTestrigInvalidParas() throws Exception {
-    testInvalidInput(SET_DELTA_TESTRIG, new String[] {}, new String[] {});
+  public void testSetDeltaSnapshotInvalidParas() throws Exception {
+    testInvalidInput(SET_DELTA_SNAPSHOT, new String[] {}, new String[] {});
   }
 
   @Test
-  public void testSetDeltaTestrigValidParas() throws Exception {
+  public void testSetDeltaSnapshotValidParas() throws Exception {
     String[] parameters = new String[] {"parameter1"};
     testProcessCommandWithValidInput(
-        SET_DELTA_TESTRIG,
+        SET_DELTA_SNAPSHOT,
         parameters,
-        String.format("Delta testrig->env is now %s->env_default\n", parameters[0]));
+        String.format("Delta snapshot->env is now %s->env_default\n", parameters[0]));
   }
 
   @Test
@@ -1306,7 +1307,7 @@ public class ClientTest {
   @Test
   public void testSetEnvValidParas() throws Exception {
     String[] parameters = new String[] {"parameter1"};
-    checkProcessCommandErrorMessage(SET_ENV, parameters, TESTRIG_NOT_SET);
+    checkProcessCommandErrorMessage(SET_ENV, parameters, SNAPSHOT_NOT_SET);
   }
 
   @Test
@@ -1334,14 +1335,14 @@ public class ClientTest {
   }
 
   @Test
-  public void testSetTestrigInvalidParas() throws Exception {
-    testInvalidInput(SET_TESTRIG, new String[] {}, new String[] {});
+  public void testSetSnapshotInvalidParas() throws Exception {
+    testInvalidInput(SET_SNAPSHOT, new String[] {}, new String[] {});
   }
 
   @Test
-  public void testSetTestrigValidParas() throws Exception {
+  public void testSetSnapshotValidParas() throws Exception {
     String[] parameters = new String[] {"parameter1"};
-    checkProcessCommandErrorMessage(SET_TESTRIG, parameters, NETWORK_NOT_SET);
+    checkProcessCommandErrorMessage(SET_SNAPSHOT, parameters, NETWORK_NOT_SET);
   }
 
   @Test
@@ -1404,15 +1405,15 @@ public class ClientTest {
   }
 
   @Test
-  public void testShowDeltaTestrigInvalidParas() throws Exception {
+  public void testShowDeltaSnapshotInvalidParas() throws Exception {
     String[] parameters = new String[] {"parameter1"};
-    testInvalidInput(SHOW_DELTA_TESTRIG, new String[] {}, parameters);
+    testInvalidInput(SHOW_DELTA_SNAPSHOT, new String[] {}, parameters);
   }
 
   @Test
-  public void testShowDeltaTestrigValidParas() throws Exception {
+  public void testShowDeltaSnapshotValidParas() throws Exception {
     checkProcessCommandErrorMessage(
-        SHOW_DELTA_TESTRIG, new String[] {}, "Active delta testrig is not set\n");
+        SHOW_DELTA_SNAPSHOT, new String[] {}, "Active delta snapshot is not set\n");
   }
 
   @Test
@@ -1428,21 +1429,21 @@ public class ClientTest {
   }
 
   @Test
-  public void testShowTestrigInvalidParas() throws Exception {
+  public void testShowSnapshotInvalidParas() throws Exception {
     String[] parameters = new String[] {"parameter1"};
-    testInvalidInput(SHOW_TESTRIG, new String[] {}, parameters);
+    testInvalidInput(SHOW_SNAPSHOT, new String[] {}, parameters);
   }
 
   @Test
-  public void testShowTestrigValidParas() throws Exception {
+  public void testShowSnapshotValidParas() throws Exception {
     String[] parameters = new String[] {};
-    checkProcessCommandErrorMessage(SHOW_TESTRIG, parameters, TESTRIG_NOT_SET);
+    checkProcessCommandErrorMessage(SHOW_SNAPSHOT, parameters, SNAPSHOT_NOT_SET);
   }
 
   @Test
   public void testShowVersionInvalidParas() throws Exception {
     String[] parameters = new String[] {"parameter1"};
-    testInvalidInput(SHOW_TESTRIG, new String[] {}, parameters);
+    testInvalidInput(SHOW_SNAPSHOT, new String[] {}, parameters);
   }
 
   @Test
@@ -1496,7 +1497,7 @@ public class ClientTest {
   @Test
   public void testUploadCustomObjectValidParas() throws Exception {
     String[] parameters = new String[] {"parameter1", "parameter2"};
-    checkProcessCommandErrorMessage(UPLOAD_CUSTOM_OBJECT, parameters, TESTRIG_NOT_SET);
+    checkProcessCommandErrorMessage(UPLOAD_CUSTOM_OBJECT, parameters, SNAPSHOT_NOT_SET);
   }
 
   @Test

--- a/tests/ui-focused/commands
+++ b/tests/ui-focused/commands
@@ -4,11 +4,11 @@ add-batfish-option haltonconverterror
 add-batfish-option haltonparseerror
 add-batfish-option verboseparse
 
-### creating, listing, deleting testrigs
-init-testrig test_rigs/example testrig0
-init-testrig test_rigs/example testrig1
-test -raw tests/ui-focused/del-testrig.ref del-testrig testrig0
-test -raw tests/ui-focused/list-testrigs1.ref list-testrigs -nometadata
+### creating, listing, deleting snapshots
+init-snapshot test_rigs/example snapshot0
+init-snapshot test_rigs/example snapshot1
+test -raw tests/ui-focused/del-snapshot.ref del-snapshot snapshot0
+test -raw tests/ui-focused/list-snapshots1.ref list-snapshots -nometadata
 
 #### creating, listing, and deleting analyses
 test -raw tests/ui-focused/init-analysis0.ref init-analysis analysis0 tests/ui-focused/templates

--- a/tests/ui-focused/del-snapshot.ref
+++ b/tests/ui-focused/del-snapshot.ref
@@ -1,0 +1,1 @@
+Result of deleting snapshot: true

--- a/tests/ui-focused/del-testrig.ref
+++ b/tests/ui-focused/del-testrig.ref
@@ -1,1 +1,0 @@
-Result of deleting testrig: true

--- a/tests/ui-focused/list-snapshots1.ref
+++ b/tests/ui-focused/list-snapshots1.ref
@@ -1,4 +1,4 @@
-Testrig: testrig1
+Testrig: snapshot1
 configs/
   as1border1.cfg
   as1border2.cfg


### PR DESCRIPTION
Deprecates "testrig" terminology in Java client. Modeled after #1919. Also changes some internal terminology: "testrigdir" and "testrigid" became "snapshotdir" and "snapshotid". I don't think these are surfaced at all, so don't think changing them will affect existing clients. (A quick check with the web UI didn't trigger anything unusual.)