### PR TITLE
Interface: prevent and verify that vrf is never null

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -311,8 +311,12 @@ public final class Interface extends ComparableStructure<String> {
       return this;
     }
 
+    public Builder setVrf(@Nonnull Vrf vrf) {
+      return setVrfName(requireNonNull(vrf, "vrf").getName());
+    }
+
     public Builder setVrfName(@Nonnull String vrfName) {
-      _vrfName = vrfName;
+      _vrfName = requireNonNull(vrfName, "vrfName");
       return this;
     }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
@@ -1,5 +1,7 @@
 package org.batfish.representation.aws;
 
+import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
+
 import java.util.List;
 import javax.annotation.Nullable;
 import org.batfish.common.Warnings;
@@ -27,7 +29,7 @@ public class Utils {
             .setDefaultInboundAction(LineAction.ACCEPT)
             .setDefaultCrossZoneAction(LineAction.ACCEPT)
             .build();
-    FACTORY.vrfBuilder().setName(Configuration.DEFAULT_VRF_NAME).setOwner(c).build();
+    FACTORY.vrfBuilder().setName(DEFAULT_VRF_NAME).setOwner(c).build();
     c.getVendorFamily().setAws(new AwsFamily());
     return c;
   }
@@ -38,7 +40,7 @@ public class Utils {
         .interfaceBuilder()
         .setName(name)
         .setOwner(c)
-        .setVrf(c.getDefaultVrf())
+        .setVrfName(DEFAULT_VRF_NAME)
         .setActive(true)
         .setAddress(primaryAddress)
         .build();

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
@@ -1,7 +1,5 @@
 package org.batfish.representation.aws;
 
-import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
-
 import java.util.List;
 import javax.annotation.Nullable;
 import org.batfish.common.Warnings;
@@ -29,7 +27,7 @@ public class Utils {
             .setDefaultInboundAction(LineAction.ACCEPT)
             .setDefaultCrossZoneAction(LineAction.ACCEPT)
             .build();
-    FACTORY.vrfBuilder().setName(DEFAULT_VRF_NAME).setOwner(c).build();
+    FACTORY.vrfBuilder().setName(Configuration.DEFAULT_VRF_NAME).setOwner(c).build();
     c.getVendorFamily().setAws(new AwsFamily());
     return c;
   }
@@ -40,7 +38,7 @@ public class Utils {
         .interfaceBuilder()
         .setName(name)
         .setOwner(c)
-        .setVrfName(DEFAULT_VRF_NAME)
+        .setVrfName(Configuration.DEFAULT_VRF_NAME)
         .setActive(true)
         .setAddress(primaryAddress)
         .build();

--- a/projects/batfish/src/main/java/org/batfish/representation/host/HostInterface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/host/HostInterface.java
@@ -143,7 +143,7 @@ public class HostInterface implements Serializable {
             .setBandwidth(_bandwidth)
             .setDeclaredNames(ImmutableSortedSet.of(_name))
             .setProxyArp(false)
-            .setVrf(configuration.getDefaultVrf());
+            .setVrfName(Configuration.DEFAULT_VRF_NAME);
     if (_shared) {
       SourceNat sourceNat = new SourceNat();
       Ip publicIp = _address.getIp();


### PR DESCRIPTION
- Add various annotations to setters and getters, plus requireNonNull
- Make builder default to default VRF
- Get rid of two-object-accounting: never store _vrf instead always deriving
  it from vrfName