### PR TITLE
Juniper: extract autonomous-system loops

### DIFF
--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpNeighborMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpNeighborMatchers.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.equalTo;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.BgpPeerConfig;
+import org.batfish.datamodel.matchers.BgpNeighborMatchersImpl.HasAllowLocalAsIn;
 import org.batfish.datamodel.matchers.BgpNeighborMatchersImpl.HasAllowRemoteAsOut;
 import org.batfish.datamodel.matchers.BgpNeighborMatchersImpl.HasClusterId;
 import org.batfish.datamodel.matchers.BgpNeighborMatchersImpl.HasEnforceFirstAs;
@@ -12,7 +13,15 @@ import org.batfish.datamodel.matchers.BgpNeighborMatchersImpl.HasLocalAs;
 import org.batfish.datamodel.matchers.BgpNeighborMatchersImpl.HasRemoteAs;
 import org.hamcrest.Matcher;
 
+/** Matchers for {@link BgpPeerConfig} */
 public class BgpNeighborMatchers {
+
+  /**
+   * Provides a matcher that matches if the {@link BgpPeerConfig}'s allowLocalAsIn is {@code value}.
+   */
+  public static HasAllowLocalAsIn hasAllowLocalAsIn(boolean value) {
+    return new HasAllowLocalAsIn(equalTo(value));
+  }
 
   /**
    * Provides a matcher that matches if the {@link BgpPeerConfig}'s allowRemoteAsOut is {@code

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpNeighborMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpNeighborMatchersImpl.java
@@ -9,6 +9,16 @@ import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 
 final class BgpNeighborMatchersImpl {
+  static final class HasAllowLocalAsIn extends FeatureMatcher<BgpPeerConfig, Boolean> {
+    HasAllowLocalAsIn(@Nonnull Matcher<? super Boolean> subMatcher) {
+      super(subMatcher, "A BgpPeerConfig with allowRemoteAsOut:", "allowRemoteAsOut");
+    }
+
+    @Override
+    protected Boolean featureValueOf(BgpPeerConfig actual) {
+      return actual.getAllowLocalAsIn();
+    }
+  }
 
   static final class HasAllowRemoteAsOut extends FeatureMatcher<BgpPeerConfig, Boolean> {
     HasAllowRemoteAsOut(@Nonnull Matcher<? super Boolean> subMatcher) {

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpNeighborMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpNeighborMatchersImpl.java
@@ -11,7 +11,7 @@ import org.hamcrest.Matcher;
 final class BgpNeighborMatchersImpl {
   static final class HasAllowLocalAsIn extends FeatureMatcher<BgpPeerConfig, Boolean> {
     HasAllowLocalAsIn(@Nonnull Matcher<? super Boolean> subMatcher) {
-      super(subMatcher, "A BgpPeerConfig with allowRemoteAsOut:", "allowRemoteAsOut");
+      super(subMatcher, "A BgpPeerConfig with allowLocalAsIn:", "allowLocalAsIn");
     }
 
     @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -332,6 +332,7 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Roa_communityContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Roa_preferenceContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Roa_tagContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Roaa_pathContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Roas_loopsContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Rof_exportContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Rog_metricContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Rog_policyContext;
@@ -613,6 +614,9 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
 
   private static final String F_POLICY_TERM_THEN_NEXT_HOP =
       "policy-statement - term - then - next-hop";
+
+  private static final String F_ROUTING_OPTIONS_LOOPS =
+      "routing-options autonomous-system loops - currently we allow infinite occurences of local as";
 
   private static final String GLOBAL_ADDRESS_BOOK_NAME = "global";
 
@@ -4199,6 +4203,14 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   public void exitRoaa_path(Roaa_pathContext ctx) {
     AsPath asPath = toAsPath(ctx.path);
     _currentAggregateRoute.setAsPath(asPath);
+  }
+
+  @Override
+  public void exitRoas_loops(Roas_loopsContext ctx) {
+    if (ctx.DEC() != null) {
+      _currentRoutingInstance.setLoops(toInt(ctx.DEC()));
+      todo(ctx, F_ROUTING_OPTIONS_LOOPS);
+    }
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -25,6 +25,7 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.collections4.list.TreeList;
@@ -39,7 +40,7 @@ import org.batfish.datamodel.BgpActivePeerConfig;
 import org.batfish.datamodel.BgpAuthenticationAlgorithm;
 import org.batfish.datamodel.BgpAuthenticationSettings;
 import org.batfish.datamodel.BgpPassivePeerConfig;
-import org.batfish.datamodel.BgpPeerConfig;
+import org.batfish.datamodel.BgpPeerConfig.Builder;
 import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
@@ -337,7 +338,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
     for (Entry<Prefix, IpBgpGroup> e : routingInstance.getIpBgpGroups().entrySet()) {
       Prefix prefix = e.getKey();
       IpBgpGroup ig = e.getValue();
-      BgpPeerConfig.Builder<?, ?> neighbor;
+      Builder<?, ?> neighbor;
       Long remoteAs = ig.getType() == BgpGroupType.INTERNAL ? ig.getLocalAs() : ig.getPeerAs();
       if (ig.getDynamic()) {
         neighbor =
@@ -391,8 +392,16 @@ public final class JuniperConfiguration extends VendorConfiguration {
       }
       neighbor.setEbgpMultihop(ebgpMultihop);
       neighbor.setEnforceFirstAs(firstNonNull(ig.getEnforceFirstAs(), Boolean.FALSE));
-      Integer loops = ig.getLoops();
-      boolean allowLocalAsIn = loops != null && loops > 0;
+
+      // Check for loops in the following order:
+      Integer loops =
+          Stream.of(
+                  ig.getLoops(), routingInstance.getLoops(), _defaultRoutingInstance.getLoops(), 0)
+              .filter(Objects::nonNull)
+              .findFirst()
+              .get();
+
+      boolean allowLocalAsIn = loops > 0;
       neighbor.setAllowLocalAsIn(allowLocalAsIn);
       Boolean advertisePeerAs = ig.getAdvertisePeerAs();
       if (advertisePeerAs == null) {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/RoutingInstance.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/RoutingInstance.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import javax.annotation.Nullable;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.SnmpServer;
@@ -42,6 +43,8 @@ public class RoutingInstance implements Serializable {
   private Map<Prefix, IpBgpGroup> _ipBgpGroups;
 
   private final IsisSettings _isisSettings;
+
+  @Nullable private Integer _loops;
 
   private BgpGroup _masterBgpGroup;
 
@@ -152,6 +155,11 @@ public class RoutingInstance implements Serializable {
     return _isisSettings;
   }
 
+  @Nullable
+  public Integer getLoops() {
+    return _loops;
+  }
+
   public BgpGroup getMasterBgpGroup() {
     return _masterBgpGroup;
   }
@@ -222,6 +230,10 @@ public class RoutingInstance implements Serializable {
 
   public void setOspfReferenceBandwidth(double ospfReferenceBandwidth) {
     _ospfReferenceBandwidth = ospfReferenceBandwidth;
+  }
+
+  public void setLoops(@Nullable Integer loops) {
+    _loops = loops;
   }
 
   public void setRouterId(Ip routerId) {

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -5,6 +5,7 @@ import static org.batfish.datamodel.AuthenticationMethod.GROUP_TACACS;
 import static org.batfish.datamodel.AuthenticationMethod.PASSWORD;
 import static org.batfish.datamodel.matchers.AaaAuthenticationLoginListMatchers.hasMethods;
 import static org.batfish.datamodel.matchers.AbstractRouteMatchers.hasPrefix;
+import static org.batfish.datamodel.matchers.BgpNeighborMatchers.hasAllowLocalAsIn;
 import static org.batfish.datamodel.matchers.BgpNeighborMatchers.hasClusterId;
 import static org.batfish.datamodel.matchers.BgpNeighborMatchers.hasEnforceFirstAs;
 import static org.batfish.datamodel.matchers.BgpNeighborMatchers.hasLocalAs;
@@ -485,33 +486,6 @@ public class FlatJuniperGrammarTest {
   }
 
   @Test
-  public void testPredefinedJunosApplications() throws IOException {
-    Batfish batfish = getBatfishForConfigurationNames("pre-defined-junos-applications");
-    InitInfoAnswerElement answer = batfish.initInfo(false, true);
-    assertThat(
-        answer.prettyPrint(),
-        not(Matchers.containsString("unimplemented pre-defined junos application")));
-  }
-
-  @Test
-  public void testPredefinedJunosApplicationSets() throws IOException {
-    Batfish batfish = getBatfishForConfigurationNames("pre-defined-junos-application-sets");
-    InitInfoAnswerElement answer = batfish.initInfo(false, true);
-    assertThat(
-        answer.prettyPrint(),
-        not(Matchers.containsString("unimplemented pre-defined junos application-set")));
-  }
-
-  /** Tests support for dynamic bgp parsing using "bgp allow" command */
-  @Test
-  public void testBgpAllow() throws IOException {
-    Configuration c = parseConfig("bgp-allow");
-    assertThat(
-        c,
-        hasDefaultVrf(hasBgpProcess(hasPassiveNeighbor(Prefix.parse("10.1.1.0/24"), anything()))));
-  }
-
-  @Test
   public void testAutonomousSystem() throws IOException {
     String testrigName = "autonomous-system";
     String c1Name = "as1";
@@ -534,6 +508,26 @@ public class FlatJuniperGrammarTest {
     assertThat(c1, hasDefaultVrf(hasBgpProcess(hasActiveNeighbor(neighborPrefix, hasLocalAs(1L)))));
     assertThat(c2, hasDefaultVrf(hasBgpProcess(hasActiveNeighbor(neighborPrefix, hasLocalAs(1L)))));
     assertThat(c3, hasDefaultVrf(hasBgpProcess(hasActiveNeighbor(neighborPrefix, hasLocalAs(1L)))));
+  }
+
+  @Test
+  public void testAutonomousSystemLoops() throws IOException {
+    Configuration c = parseConfig("autonomous-system-loops");
+    assertThat(
+        c,
+        hasDefaultVrf(
+            hasBgpProcess(
+                hasActiveNeighbor(
+                    Prefix.parse("2.2.2.2/32"), allOf(hasAllowLocalAsIn(true), hasLocalAs(1L))))));
+  }
+
+  /** Tests support for dynamic bgp parsing using "bgp allow" command */
+  @Test
+  public void testBgpAllow() throws IOException {
+    Configuration c = parseConfig("bgp-allow");
+    assertThat(
+        c,
+        hasDefaultVrf(hasBgpProcess(hasPassiveNeighbor(Prefix.parse("10.1.1.0/24"), anything()))));
   }
 
   @Test
@@ -2293,6 +2287,24 @@ public class FlatJuniperGrammarTest {
 
     assertThat(extractor.getNumSets(), equalTo(8));
     assertThat(extractor.getNumErrorNodes(), equalTo(8));
+  }
+
+  @Test
+  public void testPredefinedJunosApplications() throws IOException {
+    Batfish batfish = getBatfishForConfigurationNames("pre-defined-junos-applications");
+    InitInfoAnswerElement answer = batfish.initInfo(false, true);
+    assertThat(
+        answer.prettyPrint(),
+        not(Matchers.containsString("unimplemented pre-defined junos application")));
+  }
+
+  @Test
+  public void testPredefinedJunosApplicationSets() throws IOException {
+    Batfish batfish = getBatfishForConfigurationNames("pre-defined-junos-application-sets");
+    InitInfoAnswerElement answer = batfish.initInfo(false, true);
+    assertThat(
+        answer.prettyPrint(),
+        not(Matchers.containsString("unimplemented pre-defined junos application-set")));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -519,6 +519,13 @@ public class FlatJuniperGrammarTest {
             hasBgpProcess(
                 hasActiveNeighbor(
                     Prefix.parse("2.2.2.2/32"), allOf(hasAllowLocalAsIn(true), hasLocalAs(1L))))));
+    assertThat(
+        c,
+        hasVrf(
+            "FOO",
+            hasBgpProcess(
+                hasActiveNeighbor(
+                    Prefix.parse("3.3.3.3/32"), allOf(hasAllowLocalAsIn(true), hasLocalAs(1L))))));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -521,6 +521,18 @@ public class FlatJuniperGrammarTest {
                     Prefix.parse("2.2.2.2/32"), allOf(hasAllowLocalAsIn(true), hasLocalAs(1L))))));
   }
 
+  @Test
+  public void testAutonomousSystemLoopsNonDefaultRoutingInstance() throws IOException {
+    Configuration c = parseConfig("autonomous-system-loops-routing-instance");
+    assertThat(
+        c,
+        hasVrf(
+            "FOO",
+            hasBgpProcess(
+                hasActiveNeighbor(
+                    Prefix.parse("2.2.2.2/32"), allOf(hasAllowLocalAsIn(true), hasLocalAs(1L))))));
+  }
+
   /** Tests support for dynamic bgp parsing using "bgp allow" command */
   @Test
   public void testBgpAllow() throws IOException {

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/autonomous-system-loops
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/autonomous-system-loops
@@ -7,3 +7,9 @@ set routing-options autonomous-system loops 2
 set protocols bgp group GROUP peer-as 2
 set protocols bgp group GROUP local-address 1.1.1.1
 set protocols bgp group GROUP neighbor 2.2.2.2
+#
+set routing-instances FOO routing-options autonomous-system 1
+#
+set routing-instances FOO protocols bgp group GROUP_TWO peer-as 2
+set routing-instances FOO protocols bgp group GROUP_TWO local-address 1.1.1.2
+set routing-instances FOO protocols bgp group GROUP_TWO neighbor 3.3.3.3

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/autonomous-system-loops
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/autonomous-system-loops
@@ -1,0 +1,9 @@
+#
+set system host-name autonomous-system-loops
+#
+set routing-options autonomous-system 1
+set routing-options autonomous-system loops 2
+#
+set protocols bgp group GROUP peer-as 2
+set protocols bgp group GROUP local-address 1.1.1.1
+set protocols bgp group GROUP neighbor 2.2.2.2

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/autonomous-system-loops-routing-instance
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/autonomous-system-loops-routing-instance
@@ -1,0 +1,9 @@
+#
+set system host-name autonomous-system-loops-routing-instance
+#
+set routing-instances FOO routing-options autonomous-system 1
+set routing-instances FOO routing-options autonomous-system loops 2
+#
+set routing-instances FOO protocols bgp group GROUP peer-as 2
+set routing-instances FOO protocols bgp group GROUP local-address 1.1.1.1
+set routing-instances FOO protocols bgp group GROUP neighbor 2.2.2.2


### PR DESCRIPTION
Allowas-in can also be expressed as `loops` [Docs](https://www.juniper.net/documentation/en_US/junos/topics/reference/configuration-statement/loops-edit-routing-options-autonomous-system.html) so write extraction code for that.

*Note*: this does not implement the logic for how many times local as can appear in as path, that's still unhandled across all vendors.

*Side effect*: alphabetized some more tests in FlatJuniperGrammarTest, only `testAutonomousSystemLoops` is new.


CC @anothermattbrown if you are curious about the fix.

