### PR TITLE
Hotfix NPE in reachfilter

### DIFF
--- a/projects/question/src/main/java/org/batfish/question/reachfilter/ReachFilterAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/reachfilter/ReachFilterAnswerer.java
@@ -49,7 +49,7 @@ public class ReachFilterAnswerer extends Answerer {
     TableAnswerElement initialAnswer = null;
     Map<String, Configuration> configurations = _batfish.loadConfigurations();
     for (Pair<String, IpAccessList> pair : acls) {
-      Optional<Flow> result = null;
+      Optional<Flow> result;
       try {
         result = _batfish.reachFilter(configurations.get(pair.getFirst()), pair.getSecond());
       } catch (Throwable t) {
@@ -69,7 +69,9 @@ public class ReachFilterAnswerer extends Answerer {
       }
     }
     TableAnswerElement answer = TraceFiltersAnswerer.create(new TraceFiltersQuestion(null, null));
-    answer.postProcessAnswer(question, initialAnswer.getRows().getData());
+    if (initialAnswer != null) {
+      answer.postProcessAnswer(question, initialAnswer.getRows().getData());
+    }
     return answer;
   }
 


### PR DESCRIPTION
The root cause here (I believe) is the fact that PAN does not properly populate ipSpaces during conversion; until then reachfilter won't work properly.

This hotfix prevents the crash and returns an empty answer; The error message is (still) written to disk via `catch (Throwable t)` block.
