### PR TITLE
Allow old or new SVC_KEYs in WorkMgrService

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/CoordConsts.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/CoordConsts.java
@@ -81,6 +81,7 @@ public class CoordConsts {
   public static final String SVC_KEY_DEL_ANALYSIS_QUESTIONS = "delanalysisquestions";
   public static final String SVC_KEY_DEL_WORKER = "delworker";
   public static final String SVC_KEY_DELTA_ENV_NAME = "deltaenvname";
+  public static final String SVC_KEY_DELTA_SNAPSHOT_NAME = "deltasnapshotname";
   public static final String SVC_KEY_DELTA_TESTRIG_NAME = "deltatestrigname";
   public static final String SVC_KEY_ENV_NAME = "envname";
   public static final String SVC_KEY_ENVIRONMENT_LIST = "environmentlist";

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/CoordConsts.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/CoordConsts.java
@@ -75,7 +75,6 @@ public class CoordConsts {
   public static final String SVC_KEY_BASE_ENV_NAME = "baseenvname";
   public static final String SVC_KEY_COMPLETION_TYPE = "completiontype";
   public static final String SVC_KEY_CONFIGURATION_NAME = "configurationname";
-  public static final String SVC_KEY_CONTAINERS = "containers";
   public static final String SVC_KEY_CONTAINER_LIST = "containerlist";
   public static final String SVC_KEY_CONTAINER_NAME = "container";
   public static final String SVC_KEY_CONTAINER_PREFIX = "containerprefix";
@@ -88,7 +87,6 @@ public class CoordConsts {
   public static final String SVC_KEY_EXCEPTIONS = "exceptions";
   public static final String SVC_KEY_FAILURE = "failure";
   public static final String SVC_KEY_FILE = "file";
-  public static final String SVC_KEY_FILE2 = "file2";
   public static final String SVC_KEY_FORCE = "force";
   public static final String SVC_KEY_MAX_SUGGESTIONS = "maxsuggestions";
   public static final String SVC_KEY_NETWORK_LIST = "networklist";
@@ -121,7 +119,6 @@ public class CoordConsts {
   public static final String SVC_KEY_WORK_TYPE = "worktype";
   public static final String SVC_KEY_WORKID = "workid";
   public static final String SVC_KEY_WORKITEM = "workitem";
-  public static final String SVC_KEY_WORKSPACE_NAME = "workspace";
   public static final String SVC_KEY_WORKSTATUS = "workstatus";
   public static final String SVC_KEY_ZIPFILE = "zipfile";
 
@@ -143,11 +140,9 @@ public class CoordConsts {
   public static final String SVC_RSC_GET_ANSWER = "getanswer";
   public static final String SVC_RSC_GET_CONFIGURATION = "getconfiguration";
   public static final String SVC_RSC_GET_CONTAINER = "getcontainer";
-  public static final String SVC_RSC_GET_DATAPLANING_WORK = "getdataplaningwork";
   public static final String SVC_RSC_GET_NETWORK = "getnetwork";
   public static final String SVC_RSC_GET_OBJECT = "getobject";
   public static final String SVC_RSC_GET_PARSING_RESULTS = "getparsingresults";
-  public static final String SVC_RSC_GET_PARSING_WORK = "getparsingwork";
   public static final String SVC_RSC_GET_QUESTION_TEMPLATES = "getquestiontemplates";
   public static final String SVC_RSC_GET_WORKSTATUS = "getworkstatus";
   public static final String SVC_RSC_GETSTATUS = "getstatus";

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -313,7 +313,8 @@ public class WorkMgr extends AbstractCoordinator {
       case NODE:
         {
           checkArgument(
-              !isNullOrEmpty(testrig), "Testrig name should be supplied for 'NODE' autoCompletion");
+              !isNullOrEmpty(testrig),
+              "Snapshot name should be supplied for 'NODE' autoCompletion");
           List<AutocompleteSuggestion> suggestions =
               NodesSpecifier.autoComplete(
                   query, getNodes(container, testrig), getNodeRolesData(container));
@@ -890,7 +891,7 @@ public class WorkMgr extends AbstractCoordinator {
   public Path getdirTestrig(String containerName, String testrigName) {
     Path snapshotDir = getdirSnapshots(containerName).resolve(Paths.get(testrigName));
     if (!Files.exists(snapshotDir)) {
-      throw new BatfishException("Testrig '" + testrigName + "' does not exist");
+      throw new BatfishException("Snapshot '" + testrigName + "' does not exist");
     }
     return snapshotDir;
   }
@@ -1024,7 +1025,7 @@ public class WorkMgr extends AbstractCoordinator {
     if (!Files.exists(submittedTestrigDir)) {
       return "Missing folder '"
           + BfConsts.RELPATH_TEST_RIG_DIR
-          + "' for testrig '"
+          + "' for snapshot '"
           + testrigName
           + "'\n";
     }
@@ -1146,7 +1147,7 @@ public class WorkMgr extends AbstractCoordinator {
     SortedSet<Path> srcDirEntries = CommonUtil.getEntries(srcDir);
     if (srcDirEntries.size() != 1 || !Files.isDirectory(srcDirEntries.iterator().next())) {
       throw new BatfishException(
-          "Unexpected packaging of testrig. There should be just one top-level folder");
+          "Unexpected packaging of snapshot. There should be just one top-level folder");
     }
 
     Path srcSubdir = srcDirEntries.iterator().next();
@@ -1237,7 +1238,7 @@ public class WorkMgr extends AbstractCoordinator {
       }
     }
     _logger.infof(
-        "Environment data for testrig:%s; bgpTables:%s, routingTables:%s, nodeRoles:%s referenceBooks:%s\n",
+        "Environment data for snapshot:%s; bgpTables:%s, routingTables:%s, nodeRoles:%s referenceBooks:%s\n",
         snapshotName, bgpTables, routingTables, roleData, referenceLibraryData);
 
     if (autoAnalyze) {
@@ -1521,7 +1522,7 @@ public class WorkMgr extends AbstractCoordinator {
   public boolean queueWork(WorkItem workItem) {
     Path testrigDir = getdirTestrig(workItem.getContainerName(), workItem.getTestrigName());
     if (workItem.getTestrigName().isEmpty() || !Files.exists(testrigDir)) {
-      throw new BatfishException("Non-existent testrig: '" + testrigDir.getFileName() + "'");
+      throw new BatfishException("Non-existent snapshot: '" + testrigDir.getFileName() + "'");
     }
     boolean success;
     try {
@@ -1538,7 +1539,7 @@ public class WorkMgr extends AbstractCoordinator {
           throw new BatfishException("Environment metadata not found");
         }
       } catch (Exception e) {
-        throw new BatfishException("Testrig/environment metadata not found.");
+        throw new BatfishException("Snapshot/environment metadata not found.");
       }
       success = _workQueueMgr.queueUnassignedWork(new QueuedWork(workItem, workDetails));
     } catch (Exception e) {
@@ -1612,7 +1613,7 @@ public class WorkMgr extends AbstractCoordinator {
     Path dstDir = newEnvDir.resolve(BfConsts.RELPATH_ENV_DIR);
     if (Files.exists(newEnvDir)) {
       throw new BatfishException(
-          "Environment: '" + newEnvName + "' already exists for testrig: '" + testrigName + "'");
+          "Environment: '" + newEnvName + "' already exists for snapshot: '" + testrigName + "'");
     }
     if (!dstDir.toFile().mkdirs()) {
       throw new BatfishException("Failed to create directory: '" + dstDir + "'");

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -775,12 +775,12 @@ public class WorkMgr extends AbstractCoordinator {
       if (configPaths.isEmpty()) {
         throw new BatfishException(
             String.format(
-                "Configuration file %s does not exist in testrig %s for container %s",
+                "Configuration file %s does not exist in snapshot %s for network %s",
                 configName, testrigName, containerName));
       } else if (configPaths.size() > 1) {
         throw new BatfishException(
             String.format(
-                "More than one configuration file with name %s in testrig %s for container %s",
+                "More than one configuration file with name %s in snapshot %s for network %s",
                 configName, testrigName, containerName));
       }
       String configContent = "";
@@ -789,7 +789,7 @@ public class WorkMgr extends AbstractCoordinator {
       } catch (IOException e) {
         throw new BatfishException(
             String.format(
-                "Failed to read configuration file %s in testrig %s for container %s",
+                "Failed to read configuration file %s in snapshot %s for network %s",
                 configName, testrigName, containerName),
             e);
       }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
@@ -1258,7 +1258,7 @@ public class WorkMgrService {
    *     containerName} is not empty)
    * @return TODO: document JSON response
    * @deprecated because containers were renamed to networks. Use {@link #initNetwork(String,
-   *     String, String, String, String) initNetwork} instead.
+   *     String, String, String, String, String) initNetwork} instead.
    */
   @POST
   @Path(CoordConsts.SVC_RSC_INIT_CONTAINER)
@@ -1291,10 +1291,16 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
       @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
       @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
+      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_PREFIX) String containerPrefix,
       @FormDataParam(CoordConsts.SVC_KEY_NETWORK_PREFIX) String networkPrefix) {
     String networkNameParam = networkName == null ? containerName : networkName;
+    String networkPrefixParam = networkPrefix == null ? containerPrefix : networkPrefix;
     return initNetworkHelper(
-        apiKey, clientVersion, networkNameParam, networkPrefix, CoordConsts.SVC_KEY_NETWORK_NAME);
+        apiKey,
+        clientVersion,
+        networkNameParam,
+        networkPrefixParam,
+        CoordConsts.SVC_KEY_NETWORK_NAME);
   }
 
   private JSONArray initNetworkHelper(

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
@@ -604,7 +604,8 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String testrigName,
       @FormDataParam(CoordConsts.SVC_KEY_SNAPSHOT_NAME) String snapshotName,
       @FormDataParam(CoordConsts.SVC_KEY_ENV_NAME) String baseEnv,
-      @FormDataParam(CoordConsts.SVC_KEY_DELTA_TESTRIG_NAME) String deltaSnapshot,
+      @FormDataParam(CoordConsts.SVC_KEY_DELTA_TESTRIG_NAME) String deltaTestrig,
+      @FormDataParam(CoordConsts.SVC_KEY_DELTA_SNAPSHOT_NAME) String deltaSnapshot,
       @FormDataParam(CoordConsts.SVC_KEY_DELTA_ENV_NAME) String deltaEnv,
       @FormDataParam(CoordConsts.SVC_KEY_ANALYSIS_NAME) String analysisName,
       @FormDataParam(CoordConsts.SVC_KEY_QUESTION_NAME) String questionName,
@@ -612,6 +613,7 @@ public class WorkMgrService {
     try {
       networkName = networkName == null ? containerName : networkName;
       snapshotName = snapshotName == null ? testrigName : snapshotName;
+      deltaSnapshot = deltaSnapshot == null ? deltaTestrig : deltaSnapshot;
       _logger.infof(
           "WMS:getAnalysisAnswer %s %s %s %s\n", apiKey, networkName, snapshotName, analysisName);
 
@@ -701,13 +703,15 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String testrigName,
       @FormDataParam(CoordConsts.SVC_KEY_SNAPSHOT_NAME) String snapshotName,
       @FormDataParam(CoordConsts.SVC_KEY_ENV_NAME) String baseEnv,
-      @FormDataParam(CoordConsts.SVC_KEY_DELTA_TESTRIG_NAME) String deltaSnapshot,
+      @FormDataParam(CoordConsts.SVC_KEY_DELTA_TESTRIG_NAME) String deltaTestrig,
+      @FormDataParam(CoordConsts.SVC_KEY_DELTA_SNAPSHOT_NAME) String deltaSnapshot,
       @FormDataParam(CoordConsts.SVC_KEY_DELTA_ENV_NAME) String deltaEnv,
       @FormDataParam(CoordConsts.SVC_KEY_ANALYSIS_NAME) String analysisName,
       @FormDataParam(CoordConsts.SVC_KEY_WORKITEM) String workItemStr /* optional */) {
     try {
       networkName = networkName == null ? containerName : networkName;
       snapshotName = snapshotName == null ? testrigName : snapshotName;
+      deltaSnapshot = deltaSnapshot == null ? deltaTestrig : deltaSnapshot;
       _logger.infof(
           "WMS:getAnalysisAnswers %s %s %s %s\n", apiKey, networkName, snapshotName, analysisName);
 
@@ -790,13 +794,15 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String testrigName,
       @FormDataParam(CoordConsts.SVC_KEY_SNAPSHOT_NAME) String snapshotName,
       @FormDataParam(CoordConsts.SVC_KEY_ENV_NAME) String baseEnv,
-      @FormDataParam(CoordConsts.SVC_KEY_DELTA_TESTRIG_NAME) String deltaSnapshot,
+      @FormDataParam(CoordConsts.SVC_KEY_DELTA_TESTRIG_NAME) String deltaTestrig,
+      @FormDataParam(CoordConsts.SVC_KEY_DELTA_SNAPSHOT_NAME) String deltaSnapshot,
       @FormDataParam(CoordConsts.SVC_KEY_DELTA_ENV_NAME) String deltaEnv,
       @FormDataParam(CoordConsts.SVC_KEY_QUESTION_NAME) String questionName,
       @FormDataParam(CoordConsts.SVC_KEY_WORKITEM) String workItemStr /* optional */) {
     try {
       networkName = networkName == null ? containerName : networkName;
       snapshotName = snapshotName == null ? testrigName : snapshotName;
+      deltaSnapshot = deltaSnapshot == null ? deltaTestrig : deltaSnapshot;
       _logger.infof("WMS:getAnswer %s %s %s %s\n", apiKey, networkName, snapshotName, questionName);
 
       checkStringParam(apiKey, "API key");
@@ -2149,10 +2155,12 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String testrigName,
       @FormDataParam(CoordConsts.SVC_KEY_SNAPSHOT_NAME) String snapshotName,
       @FormDataParam(CoordConsts.SVC_KEY_ZIPFILE) InputStream fileStream,
+      @FormDataParam(CoordConsts.SVC_KEY_AUTO_ANALYZE_TESTRIG) String autoAnalyzeTestrigStr,
       @FormDataParam(CoordConsts.SVC_KEY_AUTO_ANALYZE) String autoAnalyzeStr) {
     try {
       networkName = networkName == null ? containerName : networkName;
       snapshotName = snapshotName == null ? testrigName : snapshotName;
+      autoAnalyzeStr = autoAnalyzeStr == null ? autoAnalyzeTestrigStr : autoAnalyzeStr;
       _logger.infof("WMS:uploadSnapshot %s %s %s\n", apiKey, networkName, snapshotName);
 
       checkStringParam(apiKey, "API key");
@@ -2203,7 +2211,7 @@ public class WorkMgrService {
    * @param fileStream The stream from which the new testrig is read
    * @return TODO: document JSON response
    * @deprecated because testrigs were renamed to snapshots. Use {@link #uploadSnapshot(String,
-   *     String, String, String, String, String, InputStream, String)} instead.
+   *     String, String, String, String, String, InputStream, String, String)} instead.
    */
   @POST
   @Path(CoordConsts.SVC_RSC_UPLOAD_TESTRIG)
@@ -2218,6 +2226,14 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_ZIPFILE) InputStream fileStream,
       @FormDataParam(CoordConsts.SVC_KEY_AUTO_ANALYZE_TESTRIG) String autoAnalyzeStr) {
     return uploadSnapshot(
-        apiKey, clientVersion, containerName, null, testrigName, null, fileStream, autoAnalyzeStr);
+        apiKey,
+        clientVersion,
+        containerName,
+        null,
+        testrigName,
+        null,
+        fileStream,
+        autoAnalyzeStr,
+        null);
   }
 }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
@@ -1466,8 +1466,8 @@ public class WorkMgrService {
    * @param apiKey The API key of the client
    * @param clientVersion The version of the client
    * @return On success, a JSON object with key {@link CoordConsts#SVC_KEY_NETWORK_LIST
-   *     "networklist"} and a list of the accessible networks as the value.
-   *     <p>TODO document failure response
+   *     "networklist"} and a list of the accessible networks as the value. TODO document failure
+   *     response
    */
   @POST
   @Path(CoordConsts.SVC_RSC_LIST_NETWORKS)

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
@@ -69,7 +69,8 @@ public class WorkMgrService {
   public JSONArray autoComplete(
       @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
-      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String networkName,
+      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
+      @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
       /* Optional: not needed for some completions */
       @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String snapshotName,
       @FormDataParam(CoordConsts.SVC_KEY_COMPLETION_TYPE) String completionType,
@@ -77,6 +78,7 @@ public class WorkMgrService {
       /* Optional */
       @FormDataParam(CoordConsts.SVC_KEY_MAX_SUGGESTIONS) String maxSuggestions) {
     try {
+      networkName = networkName == null ? containerName : networkName;
       _logger.infof("WMS:autoComplete %s %s %s\n", completionType, query, maxSuggestions);
 
       checkStringParam(apiKey, "API key");
@@ -183,13 +185,15 @@ public class WorkMgrService {
   public JSONArray configureAnalysis(
       @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
-      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String networkName,
+      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
+      @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
       @FormDataParam(CoordConsts.SVC_KEY_NEW_ANALYSIS) String newAnalysisStr,
       @FormDataParam(CoordConsts.SVC_KEY_ANALYSIS_NAME) String analysisName,
       @FormDataParam(CoordConsts.SVC_KEY_FILE) InputStream addQuestionsStream,
       @FormDataParam(CoordConsts.SVC_KEY_DEL_ANALYSIS_QUESTIONS) String delQuestions,
       @Nullable @FormDataParam(CoordConsts.SVC_KEY_SUGGESTED) Boolean suggested) {
     try {
+      networkName = networkName == null ? containerName : networkName;
       _logger.infof(
           "WMS:configureAnalysis %s %s %s %s %s\n",
           apiKey, networkName, newAnalysisStr, analysisName, delQuestions);
@@ -309,9 +313,11 @@ public class WorkMgrService {
   public JSONArray delAnalysis(
       @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
-      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String networkName,
+      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
+      @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
       @FormDataParam(CoordConsts.SVC_KEY_ANALYSIS_NAME) String analysisName) {
     try {
+      networkName = networkName == null ? containerName : networkName;
       _logger.infof("WMS:delAnalysis %s %s %s", apiKey, networkName, analysisName);
 
       checkStringParam(apiKey, "API key");
@@ -347,7 +353,7 @@ public class WorkMgrService {
    * @param containerName The name of the network to delete
    * @return TODO: document JSON response
    * @deprecated because containers were renamed to networks. Use {@link #delNetwork(String, String,
-   *     String) delNetwork} instead.
+   *     String, String) delNetwork} instead.
    */
   @POST
   @Path(CoordConsts.SVC_RSC_DEL_CONTAINER)
@@ -357,7 +363,7 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
       @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName) {
-    return delNetwork(apiKey, clientVersion, containerName);
+    return delNetwork(apiKey, clientVersion, containerName, null);
   }
 
   /**
@@ -374,7 +380,9 @@ public class WorkMgrService {
   public JSONArray delNetwork(
       @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
+      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
       @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName) {
+    networkName = networkName == null ? containerName : networkName;
     try {
       _logger.infof("WMS:delNetwork %s\n", networkName);
 
@@ -465,9 +473,11 @@ public class WorkMgrService {
   public JSONArray delQuestion(
       @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
-      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String networkName,
+      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
+      @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
       @FormDataParam(CoordConsts.SVC_KEY_QUESTION_NAME) String questionName) {
     try {
+      networkName = networkName == null ? containerName : networkName;
       _logger.infof("WMS:delQuestion %s\n", networkName);
 
       checkStringParam(apiKey, "API key");
@@ -504,7 +514,7 @@ public class WorkMgrService {
    * @param testrigName The name of the snapshot to delete
    * @return TODO: document JSON response
    * @deprecated because testrigs were renamed to snapshots. Use {@link #delSnapshot(String, String,
-   *     String, String) delSnapshot} instead.
+   *     String, String, String) delSnapshot} instead.
    */
   @POST
   @Path(CoordConsts.SVC_RSC_DEL_TESTRIG)
@@ -515,7 +525,7 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
       @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
       @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String testrigName) {
-    return delSnapshot(apiKey, clientVersion, containerName, testrigName);
+    return delSnapshot(apiKey, clientVersion, containerName, null, testrigName);
   }
 
   /**
@@ -533,8 +543,10 @@ public class WorkMgrService {
   public JSONArray delSnapshot(
       @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
+      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
       @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
       @FormDataParam(CoordConsts.SVC_KEY_SNAPSHOT_NAME) String snapshotName) {
+    networkName = networkName == null ? containerName : networkName;
     try {
       _logger.infof("WMS:delSnapshot %s\n", networkName);
 
@@ -583,7 +595,8 @@ public class WorkMgrService {
   public JSONArray getAnalysisAnswer(
       @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
-      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String networkName,
+      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
+      @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
       @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String snapshotName,
       @FormDataParam(CoordConsts.SVC_KEY_ENV_NAME) String baseEnv,
       @FormDataParam(CoordConsts.SVC_KEY_DELTA_TESTRIG_NAME) String deltaSnapshot,
@@ -592,6 +605,7 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_QUESTION_NAME) String questionName,
       @FormDataParam(CoordConsts.SVC_KEY_WORKITEM) String workItemStr /* optional */) {
     try {
+      networkName = networkName == null ? containerName : networkName;
       _logger.infof(
           "WMS:getAnalysisAnswer %s %s %s %s\n", apiKey, networkName, snapshotName, analysisName);
 
@@ -676,7 +690,8 @@ public class WorkMgrService {
   public JSONArray getAnalysisAnswers(
       @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
-      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String networkName,
+      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
+      @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
       @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String snapshotName,
       @FormDataParam(CoordConsts.SVC_KEY_ENV_NAME) String baseEnv,
       @FormDataParam(CoordConsts.SVC_KEY_DELTA_TESTRIG_NAME) String deltaSnapshot,
@@ -684,6 +699,7 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_ANALYSIS_NAME) String analysisName,
       @FormDataParam(CoordConsts.SVC_KEY_WORKITEM) String workItemStr /* optional */) {
     try {
+      networkName = networkName == null ? containerName : networkName;
       _logger.infof(
           "WMS:getAnalysisAnswers %s %s %s %s\n", apiKey, networkName, snapshotName, analysisName);
 
@@ -761,7 +777,8 @@ public class WorkMgrService {
   public JSONArray getAnswer(
       @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
-      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String networkName,
+      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
+      @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
       @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String snapshotName,
       @FormDataParam(CoordConsts.SVC_KEY_ENV_NAME) String baseEnv,
       @FormDataParam(CoordConsts.SVC_KEY_DELTA_TESTRIG_NAME) String deltaSnapshot,
@@ -769,6 +786,7 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_QUESTION_NAME) String questionName,
       @FormDataParam(CoordConsts.SVC_KEY_WORKITEM) String workItemStr /* optional */) {
     try {
+      networkName = networkName == null ? containerName : networkName;
       _logger.infof("WMS:getAnswer %s %s %s %s\n", apiKey, networkName, snapshotName, questionName);
 
       checkStringParam(apiKey, "API key");
@@ -841,10 +859,12 @@ public class WorkMgrService {
   public Response getConfiguration(
       @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
-      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String networkName,
+      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
+      @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
       @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String snapshotName,
       @FormDataParam(CoordConsts.SVC_KEY_CONFIGURATION_NAME) String configName) {
     try {
+      networkName = networkName == null ? containerName : networkName;
       _logger.infof("WMS:getConfiguration %s\n", networkName);
 
       checkStringParam(apiKey, "API key");
@@ -899,7 +919,7 @@ public class WorkMgrService {
    *     network {@code containerName} or an error message if: the network {@code containerName}
    *     does not exist or the {@code apiKey} has no access to the network {@code containerName}
    * @deprecated because containers were renamed to networks. Use {@link #getNetwork(String, String,
-   *     String) getNetwork} instead.
+   *     String, String) getNetwork} instead.
    */
   @POST
   @Path(CoordConsts.SVC_RSC_GET_CONTAINER)
@@ -909,7 +929,7 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
       @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName) {
-    return getNetwork(apiKey, clientVersion, containerName);
+    return getNetwork(apiKey, clientVersion, containerName, null);
   }
 
   /**
@@ -928,7 +948,9 @@ public class WorkMgrService {
   public Response getNetwork(
       @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
+      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
       @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName) {
+    networkName = networkName == null ? containerName : networkName;
     try {
       _logger.infof("WMS:getNetwork %s\n", networkName);
 
@@ -1010,10 +1032,12 @@ public class WorkMgrService {
   public Response getObject(
       @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
-      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String networkName,
+      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
+      @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
       @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String snapshotName,
       @FormDataParam(CoordConsts.SVC_KEY_OBJECT_NAME) String objectName) {
     try {
+      networkName = networkName == null ? containerName : networkName;
       _logger.infof("WMS:getObject %s --> %s\n", snapshotName, objectName);
 
       checkStringParam(apiKey, "API key");
@@ -1064,9 +1088,11 @@ public class WorkMgrService {
   public JSONArray getParsingResults(
       @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
-      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String networkName,
+      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
+      @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
       @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String snapshotName) {
     try {
+      networkName = networkName == null ? containerName : networkName;
       _logger.infof("WMS:getParsingResults %s %s %s\n", apiKey, networkName, snapshotName);
       checkStringParam(apiKey, "API key");
       checkStringParam(clientVersion, "Client version");
@@ -1189,7 +1215,7 @@ public class WorkMgrService {
    *     containerName} is not empty)
    * @return TODO: document JSON response
    * @deprecated because containers were renamed to networks. Use {@link #initNetwork(String,
-   *     String, String, String) initNetwork} instead.
+   *     String, String, String, String) initNetwork} instead.
    */
   @POST
   @Path(CoordConsts.SVC_RSC_INIT_CONTAINER)
@@ -1220,8 +1246,10 @@ public class WorkMgrService {
   public JSONArray initNetwork(
       @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
+      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
       @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
       @FormDataParam(CoordConsts.SVC_KEY_NETWORK_PREFIX) String networkPrefix) {
+    networkName = networkName == null ? containerName : networkName;
     return initNetworkHelper(
         apiKey, clientVersion, networkName, networkPrefix, CoordConsts.SVC_KEY_NETWORK_NAME);
   }
@@ -1324,9 +1352,11 @@ public class WorkMgrService {
   public JSONArray listAnalyses(
       @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
-      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String networkName,
+      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
+      @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
       @Nullable @FormDataParam(CoordConsts.SVC_KEY_ANALYSIS_TYPE) AnalysisType analysisType) {
     try {
+      networkName = networkName == null ? containerName : networkName;
       _logger.infof("WMS:listAnalyses %s %s\n", apiKey, networkName);
 
       checkStringParam(apiKey, "API key");
@@ -1486,10 +1516,12 @@ public class WorkMgrService {
   public JSONArray listIncompleteWork(
       @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
-      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String networkName,
+      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
+      @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
       @Nullable @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String snapshotName, /* optional */
       @Nullable @FormDataParam(CoordConsts.SVC_KEY_WORK_TYPE) WorkType workType /* optional */) {
     try {
+      networkName = networkName == null ? containerName : networkName;
       _logger.infof("WMS:listIncompleteWork %s %s\n", apiKey, networkName);
 
       checkStringParam(apiKey, "API key");
@@ -1539,9 +1571,11 @@ public class WorkMgrService {
   public JSONArray listQuestions(
       @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
-      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String networkName,
+      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
+      @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
       @FormDataParam(CoordConsts.SVC_KEY_VERBOSE) boolean verbose) {
     try {
+      networkName = networkName == null ? containerName : networkName;
       _logger.infof("WMS:listQuestions %s %s\n", apiKey, networkName);
 
       checkStringParam(apiKey, "API key");
@@ -1581,7 +1615,7 @@ public class WorkMgrService {
    * @param containerName The name of the network whose testrigs are to be listed
    * @return TODO: document JSON response
    * @deprecated because testrigs were renamed to snapshots. Use {@link #listSnapshots(String,
-   *     String, String) listSnapshots} instead.
+   *     String, String, String) listSnapshots} instead.
    */
   @POST
   @Path(CoordConsts.SVC_RSC_LIST_TESTRIGS)
@@ -1615,7 +1649,9 @@ public class WorkMgrService {
   public JSONArray listSnapshots(
       @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
+      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
       @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName) {
+    networkName = networkName == null ? containerName : networkName;
     return listSnapshotsHelper(
         apiKey,
         clientVersion,
@@ -1695,11 +1731,13 @@ public class WorkMgrService {
   public JSONArray putObject(
       @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
-      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String networkName,
+      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
+      @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
       @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String snapshotName,
       @FormDataParam(CoordConsts.SVC_KEY_OBJECT_NAME) String objectName,
       @FormDataParam(CoordConsts.SVC_KEY_FILE) InputStream fileStream) {
     try {
+      networkName = networkName == null ? containerName : networkName;
       _logger.infof("WMS:putObject %s %s %s / %s\n", apiKey, networkName, snapshotName, objectName);
 
       checkStringParam(apiKey, "API key");
@@ -1785,7 +1823,8 @@ public class WorkMgrService {
    * @param pluginId The plugin id to use for syncing
    * @return TODO: document JSON response
    * @deprecated because testrigs were renamed to snapshots. Use {@link
-   *     #syncSnapshotsSyncNow(String, String, String, String, String) syncSnapshots} instead.
+   *     #syncSnapshotsSyncNow(String, String, String, String, String, String) syncSnapshots}
+   *     instead.
    */
   @POST
   @Path(CoordConsts.SVC_RSC_SYNC_TESTRIGS_SYNC_NOW)
@@ -1797,7 +1836,7 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
       @FormDataParam(CoordConsts.SVC_KEY_PLUGIN_ID) String pluginId,
       @FormDataParam(CoordConsts.SVC_KEY_FORCE) String forceStr) {
-    return syncSnapshotsSyncNow(apiKey, clientVersion, containerName, pluginId, forceStr);
+    return syncSnapshotsSyncNow(apiKey, clientVersion, containerName, null, pluginId, forceStr);
   }
 
   /**
@@ -1815,10 +1854,12 @@ public class WorkMgrService {
   public JSONArray syncSnapshotsSyncNow(
       @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
+      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
       @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
       @FormDataParam(CoordConsts.SVC_KEY_PLUGIN_ID) String pluginId,
       @FormDataParam(CoordConsts.SVC_KEY_FORCE) String forceStr) {
     try {
+      networkName = networkName == null ? containerName : networkName;
       _logger.infof("WMS:syncSnapshotsSyncNow %s %s %s\n", apiKey, networkName, pluginId);
 
       checkStringParam(apiKey, "API key");
@@ -1857,7 +1898,7 @@ public class WorkMgrService {
    * @param settingsStr The stringified version of settings
    * @return TODO: document JSON response
    * @deprecated because testrigs were renamed to snapshots. Use {@link
-   *     #syncSnapshotsUpdateSettings(String, String, String, String, String)
+   *     #syncSnapshotsUpdateSettings(String, String, String, String, String, String)
    *     syncSnapshotsUpdateSettings} instead.
    */
   @POST
@@ -1870,7 +1911,8 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
       @FormDataParam(CoordConsts.SVC_KEY_PLUGIN_ID) String pluginId,
       @FormDataParam(CoordConsts.SVC_KEY_SETTINGS) String settingsStr) {
-    return syncSnapshotsUpdateSettings(apiKey, clientVersion, containerName, pluginId, settingsStr);
+    return syncSnapshotsUpdateSettings(
+        apiKey, clientVersion, containerName, null, pluginId, settingsStr);
   }
 
   /**
@@ -1889,10 +1931,12 @@ public class WorkMgrService {
   public JSONArray syncSnapshotsUpdateSettings(
       @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
+      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
       @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
       @FormDataParam(CoordConsts.SVC_KEY_PLUGIN_ID) String pluginId,
       @FormDataParam(CoordConsts.SVC_KEY_SETTINGS) String settingsStr) {
     try {
+      networkName = networkName == null ? containerName : networkName;
       _logger.infof(
           "WMS:syncSnapshotsUpdateSettings %s %s %s %s\n",
           apiKey, networkName, pluginId, settingsStr);
@@ -2027,11 +2071,13 @@ public class WorkMgrService {
   public JSONArray uploadQuestion(
       @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
-      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String networkName,
+      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
+      @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
       @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String snapshotName,
       @FormDataParam(CoordConsts.SVC_KEY_QUESTION_NAME) String qName,
       @FormDataParam(CoordConsts.SVC_KEY_FILE) String questionJson) {
     try {
+      networkName = networkName == null ? containerName : networkName;
       _logger.infof("WMS:uploadQuestion %s %s %s/%s\n", apiKey, networkName, snapshotName, qName);
 
       checkStringParam(apiKey, "API key");
@@ -2076,11 +2122,13 @@ public class WorkMgrService {
   public JSONArray uploadSnapshot(
       @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
+      @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
       @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
       @FormDataParam(CoordConsts.SVC_KEY_SNAPSHOT_NAME) String snapshotName,
       @FormDataParam(CoordConsts.SVC_KEY_ZIPFILE) InputStream fileStream,
       @FormDataParam(CoordConsts.SVC_KEY_AUTO_ANALYZE) String autoAnalyzeStr) {
     try {
+      networkName = networkName == null ? containerName : networkName;
       _logger.infof("WMS:uploadSnapshot %s %s %s\n", apiKey, networkName, snapshotName);
 
       checkStringParam(apiKey, "API key");
@@ -2131,7 +2179,7 @@ public class WorkMgrService {
    * @param fileStream The stream from which the new testrig is read
    * @return TODO: document JSON response
    * @deprecated because testrigs were renamed to snapshots. Use {@link #uploadSnapshot(String,
-   *     String, String, String, InputStream, String)} instead.
+   *     String, String, String, String, InputStream, String)} instead.
    */
   @POST
   @Path(CoordConsts.SVC_RSC_UPLOAD_TESTRIG)
@@ -2146,6 +2194,6 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_ZIPFILE) InputStream fileStream,
       @FormDataParam(CoordConsts.SVC_KEY_AUTO_ANALYZE_TESTRIG) String autoAnalyzeStr) {
     return uploadSnapshot(
-        apiKey, clientVersion, containerName, testrigName, fileStream, autoAnalyzeStr);
+        apiKey, clientVersion, containerName, null, testrigName, fileStream, autoAnalyzeStr);
   }
 }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
@@ -78,25 +78,25 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_QUERY) String query,
       /* Optional */
       @FormDataParam(CoordConsts.SVC_KEY_MAX_SUGGESTIONS) String maxSuggestions) {
+    String networkNameParam = networkName == null ? containerName : networkName;
+    String snapshotNameParam = snapshotName == null ? testrigName : snapshotName;
     try {
-      networkName = networkName == null ? containerName : networkName;
-      snapshotName = snapshotName == null ? testrigName : snapshotName;
       _logger.infof("WMS:autoComplete %s %s %s\n", completionType, query, maxSuggestions);
 
       checkStringParam(apiKey, "API key");
       checkStringParam(clientVersion, "Client version");
-      checkStringParam(networkName, "Network name");
+      checkStringParam(networkNameParam, "Network name");
       checkStringParam(completionType, "Completion type");
 
       checkApiKeyValidity(apiKey);
       checkClientVersion(clientVersion);
-      checkNetworkAccessibility(apiKey, networkName);
+      checkNetworkAccessibility(apiKey, networkNameParam);
 
       List<AutocompleteSuggestion> answer =
           Main.getWorkMgr()
               .autoComplete(
-                  networkName,
-                  snapshotName,
+                  networkNameParam,
+                  snapshotNameParam,
                   CompletionType.valueOf(completionType.toUpperCase()),
                   query,
                   Strings.isNullOrEmpty(maxSuggestions)
@@ -194,20 +194,20 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_FILE) InputStream addQuestionsStream,
       @FormDataParam(CoordConsts.SVC_KEY_DEL_ANALYSIS_QUESTIONS) String delQuestions,
       @Nullable @FormDataParam(CoordConsts.SVC_KEY_SUGGESTED) Boolean suggested) {
+    String networkNameParam = networkName == null ? containerName : networkName;
     try {
-      networkName = networkName == null ? containerName : networkName;
       _logger.infof(
           "WMS:configureAnalysis %s %s %s %s %s\n",
-          apiKey, networkName, newAnalysisStr, analysisName, delQuestions);
+          apiKey, networkNameParam, newAnalysisStr, analysisName, delQuestions);
 
       checkStringParam(apiKey, "API key");
       checkStringParam(clientVersion, "Client version");
-      checkStringParam(networkName, "Network name");
+      checkStringParam(networkNameParam, "Network name");
       checkStringParam(analysisName, "Analysis name");
 
       checkApiKeyValidity(apiKey);
       checkClientVersion(clientVersion);
-      checkNetworkAccessibility(apiKey, networkName);
+      checkNetworkAccessibility(apiKey, networkNameParam);
 
       Map<String, String> questionsToAdd = new HashMap<>();
       if (addQuestionsStream != null) {
@@ -235,7 +235,12 @@ public class WorkMgrService {
 
       Main.getWorkMgr()
           .configureAnalysis(
-              networkName, newAnalysis, analysisName, questionsToAdd, questionsToDelete, suggested);
+              networkNameParam,
+              newAnalysis,
+              analysisName,
+              questionsToAdd,
+              questionsToDelete,
+              suggested);
 
       return successResponse(new JSONObject().put("result", "successfully configured analysis"));
 
@@ -246,7 +251,7 @@ public class WorkMgrService {
       String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf(
           "WMS:configureAnalysis exception for apikey:%s in network:%s; exception:%s",
-          apiKey, networkName, stackTrace);
+          apiKey, networkNameParam, stackTrace);
       return failureResponse(e.getMessage());
     }
   }
@@ -318,20 +323,20 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
       @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
       @FormDataParam(CoordConsts.SVC_KEY_ANALYSIS_NAME) String analysisName) {
+    String networkNameParam = networkName == null ? containerName : networkName;
     try {
-      networkName = networkName == null ? containerName : networkName;
-      _logger.infof("WMS:delAnalysis %s %s %s", apiKey, networkName, analysisName);
+      _logger.infof("WMS:delAnalysis %s %s %s", apiKey, networkNameParam, analysisName);
 
       checkStringParam(apiKey, "API key");
       checkStringParam(clientVersion, "Client version");
-      checkStringParam(networkName, "Network name");
+      checkStringParam(networkNameParam, "Network name");
       checkStringParam(analysisName, "Analysis name");
 
       checkApiKeyValidity(apiKey);
       checkClientVersion(clientVersion);
-      checkNetworkAccessibility(apiKey, networkName);
+      checkNetworkAccessibility(apiKey, networkNameParam);
 
-      Main.getWorkMgr().delAnalysis(networkName, analysisName);
+      Main.getWorkMgr().delAnalysis(networkNameParam, analysisName);
 
       return successResponse(new JSONObject().put("result", "successfully configured analysis"));
 
@@ -342,7 +347,7 @@ public class WorkMgrService {
       String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf(
           "WMS:delAnalysis exception for apikey:%s in network:%s; exception:%s",
-          apiKey, networkName, stackTrace);
+          apiKey, networkNameParam, stackTrace);
       return failureResponse(e.getMessage());
     }
   }
@@ -384,19 +389,19 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
       @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
       @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName) {
-    networkName = networkName == null ? containerName : networkName;
+    String networkNameParam = networkName == null ? containerName : networkName;
     try {
-      _logger.infof("WMS:delNetwork %s\n", networkName);
+      _logger.infof("WMS:delNetwork %s\n", networkNameParam);
 
       checkStringParam(apiKey, "API key");
       checkStringParam(clientVersion, "Client version");
-      checkStringParam(networkName, "Network name");
+      checkStringParam(networkNameParam, "Network name");
 
       checkApiKeyValidity(apiKey);
       checkClientVersion(clientVersion);
-      checkNetworkAccessibility(apiKey, networkName);
+      checkNetworkAccessibility(apiKey, networkNameParam);
 
-      boolean status = Main.getWorkMgr().delContainer(networkName);
+      boolean status = Main.getWorkMgr().delContainer(networkNameParam);
 
       return successResponse(new JSONObject().put("result", status));
 
@@ -407,7 +412,7 @@ public class WorkMgrService {
       String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf(
           "WMS:delNetwork exception for apikey:%s in network:%s; exception:%s",
-          apiKey, networkName, stackTrace);
+          apiKey, networkNameParam, stackTrace);
       return failureResponse(e.getMessage());
     }
   }
@@ -478,20 +483,20 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
       @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
       @FormDataParam(CoordConsts.SVC_KEY_QUESTION_NAME) String questionName) {
+    String networkNameParam = networkName == null ? containerName : networkName;
     try {
-      networkName = networkName == null ? containerName : networkName;
-      _logger.infof("WMS:delQuestion %s\n", networkName);
+      _logger.infof("WMS:delQuestion %s\n", networkNameParam);
 
       checkStringParam(apiKey, "API key");
       checkStringParam(clientVersion, "Client version");
-      checkStringParam(networkName, "Network name");
+      checkStringParam(networkNameParam, "Network name");
       checkStringParam(questionName, "Question name");
 
       checkApiKeyValidity(apiKey);
       checkClientVersion(clientVersion);
-      checkNetworkAccessibility(apiKey, networkName);
+      checkNetworkAccessibility(apiKey, networkNameParam);
 
-      Main.getWorkMgr().delQuestion(networkName, questionName);
+      Main.getWorkMgr().delQuestion(networkNameParam, questionName);
 
       return successResponse(new JSONObject().put("result", "true"));
 
@@ -502,7 +507,7 @@ public class WorkMgrService {
       String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf(
           "WMS:delQuestion exception for apikey:%s in network:%s; exception:%s",
-          apiKey, networkName, stackTrace);
+          apiKey, networkNameParam, stackTrace);
       return failureResponse(e.getMessage());
     }
   }
@@ -549,21 +554,21 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
       @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String testrigName,
       @FormDataParam(CoordConsts.SVC_KEY_SNAPSHOT_NAME) String snapshotName) {
-    networkName = networkName == null ? containerName : networkName;
-    snapshotName = snapshotName == null ? testrigName : snapshotName;
+    String networkNameParam = networkName == null ? containerName : networkName;
+    String snapshotNameParam = snapshotName == null ? testrigName : snapshotName;
     try {
-      _logger.infof("WMS:delSnapshot %s\n", networkName);
+      _logger.infof("WMS:delSnapshot %s\n", networkNameParam);
 
       checkStringParam(apiKey, "API key");
       checkStringParam(clientVersion, "Client version");
-      checkStringParam(networkName, "Network name");
-      checkStringParam(snapshotName, "Snapshot name");
+      checkStringParam(networkNameParam, "Network name");
+      checkStringParam(snapshotNameParam, "Snapshot name");
 
       checkApiKeyValidity(apiKey);
       checkClientVersion(clientVersion);
-      checkNetworkAccessibility(apiKey, networkName);
+      checkNetworkAccessibility(apiKey, networkNameParam);
 
-      Main.getWorkMgr().delTestrig(networkName, snapshotName);
+      Main.getWorkMgr().delTestrig(networkNameParam, snapshotNameParam);
 
       return successResponse(new JSONObject().put("result", "true"));
 
@@ -574,7 +579,7 @@ public class WorkMgrService {
       String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf(
           "WMS:delSnapshot exception for apikey:%s in network:%s, snapshot:%s; exception:%s",
-          apiKey, networkName, snapshotName, stackTrace);
+          apiKey, networkNameParam, snapshotNameParam, stackTrace);
       return failureResponse(e.getMessage());
     }
   }
@@ -610,31 +615,32 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_ANALYSIS_NAME) String analysisName,
       @FormDataParam(CoordConsts.SVC_KEY_QUESTION_NAME) String questionName,
       @FormDataParam(CoordConsts.SVC_KEY_WORKITEM) String workItemStr /* optional */) {
+    String networkNameParam = networkName == null ? containerName : networkName;
+    String snapshotNameParam = snapshotName == null ? testrigName : snapshotName;
+    String deltaSnapshotParam = deltaSnapshot == null ? deltaTestrig : deltaSnapshot;
     try {
-      networkName = networkName == null ? containerName : networkName;
-      snapshotName = snapshotName == null ? testrigName : snapshotName;
-      deltaSnapshot = deltaSnapshot == null ? deltaTestrig : deltaSnapshot;
       _logger.infof(
-          "WMS:getAnalysisAnswer %s %s %s %s\n", apiKey, networkName, snapshotName, analysisName);
+          "WMS:getAnalysisAnswer %s %s %s %s\n",
+          apiKey, networkNameParam, snapshotNameParam, analysisName);
 
       checkStringParam(apiKey, "API key");
       checkStringParam(clientVersion, "Client version");
-      checkStringParam(networkName, "Network name");
-      checkStringParam(snapshotName, "Base snapshot name");
+      checkStringParam(networkNameParam, "Network name");
+      checkStringParam(snapshotNameParam, "Base snapshot name");
       checkStringParam(baseEnv, "Base environment name");
       checkStringParam(analysisName, "Analysis name");
       checkStringParam(questionName, "Question name");
 
       checkApiKeyValidity(apiKey);
       checkClientVersion(clientVersion);
-      checkNetworkAccessibility(apiKey, networkName);
+      checkNetworkAccessibility(apiKey, networkNameParam);
 
       JSONObject response = new JSONObject();
 
       if (!Strings.isNullOrEmpty(workItemStr)) {
         WorkItem workItem = BatfishObjectMapper.mapper().readValue(workItemStr, WorkItem.class);
-        if (!workItem.getContainerName().equals(networkName)
-            || !workItem.getTestrigName().equals(snapshotName)) {
+        if (!workItem.getContainerName().equals(networkNameParam)
+            || !workItem.getTestrigName().equals(snapshotNameParam)) {
           return failureResponse(
               "Mismatch in parameters: WorkItem is not for the supplied network or snapshot");
         }
@@ -651,10 +657,10 @@ public class WorkMgrService {
       String answer =
           Main.getWorkMgr()
               .getAnalysisAnswer(
-                  networkName,
-                  snapshotName,
+                  networkNameParam,
+                  snapshotNameParam,
                   baseEnv,
-                  deltaSnapshot,
+                  deltaSnapshotParam,
                   deltaEnv,
                   analysisName,
                   questionName);
@@ -671,9 +677,9 @@ public class WorkMgrService {
           "WMS:getAnalysisAnswer exception for apikey:%s in network:%s, snapshot:%s, "
               + "deltasnapshot:%s; exception:%s",
           apiKey,
-          networkName,
-          snapshotName,
-          deltaSnapshot == null ? "" : deltaSnapshot,
+          networkNameParam,
+          snapshotNameParam,
+          deltaSnapshotParam == null ? "" : deltaSnapshotParam,
           stackTrace);
       return failureResponse(e.getMessage());
     }
@@ -708,30 +714,31 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_DELTA_ENV_NAME) String deltaEnv,
       @FormDataParam(CoordConsts.SVC_KEY_ANALYSIS_NAME) String analysisName,
       @FormDataParam(CoordConsts.SVC_KEY_WORKITEM) String workItemStr /* optional */) {
+    String networkNameParam = networkName == null ? containerName : networkName;
+    String snapshotNameParam = snapshotName == null ? testrigName : snapshotName;
+    String deltaSnapshotParam = deltaSnapshot == null ? deltaTestrig : deltaSnapshot;
     try {
-      networkName = networkName == null ? containerName : networkName;
-      snapshotName = snapshotName == null ? testrigName : snapshotName;
-      deltaSnapshot = deltaSnapshot == null ? deltaTestrig : deltaSnapshot;
       _logger.infof(
-          "WMS:getAnalysisAnswers %s %s %s %s\n", apiKey, networkName, snapshotName, analysisName);
+          "WMS:getAnalysisAnswers %s %s %s %s\n",
+          apiKey, networkNameParam, snapshotNameParam, analysisName);
 
       checkStringParam(apiKey, "API key");
       checkStringParam(clientVersion, "Client version");
-      checkStringParam(networkName, "Network name");
-      checkStringParam(snapshotName, "Base snapshot name");
+      checkStringParam(networkNameParam, "Network name");
+      checkStringParam(snapshotNameParam, "Base snapshot name");
       checkStringParam(baseEnv, "Base environment name");
       checkStringParam(analysisName, "Analysis name");
 
       checkApiKeyValidity(apiKey);
       checkClientVersion(clientVersion);
-      checkNetworkAccessibility(apiKey, networkName);
+      checkNetworkAccessibility(apiKey, networkNameParam);
 
       JSONObject response = new JSONObject();
 
       if (!Strings.isNullOrEmpty(workItemStr)) {
         WorkItem workItem = BatfishObjectMapper.mapper().readValue(workItemStr, WorkItem.class);
-        if (!workItem.getContainerName().equals(networkName)
-            || !workItem.getTestrigName().equals(snapshotName)) {
+        if (!workItem.getContainerName().equals(networkNameParam)
+            || !workItem.getTestrigName().equals(snapshotNameParam)) {
           return failureResponse(
               "Mismatch in parameters: WorkItem is not for the supplied network or snapshot");
         }
@@ -748,7 +755,12 @@ public class WorkMgrService {
       Map<String, String> answers =
           Main.getWorkMgr()
               .getAnalysisAnswers(
-                  networkName, snapshotName, baseEnv, deltaSnapshot, deltaEnv, analysisName);
+                  networkNameParam,
+                  snapshotNameParam,
+                  baseEnv,
+                  deltaSnapshotParam,
+                  deltaEnv,
+                  analysisName);
 
       String answersStr = BatfishObjectMapper.writePrettyString(answers);
 
@@ -762,9 +774,9 @@ public class WorkMgrService {
           "WMS:getAnalysisAnswers exception for apikey:%s in network:%s, snapshot:%s, "
               + "deltasnapshot:%s; exception:%s",
           apiKey,
-          networkName,
-          snapshotName,
-          deltaSnapshot == null ? "" : deltaSnapshot,
+          networkNameParam,
+          snapshotNameParam,
+          deltaSnapshotParam == null ? "" : deltaSnapshotParam,
           stackTrace);
       return failureResponse(e.getMessage());
     }
@@ -799,27 +811,28 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_DELTA_ENV_NAME) String deltaEnv,
       @FormDataParam(CoordConsts.SVC_KEY_QUESTION_NAME) String questionName,
       @FormDataParam(CoordConsts.SVC_KEY_WORKITEM) String workItemStr /* optional */) {
+    String networkNameParam = networkName == null ? containerName : networkName;
+    String snapshotNameParam = snapshotName == null ? testrigName : snapshotName;
+    String deltaSnapshotParam = deltaSnapshot == null ? deltaTestrig : deltaSnapshot;
     try {
-      networkName = networkName == null ? containerName : networkName;
-      snapshotName = snapshotName == null ? testrigName : snapshotName;
-      deltaSnapshot = deltaSnapshot == null ? deltaTestrig : deltaSnapshot;
-      _logger.infof("WMS:getAnswer %s %s %s %s\n", apiKey, networkName, snapshotName, questionName);
+      _logger.infof(
+          "WMS:getAnswer %s %s %s %s\n", apiKey, networkNameParam, snapshotNameParam, questionName);
 
       checkStringParam(apiKey, "API key");
       checkStringParam(clientVersion, "Client version");
-      checkStringParam(networkName, "Network name");
-      checkStringParam(snapshotName, "Base snapshot name");
+      checkStringParam(networkNameParam, "Network name");
+      checkStringParam(snapshotNameParam, "Base snapshot name");
       checkStringParam(baseEnv, "Base environment name");
       checkStringParam(questionName, "Question name");
 
       checkApiKeyValidity(apiKey);
       checkClientVersion(clientVersion);
-      checkNetworkAccessibility(apiKey, networkName);
+      checkNetworkAccessibility(apiKey, networkNameParam);
 
       if (!Strings.isNullOrEmpty(workItemStr)) {
         WorkItem workItem = BatfishObjectMapper.mapper().readValue(workItemStr, WorkItem.class);
-        if (!workItem.getContainerName().equals(networkName)
-            || !workItem.getTestrigName().equals(snapshotName)) {
+        if (!workItem.getContainerName().equals(networkNameParam)
+            || !workItem.getTestrigName().equals(snapshotNameParam)) {
           return failureResponse(
               "Mismatch in parameters: WorkItem is not for the supplied network or snapshot");
         }
@@ -836,7 +849,13 @@ public class WorkMgrService {
 
       String answer =
           Main.getWorkMgr()
-              .getAnswer(networkName, snapshotName, baseEnv, deltaSnapshot, deltaEnv, questionName);
+              .getAnswer(
+                  networkNameParam,
+                  snapshotNameParam,
+                  baseEnv,
+                  deltaSnapshotParam,
+                  deltaEnv,
+                  questionName);
 
       return successResponse(new JSONObject().put(CoordConsts.SVC_KEY_ANSWER, answer));
     } catch (IllegalArgumentException | AccessControlException e) {
@@ -848,9 +867,9 @@ public class WorkMgrService {
           "WMS:getAnswer exception for apikey:%s in network:%s, snapshot:%s, deltasnapshot:%s; "
               + "exception:%s",
           apiKey,
-          networkName,
-          snapshotName,
-          deltaSnapshot == null ? "" : deltaSnapshot,
+          networkNameParam,
+          snapshotNameParam,
+          deltaSnapshotParam == null ? "" : deltaSnapshotParam,
           stackTrace);
       return failureResponse(e.getMessage());
     }
@@ -880,31 +899,31 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String testrigName,
       @FormDataParam(CoordConsts.SVC_KEY_SNAPSHOT_NAME) String snapshotName,
       @FormDataParam(CoordConsts.SVC_KEY_CONFIGURATION_NAME) String configName) {
+    String networkNameParam = networkName == null ? containerName : networkName;
+    String snapshotNameParam = snapshotName == null ? testrigName : snapshotName;
     try {
-      networkName = networkName == null ? containerName : networkName;
-      snapshotName = snapshotName == null ? testrigName : snapshotName;
-      _logger.infof("WMS:getConfiguration %s\n", networkName);
+      _logger.infof("WMS:getConfiguration %s\n", networkNameParam);
 
       checkStringParam(apiKey, "API key");
       checkStringParam(clientVersion, "Client version");
-      checkStringParam(networkName, "Network name");
+      checkStringParam(networkNameParam, "Network name");
 
       checkApiKeyValidity(apiKey);
       checkClientVersion(clientVersion);
 
       java.nio.file.Path networkDir =
-          Main.getSettings().getContainersLocation().resolve(networkName).toAbsolutePath();
+          Main.getSettings().getContainersLocation().resolve(networkNameParam).toAbsolutePath();
       if (networkDir == null || !Files.exists(networkDir)) {
         return Response.status(Response.Status.NOT_FOUND)
-            .entity("Network '" + networkName + "' not found")
+            .entity("Network '" + networkNameParam + "' not found")
             .type(MediaType.TEXT_PLAIN)
             .build();
       }
 
-      checkNetworkAccessibility(apiKey, networkName);
+      checkNetworkAccessibility(apiKey, networkNameParam);
 
       String configContent =
-          Main.getWorkMgr().getConfiguration(networkName, snapshotName, configName);
+          Main.getWorkMgr().getConfiguration(networkNameParam, snapshotNameParam, configName);
 
       return Response.ok(configContent).build();
     } catch (AccessControlException e) {
@@ -968,27 +987,27 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
       @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
       @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName) {
-    networkName = networkName == null ? containerName : networkName;
+    String networkNameParam = networkName == null ? containerName : networkName;
     try {
-      _logger.infof("WMS:getNetwork %s\n", networkName);
+      _logger.infof("WMS:getNetwork %s\n", networkNameParam);
 
       checkStringParam(apiKey, "API key");
       checkStringParam(clientVersion, "Client version");
-      checkStringParam(networkName, "Network name");
+      checkStringParam(networkNameParam, "Network name");
 
       checkApiKeyValidity(apiKey);
       checkClientVersion(clientVersion);
 
       java.nio.file.Path networkDir =
-          Main.getSettings().getContainersLocation().resolve(networkName).toAbsolutePath();
+          Main.getSettings().getContainersLocation().resolve(networkNameParam).toAbsolutePath();
       if (networkDir == null || !Files.exists(networkDir)) {
         return Response.status(Response.Status.NOT_FOUND)
-            .entity("Network '" + networkName + "' not found")
+            .entity("Network '" + networkNameParam + "' not found")
             .type(MediaType.TEXT_PLAIN)
             .build();
       }
 
-      checkNetworkAccessibility(apiKey, networkName);
+      checkNetworkAccessibility(apiKey, networkNameParam);
 
       Container network = Main.getWorkMgr().getContainer(networkDir);
       String networkString = BatfishObjectMapper.writeString(network);
@@ -1008,7 +1027,7 @@ public class WorkMgrService {
       String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf(
           "WMS:getNetwork exception for apikey:%s in network:%s; exception:%s",
-          apiKey, networkName, stackTrace);
+          apiKey, networkNameParam, stackTrace);
       return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
           .entity(e.getCause())
           .type(MediaType.TEXT_PLAIN)
@@ -1055,23 +1074,23 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String testrigName,
       @FormDataParam(CoordConsts.SVC_KEY_SNAPSHOT_NAME) String snapshotName,
       @FormDataParam(CoordConsts.SVC_KEY_OBJECT_NAME) String objectName) {
+    String networkNameParam = networkName == null ? containerName : networkName;
+    String snapshotNameParam = snapshotName == null ? testrigName : snapshotName;
     try {
-      networkName = networkName == null ? containerName : networkName;
-      snapshotName = snapshotName == null ? testrigName : snapshotName;
-      _logger.infof("WMS:getObject %s --> %s\n", snapshotName, objectName);
+      _logger.infof("WMS:getObject %s --> %s\n", snapshotNameParam, objectName);
 
       checkStringParam(apiKey, "API key");
       checkStringParam(clientVersion, "Client version");
-      checkStringParam(networkName, "Network name");
-      checkStringParam(snapshotName, "Snapshot name");
+      checkStringParam(networkNameParam, "Network name");
+      checkStringParam(snapshotNameParam, "Snapshot name");
       checkStringParam(objectName, "Object name");
 
       checkApiKeyValidity(apiKey);
       checkClientVersion(clientVersion);
-      checkNetworkAccessibility(apiKey, networkName);
+      checkNetworkAccessibility(apiKey, networkNameParam);
 
       java.nio.file.Path file =
-          Main.getWorkMgr().getTestrigObject(networkName, snapshotName, objectName);
+          Main.getWorkMgr().getTestrigObject(networkNameParam, snapshotNameParam, objectName);
 
       if (file == null || !Files.exists(file)) {
         return Response.status(Response.Status.NOT_FOUND)
@@ -1094,7 +1113,7 @@ public class WorkMgrService {
       String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf(
           "WMS:getObject exception for apikey:%s in network:%s, snapshot:%s; exception:%s",
-          apiKey, networkName, snapshotName, stackTrace);
+          apiKey, networkNameParam, snapshotNameParam, stackTrace);
       return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
           .entity(e.getCause())
           .type(MediaType.TEXT_PLAIN)
@@ -1112,25 +1131,27 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
       @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String testrigName,
       @FormDataParam(CoordConsts.SVC_KEY_SNAPSHOT_NAME) String snapshotName) {
+    String networkNameParam = networkName == null ? containerName : networkName;
+    String snapshotNameParam = snapshotName == null ? testrigName : snapshotName;
     try {
-      networkName = networkName == null ? containerName : networkName;
-      snapshotName = snapshotName == null ? testrigName : snapshotName;
-      _logger.infof("WMS:getParsingResults %s %s %s\n", apiKey, networkName, snapshotName);
+      _logger.infof(
+          "WMS:getParsingResults %s %s %s\n", apiKey, networkNameParam, snapshotNameParam);
       checkStringParam(apiKey, "API key");
       checkStringParam(clientVersion, "Client version");
-      checkStringParam(networkName, "Network name");
-      checkStringParam(snapshotName, "Snapshot name");
+      checkStringParam(networkNameParam, "Network name");
+      checkStringParam(snapshotNameParam, "Snapshot name");
 
       checkApiKeyValidity(apiKey);
       checkClientVersion(clientVersion);
-      checkNetworkAccessibility(apiKey, networkName);
+      checkNetworkAccessibility(apiKey, networkNameParam);
 
-      return successResponse(Main.getWorkMgr().getParsingResults(networkName, snapshotName));
+      return successResponse(
+          Main.getWorkMgr().getParsingResults(networkNameParam, snapshotNameParam));
     } catch (Exception e) {
       String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf(
           "WMS:getParsingResults exception for apikey:%s in network:%s, snapshot:%s; exception:%s",
-          apiKey, networkName, snapshotName, stackTrace);
+          apiKey, networkNameParam, snapshotNameParam, stackTrace);
       return failureResponse(e.getMessage());
     }
   }
@@ -1271,9 +1292,9 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
       @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
       @FormDataParam(CoordConsts.SVC_KEY_NETWORK_PREFIX) String networkPrefix) {
-    networkName = networkName == null ? containerName : networkName;
+    String networkNameParam = networkName == null ? containerName : networkName;
     return initNetworkHelper(
-        apiKey, clientVersion, networkName, networkPrefix, CoordConsts.SVC_KEY_NETWORK_NAME);
+        apiKey, clientVersion, networkNameParam, networkPrefix, CoordConsts.SVC_KEY_NETWORK_NAME);
   }
 
   private JSONArray initNetworkHelper(
@@ -1377,30 +1398,30 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
       @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
       @Nullable @FormDataParam(CoordConsts.SVC_KEY_ANALYSIS_TYPE) AnalysisType analysisType) {
+    String networkNameParam = networkName == null ? containerName : networkName;
     try {
-      networkName = networkName == null ? containerName : networkName;
-      _logger.infof("WMS:listAnalyses %s %s\n", apiKey, networkName);
+      _logger.infof("WMS:listAnalyses %s %s\n", apiKey, networkNameParam);
 
       checkStringParam(apiKey, "API key");
       checkStringParam(clientVersion, "Client version");
-      checkStringParam(networkName, "Network name");
+      checkStringParam(networkNameParam, "Network name");
 
       checkApiKeyValidity(apiKey);
       checkClientVersion(clientVersion);
-      checkNetworkAccessibility(apiKey, networkName);
+      checkNetworkAccessibility(apiKey, networkNameParam);
 
       JSONObject retObject = new JSONObject();
 
       for (String analysisName :
           Main.getWorkMgr()
-              .listAnalyses(networkName, firstNonNull(analysisType, AnalysisType.USER))) {
+              .listAnalyses(networkNameParam, firstNonNull(analysisType, AnalysisType.USER))) {
 
         JSONObject analysisJson = new JSONObject();
 
         for (String questionName :
-            Main.getWorkMgr().listAnalysisQuestions(networkName, analysisName)) {
+            Main.getWorkMgr().listAnalysisQuestions(networkNameParam, analysisName)) {
           String questionText =
-              Main.getWorkMgr().getAnalysisQuestion(networkName, analysisName, questionName);
+              Main.getWorkMgr().getAnalysisQuestion(networkNameParam, analysisName, questionName);
 
           analysisJson.put(questionName, new JSONObject(questionText));
         }
@@ -1416,7 +1437,7 @@ public class WorkMgrService {
       String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf(
           "WMS:listAnalyses exception for apikey:%s in network:%s; exception:%s",
-          apiKey, networkName, stackTrace);
+          apiKey, networkNameParam, stackTrace);
       return failureResponse(e.getMessage());
     }
   }
@@ -1543,25 +1564,25 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String testrigName,
       @FormDataParam(CoordConsts.SVC_KEY_SNAPSHOT_NAME) String snapshotName, /* optional */
       @Nullable @FormDataParam(CoordConsts.SVC_KEY_WORK_TYPE) WorkType workType /* optional */) {
+    String networkNameParam = networkName == null ? containerName : networkName;
+    String snapshotNameParam = snapshotName == null ? testrigName : snapshotName;
     try {
-      networkName = networkName == null ? containerName : networkName;
-      snapshotName = snapshotName == null ? testrigName : snapshotName;
-      _logger.infof("WMS:listIncompleteWork %s %s\n", apiKey, networkName);
+      _logger.infof("WMS:listIncompleteWork %s %s\n", apiKey, networkNameParam);
 
       checkStringParam(apiKey, "API key");
       checkStringParam(clientVersion, "Client version");
-      checkStringParam(networkName, "Network name");
-      if (snapshotName != null) {
-        checkStringParam(snapshotName, "Snapshot name");
+      checkStringParam(networkNameParam, "Network name");
+      if (snapshotNameParam != null) {
+        checkStringParam(snapshotNameParam, "Snapshot name");
       }
 
       checkApiKeyValidity(apiKey);
       checkClientVersion(clientVersion);
-      checkNetworkAccessibility(apiKey, networkName);
+      checkNetworkAccessibility(apiKey, networkNameParam);
 
       List<WorkStatus> workList = new LinkedList<>();
       for (QueuedWork work :
-          Main.getWorkMgr().listIncompleteWork(networkName, snapshotName, workType)) {
+          Main.getWorkMgr().listIncompleteWork(networkNameParam, snapshotNameParam, workType)) {
         WorkStatus workStatus =
             new WorkStatus(work.getWorkItem(), work.getStatus(), work.getLastTaskCheckResult());
         workList.add(workStatus);
@@ -1598,22 +1619,22 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
       @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
       @FormDataParam(CoordConsts.SVC_KEY_VERBOSE) boolean verbose) {
+    String networkNameParam = networkName == null ? containerName : networkName;
     try {
-      networkName = networkName == null ? containerName : networkName;
-      _logger.infof("WMS:listQuestions %s %s\n", apiKey, networkName);
+      _logger.infof("WMS:listQuestions %s %s\n", apiKey, networkNameParam);
 
       checkStringParam(apiKey, "API key");
       checkStringParam(clientVersion, "Client version");
-      checkStringParam(networkName, "Network name");
+      checkStringParam(networkNameParam, "Network name");
 
       checkApiKeyValidity(apiKey);
       checkClientVersion(clientVersion);
-      checkNetworkAccessibility(apiKey, networkName);
+      checkNetworkAccessibility(apiKey, networkNameParam);
 
       JSONObject retObject = new JSONObject();
 
-      for (String questionName : Main.getWorkMgr().listQuestions(networkName, verbose)) {
-        String questionText = Main.getWorkMgr().getQuestion(networkName, questionName);
+      for (String questionName : Main.getWorkMgr().listQuestions(networkNameParam, verbose)) {
+        String questionText = Main.getWorkMgr().getQuestion(networkNameParam, questionName);
 
         retObject.put(questionName, new JSONObject(questionText));
       }
@@ -1626,7 +1647,7 @@ public class WorkMgrService {
       String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf(
           "WMS:listQuestions exception for apikey:%s in network:%s; exception:%s",
-          apiKey, networkName, stackTrace);
+          apiKey, networkNameParam, stackTrace);
       return failureResponse(e.getMessage());
     }
   }
@@ -1675,11 +1696,11 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
       @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
       @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName) {
-    networkName = networkName == null ? containerName : networkName;
+    String networkNameParam = networkName == null ? containerName : networkName;
     return listSnapshotsHelper(
         apiKey,
         clientVersion,
-        networkName,
+        networkNameParam,
         CoordConsts.SVC_KEY_SNAPSHOT_NAME,
         CoordConsts.SVC_KEY_SNAPSHOT_INFO,
         CoordConsts.SVC_KEY_SNAPSHOT_METADATA,
@@ -1761,22 +1782,23 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_SNAPSHOT_NAME) String snapshotName,
       @FormDataParam(CoordConsts.SVC_KEY_OBJECT_NAME) String objectName,
       @FormDataParam(CoordConsts.SVC_KEY_FILE) InputStream fileStream) {
+    String networkNameParam = networkName == null ? containerName : networkName;
+    String snapshotNameParam = snapshotName == null ? testrigName : snapshotName;
     try {
-      networkName = networkName == null ? containerName : networkName;
-      snapshotName = snapshotName == null ? testrigName : snapshotName;
-      _logger.infof("WMS:putObject %s %s %s / %s\n", apiKey, networkName, snapshotName, objectName);
+      _logger.infof(
+          "WMS:putObject %s %s %s / %s\n", apiKey, networkNameParam, snapshotNameParam, objectName);
 
       checkStringParam(apiKey, "API key");
       checkStringParam(clientVersion, "Client version");
-      checkStringParam(networkName, "Network name");
-      checkStringParam(snapshotName, "Snapshot name");
+      checkStringParam(networkNameParam, "Network name");
+      checkStringParam(snapshotNameParam, "Snapshot name");
       checkStringParam(objectName, "Object name");
 
       checkApiKeyValidity(apiKey);
       checkClientVersion(clientVersion);
-      checkNetworkAccessibility(apiKey, networkName);
+      checkNetworkAccessibility(apiKey, networkNameParam);
 
-      Main.getWorkMgr().putObject(networkName, snapshotName, objectName, fileStream);
+      Main.getWorkMgr().putObject(networkNameParam, snapshotNameParam, objectName, fileStream);
 
       return successResponse(new JSONObject().put("result", "successfully uploaded custom object"));
 
@@ -1884,22 +1906,22 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
       @FormDataParam(CoordConsts.SVC_KEY_PLUGIN_ID) String pluginId,
       @FormDataParam(CoordConsts.SVC_KEY_FORCE) String forceStr) {
+    String networkNameParam = networkName == null ? containerName : networkName;
     try {
-      networkName = networkName == null ? containerName : networkName;
-      _logger.infof("WMS:syncSnapshotsSyncNow %s %s %s\n", apiKey, networkName, pluginId);
+      _logger.infof("WMS:syncSnapshotsSyncNow %s %s %s\n", apiKey, networkNameParam, pluginId);
 
       checkStringParam(apiKey, "API key");
       checkStringParam(clientVersion, "Client version");
-      checkStringParam(networkName, "Network name");
+      checkStringParam(networkNameParam, "Network name");
       checkStringParam(pluginId, "Plugin Id");
 
       checkApiKeyValidity(apiKey);
       checkClientVersion(clientVersion);
-      checkNetworkAccessibility(apiKey, networkName);
+      checkNetworkAccessibility(apiKey, networkNameParam);
 
       boolean force = !Strings.isNullOrEmpty(forceStr) && Boolean.parseBoolean(forceStr);
 
-      int numCommits = Main.getWorkMgr().syncTestrigsSyncNow(networkName, pluginId, force);
+      int numCommits = Main.getWorkMgr().syncTestrigsSyncNow(networkNameParam, pluginId, force);
 
       return successResponse(new JSONObject().put("numCommits", numCommits));
     } catch (IllegalArgumentException | AccessControlException e) {
@@ -1909,7 +1931,7 @@ public class WorkMgrService {
       String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf(
           "WMS:syncSnapshotsSyncNow exception for apikey:%s in network:%s; exception:%s",
-          apiKey, networkName, stackTrace);
+          apiKey, networkNameParam, stackTrace);
       return failureResponse(e.getMessage());
     }
   }
@@ -1961,28 +1983,28 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
       @FormDataParam(CoordConsts.SVC_KEY_PLUGIN_ID) String pluginId,
       @FormDataParam(CoordConsts.SVC_KEY_SETTINGS) String settingsStr) {
+    String networkNameParam = networkName == null ? containerName : networkName;
     try {
-      networkName = networkName == null ? containerName : networkName;
       _logger.infof(
           "WMS:syncSnapshotsUpdateSettings %s %s %s %s\n",
-          apiKey, networkName, pluginId, settingsStr);
+          apiKey, networkNameParam, pluginId, settingsStr);
 
       checkStringParam(apiKey, "API key");
       checkStringParam(clientVersion, "Client version");
-      checkStringParam(networkName, "Network name");
+      checkStringParam(networkNameParam, "Network name");
       checkStringParam(pluginId, "Plugin Id");
       checkStringParam(settingsStr, "Settings");
 
       checkApiKeyValidity(apiKey);
       checkClientVersion(clientVersion);
-      checkNetworkAccessibility(apiKey, networkName);
+      checkNetworkAccessibility(apiKey, networkNameParam);
 
       Map<String, String> settings =
           BatfishObjectMapper.mapper()
               .readValue(settingsStr, new TypeReference<Map<String, String>>() {});
 
       boolean result =
-          Main.getWorkMgr().syncTestrigsUpdateSettings(networkName, pluginId, settings);
+          Main.getWorkMgr().syncTestrigsUpdateSettings(networkNameParam, pluginId, settings);
 
       return successResponse(new JSONObject().put("result", result));
     } catch (FileExistsException
@@ -1995,7 +2017,7 @@ public class WorkMgrService {
       String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf(
           "WMS:syncSnapshotsUpdateSettings exception for apikey:%s in network:%s; exception:%s",
-          apiKey, networkName, stackTrace);
+          apiKey, networkNameParam, stackTrace);
       return failureResponse(e.getMessage());
     }
   }
@@ -2103,21 +2125,22 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_SNAPSHOT_NAME) String snapshotName,
       @FormDataParam(CoordConsts.SVC_KEY_QUESTION_NAME) String qName,
       @FormDataParam(CoordConsts.SVC_KEY_FILE) String questionJson) {
+    String networkNameParam = networkName == null ? containerName : networkName;
+    String snapshotNameParam = snapshotName == null ? testrigName : snapshotName;
     try {
-      networkName = networkName == null ? containerName : networkName;
-      snapshotName = snapshotName == null ? testrigName : snapshotName;
-      _logger.infof("WMS:uploadQuestion %s %s %s/%s\n", apiKey, networkName, snapshotName, qName);
+      _logger.infof(
+          "WMS:uploadQuestion %s %s %s/%s\n", apiKey, networkNameParam, snapshotNameParam, qName);
 
       checkStringParam(apiKey, "API key");
       checkStringParam(clientVersion, "Client version");
-      checkStringParam(networkName, "Network name");
+      checkStringParam(networkNameParam, "Network name");
       checkStringParam(qName, "Question name");
 
       checkApiKeyValidity(apiKey);
       checkClientVersion(clientVersion);
-      checkNetworkAccessibility(apiKey, networkName);
+      checkNetworkAccessibility(apiKey, networkNameParam);
 
-      Main.getWorkMgr().uploadQuestion(networkName, qName, questionJson);
+      Main.getWorkMgr().uploadQuestion(networkNameParam, qName, questionJson);
 
       return successResponse(new JSONObject().put("result", "successfully uploaded question"));
 
@@ -2128,7 +2151,7 @@ public class WorkMgrService {
       String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf(
           "WMS:uploadQuestion exception for apikey:%s in network:%s; exception:%s",
-          apiKey, networkName, stackTrace);
+          apiKey, networkNameParam, stackTrace);
       return failureResponse(e.getMessage());
     }
   }
@@ -2157,20 +2180,20 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_ZIPFILE) InputStream fileStream,
       @FormDataParam(CoordConsts.SVC_KEY_AUTO_ANALYZE_TESTRIG) String autoAnalyzeTestrigStr,
       @FormDataParam(CoordConsts.SVC_KEY_AUTO_ANALYZE) String autoAnalyzeStr) {
+    String networkNameParam = networkName == null ? containerName : networkName;
+    String snapshotNameParam = snapshotName == null ? testrigName : snapshotName;
     try {
-      networkName = networkName == null ? containerName : networkName;
-      snapshotName = snapshotName == null ? testrigName : snapshotName;
       autoAnalyzeStr = autoAnalyzeStr == null ? autoAnalyzeTestrigStr : autoAnalyzeStr;
-      _logger.infof("WMS:uploadSnapshot %s %s %s\n", apiKey, networkName, snapshotName);
+      _logger.infof("WMS:uploadSnapshot %s %s %s\n", apiKey, networkNameParam, snapshotNameParam);
 
       checkStringParam(apiKey, "API key");
       checkStringParam(clientVersion, "Client version");
-      checkStringParam(networkName, "Network name");
-      checkStringParam(snapshotName, "Snapshot name");
+      checkStringParam(networkNameParam, "Network name");
+      checkStringParam(snapshotNameParam, "Snapshot name");
 
       checkApiKeyValidity(apiKey);
       checkClientVersion(clientVersion);
-      checkNetworkAccessibility(apiKey, networkName);
+      checkNetworkAccessibility(apiKey, networkNameParam);
 
       boolean autoAnalyze = false;
       if (!Strings.isNullOrEmpty(autoAnalyzeStr)) {
@@ -2180,14 +2203,15 @@ public class WorkMgrService {
       if (GlobalTracer.get().activeSpan() != null) {
         GlobalTracer.get()
             .activeSpan()
-            .setTag("network-name", networkName)
-            .setTag("snapshot-name", snapshotName);
+            .setTag("network-name", networkNameParam)
+            .setTag("snapshot-name", snapshotNameParam);
       }
 
-      Main.getWorkMgr().uploadSnapshot(networkName, snapshotName, fileStream, autoAnalyze);
+      Main.getWorkMgr()
+          .uploadSnapshot(networkNameParam, snapshotNameParam, fileStream, autoAnalyze);
       _logger.infof(
           "Uploaded snapshot:%s for network:%s using api-key:%s\n",
-          snapshotName, networkName, apiKey);
+          snapshotNameParam, networkNameParam, apiKey);
       return successResponse(new JSONObject().put("result", "successfully uploaded snapshot"));
     } catch (IllegalArgumentException | AccessControlException e) {
       _logger.errorf("WMS:uploadSnapshot exception: %s\n", e.getMessage());
@@ -2196,7 +2220,7 @@ public class WorkMgrService {
       String stackTrace = Throwables.getStackTraceAsString(e);
       _logger.errorf(
           "WMS:uploadSnapshot exception for apikey:%s in network:%s, snapshot:%s; exception:%s",
-          apiKey, networkName, snapshotName, stackTrace);
+          apiKey, networkNameParam, snapshotNameParam, stackTrace);
       return failureResponse(e.getMessage());
     }
   }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
@@ -72,13 +72,15 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
       @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
       /* Optional: not needed for some completions */
-      @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String snapshotName,
+      @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String testrigName,
+      @FormDataParam(CoordConsts.SVC_KEY_SNAPSHOT_NAME) String snapshotName,
       @FormDataParam(CoordConsts.SVC_KEY_COMPLETION_TYPE) String completionType,
       @FormDataParam(CoordConsts.SVC_KEY_QUERY) String query,
       /* Optional */
       @FormDataParam(CoordConsts.SVC_KEY_MAX_SUGGESTIONS) String maxSuggestions) {
     try {
       networkName = networkName == null ? containerName : networkName;
+      snapshotName = snapshotName == null ? testrigName : snapshotName;
       _logger.infof("WMS:autoComplete %s %s %s\n", completionType, query, maxSuggestions);
 
       checkStringParam(apiKey, "API key");
@@ -514,7 +516,7 @@ public class WorkMgrService {
    * @param testrigName The name of the snapshot to delete
    * @return TODO: document JSON response
    * @deprecated because testrigs were renamed to snapshots. Use {@link #delSnapshot(String, String,
-   *     String, String, String) delSnapshot} instead.
+   *     String, String, String, String) delSnapshot} instead.
    */
   @POST
   @Path(CoordConsts.SVC_RSC_DEL_TESTRIG)
@@ -525,7 +527,7 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
       @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
       @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String testrigName) {
-    return delSnapshot(apiKey, clientVersion, containerName, null, testrigName);
+    return delSnapshot(apiKey, clientVersion, containerName, null, testrigName, null);
   }
 
   /**
@@ -545,8 +547,10 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
       @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
       @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
+      @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String testrigName,
       @FormDataParam(CoordConsts.SVC_KEY_SNAPSHOT_NAME) String snapshotName) {
     networkName = networkName == null ? containerName : networkName;
+    snapshotName = snapshotName == null ? testrigName : snapshotName;
     try {
       _logger.infof("WMS:delSnapshot %s\n", networkName);
 
@@ -597,7 +601,8 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
       @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
       @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
-      @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String snapshotName,
+      @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String testrigName,
+      @FormDataParam(CoordConsts.SVC_KEY_SNAPSHOT_NAME) String snapshotName,
       @FormDataParam(CoordConsts.SVC_KEY_ENV_NAME) String baseEnv,
       @FormDataParam(CoordConsts.SVC_KEY_DELTA_TESTRIG_NAME) String deltaSnapshot,
       @FormDataParam(CoordConsts.SVC_KEY_DELTA_ENV_NAME) String deltaEnv,
@@ -606,6 +611,7 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_WORKITEM) String workItemStr /* optional */) {
     try {
       networkName = networkName == null ? containerName : networkName;
+      snapshotName = snapshotName == null ? testrigName : snapshotName;
       _logger.infof(
           "WMS:getAnalysisAnswer %s %s %s %s\n", apiKey, networkName, snapshotName, analysisName);
 
@@ -692,7 +698,8 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
       @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
       @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
-      @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String snapshotName,
+      @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String testrigName,
+      @FormDataParam(CoordConsts.SVC_KEY_SNAPSHOT_NAME) String snapshotName,
       @FormDataParam(CoordConsts.SVC_KEY_ENV_NAME) String baseEnv,
       @FormDataParam(CoordConsts.SVC_KEY_DELTA_TESTRIG_NAME) String deltaSnapshot,
       @FormDataParam(CoordConsts.SVC_KEY_DELTA_ENV_NAME) String deltaEnv,
@@ -700,6 +707,7 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_WORKITEM) String workItemStr /* optional */) {
     try {
       networkName = networkName == null ? containerName : networkName;
+      snapshotName = snapshotName == null ? testrigName : snapshotName;
       _logger.infof(
           "WMS:getAnalysisAnswers %s %s %s %s\n", apiKey, networkName, snapshotName, analysisName);
 
@@ -779,7 +787,8 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
       @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
       @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
-      @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String snapshotName,
+      @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String testrigName,
+      @FormDataParam(CoordConsts.SVC_KEY_SNAPSHOT_NAME) String snapshotName,
       @FormDataParam(CoordConsts.SVC_KEY_ENV_NAME) String baseEnv,
       @FormDataParam(CoordConsts.SVC_KEY_DELTA_TESTRIG_NAME) String deltaSnapshot,
       @FormDataParam(CoordConsts.SVC_KEY_DELTA_ENV_NAME) String deltaEnv,
@@ -787,6 +796,7 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_WORKITEM) String workItemStr /* optional */) {
     try {
       networkName = networkName == null ? containerName : networkName;
+      snapshotName = snapshotName == null ? testrigName : snapshotName;
       _logger.infof("WMS:getAnswer %s %s %s %s\n", apiKey, networkName, snapshotName, questionName);
 
       checkStringParam(apiKey, "API key");
@@ -861,10 +871,12 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
       @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
       @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
-      @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String snapshotName,
+      @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String testrigName,
+      @FormDataParam(CoordConsts.SVC_KEY_SNAPSHOT_NAME) String snapshotName,
       @FormDataParam(CoordConsts.SVC_KEY_CONFIGURATION_NAME) String configName) {
     try {
       networkName = networkName == null ? containerName : networkName;
+      snapshotName = snapshotName == null ? testrigName : snapshotName;
       _logger.infof("WMS:getConfiguration %s\n", networkName);
 
       checkStringParam(apiKey, "API key");
@@ -1034,10 +1046,12 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
       @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
       @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
-      @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String snapshotName,
+      @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String testrigName,
+      @FormDataParam(CoordConsts.SVC_KEY_SNAPSHOT_NAME) String snapshotName,
       @FormDataParam(CoordConsts.SVC_KEY_OBJECT_NAME) String objectName) {
     try {
       networkName = networkName == null ? containerName : networkName;
+      snapshotName = snapshotName == null ? testrigName : snapshotName;
       _logger.infof("WMS:getObject %s --> %s\n", snapshotName, objectName);
 
       checkStringParam(apiKey, "API key");
@@ -1090,9 +1104,11 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
       @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
       @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
-      @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String snapshotName) {
+      @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String testrigName,
+      @FormDataParam(CoordConsts.SVC_KEY_SNAPSHOT_NAME) String snapshotName) {
     try {
       networkName = networkName == null ? containerName : networkName;
+      snapshotName = snapshotName == null ? testrigName : snapshotName;
       _logger.infof("WMS:getParsingResults %s %s %s\n", apiKey, networkName, snapshotName);
       checkStringParam(apiKey, "API key");
       checkStringParam(clientVersion, "Client version");
@@ -1518,10 +1534,12 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
       @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
       @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
-      @Nullable @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String snapshotName, /* optional */
+      @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String testrigName,
+      @FormDataParam(CoordConsts.SVC_KEY_SNAPSHOT_NAME) String snapshotName, /* optional */
       @Nullable @FormDataParam(CoordConsts.SVC_KEY_WORK_TYPE) WorkType workType /* optional */) {
     try {
       networkName = networkName == null ? containerName : networkName;
+      snapshotName = snapshotName == null ? testrigName : snapshotName;
       _logger.infof("WMS:listIncompleteWork %s %s\n", apiKey, networkName);
 
       checkStringParam(apiKey, "API key");
@@ -1733,11 +1751,13 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
       @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
       @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
-      @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String snapshotName,
+      @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String testrigName,
+      @FormDataParam(CoordConsts.SVC_KEY_SNAPSHOT_NAME) String snapshotName,
       @FormDataParam(CoordConsts.SVC_KEY_OBJECT_NAME) String objectName,
       @FormDataParam(CoordConsts.SVC_KEY_FILE) InputStream fileStream) {
     try {
       networkName = networkName == null ? containerName : networkName;
+      snapshotName = snapshotName == null ? testrigName : snapshotName;
       _logger.infof("WMS:putObject %s %s %s / %s\n", apiKey, networkName, snapshotName, objectName);
 
       checkStringParam(apiKey, "API key");
@@ -2073,11 +2093,13 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
       @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
       @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
-      @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String snapshotName,
+      @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String testrigName,
+      @FormDataParam(CoordConsts.SVC_KEY_SNAPSHOT_NAME) String snapshotName,
       @FormDataParam(CoordConsts.SVC_KEY_QUESTION_NAME) String qName,
       @FormDataParam(CoordConsts.SVC_KEY_FILE) String questionJson) {
     try {
       networkName = networkName == null ? containerName : networkName;
+      snapshotName = snapshotName == null ? testrigName : snapshotName;
       _logger.infof("WMS:uploadQuestion %s %s %s/%s\n", apiKey, networkName, snapshotName, qName);
 
       checkStringParam(apiKey, "API key");
@@ -2124,11 +2146,13 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
       @FormDataParam(CoordConsts.SVC_KEY_CONTAINER_NAME) String containerName,
       @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
+      @FormDataParam(CoordConsts.SVC_KEY_TESTRIG_NAME) String testrigName,
       @FormDataParam(CoordConsts.SVC_KEY_SNAPSHOT_NAME) String snapshotName,
       @FormDataParam(CoordConsts.SVC_KEY_ZIPFILE) InputStream fileStream,
       @FormDataParam(CoordConsts.SVC_KEY_AUTO_ANALYZE) String autoAnalyzeStr) {
     try {
       networkName = networkName == null ? containerName : networkName;
+      snapshotName = snapshotName == null ? testrigName : snapshotName;
       _logger.infof("WMS:uploadSnapshot %s %s %s\n", apiKey, networkName, snapshotName);
 
       checkStringParam(apiKey, "API key");
@@ -2179,7 +2203,7 @@ public class WorkMgrService {
    * @param fileStream The stream from which the new testrig is read
    * @return TODO: document JSON response
    * @deprecated because testrigs were renamed to snapshots. Use {@link #uploadSnapshot(String,
-   *     String, String, String, String, InputStream, String)} instead.
+   *     String, String, String, String, String, InputStream, String)} instead.
    */
   @POST
   @Path(CoordConsts.SVC_RSC_UPLOAD_TESTRIG)
@@ -2194,6 +2218,6 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_ZIPFILE) InputStream fileStream,
       @FormDataParam(CoordConsts.SVC_KEY_AUTO_ANALYZE_TESTRIG) String autoAnalyzeStr) {
     return uploadSnapshot(
-        apiKey, clientVersion, containerName, null, testrigName, fileStream, autoAnalyzeStr);
+        apiKey, clientVersion, containerName, null, testrigName, null, fileStream, autoAnalyzeStr);
   }
 }

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrServiceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrServiceTest.java
@@ -40,12 +40,12 @@ import org.junit.rules.TemporaryFolder;
 /** Tests for {@link WorkMgrService}. */
 public class WorkMgrServiceTest {
 
-  @Rule public TemporaryFolder _containersFolder = new TemporaryFolder();
+  @Rule public TemporaryFolder _networksFolder = new TemporaryFolder();
   @Rule public TemporaryFolder _questionsTemplatesFolder = new TemporaryFolder();
 
   private WorkMgrService _service;
 
-  private String _containerName = "myContainer";
+  private String _networkName = "myNetwork";
 
   private void initContainerEnvironment() throws Exception {
     Settings settings = new Settings(new String[] {});
@@ -53,7 +53,7 @@ public class WorkMgrServiceTest {
     Main.mainInit(
         new String[] {
           "-containerslocation",
-          _containersFolder.getRoot().toString(),
+          _networksFolder.getRoot().toString(),
           "-templatedirs",
           _questionsTemplatesFolder.getRoot().toString()
         });
@@ -61,48 +61,48 @@ public class WorkMgrServiceTest {
     Main.initAuthorizer();
     WorkMgr manager = new WorkMgr(settings, logger);
     Main.setWorkMgr(manager);
-    manager.initContainer(_containerName, null);
+    manager.initContainer(_networkName, null);
     _service = new WorkMgrService();
   }
 
   @Test
-  public void getEmptyContainer() throws Exception {
+  public void getEmptyNetwork() throws Exception {
     initContainerEnvironment();
-    Response response = _service.getNetwork("100", "0.0.0", _containerName);
+    Response response = _service.getNetwork("100", "0.0.0", null, _networkName);
     String containerJson = response.getEntity().toString();
-    assertThat(containerJson, equalTo("{\"name\":\"myContainer\"}"));
+    assertThat(containerJson, equalTo("{\"name\":\"myNetwork\"}"));
   }
 
   @Test
-  public void getNonExistContainer() throws Exception {
+  public void getNonExistNetwork() throws Exception {
     String containerName = "non-existing-folder";
     initContainerEnvironment();
-    Response response = _service.getNetwork("100", "0.0.0", containerName);
+    Response response = _service.getNetwork("100", "0.0.0", null, containerName);
     String actualMessage = response.getEntity().toString();
     String expected = "Network '" + containerName + "' not found";
     assertThat(actualMessage, equalTo(expected));
   }
 
   @Test
-  public void getContainerWithBadVersion() throws Exception {
+  public void getNetworkWithBadVersion() throws Exception {
     initContainerEnvironment();
-    Response response = _service.getNetwork("100", "invalid version", _containerName);
+    Response response = _service.getNetwork("100", "invalid version", null, _networkName);
     String actualMessage = response.getEntity().toString();
     String expected = "Illegal version 'invalid version' for Client";
     assertThat(actualMessage, equalTo(expected));
   }
 
   @Test
-  public void getNonEmptyContainer() throws Exception {
+  public void getNonEmptyNetwork() throws Exception {
     initContainerEnvironment();
-    Path containerPath = _containersFolder.getRoot().toPath().resolve(_containerName);
+    Path containerPath = _networksFolder.getRoot().toPath().resolve(_networkName);
     Path testrigPath = containerPath.resolve(BfConsts.RELPATH_TESTRIGS_DIR).resolve("testrig");
     assertThat(testrigPath.toFile().mkdirs(), is(true));
-    Response response = _service.getNetwork("100", "0.0.0", _containerName);
+    Response response = _service.getNetwork("100", "0.0.0", null, _networkName);
     Container container =
         BatfishObjectMapper.mapper().readValue(response.getEntity().toString(), Container.class);
     Container expected =
-        Container.of(_containerName, Sets.newTreeSet(Collections.singleton("testrig")));
+        Container.of(_networkName, Sets.newTreeSet(Collections.singleton("testrig")));
     assertThat(container, equalTo(expected));
   }
 
@@ -111,24 +111,25 @@ public class WorkMgrServiceTest {
     initContainerEnvironment();
     // test init and add questions to analysis
     String analysisJsonString = "{\"question\":{\"question\":\"questionContent\"}}";
-    File analysisFile = _containersFolder.newFile("analysis");
+    File analysisFile = _networksFolder.newFile("analysis");
     FileUtils.writeStringToFile(analysisFile, analysisJsonString);
     _service.configureAnalysis(
         CoordConsts.DEFAULT_API_KEY,
         Version.getVersion(),
-        _containerName,
+        null,
+        _networkName,
         "new",
         "analysis",
         new FileInputStream(analysisFile),
         "",
         null);
     Path questionPath =
-        _containersFolder
+        _networksFolder
             .getRoot()
             .toPath()
             .resolve(
                 Paths.get(
-                    _containerName,
+                    _networkName,
                     BfConsts.RELPATH_ANALYSES_DIR,
                     "analysis",
                     BfConsts.RELPATH_QUESTIONS_DIR,
@@ -139,7 +140,8 @@ public class WorkMgrServiceTest {
     _service.configureAnalysis(
         CoordConsts.DEFAULT_API_KEY,
         Version.getVersion(),
-        _containerName,
+        null,
+        _networkName,
         "",
         "analysis",
         null,
@@ -150,7 +152,8 @@ public class WorkMgrServiceTest {
         _service.configureAnalysis(
             CoordConsts.DEFAULT_API_KEY,
             Version.getVersion(),
-            _containerName,
+            null,
+            _networkName,
             "",
             "analysis",
             null,
@@ -172,13 +175,14 @@ public class WorkMgrServiceTest {
 
     String analysisJsonString =
         String.format("{\"%s\":{\"question\":\"%s\"}}", questionName, questionContent);
-    File analysisFile = _containersFolder.newFile(analysisName);
+    File analysisFile = _networksFolder.newFile(analysisName);
     FileUtils.writeStringToFile(analysisFile, analysisJsonString);
 
     _service.configureAnalysis(
         CoordConsts.DEFAULT_API_KEY,
         Version.getVersion(),
-        _containerName,
+        null,
+        _networkName,
         "new",
         analysisName,
         new FileInputStream(analysisFile),
@@ -186,12 +190,12 @@ public class WorkMgrServiceTest {
         null);
 
     Path answerDir =
-        _containersFolder
+        _networksFolder
             .getRoot()
             .toPath()
             .resolve(
                 Paths.get(
-                    _containerName,
+                    _networkName,
                     BfConsts.RELPATH_TESTRIGS_DIR,
                     testrigName,
                     BfConsts.RELPATH_ANALYSES_DIR,
@@ -205,14 +209,15 @@ public class WorkMgrServiceTest {
     answerDir.toFile().mkdirs();
     CommonUtil.writeFile(answer1Path, answer);
 
-    WorkItem workItem = new WorkItem(_containerName, testrigName);
+    WorkItem workItem = new WorkItem(_networkName, testrigName);
     String workItemString = BatfishObjectMapper.mapper().writeValueAsString(workItem);
 
     JSONArray answer1Output =
         _service.getAnalysisAnswer(
             CoordConsts.DEFAULT_API_KEY,
             Version.getVersion(),
-            _containerName,
+            null,
+            _networkName,
             testrigName,
             BfConsts.RELPATH_DEFAULT_ENVIRONMENT_NAME,
             null,
@@ -225,7 +230,8 @@ public class WorkMgrServiceTest {
         _service.getAnalysisAnswer(
             CoordConsts.DEFAULT_API_KEY,
             Version.getVersion(),
-            _containerName,
+            null,
+            _networkName,
             testrigName,
             BfConsts.RELPATH_DEFAULT_ENVIRONMENT_NAME,
             null,
@@ -245,23 +251,24 @@ public class WorkMgrServiceTest {
   }
 
   @Test
-  public void getConfigNonExistContainer() throws Exception {
+  public void getConfigNonExistNetwork() throws Exception {
     initContainerEnvironment();
     Response response =
         _service.getConfiguration(
             CoordConsts.DEFAULT_API_KEY,
             Version.getVersion(),
-            "nonExistContainer",
+            null,
+            "nonExistNetwork",
             "testrig",
             "config1.cfg");
     String actualMessage = response.getEntity().toString();
-    assertThat(actualMessage, equalTo("Network 'nonExistContainer' not found"));
+    assertThat(actualMessage, equalTo("Network 'nonExistNetwork' not found"));
   }
 
   @Test
   public void getNonExistConfig() throws Exception {
     initContainerEnvironment();
-    Path containerDir = _containersFolder.getRoot().toPath().resolve(_containerName);
+    Path containerDir = _networksFolder.getRoot().toPath().resolve(_networkName);
     Path testrigPath =
         containerDir.resolve(
             Paths.get(BfConsts.RELPATH_TESTRIGS_DIR, "testrig", BfConsts.RELPATH_TEST_RIG_DIR));
@@ -270,19 +277,20 @@ public class WorkMgrServiceTest {
         _service.getConfiguration(
             CoordConsts.DEFAULT_API_KEY,
             Version.getVersion(),
-            _containerName,
+            null,
+            _networkName,
             "testrig",
             "config.cfg");
     String actualMessage = response.getEntity().toString();
     String expected =
-        "Configuration file config.cfg does not exist in testrig testrig for container myContainer";
+        "Configuration file config.cfg does not exist in snapshot testrig for network myNetwork";
     assertThat(actualMessage, equalTo(expected));
   }
 
   @Test
   public void getConfigContent() throws Exception {
     initContainerEnvironment();
-    Path containerPath = _containersFolder.getRoot().toPath().resolve(_containerName);
+    Path containerPath = _networksFolder.getRoot().toPath().resolve(_networkName);
     Path configPath =
         containerPath.resolve(
             Paths.get(
@@ -296,7 +304,8 @@ public class WorkMgrServiceTest {
         _service.getConfiguration(
             CoordConsts.DEFAULT_API_KEY,
             Version.getVersion(),
-            _containerName,
+            null,
+            _networkName,
             "testrig",
             "config.cfg");
     String actualMessage = response.getEntity().toString();
@@ -369,5 +378,254 @@ public class WorkMgrServiceTest {
 
     testQuestion.setInstance(instanceData);
     return testQuestion;
+  }
+
+  // TODO Remove these tests after container and testrig keys are removed
+
+  @Test
+  public void getEmptyContainer() throws Exception {
+    initContainerEnvironment();
+    Response response = _service.getNetwork("100", "0.0.0", _networkName, null);
+    String containerJson = response.getEntity().toString();
+    assertThat(containerJson, equalTo("{\"name\":\"myNetwork\"}"));
+  }
+
+  @Test
+  public void getNonExistContainer() throws Exception {
+    String containerName = "non-existing-folder";
+    initContainerEnvironment();
+    Response response = _service.getNetwork("100", "0.0.0", containerName, null);
+    String actualMessage = response.getEntity().toString();
+    String expected = "Network '" + containerName + "' not found";
+    assertThat(actualMessage, equalTo(expected));
+  }
+
+  @Test
+  public void getContainerWithBadVersion() throws Exception {
+    initContainerEnvironment();
+    Response response = _service.getNetwork("100", "invalid version", _networkName, null);
+    String actualMessage = response.getEntity().toString();
+    String expected = "Illegal version 'invalid version' for Client";
+    assertThat(actualMessage, equalTo(expected));
+  }
+
+  @Test
+  public void getNonEmptyContainer() throws Exception {
+    initContainerEnvironment();
+    Path containerPath = _networksFolder.getRoot().toPath().resolve(_networkName);
+    Path testrigPath = containerPath.resolve(BfConsts.RELPATH_TESTRIGS_DIR).resolve("testrig");
+    assertThat(testrigPath.toFile().mkdirs(), is(true));
+    Response response = _service.getNetwork("100", "0.0.0", _networkName, null);
+    Container container =
+        BatfishObjectMapper.mapper().readValue(response.getEntity().toString(), Container.class);
+    Container expected =
+        Container.of(_networkName, Sets.newTreeSet(Collections.singleton("testrig")));
+    assertThat(container, equalTo(expected));
+  }
+
+  @Test
+  public void testConfigureAnalysisInContainer() throws Exception {
+    initContainerEnvironment();
+    // test init and add questions to analysis
+    String analysisJsonString = "{\"question\":{\"question\":\"questionContent\"}}";
+    File analysisFile = _networksFolder.newFile("analysis");
+    FileUtils.writeStringToFile(analysisFile, analysisJsonString);
+    _service.configureAnalysis(
+        CoordConsts.DEFAULT_API_KEY,
+        Version.getVersion(),
+        _networkName,
+        null,
+        "new",
+        "analysis",
+        new FileInputStream(analysisFile),
+        "",
+        null);
+    Path questionPath =
+        _networksFolder
+            .getRoot()
+            .toPath()
+            .resolve(
+                Paths.get(
+                    _networkName,
+                    BfConsts.RELPATH_ANALYSES_DIR,
+                    "analysis",
+                    BfConsts.RELPATH_QUESTIONS_DIR,
+                    "question"));
+    assertTrue(Files.exists(questionPath));
+    // test delete questions
+    String questionsToDelete = "[question]";
+    _service.configureAnalysis(
+        CoordConsts.DEFAULT_API_KEY,
+        Version.getVersion(),
+        _networkName,
+        null,
+        "",
+        "analysis",
+        null,
+        questionsToDelete,
+        null);
+    assertFalse(Files.exists(questionPath));
+    JSONArray result =
+        _service.configureAnalysis(
+            CoordConsts.DEFAULT_API_KEY,
+            Version.getVersion(),
+            _networkName,
+            null,
+            "",
+            "analysis",
+            null,
+            questionsToDelete,
+            null);
+    assertThat(result.getString(0), equalTo(CoordConsts.SVC_KEY_FAILURE));
+  }
+
+  @Test
+  public void testGetAnalysisAnswerInContainer() throws Exception {
+    String testrigName = "testrig1";
+    String analysisName = "analysis1";
+    String questionName = "question1";
+    String questionContent = "questionContent";
+    String question2Name = "question2Name";
+    String answer = "answerContent";
+
+    initContainerEnvironment();
+
+    String analysisJsonString =
+        String.format("{\"%s\":{\"question\":\"%s\"}}", questionName, questionContent);
+    File analysisFile = _networksFolder.newFile(analysisName);
+    FileUtils.writeStringToFile(analysisFile, analysisJsonString);
+
+    _service.configureAnalysis(
+        CoordConsts.DEFAULT_API_KEY,
+        Version.getVersion(),
+        _networkName,
+        null,
+        "new",
+        analysisName,
+        new FileInputStream(analysisFile),
+        "",
+        null);
+
+    Path answerDir =
+        _networksFolder
+            .getRoot()
+            .toPath()
+            .resolve(
+                Paths.get(
+                    _networkName,
+                    BfConsts.RELPATH_TESTRIGS_DIR,
+                    testrigName,
+                    BfConsts.RELPATH_ANALYSES_DIR,
+                    analysisName,
+                    BfConsts.RELPATH_QUESTIONS_DIR,
+                    questionName,
+                    BfConsts.RELPATH_ENVIRONMENTS_DIR,
+                    BfConsts.RELPATH_DEFAULT_ENVIRONMENT_NAME));
+
+    Path answer1Path = answerDir.resolve(BfConsts.RELPATH_ANSWER_JSON);
+    answerDir.toFile().mkdirs();
+    CommonUtil.writeFile(answer1Path, answer);
+
+    WorkItem workItem = new WorkItem(_networkName, testrigName);
+    String workItemString = BatfishObjectMapper.mapper().writeValueAsString(workItem);
+
+    JSONArray answer1Output =
+        _service.getAnalysisAnswer(
+            CoordConsts.DEFAULT_API_KEY,
+            Version.getVersion(),
+            _networkName,
+            null,
+            testrigName,
+            BfConsts.RELPATH_DEFAULT_ENVIRONMENT_NAME,
+            null,
+            null,
+            analysisName,
+            questionName,
+            workItemString);
+
+    JSONArray answer2Output =
+        _service.getAnalysisAnswer(
+            CoordConsts.DEFAULT_API_KEY,
+            Version.getVersion(),
+            _networkName,
+            null,
+            testrigName,
+            BfConsts.RELPATH_DEFAULT_ENVIRONMENT_NAME,
+            null,
+            null,
+            analysisName,
+            question2Name,
+            null);
+
+    assertThat(answer1Output.get(0), equalTo(CoordConsts.SVC_KEY_SUCCESS));
+    assertThat(answer2Output.get(0), equalTo(CoordConsts.SVC_KEY_FAILURE));
+
+    JSONObject answerJsonObject = (JSONObject) answer1Output.get(1);
+    String answerJsonString = answerJsonObject.getString(CoordConsts.SVC_KEY_ANSWER);
+    String answerString =
+        BatfishObjectMapper.mapper().readValue(answerJsonString, new TypeReference<String>() {});
+    assertThat(answerString, equalTo(answer));
+  }
+
+  @Test
+  public void getConfigNonExistContainer() throws Exception {
+    initContainerEnvironment();
+    Response response =
+        _service.getConfiguration(
+            CoordConsts.DEFAULT_API_KEY,
+            Version.getVersion(),
+            "nonExistContainer",
+            null,
+            "testrig",
+            "config1.cfg");
+    String actualMessage = response.getEntity().toString();
+    assertThat(actualMessage, equalTo("Network 'nonExistContainer' not found"));
+  }
+
+  @Test
+  public void getNonExistConfigInContainer() throws Exception {
+    initContainerEnvironment();
+    Path containerDir = _networksFolder.getRoot().toPath().resolve(_networkName);
+    Path testrigPath =
+        containerDir.resolve(
+            Paths.get(BfConsts.RELPATH_TESTRIGS_DIR, "testrig", BfConsts.RELPATH_TEST_RIG_DIR));
+    assertTrue(testrigPath.toFile().mkdirs());
+    Response response =
+        _service.getConfiguration(
+            CoordConsts.DEFAULT_API_KEY,
+            Version.getVersion(),
+            _networkName,
+            null,
+            "testrig",
+            "config.cfg");
+    String actualMessage = response.getEntity().toString();
+    String expected =
+        "Configuration file config.cfg does not exist in snapshot testrig for network myNetwork";
+    assertThat(actualMessage, equalTo(expected));
+  }
+
+  @Test
+  public void getConfigContentInContainer() throws Exception {
+    initContainerEnvironment();
+    Path containerPath = _networksFolder.getRoot().toPath().resolve(_networkName);
+    Path configPath =
+        containerPath.resolve(
+            Paths.get(
+                BfConsts.RELPATH_TESTRIGS_DIR,
+                "testrig",
+                BfConsts.RELPATH_TEST_RIG_DIR,
+                BfConsts.RELPATH_CONFIGURATIONS_DIR));
+    assertTrue(configPath.toFile().mkdirs());
+    CommonUtil.writeFile(configPath.resolve("config.cfg"), "config content");
+    Response response =
+        _service.getConfiguration(
+            CoordConsts.DEFAULT_API_KEY,
+            Version.getVersion(),
+            _networkName,
+            null,
+            "testrig",
+            "config.cfg");
+    String actualMessage = response.getEntity().toString();
+    assertThat(actualMessage, equalTo("config content"));
   }
 }

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrServiceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrServiceTest.java
@@ -223,6 +223,7 @@ public class WorkMgrServiceTest {
             BfConsts.RELPATH_DEFAULT_ENVIRONMENT_NAME,
             null,
             null,
+            null,
             analysisName,
             questionName,
             workItemString);
@@ -236,6 +237,7 @@ public class WorkMgrServiceTest {
             null,
             _snapshotName,
             BfConsts.RELPATH_DEFAULT_ENVIRONMENT_NAME,
+            null,
             null,
             null,
             analysisName,
@@ -546,6 +548,7 @@ public class WorkMgrServiceTest {
             BfConsts.RELPATH_DEFAULT_ENVIRONMENT_NAME,
             null,
             null,
+            null,
             analysisName,
             questionName,
             workItemString);
@@ -559,6 +562,7 @@ public class WorkMgrServiceTest {
             _snapshotName,
             null,
             BfConsts.RELPATH_DEFAULT_ENVIRONMENT_NAME,
+            null,
             null,
             null,
             analysisName,

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
@@ -229,8 +229,8 @@ public class WorkMgrTest {
     _thrown.expect(Exception.class);
     _thrown.expectMessage(
         equalTo(
-            "Configuration file config.cfg does not exist in testrig testrig "
-                + "for container container"));
+            "Configuration file config.cfg does not exist in snapshot testrig "
+                + "for network container"));
     _manager.getConfiguration("container", "testrig", "config.cfg");
   }
 


### PR DESCRIPTION
The issue: Many API calls that we don't want to deprecate take a parameter whose key contains "testrig" or "container" -- for example, `getAnswer` requires network and snapshot names with keys `SVC_KEY_CONTAINER_NAME` and `SVC_KEY_TESTRIG_NAME`. Meanwhile, we have some new API calls that require new versions of those keys; for example `delSnapshot`, intended to replace `delTestrig`, requires network and snapshot names with new keys `SVC_KEY_NETWORK_NAME` and `SVC_KEY_SNAPSHOT_NAME`. We don't want clients to have to know multiple versions of these keys, but with this setup they would be forced to do so if they wanted to stop using deprecated API calls.

The solution: API calls that use these keys now take one parameter for each version; e.g. one parameter with key `SVC_KEY_CONTAINER_NAME` and one with key `SVC_KEY_NETWORK_NAME`. Then the network name is internally determined by using the newer key's value if defined, otherwise defaulting to the older key's value. Consequently, it should be fine to switch clients away from the deprecated API calls without changing their keys once this is merged. When all clients have switched to the new API calls AND updated their keys, another update can be made here to delete the old API calls and keys, and remove the extra parameters in remaining API calls.

The following API calls were NOT subjected to this update:
- Deprecated API calls (anything with `container` or `testrig` in the name): so clients should not update keys before switching away from deprecated API calls
- API calls concerning environments, since those are going to be removed soon

Another similar issue is that some API calls return a JSON object with old `SVC_KEY` strings as keys. For example, `listContainers` returns an object with key `SVC_KEY_CONTAINER_LIST`, but `listNetworks` returns it with the key `SVC_KEY_NETWORK_LIST`. This was resolved by putting the value into the JSON response twice, once under each key.

This PR also removes a few unused fields from `CoordConsts`.