### PR TITLE
Fix angle brackets in javadocs

### DIFF
--- a/projects/allinone/src/test/java/org/batfish/allinone/PathDiffTest.java
+++ b/projects/allinone/src/test/java/org/batfish/allinone/PathDiffTest.java
@@ -32,7 +32,7 @@ import org.junit.rules.TemporaryFolder;
 public class PathDiffTest {
   @Rule public TemporaryFolder tmp = new TemporaryFolder();
 
-  /** 3.3.3.3/32 <--- A <---> B ---> 4.4.4.4/32 */
+  /** 3.3.3.3/32 &lt;--- A &lt;---&gt; B ---&gt; 4.4.4.4/32 */
   private static SortedMap<String, Configuration> twoNodeNetwork(boolean connected) {
     NetworkFactory nf = new NetworkFactory();
     Configuration.Builder cb =

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
@@ -316,7 +316,10 @@ public class CommonUtil {
     return 0;
   }
 
-  /** Compute the {@link Ip}s owned by each interface. hostname -> interface name -> {@link Ip}s. */
+  /**
+   * Compute the {@link Ip}s owned by each interface. hostname -&gt; interface name -&gt; {@link
+   * Ip}s.
+   */
   public static Map<String, Map<String, Set<Ip>>> computeInterfaceOwnedIps(
       Map<String, Configuration> configurations, boolean excludeInactive) {
     return computeInterfaceOwnedIps(
@@ -324,8 +327,8 @@ public class CommonUtil {
   }
 
   /**
-   * Invert a mapping from {@link Ip} to owner interfaces (Ip -> hostname -> interface name) to
-   * (hostname -> interface name -> Ip).
+   * Invert a mapping from {@link Ip} to owner interfaces (Ip -&gt; hostname -&gt; interface name)
+   * to (hostname -&gt; interface name -&gt; Ip).
    */
   public static Map<String, Map<String, Set<Ip>>> computeInterfaceOwnedIps(
       Map<Ip, Map<String, Set<String>>> ipInterfaceOwners) {
@@ -354,8 +357,8 @@ public class CommonUtil {
   }
 
   /**
-   * Invert a mapping from {@link Ip} to owner interfaces (Ip -> hostname -> interface name) and
-   * convert the set of owned Ips into an IpSpace.
+   * Invert a mapping from {@link Ip} to owner interfaces (Ip -&gt; hostname -&gt; interface name)
+   * and convert the set of owned Ips into an IpSpace.
    */
   public static Map<String, Map<String, IpSpace>> computeInterfaceOwnedIpSpaces(
       Map<Ip, Map<String, Set<String>>> ipInterfaceOwners) {
@@ -397,8 +400,8 @@ public class CommonUtil {
    * Compute a mapping from IP address to the interfaces that "own" that IP (e.g., as an network
    * interface address)
    *
-   * @param enabledInterfaces A mapping of enabled interfaces hostname -> interface name -> {@link
-   *     Interface}
+   * @param enabledInterfaces A mapping of enabled interfaces hostname -&gt; interface name -&gt;
+   *     {@link Interface}
    * @param excludeInactive whether to ignore inactive interfaces
    * @return A map from {@link Ip}s to the {@link Interface}s that own them
    */
@@ -478,8 +481,8 @@ public class CommonUtil {
    * address).
    *
    * @param excludeInactive whether to ignore inactive interfaces
-   * @param enabledInterfaces A mapping of enabled interfaces hostname -> interface name -> {@link
-   *     Interface}
+   * @param enabledInterfaces A mapping of enabled interfaces hostname -&gt; interface name -&gt;
+   *     {@link Interface}
    * @return A map of {@link Ip}s to a map of hostnames to vrfs that own the Ip.
    */
   public static Map<Ip, Map<String, Set<String>>> computeIpVrfOwners(
@@ -511,7 +514,10 @@ public class CommonUtil {
                         .collect(ImmutableSet.toImmutableSet())));
   }
 
-  /** Aggregate a mapping (Ip -> host name -> interface name) to (Ip -> host name -> vrf name) */
+  /**
+   * Aggregate a mapping (Ip -&gt; host name -&gt; interface name) to (Ip -&gt; host name -&gt; vrf
+   * name)
+   */
   public static Map<Ip, Map<String, Set<String>>> computeIpVrfOwners(
       Map<Ip, Map<String, Set<String>>> ipInterfaceOwners, Map<String, Configuration> configs) {
     return toImmutableMap(
@@ -537,8 +543,8 @@ public class CommonUtil {
   }
 
   /**
-   * Invert a mapping from Ip to VRF owners (Ip -> host name -> VRF name) and combine all IPs owned
-   * by each VRF into an IpSpace.
+   * Invert a mapping from Ip to VRF owners (Ip -&gt; host name -&gt; VRF name) and combine all IPs
+   * owned by each VRF into an IpSpace.
    */
   public static Map<String, Map<String, IpSpace>> computeVrfOwnedIpSpaces(
       Map<Ip, Map<String, Set<String>>> ipVrfOwners) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Configuration.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Configuration.java
@@ -231,7 +231,7 @@ public final class Configuration implements Serializable {
 
   private final String _name;
 
-  /** Normal => Excluding extended and reserved vlans that should not be modified or deleted. */
+  /** Normal =&gt; Excluding extended and reserved vlans that should not be modified or deleted. */
   private SubRange _normalVlanRange;
 
   private NavigableSet<String> _ntpServers;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/DataPlane.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/DataPlane.java
@@ -21,18 +21,18 @@ public interface DataPlane extends Serializable {
   ForwardingAnalysis getForwardingAnalysis();
 
   /**
-   * Return the map of Ip owners (as computed during dataplane computation). Map structure: Ip ->
+   * Return the map of Ip owners (as computed during dataplane computation). Map structure: Ip -&gt;
    * Set of hostnames
    */
   Map<Ip, Set<String>> getIpOwners();
 
   /**
    * Return the map of Vrfs that own each Ip (as computed during dataplane computation). Map
-   * structure: Ip -> hostname -> set of Vrfs
+   * structure: Ip -&gt; hostname -&gt; set of Vrfs
    */
   Map<Ip, Map<String, Set<String>>> getIpVrfOwners();
 
-  /** Return the set of all (main) RIBs. Map structure: hostname -> VRF name -> GenericRib */
+  /** Return the set of all (main) RIBs. Map structure: hostname -&gt; VRF name -&gt; GenericRib */
   SortedMap<String, SortedMap<String, GenericRib<AbstractRoute>>> getRibs();
 
   /** Return the network (i.e., layer 3) topology */
@@ -42,8 +42,8 @@ public interface DataPlane extends Serializable {
   SortedSet<Edge> getTopologyEdges();
 
   /**
-   * Return the summary of route prefix propagation. Map structure: Hostname -> VRF name -> Prefix
-   * -> action taken -> set of hostnames (peers).
+   * Return the summary of route prefix propagation. Map structure: Hostname -&gt; VRF name -&gt;
+   * Prefix -&gt; action taken -&gt; set of hostnames (peers).
    */
   SortedMap<String, SortedMap<String, Map<Prefix, Map<String, Set<String>>>>>
       getPrefixTracingInfoSummary();

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Fib.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Fib.java
@@ -7,11 +7,11 @@ import javax.annotation.Nonnull;
 
 public interface Fib extends Serializable {
 
-  /** Mapping: route -> nexthopinterface -> nextHopIp -> interfaceRoutes */
+  /** Mapping: route -&gt; nexthopinterface -&gt; nextHopIp -&gt; interfaceRoutes */
   @Nonnull
   Map<AbstractRoute, Map<String, Map<Ip, Set<AbstractRoute>>>> getNextHopInterfaces();
 
-  /** Mapping: nextHopInterface -> nextHopIp -> interfaceRoutes */
+  /** Mapping: nextHopInterface -&gt; nextHopIp -&gt; interfaceRoutes */
   @Nonnull
   Map<String, Map<Ip, Set<AbstractRoute>>> getNextHopInterfaces(Ip ip);
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibImpl.java
@@ -38,7 +38,7 @@ public class FibImpl implements Fib {
    *
    * @param rib {@link GenericRib} for which to do the resolution.
    * @param route {@link AbstractRoute} with a next hop IP to be resolved.
-   * @return A map (interface name -> last hop IP -> last taken route) for
+   * @return A map (interface name -&gt; last hop IP -&gt; last taken route) for
    * @throws BatfishException if resolution depth is exceeded (high likelihood of a routing loop) OR
    *     an invalid route in the RIB has been encountered.
    */
@@ -108,7 +108,7 @@ public class FibImpl implements Fib {
     }
   }
 
-  /** Mapping: route -> nextHopInterface -> nextHopIp -> interfaceRoutes */
+  /** Mapping: route -&gt; nextHopInterface -&gt; nextHopIp -&gt; interfaceRoutes */
   @Override
   public @Nonnull Map<AbstractRoute, Map<String, Map<Ip, Set<AbstractRoute>>>>
       getNextHopInterfaces() {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ForwardingAnalysis.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ForwardingAnalysis.java
@@ -4,24 +4,24 @@ import java.util.Map;
 
 public interface ForwardingAnalysis {
 
-  /** Mapping: hostname -> inInterface -> ipsToArpReplyTo */
+  /** Mapping: hostname -&gt; inInterface -&gt; ipsToArpReplyTo */
   Map<String, Map<String, IpSpace>> getArpReplies();
 
-  /** Mapping: edge -> dstIpsForWhichArpReplySent */
+  /** Mapping: edge -&gt; dstIpsForWhichArpReplySent */
   Map<Edge, IpSpace> getArpTrueEdge();
 
-  /** Mapping: hostname -> vrfName -> outInterface -> dstIpsForWhichNoArpResponse */
+  /** Mapping: hostname -&gt; vrfName -&gt; outInterface -&gt; dstIpsForWhichNoArpResponse */
   Map<String, Map<String, Map<String, IpSpace>>> getNeighborUnreachable();
 
   /**
-   * Mapping: hostname -> vrfName -> nullRoutedIps <br>
+   * Mapping: hostname -&gt; vrfName -&gt; nullRoutedIps <br>
    * A nullable IP is a destination IP for which there is a longest-prefix-match route that discards
    * the packet rather than forwarding it out some interface.
    */
   Map<String, Map<String, IpSpace>> getNullRoutedIps();
 
   /**
-   * Mapping: hostname -> vrfName -> routableIps <br>
+   * Mapping: hostname -&gt; vrfName -&gt; routableIps <br>
    * A routable IP is a destination IP for which there is a longest-prefix-match route.
    */
   Map<String, Map<String, IpSpace>> getRoutableIps();

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/NamedStructureEquivalenceSets.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/NamedStructureEquivalenceSets.java
@@ -177,7 +177,7 @@ public class NamedStructureEquivalenceSets<T> {
   }
 
   /**
-   * Mapping: hostname -> names of structures of this type for which named host is the
+   * Mapping: hostname -&gt; names of structures of this type for which named host is the
    * representative
    */
   @JsonIgnore

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/FiltersSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/FiltersSpecifier.java
@@ -19,8 +19,8 @@ import org.batfish.datamodel.IpAccessList;
  * <p>Currently supported example specifiers:
  *
  * <ul>
- *   <li>lhr-.* —> all filters with matching names
- *   <li>name:lhr-.* -> same as above; name: is optional
+ *   <li>lhr-.* -&gt; all filters with matching names
+ *   <li>name:lhr-.* -&gt; same as above; name: is optional
  *   <li>ipv4:lhr-.* all IPv4 access lists with matching names
  *   <li>ipv6:lhr-.* all IPv6 access lists with matching names
  * </ul>

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/InterfacePropertySpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/InterfacePropertySpecifier.java
@@ -18,7 +18,7 @@ import org.batfish.datamodel.answers.Schema;
  * <p>Currently supported example specifiers:
  *
  * <ul>
- *   <li>channel-group —> gets the interface's channel groups using a configured Java function
+ *   <li>channel-group -&gt; gets the interface's channel groups using a configured Java function
  *   <li>channel.* gets all properties that start with 'channel'
  * </ul>
  *

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/InterfacesSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/InterfacesSpecifier.java
@@ -15,8 +15,8 @@ import org.batfish.datamodel.Interface;
  * <p>Currently supported example specifiers:
  *
  * <ul>
- *   <li>Loopback.* —> all interfaces with matching names
- *   <li>desc:KK.* -> all interfaces whose description matches KK.*
+ *   <li>Loopback.* -&gt; all interfaces with matching names
+ *   <li>desc:KK.* -&gt; all interfaces whose description matches KK.*
  * </ul>
  *
  * <p>In the future, we might need other tags and boolean expressions over tags.

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/NodePropertySpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/NodePropertySpecifier.java
@@ -18,7 +18,7 @@ import org.batfish.datamodel.answers.Schema;
  * <p>Currently supported example specifier:
  *
  * <ul>
- *   <li>ntp-servers —> gets NTP servers using a configured Java function
+ *   <li>ntp-servers -&gt; gets NTP servers using a configured Java function
  *   <li>ntp.* gets all properties that start with 'ntp'
  * </ul>
  *

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/NodesSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/NodesSpecifier.java
@@ -25,9 +25,9 @@ import org.batfish.role.NodeRolesData;
  * <p>Currently supported example specifiers:
  *
  * <ul>
- *   <li>lhr-.* —> all nodes with matching names (old style)
- *   <li>name:lhr-.* -> same as above; name: is optional
- *   <li>role:auto0:a1.* —> all nodes with roles that match a1.* in role dimension auto0
+ *   <li>lhr-.* -&gt; all nodes with matching names (old style)
+ *   <li>name:lhr-.* -&gt; same as above; name: is optional
+ *   <li>role:auto0:a1.* -&gt; all nodes with roles that match a1.* in role dimension auto0
  * </ul>
  *
  * <p>In the future, we might need other tags (e.g., loc:) and boolean expressions (e.g.,
@@ -128,8 +128,9 @@ public class NodesSpecifier {
    * <p>What is produced for various queries:
    *
    * <ul>
-   *   <li>na --> all {@link Type}s whose names begin with srv and nodes whose name begins with srv
-   *   <li>NAME:srv --> all nodes whose names with srv
+   *   <li>na -&gt; all {@link Type}s whose names begin with srv and nodes whose name begins with
+   *       srv
+   *   <li>NAME:srv -&gt; all nodes whose names with srv
    *   <li>ROLE:d all role dimensions that begin with r
    *   <li>ROLE:dim:r all roles in dimension 'dim' that begin with r
    * </ul>

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/OspfPropertySpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/OspfPropertySpecifier.java
@@ -18,8 +18,8 @@ import org.batfish.datamodel.ospf.OspfProcess;
  * <p>Example specifiers:
  *
  * <ul>
- *   <li>max-metric-summary-links —> gets the process's corresponding value
- *   <li>max-metric-.* --> gets all properties that start with 'max-metric-'
+ *   <li>max-metric-summary-links -&gt; gets the process's corresponding value
+ *   <li>max-metric-.* -&gt; gets all properties that start with 'max-metric-'
  * </ul>
  */
 public class OspfPropertySpecifier extends PropertySpecifier {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/AltFlexibleLocationSpecifierFactory.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/AltFlexibleLocationSpecifierFactory.java
@@ -6,14 +6,14 @@ package org.batfish.specifier;
  * <p>Examples include:
  *
  * <pre>
- *   rtr-.*              --> nodes matching this regex
- *   rtr-.*:Eth.*        --> interfaces matching the second regex on nodes matching the first
- *   interface(Eth.*)    --> interfaces matching the regex
- *   enter(vrf(default)) --> inbound into all interfaces in VRF default
- *   vrf(default)        --> interfaces in VRF default
- *   ref.noderole(border.*, dim) -> nodes in roles matching the first parameter in dimension dim
- *   a + b               --> union of locations denoted by a and b
- *   a - b               --> difference of locations denoted a and b
+ *   rtr-.*              -&gt; nodes matching this regex
+ *   rtr-.*:Eth.*        -&gt; interfaces matching the second regex on nodes matching the first
+ *   interface(Eth.*)    -&gt; interfaces matching the regex
+ *   enter(vrf(default)) -&gt; inbound into all interfaces in VRF default
+ *   vrf(default)        -&gt; interfaces in VRF default
+ *   ref.noderole(border.*, dim) -&gt; nodes in roles matching the first parameter in dimension dim
+ *   a + b               -&gt; union of locations denoted by a and b
+ *   a - b               -&gt; difference of locations denoted a and b
  * </pre>
  *
  * <p>More formally, the grammar is:

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/SpecifierContext.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/SpecifierContext.java
@@ -28,8 +28,8 @@ public interface SpecifierContext {
   Set<NodeRole> getNodeRolesByDimension(String dimension);
 
   /**
-   * @return the {@link IpSpace}s owned by each interface in the network. Mapping: hostname ->
-   *     interface name -> IpSpace.
+   * @return the {@link IpSpace}s owned by each interface in the network. Mapping: hostname -&gt;
+   *     interface name -&gt; IpSpace.
    */
   Map<String, Map<String, IpSpace>> getInterfaceOwnedIps();
 
@@ -47,8 +47,8 @@ public interface SpecifierContext {
   }
 
   /**
-   * @return the {@link IpSpace}s owned by each VRF in the network. Mapping: hostname -> VRF name ->
-   *     IpSpace.
+   * @return the {@link IpSpace}s owned by each VRF in the network. Mapping: hostname -&gt; VRF name
+   *     -&gt; IpSpace.
    */
   Map<String, Map<String, IpSpace>> getVrfOwnedIps();
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -671,7 +671,8 @@ class IncrementalBdpEngine {
   }
 
   /**
-   * Return the main RIB routes for each node. Map structure: Hostname -> VRF name -> Set of routes
+   * Return the main RIB routes for each node. Map structure: Hostname -&gt; VRF name -&gt; Set of
+   * routes
    */
   static SortedMap<String, SortedMap<String, SortedSet<AbstractRoute>>> getRoutes(
       IncrementalDataPlane dp) {

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlane.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlane.java
@@ -230,7 +230,7 @@ public final class IncrementalDataPlane implements Serializable, DataPlane {
 
   /**
    * Retrieve the {@link PrefixTracer} for each {@link VirtualRouter} after dataplane computation.
-   * Map structure: Hostname -> VRF name -> prefix tracer.
+   * Map structure: Hostname -&gt; VRF name -&gt; prefix tracer.
    */
   public SortedMap<String, SortedMap<String, PrefixTracer>> getPrefixTracingInfo() {
     /*

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/PrefixTracer.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/PrefixTracer.java
@@ -195,7 +195,7 @@ public class PrefixTracer implements Serializable {
     }
   }
 
-  /** Structure: prefix -> action -> set of hostnames */
+  /** Structure: prefix -&gt; action -&gt; set of hostnames */
   public Map<Prefix, Map<String, Set<String>>> summarize() {
     Map<Prefix, Map<String, Set<String>>> result = new HashMap<>();
     _sent.forEach(

--- a/projects/batfish/src/main/java/org/batfish/symbolic/CommunityVar.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/CommunityVar.java
@@ -8,7 +8,7 @@ import javax.annotation.Nullable;
  * Representation of a community variable for the symbolic encoding. Configuration languages allow
  * users match community values using either <b>exact matches</b> or <b>regular expression</b>
  * matches. For example, a regular expression match such as .*:65001 will match any community string
- * that ends with 65001. >
+ * that ends with 65001.
  *
  * <p>To encode community semantics, the model introduces a single new boolean variable for every
  * exact match, and two new boolean variables for every regex match. The first variable says whether

--- a/projects/batfish/src/main/java/org/batfish/symbolic/smt/Encoder.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/smt/Encoder.java
@@ -45,7 +45,7 @@ import org.batfish.symbolic.utils.Tuple;
 /**
  * A class responsible for building a symbolic encoding of the entire network. The encoder does this
  * by maintaining a collection of encoding slices, where each slice encodes the forwarding behavior
- * for a particular packet. >
+ * for a particular packet.
  *
  * <p>The encoder object is architected this way to allow for modeling of features such as iBGP or
  * non-local next-hop ip addresses in static routes, where the forwarding behavior of one packet

--- a/projects/batfish/src/main/java/org/batfish/z3/IpSpaceIpSpaceSpecializer.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/IpSpaceIpSpaceSpecializer.java
@@ -31,10 +31,10 @@ public class IpSpaceIpSpaceSpecializer extends IpSpaceSpecializer {
 
   /**
    * Specialize the whitelist using a refined specializer obtained by specializing _ipSpace to the
-   * blacklist. This helps situations like this: _ipSpace <= blacklist <= whitelist If _ipSpace is
-   * covered by the blacklist, then refinedIpSpace will be empty, and we will later infer that the
-   * input ipWildcardSetIpSpace should be specialized to empty as well. Without this, specialization
-   * would not be able to infer this, so we'd do less optimization.
+   * blacklist. This helps situations like this: _ipSpace &lt;= blacklist &lt;= whitelist If
+   * _ipSpace is covered by the blacklist, then refinedIpSpace will be empty, and we will later
+   * infer that the input ipWildcardSetIpSpace should be specialized to empty as well. Without this,
+   * specialization would not be able to infer this, so we'd do less optimization.
    */
   @Override
   protected Optional<IpSpaceSpecializer> restrictSpecializerToBlacklist(Set<IpWildcard> blacklist) {

--- a/projects/batfish/src/main/java/org/batfish/z3/SynthesizerInput.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/SynthesizerInput.java
@@ -22,7 +22,7 @@ public interface SynthesizerInput {
   int getNodeInterfaceId(String node, String iface);
 
   /**
-   * Mapping: hostname -> aclName -> lineNumber -> lineAction <br>
+   * Mapping: hostname -&gt; aclName -&gt; lineNumber -&gt; lineAction <br>
    * This mapping contains only the acls that are required for the operation this {@link
    * SynthesizerInput} is being used for. Specifically, for ACL-reachability this should contain all
    * ACLs, while for other reachability queries this will only contain ACLs that a packet could
@@ -31,47 +31,49 @@ public interface SynthesizerInput {
   Map<String, Map<String, List<LineAction>>> getAclActions();
 
   /**
-   * Mapping: hostname -> aclName -> lineNumber -> lineConditions <br>
+   * Mapping: hostname -&gt; aclName -&gt; lineNumber -&gt; lineConditions <br>
    * lineConditions is a boolean expression representing the constraints on a header necessary for
    * that line to be matched.
    */
   Map<String, Map<String, List<BooleanExpr>>> getAclConditions();
 
   /**
-   * Mapping: hostname -> vrfName -> outInterface -> recvNode -> recvInterface ->
+   * Mapping: hostname -&gt; vrfName -&gt; outInterface -&gt; recvNode -&gt; recvInterface -&gt;
    * dstIpConstraintForWhichArpReplySent
    */
   Map<String, Map<String, Map<String, Map<String, Map<String, BooleanExpr>>>>> getArpTrueEdge();
 
   Set<Edge> getEnabledEdges();
 
-  /** Mapping: hostname -> interfaces */
+  /** Mapping: hostname -&gt; interfaces */
   Map<String, Set<String>> getEnabledInterfaces();
 
-  /** Mapping: hostname -> vrf -> interfaces */
+  /** Mapping: hostname -&gt; vrf -&gt; interfaces */
   Map<String, Map<String, Set<String>>> getEnabledInterfacesByNodeVrf();
 
   Set<String> getEnabledNodes();
 
-  /** Mapping: hostname -> vrfs */
+  /** Mapping: hostname -&gt; vrfs */
   Map<String, Set<String>> getEnabledVrfs();
 
-  /** Mapping: hostname -> interface-> incomingAcl */
+  /** Mapping: hostname -&gt; interface-&gt; incomingAcl */
   Map<String, Map<String, String>> getIncomingAcls();
 
   /** Ingress locations grouped by the required constraint on src IP */
   Map<IngressLocation, BooleanExpr> getSrcIpConstraints();
 
-  /** Mapping: hostname -> ipsOwnedByHostname */
+  /** Mapping: hostname -&gt; ipsOwnedByHostname */
   Map<String, Set<Ip>> getIpsByHostname();
 
-  /** Mapping: hostname -> vrf -> ipsOwnedByVrf */
+  /** Mapping: hostname -&gt; vrf -&gt; ipsOwnedByVrf */
   Map<String, Map<String, Set<Ip>>> getIpsByNodeVrf();
 
-  /** Mapping: hostname -> IpSpace name -> IpSpace */
+  /** Mapping: hostname -&gt; IpSpace name -&gt; IpSpace */
   Map<String, Map<String, IpSpace>> getNamedIpSpaces();
 
-  /** Mapping: hostname -> vrfName -> outInterface -> dstIpConstraintForWhichNoArpReplySent */
+  /**
+   * Mapping: hostname -&gt; vrfName -&gt; outInterface -&gt; dstIpConstraintForWhichNoArpReplySent
+   */
   Map<String, Map<String, Map<String, BooleanExpr>>> getNeighborUnreachable();
 
   /** Set of hostnames of nodes that have a firewall with a MatchSrcInterface AclLineMatchExpr */
@@ -80,27 +82,28 @@ public interface SynthesizerInput {
   /** Set of nodes that should not be transited */
   Set<String> getNonTransitNodes();
 
-  /** Mapping: hostname -> vrfName -> nullRoutedIps */
+  /** Mapping: hostname -&gt; vrfName -&gt; nullRoutedIps */
   Map<String, Map<String, BooleanExpr>> getNullRoutedIps();
 
-  /** Mapping: hostname -> interface-> outgoingAcl */
+  /** Mapping: hostname -&gt; interface-&gt; outgoingAcl */
   Map<String, Map<String, String>> getOutgoingAcls();
 
-  /** Mapping: hostname -> vrfName -> routableIps */
+  /** Mapping: hostname -&gt; vrfName -&gt; routableIps */
   Map<String, Map<String, BooleanExpr>> getRoutableIps();
 
   /** Whether to run simplifier on AST after rule generation */
   boolean getSimplify();
 
   /**
-   * Mapping: hostname -> interface -> [(preconditionPreTransformationState, transformationToApply)]
+   * Mapping: hostname -&gt; interface -&gt; [(preconditionPreTransformationState,
+   * transformationToApply)]
    */
   Map<String, Map<String, List<Entry<AclPermit, BooleanExpr>>>> getSourceNats();
 
   /** The set of nodes for which we should track whether they are transited */
   Set<String> getTransitNodes();
 
-  /** Mapping: hostname -> interfacesAllowedToBelongToAnEdge */
+  /** Mapping: hostname -&gt; interfacesAllowedToBelongToAnEdge */
   Map<String, Set<String>> getTraversableInterfaces();
 
   /**
@@ -118,7 +121,7 @@ public interface SynthesizerInput {
    */
   Field getSourceInterfaceField();
 
-  /** Mapping: hostname -> interface -> constraint on transformed source interface field */
+  /** Mapping: hostname -&gt; interface -&gt; constraint on transformed source interface field */
   Map<String, Map<String, IntExpr>> getSourceInterfaceFieldValues();
 
   /** Whether it's synthesizing data plane rules */

--- a/projects/batfish/src/main/java/org/batfish/z3/SynthesizerInputImpl.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/SynthesizerInputImpl.java
@@ -815,7 +815,7 @@ public final class SynthesizerInputImpl implements SynthesizerInput {
   }
 
   /**
-   * Mapping: hostname -> aclName -> lineNumber -> lineConditions <br>
+   * Mapping: hostname -&gt; aclName -&gt; lineNumber -&gt; lineConditions <br>
    * lineConditions is a boolean expression representing the constraints on a header necessary for
    * that line to be matched.
    */

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
@@ -237,7 +237,7 @@ public class BatfishTestUtils {
    * Get a new Batfish instance with given configurations, tempFolder should be present for
    * non-empty configurations
    *
-   * @param configurations Map of all Configuration Name -> Configuration Object
+   * @param configurations Map of all Configuration Name -&gt; Configuration Object
    * @param tempFolder Temporary folder to be used to files required for Batfish
    * @return New Batfish instance
    */
@@ -251,8 +251,8 @@ public class BatfishTestUtils {
    * Get a new Batfish instance with given base and delta configurations, tempFolder should be
    * present for non-empty configurations
    *
-   * @param baseConfigs Map of all Configuration Name -> Configuration Object
-   * @param deltaConfigs Map of all Configuration Name -> Configuration Object
+   * @param baseConfigs Map of all Configuration Name -&gt; Configuration Object
+   * @param deltaConfigs Map of all Configuration Name -&gt; Configuration Object
    * @param tempFolder Temporary folder to be used to files required for Batfish
    * @return New Batfish instance
    */

--- a/projects/batfish/src/test/java/org/batfish/symbolic/abstraction/BatfishCompressionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/symbolic/abstraction/BatfishCompressionTest.java
@@ -116,8 +116,8 @@ public class BatfishCompressionTest {
   }
 
   /**
-   * This network should be compressed from: A --> B --> D, A --> C --> D to A --> {B,C} --> D.
-   * i.e., B and C should be merged into one node.
+   * This network should be compressed from: A -&gt; B -&gt; D, A -&gt; C -&gt; D to A -&gt; {B,C}
+   * -&gt; D. i.e., B and C should be merged into one node.
    *
    * @return Configurations for the original (uncompressed) network.
    */

--- a/projects/batfish/src/test/java/org/batfish/z3/expr/visitors/SimplifierTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/expr/visitors/SimplifierTest.java
@@ -65,7 +65,7 @@ public class SimplifierTest {
     assertThat(simplifyBooleanExpr(and), equalTo(p1));
   }
 
-  /** Test simplifications: false AND E --> false E AND false --> false. */
+  /** Test simplifications: false AND E -&gt; false E AND false -&gt; false. */
   @Test
   public void testSimplifyAndExprFalseConjunct() {
     BooleanExpr p1 = newAtom();
@@ -217,7 +217,7 @@ public class SimplifierTest {
     assertThat(simplifyBooleanExpr(ifExpr), sameInstance(ifExpr));
   }
 
-  /** IfThenElse(A,True,B) --> Or(A,B) */
+  /** IfThenElse(A,True,B) -&gt; Or(A,B) */
   @Test
   public void testIfThenElse_thenTrue() {
     BooleanExpr a = newAtom();
@@ -227,7 +227,7 @@ public class SimplifierTest {
         equalTo(new OrExpr(of(a, b))));
   }
 
-  /** IfThenElse(A,False,B) --> And(Not(A),B) */
+  /** IfThenElse(A,False,B) -&gt; And(Not(A),B) */
   @Test
   public void testIfThenElse_thenFalse() {
     BooleanExpr a = newAtom();
@@ -237,7 +237,7 @@ public class SimplifierTest {
         equalTo(new AndExpr(of(new NotExpr(a), b))));
   }
 
-  /** IfThenElse(A,B,False) --> And(A,B) */
+  /** IfThenElse(A,B,False) -&gt; And(A,B) */
   @Test
   public void testIfThenElse_elseFalse() {
     BooleanExpr a = newAtom();
@@ -247,7 +247,7 @@ public class SimplifierTest {
         equalTo(new AndExpr(of(a, b))));
   }
 
-  /** IfThenElse(A,B,True) --> Or(Not(A),B) */
+  /** IfThenElse(A,B,True) -&gt; Or(Not(A),B) */
   @Test
   public void testIfThenElse_elseTrue() {
     BooleanExpr a = newAtom();

--- a/projects/question/src/main/java/org/batfish/question/filtertable/Filter.java
+++ b/projects/question/src/main/java/org/batfish/question/filtertable/Filter.java
@@ -157,8 +157,8 @@ public class Filter {
    *
    * <ul>
    *   <li>colName LE 42
-   *   <li>colName GT "fourty two" ==> Strings must be double-quoted
-   *   <li>colName NE null ==> null literal
+   *   <li>colName GT "forty two" -&gt; Strings must be double-quoted
+   *   <li>colName NE null -&gt; null literal
    *   <li>colName EQ true
    * </ul>
    *


### PR DESCRIPTION
Replaced all the non-tag instances of `<` with `&lt;` and of `>` with `&gt;`. Also mostly standardized arrows to use one n-dash.