### PR TITLE
Order variables for IP addresses MSB-first.

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/symbolic/bdd/BDDPacket.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/bdd/BDDPacket.java
@@ -157,8 +157,8 @@ public class BDDPacket {
 
     _bitNames = new HashMap<>();
 
-    _dstIp = allocateBDDInteger("dstIp", IP_LENGTH, true);
-    _srcIp = allocateBDDInteger("srcIp", IP_LENGTH, true);
+    _dstIp = allocateBDDInteger("dstIp", IP_LENGTH, false);
+    _srcIp = allocateBDDInteger("srcIp", IP_LENGTH, false);
     _dstPort = allocateBDDInteger("dstPort", PORT_LENGTH, false);
     _srcPort = allocateBDDInteger("srcPort", PORT_LENGTH, false);
     _ipProtocol = allocateBDDInteger("ipProtocol", IP_PROTOCOL_LENGTH, false);


### PR DESCRIPTION
Experiments show this to be significantly better than LSB-first (2x-15x) for both control plane and data plane.