### PR TITLE
New flexible IpSpaceSpecifierFactory with universe as the default

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/FlexibleInferFromLocationIpSpaceSpecifierFactory.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/FlexibleInferFromLocationIpSpaceSpecifierFactory.java
@@ -1,0 +1,23 @@
+package org.batfish.specifier;
+
+import com.google.auto.service.AutoService;
+
+/**
+ * An {@link FlexibleIpSpaceSpecifierFactory} that uses {@link InferFromLocationIpSpaceSpecifier} as
+ * the default.
+ */
+@AutoService(IpSpaceSpecifierFactory.class)
+public final class FlexibleInferFromLocationIpSpaceSpecifierFactory
+    extends FlexibleIpSpaceSpecifierFactory {
+  static final String NAME = FlexibleInferFromLocationIpSpaceSpecifierFactory.class.getSimpleName();
+
+  @Override
+  protected IpSpaceSpecifier defaultIpSpaceSpecifier() {
+    return InferFromLocationIpSpaceSpecifier.INSTANCE;
+  }
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/FlexibleInferFromLocationIpSpaceSpecifierFactory.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/FlexibleInferFromLocationIpSpaceSpecifierFactory.java
@@ -9,7 +9,8 @@ import com.google.auto.service.AutoService;
 @AutoService(IpSpaceSpecifierFactory.class)
 public final class FlexibleInferFromLocationIpSpaceSpecifierFactory
     extends FlexibleIpSpaceSpecifierFactory {
-  static final String NAME = FlexibleInferFromLocationIpSpaceSpecifierFactory.class.getSimpleName();
+  public static final String NAME =
+      FlexibleInferFromLocationIpSpaceSpecifierFactory.class.getSimpleName();
 
   @Override
   protected IpSpaceSpecifier defaultIpSpaceSpecifier() {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/FlexibleIpSpaceSpecifierFactory.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/FlexibleIpSpaceSpecifierFactory.java
@@ -2,37 +2,30 @@ package org.batfish.specifier;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.google.auto.service.AutoService;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * An IpSpaceSpecifierFactory that accepts three types of inputs:
+ * An abstract IpSpaceSpecifierFactory that accepts three types of inputs:
  *
  * <ul>
- *   <li>null, which returns {@link InferFromLocationIpSpaceSpecifier};
+ *   <li>null, which returns a default factory provided by the subclass.
  *   <li>ref.addressgroup(foo, bar), which returns {@link ReferenceAddressGroupIpSpaceSpecifier};
  *   <li>inputs accepted by {@link ConstantWildcardSetIpSpaceSpecifierFactory}
  * </ul>
  */
-@AutoService(IpSpaceSpecifierFactory.class)
-public class FlexibleIpSpaceSpecifierFactory implements IpSpaceSpecifierFactory {
-  public static final String NAME = FlexibleIpSpaceSpecifierFactory.class.getSimpleName();
-
+public abstract class FlexibleIpSpaceSpecifierFactory implements IpSpaceSpecifierFactory {
   private static final Pattern REF_PATTERN =
       Pattern.compile("ref\\.addressgroup\\((.*)\\)", Pattern.CASE_INSENSITIVE);
 
-  @Override
-  public String getName() {
-    return NAME;
-  }
+  protected abstract IpSpaceSpecifier defaultIpSpaceSpecifier();
 
   @Override
   public IpSpaceSpecifier buildIpSpaceSpecifier(Object input) {
     if (input == null) {
-      return InferFromLocationIpSpaceSpecifier.INSTANCE;
+      return defaultIpSpaceSpecifier();
     }
-    checkArgument(input instanceof String, NAME + " requires String input");
+    checkArgument(input instanceof String, getName() + " requires String input");
     String str = ((String) input).trim();
     Matcher matcher = REF_PATTERN.matcher(str);
     if (matcher.find()) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/FlexibleUniverseIpSpaceSpecifierFactory.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/FlexibleUniverseIpSpaceSpecifierFactory.java
@@ -1,0 +1,23 @@
+package org.batfish.specifier;
+
+import com.google.auto.service.AutoService;
+import org.batfish.datamodel.UniverseIpSpace;
+
+/**
+ * An {@link FlexibleIpSpaceSpecifierFactory} that returns a {@link ConstantIpSpaceSpecifier
+ * constant} {@link UniverseIpSpace universe} {@link IpSpaceSpecifier} by default.
+ */
+@AutoService(IpSpaceSpecifierFactory.class)
+public final class FlexibleUniverseIpSpaceSpecifierFactory extends FlexibleIpSpaceSpecifierFactory {
+  static final String NAME = FlexibleUniverseIpSpaceSpecifierFactory.class.getSimpleName();
+
+  @Override
+  protected IpSpaceSpecifier defaultIpSpaceSpecifier() {
+    return new ConstantIpSpaceSpecifier(UniverseIpSpace.INSTANCE);
+  }
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/FlexibleInferFromLocationIpSpaceSpecifierFactoryTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/FlexibleInferFromLocationIpSpaceSpecifierFactoryTest.java
@@ -8,11 +8,11 @@ import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.IpWildcardSetIpSpace;
 import org.junit.Test;
 
-public class FlexibleIpSpaceSpecifierFactoryTest {
+public class FlexibleInferFromLocationIpSpaceSpecifierFactoryTest {
   @Test
   public void testConstantIpSpace() {
     assertThat(
-        new FlexibleIpSpaceSpecifierFactory().buildIpSpaceSpecifier("1.1.1.1"),
+        new FlexibleInferFromLocationIpSpaceSpecifierFactory().buildIpSpaceSpecifier("1.1.1.1"),
         equalTo(
             new ConstantIpSpaceSpecifier(
                 IpWildcardSetIpSpace.builder().including(new IpWildcard("1.1.1.1")).build())));
@@ -21,22 +21,23 @@ public class FlexibleIpSpaceSpecifierFactoryTest {
   @Test
   public void testLoad() {
     assertThat(
-        IpSpaceSpecifierFactory.load(FlexibleIpSpaceSpecifierFactory.NAME)
-            instanceof FlexibleIpSpaceSpecifierFactory,
+        IpSpaceSpecifierFactory.load(FlexibleInferFromLocationIpSpaceSpecifierFactory.NAME)
+            instanceof FlexibleInferFromLocationIpSpaceSpecifierFactory,
         is(true));
   }
 
   @Test
   public void testNull() {
     assertThat(
-        new FlexibleIpSpaceSpecifierFactory().buildIpSpaceSpecifier(null),
+        new FlexibleInferFromLocationIpSpaceSpecifierFactory().buildIpSpaceSpecifier(null),
         is(InferFromLocationIpSpaceSpecifier.INSTANCE));
   }
 
   @Test
   public void testRefAddressGroup() {
     assertThat(
-        new FlexibleIpSpaceSpecifierFactory().buildIpSpaceSpecifier("rEf.AddressGroup(a, b)"),
+        new FlexibleInferFromLocationIpSpaceSpecifierFactory()
+            .buildIpSpaceSpecifier("rEf.AddressGroup(a, b)"),
         equalTo(new ReferenceAddressGroupIpSpaceSpecifier("a", "b")));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/IpSpaceSpecifierFactoryTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/IpSpaceSpecifierFactoryTest.java
@@ -28,6 +28,16 @@ public class IpSpaceSpecifierFactoryTest {
   }
 
   @Test
+  public void testFlexibleInferFromLocationIpSpaceSpecifierFactory() {
+    assertThat(
+        load(FlexibleInferFromLocationIpSpaceSpecifierFactory.NAME),
+        Matchers.instanceOf(FlexibleInferFromLocationIpSpaceSpecifierFactory.class));
+    assertThat(
+        new FlexibleInferFromLocationIpSpaceSpecifierFactory().buildIpSpaceSpecifier(null),
+        equalTo(InferFromLocationIpSpaceSpecifier.INSTANCE));
+  }
+
+  @Test
   public void testFlexibleLocationIpSpaceSpecifierFactory() {
     assertThat(
         load(FlexibleLocationIpSpaceSpecifierFactory.NAME),
@@ -40,6 +50,16 @@ public class IpSpaceSpecifierFactoryTest {
             new LocationIpSpaceSpecifier(
                 new InterfaceSpecifierInterfaceLocationSpecifier(
                     new VrfNameRegexInterfaceSpecifier(Pattern.compile("foo"))))));
+  }
+
+  @Test
+  public void testFlexibleUniverseIpSpaceSpecifierFactory() {
+    assertThat(
+        load(FlexibleUniverseIpSpaceSpecifierFactory.NAME),
+        instanceOf(FlexibleUniverseIpSpaceSpecifierFactory.class));
+    assertThat(
+        new FlexibleUniverseIpSpaceSpecifierFactory().buildIpSpaceSpecifier(null),
+        equalTo(new ConstantIpSpaceSpecifier(UniverseIpSpace.INSTANCE)));
   }
 
   @Test

--- a/projects/question/src/main/java/org/batfish/question/specifiers/SpecifiersReachabilityQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/specifiers/SpecifiersReachabilityQuestion.java
@@ -15,7 +15,7 @@ import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.questions.Question;
 import org.batfish.question.ReachabilityParameters;
 import org.batfish.specifier.AllNodesNodeSpecifier;
-import org.batfish.specifier.FlexibleIpSpaceSpecifierFactory;
+import org.batfish.specifier.FlexibleInferFromLocationIpSpaceSpecifierFactory;
 import org.batfish.specifier.FlexibleLocationSpecifierFactory;
 import org.batfish.specifier.IpSpaceSpecifier;
 import org.batfish.specifier.IpSpaceSpecifierFactory;
@@ -35,7 +35,7 @@ public final class SpecifiersReachabilityQuestion extends Question {
       NodeNameRegexConnectedHostsIpSpaceSpecifierFactory.NAME;
 
   private static final String DEFAULT_SOURCE_IP_SPACE_SPECIFIER_FACTORY =
-      FlexibleIpSpaceSpecifierFactory.NAME;
+      FlexibleInferFromLocationIpSpaceSpecifierFactory.NAME;
 
   private static final String DEFAULT_SOURCE_LOCATION_SPECIFIER_FACTORY =
       FlexibleLocationSpecifierFactory.NAME;

--- a/projects/question/src/main/java/org/batfish/question/traceroute/TracerouteQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/traceroute/TracerouteQuestion.java
@@ -9,7 +9,7 @@ import javax.annotation.Nullable;
 import org.batfish.common.BatfishException;
 import org.batfish.datamodel.Flow.Builder;
 import org.batfish.datamodel.questions.IPacketTraceQuestion;
-import org.batfish.specifier.FlexibleIpSpaceSpecifierFactory;
+import org.batfish.specifier.FlexibleInferFromLocationIpSpaceSpecifierFactory;
 import org.batfish.specifier.FlexibleLocationSpecifierFactory;
 
 /**
@@ -28,7 +28,7 @@ public final class TracerouteQuestion extends IPacketTraceQuestion {
       FlexibleLocationSpecifierFactory.NAME;
 
   private static final String DEFAULT_SOURCE_IP_SPACE_SPECIFIER_FACTORY =
-      FlexibleIpSpaceSpecifierFactory.NAME;
+      FlexibleInferFromLocationIpSpaceSpecifierFactory.NAME;
 
   private static final String PROP_IGNORE_ACLS = "ignoreAcls";
 

--- a/tests/questions/experimental/traceroute.ref
+++ b/tests/questions/experimental/traceroute.ref
@@ -177,7 +177,7 @@
   "ipProtocol" : "TRUNK1",
   "packetLength" : 12,
   "srcIpSpace" : "1.1.1.1",
-  "srcIpSpaceSpecifierFactory" : "FlexibleIpSpaceSpecifierFactory",
+  "srcIpSpaceSpecifierFactory" : "FlexibleInferFromLocationIpSpaceSpecifierFactory",
   "srcPort" : 123,
   "srcProtocol" : "tcp",
   "state" : "NEW",


### PR DESCRIPTION
Factored out an abstract superclass from FlexibleIpSpaceSpecifierFactory
so we can have two factories that share the parsing logic but have
different defaults.