### PR TITLE
Cisco: Fix conversion of standard ACLs to route filter lists

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -3049,14 +3049,17 @@ public final class CiscoConfiguration extends VendorConfiguration {
     // convert standard/extended ipv6 access lists to ipv6 access lists or
     // route6 filter
     // lists
-    List<ExtendedIpv6AccessList> allIpv6ACLs = new ArrayList<>();
     for (StandardIpv6AccessList saList : _standardIpv6AccessLists.values()) {
-      ExtendedIpv6AccessList eaList = saList.toExtendedIpv6AccessList();
-      allIpv6ACLs.add(eaList);
-      // TODO: update correct conversion of standard ACLs to router filter lists for IPv6
+      if (isAclUsedForRoutingv6(saList.getName())) {
+        Route6FilterList rfList = CiscoConversions.toRoute6FilterList(saList);
+        c.getRoute6FilterLists().put(rfList.getName(), rfList);
+      }
+      c.getIp6AccessLists()
+          .put(
+              saList.getName(),
+              CiscoConversions.toIp6AccessList(saList.toExtendedIpv6AccessList()));
     }
-    allIpv6ACLs.addAll(_extendedIpv6AccessLists.values());
-    for (ExtendedIpv6AccessList eaList : allIpv6ACLs) {
+    for (ExtendedIpv6AccessList eaList : _extendedIpv6AccessLists.values()) {
       if (isAclUsedForRoutingv6(eaList.getName())) {
         Route6FilterList rfList = CiscoConversions.toRoute6FilterList(eaList);
         c.getRoute6FilterLists().put(rfList.getName(), rfList);

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
@@ -1093,6 +1093,17 @@ class CiscoConversions {
     return new Route6FilterList(name, lines);
   }
 
+  static Route6FilterList toRoute6FilterList(StandardIpv6AccessList eaList) {
+    String name = eaList.getName();
+    List<Route6FilterLine> lines =
+        eaList
+            .getLines()
+            .stream()
+            .map(CiscoConversions::toRoute6FilterLine)
+            .collect(ImmutableList.toImmutableList());
+    return new Route6FilterList(name, lines);
+  }
+
   static Route6FilterList toRoute6FilterList(Prefix6List list) {
     List<Route6FilterLine> lines =
         list.getLines()
@@ -1248,6 +1259,17 @@ class CiscoConversions {
     return new Route6FilterLine(action, prefix, new SubRange(minPrefixLength, maxPrefixLength));
   }
 
+  /** Convert a standard IPv6 access list line to a route filter list line */
+  private static Route6FilterLine toRoute6FilterLine(StandardIpv6AccessListLine fromLine) {
+    LineAction action = fromLine.getAction();
+    Prefix6 prefix = fromLine.getIpWildcard().toPrefix();
+
+    return new Route6FilterLine(
+        action,
+        new Ip6Wildcard(prefix),
+        new SubRange(prefix.getPrefixLength(), Prefix6.MAX_PREFIX_LENGTH));
+  }
+
   private static RouteFilterLine toRouteFilterLine(ExtendedAccessListLine fromLine) {
     LineAction action = fromLine.getAction();
     IpWildcard srcIpWildcard =
@@ -1269,6 +1291,10 @@ class CiscoConversions {
   /** Convert a standard access list line to a route filter list line */
   private static RouteFilterLine toRouteFilterLine(StandardAccessListLine fromLine) {
     LineAction action = fromLine.getAction();
+    /*
+     * This cast is safe since the other address specifier (network object group specifier)
+     * can be used only from extended ACLs.
+     */
     IpWildcard srcIpWildcard =
         ((WildcardAddressSpecifier) fromLine.getSrcAddressSpecifier()).getIpWildcard();
     Prefix prefix = srcIpWildcard.toPrefix();

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
@@ -1112,6 +1112,16 @@ class CiscoConversions {
     return new RouteFilterList(eaList.getName(), lines);
   }
 
+  static RouteFilterList toRouteFilterList(StandardAccessList saList) {
+    List<RouteFilterLine> lines =
+        saList
+            .getLines()
+            .stream()
+            .map(CiscoConversions::toRouteFilterLine)
+            .collect(ImmutableList.toImmutableList());
+    return new RouteFilterList(saList.getName(), lines);
+  }
+
   static RouteFilterList toRouteFilterList(PrefixList list) {
     RouteFilterList newRouteFilterList = new RouteFilterList(list.getName());
     List<RouteFilterLine> newLines =
@@ -1254,6 +1264,19 @@ class CiscoConversions {
     Prefix prefix = new Prefix(ip, prefixLength);
     return new RouteFilterLine(
         action, new IpWildcard(prefix), new SubRange(minPrefixLength, maxPrefixLength));
+  }
+
+  /** Convert a standard access list line to a route filter list line */
+  private static RouteFilterLine toRouteFilterLine(StandardAccessListLine fromLine) {
+    LineAction action = fromLine.getAction();
+    IpWildcard srcIpWildcard =
+        ((WildcardAddressSpecifier) fromLine.getSrcAddressSpecifier()).getIpWildcard();
+    Prefix prefix = srcIpWildcard.toPrefix();
+
+    return new RouteFilterLine(
+        action,
+        new IpWildcard(prefix),
+        new SubRange(prefix.getPrefixLength(), Prefix.MAX_PREFIX_LENGTH));
   }
 
   private CiscoConversions() {} // prevent instantiation of utility class

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/StandardAccessList.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/StandardAccessList.java
@@ -25,6 +25,10 @@ public class StandardAccessList implements Serializable {
     return _lines;
   }
 
+  public String getName() {
+    return _name;
+  }
+
   public ExtendedAccessList toExtendedAccessList() {
     ExtendedAccessList eal = new ExtendedAccessList(_name);
     eal.setParent(this);

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/StandardIpv6AccessList.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/StandardIpv6AccessList.java
@@ -25,6 +25,10 @@ public class StandardIpv6AccessList implements Serializable {
     return _lines;
   }
 
+  public String getName() {
+    return _name;
+  }
+
   public ExtendedIpv6AccessList toExtendedIpv6AccessList() {
     ExtendedIpv6AccessList eal = new ExtendedIpv6AccessList(_name);
     eal.setParent(this);

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -296,6 +296,7 @@ import org.batfish.datamodel.matchers.IpsecPolicyMatchers;
 import org.batfish.datamodel.matchers.IpsecProposalMatchers;
 import org.batfish.datamodel.matchers.IpsecVpnMatchers;
 import org.batfish.datamodel.matchers.OspfAreaMatchers;
+import org.batfish.datamodel.matchers.Route6FilterListMatchers;
 import org.batfish.datamodel.matchers.RouteFilterListMatchers;
 import org.batfish.datamodel.matchers.StubSettingsMatchers;
 import org.batfish.datamodel.ospf.OspfArea;
@@ -690,6 +691,12 @@ public class CiscoGrammarTest {
                     .build(),
                 "Ethernet1",
                 c)));
+    // Check Ipv6 as well
+    assertThat(c, hasRoute6FilterList("v6list", permits(new Prefix6("::FFFF:10.0.0.0/105"))));
+    assertThat(
+        c,
+        hasRoute6FilterList(
+            "v6list", Route6FilterListMatchers.rejects(new Prefix6("::FFFF:10.0.0.0/103"))));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-acl-in-routemap
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-acl-in-routemap
@@ -1,0 +1,17 @@
+!
+hostname ios-acl-in-routemap
+!
+!
+access-list 10 permit 10.0.0.0 0.255.255.255
+!
+route-map RM permit 100
+  match ip address 10
+!
+interface Ethernet1
+ ip address 10.1.1.0 255.255.255.0
+ ip access-group 10 in
+!
+router bgp 1
+ neighbor 2.2.2.2 remote-as 2
+ neighbor 2.2.2.2 route-map RM out
+ network 10.1.1.0/24

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-acl-in-routemap
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-acl-in-routemap
@@ -3,9 +3,13 @@ hostname ios-acl-in-routemap
 !
 !
 access-list 10 permit 10.0.0.0 0.255.255.255
+ipv6 access-list standard v6list permit ::FFFF:10.0.0.0/104
 !
 route-map RM permit 100
   match ip address 10
+!
+route-map RM6 permit 110
+  match ipv6 address v6list
 !
 interface Ethernet1
  ip address 10.1.1.0 255.255.255.0
@@ -15,3 +19,5 @@ router bgp 1
  neighbor 2.2.2.2 remote-as 2
  neighbor 2.2.2.2 route-map RM out
  network 10.1.1.0/24
+ neighbor ::FFFF:2.2.2.2 remote-as 2
+ neighbor ::FFFF:2.2.2.2 route-map RM6 out


### PR DESCRIPTION
*Problem*: We did this dance of converting standard ACLs to extended ACLs and then to route filter lists, which incorrectly captures how standard ACLs are used in route maps.
In reality route prefixes are matched against source wildcards in standard acls.

*Fix*: convert standard and extended acls to routelists separately. 

Side effects: tweaked some helper functions that relied only on acl name.