### PR TITLE
Warnings

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/Warnings.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/Warnings.java
@@ -1,6 +1,7 @@
 package org.batfish.common;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static java.util.Objects.requireNonNull;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -27,7 +28,7 @@ public class Warnings implements Serializable {
 
   private static final String PROP_UNIMPLEMENTED = "Unimplemented features";
 
-  private final List<ParseWarning> _parseWarnings;
+  @Nonnull private final List<ParseWarning> _parseWarnings;
 
   private transient boolean _pedanticRecord;
 
@@ -64,6 +65,7 @@ public class Warnings implements Serializable {
     _unimplementedRecord = unimplementedRecord;
   }
 
+  @Nonnull
   @JsonProperty(PROP_PARSE_WARNINGS)
   public List<ParseWarning> getParseWarnings() {
     return _parseWarnings;
@@ -145,12 +147,13 @@ public class Warnings implements Serializable {
     _unimplementedWarnings.add(new Warning(msg, "UNIMPLEMENTED"));
   }
 
-  static class ParseWarning implements Serializable {
+  /** A class to represent a parse warning in a file. */
+  public static class ParseWarning implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private static final String PROP_COMMENT = "Comment";
     private static final String PROP_LINE = "Line";
-    private static final String PROP_PARSE_CONTEXT = "Parser_Context";
+    private static final String PROP_PARSER_CONTEXT = "Parser_Context";
     private static final String PROP_TEXT = "Text";
 
     @Nullable private final String _comment;
@@ -159,14 +162,14 @@ public class Warnings implements Serializable {
     @Nonnull private final String _text;
 
     @JsonCreator
-    private ParseWarning(
+    public ParseWarning(
         @JsonProperty(PROP_LINE) int line,
         @JsonProperty(PROP_TEXT) @Nonnull String text,
-        @JsonProperty(PROP_PARSE_CONTEXT) @Nonnull String parserContext,
+        @JsonProperty(PROP_PARSER_CONTEXT) @Nonnull String parserContext,
         @JsonProperty(PROP_COMMENT) @Nullable String comment) {
       _line = line;
-      _text = text;
-      _parserContext = parserContext;
+      _text = requireNonNull(text, PROP_TEXT);
+      _parserContext = requireNonNull(parserContext, PROP_PARSER_CONTEXT);
       _comment = comment;
     }
 
@@ -181,7 +184,7 @@ public class Warnings implements Serializable {
       return _line;
     }
 
-    @JsonProperty(PROP_PARSE_CONTEXT)
+    @JsonProperty(PROP_PARSER_CONTEXT)
     @Nonnull
     public String getParserContext() {
       return _parserContext;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/Warnings.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/Warnings.java
@@ -47,7 +47,7 @@ public class Warnings implements Serializable {
       @Nullable @JsonProperty(PROP_PEDANTIC) List<Warning> pedanticWarnings,
       @Nullable @JsonProperty(PROP_RED_FLAGS) List<Warning> redFlagWarnings,
       @Nullable @JsonProperty(PROP_UNIMPLEMENTED) List<Warning> unimplementedWarnings,
-      @Nullable @JsonProperty(PROP_PARSE_WARNINGS) LinkedList<ParseWarning> parseWarnings) {
+      @Nullable @JsonProperty(PROP_PARSE_WARNINGS) List<ParseWarning> parseWarnings) {
     _pedanticWarnings = firstNonNull(pedanticWarnings, new LinkedList<>());
     _redFlagWarnings = firstNonNull(redFlagWarnings, new LinkedList<>());
     _parseWarnings = firstNonNull(parseWarnings, new LinkedList<>());

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -2658,6 +2658,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
               (hostname, initStepWarnings) -> {
                 Warnings combined =
                     warnings.computeIfAbsent(hostname, h -> buildWarnings(_settings));
+                combined.getParseWarnings().addAll(initStepWarnings.getParseWarnings());
                 combined.getPedanticWarnings().addAll(initStepWarnings.getPedanticWarnings());
                 combined.getRedFlagWarnings().addAll(initStepWarnings.getRedFlagWarnings());
                 combined

--- a/projects/question/src/main/java/org/batfish/question/initialization/ParseWarningAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/initialization/ParseWarningAnswerer.java
@@ -1,0 +1,101 @@
+package org.batfish.question.initialization;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import org.batfish.common.Answerer;
+import org.batfish.common.Warnings;
+import org.batfish.common.Warnings.ParseWarning;
+import org.batfish.common.plugin.IBatfish;
+import org.batfish.datamodel.answers.ParseVendorConfigurationAnswerElement;
+import org.batfish.datamodel.answers.Schema;
+import org.batfish.datamodel.table.ColumnMetadata;
+import org.batfish.datamodel.table.Row;
+import org.batfish.datamodel.table.Rows;
+import org.batfish.datamodel.table.TableAnswerElement;
+import org.batfish.datamodel.table.TableMetadata;
+
+/** Implements {@link ParseWarningQuestion}. */
+class ParseWarningAnswerer extends Answerer {
+  @Override
+  public TableAnswerElement answer() {
+    ParseVendorConfigurationAnswerElement pvcae =
+        _batfish.loadParseVendorConfigurationAnswerElement();
+
+    Map<String, Warnings> fileWarnings = pvcae.getWarnings();
+
+    Rows rows = new Rows();
+    fileWarnings.forEach(
+        (filename, warnings) -> {
+          for (ParseWarning w : warnings.getParseWarnings()) {
+            rows.add(getRow(filename, w));
+          }
+        });
+
+    TableAnswerElement answerElement = new TableAnswerElement(TABLE_METADATA);
+    answerElement.postProcessAnswer(_question, rows.getData());
+    return answerElement;
+  }
+
+  ParseWarningAnswerer(ParseWarningQuestion question, IBatfish batfish) {
+    super(question, batfish);
+  }
+
+  @Nonnull
+  @VisibleForTesting
+  static Row getRow(String filename, ParseWarning warning) {
+    return Row.builder(TABLE_METADATA.toColumnMap())
+        .put(COL_FILENAME, filename)
+        .put(COL_LINE, warning.getLine())
+        .put(COL_TEXT, warning.getText())
+        .put(COL_PARSER_CONTEXT, warning.getParserContext())
+        .put(COL_COMMENT, firstNonNull(warning.getComment(), "(not provided)"))
+        .build();
+  }
+
+  static final String COL_FILENAME = "Filename";
+  static final String COL_LINE = "Line";
+  static final String COL_TEXT = "Text";
+  static final String COL_COMMENT = "Comment";
+  static final String COL_PARSER_CONTEXT = "Parser_Context";
+
+  private static final List<ColumnMetadata> METADATA =
+      ImmutableList.of(
+          new ColumnMetadata(COL_FILENAME, Schema.STRING, "The file that was parsed", true, false),
+          new ColumnMetadata(
+              COL_TEXT,
+              Schema.STRING,
+              "The text of the input that caused the warning",
+              true,
+              false),
+          new ColumnMetadata(
+              COL_LINE,
+              Schema.INTEGER,
+              "The line number in the input file that caused the warning",
+              false,
+              false),
+          new ColumnMetadata(
+              COL_PARSER_CONTEXT,
+              Schema.STRING,
+              "The context of the Batfish parser when the warning occurred",
+              false,
+              false),
+          new ColumnMetadata(
+              COL_COMMENT,
+              Schema.STRING,
+              "An optional comment explaining more information about the warning",
+              false,
+              false));
+
+  private static final String TEXT_DESC =
+      String.format(
+          "File ${%s}: warning at line ${%s}: ${%s} when the Batfish parser was in state ${%s}."
+              + " Optional comment: ${%s}.",
+          COL_FILENAME, COL_LINE, COL_TEXT, COL_PARSER_CONTEXT, COL_COMMENT);
+
+  private static final TableMetadata TABLE_METADATA = new TableMetadata(METADATA, TEXT_DESC);
+}

--- a/projects/question/src/main/java/org/batfish/question/initialization/ParseWarningQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/initialization/ParseWarningQuestion.java
@@ -1,0 +1,18 @@
+package org.batfish.question.initialization;
+
+import org.batfish.datamodel.questions.Question;
+
+/** A question that returns a table with the parse warnings for each file. */
+public final class ParseWarningQuestion extends Question {
+  @Override
+  public boolean getDataPlane() {
+    return false;
+  }
+
+  @Override
+  public String getName() {
+    return "parsewarning";
+  }
+
+  ParseWarningQuestion() {} // package-private constructor
+}

--- a/projects/question/src/main/java/org/batfish/question/initialization/ParseWarningQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/initialization/ParseWarningQuestionPlugin.java
@@ -1,0 +1,28 @@
+package org.batfish.question.initialization;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.auto.service.AutoService;
+import org.batfish.common.Answerer;
+import org.batfish.common.plugin.IBatfish;
+import org.batfish.common.plugin.Plugin;
+import org.batfish.datamodel.questions.Question;
+import org.batfish.question.QuestionPlugin;
+
+/** Exposes {@link ParseWarningQuestion}. */
+@AutoService(Plugin.class)
+public class ParseWarningQuestionPlugin extends QuestionPlugin {
+  @Override
+  protected Answerer createAnswerer(Question question, IBatfish batfish) {
+    checkArgument(
+        question instanceof ParseWarningQuestion,
+        "Unsupported question type %s",
+        question.getClass());
+    return new ParseWarningAnswerer((ParseWarningQuestion) question, batfish);
+  }
+
+  @Override
+  protected Question createQuestion() {
+    return new ParseWarningQuestion();
+  }
+}

--- a/projects/question/src/test/java/org/batfish/question/initialization/ParseWarningAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/initialization/ParseWarningAnswererTest.java
@@ -1,0 +1,103 @@
+package org.batfish.question.initialization;
+
+import static org.batfish.question.initialization.ParseWarningAnswerer.COL_COMMENT;
+import static org.batfish.question.initialization.ParseWarningAnswerer.COL_FILENAME;
+import static org.batfish.question.initialization.ParseWarningAnswerer.COL_LINE;
+import static org.batfish.question.initialization.ParseWarningAnswerer.COL_PARSER_CONTEXT;
+import static org.batfish.question.initialization.ParseWarningAnswerer.COL_TEXT;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableSortedMap;
+import org.batfish.common.BatfishLogger;
+import org.batfish.common.Warnings;
+import org.batfish.common.Warnings.ParseWarning;
+import org.batfish.common.plugin.IBatfishTestAdapter;
+import org.batfish.datamodel.answers.ParseVendorConfigurationAnswerElement;
+import org.batfish.datamodel.table.Row;
+import org.batfish.datamodel.table.Rows;
+import org.batfish.datamodel.table.TableAnswerElement;
+import org.junit.Test;
+
+/** Tests of {@link ParseWarningAnswerer}. */
+public class ParseWarningAnswererTest {
+
+  @Test
+  public void testGetRowWithoutComment() {
+    ParseWarning input = new ParseWarning(3, "text", "[configuration]", null);
+    Row expected =
+        Row.of(
+            COL_FILENAME,
+            "nohost",
+            COL_LINE,
+            input.getLine(),
+            COL_TEXT,
+            input.getText(),
+            COL_PARSER_CONTEXT,
+            input.getParserContext(),
+            COL_COMMENT,
+            "(not provided)");
+
+    Row row = ParseWarningAnswerer.getRow("nohost", input);
+    assertThat(row, equalTo(expected));
+  }
+
+  @Test
+  public void testGetRowWithComment() {
+    ParseWarning input = new ParseWarning(3, "text", "[configuration]", "comment");
+    Row expected =
+        Row.of(
+            COL_FILENAME,
+            "nohost",
+            COL_LINE,
+            input.getLine(),
+            COL_TEXT,
+            input.getText(),
+            COL_PARSER_CONTEXT,
+            input.getParserContext(),
+            COL_COMMENT,
+            input.getComment());
+
+    Row row = ParseWarningAnswerer.getRow("nohost", input);
+    assertThat(row, equalTo(expected));
+  }
+
+  @Test
+  public void testAnswererFlow() {
+    ParseWarningAnswerer answerer =
+        new ParseWarningAnswerer(new ParseWarningQuestion(), new TestBatfish());
+    TableAnswerElement answer = answerer.answer();
+    assertThat(
+        answer.getRows(),
+        equalTo(
+            new Rows()
+                .add(
+                    Row.of(
+                        COL_FILENAME,
+                        "f",
+                        COL_LINE,
+                        3,
+                        COL_TEXT,
+                        "text",
+                        COL_PARSER_CONTEXT,
+                        "ctx",
+                        COL_COMMENT,
+                        "comment"))));
+  }
+
+  private static class TestBatfish extends IBatfishTestAdapter {
+    @Override
+    public BatfishLogger getLogger() {
+      return null;
+    }
+
+    @Override
+    public ParseVendorConfigurationAnswerElement loadParseVendorConfigurationAnswerElement() {
+      ParseVendorConfigurationAnswerElement pvcae = new ParseVendorConfigurationAnswerElement();
+      Warnings warnings = new Warnings();
+      warnings.getParseWarnings().add(new ParseWarning(3, "text", "ctx", "comment"));
+      pvcae.setWarnings(ImmutableSortedMap.of("nowarnings", new Warnings(), "f", warnings));
+      return pvcae;
+    }
+  }
+}

--- a/tests/parsing-tests/commands
+++ b/tests/parsing-tests/commands
@@ -10,6 +10,7 @@ test -compareall tests/parsing-tests/unit-tests.ref init-snapshot tests/parsing-
 test tests/parsing-tests/unit-tests-undefined.ref get undefinedreferences
 test tests/parsing-tests/unit-tests-unused.ref get unusedstructures
 test tests/parsing-tests/unit-tests-nodes.ref get nodes summary=false
+test tests/parsing-tests/unit-tests-warnings.ref get parsewarning
 
 # The srx-testbed currently has a bunch of stuff not in unit-tests. Keep testing it for now.
 test -compareall tests/parsing-tests/srx-testbed.ref init-snapshot tests/parsing-tests/networks/srx-testbed

--- a/tests/parsing-tests/unit-tests-warnings.ref
+++ b/tests/parsing-tests/unit-tests-warnings.ref
@@ -1,0 +1,368 @@
+[
+  {
+    "class" : "org.batfish.datamodel.table.TableAnswerElement",
+    "metadata" : {
+      "columnMetadata" : [
+        {
+          "description" : "The file that was parsed",
+          "isKey" : true,
+          "isValue" : false,
+          "name" : "Filename",
+          "schema" : "String"
+        },
+        {
+          "description" : "The text of the input that caused the warning",
+          "isKey" : true,
+          "isValue" : false,
+          "name" : "Text",
+          "schema" : "String"
+        },
+        {
+          "description" : "The line number in the input file that caused the warning",
+          "isKey" : false,
+          "isValue" : false,
+          "name" : "Line",
+          "schema" : "Integer"
+        },
+        {
+          "description" : "The context of the Batfish parser when the warning occurred",
+          "isKey" : false,
+          "isValue" : false,
+          "name" : "Parser_Context",
+          "schema" : "String"
+        },
+        {
+          "description" : "An optional comment explaining more information about the warning",
+          "isKey" : false,
+          "isValue" : false,
+          "name" : "Comment",
+          "schema" : "String"
+        }
+      ],
+      "textDesc" : "File ${Filename}: warning at line ${Line}: ${Text} when the Batfish parser was in state ${Parser_Context}. Optional comment: ${Comment}."
+    },
+    "rows" : [
+      {
+        "Filename" : "aruba_misc",
+        "Line" : 90,
+        "Text" : "no ip default-gateway import cell",
+        "Parser_Context" : "[s_ip_default_gateway stanza cisco_configuration]",
+        "Comment" : "(not provided)"
+      },
+      {
+        "Filename" : "aruba_misc",
+        "Line" : 91,
+        "Text" : "no ip default-gateway import pppoe",
+        "Parser_Context" : "[s_ip_default_gateway stanza cisco_configuration]",
+        "Comment" : "(not provided)"
+      },
+      {
+        "Filename" : "asa_acl",
+        "Line" : 7,
+        "Text" : "interface outside",
+        "Parser_Context" : "[access_list_ip_range extended_access_list_tail extended_access_list_stanza stanza cisco_configuration]",
+        "Comment" : "(not provided)"
+      },
+      {
+        "Filename" : "cisco_acl",
+        "Line" : 10,
+        "Text" : "60 permit tcp any any eq mlag ttl eq 255",
+        "Parser_Context" : "[extended_access_list_tail extended_access_list_stanza stanza cisco_configuration]",
+        "Comment" : "matching ttl in extended access list"
+      },
+      {
+        "Filename" : "cisco_acl",
+        "Line" : 11,
+        "Text" : "70 permit udp any any eq mlag ttl eq 255",
+        "Parser_Context" : "[extended_access_list_tail extended_access_list_stanza stanza cisco_configuration]",
+        "Comment" : "matching ttl in extended access list"
+      },
+      {
+        "Filename" : "cisco_bgp",
+        "Line" : 28,
+        "Text" : "redistribute ospf 2",
+        "Parser_Context" : "[redistribute_ospf_bgp_tail bgp_tail router_bgp_stanza_tail router_bgp_stanza stanza cisco_configuration]",
+        "Comment" : "(not provided)"
+      },
+      {
+        "Filename" : "cisco_bgp",
+        "Line" : 29,
+        "Text" : "redistribute ospf 2 vrf vrf1",
+        "Parser_Context" : "[redistribute_ospf_bgp_tail bgp_tail router_bgp_stanza_tail router_bgp_stanza stanza cisco_configuration]",
+        "Comment" : "(not provided)"
+      },
+      {
+        "Filename" : "cisco_bgp_confederation",
+        "Line" : 7,
+        "Text" : "bgp confederation identifier 100",
+        "Parser_Context" : "[bgp_confederation_rb_stanza router_bgp_stanza_tail router_bgp_stanza stanza cisco_configuration]",
+        "Comment" : "(not provided)"
+      },
+      {
+        "Filename" : "cisco_bgp_confederation",
+        "Line" : 8,
+        "Text" : "bgp confederation peers 10 11",
+        "Parser_Context" : "[bgp_confederation_rb_stanza router_bgp_stanza_tail router_bgp_stanza stanza cisco_configuration]",
+        "Comment" : "(not provided)"
+      },
+      {
+        "Filename" : "cisco_eigrp",
+        "Line" : 115,
+        "Text" : "addrgroup bleep_blorp",
+        "Parser_Context" : "[access_list_ip_range extended_access_list_tail extended_access_list_stanza stanza cisco_configuration]",
+        "Comment" : "(not provided)"
+      },
+      {
+        "Filename" : "cisco_eigrp",
+        "Line" : 118,
+        "Text" : "address-family ipv4 multicast vrf autonomous-system autonomous-system 4\n  af-interface Ethernet0\n   add-paths 4\n   bandwidth-percent 75\n   dampening-change 75\n   dampening-interval 45\n   hold-time 40\n   passive-interface\n  exit-af-interface\n  eigrp default-route-tag 2\n  network 1.1.1.100\n  remote-neighbors source GigabitEthernet0/0/1 unicast-listen lisp-encap 2\n  topology base\n   offset-list 21 out 10\n   summary-metric 192.168.0.0/16 10000 10 255 1 1500 distance 20\n   traffic-share balanced\n   variance 4\n  exit-af-topology\n  topology VOICE tid 1000\n   no auto-summary\n  exit-af-topology\n  passive-interface default\n  no passive-interface FastEthernet0/1\n exit-address-family",
+        "Parser_Context" : "[ren_address_family re_named_tail re_named s_router_eigrp stanza cisco_configuration]",
+        "Comment" : "(not provided)"
+      },
+      {
+        "Filename" : "cisco_eigrp",
+        "Line" : 15,
+        "Text" : "default-metric 1 2 3 4 5",
+        "Parser_Context" : "[re_default_metric re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]",
+        "Comment" : "(not provided)"
+      },
+      {
+        "Filename" : "cisco_eigrp",
+        "Line" : 15,
+        "Text" : "default-metric 1 2 3 4 5",
+        "Parser_Context" : "[re_default_metric re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]",
+        "Comment" : "(not provided)"
+      },
+      {
+        "Filename" : "cisco_eigrp",
+        "Line" : 15,
+        "Text" : "default-metric 1 2 3 4 5",
+        "Parser_Context" : "[re_default_metric re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]",
+        "Comment" : "(not provided)"
+      },
+      {
+        "Filename" : "cisco_eigrp",
+        "Line" : 34,
+        "Text" : "redistribute isis route-map ISIS_TO_EIGRP",
+        "Parser_Context" : "[re_redistribute_isis re_redistribute re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]",
+        "Comment" : "ISIS redistirution in EIGRP is not implemented"
+      },
+      {
+        "Filename" : "cisco_eigrp",
+        "Line" : 35,
+        "Text" : "redistribute ospf 4 route-map OSPF_TO_EIGRP",
+        "Parser_Context" : "[re_redistribute_ospf re_redistribute re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]",
+        "Comment" : "(not provided)"
+      },
+      {
+        "Filename" : "cisco_eigrp",
+        "Line" : 37,
+        "Text" : "redistribute static metric 10000 10 255 1 1500 route-map STATIC_TO_EIGRP",
+        "Parser_Context" : "[re_redistribute_static re_redistribute re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]",
+        "Comment" : "(not provided)"
+      },
+      {
+        "Filename" : "cisco_eigrp",
+        "Line" : 37,
+        "Text" : "redistribute static metric 10000 10 255 1 1500 route-map STATIC_TO_EIGRP",
+        "Parser_Context" : "[re_redistribute_static re_redistribute re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]",
+        "Comment" : "(not provided)"
+      },
+      {
+        "Filename" : "cisco_eigrp",
+        "Line" : 37,
+        "Text" : "redistribute static metric 10000 10 255 1 1500 route-map STATIC_TO_EIGRP",
+        "Parser_Context" : "[re_redistribute_static re_redistribute re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]",
+        "Comment" : "(not provided)"
+      },
+      {
+        "Filename" : "cisco_interface",
+        "Line" : 276,
+        "Text" : "mode gre multipoint",
+        "Parser_Context" : "[iftunnel_mode if_tunnel if_inner s_interface stanza cisco_configuration]",
+        "Comment" : "(not provided)"
+      },
+      {
+        "Filename" : "cisco_ospf",
+        "Line" : 23,
+        "Text" : "area 0.0.0.0 filter-list prefix filterName in",
+        "Parser_Context" : "[ro_area_filterlist s_router_ospf stanza cisco_configuration]",
+        "Comment" : "(not provided)"
+      },
+      {
+        "Filename" : "cisco_ospf",
+        "Line" : 24,
+        "Text" : "area 0.0.0.0 filter-list prefix filterName out",
+        "Parser_Context" : "[ro_area_filterlist s_router_ospf stanza cisco_configuration]",
+        "Comment" : "(not provided)"
+      },
+      {
+        "Filename" : "cisco_ospf",
+        "Line" : 29,
+        "Text" : "area 0.0.0.0 nssa no-redistribution",
+        "Parser_Context" : "[ro_area_nssa s_router_ospf stanza cisco_configuration]",
+        "Comment" : "(not provided)"
+      },
+      {
+        "Filename" : "cisco_ospf",
+        "Line" : 30,
+        "Text" : "area 0.0.0.0 nssa no-redistribution no-summary",
+        "Parser_Context" : "[ro_area_nssa s_router_ospf stanza cisco_configuration]",
+        "Comment" : "(not provided)"
+      },
+      {
+        "Filename" : "cisco_ospf",
+        "Line" : 31,
+        "Text" : "area 0.0.0.0 nssa no-redistribution default-information-originate no-summary",
+        "Parser_Context" : "[ro_area_nssa s_router_ospf stanza cisco_configuration]",
+        "Comment" : "(not provided)"
+      },
+      {
+        "Filename" : "cisco_ospf",
+        "Line" : 60,
+        "Text" : "maximum-paths 32",
+        "Parser_Context" : "[ro_maximum_paths s_router_ospf stanza cisco_configuration]",
+        "Comment" : "(not provided)"
+      },
+      {
+        "Filename" : "cisco_ospf",
+        "Line" : 75,
+        "Text" : "area 0 filter-list prefix INFILTER in",
+        "Parser_Context" : "[ro_area_filterlist s_router_ospf stanza cisco_configuration]",
+        "Comment" : "(not provided)"
+      },
+      {
+        "Filename" : "cisco_ospf",
+        "Line" : 76,
+        "Text" : "area 0 filter-list prefix OUTFILTER out",
+        "Parser_Context" : "[ro_area_filterlist s_router_ospf stanza cisco_configuration]",
+        "Comment" : "(not provided)"
+      },
+      {
+        "Filename" : "cisco_route_map",
+        "Line" : 33,
+        "Text" : "match source-protocol ospf 1",
+        "Parser_Context" : "[match_source_protocol_rm_stanza match_rm_stanza rm_stanza route_map_stanza stanza cisco_configuration]",
+        "Comment" : "(not provided)"
+      },
+      {
+        "Filename" : "cisco_route_map",
+        "Line" : 41,
+        "Text" : "match source-protocol static",
+        "Parser_Context" : "[match_source_protocol_rm_stanza match_rm_stanza rm_stanza route_map_stanza stanza cisco_configuration]",
+        "Comment" : "(not provided)"
+      },
+      {
+        "Filename" : "cisco_vrf",
+        "Line" : 7,
+        "Text" : "ip route 0.0.0.0/0 1.2.3.4",
+        "Parser_Context" : "[vrfc_ip_route s_vrf_context stanza cisco_configuration]",
+        "Comment" : "(not provided)"
+      },
+      {
+        "Filename" : "ios_xr_bgp_neighbor_group",
+        "Line" : 17,
+        "Text" : "use session-group blabber",
+        "Parser_Context" : "[use_session_group_bgp_tail session_group_rb_stanza router_bgp_stanza_tail router_bgp_stanza stanza cisco_configuration]",
+        "Comment" : "(not provided)"
+      },
+      {
+        "Filename" : "ios_xr_bgp_neighbor_group",
+        "Line" : 94,
+        "Text" : "use session-group CIAO",
+        "Parser_Context" : "[use_session_group_bgp_tail session_group_rb_stanza router_bgp_stanza_tail router_bgp_stanza stanza cisco_configuration]",
+        "Comment" : "(not provided)"
+      },
+      {
+        "Filename" : "ios_xr_class_map",
+        "Line" : 10,
+        "Text" : "match not dscp ipv4 cs2 cs3 cs4",
+        "Parser_Context" : "[cm_match s_class_map stanza cisco_configuration]",
+        "Comment" : "(not provided)"
+      },
+      {
+        "Filename" : "ios_xr_ospf",
+        "Line" : 9,
+        "Text" : "maximum paths 16",
+        "Parser_Context" : "[ro_maximum_paths s_router_ospf stanza cisco_configuration]",
+        "Comment" : "(not provided)"
+      },
+      {
+        "Filename" : "iptables/host1.iptables",
+        "Line" : 16,
+        "Text" : "-s 1.2.3.4/32 -p tcp -m tcp --dport 22 -j ACCEPT",
+        "Parser_Context" : "[rule_spec command_append command_tail command iptables_configuration]",
+        "Comment" : "(not provided)"
+      },
+      {
+        "Filename" : "iptables/host1.iptables",
+        "Line" : 17,
+        "Text" : "-s 11.22.33.44/32 -p tcp -m tcp --dport 25 -j ACCEPT",
+        "Parser_Context" : "[rule_spec command_append command_tail command iptables_configuration]",
+        "Comment" : "(not provided)"
+      },
+      {
+        "Filename" : "iptables/host1.iptables",
+        "Line" : 18,
+        "Text" : "-s 111.222.111.222/32 -p tcp -m tcp --dport 80 -j ACCEPT",
+        "Parser_Context" : "[rule_spec command_append command_tail command iptables_configuration]",
+        "Comment" : "(not provided)"
+      },
+      {
+        "Filename" : "iptables/host1.iptables",
+        "Line" : 19,
+        "Text" : "-s 4.3.2.1/32 -p tcp -m tcp --dport 110 -j ACCEPT",
+        "Parser_Context" : "[rule_spec command_append command_tail command iptables_configuration]",
+        "Comment" : "(not provided)"
+      },
+      {
+        "Filename" : "iptables/host1.iptables",
+        "Line" : 20,
+        "Text" : "-s 44.22.33.11/32 -p tcp -m tcp --dport 143 -j ACCEPT",
+        "Parser_Context" : "[rule_spec command_append command_tail command iptables_configuration]",
+        "Comment" : "(not provided)"
+      },
+      {
+        "Filename" : "juniper-ospf",
+        "Line" : 11,
+        "Text" : "area-range dead:beef::/56 override-metric 100",
+        "Parser_Context" : "[oa_area_range o_area o_common p_ospf3 s_protocols s_common statement set_line_tail set_line flat_juniper_configuration]",
+        "Comment" : "(not provided)"
+      },
+      {
+        "Filename" : "juniper-ospf",
+        "Line" : 11,
+        "Text" : "area-range dead:beef::/56 override-metric 100",
+        "Parser_Context" : "[oa_area_range o_area o_common p_ospf3 s_protocols s_common statement set_line_tail set_line flat_juniper_configuration]",
+        "Comment" : "(not provided)"
+      },
+      {
+        "Filename" : "peer_template",
+        "Line" : 24,
+        "Text" : "allowas-in 1",
+        "Parser_Context" : "[rbnx_n_af_allowas_in rbnx_n_af_inner rbnx_n_address_family rbnx_n_inner rbnx_template_peer router_bgp_nxos_toplevel router_bgp_stanza stanza cisco_configuration]",
+        "Comment" : "(not provided)"
+      },
+      {
+        "Filename" : "test",
+        "Line" : 4,
+        "Text" : "ip default-gateway 128.125.253.254",
+        "Parser_Context" : "[s_ip_default_gateway stanza cisco_configuration]",
+        "Comment" : "(not provided)"
+      },
+      {
+        "Filename" : "vrf_context",
+        "Line" : 7,
+        "Text" : "ip route 0.0.0.0/0 1.2.3.4",
+        "Parser_Context" : "[vrfc_ip_route s_vrf_context stanza cisco_configuration]",
+        "Comment" : "(not provided)"
+      }
+    ],
+    "summary" : {
+      "notes" : "Found 45 results",
+      "numFailed" : 0,
+      "numPassed" : 0,
+      "numResults" : 45
+    }
+  }
+]

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -55724,22 +55724,25 @@
       "version" : "0.36.0",
       "warnings" : {
         "aruba_misc" : {
-          "Unimplemented features" : [
+          "Parse warnings" : [
             {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "no ip default-gateway import cell [Batfish parser context: [s_ip_default_gateway stanza cisco_configuration]]"
+              "Line" : 90,
+              "Parser_Context" : "[s_ip_default_gateway stanza cisco_configuration]",
+              "Text" : "no ip default-gateway import cell"
             },
             {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "no ip default-gateway import pppoe [Batfish parser context: [s_ip_default_gateway stanza cisco_configuration]]"
+              "Line" : 91,
+              "Parser_Context" : "[s_ip_default_gateway stanza cisco_configuration]",
+              "Text" : "no ip default-gateway import pppoe"
             }
           ]
         },
         "asa_acl" : {
-          "Unimplemented features" : [
+          "Parse warnings" : [
             {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "interface outside [Batfish parser context: [access_list_ip_range extended_access_list_tail extended_access_list_stanza stanza cisco_configuration]]"
+              "Line" : 7,
+              "Parser_Context" : "[access_list_ip_range extended_access_list_tail extended_access_list_stanza stanza cisco_configuration]",
+              "Text" : "interface outside"
             }
           ]
         },
@@ -55796,14 +55799,18 @@
           ]
         },
         "cisco_acl" : {
-          "Unimplemented features" : [
+          "Parse warnings" : [
             {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "60 permit tcp any any eq mlag ttl eq 255 [comment: matching ttl in extended access list] [Batfish parser context: [extended_access_list_tail extended_access_list_stanza stanza cisco_configuration]]"
+              "Comment" : "matching ttl in extended access list",
+              "Line" : 10,
+              "Parser_Context" : "[extended_access_list_tail extended_access_list_stanza stanza cisco_configuration]",
+              "Text" : "60 permit tcp any any eq mlag ttl eq 255"
             },
             {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "70 permit udp any any eq mlag ttl eq 255 [comment: matching ttl in extended access list] [Batfish parser context: [extended_access_list_tail extended_access_list_stanza stanza cisco_configuration]]"
+              "Comment" : "matching ttl in extended access list",
+              "Line" : 11,
+              "Parser_Context" : "[extended_access_list_tail extended_access_list_stanza stanza cisco_configuration]",
+              "Text" : "70 permit udp any any eq mlag ttl eq 255"
             }
           ]
         },
@@ -55820,6 +55827,18 @@
           ]
         },
         "cisco_bgp" : {
+          "Parse warnings" : [
+            {
+              "Line" : 28,
+              "Parser_Context" : "[redistribute_ospf_bgp_tail bgp_tail router_bgp_stanza_tail router_bgp_stanza stanza cisco_configuration]",
+              "Text" : "redistribute ospf 2"
+            },
+            {
+              "Line" : 29,
+              "Parser_Context" : "[redistribute_ospf_bgp_tail bgp_tail router_bgp_stanza_tail router_bgp_stanza stanza cisco_configuration]",
+              "Text" : "redistribute ospf 2 vrf vrf1"
+            }
+          ],
           "Red flags" : [
             {
               "tag" : "MISCELLANEOUS",
@@ -55841,133 +55860,147 @@
               "tag" : "MISCELLANEOUS",
               "text" : "Ignoring reference to undeclared peer group: '10.0.0.1'"
             }
-          ],
-          "Unimplemented features" : [
-            {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "redistribute ospf 2 [Batfish parser context: [redistribute_ospf_bgp_tail bgp_tail router_bgp_stanza_tail router_bgp_stanza stanza cisco_configuration]]"
-            },
-            {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "redistribute ospf 2 vrf vrf1 [Batfish parser context: [redistribute_ospf_bgp_tail bgp_tail router_bgp_stanza_tail router_bgp_stanza stanza cisco_configuration]]"
-            }
           ]
         },
         "cisco_bgp_confederation" : {
-          "Unimplemented features" : [
+          "Parse warnings" : [
             {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "bgp confederation identifier 100 [Batfish parser context: [bgp_confederation_rb_stanza router_bgp_stanza_tail router_bgp_stanza stanza cisco_configuration]]"
+              "Line" : 7,
+              "Parser_Context" : "[bgp_confederation_rb_stanza router_bgp_stanza_tail router_bgp_stanza stanza cisco_configuration]",
+              "Text" : "bgp confederation identifier 100"
             },
             {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "bgp confederation peers 10 11 [Batfish parser context: [bgp_confederation_rb_stanza router_bgp_stanza_tail router_bgp_stanza stanza cisco_configuration]]"
+              "Line" : 8,
+              "Parser_Context" : "[bgp_confederation_rb_stanza router_bgp_stanza_tail router_bgp_stanza stanza cisco_configuration]",
+              "Text" : "bgp confederation peers 10 11"
             }
           ]
         },
         "cisco_eigrp" : {
-          "Unimplemented features" : [
+          "Parse warnings" : [
             {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "default-metric 1 2 3 4 5 [Batfish parser context: [re_default_metric re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]]"
+              "Line" : 15,
+              "Parser_Context" : "[re_default_metric re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]",
+              "Text" : "default-metric 1 2 3 4 5"
             },
             {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "default-metric 1 2 3 4 5 [Batfish parser context: [re_default_metric re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]]"
+              "Line" : 15,
+              "Parser_Context" : "[re_default_metric re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]",
+              "Text" : "default-metric 1 2 3 4 5"
             },
             {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "default-metric 1 2 3 4 5 [Batfish parser context: [re_default_metric re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]]"
+              "Line" : 15,
+              "Parser_Context" : "[re_default_metric re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]",
+              "Text" : "default-metric 1 2 3 4 5"
             },
             {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "redistribute isis route-map ISIS_TO_EIGRP [comment: ISIS redistirution in EIGRP is not implemented] [Batfish parser context: [re_redistribute_isis re_redistribute re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]]"
+              "Comment" : "ISIS redistirution in EIGRP is not implemented",
+              "Line" : 34,
+              "Parser_Context" : "[re_redistribute_isis re_redistribute re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]",
+              "Text" : "redistribute isis route-map ISIS_TO_EIGRP"
             },
             {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "redistribute ospf 4 route-map OSPF_TO_EIGRP [Batfish parser context: [re_redistribute_ospf re_redistribute re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]]"
+              "Line" : 35,
+              "Parser_Context" : "[re_redistribute_ospf re_redistribute re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]",
+              "Text" : "redistribute ospf 4 route-map OSPF_TO_EIGRP"
             },
             {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "redistribute static metric 10000 10 255 1 1500 route-map STATIC_TO_EIGRP [Batfish parser context: [re_redistribute_static re_redistribute re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]]"
+              "Line" : 37,
+              "Parser_Context" : "[re_redistribute_static re_redistribute re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]",
+              "Text" : "redistribute static metric 10000 10 255 1 1500 route-map STATIC_TO_EIGRP"
             },
             {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "redistribute static metric 10000 10 255 1 1500 route-map STATIC_TO_EIGRP [Batfish parser context: [re_redistribute_static re_redistribute re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]]"
+              "Line" : 37,
+              "Parser_Context" : "[re_redistribute_static re_redistribute re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]",
+              "Text" : "redistribute static metric 10000 10 255 1 1500 route-map STATIC_TO_EIGRP"
             },
             {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "redistribute static metric 10000 10 255 1 1500 route-map STATIC_TO_EIGRP [Batfish parser context: [re_redistribute_static re_redistribute re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]]"
+              "Line" : 37,
+              "Parser_Context" : "[re_redistribute_static re_redistribute re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]",
+              "Text" : "redistribute static metric 10000 10 255 1 1500 route-map STATIC_TO_EIGRP"
             },
             {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "addrgroup bleep_blorp [Batfish parser context: [access_list_ip_range extended_access_list_tail extended_access_list_stanza stanza cisco_configuration]]"
+              "Line" : 115,
+              "Parser_Context" : "[access_list_ip_range extended_access_list_tail extended_access_list_stanza stanza cisco_configuration]",
+              "Text" : "addrgroup bleep_blorp"
             },
             {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "address-family ipv4 multicast vrf autonomous-system autonomous-system 4\n  af-interface Ethernet0\n   add-paths 4\n   bandwidth-percent 75\n   dampening-change 75\n   dampening-interval 45\n   hold-time 40\n   passive-interface\n  exit-af-interface\n  eigrp default-route-tag 2\n  network 1.1.1.100\n  remote-neighbors source GigabitEthernet0/0/1 unicast-listen lisp-encap 2\n  topology base\n   offset-list 21 out 10\n   summary-metric 192.168.0.0/16 10000 10 255 1 1500 distance 20\n   traffic-share balanced\n   variance 4\n  exit-af-topology\n  topology VOICE tid 1000\n   no auto-summary\n  exit-af-topology\n  passive-interface default\n  no passive-interface FastEthernet0/1\n exit-address-family [Batfish parser context: [ren_address_family re_named_tail re_named s_router_eigrp stanza cisco_configuration]]"
+              "Line" : 118,
+              "Parser_Context" : "[ren_address_family re_named_tail re_named s_router_eigrp stanza cisco_configuration]",
+              "Text" : "address-family ipv4 multicast vrf autonomous-system autonomous-system 4\n  af-interface Ethernet0\n   add-paths 4\n   bandwidth-percent 75\n   dampening-change 75\n   dampening-interval 45\n   hold-time 40\n   passive-interface\n  exit-af-interface\n  eigrp default-route-tag 2\n  network 1.1.1.100\n  remote-neighbors source GigabitEthernet0/0/1 unicast-listen lisp-encap 2\n  topology base\n   offset-list 21 out 10\n   summary-metric 192.168.0.0/16 10000 10 255 1 1500 distance 20\n   traffic-share balanced\n   variance 4\n  exit-af-topology\n  topology VOICE tid 1000\n   no auto-summary\n  exit-af-topology\n  passive-interface default\n  no passive-interface FastEthernet0/1\n exit-address-family"
             }
           ]
         },
         "cisco_interface" : {
-          "Unimplemented features" : [
+          "Parse warnings" : [
             {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "mode gre multipoint [Batfish parser context: [iftunnel_mode if_tunnel if_inner s_interface stanza cisco_configuration]]"
+              "Line" : 276,
+              "Parser_Context" : "[iftunnel_mode if_tunnel if_inner s_interface stanza cisco_configuration]",
+              "Text" : "mode gre multipoint"
             }
           ]
         },
         "cisco_ospf" : {
-          "Unimplemented features" : [
+          "Parse warnings" : [
             {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "area 0.0.0.0 filter-list prefix filterName in [Batfish parser context: [ro_area_filterlist s_router_ospf stanza cisco_configuration]]"
+              "Line" : 23,
+              "Parser_Context" : "[ro_area_filterlist s_router_ospf stanza cisco_configuration]",
+              "Text" : "area 0.0.0.0 filter-list prefix filterName in"
             },
             {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "area 0.0.0.0 filter-list prefix filterName out [Batfish parser context: [ro_area_filterlist s_router_ospf stanza cisco_configuration]]"
+              "Line" : 24,
+              "Parser_Context" : "[ro_area_filterlist s_router_ospf stanza cisco_configuration]",
+              "Text" : "area 0.0.0.0 filter-list prefix filterName out"
             },
             {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "area 0.0.0.0 nssa no-redistribution [Batfish parser context: [ro_area_nssa s_router_ospf stanza cisco_configuration]]"
+              "Line" : 29,
+              "Parser_Context" : "[ro_area_nssa s_router_ospf stanza cisco_configuration]",
+              "Text" : "area 0.0.0.0 nssa no-redistribution"
             },
             {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "area 0.0.0.0 nssa no-redistribution no-summary [Batfish parser context: [ro_area_nssa s_router_ospf stanza cisco_configuration]]"
+              "Line" : 30,
+              "Parser_Context" : "[ro_area_nssa s_router_ospf stanza cisco_configuration]",
+              "Text" : "area 0.0.0.0 nssa no-redistribution no-summary"
             },
             {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "area 0.0.0.0 nssa no-redistribution default-information-originate no-summary [Batfish parser context: [ro_area_nssa s_router_ospf stanza cisco_configuration]]"
+              "Line" : 31,
+              "Parser_Context" : "[ro_area_nssa s_router_ospf stanza cisco_configuration]",
+              "Text" : "area 0.0.0.0 nssa no-redistribution default-information-originate no-summary"
             },
             {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "maximum-paths 32 [Batfish parser context: [ro_maximum_paths s_router_ospf stanza cisco_configuration]]"
+              "Line" : 60,
+              "Parser_Context" : "[ro_maximum_paths s_router_ospf stanza cisco_configuration]",
+              "Text" : "maximum-paths 32"
             },
             {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "area 0 filter-list prefix INFILTER in [Batfish parser context: [ro_area_filterlist s_router_ospf stanza cisco_configuration]]"
+              "Line" : 75,
+              "Parser_Context" : "[ro_area_filterlist s_router_ospf stanza cisco_configuration]",
+              "Text" : "area 0 filter-list prefix INFILTER in"
             },
             {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "area 0 filter-list prefix OUTFILTER out [Batfish parser context: [ro_area_filterlist s_router_ospf stanza cisco_configuration]]"
+              "Line" : 76,
+              "Parser_Context" : "[ro_area_filterlist s_router_ospf stanza cisco_configuration]",
+              "Text" : "area 0 filter-list prefix OUTFILTER out"
             }
           ]
         },
         "cisco_route_map" : {
+          "Parse warnings" : [
+            {
+              "Line" : 33,
+              "Parser_Context" : "[match_source_protocol_rm_stanza match_rm_stanza rm_stanza route_map_stanza stanza cisco_configuration]",
+              "Text" : "match source-protocol ospf 1"
+            },
+            {
+              "Line" : 41,
+              "Parser_Context" : "[match_source_protocol_rm_stanza match_rm_stanza rm_stanza route_map_stanza stanza cisco_configuration]",
+              "Text" : "match source-protocol static"
+            }
+          ],
           "Red flags" : [
             {
               "tag" : "MISCELLANEOUS",
               "text" : "Route map 'MAP_NAME2' already contains clause numbered '20'. Duplicate clause will be merged with original clause."
-            }
-          ],
-          "Unimplemented features" : [
-            {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "match source-protocol ospf 1 [Batfish parser context: [match_source_protocol_rm_stanza match_rm_stanza rm_stanza route_map_stanza stanza cisco_configuration]]"
-            },
-            {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "match source-protocol static [Batfish parser context: [match_source_protocol_rm_stanza match_rm_stanza rm_stanza route_map_stanza stanza cisco_configuration]]"
             }
           ]
         },
@@ -55988,10 +56021,11 @@
           ]
         },
         "cisco_vrf" : {
-          "Unimplemented features" : [
+          "Parse warnings" : [
             {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "ip route 0.0.0.0/0 1.2.3.4 [Batfish parser context: [vrfc_ip_route s_vrf_context stanza cisco_configuration]]"
+              "Line" : 7,
+              "Parser_Context" : "[vrfc_ip_route s_vrf_context stanza cisco_configuration]",
+              "Text" : "ip route 0.0.0.0/0 1.2.3.4"
             }
           ]
         },
@@ -56008,26 +56042,36 @@
           ]
         },
         "ios_xr_bgp_neighbor_group" : {
-          "Unimplemented features" : [
+          "Parse warnings" : [
             {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "use session-group blabber [Batfish parser context: [use_session_group_bgp_tail session_group_rb_stanza router_bgp_stanza_tail router_bgp_stanza stanza cisco_configuration]]"
+              "Line" : 17,
+              "Parser_Context" : "[use_session_group_bgp_tail session_group_rb_stanza router_bgp_stanza_tail router_bgp_stanza stanza cisco_configuration]",
+              "Text" : "use session-group blabber"
             },
             {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "use session-group CIAO [Batfish parser context: [use_session_group_bgp_tail session_group_rb_stanza router_bgp_stanza_tail router_bgp_stanza stanza cisco_configuration]]"
+              "Line" : 94,
+              "Parser_Context" : "[use_session_group_bgp_tail session_group_rb_stanza router_bgp_stanza_tail router_bgp_stanza stanza cisco_configuration]",
+              "Text" : "use session-group CIAO"
             }
           ]
         },
         "ios_xr_class_map" : {
-          "Unimplemented features" : [
+          "Parse warnings" : [
             {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "match not dscp ipv4 cs2 cs3 cs4 [Batfish parser context: [cm_match s_class_map stanza cisco_configuration]]"
+              "Line" : 10,
+              "Parser_Context" : "[cm_match s_class_map stanza cisco_configuration]",
+              "Text" : "match not dscp ipv4 cs2 cs3 cs4"
             }
           ]
         },
         "ios_xr_ospf" : {
+          "Parse warnings" : [
+            {
+              "Line" : 9,
+              "Parser_Context" : "[ro_maximum_paths s_router_ospf stanza cisco_configuration]",
+              "Text" : "maximum paths 16"
+            }
+          ],
           "Red flags" : [
             {
               "tag" : "MISCELLANEOUS",
@@ -56065,47 +56109,48 @@
               "tag" : "MISCELLANEOUS",
               "text" : "OSPF: Interface: 'TenGigE0/0/0/2' not declared before OSPF process"
             }
-          ],
-          "Unimplemented features" : [
-            {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "maximum paths 16 [Batfish parser context: [ro_maximum_paths s_router_ospf stanza cisco_configuration]]"
-            }
           ]
         },
         "iptables/host1.iptables" : {
-          "Unimplemented features" : [
+          "Parse warnings" : [
             {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "-s 1.2.3.4/32 -p tcp -m tcp --dport 22 -j ACCEPT [Batfish parser context: [rule_spec command_append command_tail command iptables_configuration]]"
+              "Line" : 16,
+              "Parser_Context" : "[rule_spec command_append command_tail command iptables_configuration]",
+              "Text" : "-s 1.2.3.4/32 -p tcp -m tcp --dport 22 -j ACCEPT"
             },
             {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "-s 11.22.33.44/32 -p tcp -m tcp --dport 25 -j ACCEPT [Batfish parser context: [rule_spec command_append command_tail command iptables_configuration]]"
+              "Line" : 17,
+              "Parser_Context" : "[rule_spec command_append command_tail command iptables_configuration]",
+              "Text" : "-s 11.22.33.44/32 -p tcp -m tcp --dport 25 -j ACCEPT"
             },
             {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "-s 111.222.111.222/32 -p tcp -m tcp --dport 80 -j ACCEPT [Batfish parser context: [rule_spec command_append command_tail command iptables_configuration]]"
+              "Line" : 18,
+              "Parser_Context" : "[rule_spec command_append command_tail command iptables_configuration]",
+              "Text" : "-s 111.222.111.222/32 -p tcp -m tcp --dport 80 -j ACCEPT"
             },
             {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "-s 4.3.2.1/32 -p tcp -m tcp --dport 110 -j ACCEPT [Batfish parser context: [rule_spec command_append command_tail command iptables_configuration]]"
+              "Line" : 19,
+              "Parser_Context" : "[rule_spec command_append command_tail command iptables_configuration]",
+              "Text" : "-s 4.3.2.1/32 -p tcp -m tcp --dport 110 -j ACCEPT"
             },
             {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "-s 44.22.33.11/32 -p tcp -m tcp --dport 143 -j ACCEPT [Batfish parser context: [rule_spec command_append command_tail command iptables_configuration]]"
+              "Line" : 20,
+              "Parser_Context" : "[rule_spec command_append command_tail command iptables_configuration]",
+              "Text" : "-s 44.22.33.11/32 -p tcp -m tcp --dport 143 -j ACCEPT"
             }
           ]
         },
         "juniper-ospf" : {
-          "Unimplemented features" : [
+          "Parse warnings" : [
             {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "area-range dead:beef::/56 override-metric 100 [Batfish parser context: [oa_area_range o_area o_common p_ospf3 s_protocols s_common statement set_line_tail set_line flat_juniper_configuration]]"
+              "Line" : 11,
+              "Parser_Context" : "[oa_area_range o_area o_common p_ospf3 s_protocols s_common statement set_line_tail set_line flat_juniper_configuration]",
+              "Text" : "area-range dead:beef::/56 override-metric 100"
             },
             {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "area-range dead:beef::/56 override-metric 100 [Batfish parser context: [oa_area_range o_area o_common p_ospf3 s_protocols s_common statement set_line_tail set_line flat_juniper_configuration]]"
+              "Line" : 11,
+              "Parser_Context" : "[oa_area_range o_area o_common p_ospf3 s_protocols s_common statement set_line_tail set_line flat_juniper_configuration]",
+              "Text" : "area-range dead:beef::/56 override-metric 100"
             }
           ]
         },
@@ -56154,10 +56199,11 @@
           ]
         },
         "peer_template" : {
-          "Unimplemented features" : [
+          "Parse warnings" : [
             {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "allowas-in 1 [Batfish parser context: [rbnx_n_af_allowas_in rbnx_n_af_inner rbnx_n_address_family rbnx_n_inner rbnx_template_peer router_bgp_nxos_toplevel router_bgp_stanza stanza cisco_configuration]]"
+              "Line" : 24,
+              "Parser_Context" : "[rbnx_n_af_allowas_in rbnx_n_af_inner rbnx_n_address_family rbnx_n_inner rbnx_template_peer router_bgp_nxos_toplevel router_bgp_stanza stanza cisco_configuration]",
+              "Text" : "allowas-in 1"
             }
           ]
         },
@@ -56170,10 +56216,11 @@
           ]
         },
         "test" : {
-          "Unimplemented features" : [
+          "Parse warnings" : [
             {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "ip default-gateway 128.125.253.254 [Batfish parser context: [s_ip_default_gateway stanza cisco_configuration]]"
+              "Line" : 4,
+              "Parser_Context" : "[s_ip_default_gateway stanza cisco_configuration]",
+              "Text" : "ip default-gateway 128.125.253.254"
             }
           ]
         },
@@ -56186,10 +56233,11 @@
           ]
         },
         "vrf_context" : {
-          "Unimplemented features" : [
+          "Parse warnings" : [
             {
-              "tag" : "UNIMPLEMENTED",
-              "text" : "ip route 0.0.0.0/0 1.2.3.4 [Batfish parser context: [vrfc_ip_route s_vrf_context stanza cisco_configuration]]"
+              "Line" : 7,
+              "Parser_Context" : "[vrfc_ip_route s_vrf_context stanza cisco_configuration]",
+              "Text" : "ip route 0.0.0.0/0 1.2.3.4"
             }
           ]
         }


### PR DESCRIPTION
Track parse warnings (that have a filename and line number) as structures, not strings. Add a question `ParseWarningQuestion` to retrieve them.

Currently only handles "unimplemented warnings". Next on the queue is the unrecognized lines.

Has unit tests and ref tests.