### PR TITLE
Support additional types of characters in the metada.

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/table/ColumnMetadata.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/table/ColumnMetadata.java
@@ -20,8 +20,12 @@ public final class ColumnMetadata {
   private static final String PROP_NAME = "name";
   private static final String PROP_SCHEMA = "schema";
 
-  // must start with letters or underscore, and only contain {-,\w} ( i.e., [-a-zA-Z_0-9])
+  /**
+   * Must start with alpha numerical letters, underscore or tilde. In addition, consecutive
+   * characters could include [-.:~@].
+   */
   public static final String COLUMN_NAME_PATTERN = "[a-zA-Z0-9_~]+[-\\w\\.:~@]*";
+
   private static final Pattern _COLUMN_NAME_PATTERN = Pattern.compile(COLUMN_NAME_PATTERN);
 
   @Nonnull private String _description;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/table/ColumnMetadata.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/table/ColumnMetadata.java
@@ -21,8 +21,8 @@ public final class ColumnMetadata {
   private static final String PROP_SCHEMA = "schema";
 
   /**
-   * Must start with alpha numerical letters, underscore or tilde. In addition, consecutive
-   * characters could include [-.:~@].
+   * Must start with alpha numerical letters, underscore or tilde. In addition, following characters
+   * could include [-.:~@].
    */
   public static final String COLUMN_NAME_PATTERN = "[a-zA-Z0-9_~]+[-\\w\\.:~@]*";
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/table/ColumnMetadata.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/table/ColumnMetadata.java
@@ -21,7 +21,7 @@ public final class ColumnMetadata {
   private static final String PROP_SCHEMA = "schema";
 
   // must start with letters or underscore, and only contain {-,\w} ( i.e., [-a-zA-Z_0-9])
-  public static final String COLUMN_NAME_PATTERN = "[a-zA-Z0-9_.~]*[-\\s\\w/.:~]*";
+  public static final String COLUMN_NAME_PATTERN = "[a-zA-Z0-9_~]+[-\\w\\.:~@]*";
   private static final Pattern _COLUMN_NAME_PATTERN = Pattern.compile(COLUMN_NAME_PATTERN);
 
   @Nonnull private String _description;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/table/ColumnMetadata.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/table/ColumnMetadata.java
@@ -21,7 +21,7 @@ public final class ColumnMetadata {
   private static final String PROP_SCHEMA = "schema";
 
   // must start with letters or underscore, and only contain {-,\w} ( i.e., [-a-zA-Z_0-9])
-  public static final String COLUMN_NAME_PATTERN = "[a-zA-Z_][-\\w]*";
+  public static final String COLUMN_NAME_PATTERN = "[a-zA-Z0-9_.~]*[-\\s\\w/.:~]*";
   private static final Pattern _COLUMN_NAME_PATTERN = Pattern.compile(COLUMN_NAME_PATTERN);
 
   @Nonnull private String _description;

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/table/ColumnMetadataTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/table/ColumnMetadataTest.java
@@ -73,5 +73,9 @@ public class ColumnMetadataTest {
     // Allow the under score, tilde, hyphen, numbers in the column name
     assertThat(
         ColumnMetadata.isLegalColumnName("colNameWith!@#$%^&*()+Characters"), equalTo(false));
+
+    // Atleast one character should be given as column name
+    assertThat(ColumnMetadata.isLegalColumnName(""), equalTo(false));
+    assertThat(ColumnMetadata.isLegalColumnName("a"), equalTo(true));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/table/ColumnMetadataTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/table/ColumnMetadataTest.java
@@ -42,4 +42,36 @@ public class ColumnMetadataTest {
     assertThat(c.getIsKey(), equalTo(true));
     assertThat(c.getIsValue(), equalTo(true));
   }
+
+  @Test
+  public void testInvalidColumnNameWithSpecialCharacters() {
+
+    // Allow the tilde character in the column name
+    assertThat(ColumnMetadata.isLegalColumnName("~colNamewith~Tilde"), equalTo(true));
+
+    // Allow the under score in the column name
+    assertThat(ColumnMetadata.isLegalColumnName("_colNameWith_UnderScore"), equalTo(true));
+
+    // Do not allow the hyphen in the start of column name
+    assertThat(ColumnMetadata.isLegalColumnName("-colNameWith-hyphen"), equalTo(false));
+    assertThat(ColumnMetadata.isLegalColumnName("colNameWith-hyphen"), equalTo(true));
+
+    // Do not allow the space in the column name
+    assertThat(ColumnMetadata.isLegalColumnName("column name"), equalTo(false));
+
+    // Do not allow . characters in the start of column name
+    assertThat(ColumnMetadata.isLegalColumnName(".test.colName"), equalTo(false));
+    assertThat(ColumnMetadata.isLegalColumnName("test.colName"), equalTo(true));
+
+    // Do not allow @ characters in the start of column name
+    assertThat(ColumnMetadata.isLegalColumnName("@test@colName"), equalTo(false));
+    assertThat(ColumnMetadata.isLegalColumnName("test@colName"), equalTo(true));
+
+    // Allow the under score, tilde, hyphen, numbers in the column name
+    assertThat(ColumnMetadata.isLegalColumnName("_colName_With~Under-Score0-9"), equalTo(true));
+
+    // Allow the under score, tilde, hyphen, numbers in the column name
+    assertThat(
+        ColumnMetadata.isLegalColumnName("colNameWith!@#$%^&*()+Characters"), equalTo(false));
+  }
 }


### PR DESCRIPTION
Support additional types of characters in the metada required for space and characters such as ~ which is required to support configurations for named structures.