### PR TITLE
BDD parameter tuning

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/symbolic/bdd/BDDPacket.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/bdd/BDDPacket.java
@@ -118,8 +118,10 @@ public class BDDPacket {
    */
   public BDDPacket() {
     _factory = JFactory.init(JFACTORY_INITIAL_NODE_TABLE_SIZE, JFACTORY_INITIAL_NODE_CACHE_SIZE);
-    _factory.disableReorder();
+    _factory.enableReorder();
     _factory.setCacheRatio(JFACTORY_CACHE_RATIO);
+    // Do not impose a maximum node table increase
+    _factory.setMaxIncrease(0);
     // Disables printing
     /*
     try {
@@ -153,11 +155,11 @@ public class BDDPacket {
 
     _bitNames = new HashMap<>();
 
-    _ipProtocol = allocateBDDInteger("ipProtocol", IP_PROTOCOL_LENGTH, false);
     _dstIp = allocateBDDInteger("dstIp", IP_LENGTH, true);
     _srcIp = allocateBDDInteger("srcIp", IP_LENGTH, true);
     _dstPort = allocateBDDInteger("dstPort", PORT_LENGTH, false);
     _srcPort = allocateBDDInteger("srcPort", PORT_LENGTH, false);
+    _ipProtocol = allocateBDDInteger("ipProtocol", IP_PROTOCOL_LENGTH, false);
     _icmpCode = allocateBDDInteger("icmpCode", ICMP_CODE_LENGTH, false);
     _icmpType = allocateBDDInteger("icmpType", ICMP_TYPE_LENGTH, false);
     _tcpAck = allocateBDDBit("tcpAck");


### PR DESCRIPTION
Enable automatic variable reordering. This seems to have a small
performance benefit (< 10%), but doesn't seem to hurt.

Remove maximum node table increase size. The factory dynamically grows
the node table. If we limit its growth, we end up collecting more often
for large jobs. Removing the limit thus reduces the frequence of GCs,
and can save significant time for large jobs. For smaller jobs, this
doesn't make a difference as we wouldn't reach the default limit.

Change the default variable ordering by moving the ip protocol to after the IP
addresses and ports. This provides significant speedup for dataplane
analysis. It's possible that the old order is better for control plane,
so we may want to provide different orderings. For now, this seems to
be the better ordering.