### PR TITLE
TableMetadata: remove display hints

### DIFF
--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/table/TableAnswerElementTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/table/TableAnswerElementTest.java
@@ -23,7 +23,7 @@ public class TableAnswerElementTest {
   @Test
   public void testComputeSummary() {
     // generate an answer with two rows
-    TableAnswerElement answer = new TableAnswerElement(new TableMetadata());
+    TableAnswerElement answer = new TableAnswerElement(new TableMetadata(null, "no desc"));
     answer.addRow(Row.builder().build());
     answer.addRow(Row.builder().build());
 
@@ -40,10 +40,10 @@ public class TableAnswerElementTest {
   public void testEvaluateAssertionCount() {
     Assertion twoCount = new Assertion(AssertionType.countequals, new IntNode(2));
 
-    TableAnswerElement oneRow = new TableAnswerElement(new TableMetadata());
+    TableAnswerElement oneRow = new TableAnswerElement(new TableMetadata(null, "no desc"));
     oneRow.addRow(Row.builder().build());
 
-    TableAnswerElement twoRows = new TableAnswerElement(new TableMetadata());
+    TableAnswerElement twoRows = new TableAnswerElement(new TableMetadata(null, "no desc"));
     twoRows.addRow(Row.builder().build());
     twoRows.addRow(Row.builder().build());
 
@@ -61,7 +61,7 @@ public class TableAnswerElementTest {
                 .readValue("[{\"key1\": \"value1\"}, {\"key2\": \"value2\"}]", JsonNode.class));
 
     // adding rows in different order shouldn't matter
-    TableAnswerElement otherRows = new TableAnswerElement(new TableMetadata());
+    TableAnswerElement otherRows = new TableAnswerElement(new TableMetadata(null, "no desc"));
     otherRows.addRow(Row.builder().put("key2", "value2").build());
     otherRows.addRow(Row.builder().put("key1", "value1").build());
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/table/TableDiffTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/table/TableDiffTest.java
@@ -12,7 +12,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import org.batfish.datamodel.answers.Schema;
-import org.batfish.datamodel.questions.DisplayHints;
 import org.batfish.datamodel.table.Row.RowBuilder;
 import org.junit.Test;
 
@@ -133,10 +132,10 @@ public class TableDiffTest {
                     TableDiff.baseColumnName("neither"), Schema.STRING, "neither", false, false),
                 new ColumnMetadata(
                     TableDiff.deltaColumnName("neither"), Schema.STRING, "neither", false, false)),
-            new DisplayHints(null, null, "[key, both]"));
+            "[key, both]");
 
     assertThat(
-        TableDiff.diffMetadata(new TableMetadata(inputColumns, null)), equalTo(expectedMetadata));
+        TableDiff.diffMetadata(new TableMetadata(inputColumns, "desc")), equalTo(expectedMetadata));
   }
 
   @Test
@@ -145,7 +144,7 @@ public class TableDiffTest {
     Row deltaRow = mixRow(null, null, null, "neither2");
 
     RowBuilder diff = Row.builder();
-    TableDiff.diffRowValues(diff, baseRow, deltaRow, new TableMetadata(mixColumns(), null));
+    TableDiff.diffRowValues(diff, baseRow, deltaRow, new TableMetadata(mixColumns(), "desc"));
     assertThat(
         diff.build(),
         equalTo(
@@ -172,7 +171,8 @@ public class TableDiffTest {
     Row row = Row.of("key", "value");
     TableMetadata metadata =
         new TableMetadata(
-            ImmutableList.of(new ColumnMetadata("key", Schema.STRING, "desc", false, true)), null);
+            ImmutableList.of(new ColumnMetadata("key", Schema.STRING, "desc", false, true)),
+            "desc");
 
     // delta is null
     RowBuilder diff1 = Row.builder();
@@ -214,7 +214,7 @@ public class TableDiffTest {
         ImmutableList.of(
             new ColumnMetadata("key", Schema.STRING, "key", true, false),
             new ColumnMetadata("value", Schema.STRING, "value", false, true));
-    TableMetadata metadata = new TableMetadata(columns, null);
+    TableMetadata metadata = new TableMetadata(columns, "desc");
 
     Row row1 = Row.of("key", "sameKey", "value", "value1");
     Row row2 = Row.of("key", "sameKey", "value", "value2");
@@ -248,7 +248,7 @@ public class TableDiffTest {
         ImmutableList.of(
             new ColumnMetadata("key", Schema.STRING, "key", true, false),
             new ColumnMetadata("value", Schema.STRING, "value", false, true));
-    TableMetadata metadata = new TableMetadata(columns, null);
+    TableMetadata metadata = new TableMetadata(columns, "desc");
 
     Row row1 = Row.of("key", "sameKey", "value", "value1");
     Row row2 = Row.of("key", "sameKey", "value", "value2");
@@ -278,7 +278,7 @@ public class TableDiffTest {
   @Test
   public void diffTablesTestRowContent() {
     List<ColumnMetadata> columns = mixColumns();
-    TableMetadata metadata = new TableMetadata(columns, null);
+    TableMetadata metadata = new TableMetadata(columns, "desc");
 
     Row row1 = mixRow("key1", "both1", "value1", "neither1");
     Row row2 = mixRow("key1", "both1", "value2", "neither2");
@@ -309,7 +309,7 @@ public class TableDiffTest {
     TableMetadata noKeys =
         new TableMetadata(
             ImmutableList.of(new ColumnMetadata("value", Schema.STRING, "value", false, true)),
-            null);
+            "desc");
 
     Row row1 = Row.of("value", "value1");
     Row row2 = Row.of("value", "value2");
@@ -335,7 +335,7 @@ public class TableDiffTest {
   public void diffTablesTestAllKeys() {
     TableMetadata noKeys =
         new TableMetadata(
-            ImmutableList.of(new ColumnMetadata("key", Schema.STRING, "key", true, false)), null);
+            ImmutableList.of(new ColumnMetadata("key", Schema.STRING, "key", true, false)), "desc");
 
     Row row1 = Row.of("key", "key1");
     Row row2 = Row.of("key", "key2");

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/table/TableMetadataTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/table/TableMetadataTest.java
@@ -22,6 +22,6 @@ public class TableMetadataTest {
     _thrown.expect(IllegalArgumentException.class);
     _thrown.expectMessage("Cannot have two columns with the same name");
 
-    new TableMetadata(columns, null);
+    new TableMetadata(columns, "desc");
   }
 }

--- a/projects/question/src/main/java/org/batfish/question/aaaauthenticationlogin/AaaAuthenticationLoginAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/aaaauthenticationlogin/AaaAuthenticationLoginAnswerer.java
@@ -1,5 +1,7 @@
 package org.batfish.question.aaaauthenticationlogin;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
@@ -28,6 +30,11 @@ public class AaaAuthenticationLoginAnswerer extends Answerer {
   public static final String COLUMN_NODE = "node";
   public static final String COLUMN_LINE_NAMES = "lineNames";
 
+  private static final String TEXT_DESC =
+      String.format(
+          "Node ${%s} does not require authentication on line(s) ${%s}",
+          COLUMN_NODE, COLUMN_LINE_NAMES);
+
   public AaaAuthenticationLoginAnswerer(Question question, IBatfish batfish) {
     super(question, batfish);
   }
@@ -46,15 +53,13 @@ public class AaaAuthenticationLoginAnswerer extends Answerer {
             new ColumnMetadata(COLUMN_NODE, Schema.NODE, "Node", true, false),
             new ColumnMetadata(
                 COLUMN_LINE_NAMES, Schema.list(Schema.STRING), "Line names", false, true));
+    String textDesc = TEXT_DESC;
     DisplayHints dhints = question.getDisplayHints();
-    if (dhints == null) {
-      dhints = new DisplayHints();
-      dhints.setTextDesc(
-          String.format(
-              "Node ${%s} does not require authentication on line(s) ${%s}",
-              COLUMN_NODE, COLUMN_LINE_NAMES));
+    if (dhints != null) {
+      textDesc = firstNonNull(dhints.getTextDesc(), textDesc);
     }
-    TableMetadata metadata = new TableMetadata(columnMetadata, dhints);
+
+    TableMetadata metadata = new TableMetadata(columnMetadata, textDesc);
     return new TableAnswerElement(metadata);
   }
 

--- a/projects/question/src/main/java/org/batfish/question/aclreachability2/AclReachability2Answerer.java
+++ b/projects/question/src/main/java/org/batfish/question/aclreachability2/AclReachability2Answerer.java
@@ -94,11 +94,11 @@ public class AclReachability2Answerer extends Answerer {
                     AclLines2Rows.COL_MESSAGE, Schema.STRING, "Message", false, false))
             .build();
 
+    String textDesc = String.format("${%s}", AclLines2Rows.COL_MESSAGE);
     DisplayHints dhints = question.getDisplayHints();
-    if (dhints == null) {
-      dhints = new DisplayHints();
-      dhints.setTextDesc(String.format("${%s}", AclLines2Rows.COL_MESSAGE));
+    if (dhints != null && dhints.getTextDesc() != null) {
+      textDesc = dhints.getTextDesc();
     }
-    return new TableMetadata(columnMetadata, dhints);
+    return new TableMetadata(columnMetadata, textDesc);
   }
 }

--- a/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionStatusAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionStatusAnswerer.java
@@ -290,15 +290,15 @@ public class BgpSessionStatusAnswerer extends Answerer {
                 false,
                 true));
 
+    String textDesc =
+        String.format(
+            "On ${%s} session ${%s}:${%s} has configured status ${%s}.",
+            COL_NODE, COL_VRF_NAME, COL_REMOTE_PREFIX, COL_CONFIGURED_STATUS);
     DisplayHints dhints = question.getDisplayHints();
-    if (dhints == null) {
-      dhints = new DisplayHints();
-      dhints.setTextDesc(
-          String.format(
-              "On ${%s} session ${%s}:${%s} has configured status ${%s}.",
-              COL_NODE, COL_VRF_NAME, COL_REMOTE_PREFIX, COL_CONFIGURED_STATUS));
+    if (dhints != null && dhints.getTextDesc() != null) {
+      textDesc = dhints.getTextDesc();
     }
-    return new TableMetadata(columnMetadata, dhints);
+    return new TableMetadata(columnMetadata, textDesc);
   }
 
   /**

--- a/projects/question/src/main/java/org/batfish/question/definedstructures/DefinedStructuresAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/definedstructures/DefinedStructuresAnswerer.java
@@ -92,19 +92,19 @@ public class DefinedStructuresAnswerer extends Answerer {
                 false,
                 true));
 
+    String textDesc =
+        String.format(
+            "On ${%s} struct ${%s}:${%s} on lines ${%s} has ${%s} references.",
+            COL_NODE_NAME,
+            COL_STRUCT_TYPE,
+            COL_STRUCT_NAME,
+            COL_DEFINITION_LINES,
+            COL_NUM_REFERENCES);
     DisplayHints dhints = question.getDisplayHints();
-    if (dhints == null) {
-      dhints = new DisplayHints();
-      dhints.setTextDesc(
-          String.format(
-              "On ${%s} struct ${%s}:${%s} on lines ${%s} has ${%s} references.",
-              COL_NODE_NAME,
-              COL_STRUCT_TYPE,
-              COL_STRUCT_NAME,
-              COL_DEFINITION_LINES,
-              COL_NUM_REFERENCES));
+    if (dhints != null && dhints.getTextDesc() != null) {
+      textDesc = dhints.getTextDesc();
     }
-    return new TableMetadata(columnMetadataMap, dhints);
+    return new TableMetadata(columnMetadataMap, textDesc);
   }
 
   private static Row toRow(DefinedStructureRow info) {

--- a/projects/question/src/main/java/org/batfish/question/filtertable/FilterTableAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/filtertable/FilterTableAnswerer.java
@@ -54,9 +54,7 @@ public class FilterTableAnswerer extends Answerer {
               .filter(cm -> question.getColumns().contains(cm.getName()))
               .collect(Collectors.toList());
 
-      // this copying can create issues when displayHints mention columns we have removed
-      // leaving this alone as we are likely to get rid of displayHints altogether
-      return new TableMetadata(columnMetadata, innerMetadata.getDisplayHints());
+      return new TableMetadata(columnMetadata, innerMetadata.getTextDesc());
     }
   }
 

--- a/projects/question/src/main/java/org/batfish/question/interfaceproperties/InterfacePropertiesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/interfaceproperties/InterfacePropertiesAnswerer.java
@@ -61,12 +61,12 @@ public class InterfacePropertiesAnswerer extends Answerer {
                     .collect(Collectors.toList()))
             .build();
 
+    String textDesc = String.format("Properties of interface ${%s}.", COL_INTERFACE);
     DisplayHints dhints = question.getDisplayHints();
-    if (dhints == null) {
-      dhints = new DisplayHints();
-      dhints.setTextDesc(String.format("Properties of interface ${%s}.", COL_INTERFACE));
+    if (dhints != null && dhints.getTextDesc() != null) {
+      textDesc = dhints.getTextDesc();
     }
-    return new TableMetadata(columnMetadata, dhints);
+    return new TableMetadata(columnMetadata, textDesc);
   }
 
   @Override

--- a/projects/question/src/main/java/org/batfish/question/ipowners/IpOwnersAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/ipowners/IpOwnersAnswerer.java
@@ -17,7 +17,6 @@ import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.answers.AnswerElement;
 import org.batfish.datamodel.answers.Schema;
 import org.batfish.datamodel.pojo.Node;
-import org.batfish.datamodel.questions.DisplayHints;
 import org.batfish.datamodel.questions.Question;
 import org.batfish.datamodel.table.ColumnMetadata;
 import org.batfish.datamodel.table.Row;
@@ -86,12 +85,11 @@ class IpOwnersAnswerer extends Answerer {
   /** Create table metadata for this answer. */
   private static TableMetadata getTableMetadata() {
     List<ColumnMetadata> columnMetadata = getColumnMetadata();
-    DisplayHints displayHints = new DisplayHints();
-    displayHints.setTextDesc(
+    return new TableMetadata(
+        columnMetadata,
         String.format(
             "On node ${%s} in VRF ${%s}, interface ${%s} has IP ${%s}.",
             COL_NODE, COL_VRFNAME, COL_INTERFACE_NAME, COL_IP));
-    return new TableMetadata(columnMetadata, displayHints);
   }
 
   /** Create column metadata. */

--- a/projects/question/src/main/java/org/batfish/question/nodeproperties/NodePropertiesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/nodeproperties/NodePropertiesAnswerer.java
@@ -58,12 +58,12 @@ public class NodePropertiesAnswerer extends Answerer {
                     .collect(Collectors.toList()))
             .build();
 
+    String textDesc = String.format("Properties of node ${%s}.", COL_NODE);
     DisplayHints dhints = question.getDisplayHints();
-    if (dhints == null) {
-      dhints = new DisplayHints();
-      dhints.setTextDesc(String.format("Properties of node ${%s}.", COL_NODE));
+    if (dhints != null && dhints.getTextDesc() != null) {
+      textDesc = dhints.getTextDesc();
     }
-    return new TableMetadata(columnMetadata, dhints);
+    return new TableMetadata(columnMetadata, textDesc);
   }
 
   @Override

--- a/projects/question/src/main/java/org/batfish/question/prefixtracer/PrefixTracerAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/prefixtracer/PrefixTracerAnswerer.java
@@ -17,7 +17,6 @@ import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.answers.AnswerElement;
 import org.batfish.datamodel.answers.Schema;
 import org.batfish.datamodel.pojo.Node;
-import org.batfish.datamodel.questions.DisplayHints;
 import org.batfish.datamodel.questions.NodesSpecifier;
 import org.batfish.datamodel.questions.Question;
 import org.batfish.datamodel.table.ColumnMetadata;
@@ -100,12 +99,11 @@ class PrefixTracerAnswerer extends Answerer {
             new ColumnMetadata(COL_ACTION, Schema.STRING, "The action that takes place"),
             new ColumnMetadata(COL_PREFIX, Schema.PREFIX, "The prefix in question"));
 
-    DisplayHints dhints = new DisplayHints();
-    dhints.setTextDesc(
-        String.format(
-            "For prefix ${%s}, on node ${%s} action ${%s} was taken for peer {%s}",
-            COL_PREFIX, COL_NODE, COL_ACTION, COL_PEER));
-
-    return new TableMetadata(columnMetadata, dhints);
+    return new TableMetadata(columnMetadata, TEXT_DESC);
   }
+
+  private static final String TEXT_DESC =
+      String.format(
+          "For prefix ${%s}, on node ${%s} action ${%s} was taken for peer {%s}",
+          COL_PREFIX, COL_NODE, COL_ACTION, COL_PEER);
 }

--- a/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswerer.java
@@ -29,7 +29,6 @@ import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.answers.AnswerElement;
 import org.batfish.datamodel.answers.Schema;
 import org.batfish.datamodel.pojo.Node;
-import org.batfish.datamodel.questions.DisplayHints;
 import org.batfish.datamodel.questions.Question;
 import org.batfish.datamodel.table.ColumnMetadata;
 import org.batfish.datamodel.table.Row;
@@ -265,9 +264,7 @@ public class RoutesAnswerer extends Answerer {
             new ColumnMetadata(
                 COL_METRIC, Schema.INTEGER, "Route's metric", Boolean.FALSE, Boolean.TRUE));
     }
-    DisplayHints dh = new DisplayHints();
-    dh.setTextDesc("Display RIB routes");
-    return new TableMetadata(columnBuilder.build(), dh);
+    return new TableMetadata(columnBuilder.build(), "Display RIB routes");
   }
 
   /** Generate table columns that should be always present, at the start of table. */

--- a/projects/question/src/main/java/org/batfish/question/tracefilters/TraceFiltersAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/tracefilters/TraceFiltersAnswerer.java
@@ -56,20 +56,20 @@ public class TraceFiltersAnswerer extends Answerer {
             new ColumnMetadata(COLUMN_LINE_NUMBER, Schema.INTEGER, "Line number", false, true),
             new ColumnMetadata(COLUMN_LINE_CONTENT, Schema.STRING, "Line content", false, true),
             new ColumnMetadata(COLUMN_TRACE, Schema.ACL_TRACE, "ACL trace", false, true));
+    String textDesc =
+        String.format(
+            "Filter ${%s} on node ${%s} will ${%s} flow ${%s} at line ${%s} ${%s}",
+            COLUMN_FILTER_NAME,
+            COLUMN_NODE,
+            COLUMN_ACTION,
+            COLUMN_FLOW,
+            COLUMN_LINE_NUMBER,
+            COLUMN_LINE_CONTENT);
     DisplayHints dhints = question.getDisplayHints();
-    if (dhints == null) {
-      dhints = new DisplayHints();
-      dhints.setTextDesc(
-          String.format(
-              "Filter ${%s} on node ${%s} will ${%s} flow ${%s} at line ${%s} ${%s}",
-              COLUMN_FILTER_NAME,
-              COLUMN_NODE,
-              COLUMN_ACTION,
-              COLUMN_FLOW,
-              COLUMN_LINE_NUMBER,
-              COLUMN_LINE_CONTENT));
+    if (dhints != null && dhints.getTextDesc() != null) {
+      textDesc = dhints.getTextDesc();
     }
-    TableMetadata metadata = new TableMetadata(columnMetadata, dhints);
+    TableMetadata metadata = new TableMetadata(columnMetadata, textDesc);
     return new TableAnswerElement(metadata);
   }
 

--- a/projects/question/src/main/java/org/batfish/question/traceroute/TracerouteAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/traceroute/TracerouteAnswerer.java
@@ -24,7 +24,6 @@ import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.answers.AnswerElement;
 import org.batfish.datamodel.answers.Schema;
 import org.batfish.datamodel.pojo.Node;
-import org.batfish.datamodel.questions.DisplayHints;
 import org.batfish.datamodel.questions.Question;
 import org.batfish.datamodel.table.ColumnMetadata;
 import org.batfish.datamodel.table.Row;
@@ -103,10 +102,7 @@ public final class TracerouteAnswerer extends Answerer {
                 COL_RESULTS, Schema.set(Schema.STRING), "The set of outcomes", false, true),
             new ColumnMetadata(COL_PATHS, Schema.set(Schema.FLOW_TRACE), "The paths", false, true));
 
-    DisplayHints dhints = new DisplayHints();
-    dhints.setTextDesc(String.format("Paths for flow ${%s}", COL_FLOW));
-
-    return new TableMetadata(columnMetadata, dhints);
+    return new TableMetadata(columnMetadata, String.format("Paths for flow ${%s}", COL_FLOW));
   }
 
   /**

--- a/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
@@ -60,7 +60,6 @@ import org.batfish.datamodel.StaticRoute;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.answers.AnswerElement;
 import org.batfish.datamodel.answers.Schema;
-import org.batfish.datamodel.questions.DisplayHints;
 import org.batfish.datamodel.table.ColumnMetadata;
 import org.batfish.datamodel.table.Row;
 import org.batfish.question.routes.RoutesQuestion.RibProtocol;
@@ -308,12 +307,11 @@ public class RoutesAnswererTest {
   }
 
   @Test
-  public void testHasDisplayHints() {
-    DisplayHints dh = getTableMetadata(RibProtocol.ALL).getDisplayHints();
+  public void testHasTextDesc() {
+    String textDesc = getTableMetadata(RibProtocol.ALL).getTextDesc();
 
-    assert dh != null;
-    assertThat(dh.getTextDesc(), notNullValue());
-    assertThat(dh.getTextDesc(), not(emptyString()));
+    assertThat(textDesc, notNullValue());
+    assertThat(textDesc, not(emptyString()));
   }
 
   static class MockBatfish extends IBatfishTestAdapter {

--- a/tests/basic/aclReachability2.ref
+++ b/tests/basic/aclReachability2.ref
@@ -46,9 +46,7 @@
           "schema" : "String"
         }
       ],
-      "displayHints" : {
-        "textDesc" : "${message}"
-      }
+      "textDesc" : "${message}"
     },
     "rows" : [
       {

--- a/tests/basic/bgpSessionStatusNew.ref
+++ b/tests/basic/bgpSessionStatusNew.ref
@@ -67,9 +67,7 @@
           "schema" : "Integer"
         }
       ],
-      "displayHints" : {
-        "textDesc" : "On ${node} session ${vrfName}:${remotePrefix} has configured status ${configuredStatus}."
-      }
+      "textDesc" : "On ${node} session ${vrfName}:${remotePrefix} has configured status ${configuredStatus}."
     },
     "rows" : [
       {

--- a/tests/basic/tracefilters.ref
+++ b/tests/basic/tracefilters.ref
@@ -53,9 +53,7 @@
           "schema" : "AclTrace"
         }
       ],
-      "displayHints" : {
-        "textDesc" : "Filter ${filterName} on node ${node} will ${action} flow ${flow} at line ${lineNumber} ${lineContent}"
-      }
+      "textDesc" : "Filter ${filterName} on node ${node} will ${action} flow ${flow} at line ${lineNumber} ${lineContent}"
     },
     "rows" : [
       {

--- a/tests/basic/traceroute2-1-2.ref
+++ b/tests/basic/traceroute2-1-2.ref
@@ -46,9 +46,7 @@
           "schema" : "Set<FlowTrace>"
         }
       ],
-      "displayHints" : {
-        "textDesc" : "Paths for flow ${flow}"
-      }
+      "textDesc" : "Paths for flow ${flow}"
     },
     "rows" : [
       {

--- a/tests/basic/traceroute2-2-1.ref
+++ b/tests/basic/traceroute2-2-1.ref
@@ -46,9 +46,7 @@
           "schema" : "Set<FlowTrace>"
         }
       ],
-      "displayHints" : {
-        "textDesc" : "Paths for flow ${flow}"
-      }
+      "textDesc" : "Paths for flow ${flow}"
     },
     "rows" : [
       {

--- a/tests/jsonpathtotable/ntpservers.ref
+++ b/tests/jsonpathtotable/ntpservers.ref
@@ -18,9 +18,7 @@
           "schema" : "Node"
         }
       ],
-      "displayHints" : {
-        "textDesc" : "The NTP servers of ${node} are ${ntpServers}"
-      }
+      "textDesc" : "The NTP servers of ${node} are ${ntpServers}"
     },
     "excludedRows" : [
       {


### PR DESCRIPTION
Replace it with text description. This is backwards-compatible: questions that
have a displayHints field will get parsed but all will be ignored other than
the textDesc property.

(see ref changes, but no json changes).