### PR TITLE
AclLineMatchExprToBDD: fix BDD encoding of notIcmpTypes headerspace constraint

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/symbolic/bdd/AclLineMatchExprToBDD.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/bdd/AclLineMatchExprToBDD.java
@@ -159,7 +159,7 @@ public class AclLineMatchExprToBDD implements GenericAclLineMatchExprVisitor<BDD
         toBDD(headerSpace.getIcmpCodes(), _packet.getIcmpCode()),
         BDDOps.negateIfNonNull(toBDD(headerSpace.getNotIcmpCodes(), _packet.getIcmpCode())),
         toBDD(headerSpace.getIcmpTypes(), _packet.getIcmpType()),
-        BDDOps.negateIfNonNull(toBDD(headerSpace.getIcmpTypes(), _packet.getIcmpType())),
+        BDDOps.negateIfNonNull(toBDD(headerSpace.getNotIcmpTypes(), _packet.getIcmpType())),
         toBDD(headerSpace.getIpProtocols()),
         BDDOps.negateIfNonNull(toBDD(headerSpace.getNotIpProtocols())),
         toBDD(headerSpace.getDscps(), _packet.getDscp()),

--- a/projects/batfish/src/test/java/org/batfish/symbolic/bdd/AclLineMatchExprToBDDTest.java
+++ b/projects/batfish/src/test/java/org/batfish/symbolic/bdd/AclLineMatchExprToBDDTest.java
@@ -172,6 +172,16 @@ public class AclLineMatchExprToBDDTest {
   }
 
   @Test
+  public void testMatchHeaderSpace_icmpType() {
+    HeaderSpace headerSpace =
+        HeaderSpace.builder().setIcmpTypes(ImmutableList.of(new SubRange(8, 8))).build();
+    AclLineMatchExpr matchExpr = new MatchHeaderSpace(headerSpace);
+    BDD matchExprBDD = _toBDD.visit(matchExpr);
+    BDD icmpTypeBDD = _pkt.getIcmpType().value(8);
+    assertThat(matchExprBDD, equalTo(icmpTypeBDD));
+  }
+
+  @Test
   public void testMatchHeaderSpace_state() {
     HeaderSpace headerSpace =
         HeaderSpace.builder()


### PR DESCRIPTION
Fixed a typo: we used icmpTypes instead of notIcmpTypes, which meant
that any headerspace constraint that constrained icmpTypes would be
encoded as false.