### PR TITLE
JUnit: fix names of test classes

### DIFF
--- a/projects/allinone/src/test/java/org/batfish/question/multipath/MultipathConsistencyQuestionTest.java
+++ b/projects/allinone/src/test/java/org/batfish/question/multipath/MultipathConsistencyQuestionTest.java
@@ -18,8 +18,12 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
-public class TestMultipathQuestion {
+/** Tests of {@link MultipathConsistencyQuestion}. */
+@RunWith(JUnit4.class)
+public class MultipathConsistencyQuestionTest {
   @Rule public TemporaryFolder temp = new TemporaryFolder();
 
   private TestNetwork _testNetwork;

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/RoutingPolicyReferenceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/RoutingPolicyReferenceTest.java
@@ -23,8 +23,12 @@ import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.Statement;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
-public class RoutingPolicyTests {
+/** Tests reference tracking in {@link RoutingPolicy}. */
+@RunWith(JUnit4.class)
+public class RoutingPolicyReferenceTest {
 
   private static Configuration _c;
 


### PR DESCRIPTION
JUnit test classes are supposed to end with `Test` -- if not, they are not detected
by several test finders (including bazel). Fix a few, and add comments.