### PR TITLE
Remove zone indirection from interface class, just store names

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -685,9 +685,7 @@ public final class Interface extends ComparableStructure<String> {
 
   private SortedMap<Integer, VrrpGroup> _vrrpGroups;
 
-  private Zone _zone;
-
-  private transient String _zoneName;
+  private String _zoneName;
 
   private String _hsrpVersion;
 
@@ -805,9 +803,6 @@ public final class Interface extends ComparableStructure<String> {
       return false;
     }
     if (!Objects.equals(this._switchportMode, other._switchportMode)) {
-      return false;
-    }
-    if (!Objects.equals(this._zone, other._zone)) {
       return false;
     }
     return true;
@@ -1165,19 +1160,10 @@ public final class Interface extends ComparableStructure<String> {
     return _vrrpGroups;
   }
 
-  @JsonIgnore
-  public Zone getZone() {
-    return _zone;
-  }
-
   @JsonProperty(PROP_ZONE)
   @JsonPropertyDescription("The firewall zone to which this interface belongs.")
   public String getZoneName() {
-    if (_zone != null) {
-      return _zone.getName();
-    } else {
-      return _zoneName;
-    }
+    return _zoneName;
   }
 
   public boolean isLoopback(ConfigurationFormat vendor) {
@@ -1485,11 +1471,6 @@ public final class Interface extends ComparableStructure<String> {
   @JsonProperty(PROP_VRRP_GROUPS)
   public void setVrrpGroups(SortedMap<Integer, VrrpGroup> vrrpGroups) {
     _vrrpGroups = vrrpGroups;
-  }
-
-  @JsonIgnore
-  public void setZone(Zone zone) {
-    _zone = zone;
   }
 
   @JsonProperty(PROP_ZONE)

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -2389,6 +2389,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
   }
 
   private org.batfish.datamodel.Zone toZone(Zone zone) {
+    String zoneName = zone.getName();
 
     FirewallFilter inboundFilter = zone.getInboundFilter();
     IpAccessList inboundFilterList = null;
@@ -2408,7 +2409,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
       toHostFilterList = _c.getIpAccessLists().get(toHostFilter.getName());
     }
 
-    org.batfish.datamodel.Zone newZone = new org.batfish.datamodel.Zone(zone.getName());
+    org.batfish.datamodel.Zone newZone = new org.batfish.datamodel.Zone(zoneName);
     if (fromHostFilterList != null) {
       newZone.setFromHostFilterName(fromHostFilterList.getName());
     }
@@ -2440,7 +2441,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
     for (Interface iface : zone.getInterfaces()) {
       String ifaceName = iface.getName();
       org.batfish.datamodel.Interface newIface = _c.getInterfaces().get(ifaceName);
-      newIface.setZone(newZone);
+      newIface.setZoneName(zoneName);
       FirewallFilter inboundInterfaceFilter = zone.getInboundInterfaceFilters().get(ifaceName);
       if (inboundInterfaceFilter != null) {
         newZone


### PR DESCRIPTION
No longer accept either zone or zone name when populating interface data model and dynamically reading name from one or the other, just accept and store zone name directly.
