### PR TITLE
restore FlexibleLocationIpSpaceSpecifierFactory

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/FlexibleLocationIpSpaceSpecifierFactory.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/FlexibleLocationIpSpaceSpecifierFactory.java
@@ -1,0 +1,24 @@
+package org.batfish.specifier;
+
+import com.google.auto.service.AutoService;
+import javax.annotation.Nullable;
+
+/**
+ * Builds a {@link LocationIpSpaceSpecifier} using {@link FlexibleLocationSpecifierFactory} to build
+ * its {@link LocationSpecifier} input.
+ */
+@AutoService(IpSpaceSpecifierFactory.class)
+public final class FlexibleLocationIpSpaceSpecifierFactory implements IpSpaceSpecifierFactory {
+  public static final String NAME = FlexibleLocationIpSpaceSpecifierFactory.class.getSimpleName();
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
+  public IpSpaceSpecifier buildIpSpaceSpecifier(@Nullable Object input) {
+    return new LocationIpSpaceSpecifier(
+        new FlexibleLocationSpecifierFactory().buildLocationSpecifier(input));
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/IpSpaceSpecifierFactoryTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/IpSpaceSpecifierFactoryTest.java
@@ -28,6 +28,21 @@ public class IpSpaceSpecifierFactoryTest {
   }
 
   @Test
+  public void testFlexibleLocationIpSpaceSpecifierFactory() {
+    assertThat(
+        load(FlexibleLocationIpSpaceSpecifierFactory.NAME),
+        instanceOf(FlexibleLocationIpSpaceSpecifierFactory.class));
+    IpSpaceSpecifier actual =
+        new FlexibleLocationIpSpaceSpecifierFactory().buildIpSpaceSpecifier("[vrf(foo)]");
+    assertThat(
+        actual,
+        equalTo(
+            new LocationIpSpaceSpecifier(
+                new InterfaceSpecifierInterfaceLocationSpecifier(
+                    new VrfNameRegexInterfaceSpecifier(Pattern.compile("foo"))))));
+  }
+
+  @Test
   public void testInferFromLocationIpSpaceSpecifierFactory() {
     assertThat(
         new InferFromLocationIpSpaceSpecifierFactory().buildIpSpaceSpecifier(null),


### PR DESCRIPTION
We're not ready to remove this yet. This is used to specify an `IpSpace` using locations specified by `FlexibleLocationSpecifierFactory`. Specifically useful for destination IP. The recent changes to `FlexibleLocationSpecifierFactory` affect how this is used, but it still works.