### PR TITLE
Cisco: treat unimplemented ACL match clauses as unmatchable

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -1134,6 +1134,7 @@ import org.batfish.representation.cisco.TcpServiceObjectGroupLine;
 import org.batfish.representation.cisco.Tunnel;
 import org.batfish.representation.cisco.Tunnel.TunnelMode;
 import org.batfish.representation.cisco.UdpServiceObjectGroupLine;
+import org.batfish.representation.cisco.UnimplementedAccessListServiceSpecifier;
 import org.batfish.representation.cisco.Vrf;
 import org.batfish.representation.cisco.VrrpGroup;
 import org.batfish.representation.cisco.VrrpInterface;
@@ -4700,7 +4701,8 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
           tcpFlags.add(alt);
         }
         if (feature.FRAGMENTS() != null) {
-          todo(ctx, F_FRAGMENTS);
+          _w.unimplemented("matching fragments in extended access list: " + getFullText(ctx));
+          return UnimplementedAccessListServiceSpecifier.INSTANCE;
         }
         if (feature.HOST_UNKNOWN() != null) {
           icmpType = IcmpType.DESTINATION_UNREACHABLE;
@@ -4758,7 +4760,8 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
           icmpType = IcmpType.TIME_EXCEEDED;
         }
         if (feature.TTL() != null) {
-          todo(ctx, F_TTL);
+          _w.unimplemented("matching ttl in extended access list: " + getFullText(ctx));
+          return UnimplementedAccessListServiceSpecifier.INSTANCE;
         }
         if (feature.TTL_EXCEEDED() != null) {
           icmpType = IcmpType.TIME_EXCEEDED;
@@ -4803,7 +4806,8 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
           line);
       return new ProtocolOrServiceObjectGroupServiceSpecifier(name);
     } else {
-      throw convError(AccessListServiceSpecifier.class, ctx);
+      return convProblem(
+          AccessListServiceSpecifier.class, ctx, UnimplementedAccessListServiceSpecifier.INSTANCE);
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/UnimplementedAccessListServiceSpecifier.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/UnimplementedAccessListServiceSpecifier.java
@@ -1,0 +1,23 @@
+package org.batfish.representation.cisco;
+
+import java.util.Map;
+import javax.annotation.Nonnull;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.acl.FalseExpr;
+
+/**
+ * An {@link AccessListServiceSpecifier} that is used for unimplemented features that Cisco-like
+ * configurations may match against. Can never match any line.
+ */
+public final class UnimplementedAccessListServiceSpecifier implements AccessListServiceSpecifier {
+  public static final UnimplementedAccessListServiceSpecifier INSTANCE =
+      new UnimplementedAccessListServiceSpecifier();
+
+  @Nonnull
+  @Override
+  public AclLineMatchExpr toAclLineMatchExpr(Map<String, ObjectGroup> objectGroups) {
+    return FalseExpr.INSTANCE;
+  }
+
+  private UnimplementedAccessListServiceSpecifier() {} // prevent instantiation
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/UnimplementedAccessListServiceSpecifier.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/UnimplementedAccessListServiceSpecifier.java
@@ -10,6 +10,8 @@ import org.batfish.datamodel.acl.FalseExpr;
  * configurations may match against. Can never match any line.
  */
 public final class UnimplementedAccessListServiceSpecifier implements AccessListServiceSpecifier {
+  private static final long serialVersionUID = 1L;
+
   public static final UnimplementedAccessListServiceSpecifier INSTANCE =
       new UnimplementedAccessListServiceSpecifier();
 

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -4596,48 +4596,52 @@
               {
                 "action" : "ACCEPT",
                 "matchCondition" : {
-                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                  "headerSpace" : {
-                    "dstIps" : {
-                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
-                      "ipWildcard" : "0.0.0.0/0"
+                  "class" : "org.batfish.datamodel.acl.AndMatchExpr",
+                  "conjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.acl.FalseExpr"
                     },
-                    "dstPorts" : [
-                      "6784-6784"
-                    ],
-                    "ipProtocols" : [
-                      "TCP"
-                    ],
-                    "negate" : false,
-                    "srcIps" : {
-                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
-                      "ipWildcard" : "0.0.0.0/0"
+                    {
+                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                      "headerSpace" : {
+                        "dstIps" : {
+                          "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                          "ipWildcard" : "0.0.0.0/0"
+                        },
+                        "negate" : false,
+                        "srcIps" : {
+                          "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                          "ipWildcard" : "0.0.0.0/0"
+                        }
+                      }
                     }
-                  }
+                  ]
                 },
                 "name" : "60 permit tcp any any eq mlag ttl eq 255"
               },
               {
                 "action" : "ACCEPT",
                 "matchCondition" : {
-                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                  "headerSpace" : {
-                    "dstIps" : {
-                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
-                      "ipWildcard" : "0.0.0.0/0"
+                  "class" : "org.batfish.datamodel.acl.AndMatchExpr",
+                  "conjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.acl.FalseExpr"
                     },
-                    "dstPorts" : [
-                      "6784-6784"
-                    ],
-                    "ipProtocols" : [
-                      "UDP"
-                    ],
-                    "negate" : false,
-                    "srcIps" : {
-                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
-                      "ipWildcard" : "0.0.0.0/0"
+                    {
+                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                      "headerSpace" : {
+                        "dstIps" : {
+                          "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                          "ipWildcard" : "0.0.0.0/0"
+                        },
+                        "negate" : false,
+                        "srcIps" : {
+                          "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                          "ipWildcard" : "0.0.0.0/0"
+                        }
+                      }
                     }
-                  }
+                  ]
                 },
                 "name" : "70 permit udp any any eq mlag ttl eq 255"
               },


### PR DESCRIPTION
Fixes #1955