### PR TITLE
Reachfilter: make headerspace specifiers optional

### DIFF
--- a/questions/experimental/reachfilter.json
+++ b/questions/experimental/reachfilter.json
@@ -25,7 +25,7 @@
       },
       "dst": {
         "description": "Flexible specification of destinoation IpSpace",
-        "optional": false,
+        "optional": true,
         "type": "string"
       },
       "filterRegex": {
@@ -50,7 +50,7 @@
       },
       "src": {
         "description": "Flexible specification of source IpSpace",
-        "optional": false,
+        "optional": true,
         "type": "string"
       },
       "query": {

--- a/tests/questions/experimental/reachfilter.ref
+++ b/tests/questions/experimental/reachfilter.ref
@@ -26,7 +26,7 @@
       },
       "dst" : {
         "description" : "Flexible specification of destinoation IpSpace",
-        "optional" : false,
+        "optional" : true,
         "type" : "string",
         "value" : "2.2.2.2"
       },
@@ -62,7 +62,7 @@
       },
       "src" : {
         "description" : "Flexible specification of source IpSpace",
-        "optional" : false,
+        "optional" : true,
         "type" : "string",
         "value" : "1.1.1.1"
       }


### PR DESCRIPTION
No need to force specification of src/dst IPs