### PR TITLE
add injectDefaultRoute and metricOfDefaultRoute properties to OspfArea

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfArea.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfArea.java
@@ -27,10 +27,8 @@ public class OspfArea extends ComparableStructure<Long> implements Serializable 
 
     private StubType _stubType;
 
-    /** For CISCO, we inject the default route by default. For Juniper, we don't. */
     private boolean _injectDefaultRoute = DEFAULT_INJECT_DEFAULT_ROUTE;
 
-    /** The metric to use when injecting the default route. */
     private int _metricOfDefaultRoute = DEFAULT_METRIC_OF_DEFAULT_ROUTE;
 
     Builder(NetworkFactory networkFactory) {
@@ -90,8 +88,17 @@ public class OspfArea extends ComparableStructure<Long> implements Serializable 
     }
   }
 
+  /*
+   * Whether this OSPF Area should inject the default route. Some systems (like IOS) inject the
+   * default route into OSPF by default, others don't (like JunOS). The default encodes the IOS
+   * behavior; other implementations must override the default.
+   */
   private static final boolean DEFAULT_INJECT_DEFAULT_ROUTE = true;
 
+  /*
+   * The metric of the default route injected by the OSPF Area (if it does inject the default
+   * route). The default encodes the IOS behavior; other implementations must override the default.
+   */
   private static final int DEFAULT_METRIC_OF_DEFAULT_ROUTE = 0;
 
   private static final String PROP_INJECT_DEFAULT_ROUTE = "injectDefaultRoute";

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfArea.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfArea.java
@@ -193,6 +193,11 @@ public class OspfArea extends ComparableStructure<Long> implements Serializable 
     _interfaces = interfaces;
   }
 
+  @JsonProperty(PROP_METRIC_OF_DEFAULT_ROUTE)
+  public void setMetricOfDefaultRoute(int metricOfDefaultRoute) {
+    _metricOfDefaultRoute = metricOfDefaultRoute;
+  }
+
   @JsonProperty(PROP_NSSA)
   public void setNssa(NssaSettings nssa) {
     _nssa = nssa;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfArea.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfArea.java
@@ -27,6 +27,12 @@ public class OspfArea extends ComparableStructure<Long> implements Serializable 
 
     private StubType _stubType;
 
+    /** For CISCO, we inject the default route by default. For Juniper, we don't. */
+    private boolean _injectDefaultRoute = DEFAULT_INJECT_DEFAULT_ROUTE;
+
+    /** The metric to use when injecting the default route. */
+    private int _metricOfDefaultRoute = DEFAULT_METRIC_OF_DEFAULT_ROUTE;
+
     Builder(NetworkFactory networkFactory) {
       super(networkFactory, OspfArea.class);
       _stubType = StubType.NONE;
@@ -42,6 +48,8 @@ public class OspfArea extends ComparableStructure<Long> implements Serializable 
       ospfArea._nssa = _nssa;
       ospfArea._stub = _stub;
       ospfArea._stubType = _stubType;
+      ospfArea._injectDefaultRoute = _injectDefaultRoute;
+      ospfArea._metricOfDefaultRoute = _metricOfDefaultRoute;
       return ospfArea;
     }
 
@@ -82,7 +90,15 @@ public class OspfArea extends ComparableStructure<Long> implements Serializable 
     }
   }
 
+  private static final boolean DEFAULT_INJECT_DEFAULT_ROUTE = true;
+
+  private static final int DEFAULT_METRIC_OF_DEFAULT_ROUTE = 0;
+
+  private static final String PROP_INJECT_DEFAULT_ROUTE = "injectDefaultRoute";
+
   private static final String PROP_INTERFACES = "interfaces";
+
+  private static final String PROP_METRIC_OF_DEFAULT_ROUTE = "metricOfDefaultRoute";
 
   private static final String PROP_NSSA = "nssa";
 
@@ -100,7 +116,11 @@ public class OspfArea extends ComparableStructure<Long> implements Serializable 
     return new Builder(networkFactory);
   }
 
+  private boolean _injectDefaultRoute = DEFAULT_INJECT_DEFAULT_ROUTE;
+
   private SortedSet<String> _interfaces;
+
+  private int _metricOfDefaultRoute = DEFAULT_METRIC_OF_DEFAULT_ROUTE;
 
   private NssaSettings _nssa;
 
@@ -120,10 +140,22 @@ public class OspfArea extends ComparableStructure<Long> implements Serializable 
     _summaries = new TreeMap<>();
   }
 
+  @JsonProperty(PROP_INJECT_DEFAULT_ROUTE)
+  @JsonPropertyDescription("Whether the default route should be injected")
+  public boolean getInjectDefaultRoute() {
+    return _injectDefaultRoute;
+  }
+
   @JsonProperty(PROP_INTERFACES)
   @JsonPropertyDescription("The interfaces assigned to this OSPF area")
   public SortedSet<String> getInterfaces() {
     return _interfaces;
+  }
+
+  @JsonProperty(PROP_METRIC_OF_DEFAULT_ROUTE)
+  @JsonPropertyDescription("The metric to use for the injected default route")
+  public int getMetricOfDefaultRoute() {
+    return _metricOfDefaultRoute;
   }
 
   @JsonProperty(PROP_NSSA)
@@ -149,6 +181,11 @@ public class OspfArea extends ComparableStructure<Long> implements Serializable 
   @JsonProperty(PROP_SUMMARY_FILTER)
   public String getSummaryFilter() {
     return _summaryFilter;
+  }
+
+  @JsonProperty(PROP_INJECT_DEFAULT_ROUTE)
+  public void setInjectDefaultRoute(boolean injectDefaultRoute) {
+    _injectDefaultRoute = injectDefaultRoute;
   }
 
   @JsonProperty(PROP_INTERFACES)

--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/OspfProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/OspfProtocolHelper.java
@@ -62,9 +62,10 @@ public class OspfProtocolHelper {
    * @return {@code true} iff the route should be considered for installation into the OSPF RIB
    */
   public static boolean isOspfInterAreaDefaultOriginationAllowed(
-      OspfProcess process, OspfProcess neighborProc, OspfArea neighborArea) {
+      OspfProcess process, OspfProcess neighborProc, OspfArea area, OspfArea neighborArea) {
     return neighborProc.isAreaBorderRouter()
         && !process.isAreaBorderRouter()
+        && area.getInjectDefaultRoute()
         && (neighborArea.getStubType() == StubType.STUB
             || (neighborArea.getStubType() == StubType.NSSA
                 && neighborArea.getNssa().getDefaultOriginateType()

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/OspfProtocolHelperTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/OspfProtocolHelperTest.java
@@ -85,16 +85,25 @@ public class OspfProtocolHelperTest {
     Builder b = nf.ospfProcessBuilder();
     OspfProcess proc = b.build();
     OspfProcess neighborProc = b.build();
+    OspfArea area0 = new OspfArea(0L);
     OspfArea area1 = new OspfArea(1L);
     area1.setStubType(StubType.STUB);
-    neighborProc.setAreas(ImmutableSortedMap.of(0L, new OspfArea(0L), 1L, area1));
+    neighborProc.setAreas(ImmutableSortedMap.of(0L, area0, 1L, area1));
 
     // Receiving process is NOT an ABR
     proc.setAreas(ImmutableSortedMap.of(1L, area1));
-    assertThat(isOspfInterAreaDefaultOriginationAllowed(proc, neighborProc, area1), equalTo(true));
+    assertThat(
+        isOspfInterAreaDefaultOriginationAllowed(proc, neighborProc, area0, area1), equalTo(true));
 
-    // Receiving process IS an ABR
-    proc.setAreas(ImmutableSortedMap.of(0L, new OspfArea(0L), 1L, area1));
-    assertThat(isOspfInterAreaDefaultOriginationAllowed(proc, neighborProc, area1), equalTo(false));
+    // Area does not inject the default route
+    area0.setInjectDefaultRoute(false);
+    assertThat(
+        isOspfInterAreaDefaultOriginationAllowed(proc, neighborProc, area0, area1), equalTo(false));
+
+    // Area injects the default route, but the receiving process IS an ABR
+    area0.setInjectDefaultRoute(true);
+    proc.setAreas(ImmutableSortedMap.of(0L, area0, 1L, area1));
+    assertThat(
+        isOspfInterAreaDefaultOriginationAllowed(proc, neighborProc, area0, area1), equalTo(false));
   }
 }

--- a/tests/aws/nodes-example-aws.ref
+++ b/tests/aws/nodes-example-aws.ref
@@ -1993,11 +1993,13 @@
               "areas" : {
                 "0" : {
                   "name" : 0,
+                  "injectDefaultRoute" : true,
                   "interfaces" : [
                     "Ethernet1/0",
                     "Ethernet1/1",
                     "Loopback0"
                   ],
+                  "metricOfDefaultRoute" : 0,
                   "stubType" : "NONE"
                 }
               },

--- a/tests/basic/nodes.ref
+++ b/tests/basic/nodes.ref
@@ -1188,10 +1188,12 @@
               "areas" : {
                 "1" : {
                   "name" : 1,
+                  "injectDefaultRoute" : true,
                   "interfaces" : [
                     "GigabitEthernet0/0",
                     "Loopback0"
                   ],
+                  "metricOfDefaultRoute" : 0,
                   "stubType" : "NONE"
                 }
               },
@@ -2432,10 +2434,12 @@
               "areas" : {
                 "1" : {
                   "name" : 1,
+                  "injectDefaultRoute" : true,
                   "interfaces" : [
                     "GigabitEthernet1/0",
                     "Loopback0"
                   ],
+                  "metricOfDefaultRoute" : 0,
                   "stubType" : "NONE"
                 }
               },
@@ -2826,11 +2830,13 @@
               "areas" : {
                 "1" : {
                   "name" : 1,
+                  "injectDefaultRoute" : true,
                   "interfaces" : [
                     "GigabitEthernet0/0",
                     "GigabitEthernet1/0",
                     "Loopback0"
                   ],
+                  "metricOfDefaultRoute" : 0,
                   "stubType" : "NONE"
                 }
               },
@@ -4091,11 +4097,13 @@
               "areas" : {
                 "1" : {
                   "name" : 1,
+                  "injectDefaultRoute" : true,
                   "interfaces" : [
                     "GigabitEthernet1/0",
                     "GigabitEthernet2/0",
                     "Loopback0"
                   ],
+                  "metricOfDefaultRoute" : 0,
                   "stubType" : "NONE"
                 }
               },
@@ -5299,11 +5307,13 @@
               "areas" : {
                 "1" : {
                   "name" : 1,
+                  "injectDefaultRoute" : true,
                   "interfaces" : [
                     "GigabitEthernet1/0",
                     "GigabitEthernet2/0",
                     "Loopback0"
                   ],
+                  "metricOfDefaultRoute" : 0,
                   "stubType" : "NONE"
                 }
               },
@@ -5905,6 +5915,7 @@
               "areas" : {
                 "1" : {
                   "name" : 1,
+                  "injectDefaultRoute" : true,
                   "interfaces" : [
                     "GigabitEthernet0/0",
                     "GigabitEthernet1/0",
@@ -5912,6 +5923,7 @@
                     "GigabitEthernet3/0",
                     "Loopback0"
                   ],
+                  "metricOfDefaultRoute" : 0,
                   "stubType" : "NONE"
                 }
               },
@@ -6460,6 +6472,7 @@
               "areas" : {
                 "1" : {
                   "name" : 1,
+                  "injectDefaultRoute" : true,
                   "interfaces" : [
                     "GigabitEthernet0/0",
                     "GigabitEthernet1/0",
@@ -6467,6 +6480,7 @@
                     "GigabitEthernet3/0",
                     "Loopback0"
                   ],
+                  "metricOfDefaultRoute" : 0,
                   "stubType" : "NONE"
                 }
               },
@@ -8172,11 +8186,13 @@
               "areas" : {
                 "1" : {
                   "name" : 1,
+                  "injectDefaultRoute" : true,
                   "interfaces" : [
                     "GigabitEthernet0/0",
                     "GigabitEthernet1/0",
                     "Loopback0"
                   ],
+                  "metricOfDefaultRoute" : 0,
                   "stubType" : "NONE"
                 }
               },
@@ -8927,11 +8943,13 @@
               "areas" : {
                 "1" : {
                   "name" : 1,
+                  "injectDefaultRoute" : true,
                   "interfaces" : [
                     "GigabitEthernet0/0",
                     "GigabitEthernet1/0",
                     "Loopback0"
                   ],
+                  "metricOfDefaultRoute" : 0,
                   "stubType" : "NONE"
                 }
               },
@@ -10051,10 +10069,12 @@
               "areas" : {
                 "1" : {
                   "name" : 1,
+                  "injectDefaultRoute" : true,
                   "interfaces" : [
                     "GigabitEthernet0/0",
                     "Loopback0"
                   ],
+                  "metricOfDefaultRoute" : 0,
                   "stubType" : "NONE"
                 }
               },
@@ -11126,10 +11146,12 @@
               "areas" : {
                 "1" : {
                   "name" : 1,
+                  "injectDefaultRoute" : true,
                   "interfaces" : [
                     "GigabitEthernet1/0",
                     "Loopback0"
                   ],
+                  "metricOfDefaultRoute" : 0,
                   "stubType" : "NONE"
                 }
               },
@@ -11720,11 +11742,13 @@
               "areas" : {
                 "1" : {
                   "name" : 1,
+                  "injectDefaultRoute" : true,
                   "interfaces" : [
                     "GigabitEthernet0/0",
                     "GigabitEthernet1/0",
                     "Loopback0"
                   ],
+                  "metricOfDefaultRoute" : 0,
                   "stubType" : "NONE"
                 }
               },

--- a/tests/basic/outliers-verbose.ref
+++ b/tests/basic/outliers-verbose.ref
@@ -2435,10 +2435,12 @@
             "areas" : {
               "1" : {
                 "name" : 1,
+                "injectDefaultRoute" : true,
                 "interfaces" : [
                   "GigabitEthernet0/0",
                   "Loopback0"
                 ],
+                "metricOfDefaultRoute" : 0,
                 "stubType" : "NONE"
               }
             },

--- a/tests/jsonpath-addons/jsonpath-display-hints-prefixofsuffix.ref
+++ b/tests/jsonpath-addons/jsonpath-display-hints-prefixofsuffix.ref
@@ -1270,11 +1270,13 @@
                     "areas" : {
                       "1" : {
                         "name" : 1,
+                        "injectDefaultRoute" : true,
                         "interfaces" : [
                           "GigabitEthernet1/0",
                           "GigabitEthernet2/0",
                           "Loopback0"
                         ],
+                        "metricOfDefaultRoute" : 0,
                         "stubType" : "NONE"
                       }
                     },

--- a/tests/jsonpath-addons/jsonpath-display-hints-suffixofsuffix.ref
+++ b/tests/jsonpath-addons/jsonpath-display-hints-suffixofsuffix.ref
@@ -1270,11 +1270,13 @@
                     "areas" : {
                       "1" : {
                         "name" : 1,
+                        "injectDefaultRoute" : true,
                         "interfaces" : [
                           "GigabitEthernet1/0",
                           "GigabitEthernet2/0",
                           "Loopback0"
                         ],
+                        "metricOfDefaultRoute" : 0,
                         "stubType" : "NONE"
                       }
                     },

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -1732,9 +1732,11 @@
               "areas" : {
                 "0" : {
                   "name" : 0,
+                  "injectDefaultRoute" : true,
                   "interfaces" : [
                     "Ethernet0/0"
                   ],
+                  "metricOfDefaultRoute" : 0,
                   "stubType" : "NONE"
                 }
               },
@@ -9211,6 +9213,8 @@
               "areas" : {
                 "0" : {
                   "name" : 0,
+                  "injectDefaultRoute" : true,
+                  "metricOfDefaultRoute" : 0,
                   "stubType" : "NONE",
                   "summaries" : {
                     "1.2.3.0/24" : {
@@ -9222,6 +9226,8 @@
                 },
                 "16909056" : {
                   "name" : 16909056,
+                  "injectDefaultRoute" : true,
+                  "metricOfDefaultRoute" : 0,
                   "stubType" : "NONE",
                   "summaries" : {
                     "1.2.3.0/24" : {
@@ -11755,10 +11761,12 @@
               "areas" : {
                 "0" : {
                   "name" : 0,
+                  "injectDefaultRoute" : true,
                   "interfaces" : [
                     "Ethernet0",
                     "Ethernet1"
                   ],
+                  "metricOfDefaultRoute" : 0,
                   "stubType" : "NONE"
                 }
               },
@@ -13457,6 +13465,8 @@
               "areas" : {
                 "0" : {
                   "name" : 0,
+                  "injectDefaultRoute" : true,
+                  "metricOfDefaultRoute" : 0,
                   "stubType" : "NONE",
                   "summaries" : {
                     "10.0.0.0/15" : {
@@ -13939,6 +13949,8 @@
               "areas" : {
                 "66051" : {
                   "name" : 66051,
+                  "injectDefaultRoute" : true,
+                  "metricOfDefaultRoute" : 0,
                   "nssa" : {
                     "defaultOriginateType" : "INTER_AREA",
                     "suppressType3" : true
@@ -15792,6 +15804,8 @@
               "areas" : {
                 "7" : {
                   "name" : 7,
+                  "injectDefaultRoute" : true,
+                  "metricOfDefaultRoute" : 0,
                   "stub" : {
                     "suppressType3" : false
                   },
@@ -15799,6 +15813,8 @@
                 },
                 "46" : {
                   "name" : 46,
+                  "injectDefaultRoute" : true,
+                  "metricOfDefaultRoute" : 0,
                   "stub" : {
                     "suppressType3" : true
                   },


### PR DESCRIPTION
Makes these values explicit in the datamodel, since Juniper and Cisco behave differently.  Update the logic that injects default routes for OSPF areas to check these values. 