### PR TITLE
Fix crash with converting extended communities

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
@@ -269,6 +269,7 @@ public class CommonUtil {
   }
 
   /** @throws IllegalArgumentException if the given number is over 2^16-1. */
+  @SuppressWarnings("https://github.com/batfish/batfish/issues/2103")
   private static void checkLongWithin16Bit(long l) {
     if (l > 0xFFFFL) {
       throw new IllegalArgumentException("AS Number larger than 16-bit");
@@ -284,9 +285,12 @@ public class CommonUtil {
   public static long communityStringToLong(@Nonnull String str) {
     String[] parts = str.split(":");
     long high = Long.parseLong(parts[0]);
-    checkLongWithin16Bit(high);
+    // Bug: this function is called on both regular and extended communities.
+    // Do not perform checking of as "validity"
+    // https://github.com/batfish/batfish/issues/2103
+    //    checkLongWithin16Bit(high);
     long low = Long.parseLong(parts[1]);
-    checkLongWithin16Bit(low);
+    //    checkLongWithin16Bit(low);
     return low + (high << 16);
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ExtendedCommunity.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ExtendedCommunity.java
@@ -3,23 +3,19 @@ package org.batfish.datamodel;
 import java.io.Serializable;
 import org.batfish.common.BatfishException;
 
+/** Represents extended BGP community, as described in RFC4360 */
 public final class ExtendedCommunity implements Serializable {
 
-  /** */
   private static final long serialVersionUID = 1L;
 
-  private long _value;
+  private final long _value;
 
   public ExtendedCommunity(int part1, long part2, int part3) {
     _value = (part1) | (part2 << 16) | (((long) part3) << 48);
   }
 
-  public ExtendedCommunity(long communityLong) {
-    _value = communityLong;
-  }
-
   public ExtendedCommunity(String communityStr) {
-    _value = 0L;
+    long value = 0L;
     byte subTypeByte;
     byte typeByte;
     long gaLong;
@@ -77,10 +73,11 @@ public final class ExtendedCommunity implements Serializable {
     int subTypeOffset = 8;
     int gaOffset = subTypeOffset + 8;
     int laOffset = gaOffset + (gaBytes * 8);
-    _value |= typeByte;
-    _value |= ((long) subTypeByte) << subTypeOffset;
-    _value |= gaLong << gaOffset;
-    _value |= laLong << laOffset;
+    value |= typeByte;
+    value |= ((long) subTypeByte) << subTypeOffset;
+    value |= gaLong << gaOffset;
+    value |= laLong << laOffset;
+    _value = value;
   }
 
   public long asLong() {

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/CommonUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/CommonUtilTest.java
@@ -27,6 +27,7 @@ import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.VrrpGroup;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class CommonUtilTest {
@@ -204,11 +205,13 @@ public class CommonUtilTest {
   }
 
   @Test(expected = IllegalArgumentException.class)
+  @Ignore("https://github.com/batfish/batfish/issues/2103")
   public void testCommunityStringHighTooBig() {
     communityStringToLong("65537:1");
   }
 
   @Test(expected = IllegalArgumentException.class)
+  @Ignore("https://github.com/batfish/batfish/issues/2103")
   public void testCommunityStringLowTooBig() {
     communityStringToLong("1:65537");
   }


### PR DESCRIPTION
Disable checks for whether the community is 16-bit, cleanup ExtendedCommunity class a tiny bit.