### PR TITLE
Fix PAN Vrf assignment for interfaces

### DIFF
--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/VrfMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/VrfMatchers.java
@@ -12,6 +12,7 @@ import org.batfish.datamodel.matchers.VrfMatchersImpl.HasBgpProcess;
 import org.batfish.datamodel.matchers.VrfMatchersImpl.HasEigrpProcess;
 import org.batfish.datamodel.matchers.VrfMatchersImpl.HasGeneratedRoutes;
 import org.batfish.datamodel.matchers.VrfMatchersImpl.HasInterfaces;
+import org.batfish.datamodel.matchers.VrfMatchersImpl.HasName;
 import org.batfish.datamodel.matchers.VrfMatchersImpl.HasOspfProcess;
 import org.batfish.datamodel.matchers.VrfMatchersImpl.HasSnmpServer;
 import org.batfish.datamodel.matchers.VrfMatchersImpl.HasStaticRoutes;
@@ -59,6 +60,11 @@ public class VrfMatchers {
    */
   public static HasOspfProcess hasOspfProcess(Matcher<? super OspfProcess> subMatcher) {
     return new HasOspfProcess(subMatcher);
+  }
+
+  /** Provides a matcher that matches if the provided {@code subMatcher} matches the VRF's name. */
+  public static HasName hasName(Matcher<? super String> subMatcher) {
+    return new HasName(subMatcher);
   }
 
   public static @Nonnull Matcher<Vrf> hasSnmpServer(

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/VrfMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/VrfMatchersImpl.java
@@ -81,6 +81,17 @@ final class VrfMatchersImpl {
     }
   }
 
+  static final class HasName extends FeatureMatcher<Vrf, String> {
+    HasName(@Nonnull Matcher<? super String> subMatcher) {
+      super(subMatcher, "A VRF with name:", "name");
+    }
+
+    @Override
+    protected String featureValueOf(Vrf actual) {
+      return actual.getName();
+    }
+  }
+
   static final class HasSnmpServer extends FeatureMatcher<Vrf, SnmpServer> {
     HasSnmpServer(@Nonnull Matcher<? super SnmpServer> subMatcher) {
       super(subMatcher, "A Vrf with snmpServer:", "snmpServer");

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -33,6 +33,8 @@ public final class PaloAltoConfiguration extends VendorConfiguration {
 
   public static final String DEFAULT_VSYS_NAME = "vsys1";
 
+  public static final String NULL_VRF_NAME = "~NULL_VRF~";
+
   public static final String SHARED_VSYS_NAME = "~SHARED_VSYS~";
 
   private Configuration _c;
@@ -237,6 +239,7 @@ public final class PaloAltoConfiguration extends VendorConfiguration {
       org.batfish.datamodel.Interface iface = _c.getInterfaces().get(interfaceName);
       if (iface != null) {
         map.put(interfaceName, iface);
+        iface.setVrf(vrf);
       }
     }
     vrf.setInterfaces(map);
@@ -264,8 +267,30 @@ public final class PaloAltoConfiguration extends VendorConfiguration {
       _c.getInterfaces().put(i.getKey(), toInterface(i.getValue()));
     }
 
+    // Vrf conversion uses interfaces, so must be done after interface exist in VI model
     for (Entry<String, VirtualRouter> vr : _virtualRouters.entrySet()) {
       _c.getVrfs().put(vr.getKey(), toVrf(vr.getValue()));
+    }
+
+    // Batfish cannot handle interfaces without a Vrf
+    // So put orphaned interfaces in a constructed Vrf and shut them down
+    Vrf nullVrf = new Vrf(NULL_VRF_NAME);
+    NavigableMap<String, org.batfish.datamodel.Interface> orphanedInterfaces = new TreeMap<>();
+    for (Entry<String, org.batfish.datamodel.Interface> i : _c.getInterfaces().entrySet()) {
+      org.batfish.datamodel.Interface iface = i.getValue();
+      if (iface.getVrf() == null) {
+        orphanedInterfaces.put(iface.getName(), iface);
+        iface.setVrf(nullVrf);
+        iface.setActive(false);
+        _w.redFlag(
+            String.format(
+                "Interface %s is not in a virtual-router, placing in %s and shutting it down.",
+                iface.getName(), nullVrf.getName()));
+      }
+    }
+    if (orphanedInterfaces.size() > 0) {
+      nullVrf.setInterfaces(orphanedInterfaces);
+      _c.getVrfs().put(nullVrf.getName(), nullVrf);
     }
 
     // Handle converting items within virtual systems

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -22,8 +22,10 @@ import static org.batfish.datamodel.matchers.InterfaceMatchers.isActive;
 import static org.batfish.datamodel.matchers.IpAccessListMatchers.accepts;
 import static org.batfish.datamodel.matchers.IpAccessListMatchers.rejects;
 import static org.batfish.datamodel.matchers.VrfMatchers.hasInterfaces;
+import static org.batfish.datamodel.matchers.VrfMatchers.hasName;
 import static org.batfish.datamodel.matchers.VrfMatchers.hasStaticRoutes;
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.DEFAULT_VSYS_NAME;
+import static org.batfish.representation.palo_alto.PaloAltoConfiguration.NULL_VRF_NAME;
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.SHARED_VSYS_NAME;
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.computeObjectName;
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.computeServiceGroupMemberAclName;
@@ -58,6 +60,7 @@ import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
+import org.batfish.datamodel.matchers.InterfaceMatchers;
 import org.batfish.grammar.VendorConfigurationFormatDetector;
 import org.batfish.grammar.flattener.Flattener;
 import org.batfish.grammar.flattener.FlattenerLineMap;
@@ -204,6 +207,24 @@ public class PaloAltoGrammarTest {
         ccae,
         hasUndefinedReference(
             filename, INTERFACE, "ethernet1/undefined", VIRTUAL_ROUTER_INTERFACE));
+  }
+
+  @Test
+  public void testInterfaceVirtualRouterAssignment() throws IOException {
+    String hostname = "interface-virtual-router";
+    Configuration c = parseConfig(hostname);
+
+    // Make sure each interface is associated with the correct vrf
+    assertThat(
+        c, hasInterface("ethernet1/1", InterfaceMatchers.hasVrf(hasName(equalTo("default")))));
+    assertThat(
+        c, hasInterface("ethernet1/2", InterfaceMatchers.hasVrf(hasName(equalTo("somename")))));
+    assertThat(
+        c, hasInterface("ethernet1/3", InterfaceMatchers.hasVrf(hasName(equalTo("somename")))));
+
+    // Make sure the orphaned vrf is associated with the "null", constructed vrf
+    assertThat(
+        c, hasInterface("ethernet1/4", InterfaceMatchers.hasVrf(hasName(equalTo(NULL_VRF_NAME)))));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/interface
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/interface
@@ -7,3 +7,5 @@ set network interface ethernet ethernet1/2 comment "interface's long description
 set network interface ethernet ethernet1/3 link-status down
 set network interface ethernet ethernet1/3 link-status up
 set network interface ethernet ethernet1/3 comment 'single quoted description'
+# Interfaces are not functionally active unless they are in a virtual-router
+set network virtual-router default interface [ ethernet1/1 ethernet1/2 ethernet1/3 ]

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/interface-virtual-router
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/interface-virtual-router
@@ -1,0 +1,7 @@
+set deviceconfig system hostname interface-virtual-router
+set network virtual-router default interface ethernet1/1
+set network virtual-router somename interface [ ethernet1/2 ethernet1/3 ]
+set network interface ethernet ethernet1/1 layer3 ip 1.1.1.1/24
+set network interface ethernet ethernet1/2 layer3 ip 1.1.2.1/24
+set network interface ethernet ethernet1/3 layer3 ip 1.1.3.1/24
+set network interface ethernet ethernet1/4 layer3 ip 1.1.4.1/24


### PR DESCRIPTION
Context:
Interfaces on PAN devices must explicitly be placed in a virtual-router (vrf), otherwise they are functionally inactive/shutdown.

Change:
Now, in the PAN `toVendorIndependentConfiguration` method:
* Where applicable, simply set an interface's vrf to the one specified in the config
* Add all interfaces not associated with a vrf to a constructed `null` vrf
* Shutdown these orphaned interfaces so they do not inadvertently tx/rx traffic
