### PR TITLE
don't export BGP routes with no-advertise community

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -41,6 +41,7 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.common.BatfishException;
+import org.batfish.common.WellKnownCommunity;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.AsPath;
 import org.batfish.datamodel.BgpActivePeerConfig;
@@ -1592,6 +1593,12 @@ public class VirtualRouter implements Serializable {
          */
         if (routeIsBgp) {
           BgpRoute bgpRoute = (BgpRoute) route;
+
+          if(bgpRoute.getCommunities().contains(WellKnownCommunity.NO_ADVERTISE)) {
+            // don't advertise this route
+            continue;
+          }
+
           transformedOutgoingRouteBuilder.setOriginType(bgpRoute.getOriginType());
           if (ebgpSession
               && bgpRoute.getAsPath().containsAs(neighbor.getRemoteAs())

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -1594,7 +1594,7 @@ public class VirtualRouter implements Serializable {
         if (routeIsBgp) {
           BgpRoute bgpRoute = (BgpRoute) route;
 
-          if(bgpRoute.getCommunities().contains(WellKnownCommunity.NO_ADVERTISE)) {
+          if (bgpRoute.getCommunities().contains(WellKnownCommunity.NO_ADVERTISE)) {
             // don't advertise this route
             continue;
           }


### PR DESCRIPTION
No test. The change occurs in the middle of a huge method `VirtualRoute.computeBgpAssignmentsToOutside`, which should be refactored so we can test it. Until then, it's unclear how to test this change.