### PR TITLE
IpOwners quesion: return all addresses per interface

### DIFF
--- a/projects/question/src/main/java/org/batfish/question/ipowners/IpOwnersAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/ipowners/IpOwnersAnswerer.java
@@ -60,24 +60,24 @@ class IpOwnersAnswerer extends Answerer {
         (hostname, interfaceSet) ->
             interfaceSet.forEach(
                 iface -> {
-                  if (iface.getAddress() == null) {
-                    return;
-                  }
-                  if (ipNodeOwners
-                              .getOrDefault(iface.getAddress().getIp(), ImmutableSet.of())
-                              .size()
-                          > 1
-                      || !duplicatesOnly) {
-                    rows.add(
-                        Row.builder()
-                            .put(COL_NODE, new Node(hostname))
-                            .put(COL_VRFNAME, iface.getVrfName())
-                            .put(COL_INTERFACE_NAME, iface.getName())
-                            .put(COL_IP, iface.getAddress().getIp())
-                            .put(COL_MASK, iface.getAddress().getNetworkBits())
-                            .put(COL_ACTIVE, iface.getActive())
-                            .build());
-                  }
+                  iface
+                      .getAllAddresses()
+                      .forEach(
+                          address -> {
+                            if (ipNodeOwners.getOrDefault(address.getIp(), ImmutableSet.of()).size()
+                                    > 1
+                                || !duplicatesOnly) {
+                              rows.add(
+                                  Row.builder()
+                                      .put(COL_NODE, new Node(hostname))
+                                      .put(COL_VRFNAME, iface.getVrfName())
+                                      .put(COL_INTERFACE_NAME, iface.getName())
+                                      .put(COL_IP, address.getIp())
+                                      .put(COL_MASK, address.getNetworkBits())
+                                      .put(COL_ACTIVE, iface.getActive())
+                                      .build());
+                            }
+                          });
                 }));
     return rows;
   }

--- a/projects/question/src/test/java/org/batfish/question/ipowners/IpOwnersAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/ipowners/IpOwnersAnswererTest.java
@@ -1,5 +1,7 @@
 package org.batfish.question.ipowners;
 
+import static org.batfish.datamodel.Prefix.MAX_PREFIX_LENGTH;
+import static org.batfish.datamodel.matchers.RowMatchers.hasColumn;
 import static org.batfish.question.ipowners.IpOwnersAnswerer.COL_ACTIVE;
 import static org.batfish.question.ipowners.IpOwnersAnswerer.COL_INTERFACE_NAME;
 import static org.batfish.question.ipowners.IpOwnersAnswerer.COL_IP;
@@ -7,27 +9,27 @@ import static org.batfish.question.ipowners.IpOwnersAnswerer.COL_MASK;
 import static org.batfish.question.ipowners.IpOwnersAnswerer.COL_NODE;
 import static org.batfish.question.ipowners.IpOwnersAnswerer.COL_VRFNAME;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multiset;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
-import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.answers.Schema;
+import org.batfish.datamodel.pojo.Node;
 import org.batfish.datamodel.table.ColumnMetadata;
 import org.batfish.datamodel.table.Row;
 import org.junit.Before;
@@ -38,6 +40,7 @@ public class IpOwnersAnswererTest {
   private Ip _uniqueIp = new Ip("1.1.1.1");
   private Ip _duplicateIp = new Ip("2.2.2.2");
   private Ip _noOwnersIp = new Ip("3.3.3.3");
+  private Ip _secondaryUniqueIp = new Ip("4.4.4.4");
   private ImmutableMap<Ip, Set<String>> _ownersMap;
   private Map<String, Set<Interface>> _interfaceMap;
 
@@ -46,16 +49,20 @@ public class IpOwnersAnswererTest {
   public void setup() {
     Vrf vrf = new Vrf(Configuration.DEFAULT_VRF_NAME);
     Interface.Builder ib = Interface.builder().setVrf(vrf);
-    InterfaceAddress uniqueAddr = new InterfaceAddress(_uniqueIp, Prefix.MAX_PREFIX_LENGTH - 1);
-    InterfaceAddress duplicateAddr = new InterfaceAddress(_duplicateIp, Prefix.MAX_PREFIX_LENGTH);
+    InterfaceAddress uniqueAddr = new InterfaceAddress(_uniqueIp, MAX_PREFIX_LENGTH - 1);
+    InterfaceAddress secondaryUniqueAddr =
+        new InterfaceAddress(_secondaryUniqueIp, MAX_PREFIX_LENGTH - 1);
+    InterfaceAddress duplicateAddr = new InterfaceAddress(_duplicateIp, MAX_PREFIX_LENGTH);
     _ownersMap =
         ImmutableMap.of(
             _uniqueIp,
-            ImmutableSet.of("n1"),
+            ImmutableSet.of("n2"),
             _duplicateIp,
             ImmutableSet.of("n1", "n2"),
             _noOwnersIp,
-            ImmutableSet.of());
+            ImmutableSet.of(),
+            _secondaryUniqueIp,
+            ImmutableSet.of("n2"));
     _interfaceMap =
         ImmutableMap.of(
             "n1",
@@ -64,7 +71,11 @@ public class IpOwnersAnswererTest {
             "n2",
             ImmutableSet.of(
                 ib.setActive(true).setAddress(duplicateAddr).setName("Eth2/1").build(),
-                ib.setActive(true).setAddress(uniqueAddr).setName("Eth2/2").build()));
+                ib.setActive(true)
+                    // VRRP-like scenario
+                    .setAddresses(uniqueAddr, secondaryUniqueAddr)
+                    .setName("Eth2/2")
+                    .build()));
   }
 
   /** Test that rows show up correctly if duplicatesOnly is false, and we can handle empty maps */
@@ -79,23 +90,34 @@ public class IpOwnersAnswererTest {
 
     /*
      * Test that:
-     * - We have three rows, one for _uniqueIP, two for _duplicateIp
-     * - Masks are as expected
+     * - We have rows for each IP
+     * - Masks, nodes, interfaces names are as expected
+     * - All IPs per interface are displayed
      */
-    assertThat(rows, hasSize(3));
-    Map<Ip, Long> counts =
-        rows.stream()
-            .map(r -> r.getIp(COL_IP))
-            .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
-    assertThat(counts, hasEntry(_uniqueIp, 1L));
-    assertThat(counts, hasEntry(_duplicateIp, 2L));
-
-    List<Integer> masks =
-        rows.stream().map(r -> r.getInteger(COL_MASK)).collect(Collectors.toList());
     assertThat(
-        masks,
+        rows,
         containsInAnyOrder(
-            Prefix.MAX_PREFIX_LENGTH - 1, Prefix.MAX_PREFIX_LENGTH, Prefix.MAX_PREFIX_LENGTH));
+            ImmutableList.of(
+                allOf(
+                    hasColumn(COL_IP, equalTo(_uniqueIp), Schema.IP),
+                    hasColumn(COL_MASK, equalTo(MAX_PREFIX_LENGTH - 1), Schema.INTEGER),
+                    hasColumn(COL_NODE, equalTo(new Node("n2")), Schema.NODE),
+                    hasColumn(COL_INTERFACE_NAME, equalTo("Eth2/2"), Schema.STRING)),
+                allOf(
+                    hasColumn(COL_IP, equalTo(_secondaryUniqueIp), Schema.IP),
+                    hasColumn(COL_MASK, equalTo(MAX_PREFIX_LENGTH - 1), Schema.INTEGER),
+                    hasColumn(COL_NODE, equalTo(new Node("n2")), Schema.NODE),
+                    hasColumn(COL_INTERFACE_NAME, equalTo("Eth2/2"), Schema.STRING)),
+                allOf(
+                    hasColumn(COL_IP, equalTo(_duplicateIp), Schema.IP),
+                    hasColumn(COL_MASK, equalTo(MAX_PREFIX_LENGTH), Schema.INTEGER),
+                    hasColumn(COL_NODE, equalTo(new Node("n1")), Schema.NODE),
+                    hasColumn(COL_INTERFACE_NAME, equalTo("Eth1/1"), Schema.STRING)),
+                allOf(
+                    hasColumn(COL_IP, equalTo(_duplicateIp), Schema.IP),
+                    hasColumn(COL_MASK, equalTo(MAX_PREFIX_LENGTH), Schema.INTEGER),
+                    hasColumn(COL_NODE, equalTo(new Node("n2")), Schema.NODE),
+                    hasColumn(COL_INTERFACE_NAME, equalTo("Eth2/1"), Schema.STRING)))));
   }
 
   @Test


### PR DESCRIPTION
- Return all addresses for the interface when asking the IpOwners question.
- Make tests more explicit/check more properties of rows.