### PR TITLE
Rename ACL actions to permit and deny

### DIFF
--- a/projects/allinone/src/test/java/org/batfish/allinone/AclReachability2Test.java
+++ b/projects/allinone/src/test/java/org/batfish/allinone/AclReachability2Test.java
@@ -262,7 +262,7 @@ public class AclReachability2Test {
                 .put(AclLines2Rows.COL_DIFF_ACTION, false)
                 .put(
                     AclLines2Rows.COL_MESSAGE,
-                    "ACLs { c1: acl } contain an unreachable line:\n  [index 0] IpAccessListLine{action=ACCEPT,"
+                    "ACLs { c1: acl } contain an unreachable line:\n  [index 0] IpAccessListLine{action=PERMIT,"
                         + " matchCondition=PermittedByAcl{aclName=???, defaultAccept=false}}"
                         + "\nThis line references a structure that is not defined.")
                 .build());
@@ -316,9 +316,9 @@ public class AclReachability2Test {
                 .put(AclLines2Rows.COL_DIFF_ACTION, false)
                 .put(
                     AclLines2Rows.COL_MESSAGE,
-                    "ACLs { c1: acl2 } contain an unreachable line:\n  [index 1] IpAccessListLine{action=ACCEPT, "
+                    "ACLs { c1: acl2 } contain an unreachable line:\n  [index 1] IpAccessListLine{action=PERMIT, "
                         + "matchCondition=MatchHeaderSpace{headerSpace=HeaderSpace{srcIps=PrefixIpSpace{prefix=1.0.0.0/24}}}}"
-                        + "\nBlocking line(s):\n  [index 0] IpAccessListLine{action=ACCEPT, "
+                        + "\nBlocking line(s):\n  [index 0] IpAccessListLine{action=PERMIT, "
                         + "matchCondition=PermittedByAcl{aclName=acl1, defaultAccept=false}}")
                 .build());
 
@@ -364,7 +364,7 @@ public class AclReachability2Test {
                 .put(AclLines2Rows.COL_DIFF_ACTION, false)
                 .put(
                     AclLines2Rows.COL_MESSAGE,
-                    "ACLs { c1: acl } contain an unreachable line:\n  [index 2] IpAccessListLine{action=ACCEPT, "
+                    "ACLs { c1: acl } contain an unreachable line:\n  [index 2] IpAccessListLine{action=PERMIT, "
                         + "matchCondition=MatchHeaderSpace{headerSpace=HeaderSpace{srcIps=IpWildcardIpSpace{ipWildcard=1.0.0.0/31}}}}"
                         + "\nMultiple earlier lines partially block this line, making it unreachable.")
                 .build());
@@ -411,9 +411,9 @@ public class AclReachability2Test {
                 .put(AclLines2Rows.COL_DIFF_ACTION, true)
                 .put(
                     AclLines2Rows.COL_MESSAGE,
-                    "ACLs { c1: acl } contain an unreachable line:\n  [index 1] IpAccessListLine{action=ACCEPT, "
+                    "ACLs { c1: acl } contain an unreachable line:\n  [index 1] IpAccessListLine{action=PERMIT, "
                         + "matchCondition=MatchHeaderSpace{headerSpace=HeaderSpace{srcIps=PrefixIpSpace{prefix=1.0.0.0/24}}}}"
-                        + "\nBlocking line(s):\n  [index 0] IpAccessListLine{action=REJECT, "
+                        + "\nBlocking line(s):\n  [index 0] IpAccessListLine{action=DENY, "
                         + "matchCondition=MatchHeaderSpace{headerSpace=HeaderSpace{srcIps=PrefixIpSpace{prefix=1.0.0.0/24}}}}")
                 .build(),
             Row.builder()
@@ -427,7 +427,7 @@ public class AclReachability2Test {
                 .put(
                     AclLines2Rows.COL_MESSAGE,
                     "ACLs { c1: acl } contain an unreachable line:\n"
-                        + "  [index 2] IpAccessListLine{action=ACCEPT, matchCondition=FalseExpr{}}\n"
+                        + "  [index 2] IpAccessListLine{action=PERMIT, matchCondition=FalseExpr{}}\n"
                         + "This line will never match any packet, independent of preceding lines.")
                 .build(),
             Row.builder()
@@ -440,9 +440,9 @@ public class AclReachability2Test {
                 .put(AclLines2Rows.COL_DIFF_ACTION, true)
                 .put(
                     AclLines2Rows.COL_MESSAGE,
-                    "ACLs { c1: acl } contain an unreachable line:\n  [index 3] IpAccessListLine{action=ACCEPT, "
+                    "ACLs { c1: acl } contain an unreachable line:\n  [index 3] IpAccessListLine{action=PERMIT, "
                         + "matchCondition=MatchHeaderSpace{headerSpace=HeaderSpace{srcIps=PrefixIpSpace{prefix=1.0.0.0/32}}}}"
-                        + "\nBlocking line(s):\n  [index 0] IpAccessListLine{action=REJECT, "
+                        + "\nBlocking line(s):\n  [index 0] IpAccessListLine{action=DENY, "
                         + "matchCondition=MatchHeaderSpace{headerSpace=HeaderSpace{srcIps=PrefixIpSpace{prefix=1.0.0.0/24}}}}")
                 .build());
 
@@ -517,9 +517,9 @@ public class AclReachability2Test {
                 .put(AclLines2Rows.COL_DIFF_ACTION, false)
                 .put(
                     AclLines2Rows.COL_MESSAGE,
-                    "ACLs { c1: acl } contain an unreachable line:\n  [index 1] IpAccessListLine{action=ACCEPT,"
+                    "ACLs { c1: acl } contain an unreachable line:\n  [index 1] IpAccessListLine{action=PERMIT,"
                         + " matchCondition=MatchSrcInterface{srcInterfaces=[iface]}}\n"
-                        + "Blocking line(s):\n  [index 0] IpAccessListLine{action=ACCEPT,"
+                        + "Blocking line(s):\n  [index 0] IpAccessListLine{action=PERMIT,"
                         + " matchCondition=MatchSrcInterface{srcInterfaces=[iface, iface2]}}")
                 .build());
 

--- a/projects/allinone/src/test/java/org/batfish/question/reachfilter/ReachFilterAnswererDifferentialTest.java
+++ b/projects/allinone/src/test/java/org/batfish/question/reachfilter/ReachFilterAnswererDifferentialTest.java
@@ -97,7 +97,7 @@ public class ReachFilterAnswererDifferentialTest {
                         hasColumn(equalTo(COLUMN_FLOW), hasDstIp(ip), Schema.FLOW),
                         hasColumn(
                             equalTo(COLUMN_ACTION),
-                            equalTo(LineAction.REJECT.toString()),
+                            equalTo(LineAction.DENY.toString()),
                             Schema.STRING)),
                     allOf(
                         hasColumn(equalTo(COLUMN_RESULT_TYPE), equalTo(INCREASED), Schema.STRING),
@@ -105,7 +105,7 @@ public class ReachFilterAnswererDifferentialTest {
                         hasColumn(equalTo(COLUMN_FLOW), hasDstIp(ip), Schema.FLOW),
                         hasColumn(
                             equalTo(COLUMN_ACTION),
-                            equalTo(LineAction.ACCEPT.toString()),
+                            equalTo(LineAction.PERMIT.toString()),
                             Schema.STRING))))));
   }
 }

--- a/projects/allinone/src/test/java/org/batfish/question/reachfilter/ReachFilterAnswererTest.java
+++ b/projects/allinone/src/test/java/org/batfish/question/reachfilter/ReachFilterAnswererTest.java
@@ -317,7 +317,7 @@ public final class ReachFilterAnswererTest {
         rows.getData(),
         contains(
             allOf(
-                hasColumn("action", equalTo("REJECT"), Schema.STRING),
+                hasColumn("action", equalTo("DENY"), Schema.STRING),
                 hasColumn("filterName", equalTo(ACL.getName()), Schema.STRING))));
   }
 
@@ -332,15 +332,15 @@ public final class ReachFilterAnswererTest {
             containsInAnyOrder(
                 ImmutableList.of(
                     allOf(
-                        hasColumn("action", equalTo("ACCEPT"), Schema.STRING),
+                        hasColumn("action", equalTo("PERMIT"), Schema.STRING),
                         hasColumn("filterName", equalTo(ACL.getName()), Schema.STRING),
                         hasColumn("lineNumber", oneOf(0, 3), Schema.INTEGER)),
                     allOf(
-                        hasColumn("action", equalTo("ACCEPT"), Schema.STRING),
+                        hasColumn("action", equalTo("PERMIT"), Schema.STRING),
                         hasColumn("filterName", equalTo(BLOCKED_LINE_ACL.getName()), Schema.STRING),
                         hasColumn("lineNumber", equalTo(0), Schema.INTEGER)),
                     allOf(
-                        hasColumn("action", equalTo("ACCEPT"), Schema.STRING),
+                        hasColumn("action", equalTo("PERMIT"), Schema.STRING),
                         hasColumn("filterName", equalTo(SRC_ACL.getName()), Schema.STRING),
                         hasColumn("lineNumber", oneOf(0, 1, 2), Schema.INTEGER))))));
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AclIpSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AclIpSpace.java
@@ -193,7 +193,7 @@ public class AclIpSpace extends IpSpace {
         .filter(line -> line.getIpSpace().containsIp(ip, namedIpSpaces))
         .map(AclIpSpaceLine::getAction)
         .findFirst()
-        .orElse(LineAction.REJECT);
+        .orElse(LineAction.DENY);
   }
 
   @Override
@@ -206,7 +206,7 @@ public class AclIpSpace extends IpSpace {
     Builder builder = AclIpSpace.builder();
     _lines.forEach(
         line -> {
-          if (line.getAction() == LineAction.ACCEPT) {
+          if (line.getAction() == LineAction.PERMIT) {
             builder.thenRejecting(line.getIpSpace());
           } else {
             builder.thenPermitting(line.getIpSpace());
@@ -218,7 +218,7 @@ public class AclIpSpace extends IpSpace {
 
   @Override
   public boolean containsIp(@Nonnull Ip ip, @Nonnull Map<String, IpSpace> namedIpSpaces) {
-    return action(ip, namedIpSpaces) == LineAction.ACCEPT;
+    return action(ip, namedIpSpaces) == LineAction.PERMIT;
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AclIpSpaceLine.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AclIpSpaceLine.java
@@ -21,7 +21,7 @@ public class AclIpSpaceLine implements Comparable<AclIpSpaceLine>, Serializable 
     private String _srcText;
 
     private Builder() {
-      _action = LineAction.ACCEPT;
+      _action = LineAction.PERMIT;
     }
 
     public AclIpSpaceLine build() {
@@ -66,7 +66,7 @@ public class AclIpSpaceLine implements Comparable<AclIpSpaceLine>, Serializable 
   }
 
   public static AclIpSpaceLine reject(IpSpace ipSpace) {
-    return builder().setIpSpace(ipSpace).setAction(LineAction.REJECT).build();
+    return builder().setIpSpace(ipSpace).setAction(LineAction.DENY).build();
   }
 
   private final LineAction _action;
@@ -131,7 +131,7 @@ public class AclIpSpaceLine implements Comparable<AclIpSpaceLine>, Serializable 
   @Override
   public String toString() {
     ToStringHelper helper = MoreObjects.toStringHelper(getClass());
-    if (_action != LineAction.ACCEPT) {
+    if (_action != LineAction.PERMIT) {
       helper.add(PROP_ACTION, _action);
     }
     helper.add(PROP_IP_SPACE, _ipSpace);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsPathAccessList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsPathAccessList.java
@@ -85,7 +85,7 @@ public final class AsPathAccessList implements Serializable {
       Matcher matcher = p.matcher(asPathString);
       boolean match = matcher.find();
       if (match) {
-        accept = line.getAction() == LineAction.ACCEPT;
+        accept = line.getAction() == LineAction.PERMIT;
         break;
       }
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/CommunityList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/CommunityList.java
@@ -160,7 +160,7 @@ public class CommunityList extends CommunitySetExpr {
             .findFirst();
 
     // "invert != condition" is a concise way of inverting a boolean
-    return action.isPresent() && _invertMatch != (action.get() == LineAction.ACCEPT);
+    return action.isPresent() && _invertMatch != (action.get() == LineAction.PERMIT);
   }
 
   @Override
@@ -251,7 +251,7 @@ public class CommunityList extends CommunitySetExpr {
             .findFirst();
 
     // "invert != condition" is a concise way of inverting a boolean
-    return action.isPresent() && _invertMatch != (action.get() == LineAction.ACCEPT);
+    return action.isPresent() && _invertMatch != (action.get() == LineAction.PERMIT);
   }
 
   /**

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/CommunityListLine.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/CommunityListLine.java
@@ -20,7 +20,7 @@ public class CommunityListLine implements Serializable {
   private static final long serialVersionUID = 1L;
 
   public static @Nonnull CommunityListLine accepting(CommunitySetExpr matchCondition) {
-    return new CommunityListLine(LineAction.ACCEPT, matchCondition);
+    return new CommunityListLine(LineAction.PERMIT, matchCondition);
   }
 
   private final LineAction _action;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Ip6AccessList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Ip6AccessList.java
@@ -64,7 +64,7 @@ public class Ip6AccessList extends ComparableStructure<String> {
         return new FilterResult(i, line.getAction());
       }
     }
-    return new FilterResult(null, LineAction.REJECT);
+    return new FilterResult(null, LineAction.DENY);
   }
 
   @JsonProperty(PROP_LINES)
@@ -76,7 +76,7 @@ public class Ip6AccessList extends ComparableStructure<String> {
   private boolean noDenyOrLastDeny(Ip6AccessList acl) {
     int count = 0;
     for (Ip6AccessListLine line : acl.getLines()) {
-      if (line.getAction() == LineAction.REJECT && count < acl.getLines().size() - 1) {
+      if (line.getAction() == LineAction.DENY && count < acl.getLines().size() - 1) {
         return false;
       }
       count++;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpAccessList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpAccessList.java
@@ -138,7 +138,7 @@ public class IpAccessList extends ComparableStructure<String> {
       String srcInterface,
       Map<String, IpAccessList> availableAcls,
       Map<String, IpSpace> namedIpSpaces) {
-    return filter(flow, srcInterface, availableAcls, namedIpSpaces, LineAction.REJECT);
+    return filter(flow, srcInterface, availableAcls, namedIpSpaces, LineAction.DENY);
   }
 
   public FilterResult filter(
@@ -176,7 +176,7 @@ public class IpAccessList extends ComparableStructure<String> {
   private boolean noDenyOrLastDeny(IpAccessList acl) {
     int count = 0;
     for (IpAccessListLine line : acl.getLines()) {
-      if (line.getAction() == LineAction.REJECT && count < acl.getLines().size() - 1) {
+      if (line.getAction() == LineAction.DENY && count < acl.getLines().size() - 1) {
         return false;
       }
       count++;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpAccessListLine.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpAccessListLine.java
@@ -26,7 +26,7 @@ public final class IpAccessListLine implements Serializable {
     private Builder() {}
 
     public Builder accepting() {
-      _action = LineAction.ACCEPT;
+      _action = LineAction.PERMIT;
       return this;
     }
 
@@ -35,7 +35,7 @@ public final class IpAccessListLine implements Serializable {
     }
 
     public Builder rejecting() {
-      _action = LineAction.REJECT;
+      _action = LineAction.DENY;
       return this;
     }
 
@@ -70,7 +70,7 @@ public final class IpAccessListLine implements Serializable {
   private static final long serialVersionUID = 1L;
 
   public static Builder accepting() {
-    return new Builder().setAction(LineAction.ACCEPT);
+    return new Builder().setAction(LineAction.PERMIT);
   }
 
   public static IpAccessListLine acceptingHeaderSpace(HeaderSpace headerSpace) {
@@ -82,7 +82,7 @@ public final class IpAccessListLine implements Serializable {
   }
 
   public static Builder rejecting() {
-    return new Builder().setAction(LineAction.REJECT);
+    return new Builder().setAction(LineAction.DENY);
   }
 
   public static IpAccessListLine rejectingHeaderSpace(HeaderSpace headerSpace) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/LineAction.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/LineAction.java
@@ -1,9 +1,7 @@
 package org.batfish.datamodel;
 
-import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDescription;
-
-@JsonSchemaDescription("An access-control action")
+/** An access-control action */
 public enum LineAction {
-  ACCEPT,
-  REJECT
+  PERMIT,
+  DENY
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Route6FilterList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Route6FilterList.java
@@ -81,7 +81,7 @@ public class Route6FilterList extends ComparableStructure<String> {
         int prefixLength = prefix.getPrefixLength();
         SubRange range = line.getLengthRange();
         if (prefixLength >= range.getStart() && prefixLength <= range.getEnd()) {
-          accept = line.getAction() == LineAction.ACCEPT;
+          accept = line.getAction() == LineAction.PERMIT;
           break;
         }
       }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RouteFilterList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RouteFilterList.java
@@ -107,7 +107,7 @@ public class RouteFilterList implements Serializable {
         int prefixLength = prefix.getPrefixLength();
         SubRange range = line.getLengthRange();
         if (prefixLength >= range.getStart() && prefixLength <= range.getEnd()) {
-          accept = line.getAction() == LineAction.ACCEPT;
+          accept = line.getAction() == LineAction.PERMIT;
           break;
         }
       }
@@ -134,7 +134,7 @@ public class RouteFilterList implements Serializable {
    * Returns the set of {@link IpWildcard ips} that match this filter list.
    *
    * @throws BatfishException if any line in this {@link RouteFilterList} does not have an {@link
-   *     LineAction#ACCEPT} when matching.
+   *     LineAction#PERMIT} when matching.
    */
   @JsonIgnore
   public List<IpWildcard> getMatchingIps() {
@@ -142,7 +142,7 @@ public class RouteFilterList implements Serializable {
         .stream()
         .map(
             rfLine -> {
-              if (rfLine.getAction() != LineAction.ACCEPT) {
+              if (rfLine.getAction() != LineAction.PERMIT) {
                 throw new BatfishException(
                     "Expected accept action for routerfilterlist from juniper");
               } else {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclTracer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclTracer.java
@@ -95,7 +95,7 @@ public final class AclTracer extends Evaluator {
   public void recordAction(
       @Nonnull IpAccessList ipAccessList, int index, @Nonnull IpAccessListLine line) {
     String lineDescription = firstNonNull(line.getName(), line.toString());
-    if (line.getAction() == LineAction.ACCEPT) {
+    if (line.getAction() == LineAction.PERMIT) {
       _traceEvents.add(
           new PermittedByIpAccessListLine(
               index,
@@ -122,7 +122,7 @@ public final class AclTracer extends Evaluator {
       Ip ip,
       String ipDescription,
       IpSpaceDescriber describer) {
-    if (line.getAction() == LineAction.ACCEPT) {
+    if (line.getAction() == LineAction.PERMIT) {
       _traceEvents.add(
           new PermittedByAclIpSpaceLine(
               aclIpSpaceName,
@@ -365,7 +365,7 @@ public final class AclTracer extends Evaluator {
       IpAccessListLine line = lines.get(i);
       if (line.getMatchCondition().accept(this)) {
         recordAction(ipAccessList, i, line);
-        return line.getAction() == LineAction.ACCEPT;
+        return line.getAction() == LineAction.PERMIT;
       }
     }
     recordDefaultDeny(ipAccessList);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/DefaultDeniedByIpAccessList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/DefaultDeniedByIpAccessList.java
@@ -73,7 +73,7 @@ public final class DefaultDeniedByIpAccessList implements TerminalTraceEvent {
 
   @Override
   public FilterResult toFilterResult() {
-    return new FilterResult(null, LineAction.REJECT);
+    return new FilterResult(null, LineAction.DENY);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/DeniedByIpAccessListLine.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/DeniedByIpAccessListLine.java
@@ -119,7 +119,7 @@ public final class DeniedByIpAccessListLine implements TerminalTraceEvent {
 
   @Override
   public FilterResult toFilterResult() {
-    return new FilterResult(_index, LineAction.REJECT);
+    return new FilterResult(_index, LineAction.DENY);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/Evaluator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/Evaluator.java
@@ -80,9 +80,9 @@ public class Evaluator implements GenericAclLineMatchExprVisitor<Boolean> {
                 _srcInterface,
                 _availableAcls,
                 _namedIpSpaces,
-                permittedByAcl.getDefaultAccept() ? LineAction.ACCEPT : LineAction.REJECT)
+                permittedByAcl.getDefaultAccept() ? LineAction.PERMIT : LineAction.DENY)
             .getAction()
-        == LineAction.ACCEPT;
+        == LineAction.PERMIT;
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/PermittedByIpAccessListLine.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/PermittedByIpAccessListLine.java
@@ -119,7 +119,7 @@ public final class PermittedByIpAccessListLine implements TerminalTraceEvent {
 
   @Override
   public FilterResult toFilterResult() {
-    return new FilterResult(_index, LineAction.REJECT);
+    return new FilterResult(_index, LineAction.DENY);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/visitors/IpSpaceTracer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/visitors/IpSpaceTracer.java
@@ -60,7 +60,7 @@ public class IpSpaceTracer implements GenericIpSpaceVisitor<Boolean> {
               _ipDescription,
               _ipSpaceDescriber);
         }
-        return line.getAction() == LineAction.ACCEPT;
+        return line.getAction() == LineAction.PERMIT;
       }
     }
     if (name != null) {

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/CommunityListTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/CommunityListTest.java
@@ -26,7 +26,7 @@ public class CommunityListTest {
         new CommunityList(
             NAME,
             ImmutableList.of(
-                new CommunityListLine(LineAction.ACCEPT, new LiteralCommunity(COMMUNITY1))),
+                new CommunityListLine(LineAction.PERMIT, new LiteralCommunity(COMMUNITY1))),
             false);
 
     assertThat(cl.matchCommunity(null, COMMUNITY1), equalTo(true));
@@ -38,7 +38,7 @@ public class CommunityListTest {
         new CommunityList(
             NAME,
             ImmutableList.of(
-                new CommunityListLine(LineAction.REJECT, new LiteralCommunity(COMMUNITY1))),
+                new CommunityListLine(LineAction.DENY, new LiteralCommunity(COMMUNITY1))),
             false);
 
     assertThat(cl.matchCommunity(null, COMMUNITY1), equalTo(false));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/Route6FilterListTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/Route6FilterListTest.java
@@ -22,7 +22,7 @@ public class Route6FilterListTest {
             "test-route6-filter-mask",
             ImmutableList.of(
                 new Route6FilterLine(
-                    LineAction.ACCEPT,
+                    LineAction.PERMIT,
                     new Ip6Wildcard(
                         "2001:db8:1234:2345:3456:4567:5678:6789;0:ffff:0:0:0:ffff:ffff:ffff"),
                     new SubRange(64, 64))));
@@ -31,7 +31,7 @@ public class Route6FilterListTest {
             "test-route6-filter-prefix",
             ImmutableList.of(
                 new Route6FilterLine(
-                    LineAction.ACCEPT,
+                    LineAction.PERMIT,
                     new Ip6Wildcard(
                         "2001:db8:1234:2345:3456:4567:5678:6789;0:0:0:0:ffff:ffff:ffff:ffff"),
                     new SubRange(65, 70))));
@@ -40,7 +40,7 @@ public class Route6FilterListTest {
             "test-route6-filter-prefix",
             ImmutableList.of(
                 new Route6FilterLine(
-                    LineAction.ACCEPT,
+                    LineAction.PERMIT,
                     new Ip6Wildcard(
                         "2001:db8:1234:2345:3456:4567:5678:6789;0:0:0:0:ffff:ffff:ffff:ffff"),
                     new SubRange(64, 64))));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/RouteFilterListTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/RouteFilterListTest.java
@@ -22,7 +22,7 @@ public class RouteFilterListTest {
             "test-route-filter-mask",
             ImmutableList.of(
                 new RouteFilterLine(
-                    LineAction.ACCEPT,
+                    LineAction.PERMIT,
                     new IpWildcard("1.2.3.4:0.255.0.255"),
                     new SubRange(24, 24))));
     _rfPrefixMoreSpecific =
@@ -30,7 +30,7 @@ public class RouteFilterListTest {
             "test-route-filter-prefix",
             ImmutableList.of(
                 new RouteFilterLine(
-                    LineAction.ACCEPT,
+                    LineAction.PERMIT,
                     new IpWildcard("1.2.3.4:0.0.255.255"),
                     new SubRange(26, 32))));
     _rfPrefixExact =
@@ -38,7 +38,7 @@ public class RouteFilterListTest {
             "test-route-filter-prefix",
             ImmutableList.of(
                 new RouteFilterLine(
-                    LineAction.ACCEPT,
+                    LineAction.PERMIT,
                     new IpWildcard("1.2.3.4:0.0.255.255"),
                     new SubRange(26, 26))));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/PermittedByAclTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/PermittedByAclTest.java
@@ -63,8 +63,8 @@ public class PermittedByAclTest {
   public void testAclMatch() {
     // Test ACL line expressions which are permitted by other ACLs
 
-    Map<String, IpAccessList> acceptAcl = createAclMap("acl1", "1.2.3.4/32", LineAction.ACCEPT);
-    Map<String, IpAccessList> rejectAcl = createAclMap("acl1", "1.2.3.4/32", LineAction.REJECT);
+    Map<String, IpAccessList> acceptAcl = createAclMap("acl1", "1.2.3.4/32", LineAction.PERMIT);
+    Map<String, IpAccessList> rejectAcl = createAclMap("acl1", "1.2.3.4/32", LineAction.DENY);
     PermittedByAcl exprMatch = new PermittedByAcl("acl1", false);
 
     // Confirm a flow matching the ACL is correctly identified as accepted

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/IpAccessListMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/IpAccessListMatchersImpl.java
@@ -45,7 +45,7 @@ final class IpAccessListMatchersImpl {
     @Override
     protected boolean matchesSafely(IpAccessList item, Description mismatchDescription) {
       if (item.filter(_flow, _srcInterface, _availableAcls, _namedIpSpaces).getAction()
-          != LineAction.ACCEPT) {
+          != LineAction.PERMIT) {
         mismatchDescription.appendText(String.format("does not accept flow '%s'", _flow));
         if (_srcInterface != null) {
           mismatchDescription.appendText(String.format("at source interface: %s", _srcInterface));
@@ -108,7 +108,7 @@ final class IpAccessListMatchersImpl {
     @Override
     protected boolean matchesSafely(IpAccessList item, Description mismatchDescription) {
       if (item.filter(_flow, _srcInterface, _availableAcls, _namedIpSpaces).getAction()
-          != LineAction.REJECT) {
+          != LineAction.DENY) {
         mismatchDescription.appendText(String.format("does not reject flow '%s'", _flow));
         if (_srcInterface != null) {
           mismatchDescription.appendText(String.format("at source interface: %s", _srcInterface));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/PropertySpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/PropertySpecifierTest.java
@@ -93,7 +93,7 @@ public class PropertySpecifierTest {
   @Test
   public void fillPropertyForcedString() {
     Configuration configuration = new Configuration("hostname", ConfigurationFormat.CISCO_IOS);
-    configuration.setDefaultInboundAction(LineAction.ACCEPT);
+    configuration.setDefaultInboundAction(LineAction.PERMIT);
     String property = "default-inbound-action";
     PropertyDescriptor<Configuration> propertyDescriptor =
         NodePropertySpecifier.JAVA_MAP.get(property);
@@ -103,7 +103,7 @@ public class PropertySpecifierTest {
 
     // the row should be filled out with the String value
     assertThat(
-        row.build(), equalTo(Row.builder().put(property, LineAction.ACCEPT.toString()).build()));
+        row.build(), equalTo(Row.builder().put(property, LineAction.PERMIT.toString()).build()));
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/CommunityListTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/CommunityListTest.java
@@ -86,13 +86,13 @@ public final class CommunityListTest {
         new CommunityList(
             "",
             ImmutableList.of(
-                new CommunityListLine(LineAction.REJECT, EmptyCommunitySetExpr.INSTANCE),
+                new CommunityListLine(LineAction.DENY, EmptyCommunitySetExpr.INSTANCE),
                 CommunityListLine.accepting(new LiteralCommunity(1L))),
             false);
     CommunityList rejecting =
         new CommunityList(
             "",
-            ImmutableList.of(new CommunityListLine(LineAction.REJECT, new LiteralCommunity(1L))),
+            ImmutableList.of(new CommunityListLine(LineAction.DENY, new LiteralCommunity(1L))),
             false);
     CommunityList empty = new CommunityList("", ImmutableList.of(), false);
 
@@ -119,13 +119,13 @@ public final class CommunityListTest {
         new CommunityList(
             "",
             ImmutableList.of(
-                new CommunityListLine(LineAction.REJECT, EmptyCommunitySetExpr.INSTANCE),
+                new CommunityListLine(LineAction.DENY, EmptyCommunitySetExpr.INSTANCE),
                 CommunityListLine.accepting(new LiteralCommunity(1L))),
             false);
     CommunityList rejecting =
         new CommunityList(
             "",
-            ImmutableList.of(new CommunityListLine(LineAction.REJECT, new LiteralCommunity(1L))),
+            ImmutableList.of(new CommunityListLine(LineAction.DENY, new LiteralCommunity(1L))),
             false);
     CommunityList empty = new CommunityList("", ImmutableList.of(), false);
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/visitors/IpSpaceDescriberTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/visitors/IpSpaceDescriberTest.java
@@ -55,7 +55,7 @@ public final class IpSpaceDescriberTest {
             .setLines(
                 ImmutableList.of(
                     AclIpSpaceLine.builder()
-                        .setAction(LineAction.ACCEPT)
+                        .setAction(LineAction.PERMIT)
                         .setIpSpace(lineIpSpace)
                         .build()))
             .build();

--- a/projects/batfish/src/main/java/org/batfish/datamodel/visitors/IpSpaceContainedInWildcard.java
+++ b/projects/batfish/src/main/java/org/batfish/datamodel/visitors/IpSpaceContainedInWildcard.java
@@ -35,7 +35,7 @@ public class IpSpaceContainedInWildcard implements GenericIpSpaceVisitor<Boolean
     return aclIpSpace
         .getLines()
         .stream()
-        .filter(line -> line.getAction() == LineAction.ACCEPT)
+        .filter(line -> line.getAction() == LineAction.PERMIT)
         .allMatch(line -> line.getIpSpace().accept(this));
   }
 

--- a/projects/batfish/src/main/java/org/batfish/datamodel/visitors/IpSpaceMayIntersectWildcard.java
+++ b/projects/batfish/src/main/java/org/batfish/datamodel/visitors/IpSpaceMayIntersectWildcard.java
@@ -53,11 +53,11 @@ public class IpSpaceMayIntersectWildcard implements GenericIpSpaceVisitor<Boolea
   @Override
   public Boolean visitAclIpSpace(AclIpSpace aclIpSpace) {
     for (AclIpSpaceLine line : aclIpSpace.getLines()) {
-      if (line.getAction() == LineAction.ACCEPT && ipSpaceMayIntersectWildcard(line.getIpSpace())) {
+      if (line.getAction() == LineAction.PERMIT && ipSpaceMayIntersectWildcard(line.getIpSpace())) {
         return true;
       }
 
-      if (line.getAction() == LineAction.REJECT && ipSpaceContainsWildcard(line.getIpSpace())) {
+      if (line.getAction() == LineAction.DENY && ipSpaceContainsWildcard(line.getIpSpace())) {
         return false;
       }
     }

--- a/projects/batfish/src/main/java/org/batfish/datamodel/visitors/IpSpaceMayNotContainWildcard.java
+++ b/projects/batfish/src/main/java/org/batfish/datamodel/visitors/IpSpaceMayNotContainWildcard.java
@@ -58,16 +58,16 @@ public class IpSpaceMayNotContainWildcard implements GenericIpSpaceVisitor<Boole
   @Override
   public Boolean visitAclIpSpace(AclIpSpace aclIpSpace) {
     for (AclIpSpaceLine line : aclIpSpace.getLines()) {
-      if (line.getAction() == LineAction.REJECT && ipSpaceMayIntersectWildcard(line.getIpSpace())) {
+      if (line.getAction() == LineAction.DENY && ipSpaceMayIntersectWildcard(line.getIpSpace())) {
         return true;
       }
 
-      if (line.getAction() == LineAction.ACCEPT && ipSpaceContainsWildcard(line.getIpSpace())) {
+      if (line.getAction() == LineAction.PERMIT && ipSpaceContainsWildcard(line.getIpSpace())) {
         return false;
       }
     }
     /*
-     * If we reach this point, no ACCEPT line is guaranteed to contain ipWildcard. This means
+     * If we reach this point, no PERMIT line is guaranteed to contain ipWildcard. This means
      * it's possible (though not certain) that this does not contain ipWildcard.
      */
     return true;

--- a/projects/batfish/src/main/java/org/batfish/dataplane/TracerouteEngineImplContext.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/TracerouteEngineImplContext.java
@@ -124,7 +124,7 @@ class TracerouteEngineImplContext {
                                 .getAcl()
                                 .filter(flow, srcInterface, aclDefinitions, namedIpSpaces)
                                 .getAction()
-                            != LineAction.REJECT)
+                            != LineAction.DENY)
             .findFirst();
     if (!matchingSourceNat.isPresent()) {
       // No NAT rule matched.
@@ -396,7 +396,7 @@ class TracerouteEngineImplContext {
     } else {
       lineDesc = "no-match";
     }
-    boolean denied = outResult.getAction() == LineAction.REJECT;
+    boolean denied = outResult.getAction() == LineAction.DENY;
     if (denied) {
       String notes = disposition + "{" + outFilterName + "}{" + lineDesc + "}";
       if (out) {

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -7224,12 +7224,12 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
 
   @Override
   public void exitPi_iosicd_drop(Pi_iosicd_dropContext ctx) {
-    _currentInspectPolicyMap.setClassDefaultAction(LineAction.REJECT);
+    _currentInspectPolicyMap.setClassDefaultAction(LineAction.DENY);
   }
 
   @Override
   public void exitPi_iosicd_pass(Pi_iosicd_passContext ctx) {
-    _currentInspectPolicyMap.setClassDefaultAction(LineAction.ACCEPT);
+    _currentInspectPolicyMap.setClassDefaultAction(LineAction.PERMIT);
   }
 
   @Override
@@ -7301,7 +7301,7 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
           maxLen = toInteger(ctx.eqpl);
         }
         SubRange lengthRange = new SubRange(minLen, maxLen);
-        PrefixListLine line = new PrefixListLine(LineAction.ACCEPT, prefix, lengthRange);
+        PrefixListLine line = new PrefixListLine(LineAction.PERMIT, prefix, lengthRange);
         pl.addLine(line);
       } else {
         Prefix6List pl = _configuration.getPrefix6Lists().computeIfAbsent(name, Prefix6List::new);
@@ -7326,7 +7326,7 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
           maxLen = toInteger(ctx.eqpl);
         }
         SubRange lengthRange = new SubRange(minLen, maxLen);
-        Prefix6ListLine line = new Prefix6ListLine(LineAction.ACCEPT, prefix6, lengthRange);
+        Prefix6ListLine line = new Prefix6ListLine(LineAction.PERMIT, prefix6, lengthRange);
         pl.addLine(line);
       }
     }
@@ -9493,9 +9493,9 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
 
   private LineAction toLineAction(Access_list_actionContext ctx) {
     if (ctx.PERMIT() != null) {
-      return LineAction.ACCEPT;
+      return LineAction.PERMIT;
     } else if (ctx.DENY() != null) {
-      return LineAction.REJECT;
+      return LineAction.DENY;
     } else {
       throw convError(LineAction.class, ctx);
     }

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -3354,12 +3354,12 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   public void exitFlat_juniper_configuration(Flat_juniper_configurationContext ctx) {
     if (_hasZones) {
       if (_defaultCrossZoneAction == null) {
-        _defaultCrossZoneAction = LineAction.REJECT;
+        _defaultCrossZoneAction = LineAction.DENY;
       }
       _configuration.setDefaultCrossZoneAction(_defaultCrossZoneAction);
-      _configuration.setDefaultInboundAction(LineAction.REJECT);
+      _configuration.setDefaultInboundAction(LineAction.DENY);
     } else {
-      _configuration.setDefaultInboundAction(LineAction.ACCEPT);
+      _configuration.setDefaultInboundAction(LineAction.PERMIT);
     }
   }
 
@@ -4514,9 +4514,9 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   @Override
   public void exitSep_default_policy(Sep_default_policyContext ctx) {
     if (ctx.PERMIT_ALL() != null) {
-      _defaultCrossZoneAction = LineAction.ACCEPT;
+      _defaultCrossZoneAction = LineAction.PERMIT;
     } else if (ctx.DENY_ALL() != null) {
-      _defaultCrossZoneAction = LineAction.REJECT;
+      _defaultCrossZoneAction = LineAction.DENY;
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatvyos/FlatVyosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatvyos/FlatVyosControlPlaneExtractor.java
@@ -95,9 +95,9 @@ public class FlatVyosControlPlaneExtractor extends FlatVyosParserBaseListener
 
   private static LineAction toAction(Line_actionContext ctx) {
     if (ctx.DENY() != null) {
-      return LineAction.REJECT;
+      return LineAction.DENY;
     } else if (ctx.PERMIT() != null) {
-      return LineAction.ACCEPT;
+      return LineAction.PERMIT;
     } else {
       throw new BatfishException("invalid line_action: " + ctx.getText());
     }

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -421,9 +421,9 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
   @Override
   public void exitSrs_action(Srs_actionContext ctx) {
     if (ctx.ALLOW() != null) {
-      _currentRule.setAction(LineAction.ACCEPT);
+      _currentRule.setAction(LineAction.PERMIT);
     } else {
-      _currentRule.setAction(LineAction.REJECT);
+      _currentRule.setAction(LineAction.DENY);
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -1570,7 +1570,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
     // "~STUB_ORIGINATION_ROUTE_FILTER~";
     // RouteFilterList rf = new RouteFilterList(
     // stubOriginationRouteFilterListName);
-    // RouteFilterLine rfl = new RouteFilterLine(LineAction.ACCEPT,
+    // RouteFilterLine rfl = new RouteFilterLine(LineAction.PERMIT,
     // Prefix.ZERO,
     // new SubRange(0, 0));
     // rf.addLine(rfl);

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/IpPermissions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/IpPermissions.java
@@ -108,7 +108,7 @@ public class IpPermissions implements Serializable {
 
   private HeaderSpace.Builder toHeaderSpaceBuilder() {
     HeaderSpace.Builder headerSpaceBuilder = HeaderSpace.builder();
-    //    line.setAction(LineAction.ACCEPT);
+    //    line.setAction(LineAction.PERMIT);
     IpProtocol protocol = toIpProtocol(_ipProtocol);
     if (protocol != null) {
       headerSpaceBuilder.setIpProtocols(ImmutableSet.of(protocol));

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/NetworkAcl.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/NetworkAcl.java
@@ -51,7 +51,7 @@ public class NetworkAcl implements AwsVpcEntity, Serializable {
     for (NetworkAclEntry entry : _entries) {
       if ((isEgress && entry.getIsEgress()) || (!isEgress && !entry.getIsEgress())) {
         int key = entry.getRuleNumber();
-        LineAction action = entry.getIsAllow() ? LineAction.ACCEPT : LineAction.REJECT;
+        LineAction action = entry.getIsAllow() ? LineAction.PERMIT : LineAction.DENY;
         Prefix prefix = entry.getCidrBlock();
         HeaderSpace.Builder headerSpaceBuilder = HeaderSpace.builder();
         if (!prefix.equals(Prefix.ZERO)) {
@@ -87,7 +87,7 @@ public class NetworkAcl implements AwsVpcEntity, Serializable {
         } else {
           portStr = portRange.toString();
         }
-        String actionStr = action == LineAction.ACCEPT ? "ALLOW" : "DENY";
+        String actionStr = action == LineAction.PERMIT ? "ALLOW" : "DENY";
         String lineNumber = key == 32767 ? "*" : Integer.toString(key);
         lineMap.put(
             key,

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
@@ -24,8 +24,8 @@ public class Utils {
             .setHostname(name)
             .setDomainName(domainName)
             .setConfigurationFormat(ConfigurationFormat.AWS)
-            .setDefaultInboundAction(LineAction.ACCEPT)
-            .setDefaultCrossZoneAction(LineAction.ACCEPT)
+            .setDefaultInboundAction(LineAction.PERMIT)
+            .setDefaultCrossZoneAction(LineAction.PERMIT)
             .build();
     FACTORY.vrfBuilder().setName(Configuration.DEFAULT_VRF_NAME).setOwner(c).build();
     c.getVendorFamily().setAws(new AwsFamily());

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/VpnConnection.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/VpnConnection.java
@@ -382,7 +382,7 @@ public class VpnConnection implements AwsVpcEntity, Serializable {
                 prefix -> {
                   RouteFilterLine matchOutgoingPrefix =
                       new RouteFilterLine(
-                          LineAction.ACCEPT,
+                          LineAction.PERMIT,
                           prefix,
                           new SubRange(prefix.getPrefixLength(), prefix.getPrefixLength()));
                   originationRouteFilter.addLine(matchOutgoingPrefix);

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -1398,7 +1398,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
               .getIpv6Networks()
               .keySet()
               .stream()
-              .map(p6 -> new Route6FilterLine(LineAction.ACCEPT, Prefix6Range.fromPrefix6(p6)))
+              .map(p6 -> new Route6FilterLine(LineAction.PERMIT, Prefix6Range.fromPrefix6(p6)))
               .collect(ImmutableList.toImmutableList());
       Route6FilterList localFilter6 =
           new Route6FilterList("~BGP_NETWORK6_NETWORKS_FILTER:" + vrfName + "~", lines);
@@ -1745,7 +1745,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
                 int prefixLen = prefix6.getPrefixLength();
                 Route6FilterLine line =
                     new Route6FilterLine(
-                        LineAction.ACCEPT, prefix6, new SubRange(prefixLen, prefixLen));
+                        LineAction.PERMIT, prefix6, new SubRange(prefixLen, prefixLen));
                 localFilter6.addLine(line);
                 String mapName = bgpNetwork6.getRouteMapName();
                 if (mapName != null) {
@@ -2439,14 +2439,14 @@ public final class CiscoConfiguration extends VendorConfiguration {
                 : prefixLength;
         summaryFilter.addLine(
             new RouteFilterLine(
-                LineAction.REJECT,
+                LineAction.DENY,
                 new IpWildcard(prefix),
                 new SubRange(filterMinPrefixLength, Prefix.MAX_PREFIX_LENGTH)));
       }
       area.setSummaries(ImmutableSortedMap.copyOf(summaries));
       summaryFilter.addLine(
           new RouteFilterLine(
-              LineAction.ACCEPT,
+              LineAction.PERMIT,
               new IpWildcard(Prefix.ZERO),
               new SubRange(0, Prefix.MAX_PREFIX_LENGTH)));
     }
@@ -2739,11 +2739,11 @@ public final class CiscoConfiguration extends VendorConfiguration {
         rmSet.applyTo(matchStatements, this, c, _w);
       }
       switch (rmClause.getAction()) {
-        case ACCEPT:
+        case PERMIT:
           matchStatements.add(Statements.ReturnTrue.toStaticStatement());
           break;
 
-        case REJECT:
+        case DENY:
           matchStatements.add(Statements.ReturnFalse.toStaticStatement());
           break;
 
@@ -2827,7 +2827,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
         }
       }
       switch (rmClause.getAction()) {
-        case ACCEPT:
+        case PERMIT:
           if (continueStatement == null) {
             onMatchStatements.add(Statements.ExitAccept.toStaticStatement());
           } else {
@@ -2836,7 +2836,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
           }
           break;
 
-        case REJECT:
+        case DENY:
           onMatchStatements.add(Statements.ExitReject.toStaticStatement());
           break;
 
@@ -2891,8 +2891,8 @@ public final class CiscoConfiguration extends VendorConfiguration {
   public Configuration toVendorIndependentConfiguration() {
     final Configuration c = new Configuration(_hostname, _vendor);
     c.getVendorFamily().setCisco(_cf);
-    c.setDefaultInboundAction(LineAction.ACCEPT);
-    c.setDefaultCrossZoneAction(LineAction.ACCEPT);
+    c.setDefaultInboundAction(LineAction.PERMIT);
+    c.setDefaultCrossZoneAction(LineAction.PERMIT);
     c.setDnsServers(_dnsServers);
     c.setDnsSourceInterface(_dnsSourceInterface);
     c.setDomainName(_domainName);

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
@@ -282,7 +282,7 @@ class CiscoConversions {
     prefixesToSuppress.forEachRemaining(
         p ->
             matchLonger.addLine(
-                new RouteFilterLine(LineAction.ACCEPT, PrefixRange.moreSpecificThan(p))));
+                new RouteFilterLine(LineAction.PERMIT, PrefixRange.moreSpecificThan(p))));
     // Bookkeeping: record that we created this RouteFilterList to match longer networks.
     c.getRouteFilterLists().put(matchLonger.getName(), matchLonger);
 
@@ -1222,13 +1222,13 @@ class CiscoConversions {
   private static AsPathAccessListLine toAsPathAccessListLine(AsPathSetElem elem) {
     String regex = CiscoConfiguration.toJavaRegex(elem.regex());
     AsPathAccessListLine line = new AsPathAccessListLine();
-    line.setAction(LineAction.ACCEPT);
+    line.setAction(LineAction.PERMIT);
     line.setRegex(regex);
     return line;
   }
 
   private static CommunityListLine toCommunityListLine(CommunitySetElem elem) {
-    return new CommunityListLine(LineAction.ACCEPT, elem.toCommunitySetExpr());
+    return new CommunityListLine(LineAction.PERMIT, elem.toCommunitySetExpr());
   }
 
   private static CommunityListLine toCommunityListLine(ExpandedCommunityListLine eclLine) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/InspectPolicyMap.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/InspectPolicyMap.java
@@ -18,7 +18,7 @@ public class InspectPolicyMap implements Serializable {
 
   public InspectPolicyMap(String name) {
     _name = name;
-    _classDefaultAction = LineAction.REJECT;
+    _classDefaultAction = LineAction.DENY;
     _inspectClasses = new TreeMap<>();
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/RouteMapSetAdditiveCommunityListLine.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/RouteMapSetAdditiveCommunityListLine.java
@@ -32,7 +32,7 @@ public final class RouteMapSetAdditiveCommunityListLine extends RouteMapSetLine 
         StandardCommunityList scl = cc.getStandardCommunityLists().get(communityListName);
         if (scl != null) {
           for (StandardCommunityListLine line : scl.getLines()) {
-            if (line.getAction() == LineAction.ACCEPT) {
+            if (line.getAction() == LineAction.PERMIT) {
               communities.addAll(line.getCommunities());
             } else {
               w.redFlag(

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/RouteMapSetCommunityListLine.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/RouteMapSetCommunityListLine.java
@@ -33,7 +33,7 @@ public final class RouteMapSetCommunityListLine extends RouteMapSetLine {
         StandardCommunityList scl = cc.getStandardCommunityLists().get(communityListName);
         if (scl != null) {
           for (StandardCommunityListLine line : scl.getLines()) {
-            if (line.getAction() == LineAction.ACCEPT) {
+            if (line.getAction() == LineAction.PERMIT) {
               communities.addAll(line.getCommunities());
             } else {
               w.redFlag(

--- a/projects/batfish/src/main/java/org/batfish/representation/host/HostConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/host/HostConfiguration.java
@@ -172,7 +172,7 @@ public class HostConfiguration extends VendorConfiguration {
       IpAccessList acl = _c.getIpAccessLists().get(aclName);
       if (acl != null) {
         for (IpAccessListLine line : acl.getLines()) {
-          if (line.getAction() == LineAction.REJECT) {
+          if (line.getAction() == LineAction.DENY) {
             return false;
           }
           /*
@@ -204,8 +204,8 @@ public class HostConfiguration extends VendorConfiguration {
     }
     String hostname = getHostname();
     _c = new Configuration(hostname, ConfigurationFormat.HOST);
-    _c.setDefaultCrossZoneAction(LineAction.ACCEPT);
-    _c.setDefaultInboundAction(LineAction.ACCEPT);
+    _c.setDefaultCrossZoneAction(LineAction.PERMIT);
+    _c.setDefaultInboundAction(LineAction.PERMIT);
     _c.getVrfs().put(Configuration.DEFAULT_VRF_NAME, new Vrf(Configuration.DEFAULT_VRF_NAME));
 
     // add interfaces

--- a/projects/batfish/src/main/java/org/batfish/representation/iptables/IptablesChain.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/iptables/IptablesChain.java
@@ -42,9 +42,9 @@ public class IptablesChain implements Serializable {
 
   public LineAction getIpAccessListLineAction() {
     if (_policy == ChainPolicy.ACCEPT) {
-      return LineAction.ACCEPT;
+      return LineAction.PERMIT;
     } else if (_policy == ChainPolicy.DROP) {
-      return LineAction.REJECT;
+      return LineAction.DENY;
     } else {
       throw new BatfishException("Unsupported ChainPolicy for mapping to LineAction: " + _policy);
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/iptables/IptablesRule.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/iptables/IptablesRule.java
@@ -56,9 +56,9 @@ public class IptablesRule implements Serializable {
 
   public LineAction getIpAccessListLineAction() {
     if (_actionType == IptablesActionType.ACCEPT) {
-      return LineAction.ACCEPT;
+      return LineAction.PERMIT;
     } else if (_actionType == IptablesActionType.DROP) {
-      return LineAction.REJECT;
+      return LineAction.DENY;
     } else {
       throw new BatfishException(
           "Unsupported IptablesActionType for mapping to LineAction: " + _actionType);

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineAddressMask.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineAddressMask.java
@@ -25,7 +25,7 @@ public final class Route4FilterLineAddressMask extends Route4FilterLine {
     int prefixLength = _prefix.getPrefixLength();
     org.batfish.datamodel.RouteFilterLine line =
         new org.batfish.datamodel.RouteFilterLine(
-            LineAction.ACCEPT,
+            LineAction.PERMIT,
             new IpWildcard(
                 new Prefix(_prefix.getStartIp(), prefixLength).getStartIp(), _addressMask),
             new SubRange(prefixLength, prefixLength));

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineExact.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineExact.java
@@ -19,7 +19,7 @@ public final class Route4FilterLineExact extends Route4FilterLine {
     int prefixLength = _prefix.getPrefixLength();
     org.batfish.datamodel.RouteFilterLine line =
         new org.batfish.datamodel.RouteFilterLine(
-            LineAction.ACCEPT, _prefix, new SubRange(prefixLength, prefixLength));
+            LineAction.PERMIT, _prefix, new SubRange(prefixLength, prefixLength));
     rfl.addLine(line);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineLengthRange.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineLengthRange.java
@@ -24,7 +24,7 @@ public final class Route4FilterLineLengthRange extends Route4FilterLine {
   public void applyTo(RouteFilterList rfl) {
     org.batfish.datamodel.RouteFilterLine line =
         new org.batfish.datamodel.RouteFilterLine(
-            LineAction.ACCEPT, _prefix, new SubRange(_minPrefixLength, _maxPrefixLength));
+            LineAction.PERMIT, _prefix, new SubRange(_minPrefixLength, _maxPrefixLength));
     rfl.addLine(line);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineLonger.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineLonger.java
@@ -23,7 +23,7 @@ public class Route4FilterLineLonger extends Route4FilterLine {
     }
     org.batfish.datamodel.RouteFilterLine line =
         new org.batfish.datamodel.RouteFilterLine(
-            LineAction.ACCEPT, PrefixRange.moreSpecificThan(_prefix));
+            LineAction.PERMIT, PrefixRange.moreSpecificThan(_prefix));
     rfl.addLine(line);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineOrLonger.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineOrLonger.java
@@ -19,7 +19,7 @@ public class Route4FilterLineOrLonger extends Route4FilterLine {
     int prefixLength = _prefix.getPrefixLength();
     org.batfish.datamodel.RouteFilterLine line =
         new org.batfish.datamodel.RouteFilterLine(
-            LineAction.ACCEPT, _prefix, new SubRange(prefixLength, Prefix.MAX_PREFIX_LENGTH));
+            LineAction.PERMIT, _prefix, new SubRange(prefixLength, Prefix.MAX_PREFIX_LENGTH));
     rfl.addLine(line);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineThrough.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineThrough.java
@@ -27,7 +27,7 @@ public final class Route4FilterLineThrough extends Route4FilterLine {
       Prefix currentPrefix = new Prefix(currentNetworkAddress, i);
       org.batfish.datamodel.RouteFilterLine line =
           new org.batfish.datamodel.RouteFilterLine(
-              LineAction.ACCEPT, currentPrefix, new SubRange(i, i));
+              LineAction.PERMIT, currentPrefix, new SubRange(i, i));
       rfl.addLine(line);
     }
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineUpTo.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineUpTo.java
@@ -22,7 +22,7 @@ public final class Route4FilterLineUpTo extends Route4FilterLine {
     int prefixLength = _prefix.getPrefixLength();
     org.batfish.datamodel.RouteFilterLine line =
         new org.batfish.datamodel.RouteFilterLine(
-            LineAction.ACCEPT, _prefix, new SubRange(prefixLength, _maxPrefixLength));
+            LineAction.PERMIT, _prefix, new SubRange(prefixLength, _maxPrefixLength));
     rfl.addLine(line);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Route6FilterLineAddressMask.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Route6FilterLineAddressMask.java
@@ -25,7 +25,7 @@ public final class Route6FilterLineAddressMask extends Route6FilterLine {
     int prefixLength = _prefix6.getPrefixLength();
     org.batfish.datamodel.Route6FilterLine line =
         new org.batfish.datamodel.Route6FilterLine(
-            LineAction.ACCEPT,
+            LineAction.PERMIT,
             new Ip6Wildcard(
                 new Prefix6(_prefix6.getAddress(), prefixLength).getAddress(), _addressMask),
             new SubRange(prefixLength, prefixLength));

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Route6FilterLineExact.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Route6FilterLineExact.java
@@ -19,7 +19,7 @@ public final class Route6FilterLineExact extends Route6FilterLine {
     int prefixLength = _prefix6.getPrefixLength();
     org.batfish.datamodel.Route6FilterLine line =
         new org.batfish.datamodel.Route6FilterLine(
-            LineAction.ACCEPT, _prefix6, new SubRange(prefixLength, prefixLength));
+            LineAction.PERMIT, _prefix6, new SubRange(prefixLength, prefixLength));
     rfl.addLine(line);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Route6FilterLineLengthRange.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Route6FilterLineLengthRange.java
@@ -24,7 +24,7 @@ public final class Route6FilterLineLengthRange extends Route6FilterLine {
   public void applyTo(Route6FilterList rfl) {
     org.batfish.datamodel.Route6FilterLine line =
         new org.batfish.datamodel.Route6FilterLine(
-            LineAction.ACCEPT, _prefix6, new SubRange(_minPrefixLength, _maxPrefixLength));
+            LineAction.PERMIT, _prefix6, new SubRange(_minPrefixLength, _maxPrefixLength));
     rfl.addLine(line);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Route6FilterLineLonger.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Route6FilterLineLonger.java
@@ -24,7 +24,7 @@ public class Route6FilterLineLonger extends Route6FilterLine {
     }
     org.batfish.datamodel.Route6FilterLine line =
         new org.batfish.datamodel.Route6FilterLine(
-            LineAction.ACCEPT, _prefix6, new SubRange(prefixLength + 1, Prefix6.MAX_PREFIX_LENGTH));
+            LineAction.PERMIT, _prefix6, new SubRange(prefixLength + 1, Prefix6.MAX_PREFIX_LENGTH));
     rfl.addLine(line);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Route6FilterLineOrLonger.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Route6FilterLineOrLonger.java
@@ -19,7 +19,7 @@ public class Route6FilterLineOrLonger extends Route6FilterLine {
     int prefixLength = _prefix6.getPrefixLength();
     org.batfish.datamodel.Route6FilterLine line =
         new org.batfish.datamodel.Route6FilterLine(
-            LineAction.ACCEPT, _prefix6, new SubRange(prefixLength, Prefix6.MAX_PREFIX_LENGTH));
+            LineAction.PERMIT, _prefix6, new SubRange(prefixLength, Prefix6.MAX_PREFIX_LENGTH));
     rfl.addLine(line);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Route6FilterLineThrough.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Route6FilterLineThrough.java
@@ -27,7 +27,7 @@ public final class Route6FilterLineThrough extends Route6FilterLine {
       Prefix6 currentPrefix6 = new Prefix6(currentNetworkAddress, i);
       org.batfish.datamodel.Route6FilterLine line =
           new org.batfish.datamodel.Route6FilterLine(
-              LineAction.ACCEPT, currentPrefix6, new SubRange(i, i));
+              LineAction.PERMIT, currentPrefix6, new SubRange(i, i));
       rfl.addLine(line);
     }
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Route6FilterLineUpTo.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Route6FilterLineUpTo.java
@@ -22,7 +22,7 @@ public final class Route6FilterLineUpTo extends Route6FilterLine {
     int prefixLength = _prefix6.getPrefixLength();
     org.batfish.datamodel.Route6FilterLine line =
         new org.batfish.datamodel.Route6FilterLine(
-            LineAction.ACCEPT, _prefix6, new SubRange(prefixLength, _maxPrefixLength));
+            LineAction.PERMIT, _prefix6, new SubRange(prefixLength, _maxPrefixLength));
     rfl.addLine(line);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/mrv/MrvConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/mrv/MrvConfiguration.java
@@ -42,8 +42,8 @@ public class MrvConfiguration extends VendorConfiguration {
   @Override
   public Configuration toVendorIndependentConfiguration() throws VendorConversionException {
     _c = new Configuration(_hostname, _vendor);
-    _c.setDefaultCrossZoneAction(LineAction.ACCEPT);
-    _c.setDefaultInboundAction(LineAction.ACCEPT);
+    _c.setDefaultCrossZoneAction(LineAction.PERMIT);
+    _c.setDefaultInboundAction(LineAction.PERMIT);
     return _c;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -208,7 +208,7 @@ public final class PaloAltoConfiguration extends VendorConfiguration {
       for (Service service : vsys.getServices().values()) {
         String serviceGroupAclName = computeServiceGroupMemberAclName(vsysName, service.getName());
         _c.getIpAccessLists()
-            .put(serviceGroupAclName, service.toIpAccessList(LineAction.ACCEPT, this, vsys));
+            .put(serviceGroupAclName, service.toIpAccessList(LineAction.PERMIT, this, vsys));
       }
 
       // Service groups
@@ -216,7 +216,7 @@ public final class PaloAltoConfiguration extends VendorConfiguration {
         String serviceGroupAclName =
             computeServiceGroupMemberAclName(vsysName, serviceGroup.getName());
         _c.getIpAccessLists()
-            .put(serviceGroupAclName, serviceGroup.toIpAccessList(LineAction.ACCEPT, this, vsys));
+            .put(serviceGroupAclName, serviceGroup.toIpAccessList(LineAction.PERMIT, this, vsys));
       }
     }
     _c.setLoggingServers(loggingServers);
@@ -250,7 +250,7 @@ public final class PaloAltoConfiguration extends VendorConfiguration {
     List<AclLineMatchExpr> conjuncts = new TreeList<>();
     IpAccessListLine.Builder ipAccessListLineBuilder =
         IpAccessListLine.builder().setName(rule.getName());
-    if (rule.getAction() == LineAction.ACCEPT) {
+    if (rule.getAction() == LineAction.PERMIT) {
       ipAccessListLineBuilder.accepting();
     } else {
       ipAccessListLineBuilder.rejecting();
@@ -407,8 +407,8 @@ public final class PaloAltoConfiguration extends VendorConfiguration {
   public Configuration toVendorIndependentConfiguration() throws VendorConversionException {
     String hostname = getHostname();
     _c = new Configuration(hostname, _vendor);
-    _c.setDefaultCrossZoneAction(LineAction.REJECT);
-    _c.setDefaultInboundAction(LineAction.ACCEPT);
+    _c.setDefaultCrossZoneAction(LineAction.DENY);
+    _c.setDefaultInboundAction(LineAction.PERMIT);
     _c.setDnsServers(getDnsServers());
     _c.setNtpServers(getNtpServers());
 

--- a/projects/batfish/src/main/java/org/batfish/representation/vyos/VyosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/vyos/VyosConfiguration.java
@@ -348,10 +348,10 @@ public class VyosConfiguration extends VendorConfiguration {
       }
       ifStatement.setGuard(conj.simplify());
       switch (rule.getAction()) {
-        case ACCEPT:
+        case PERMIT:
           trueStatements.add(Statements.ExitAccept.toStaticStatement());
           break;
-        case REJECT:
+        case DENY:
           trueStatements.add(Statements.ExitReject.toStaticStatement());
           break;
         default:
@@ -367,8 +367,8 @@ public class VyosConfiguration extends VendorConfiguration {
   public Configuration toVendorIndependentConfiguration() throws VendorConversionException {
     _ipToInterfaceMap = new HashMap<>();
     _c = new Configuration(_hostname, _format);
-    _c.setDefaultCrossZoneAction(LineAction.ACCEPT);
-    _c.setDefaultInboundAction(LineAction.ACCEPT);
+    _c.setDefaultCrossZoneAction(LineAction.PERMIT);
+    _c.setDefaultInboundAction(LineAction.PERMIT);
 
     convertPrefixLists();
     convertRouteMaps();

--- a/projects/batfish/src/main/java/org/batfish/symbolic/bdd/BDDAcl.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/bdd/BDDAcl.java
@@ -140,7 +140,7 @@ public final class BDDAcl {
 
     for (IpAccessListLine line : Lists.reverse(acl.getLines())) {
       BDD lineBDD = aclLineMatchExprToBDD.visit(line.getMatchCondition());
-      BDD actionBDD = line.getAction() == LineAction.ACCEPT ? _factory.one() : _factory.zero();
+      BDD actionBDD = line.getAction() == LineAction.PERMIT ? _factory.one() : _factory.zero();
       result = lineBDD.ite(actionBDD, result);
     }
     return result;

--- a/projects/batfish/src/main/java/org/batfish/symbolic/bdd/IpSpaceToBDD.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/bdd/IpSpaceToBDD.java
@@ -133,7 +133,7 @@ public final class IpSpaceToBDD implements GenericIpSpaceVisitor<BDD> {
       bdd =
           visit(aclIpSpaceLine.getIpSpace())
               .ite(
-                  aclIpSpaceLine.getAction() == LineAction.ACCEPT
+                  aclIpSpaceLine.getAction() == LineAction.PERMIT
                       ? _factory.one()
                       : _factory.zero(),
                   bdd);

--- a/projects/batfish/src/main/java/org/batfish/symbolic/bdd/TransferBDD.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/bdd/TransferBDD.java
@@ -805,7 +805,7 @@ class TransferBDD {
     Collections.reverse(lines);
     BDD acc = factory.zero();
     for (CommunityListLine line : lines) {
-      boolean action = (line.getAction() == LineAction.ACCEPT);
+      boolean action = (line.getAction() == LineAction.PERMIT);
       CommunityVar cvar = toRegexCommunityVar(toCommunityVar(line.getMatchCondition()));
       p.debug("Match Line: " + cvar);
       p.debug("Action: " + line.getAction());
@@ -877,7 +877,7 @@ class TransferBDD {
         p.debug("Prefix Range: " + range);
         p.debug("Action: " + line.getAction());
         BDD matches = isRelevantFor(other, range);
-        BDD action = mkBDD(line.getAction() == LineAction.ACCEPT);
+        BDD action = mkBDD(line.getAction() == LineAction.PERMIT);
         acc = ite(matches, action, acc);
       }
     }

--- a/projects/batfish/src/main/java/org/batfish/symbolic/smt/IpAccessListToBoolExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/smt/IpAccessListToBoolExpr.java
@@ -56,7 +56,7 @@ public class IpAccessListToBoolExpr implements GenericAclLineMatchExprVisitor<Bo
     for (IpAccessListLine line : Lists.reverse(ipAccessList.getLines())) {
       BoolExpr matchExpr = line.getMatchCondition().accept(this);
       BoolExpr actionExpr =
-          line.getAction() == LineAction.ACCEPT ? _context.mkTrue() : _context.mkFalse();
+          line.getAction() == LineAction.PERMIT ? _context.mkTrue() : _context.mkFalse();
       expr = (BoolExpr) _context.mkITE(matchExpr, actionExpr, expr);
     }
     return expr;

--- a/projects/batfish/src/main/java/org/batfish/symbolic/smt/IpSpaceToBoolExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/smt/IpSpaceToBoolExpr.java
@@ -38,7 +38,7 @@ public class IpSpaceToBoolExpr implements GenericIpSpaceVisitor<BoolExpr> {
     for (AclIpSpaceLine aclIpSpaceLine : Lists.reverse(aclIpSpace.getLines())) {
       BoolExpr matchExpr = aclIpSpaceLine.getIpSpace().accept(this);
       BoolExpr actionExpr =
-          aclIpSpaceLine.getAction() == LineAction.ACCEPT ? _context.mkTrue() : _context.mkFalse();
+          aclIpSpaceLine.getAction() == LineAction.PERMIT ? _context.mkTrue() : _context.mkFalse();
       expr = (BoolExpr) _context.mkITE(matchExpr, actionExpr, expr);
     }
     return expr;

--- a/projects/batfish/src/main/java/org/batfish/symbolic/smt/TransferSSA.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/smt/TransferSSA.java
@@ -223,7 +223,7 @@ class TransferSSA {
       SubRange r = line.getLengthRange();
       PrefixRange range = new PrefixRange(p, r);
       BoolExpr matches = _enc.isRelevantFor(other.getPrefixLength(), range);
-      BoolExpr action = _enc.mkBool(line.getAction() == LineAction.ACCEPT);
+      BoolExpr action = _enc.mkBool(line.getAction() == LineAction.PERMIT);
       acc = _enc.mkIf(matches, action, acc);
     }
     return acc;
@@ -313,7 +313,7 @@ class TransferSSA {
     Collections.reverse(lines);
     BoolExpr acc = _enc.mkFalse();
     for (CommunityListLine line : lines) {
-      boolean action = (line.getAction() == LineAction.ACCEPT);
+      boolean action = (line.getAction() == LineAction.PERMIT);
       CommunityVar cvar = toCommunityVar(line.getMatchCondition());
       BoolExpr c = other.getCommunities().get(cvar);
       acc = _enc.mkIf(c, _enc.mkBool(action), acc);

--- a/projects/batfish/src/main/java/org/batfish/z3/AclLineMatchExprToBooleanExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/AclLineMatchExprToBooleanExpr.java
@@ -126,7 +126,7 @@ public class AclLineMatchExprToBooleanExpr implements GenericAclLineMatchExprVis
       IpAccessListLine line = iter.previous();
       BooleanExpr matched = toBooleanExpr(line.getMatchCondition());
       BooleanExpr permitted =
-          line.getAction() == LineAction.ACCEPT
+          line.getAction() == LineAction.PERMIT
               ? org.batfish.z3.expr.TrueExpr.INSTANCE
               : org.batfish.z3.expr.FalseExpr.INSTANCE;
       expr = new IfThenElse(matched, permitted, expr);

--- a/projects/batfish/src/main/java/org/batfish/z3/IpSpaceSimplifier.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/IpSpaceSimplifier.java
@@ -72,14 +72,14 @@ public class IpSpaceSimplifier implements GenericIpSpaceVisitor<IpSpace> {
     /*
      * If there is only one line, and it accepts, then simplify to the space of that line.
      */
-    if (simplifiedLines.size() == 1 && simplifiedLines.get(0).getAction() == LineAction.ACCEPT) {
+    if (simplifiedLines.size() == 1 && simplifiedLines.get(0).getAction() == LineAction.PERMIT) {
       return simplifiedLines.get(0).getIpSpace();
     }
 
     /*
      * If all lines reject (or there are no lines), simplify to EmptyIpSpace.
      */
-    if (simplifiedLines.stream().allMatch(line -> line.getAction() == LineAction.REJECT)) {
+    if (simplifiedLines.stream().allMatch(line -> line.getAction() == LineAction.DENY)) {
       return EmptyIpSpace.INSTANCE;
     }
 
@@ -91,7 +91,7 @@ public class IpSpaceSimplifier implements GenericIpSpaceVisitor<IpSpace> {
             .get(simplifiedLines.size() - 1)
             .getIpSpace()
             .equals(UniverseIpSpace.INSTANCE)
-        && simplifiedLines.stream().allMatch(line -> line.getAction() == LineAction.ACCEPT)) {
+        && simplifiedLines.stream().allMatch(line -> line.getAction() == LineAction.PERMIT)) {
       return UniverseIpSpace.INSTANCE;
     }
 

--- a/projects/batfish/src/main/java/org/batfish/z3/IpSpaceSpecializer.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/IpSpaceSpecializer.java
@@ -76,7 +76,7 @@ public abstract class IpSpaceSpecializer implements GenericIpSpaceVisitor<IpSpac
 
     if (specializedLines
         .stream()
-        .allMatch(aclIpSpaceLine -> aclIpSpaceLine.getAction() == LineAction.REJECT)) {
+        .allMatch(aclIpSpaceLine -> aclIpSpaceLine.getAction() == LineAction.DENY)) {
       return EmptyIpSpace.INSTANCE;
     }
 

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/visitors/IpSpaceBooleanExprTransformer.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/visitors/IpSpaceBooleanExprTransformer.java
@@ -67,7 +67,7 @@ public class IpSpaceBooleanExprTransformer implements GenericIpSpaceVisitor<Bool
             expr =
                 new IfThenElse(
                     new IpSpaceMatchExpr(line.getIpSpace(), _namedIpSpaces, field).getExpr(),
-                    line.getAction() == LineAction.ACCEPT ? TrueExpr.INSTANCE : FalseExpr.INSTANCE,
+                    line.getAction() == LineAction.PERMIT ? TrueExpr.INSTANCE : FalseExpr.INSTANCE,
                     expr);
           }
           return expr;

--- a/projects/batfish/src/main/java/org/batfish/z3/state/visitors/DefaultTransitionGenerator.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/state/visitors/DefaultTransitionGenerator.java
@@ -145,7 +145,7 @@ public class DefaultTransitionGenerator implements StateVisitor {
                     (acl, linesActions) -> {
                       int lineNumber = 0;
                       for (LineAction linesAction : linesActions) {
-                        if (linesAction == LineAction.REJECT) {
+                        if (linesAction == LineAction.DENY) {
                           _rules.add(
                               new BasicRuleStatement(
                                   new AclLineMatch(node, acl, lineNumber), new AclDeny(node, acl)));
@@ -293,7 +293,7 @@ public class DefaultTransitionGenerator implements StateVisitor {
                       lineActions.forEach(
                           lineAction -> {
                             int line = lineNumber.getAndIncrement();
-                            if (lineAction == LineAction.ACCEPT) {
+                            if (lineAction == LineAction.PERMIT) {
                               _rules.add(
                                   new BasicRuleStatement(
                                       new AclLineMatch(hostname, acl, line),

--- a/projects/batfish/src/test/java/org/batfish/dataplane/TracerouteEngineTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/TracerouteEngineTest.java
@@ -73,7 +73,7 @@ public class TracerouteEngineTest {
     Flow flow = makeFlow();
 
     SourceNat nat = new SourceNat();
-    nat.setAcl(makeAcl("accept", LineAction.ACCEPT));
+    nat.setAcl(makeAcl("accept", LineAction.PERMIT));
     nat.setPoolIpFirst(new Ip("4.5.6.7"));
 
     Flow transformed =
@@ -87,7 +87,7 @@ public class TracerouteEngineTest {
     Flow flow = makeFlow();
 
     SourceNat nat = new SourceNat();
-    nat.setAcl(makeAcl("reject", LineAction.REJECT));
+    nat.setAcl(makeAcl("reject", LineAction.DENY));
     nat.setPoolIpFirst(new Ip("4.5.6.7"));
 
     Flow transformed =
@@ -101,11 +101,11 @@ public class TracerouteEngineTest {
     Flow flow = makeFlow();
 
     SourceNat nat = new SourceNat();
-    nat.setAcl(makeAcl("firstAccept", LineAction.ACCEPT));
+    nat.setAcl(makeAcl("firstAccept", LineAction.PERMIT));
     nat.setPoolIpFirst(new Ip("4.5.6.7"));
 
     SourceNat secondNat = new SourceNat();
-    secondNat.setAcl(makeAcl("secondAccept", LineAction.ACCEPT));
+    secondNat.setAcl(makeAcl("secondAccept", LineAction.PERMIT));
     secondNat.setPoolIpFirst(new Ip("4.5.6.8"));
 
     Flow transformed =
@@ -119,11 +119,11 @@ public class TracerouteEngineTest {
     Flow flow = makeFlow();
 
     SourceNat nat = new SourceNat();
-    nat.setAcl(makeAcl("rejectAll", LineAction.REJECT));
+    nat.setAcl(makeAcl("rejectAll", LineAction.DENY));
     nat.setPoolIpFirst(new Ip("4.5.6.7"));
 
     SourceNat secondNat = new SourceNat();
-    secondNat.setAcl(makeAcl("acceptAnyway", LineAction.ACCEPT));
+    secondNat.setAcl(makeAcl("acceptAnyway", LineAction.PERMIT));
     secondNat.setPoolIpFirst(new Ip("4.5.6.8"));
 
     Flow transformed =
@@ -137,7 +137,7 @@ public class TracerouteEngineTest {
     Flow flow = makeFlow();
 
     SourceNat nat = new SourceNat();
-    nat.setAcl(makeAcl("matchAll", LineAction.ACCEPT));
+    nat.setAcl(makeAcl("matchAll", LineAction.PERMIT));
 
     _thrown.expect(BatfishException.class);
     _thrown.expectMessage("missing NAT address or pool");

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -1495,7 +1495,7 @@ public class FlatJuniperGrammarTest {
                 equalTo(
                     ImmutableList.of(
                         IpAccessListLine.builder()
-                            .setAction(LineAction.ACCEPT)
+                            .setAction(LineAction.PERMIT)
                             .setMatchCondition(
                                 new MatchHeaderSpace(
                                     HeaderSpace.builder()
@@ -1864,7 +1864,7 @@ public class FlatJuniperGrammarTest {
                 equalTo(
                     ImmutableList.of(
                         IpAccessListLine.builder()
-                            .setAction(LineAction.ACCEPT)
+                            .setAction(LineAction.PERMIT)
                             .setMatchCondition(
                                 new MatchHeaderSpace(
                                     HeaderSpace.builder()
@@ -2430,15 +2430,15 @@ public class FlatJuniperGrammarTest {
         RouteFilterListMatchers.hasLines(
             containsInAnyOrder(
                 new RouteFilterLine(
-                    LineAction.ACCEPT, Prefix.parse("1.2.0.0/16"), new SubRange(16, 16)),
+                    LineAction.PERMIT, Prefix.parse("1.2.0.0/16"), new SubRange(16, 16)),
                 new RouteFilterLine(
-                    LineAction.ACCEPT, Prefix.parse("1.2.0.0/16"), new SubRange(17, 32)),
+                    LineAction.PERMIT, Prefix.parse("1.2.0.0/16"), new SubRange(17, 32)),
                 new RouteFilterLine(
-                    LineAction.ACCEPT, Prefix.parse("1.7.0.0/16"), new SubRange(16, 16)),
+                    LineAction.PERMIT, Prefix.parse("1.7.0.0/16"), new SubRange(16, 16)),
                 new RouteFilterLine(
-                    LineAction.ACCEPT, Prefix.parse("1.7.0.0/17"), new SubRange(17, 17)),
+                    LineAction.PERMIT, Prefix.parse("1.7.0.0/17"), new SubRange(17, 17)),
                 new RouteFilterLine(
-                    LineAction.ACCEPT,
+                    LineAction.PERMIT,
                     new IpWildcard("1.0.0.0:0.255.0.255"),
                     new SubRange(16, 16)))));
   }

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/SecurityGroupsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/SecurityGroupsTest.java
@@ -300,7 +300,7 @@ public class SecurityGroupsTest {
         outFilter
             .filter(_flowBuilder.build(), null, ImmutableMap.of(), ImmutableMap.of())
             .getAction(),
-        equalTo(LineAction.REJECT));
+        equalTo(LineAction.DENY));
   }
 
   @Test
@@ -325,7 +325,7 @@ public class SecurityGroupsTest {
         outFilter
             .filter(_flowBuilder.build(), null, ImmutableMap.of(), ImmutableMap.of())
             .getAction(),
-        equalTo(LineAction.ACCEPT));
+        equalTo(LineAction.PERMIT));
   }
 
   @Test
@@ -350,6 +350,6 @@ public class SecurityGroupsTest {
         outFilter
             .filter(_flowBuilder.build(), null, ImmutableMap.of(), ImmutableMap.of())
             .getAction(),
-        equalTo(LineAction.REJECT));
+        equalTo(LineAction.DENY));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromDestinationPrefixListExceptTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromDestinationPrefixListExceptTest.java
@@ -39,7 +39,7 @@ public class FwFromDestinationPrefixListExceptTest {
     _c = new Configuration("test", ConfigurationFormat.FLAT_JUNIPER);
     RouteFilterList rflist = new RouteFilterList(BASE_PREFIX_LIST_NAME);
     RouteFilterLine rfline =
-        new RouteFilterLine(LineAction.ACCEPT, Prefix.parse(BASE_IP_PREFIX), new SubRange(0, 0));
+        new RouteFilterLine(LineAction.PERMIT, Prefix.parse(BASE_IP_PREFIX), new SubRange(0, 0));
     rflist.addLine(rfline);
     _c.getRouteFilterLists().put(BASE_PREFIX_LIST_NAME, rflist);
   }

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromDestinationPrefixListTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromDestinationPrefixListTest.java
@@ -39,7 +39,7 @@ public class FwFromDestinationPrefixListTest {
     _c = new Configuration("test", ConfigurationFormat.FLAT_JUNIPER);
     RouteFilterList rflist = new RouteFilterList(BASE_PREFIX_LIST_NAME);
     RouteFilterLine rfline =
-        new RouteFilterLine(LineAction.ACCEPT, Prefix.parse(BASE_IP_PREFIX), new SubRange(0, 0));
+        new RouteFilterLine(LineAction.PERMIT, Prefix.parse(BASE_IP_PREFIX), new SubRange(0, 0));
     rflist.addLine(rfline);
     _c.getRouteFilterLists().put(BASE_PREFIX_LIST_NAME, rflist);
   }

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromPrefixListTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromPrefixListTest.java
@@ -39,7 +39,7 @@ public class FwFromPrefixListTest {
     _c = new Configuration("test", ConfigurationFormat.FLAT_JUNIPER);
     RouteFilterList rflist = new RouteFilterList(BASE_PREFIX_LIST_NAME);
     RouteFilterLine rfline =
-        new RouteFilterLine(LineAction.ACCEPT, Prefix.parse(BASE_IP_PREFIX), new SubRange(0, 0));
+        new RouteFilterLine(LineAction.PERMIT, Prefix.parse(BASE_IP_PREFIX), new SubRange(0, 0));
     rflist.addLine(rfline);
     _c.getRouteFilterLists().put(BASE_PREFIX_LIST_NAME, rflist);
   }

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromSourcePrefixListExceptTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromSourcePrefixListExceptTest.java
@@ -39,7 +39,7 @@ public class FwFromSourcePrefixListExceptTest {
     _c = new Configuration("test", ConfigurationFormat.FLAT_JUNIPER);
     RouteFilterList rflist = new RouteFilterList(BASE_PREFIX_LIST_NAME);
     RouteFilterLine rfline =
-        new RouteFilterLine(LineAction.ACCEPT, Prefix.parse(BASE_IP_PREFIX), new SubRange(0, 0));
+        new RouteFilterLine(LineAction.PERMIT, Prefix.parse(BASE_IP_PREFIX), new SubRange(0, 0));
     rflist.addLine(rfline);
     _c.getRouteFilterLists().put(BASE_PREFIX_LIST_NAME, rflist);
   }

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromSourcePrefixListTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromSourcePrefixListTest.java
@@ -39,7 +39,7 @@ public class FwFromSourcePrefixListTest {
     _c = new Configuration("test", ConfigurationFormat.FLAT_JUNIPER);
     RouteFilterList rflist = new RouteFilterList(BASE_PREFIX_LIST_NAME);
     RouteFilterLine rfline =
-        new RouteFilterLine(LineAction.ACCEPT, Prefix.parse(BASE_IP_PREFIX), new SubRange(0, 0));
+        new RouteFilterLine(LineAction.PERMIT, Prefix.parse(BASE_IP_PREFIX), new SubRange(0, 0));
     rflist.addLine(rfline);
     _c.getRouteFilterLists().put(BASE_PREFIX_LIST_NAME, rflist);
   }

--- a/projects/batfish/src/test/java/org/batfish/z3/AclLineMatchExprToBooleanExprTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/AclLineMatchExprToBooleanExprTest.java
@@ -127,7 +127,7 @@ public class AclLineMatchExprToBooleanExprTest {
                     HeaderSpace.builder()
                         .setDstIps(ImmutableList.of(new IpWildcard("1.2.3.4")))
                         .build()))
-            .setAction(LineAction.REJECT)
+            .setAction(LineAction.DENY)
             .build();
 
     IpAccessListLine line2 =
@@ -137,7 +137,7 @@ public class AclLineMatchExprToBooleanExprTest {
                     HeaderSpace.builder()
                         .setDstIps(ImmutableList.of(new IpWildcard("1.2.3.0/24")))
                         .build()))
-            .setAction(LineAction.ACCEPT)
+            .setAction(LineAction.PERMIT)
             .build();
 
     IpAccessList acl =

--- a/projects/batfish/src/test/java/org/batfish/z3/NodJobAclTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/NodJobAclTest.java
@@ -87,7 +87,7 @@ public class NodJobAclTest {
         aclb.setLines(
                 ImmutableList.of(
                     IpAccessListLine.builder()
-                        .setAction(LineAction.ACCEPT)
+                        .setAction(LineAction.PERMIT)
                         .setMatchCondition(new MatchSrcInterface(ImmutableList.of(iface1)))
                         .build()))
             .setOwner(dstNode)
@@ -233,7 +233,7 @@ public class NodJobAclTest {
         aclb.setLines(
                 ImmutableList.of(
                     IpAccessListLine.builder()
-                        .setAction(LineAction.ACCEPT)
+                        .setAction(LineAction.PERMIT)
                         .setMatchCondition(new MatchSrcInterface(ImmutableList.of(iface1)))
                         .build()))
             .setOwner(node)
@@ -345,12 +345,12 @@ public class NodJobAclTest {
 
   @Test
   public void testPermittedByAcl_accept() throws IOException {
-    testPermittedByAcl_helper(LineAction.ACCEPT);
+    testPermittedByAcl_helper(LineAction.PERMIT);
   }
 
   @Test
   public void testPermittedByAcl_reject() throws IOException {
-    testPermittedByAcl_helper(LineAction.REJECT);
+    testPermittedByAcl_helper(LineAction.DENY);
   }
 
   private static void testPermittedByAcl_helper(LineAction action) throws IOException {
@@ -384,7 +384,7 @@ public class NodJobAclTest {
             .setLines(
                 ImmutableList.of(
                     IpAccessListLine.builder()
-                        .setAction(LineAction.ACCEPT)
+                        .setAction(LineAction.PERMIT)
                         .setMatchCondition(new PermittedByAcl("acl1"))
                         .build()))
             .build();
@@ -442,6 +442,6 @@ public class NodJobAclTest {
     /* Run query */
     Status status = NodJobTest.checkSat(nodJob);
     assertThat(
-        status, equalTo(action == LineAction.ACCEPT ? Status.SATISFIABLE : Status.UNSATISFIABLE));
+        status, equalTo(action == LineAction.PERMIT ? Status.SATISFIABLE : Status.UNSATISFIABLE));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/z3/SynthesizerInputImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/SynthesizerInputImplTest.java
@@ -125,7 +125,7 @@ public class SynthesizerInputImplTest {
             .setForwardingAnalysis(MockForwardingAnalysis.builder().build())
             .setTopology(new Topology(ImmutableSortedSet.of(forwardEdge, backEdge)))
             .build();
-    List<LineAction> expectedActions = ImmutableList.of(LineAction.ACCEPT, LineAction.REJECT);
+    List<LineAction> expectedActions = ImmutableList.of(LineAction.PERMIT, LineAction.DENY);
     Map<String, List<LineAction>> expectedSrcNodeWithDataPlane =
         ImmutableMap.of(
             edgeInterfaceInAcl.getName(),

--- a/projects/batfish/src/test/java/org/batfish/z3/state/visitors/DefaultTransitionGeneratorTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/state/visitors/DefaultTransitionGeneratorTest.java
@@ -138,11 +138,9 @@ public class DefaultTransitionGeneratorTest {
 
   private static Map<String, Map<String, List<LineAction>>> aclActions() {
     List<LineAction> acl1ActionsByLine =
-        ImmutableList.of(
-            LineAction.ACCEPT, LineAction.REJECT, LineAction.ACCEPT, LineAction.REJECT);
+        ImmutableList.of(LineAction.PERMIT, LineAction.DENY, LineAction.PERMIT, LineAction.DENY);
     List<LineAction> acl2ActionsByLine =
-        ImmutableList.of(
-            LineAction.REJECT, LineAction.ACCEPT, LineAction.REJECT, LineAction.ACCEPT);
+        ImmutableList.of(LineAction.DENY, LineAction.PERMIT, LineAction.DENY, LineAction.PERMIT);
     ImmutableMap<String, List<LineAction>> aclActions =
         ImmutableMap.of(ACL1, acl1ActionsByLine, ACL2, acl2ActionsByLine, ACL3, ImmutableList.of());
     Map<String, Map<String, List<LineAction>>> aclActionss =

--- a/projects/question/src/main/java/org/batfish/question/ReachabilityQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/ReachabilityQuestionPlugin.java
@@ -103,7 +103,7 @@ public class ReachabilityQuestionPlugin extends QuestionPlugin {
    * @example bf_answer("Reachability", dstIps=["2.128.0.101"], dstPorts=[53], ipProtocols=["UDP"],
    *     actions=["drop"]) Finds all (starting node, packet header) combinations that cannot reach
    *     (action=drop) the 2.128.0.101 using a DNS (UDP on port 53) packet.
-   * @example bf_answer_type("Reachability", actions=["ACCEPT"], dstIps=["2.128.1.101"],
+   * @example bf_answer_type("Reachability", actions=["PERMIT"], dstIps=["2.128.1.101"],
    *     notDstPorts=[22], notIpProtocols=["TCP"]) Finds all (starting node, packet header)
    *     combinations that can reach (action=drop) 2.128.1.101 using non-SSH packets.
    */

--- a/projects/question/src/main/java/org/batfish/question/reachfilter/ReachFilterAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/reachfilter/ReachFilterAnswerer.java
@@ -271,12 +271,12 @@ public final class ReachFilterAnswerer extends Answerer {
                 acl.getLines()
                     .subList(0, lineNumber)
                     .stream()
-                    .map(l -> l.toBuilder().setAction(LineAction.REJECT).build()),
+                    .map(l -> l.toBuilder().setAction(LineAction.DENY).build()),
                 Stream.of(
                     acl.getLines()
                         .get(lineNumber)
                         .toBuilder()
-                        .setAction(LineAction.ACCEPT)
+                        .setAction(LineAction.PERMIT)
                         .build()))
             .collect(ImmutableList.toImmutableList());
     return IpAccessList.builder().setName(acl.getName()).setLines(lines).build();
@@ -293,9 +293,9 @@ public final class ReachFilterAnswerer extends Answerer {
                             l.toBuilder()
                                 // flip action
                                 .setAction(
-                                    l.getAction() == LineAction.ACCEPT
-                                        ? LineAction.REJECT
-                                        : LineAction.ACCEPT)
+                                    l.getAction() == LineAction.PERMIT
+                                        ? LineAction.DENY
+                                        : LineAction.PERMIT)
                                 .build()),
                 // accept if we reach the end of the ACL
                 Stream.of(IpAccessListLine.ACCEPT_ALL))

--- a/tests/aws/nodes-example-aws.ref
+++ b/tests/aws/nodes-example-aws.ref
@@ -5,8 +5,8 @@
       "es-domain" : {
         "configurationFormat" : "AWS",
         "name" : "es-domain",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "HOST",
         "domainName" : "aws",
         "interfaces" : {
@@ -72,7 +72,7 @@
             "name" : "~SECURITY_GROUP_EGRESS_ACL~",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -107,7 +107,7 @@
                 }
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -127,7 +127,7 @@
             "name" : "~SECURITY_GROUP_INGRESS_ACL~",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -162,7 +162,7 @@
                 }
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -218,8 +218,8 @@
       "igw-068fee63" : {
         "configurationFormat" : "AWS",
         "name" : "igw-068fee63",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "domainName" : "aws",
         "interfaces" : {
@@ -278,8 +278,8 @@
       "igw-9b93ddfc" : {
         "configurationFormat" : "AWS",
         "name" : "igw-9b93ddfc",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "domainName" : "aws",
         "interfaces" : {
@@ -338,8 +338,8 @@
       "igw-fac5839d" : {
         "configurationFormat" : "AWS",
         "name" : "igw-fac5839d",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "domainName" : "aws",
         "interfaces" : {
@@ -398,8 +398,8 @@
       "lhr-border-02" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "lhr-border-02",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "domainName" : "demo.com",
         "ikeGateways" : {
@@ -936,7 +936,7 @@
             "name" : "2001",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -957,7 +957,7 @@
                 "name" : "permit icmp 10.100.0.0 0.0.255.255 any"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -985,7 +985,7 @@
             "name" : "LIMIT_PEER",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -1003,7 +1003,7 @@
                 "name" : "permit ip 10.1.30.0 0.0.0.255 any"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -1028,7 +1028,7 @@
             "name" : "MATCH_ALL_BGP",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -1156,7 +1156,7 @@
           "MATCH_ALL_BGP" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "0.0.0.0/0",
                 "lengthRange" : "0-32"
               }
@@ -1166,12 +1166,12 @@
           "PROTECT_LOOPBACK" : {
             "lines" : [
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "ipWildcard" : "10.10.255.0/28",
                 "lengthRange" : "28-32"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "0.0.0.0/0",
                 "lengthRange" : "0-32"
               }
@@ -2043,8 +2043,8 @@
       "subnet-073b8061" : {
         "configurationFormat" : "AWS",
         "name" : "subnet-073b8061",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "domainName" : "aws",
         "interfaces" : {
@@ -2108,7 +2108,7 @@
             "name" : "acl-7b78771d_egress",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -2118,7 +2118,7 @@
                 "name" : "100 ALL ALL 0.0.0.0/0 ALLOW"
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -2135,7 +2135,7 @@
             "name" : "acl-7b78771d_ingress",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -2145,7 +2145,7 @@
                 "name" : "100 ALL ALL 0.0.0.0/0 ALLOW"
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -2190,8 +2190,8 @@
       "subnet-1641fa70" : {
         "configurationFormat" : "AWS",
         "name" : "subnet-1641fa70",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "domainName" : "aws",
         "interfaces" : {
@@ -2255,7 +2255,7 @@
             "name" : "acl-7b78771d_egress",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -2265,7 +2265,7 @@
                 "name" : "100 ALL ALL 0.0.0.0/0 ALLOW"
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -2282,7 +2282,7 @@
             "name" : "acl-7b78771d_ingress",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -2292,7 +2292,7 @@
                 "name" : "100 ALL ALL 0.0.0.0/0 ALLOW"
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -2337,8 +2337,8 @@
       "subnet-1f315846" : {
         "configurationFormat" : "AWS",
         "name" : "subnet-1f315846",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "domainName" : "aws",
         "interfaces" : {
@@ -2402,7 +2402,7 @@
             "name" : "acl-4db39c28_egress",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -2412,7 +2412,7 @@
                 "name" : "100 ALL ALL 0.0.0.0/0 ALLOW"
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -2429,7 +2429,7 @@
             "name" : "acl-4db39c28_ingress",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -2451,7 +2451,7 @@
                 "name" : "100 TCP [3306,3306] 162.243.144.192/32 ALLOW"
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -2496,8 +2496,8 @@
       "subnet-30398256" : {
         "configurationFormat" : "AWS",
         "name" : "subnet-30398256",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "domainName" : "aws",
         "interfaces" : {
@@ -2561,7 +2561,7 @@
             "name" : "acl-7b78771d_egress",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -2571,7 +2571,7 @@
                 "name" : "100 ALL ALL 0.0.0.0/0 ALLOW"
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -2588,7 +2588,7 @@
             "name" : "acl-7b78771d_ingress",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -2598,7 +2598,7 @@
                 "name" : "100 ALL ALL 0.0.0.0/0 ALLOW"
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -2643,8 +2643,8 @@
       "subnet-62f14104" : {
         "configurationFormat" : "AWS",
         "name" : "subnet-62f14104",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "domainName" : "aws",
         "interfaces" : {
@@ -2708,7 +2708,7 @@
             "name" : "acl-3d4f745b_egress",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -2718,7 +2718,7 @@
                 "name" : "100 ALL ALL 0.0.0.0/0 ALLOW"
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -2735,7 +2735,7 @@
             "name" : "acl-3d4f745b_ingress",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -2745,7 +2745,7 @@
                 "name" : "100 ALL ALL 0.0.0.0/0 ALLOW"
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -2790,8 +2790,8 @@
       "subnet-7044ff16" : {
         "configurationFormat" : "AWS",
         "name" : "subnet-7044ff16",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "domainName" : "aws",
         "interfaces" : {
@@ -2855,7 +2855,7 @@
             "name" : "acl-7b78771d_egress",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -2865,7 +2865,7 @@
                 "name" : "100 ALL ALL 0.0.0.0/0 ALLOW"
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -2882,7 +2882,7 @@
             "name" : "acl-7b78771d_ingress",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -2892,7 +2892,7 @@
                 "name" : "100 ALL ALL 0.0.0.0/0 ALLOW"
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -2937,8 +2937,8 @@
       "subnet-8d0cbdeb" : {
         "configurationFormat" : "AWS",
         "name" : "subnet-8d0cbdeb",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "domainName" : "aws",
         "interfaces" : {
@@ -3002,7 +3002,7 @@
             "name" : "acl-3d4f745b_egress",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -3012,7 +3012,7 @@
                 "name" : "100 ALL ALL 0.0.0.0/0 ALLOW"
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -3029,7 +3029,7 @@
             "name" : "acl-3d4f745b_ingress",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -3039,7 +3039,7 @@
                 "name" : "100 ALL ALL 0.0.0.0/0 ALLOW"
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -3084,8 +3084,8 @@
       "subnet-9c8adceb" : {
         "configurationFormat" : "AWS",
         "name" : "subnet-9c8adceb",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "domainName" : "aws",
         "interfaces" : {
@@ -3149,7 +3149,7 @@
             "name" : "acl-4db39c28_egress",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -3159,7 +3159,7 @@
                 "name" : "100 ALL ALL 0.0.0.0/0 ALLOW"
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -3176,7 +3176,7 @@
             "name" : "acl-4db39c28_ingress",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -3198,7 +3198,7 @@
                 "name" : "100 TCP [3306,3306] 162.243.144.192/32 ALLOW"
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -3243,8 +3243,8 @@
       "subnet-d9cafabc" : {
         "configurationFormat" : "AWS",
         "name" : "subnet-d9cafabc",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "domainName" : "aws",
         "interfaces" : {
@@ -3308,7 +3308,7 @@
             "name" : "acl-4db39c28_egress",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -3318,7 +3318,7 @@
                 "name" : "100 ALL ALL 0.0.0.0/0 ALLOW"
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -3335,7 +3335,7 @@
             "name" : "acl-4db39c28_ingress",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -3357,7 +3357,7 @@
                 "name" : "100 TCP [3306,3306] 162.243.144.192/32 ALLOW"
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -3402,8 +3402,8 @@
       "subnet-f73a8191" : {
         "configurationFormat" : "AWS",
         "name" : "subnet-f73a8191",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "domainName" : "aws",
         "interfaces" : {
@@ -3467,7 +3467,7 @@
             "name" : "acl-7b78771d_egress",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -3477,7 +3477,7 @@
                 "name" : "100 ALL ALL 0.0.0.0/0 ALLOW"
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -3494,7 +3494,7 @@
             "name" : "acl-7b78771d_ingress",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -3504,7 +3504,7 @@
                 "name" : "100 ALL ALL 0.0.0.0/0 ALLOW"
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -3549,8 +3549,8 @@
       "test-rds" : {
         "configurationFormat" : "AWS",
         "name" : "test-rds",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "HOST",
         "domainName" : "aws",
         "interfaces" : {
@@ -3588,7 +3588,7 @@
             "name" : "~SECURITY_GROUP_EGRESS_ACL~",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -3633,7 +3633,7 @@
                 }
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -3653,7 +3653,7 @@
             "name" : "~SECURITY_GROUP_INGRESS_ACL~",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -3688,7 +3688,7 @@
                 }
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -3744,8 +3744,8 @@
       "vgw-81fd279f" : {
         "configurationFormat" : "AWS",
         "name" : "vgw-81fd279f",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "domainName" : "aws",
         "ikeGateways" : {
@@ -3986,7 +3986,7 @@
           "vpn-ba2e34a8-1_origination" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "10.100.0.0/16",
                 "lengthRange" : "16-16"
               }
@@ -3996,7 +3996,7 @@
           "vpn-ba2e34a8-2_origination" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "10.100.0.0/16",
                 "lengthRange" : "16-16"
               }
@@ -4230,8 +4230,8 @@
       "vpc-815775e7" : {
         "configurationFormat" : "AWS",
         "name" : "vpc-815775e7",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "domainName" : "aws",
         "interfaces" : {
@@ -4335,8 +4335,8 @@
       "vpc-925131f4" : {
         "configurationFormat" : "AWS",
         "name" : "vpc-925131f4",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "domainName" : "aws",
         "interfaces" : {
@@ -4468,8 +4468,8 @@
       "vpc-b390fad5" : {
         "configurationFormat" : "AWS",
         "name" : "vpc-b390fad5",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "domainName" : "aws",
         "interfaces" : {
@@ -4709,8 +4709,8 @@
       "vpc-f8fad69d" : {
         "configurationFormat" : "AWS",
         "name" : "vpc-f8fad69d",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "domainName" : "aws",
         "interfaces" : {

--- a/tests/basic/nodes-diff.ref
+++ b/tests/basic/nodes-diff.ref
@@ -19,7 +19,7 @@
             "103" : {
               "class" : "org.batfish.datamodel.ConfigDiffElement",
               "inAfterOnly" : [
-                "ACCEPT 3.0.2.0/24 [24,24] "
+                "PERMIT 3.0.2.0/24 [24,24] "
               ]
             }
           }

--- a/tests/basic/nodes.ref
+++ b/tests/basic/nodes.ref
@@ -11,7 +11,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.RegexCommunitySet",
                   "regex" : "(,|\\{|\\}|^|$| )1:"
@@ -25,7 +25,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.RegexCommunitySet",
                   "regex" : "(,|\\{|\\}|^|$| )2:"
@@ -39,7 +39,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.RegexCommunitySet",
                   "regex" : "(,|\\{|\\}|^|$| )3:"
@@ -49,8 +49,8 @@
             "name" : "as3_community"
           }
         },
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "domainName" : "lab.local",
         "interfaces" : {
@@ -176,7 +176,7 @@
             "name" : "101",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -194,7 +194,7 @@
                 "name" : "permit ip host 1.0.1.0 host 255.255.255.0"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -219,7 +219,7 @@
             "name" : "102",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -237,7 +237,7 @@
                 "name" : "permit ip host 2.0.0.0 host 255.0.0.0"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -262,7 +262,7 @@
             "name" : "103",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -280,7 +280,7 @@
                 "name" : "permit ip host 3.0.1.0 host 255.255.255.0"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -306,12 +306,12 @@
           "101" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "1.0.1.0/24",
                 "lengthRange" : "24-24"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "1.0.2.0/24",
                 "lengthRange" : "24-24"
               }
@@ -321,12 +321,12 @@
           "102" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "2.0.0.0/8",
                 "lengthRange" : "8-8"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "2.128.0.0/16",
                 "lengthRange" : "16-16"
               }
@@ -336,12 +336,12 @@
           "103" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "3.0.1.0/24",
                 "lengthRange" : "24-24"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "3.0.2.0/24",
                 "lengthRange" : "24-24"
               }
@@ -351,7 +351,7 @@
           "default_list" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "0.0.0.0/0",
                 "lengthRange" : "0-0"
               }
@@ -361,12 +361,12 @@
           "inbound_route_filter" : {
             "lines" : [
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "ipWildcard" : "1.0.0.0/8",
                 "lengthRange" : "8-32"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "0.0.0.0/0",
                 "lengthRange" : "0-32"
               }
@@ -1214,7 +1214,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.RegexCommunitySet",
                   "regex" : "(,|\\{|\\}|^|$| )1:"
@@ -1228,7 +1228,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.RegexCommunitySet",
                   "regex" : "(,|\\{|\\}|^|$| )2:"
@@ -1242,7 +1242,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.RegexCommunitySet",
                   "regex" : "(,|\\{|\\}|^|$| )3:"
@@ -1256,7 +1256,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.RegexCommunitySet",
                   "regex" : "(,|\\{|\\}|^|$| )4:"
@@ -1266,8 +1266,8 @@
             "name" : "as4_community"
           }
         },
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "domainName" : "lab.local",
         "interfaces" : {
@@ -1422,7 +1422,7 @@
             "name" : "101",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -1440,7 +1440,7 @@
                 "name" : "permit ip host 1.0.1.0 host 255.255.255.0"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -1465,7 +1465,7 @@
             "name" : "102",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -1483,7 +1483,7 @@
                 "name" : "permit ip host 2.0.0.0 host 255.0.0.0"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -1508,7 +1508,7 @@
             "name" : "103",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -1538,12 +1538,12 @@
           "101" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "1.0.1.0/24",
                 "lengthRange" : "24-24"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "1.0.2.0/24",
                 "lengthRange" : "24-24"
               }
@@ -1553,12 +1553,12 @@
           "102" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "2.0.0.0/8",
                 "lengthRange" : "8-8"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "2.128.0.0/16",
                 "lengthRange" : "16-16"
               }
@@ -1568,7 +1568,7 @@
           "103" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "3.0.1.0/24",
                 "lengthRange" : "24-24"
               }
@@ -1578,7 +1578,7 @@
           "as4-prefixes" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "4.0.0.0/8",
                 "lengthRange" : "8-32"
               }
@@ -1588,12 +1588,12 @@
           "inbound_route_filter" : {
             "lines" : [
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "ipWildcard" : "1.0.0.0/8",
                 "lengthRange" : "8-32"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "0.0.0.0/0",
                 "lengthRange" : "0-32"
               }
@@ -2454,8 +2454,8 @@
       "as1core1" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "as1core1",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "domainName" : "lab.local",
         "interfaces" : {
@@ -2857,7 +2857,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.RegexCommunitySet",
                   "regex" : "(,|\\{|\\}|^|$| )1:"
@@ -2871,7 +2871,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.RegexCommunitySet",
                   "regex" : "(,|\\{|\\}|^|$| )2:"
@@ -2885,7 +2885,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.RegexCommunitySet",
                   "regex" : "(,|\\{|\\}|^|$| )3:"
@@ -2895,8 +2895,8 @@
             "name" : "as3_community"
           }
         },
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "domainName" : "lab.local",
         "interfaces" : {
@@ -3055,7 +3055,7 @@
             "name" : "101",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -3073,7 +3073,7 @@
                 "name" : "permit ip host 1.0.1.0 host 255.255.255.0"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -3098,7 +3098,7 @@
             "name" : "103",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -3116,7 +3116,7 @@
                 "name" : "permit ip host 3.0.1.0 host 255.255.255.0"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -3141,7 +3141,7 @@
             "name" : "INSIDE_TO_AS1",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -3159,7 +3159,7 @@
                 "name" : "permit ip 2.0.0.0 0.255.255.255 1.0.0.0 0.255.255.255"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -3177,7 +3177,7 @@
                 "name" : "permit ip 10.12.11.2 0.0.0.0 10.12.11.1 0.0.0.0"
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -3202,7 +3202,7 @@
             "name" : "OUTSIDE_TO_INSIDE",
             "lines" : [
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -3220,7 +3220,7 @@
                 "name" : "deny   ip 2.0.0.0 0.255.255.255 any"
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -3238,7 +3238,7 @@
                 "name" : "deny   ip any host 2.128.1.101"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -3268,12 +3268,12 @@
           "101" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "1.0.1.0/24",
                 "lengthRange" : "24-24"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "1.0.2.0/24",
                 "lengthRange" : "24-24"
               }
@@ -3283,12 +3283,12 @@
           "103" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "3.0.1.0/24",
                 "lengthRange" : "24-24"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "3.0.2.0/24",
                 "lengthRange" : "24-24"
               }
@@ -3298,12 +3298,12 @@
           "inbound_route_filter" : {
             "lines" : [
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "ipWildcard" : "2.0.0.0/8",
                 "lengthRange" : "8-32"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "0.0.0.0/0",
                 "lengthRange" : "0-32"
               }
@@ -3313,7 +3313,7 @@
           "outbound_routes" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "2.128.0.0/9",
                 "lengthRange" : "16-32"
               }
@@ -3323,7 +3323,7 @@
           "~MATCH_SUPPRESSED_SUMMARY_ONLY:default~" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "2.128.0.0/16",
                 "lengthRange" : "17-32"
               }
@@ -4124,7 +4124,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.RegexCommunitySet",
                   "regex" : "(,|\\{|\\}|^|$| )1:"
@@ -4138,7 +4138,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.RegexCommunitySet",
                   "regex" : "(,|\\{|\\}|^|$| )2:"
@@ -4152,7 +4152,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.RegexCommunitySet",
                   "regex" : "(,|\\{|\\}|^|$| )3:"
@@ -4162,8 +4162,8 @@
             "name" : "as3_community"
           }
         },
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "domainName" : "lab.local",
         "interfaces" : {
@@ -4322,7 +4322,7 @@
             "name" : "101",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -4340,7 +4340,7 @@
                 "name" : "permit ip host 1.0.1.0 host 255.255.255.0"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -4365,7 +4365,7 @@
             "name" : "103",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -4383,7 +4383,7 @@
                 "name" : "permit ip host 3.0.1.0 host 255.255.255.0"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -4408,7 +4408,7 @@
             "name" : "INSIDE_TO_AS3",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -4426,7 +4426,7 @@
                 "name" : "permit ip 2.0.0.0 0.255.255.255 3.0.0.0 0.255.255.255"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -4444,7 +4444,7 @@
                 "name" : "permit ip 10.23.21.2 0.0.0.0 10.23.21.3 0.0.0.0"
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -4469,7 +4469,7 @@
             "name" : "OUTSIDE_TO_INSIDE",
             "lines" : [
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -4487,7 +4487,7 @@
                 "name" : "deny   ip 2.0.0.0 0.255.255.255 any"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -4516,12 +4516,12 @@
           "101" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "1.0.1.0/24",
                 "lengthRange" : "24-24"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "1.0.2.0/24",
                 "lengthRange" : "24-24"
               }
@@ -4531,12 +4531,12 @@
           "103" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "3.0.1.0/24",
                 "lengthRange" : "24-24"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "3.0.2.0/24",
                 "lengthRange" : "24-24"
               }
@@ -4546,12 +4546,12 @@
           "inbound_route_filter" : {
             "lines" : [
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "ipWildcard" : "2.0.0.0/8",
                 "lengthRange" : "8-32"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "0.0.0.0/0",
                 "lengthRange" : "0-32"
               }
@@ -4561,7 +4561,7 @@
           "outbound_routes" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "2.128.0.0/9",
                 "lengthRange" : "16-32"
               }
@@ -4571,7 +4571,7 @@
           "~MATCH_SUPPRESSED_SUMMARY_ONLY:default~" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "2.128.0.0/16",
                 "lengthRange" : "17-32"
               }
@@ -5328,8 +5328,8 @@
       "as2core1" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "as2core1",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "domainName" : "lab.local",
         "interfaces" : {
@@ -5521,7 +5521,7 @@
             "name" : "blocktelnet",
             "lines" : [
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -5545,7 +5545,7 @@
                 "name" : "deny   tcp any any eq telnet"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -5938,8 +5938,8 @@
       "as2core2" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "as2core2",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "domainName" : "lab.local",
         "interfaces" : {
@@ -6501,7 +6501,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.RegexCommunitySet",
                   "regex" : "(,|\\{|\\}|^|$| )2:"
@@ -6511,8 +6511,8 @@
             "name" : "as2_community"
           }
         },
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "domainName" : "lab.local",
         "interfaces" : {
@@ -6694,7 +6694,7 @@
             "name" : "102",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -6712,7 +6712,7 @@
                 "name" : "permit ip host 2.128.0.0 host 255.255.255.0"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -6737,7 +6737,7 @@
             "name" : "105",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -6755,7 +6755,7 @@
                 "name" : "permit ip host 1.0.1.0 host 255.255.255.0"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -6773,7 +6773,7 @@
                 "name" : "permit ip host 1.0.2.0 host 255.255.255.0"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -6791,7 +6791,7 @@
                 "name" : "permit ip host 3.0.1.0 host 255.255.255.0"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -6816,7 +6816,7 @@
             "name" : "RESTRICT_HOST_TRAFFIC_IN",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -6834,7 +6834,7 @@
                 "name" : "permit ip 2.128.0.0 0.0.255.255 any"
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -6852,7 +6852,7 @@
                 "name" : "deny   ip any any"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -6880,7 +6880,7 @@
             "name" : "RESTRICT_HOST_TRAFFIC_OUT",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -6898,7 +6898,7 @@
                 "name" : "permit ip any 2.128.0.0 0.0.255.255"
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -6916,7 +6916,7 @@
                 "name" : "deny   ip 1.128.0.0 0.0.255.255 2.128.0.0 0.0.255.255"
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -6942,12 +6942,12 @@
           "102" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "2.128.0.0/24",
                 "lengthRange" : "24-24"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "2.128.1.0/24",
                 "lengthRange" : "24-24"
               }
@@ -7456,7 +7456,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.RegexCommunitySet",
                   "regex" : "(,|\\{|\\}|^|$| )65001:"
@@ -7466,8 +7466,8 @@
             "name" : "dept_community"
           }
         },
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "domainName" : "lab.local",
         "interfaces" : {
@@ -7624,7 +7624,7 @@
             "name" : "102",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -7649,7 +7649,7 @@
             "name" : "105",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -7667,7 +7667,7 @@
                 "name" : "permit ip host 1.0.1.0 host 255.255.255.0"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -7685,7 +7685,7 @@
                 "name" : "permit ip host 1.0.2.0 host 255.255.255.0"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -7703,7 +7703,7 @@
                 "name" : "permit ip host 3.0.1.0 host 255.255.255.0"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -7729,22 +7729,22 @@
           "105" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "1.0.1.0/24",
                 "lengthRange" : "24-24"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "1.0.2.0/24",
                 "lengthRange" : "24-24"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "3.0.1.0/24",
                 "lengthRange" : "24-24"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "3.0.2.0/24",
                 "lengthRange" : "24-24"
               }
@@ -8213,7 +8213,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.RegexCommunitySet",
                   "regex" : "(,|\\{|\\}|^|$| )65001:"
@@ -8223,8 +8223,8 @@
             "name" : "dept_community"
           }
         },
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "domainName" : "lab.local",
         "interfaces" : {
@@ -8381,7 +8381,7 @@
             "name" : "102",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -8406,7 +8406,7 @@
             "name" : "105",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -8424,7 +8424,7 @@
                 "name" : "permit ip host 1.0.1.0 host 255.255.255.0"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -8442,7 +8442,7 @@
                 "name" : "permit ip host 1.0.2.0 host 255.255.255.0"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -8460,7 +8460,7 @@
                 "name" : "permit ip host 3.0.1.0 host 255.255.255.0"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -8486,22 +8486,22 @@
           "105" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "1.0.1.0/24",
                 "lengthRange" : "24-24"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "1.0.2.0/24",
                 "lengthRange" : "24-24"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "3.0.1.0/24",
                 "lengthRange" : "24-24"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "3.0.2.0/24",
                 "lengthRange" : "24-24"
               }
@@ -8970,7 +8970,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.RegexCommunitySet",
                   "regex" : "(,|\\{|\\}|^|$| )1:"
@@ -8984,7 +8984,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.RegexCommunitySet",
                   "regex" : "(,|\\{|\\}|^|$| )2:"
@@ -8998,7 +8998,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.RegexCommunitySet",
                   "regex" : "(,|\\{|\\}|^|$| )3:"
@@ -9008,8 +9008,8 @@
             "name" : "as3_community"
           }
         },
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "domainName" : "lab.local",
         "interfaces" : {
@@ -9135,7 +9135,7 @@
             "name" : "101",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -9153,7 +9153,7 @@
                 "name" : "permit ip host 1.0.1.0 host 255.255.255.0"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -9178,7 +9178,7 @@
             "name" : "102",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -9196,7 +9196,7 @@
                 "name" : "permit ip host 2.0.0.0 host 255.0.0.0"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -9221,7 +9221,7 @@
             "name" : "103",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -9239,7 +9239,7 @@
                 "name" : "permit ip host 3.0.1.0 host 255.255.255.0"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -9269,12 +9269,12 @@
           "101" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "1.0.1.0/24",
                 "lengthRange" : "24-24"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "1.0.2.0/24",
                 "lengthRange" : "24-24"
               }
@@ -9284,12 +9284,12 @@
           "102" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "2.0.0.0/8",
                 "lengthRange" : "8-8"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "2.128.0.0/16",
                 "lengthRange" : "16-16"
               }
@@ -9299,12 +9299,12 @@
           "103" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "3.0.1.0/24",
                 "lengthRange" : "24-24"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "3.0.2.0/24",
                 "lengthRange" : "24-24"
               }
@@ -9314,7 +9314,7 @@
           "default_list" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "0.0.0.0/0",
                 "lengthRange" : "0-0"
               }
@@ -9324,12 +9324,12 @@
           "inbound_route_filter" : {
             "lines" : [
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "ipWildcard" : "3.0.0.0/8",
                 "lengthRange" : "8-32"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "0.0.0.0/0",
                 "lengthRange" : "0-32"
               }
@@ -10095,7 +10095,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.RegexCommunitySet",
                   "regex" : "(,|\\{|\\}|^|$| )1:"
@@ -10109,7 +10109,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.RegexCommunitySet",
                   "regex" : "(,|\\{|\\}|^|$| )2:"
@@ -10123,7 +10123,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.RegexCommunitySet",
                   "regex" : "(,|\\{|\\}|^|$| )3:"
@@ -10133,8 +10133,8 @@
             "name" : "as3_community"
           }
         },
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "domainName" : "lab.local",
         "interfaces" : {
@@ -10260,7 +10260,7 @@
             "name" : "101",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -10278,7 +10278,7 @@
                 "name" : "permit ip host 1.0.1.0 host 255.255.255.0"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -10303,7 +10303,7 @@
             "name" : "102",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -10321,7 +10321,7 @@
                 "name" : "permit ip host 2.0.0.0 host 255.0.0.0"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -10346,7 +10346,7 @@
             "name" : "103",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -10364,7 +10364,7 @@
                 "name" : "permit ip host 3.0.1.0 host 255.255.255.0"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -10394,12 +10394,12 @@
           "101" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "1.0.1.0/24",
                 "lengthRange" : "24-24"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "1.0.2.0/24",
                 "lengthRange" : "24-24"
               }
@@ -10409,12 +10409,12 @@
           "102" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "2.0.0.0/8",
                 "lengthRange" : "8-8"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "2.128.0.0/16",
                 "lengthRange" : "16-16"
               }
@@ -10424,12 +10424,12 @@
           "103" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "3.0.1.0/24",
                 "lengthRange" : "24-24"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "3.0.2.0/24",
                 "lengthRange" : "24-24"
               }
@@ -10439,12 +10439,12 @@
           "inbound_route_filter" : {
             "lines" : [
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "ipWildcard" : "3.0.0.0/8",
                 "lengthRange" : "8-32"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "0.0.0.0/0",
                 "lengthRange" : "0-32"
               }
@@ -11166,8 +11166,8 @@
       "as3core1" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "as3core1",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "domainName" : "lab.local",
         "interfaces" : {
@@ -11763,8 +11763,8 @@
       "host1" : {
         "configurationFormat" : "HOST",
         "name" : "host1",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "HOST",
         "interfaces" : {
           "eth0" : {
@@ -11804,7 +11804,7 @@
             "name" : "filter::FORWARD",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
@@ -11816,7 +11816,7 @@
             "name" : "filter::INPUT",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -11832,7 +11832,7 @@
                 "name" : "-p udp --dport 53 -j ACCEPT"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -11848,7 +11848,7 @@
                 "name" : "-p tcp --dport 22 -j ACCEPT"
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
@@ -11860,7 +11860,7 @@
             "name" : "filter::OUTPUT",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
@@ -11872,7 +11872,7 @@
             "name" : "mangle::FORWARD",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
@@ -11884,7 +11884,7 @@
             "name" : "mangle::INPUT",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
@@ -11896,7 +11896,7 @@
             "name" : "mangle::OUTPUT",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
@@ -11908,7 +11908,7 @@
             "name" : "mangle::POSTROUTING",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
@@ -11920,7 +11920,7 @@
             "name" : "mangle::PREROUTING",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
@@ -11932,7 +11932,7 @@
             "name" : "nat::OUTPUT",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
@@ -11944,7 +11944,7 @@
             "name" : "nat::POSTROUTING",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
@@ -11956,7 +11956,7 @@
             "name" : "nat::PREROUTING",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
@@ -11989,8 +11989,8 @@
       "host2" : {
         "configurationFormat" : "HOST",
         "name" : "host2",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "HOST",
         "interfaces" : {
           "eth0" : {
@@ -12030,7 +12030,7 @@
             "name" : "filter::FORWARD",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
@@ -12042,7 +12042,7 @@
             "name" : "filter::INPUT",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -12058,7 +12058,7 @@
                 "name" : "-p tcp --dport 22 -j ACCEPT"
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
@@ -12070,7 +12070,7 @@
             "name" : "filter::OUTPUT",
             "lines" : [
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -12084,7 +12084,7 @@
                 "name" : "-d 2.128.0.101 -j DROP"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
@@ -12096,7 +12096,7 @@
             "name" : "mangle::FORWARD",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
@@ -12108,7 +12108,7 @@
             "name" : "mangle::INPUT",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
@@ -12120,7 +12120,7 @@
             "name" : "mangle::OUTPUT",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
@@ -12132,7 +12132,7 @@
             "name" : "mangle::POSTROUTING",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
@@ -12144,7 +12144,7 @@
             "name" : "mangle::PREROUTING",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
@@ -12156,7 +12156,7 @@
             "name" : "nat::OUTPUT",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
@@ -12168,7 +12168,7 @@
             "name" : "nat::POSTROUTING",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
@@ -12180,7 +12180,7 @@
             "name" : "nat::PREROUTING",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },

--- a/tests/basic/outliers-verbose.ref
+++ b/tests/basic/outliers-verbose.ref
@@ -63,7 +63,7 @@
           "invertMatch" : false,
           "lines" : [
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.RegexCommunitySet",
                 "regex" : "(,|\\{|\\}|^|$| )2:"
@@ -89,7 +89,7 @@
           "invertMatch" : false,
           "lines" : [
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.RegexCommunitySet",
                 "regex" : "(,|\\{|\\}|^|$| )1:"
@@ -115,7 +115,7 @@
           "invertMatch" : false,
           "lines" : [
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.RegexCommunitySet",
                 "regex" : "(,|\\{|\\}|^|$| )3:"
@@ -141,7 +141,7 @@
           "name" : "101",
           "lines" : [
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                 "headerSpace" : {
@@ -159,7 +159,7 @@
               "name" : "permit ip host 1.0.1.0 host 255.255.255.0"
             },
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                 "headerSpace" : {
@@ -196,12 +196,12 @@
         "structDefinition" : {
           "lines" : [
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "ipWildcard" : "1.0.1.0/24",
               "lengthRange" : "24-24"
             },
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "ipWildcard" : "1.0.2.0/24",
               "lengthRange" : "24-24"
             }
@@ -222,7 +222,7 @@
           "name" : "105",
           "lines" : [
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                 "headerSpace" : {
@@ -240,7 +240,7 @@
               "name" : "permit ip host 1.0.1.0 host 255.255.255.0"
             },
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                 "headerSpace" : {
@@ -258,7 +258,7 @@
               "name" : "permit ip host 1.0.2.0 host 255.255.255.0"
             },
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                 "headerSpace" : {
@@ -276,7 +276,7 @@
               "name" : "permit ip host 3.0.1.0 host 255.255.255.0"
             },
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                 "headerSpace" : {
@@ -310,7 +310,7 @@
           "invertMatch" : false,
           "lines" : [
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.RegexCommunitySet",
                 "regex" : "(,|\\{|\\}|^|$| )65001:"
@@ -332,7 +332,7 @@
           "name" : "filter::FORWARD",
           "lines" : [
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.TrueExpr"
               },
@@ -353,7 +353,7 @@
           "name" : "mangle::FORWARD",
           "lines" : [
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.TrueExpr"
               },
@@ -374,7 +374,7 @@
           "name" : "mangle::INPUT",
           "lines" : [
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.TrueExpr"
               },
@@ -395,7 +395,7 @@
           "name" : "mangle::OUTPUT",
           "lines" : [
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.TrueExpr"
               },
@@ -416,7 +416,7 @@
           "name" : "mangle::POSTROUTING",
           "lines" : [
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.TrueExpr"
               },
@@ -437,7 +437,7 @@
           "name" : "mangle::PREROUTING",
           "lines" : [
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.TrueExpr"
               },
@@ -458,7 +458,7 @@
           "name" : "nat::OUTPUT",
           "lines" : [
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.TrueExpr"
               },
@@ -479,7 +479,7 @@
           "name" : "nat::POSTROUTING",
           "lines" : [
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.TrueExpr"
               },
@@ -500,7 +500,7 @@
           "name" : "nat::PREROUTING",
           "lines" : [
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.TrueExpr"
               },
@@ -520,22 +520,22 @@
         "structDefinition" : {
           "lines" : [
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "ipWildcard" : "1.0.1.0/24",
               "lengthRange" : "24-24"
             },
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "ipWildcard" : "1.0.2.0/24",
               "lengthRange" : "24-24"
             },
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "ipWildcard" : "3.0.1.0/24",
               "lengthRange" : "24-24"
             },
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "ipWildcard" : "3.0.2.0/24",
               "lengthRange" : "24-24"
             }
@@ -554,7 +554,7 @@
         "structDefinition" : {
           "lines" : [
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "ipWildcard" : "0.0.0.0/0",
               "lengthRange" : "0-0"
             }
@@ -573,7 +573,7 @@
         "structDefinition" : {
           "lines" : [
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "ipWildcard" : "2.128.0.0/9",
               "lengthRange" : "16-32"
             }
@@ -699,7 +699,7 @@
           "name" : "103",
           "lines" : [
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                 "headerSpace" : {
@@ -717,7 +717,7 @@
               "name" : "permit ip host 3.0.1.0 host 255.255.255.0"
             },
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                 "headerSpace" : {
@@ -756,12 +756,12 @@
         "structDefinition" : {
           "lines" : [
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "ipWildcard" : "3.0.1.0/24",
               "lengthRange" : "24-24"
             },
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "ipWildcard" : "3.0.2.0/24",
               "lengthRange" : "24-24"
             }
@@ -780,7 +780,7 @@
           "invertMatch" : false,
           "lines" : [
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.RegexCommunitySet",
                 "regex" : "(,|\\{|\\}|^|$| )4:"
@@ -801,7 +801,7 @@
           "name" : "INSIDE_TO_AS1",
           "lines" : [
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                 "headerSpace" : {
@@ -819,7 +819,7 @@
               "name" : "permit ip 2.0.0.0 0.255.255.255 1.0.0.0 0.255.255.255"
             },
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                 "headerSpace" : {
@@ -837,7 +837,7 @@
               "name" : "permit ip 10.12.11.2 0.0.0.0 10.12.11.1 0.0.0.0"
             },
             {
-              "action" : "REJECT",
+              "action" : "DENY",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                 "headerSpace" : {
@@ -870,7 +870,7 @@
           "name" : "INSIDE_TO_AS3",
           "lines" : [
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                 "headerSpace" : {
@@ -888,7 +888,7 @@
               "name" : "permit ip 2.0.0.0 0.255.255.255 3.0.0.0 0.255.255.255"
             },
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                 "headerSpace" : {
@@ -906,7 +906,7 @@
               "name" : "permit ip 10.23.21.2 0.0.0.0 10.23.21.3 0.0.0.0"
             },
             {
-              "action" : "REJECT",
+              "action" : "DENY",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                 "headerSpace" : {
@@ -939,7 +939,7 @@
           "name" : "RESTRICT_HOST_TRAFFIC_IN",
           "lines" : [
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                 "headerSpace" : {
@@ -957,7 +957,7 @@
               "name" : "permit ip 2.128.0.0 0.0.255.255 any"
             },
             {
-              "action" : "REJECT",
+              "action" : "DENY",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                 "headerSpace" : {
@@ -975,7 +975,7 @@
               "name" : "deny   ip any any"
             },
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                 "headerSpace" : {
@@ -1011,7 +1011,7 @@
           "name" : "RESTRICT_HOST_TRAFFIC_OUT",
           "lines" : [
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                 "headerSpace" : {
@@ -1029,7 +1029,7 @@
               "name" : "permit ip any 2.128.0.0 0.0.255.255"
             },
             {
-              "action" : "REJECT",
+              "action" : "DENY",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                 "headerSpace" : {
@@ -1047,7 +1047,7 @@
               "name" : "deny   ip 1.128.0.0 0.0.255.255 2.128.0.0 0.0.255.255"
             },
             {
-              "action" : "REJECT",
+              "action" : "DENY",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                 "headerSpace" : {
@@ -1080,7 +1080,7 @@
           "name" : "blocktelnet",
           "lines" : [
             {
-              "action" : "REJECT",
+              "action" : "DENY",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                 "headerSpace" : {
@@ -1104,7 +1104,7 @@
               "name" : "deny   tcp any any eq telnet"
             },
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                 "headerSpace" : {
@@ -1136,7 +1136,7 @@
         "structDefinition" : {
           "lines" : [
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "ipWildcard" : "4.0.0.0/8",
               "lengthRange" : "8-32"
             }
@@ -1349,12 +1349,12 @@
         "structDefinition" : {
           "lines" : [
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "ipWildcard" : "2.0.0.0/8",
               "lengthRange" : "8-8"
             },
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "ipWildcard" : "2.128.0.0/16",
               "lengthRange" : "16-16"
             }
@@ -1418,7 +1418,7 @@
           "name" : "OUTSIDE_TO_INSIDE",
           "lines" : [
             {
-              "action" : "REJECT",
+              "action" : "DENY",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                 "headerSpace" : {
@@ -1436,7 +1436,7 @@
               "name" : "deny   ip 2.0.0.0 0.255.255.255 any"
             },
             {
-              "action" : "REJECT",
+              "action" : "DENY",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                 "headerSpace" : {
@@ -1454,7 +1454,7 @@
               "name" : "deny   ip any host 2.128.1.101"
             },
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                 "headerSpace" : {
@@ -1490,7 +1490,7 @@
           "name" : "filter::INPUT",
           "lines" : [
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                 "headerSpace" : {
@@ -1506,7 +1506,7 @@
               "name" : "-p udp --dport 53 -j ACCEPT"
             },
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                 "headerSpace" : {
@@ -1522,7 +1522,7 @@
               "name" : "-p tcp --dport 22 -j ACCEPT"
             },
             {
-              "action" : "REJECT",
+              "action" : "DENY",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.TrueExpr"
               },
@@ -1545,7 +1545,7 @@
           "name" : "filter::OUTPUT",
           "lines" : [
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.TrueExpr"
               },
@@ -1573,7 +1573,7 @@
           "name" : "102",
           "lines" : [
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                 "headerSpace" : {
@@ -1591,7 +1591,7 @@
               "name" : "permit ip host 2.0.0.0 host 255.0.0.0"
             },
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                 "headerSpace" : {
@@ -2036,12 +2036,12 @@
         "structDefinition" : {
           "lines" : [
             {
-              "action" : "REJECT",
+              "action" : "DENY",
               "ipWildcard" : "1.0.0.0/8",
               "lengthRange" : "8-32"
             },
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "ipWildcard" : "0.0.0.0/0",
               "lengthRange" : "0-32"
             }

--- a/tests/basic/outliers.ref
+++ b/tests/basic/outliers.ref
@@ -19,7 +19,7 @@
           "name" : "103",
           "lines" : [
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                 "headerSpace" : {
@@ -37,7 +37,7 @@
               "name" : "permit ip host 3.0.1.0 host 255.255.255.0"
             },
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                 "headerSpace" : {
@@ -76,12 +76,12 @@
         "structDefinition" : {
           "lines" : [
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "ipWildcard" : "3.0.1.0/24",
               "lengthRange" : "24-24"
             },
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "ipWildcard" : "3.0.2.0/24",
               "lengthRange" : "24-24"
             }
@@ -105,12 +105,12 @@
         "structDefinition" : {
           "lines" : [
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "ipWildcard" : "2.0.0.0/8",
               "lengthRange" : "8-8"
             },
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "ipWildcard" : "2.128.0.0/16",
               "lengthRange" : "16-16"
             }

--- a/tests/basic/tracefilters.ref
+++ b/tests/basic/tracefilters.ref
@@ -87,7 +87,7 @@
           "tcpFlagsSyn" : 0,
           "tcpFlagsUrg" : 0
         },
-        "action" : "REJECT",
+        "action" : "DENY",
         "lineNumber" : 2,
         "lineContent" : "default",
         "trace" : {
@@ -133,7 +133,7 @@
           "tcpFlagsSyn" : 0,
           "tcpFlagsUrg" : 0
         },
-        "action" : "ACCEPT",
+        "action" : "PERMIT",
         "lineNumber" : 0,
         "lineContent" : "default",
         "trace" : {
@@ -142,52 +142,6 @@
               "class" : "org.batfish.datamodel.acl.PermittedByIpAccessListLine",
               "description" : "Flow permitted by ACL named 'filter::OUTPUT', index 0: default",
               "index" : 0,
-              "lineDescription" : "default",
-              "name" : "filter::OUTPUT"
-            }
-          ]
-        }
-      },
-      {
-        "node" : {
-          "id" : "node-host2",
-          "name" : "host2"
-        },
-        "filterName" : "filter::OUTPUT",
-        "flow" : {
-          "dscp" : 0,
-          "dstIp" : "1.1.1.1",
-          "dstPort" : 0,
-          "ecn" : 0,
-          "fragmentOffset" : 0,
-          "icmpCode" : 255,
-          "icmpVar" : 255,
-          "ingressNode" : "host2",
-          "ingressVrf" : "default",
-          "ipProtocol" : "IP",
-          "packetLength" : 0,
-          "srcIp" : "AUTO/NONE(-1l)",
-          "srcPort" : 0,
-          "state" : "NEW",
-          "tag" : "BASE",
-          "tcpFlagsAck" : 0,
-          "tcpFlagsCwr" : 0,
-          "tcpFlagsEce" : 0,
-          "tcpFlagsFin" : 0,
-          "tcpFlagsPsh" : 0,
-          "tcpFlagsRst" : 0,
-          "tcpFlagsSyn" : 0,
-          "tcpFlagsUrg" : 0
-        },
-        "action" : "ACCEPT",
-        "lineNumber" : 1,
-        "lineContent" : "default",
-        "trace" : {
-          "events" : [
-            {
-              "class" : "org.batfish.datamodel.acl.PermittedByIpAccessListLine",
-              "description" : "Flow permitted by ACL named 'filter::OUTPUT', index 1: default",
-              "index" : 1,
               "lineDescription" : "default",
               "name" : "filter::OUTPUT"
             }
@@ -225,7 +179,7 @@
           "tcpFlagsSyn" : 0,
           "tcpFlagsUrg" : 0
         },
-        "action" : "REJECT",
+        "action" : "DENY",
         "lineNumber" : 1,
         "lineContent" : "default",
         "trace" : {
@@ -236,6 +190,52 @@
               "index" : 1,
               "lineDescription" : "default",
               "name" : "filter::INPUT"
+            }
+          ]
+        }
+      },
+      {
+        "node" : {
+          "id" : "node-host2",
+          "name" : "host2"
+        },
+        "filterName" : "filter::OUTPUT",
+        "flow" : {
+          "dscp" : 0,
+          "dstIp" : "1.1.1.1",
+          "dstPort" : 0,
+          "ecn" : 0,
+          "fragmentOffset" : 0,
+          "icmpCode" : 255,
+          "icmpVar" : 255,
+          "ingressNode" : "host2",
+          "ingressVrf" : "default",
+          "ipProtocol" : "IP",
+          "packetLength" : 0,
+          "srcIp" : "AUTO/NONE(-1l)",
+          "srcPort" : 0,
+          "state" : "NEW",
+          "tag" : "BASE",
+          "tcpFlagsAck" : 0,
+          "tcpFlagsCwr" : 0,
+          "tcpFlagsEce" : 0,
+          "tcpFlagsFin" : 0,
+          "tcpFlagsPsh" : 0,
+          "tcpFlagsRst" : 0,
+          "tcpFlagsSyn" : 0,
+          "tcpFlagsUrg" : 0
+        },
+        "action" : "PERMIT",
+        "lineNumber" : 1,
+        "lineContent" : "default",
+        "trace" : {
+          "events" : [
+            {
+              "class" : "org.batfish.datamodel.acl.PermittedByIpAccessListLine",
+              "description" : "Flow permitted by ACL named 'filter::OUTPUT', index 1: default",
+              "index" : 1,
+              "lineDescription" : "default",
+              "name" : "filter::OUTPUT"
             }
           ]
         }
@@ -271,7 +271,7 @@
           "tcpFlagsSyn" : 0,
           "tcpFlagsUrg" : 0
         },
-        "action" : "ACCEPT",
+        "action" : "PERMIT",
         "lineNumber" : 0,
         "lineContent" : "default",
         "trace" : {
@@ -317,7 +317,7 @@
           "tcpFlagsSyn" : 0,
           "tcpFlagsUrg" : 0
         },
-        "action" : "ACCEPT",
+        "action" : "PERMIT",
         "lineNumber" : 0,
         "lineContent" : "default",
         "trace" : {

--- a/tests/jsonpath-addons/jsonpath-display-hints-prefixofsuffix.ref
+++ b/tests/jsonpath-addons/jsonpath-display-hints-prefixofsuffix.ref
@@ -30,7 +30,7 @@
                   "invertMatch" : false,
                   "lines" : [
                     {
-                      "action" : "ACCEPT",
+                      "action" : "PERMIT",
                       "matchCondition" : {
                         "class" : "org.batfish.datamodel.RegexCommunitySet",
                         "regex" : "(,|\\{|\\}|^|$| )1:"
@@ -44,7 +44,7 @@
                   "invertMatch" : false,
                   "lines" : [
                     {
-                      "action" : "ACCEPT",
+                      "action" : "PERMIT",
                       "matchCondition" : {
                         "class" : "org.batfish.datamodel.RegexCommunitySet",
                         "regex" : "(,|\\{|\\}|^|$| )2:"
@@ -58,7 +58,7 @@
                   "invertMatch" : false,
                   "lines" : [
                     {
-                      "action" : "ACCEPT",
+                      "action" : "PERMIT",
                       "matchCondition" : {
                         "class" : "org.batfish.datamodel.RegexCommunitySet",
                         "regex" : "(,|\\{|\\}|^|$| )3:"
@@ -68,8 +68,8 @@
                   "name" : "as3_community"
                 }
               },
-              "defaultCrossZoneAction" : "ACCEPT",
-              "defaultInboundAction" : "ACCEPT",
+              "defaultCrossZoneAction" : "PERMIT",
+              "defaultInboundAction" : "PERMIT",
               "deviceType" : "ROUTER",
               "domainName" : "lab.local",
               "interfaces" : {
@@ -228,7 +228,7 @@
                   "name" : "101",
                   "lines" : [
                     {
-                      "action" : "ACCEPT",
+                      "action" : "PERMIT",
                       "matchCondition" : {
                         "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                         "headerSpace" : {
@@ -246,7 +246,7 @@
                       "name" : "permit ip host 1.0.1.0 host 255.255.255.0"
                     },
                     {
-                      "action" : "ACCEPT",
+                      "action" : "PERMIT",
                       "matchCondition" : {
                         "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                         "headerSpace" : {
@@ -271,7 +271,7 @@
                   "name" : "103",
                   "lines" : [
                     {
-                      "action" : "ACCEPT",
+                      "action" : "PERMIT",
                       "matchCondition" : {
                         "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                         "headerSpace" : {
@@ -289,7 +289,7 @@
                       "name" : "permit ip host 3.0.1.0 host 255.255.255.0"
                     },
                     {
-                      "action" : "ACCEPT",
+                      "action" : "PERMIT",
                       "matchCondition" : {
                         "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                         "headerSpace" : {
@@ -314,7 +314,7 @@
                   "name" : "INSIDE_TO_AS1",
                   "lines" : [
                     {
-                      "action" : "ACCEPT",
+                      "action" : "PERMIT",
                       "matchCondition" : {
                         "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                         "headerSpace" : {
@@ -332,7 +332,7 @@
                       "name" : "permit ip 2.0.0.0 0.255.255.255 1.0.0.0 0.255.255.255"
                     },
                     {
-                      "action" : "ACCEPT",
+                      "action" : "PERMIT",
                       "matchCondition" : {
                         "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                         "headerSpace" : {
@@ -350,7 +350,7 @@
                       "name" : "permit ip 10.12.11.2 0.0.0.0 10.12.11.1 0.0.0.0"
                     },
                     {
-                      "action" : "REJECT",
+                      "action" : "DENY",
                       "matchCondition" : {
                         "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                         "headerSpace" : {
@@ -375,7 +375,7 @@
                   "name" : "OUTSIDE_TO_INSIDE",
                   "lines" : [
                     {
-                      "action" : "REJECT",
+                      "action" : "DENY",
                       "matchCondition" : {
                         "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                         "headerSpace" : {
@@ -393,7 +393,7 @@
                       "name" : "deny   ip 2.0.0.0 0.255.255.255 any"
                     },
                     {
-                      "action" : "REJECT",
+                      "action" : "DENY",
                       "matchCondition" : {
                         "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                         "headerSpace" : {
@@ -411,7 +411,7 @@
                       "name" : "deny   ip any host 2.128.1.101"
                     },
                     {
-                      "action" : "ACCEPT",
+                      "action" : "PERMIT",
                       "matchCondition" : {
                         "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                         "headerSpace" : {
@@ -441,12 +441,12 @@
                 "101" : {
                   "lines" : [
                     {
-                      "action" : "ACCEPT",
+                      "action" : "PERMIT",
                       "ipWildcard" : "1.0.1.0/24",
                       "lengthRange" : "24-24"
                     },
                     {
-                      "action" : "ACCEPT",
+                      "action" : "PERMIT",
                       "ipWildcard" : "1.0.2.0/24",
                       "lengthRange" : "24-24"
                     }
@@ -456,12 +456,12 @@
                 "103" : {
                   "lines" : [
                     {
-                      "action" : "ACCEPT",
+                      "action" : "PERMIT",
                       "ipWildcard" : "3.0.1.0/24",
                       "lengthRange" : "24-24"
                     },
                     {
-                      "action" : "ACCEPT",
+                      "action" : "PERMIT",
                       "ipWildcard" : "3.0.2.0/24",
                       "lengthRange" : "24-24"
                     }
@@ -471,12 +471,12 @@
                 "inbound_route_filter" : {
                   "lines" : [
                     {
-                      "action" : "REJECT",
+                      "action" : "DENY",
                       "ipWildcard" : "2.0.0.0/8",
                       "lengthRange" : "8-32"
                     },
                     {
-                      "action" : "ACCEPT",
+                      "action" : "PERMIT",
                       "ipWildcard" : "0.0.0.0/0",
                       "lengthRange" : "0-32"
                     }
@@ -486,7 +486,7 @@
                 "outbound_routes" : {
                   "lines" : [
                     {
-                      "action" : "ACCEPT",
+                      "action" : "PERMIT",
                       "ipWildcard" : "2.128.0.0/9",
                       "lengthRange" : "16-32"
                     }
@@ -496,7 +496,7 @@
                 "~MATCH_SUPPRESSED_SUMMARY_ONLY:default~" : {
                   "lines" : [
                     {
-                      "action" : "ACCEPT",
+                      "action" : "PERMIT",
                       "ipWildcard" : "2.128.0.0/16",
                       "lengthRange" : "17-32"
                     }

--- a/tests/jsonpath-addons/jsonpath-display-hints-suffixofsuffix.ref
+++ b/tests/jsonpath-addons/jsonpath-display-hints-suffixofsuffix.ref
@@ -30,7 +30,7 @@
                   "invertMatch" : false,
                   "lines" : [
                     {
-                      "action" : "ACCEPT",
+                      "action" : "PERMIT",
                       "matchCondition" : {
                         "class" : "org.batfish.datamodel.RegexCommunitySet",
                         "regex" : "(,|\\{|\\}|^|$| )1:"
@@ -44,7 +44,7 @@
                   "invertMatch" : false,
                   "lines" : [
                     {
-                      "action" : "ACCEPT",
+                      "action" : "PERMIT",
                       "matchCondition" : {
                         "class" : "org.batfish.datamodel.RegexCommunitySet",
                         "regex" : "(,|\\{|\\}|^|$| )2:"
@@ -58,7 +58,7 @@
                   "invertMatch" : false,
                   "lines" : [
                     {
-                      "action" : "ACCEPT",
+                      "action" : "PERMIT",
                       "matchCondition" : {
                         "class" : "org.batfish.datamodel.RegexCommunitySet",
                         "regex" : "(,|\\{|\\}|^|$| )3:"
@@ -68,8 +68,8 @@
                   "name" : "as3_community"
                 }
               },
-              "defaultCrossZoneAction" : "ACCEPT",
-              "defaultInboundAction" : "ACCEPT",
+              "defaultCrossZoneAction" : "PERMIT",
+              "defaultInboundAction" : "PERMIT",
               "deviceType" : "ROUTER",
               "domainName" : "lab.local",
               "interfaces" : {
@@ -228,7 +228,7 @@
                   "name" : "101",
                   "lines" : [
                     {
-                      "action" : "ACCEPT",
+                      "action" : "PERMIT",
                       "matchCondition" : {
                         "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                         "headerSpace" : {
@@ -246,7 +246,7 @@
                       "name" : "permit ip host 1.0.1.0 host 255.255.255.0"
                     },
                     {
-                      "action" : "ACCEPT",
+                      "action" : "PERMIT",
                       "matchCondition" : {
                         "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                         "headerSpace" : {
@@ -271,7 +271,7 @@
                   "name" : "103",
                   "lines" : [
                     {
-                      "action" : "ACCEPT",
+                      "action" : "PERMIT",
                       "matchCondition" : {
                         "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                         "headerSpace" : {
@@ -289,7 +289,7 @@
                       "name" : "permit ip host 3.0.1.0 host 255.255.255.0"
                     },
                     {
-                      "action" : "ACCEPT",
+                      "action" : "PERMIT",
                       "matchCondition" : {
                         "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                         "headerSpace" : {
@@ -314,7 +314,7 @@
                   "name" : "INSIDE_TO_AS1",
                   "lines" : [
                     {
-                      "action" : "ACCEPT",
+                      "action" : "PERMIT",
                       "matchCondition" : {
                         "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                         "headerSpace" : {
@@ -332,7 +332,7 @@
                       "name" : "permit ip 2.0.0.0 0.255.255.255 1.0.0.0 0.255.255.255"
                     },
                     {
-                      "action" : "ACCEPT",
+                      "action" : "PERMIT",
                       "matchCondition" : {
                         "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                         "headerSpace" : {
@@ -350,7 +350,7 @@
                       "name" : "permit ip 10.12.11.2 0.0.0.0 10.12.11.1 0.0.0.0"
                     },
                     {
-                      "action" : "REJECT",
+                      "action" : "DENY",
                       "matchCondition" : {
                         "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                         "headerSpace" : {
@@ -375,7 +375,7 @@
                   "name" : "OUTSIDE_TO_INSIDE",
                   "lines" : [
                     {
-                      "action" : "REJECT",
+                      "action" : "DENY",
                       "matchCondition" : {
                         "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                         "headerSpace" : {
@@ -393,7 +393,7 @@
                       "name" : "deny   ip 2.0.0.0 0.255.255.255 any"
                     },
                     {
-                      "action" : "REJECT",
+                      "action" : "DENY",
                       "matchCondition" : {
                         "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                         "headerSpace" : {
@@ -411,7 +411,7 @@
                       "name" : "deny   ip any host 2.128.1.101"
                     },
                     {
-                      "action" : "ACCEPT",
+                      "action" : "PERMIT",
                       "matchCondition" : {
                         "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                         "headerSpace" : {
@@ -441,12 +441,12 @@
                 "101" : {
                   "lines" : [
                     {
-                      "action" : "ACCEPT",
+                      "action" : "PERMIT",
                       "ipWildcard" : "1.0.1.0/24",
                       "lengthRange" : "24-24"
                     },
                     {
-                      "action" : "ACCEPT",
+                      "action" : "PERMIT",
                       "ipWildcard" : "1.0.2.0/24",
                       "lengthRange" : "24-24"
                     }
@@ -456,12 +456,12 @@
                 "103" : {
                   "lines" : [
                     {
-                      "action" : "ACCEPT",
+                      "action" : "PERMIT",
                       "ipWildcard" : "3.0.1.0/24",
                       "lengthRange" : "24-24"
                     },
                     {
-                      "action" : "ACCEPT",
+                      "action" : "PERMIT",
                       "ipWildcard" : "3.0.2.0/24",
                       "lengthRange" : "24-24"
                     }
@@ -471,12 +471,12 @@
                 "inbound_route_filter" : {
                   "lines" : [
                     {
-                      "action" : "REJECT",
+                      "action" : "DENY",
                       "ipWildcard" : "2.0.0.0/8",
                       "lengthRange" : "8-32"
                     },
                     {
-                      "action" : "ACCEPT",
+                      "action" : "PERMIT",
                       "ipWildcard" : "0.0.0.0/0",
                       "lengthRange" : "0-32"
                     }
@@ -486,7 +486,7 @@
                 "outbound_routes" : {
                   "lines" : [
                     {
-                      "action" : "ACCEPT",
+                      "action" : "PERMIT",
                       "ipWildcard" : "2.128.0.0/9",
                       "lengthRange" : "16-32"
                     }
@@ -496,7 +496,7 @@
                 "~MATCH_SUPPRESSED_SUMMARY_ONLY:default~" : {
                   "lines" : [
                     {
-                      "action" : "ACCEPT",
+                      "action" : "PERMIT",
                       "ipWildcard" : "2.128.0.0/16",
                       "lengthRange" : "17-32"
                     }

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -5,8 +5,8 @@
       "aaa_accounting" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "aaa_accounting",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -33,8 +33,8 @@
       "aaa_authentication_login_default_tacacs_local" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "aaa_authentication_login_default_tacacs_local",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -68,8 +68,8 @@
       "aaa_group_server_source_interface" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "aaa_group_server_source_interface",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -91,8 +91,8 @@
       "access_list" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "access_list",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -111,8 +111,8 @@
       "address_family" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "address_family",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
@@ -218,14 +218,14 @@
       "aggaddress" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "aggaddress",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "route6FilterLists" : {
           "ScienceDMZ-networks" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "2607:f010:3f9:8000:0:0:0:0/52",
                 "lengthRange" : "52-128"
               }
@@ -235,7 +235,7 @@
           "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "2607:f010:3f9:8000:0:0:0:0/52",
                 "lengthRange" : "52-52"
               }
@@ -247,7 +247,7 @@
           "ScienceDMZ-networks" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "192.154.2.0/24",
                 "lengthRange" : "24-32"
               }
@@ -257,7 +257,7 @@
           "~MATCH_SUPPRESSED_SUMMARY_ONLY:default~" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "192.154.2.0/24",
                 "lengthRange" : "25-32"
               }
@@ -580,8 +580,8 @@
       "arista-event-handler" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "arista-event-handler",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -600,15 +600,15 @@
       "arista_acl" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "arista_acl",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "ipAccessLists" : {
           "abcd" : {
             "name" : "abcd",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -629,7 +629,7 @@
                 "name" : "5 permit vlan 123 0x000 udp any 224.0.0.0/4"
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -668,8 +668,8 @@
       "arista_bgp" : {
         "configurationFormat" : "ARISTA",
         "name" : "arista_bgp",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "routingPolicies" : {
           "ROUTE_MAP" : {
@@ -734,8 +734,8 @@
       "arista_dhcp_relay" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "arista_dhcp_relay",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "interfaces" : {
           "Ethernet0" : {
@@ -814,8 +814,8 @@
       "arista_interface" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "arista_interface",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "interfaces" : {
           "Vlan1" : {
@@ -884,8 +884,8 @@
       "arista_ip_route" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "arista_ip_route",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -924,8 +924,8 @@
       "arista_logging" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "arista_logging",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -944,15 +944,15 @@
       "arista_misc" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "arista_misc",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "ipAccessLists" : {
           "sshabc" : {
             "name" : "sshabc",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -992,8 +992,8 @@
       "arista_ospf" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "arista_ospf",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "routingPolicies" : {
           "~OSPF_EXPORT_POLICY:default~" : {
@@ -1017,8 +1017,8 @@
       "arista_queue_monitor" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "arista_queue_monitor",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -1037,8 +1037,8 @@
       "arista_username" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "arista_username",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -1069,8 +1069,8 @@
       "arista_vrf" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "arista_vrf",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -1093,8 +1093,8 @@
       "aruba_aaa" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "aruba_aaa",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -1117,8 +1117,8 @@
       "aruba_acl" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "aruba_acl",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -1137,8 +1137,8 @@
       "aruba_airgroup" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "aruba_airgroup",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -1157,8 +1157,8 @@
       "aruba_crypto" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "aruba_crypto",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "ikePhase1Proposals" : {
           "1" : {
@@ -1197,8 +1197,8 @@
       "aruba_dhcp" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "aruba_dhcp",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -1222,8 +1222,8 @@
       "aruba_interface" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "aruba_interface",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "interfaces" : {
           "GigabitEthernet0/0/0" : {
@@ -1284,8 +1284,8 @@
       "aruba_logging" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "aruba_logging",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "loggingServers" : [
           "1.2.3.4"
@@ -1312,8 +1312,8 @@
       "aruba_misc" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "aruba_misc",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -1332,8 +1332,8 @@
       "aruba_net" : {
         "configurationFormat" : "ARUBAOS",
         "name" : "aruba_net",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -1349,8 +1349,8 @@
       "aruba_snmp" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "aruba_snmp",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "snmpTrapServers" : [
           "1.2.3.4"
@@ -1392,8 +1392,8 @@
       "aruba_time_range" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "aruba_time_range",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -1412,8 +1412,8 @@
       "aruba_user_role" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "aruba_user_role",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -1432,8 +1432,8 @@
       "aruba_vlan" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "aruba_vlan",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -1452,8 +1452,8 @@
       "aruba_voice" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "aruba_voice",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -1472,8 +1472,8 @@
       "aruba_vpn" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "aruba_vpn",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -1492,8 +1492,8 @@
       "as_path_prepend" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "as_path_prepend",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "routingPolicies" : {
           "rmap" : {
@@ -1535,15 +1535,15 @@
       "asa_acl" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "asa_acl",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "ipAccessLists" : {
           "Local_LAN_Access" : {
             "name" : "Local_LAN_Access",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -1568,7 +1568,7 @@
             "name" : "outside",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -1600,7 +1600,7 @@
             "name" : "outside_in",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -1645,8 +1645,8 @@
       "asa_banner" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "asa_banner",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -1668,8 +1668,8 @@
       "asa_ospf" : {
         "configurationFormat" : "CISCO_ASA",
         "name" : "asa_ospf",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "interfaces" : {
           "blah" : {
@@ -1752,8 +1752,8 @@
       "asa_ssh" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "asa_ssh",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -1780,8 +1780,8 @@
       "banner" : {
         "configurationFormat" : "CISCO_IOS_XR",
         "name" : "banner",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -1808,8 +1808,8 @@
       "banner_dos" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "banner_dos",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -1832,8 +1832,8 @@
       "bgp-allow" : {
         "configurationFormat" : "FLAT_JUNIPER",
         "name" : "bgp-allow",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "routingPolicies" : {
           "~DEFAULT_BGP_EXPORT_POLICY~" : {
@@ -2099,8 +2099,8 @@
       "bgp-enforce-first-as" : {
         "configurationFormat" : "FLAT_JUNIPER",
         "name" : "bgp-enforce-first-as",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "routingPolicies" : {
           "~DEFAULT_BGP_EXPORT_POLICY~" : {
@@ -2363,8 +2363,8 @@
       "bgp_address_family" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "bgp_address_family",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
@@ -2657,8 +2657,8 @@
       "bgp_default_originate_policy" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "bgp_default_originate_policy",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
@@ -2755,8 +2755,8 @@
       "bgp_foundry" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "bgp_foundry",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
@@ -2885,8 +2885,8 @@
       "bgp_nsr" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "bgp_nsr",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
@@ -2945,14 +2945,14 @@
       "bgp_route_policy" : {
         "configurationFormat" : "CISCO_IOS_XR",
         "name" : "bgp_route_policy",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "route6FilterLists" : {
           "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "2607:f380:0:0:0:0:0:0/32",
                 "lengthRange" : "32-32"
               }
@@ -3105,15 +3105,15 @@
       "cadant_acl" : {
         "configurationFormat" : "CADANT",
         "name" : "cadant_acl",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "ip6AccessLists" : {
           "ipv6-acl-foo" : {
             "name" : "ipv6-acl-foo",
             "lines" : [
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "dstIps" : [
                   "0:0:0:0:0:0:0:0/0"
                 ],
@@ -3130,7 +3130,7 @@
                 ]
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "dstIps" : [
                   "0:0:0:0:0:0:0:0/0"
                 ],
@@ -3147,7 +3147,7 @@
                 ]
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "dstIps" : [
                   "0:0:0:0:0:0:0:0/0"
                 ],
@@ -3161,7 +3161,7 @@
                 ]
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "dstIps" : [
                   "0:0:0:0:0:0:0:0/0"
                 ],
@@ -3172,7 +3172,7 @@
                 ]
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "dstIps" : [
                   "dead:0:0:0:0:0:0:0/8"
                 ],
@@ -3186,7 +3186,7 @@
                 ]
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "dstIps" : [
                   "beef:0:0:0:0:0:0:0/33"
                 ],
@@ -3203,7 +3203,7 @@
                 ]
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "dstIps" : [
                   "beef:0:0:0:0:0:0:0/33"
                 ],
@@ -3220,7 +3220,7 @@
                 ]
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "dstIps" : [
                   "beef:dead:0:0:0:0:0:0/36"
                 ],
@@ -3234,7 +3234,7 @@
                 ]
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "dstIps" : [
                   "0:0:0:0:0:0:0:0/0"
                 ],
@@ -3261,7 +3261,7 @@
             "name" : "50",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -3286,7 +3286,7 @@
             "name" : "51",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -3304,7 +3304,7 @@
                 "name" : "permit 2.3.4.0 0.0.0.255"
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -3329,7 +3329,7 @@
             "name" : "99",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -3365,8 +3365,8 @@
       "cadant_banner" : {
         "configurationFormat" : "CADANT",
         "name" : "cadant_banner",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -3385,8 +3385,8 @@
       "cadant_bgp" : {
         "configurationFormat" : "CADANT",
         "name" : "cadant_bgp",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
@@ -3442,8 +3442,8 @@
       "cadant_cable" : {
         "configurationFormat" : "CADANT",
         "name" : "cadant_cable",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -3474,8 +3474,8 @@
       "cadant_interface" : {
         "configurationFormat" : "CADANT",
         "name" : "cadant_interface",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "interfaces" : {
           "Ethernet6/0.0" : {
@@ -3926,8 +3926,8 @@
       "cadant_ip_route" : {
         "configurationFormat" : "CADANT",
         "name" : "cadant_ip_route",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -4018,8 +4018,8 @@
       "cadant_isis" : {
         "configurationFormat" : "CADANT",
         "name" : "cadant_isis",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -4041,8 +4041,8 @@
       "cadant_line" : {
         "configurationFormat" : "CADANT",
         "name" : "cadant_line",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -4058,8 +4058,8 @@
       "cadant_logging" : {
         "configurationFormat" : "CADANT",
         "name" : "cadant_logging",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "loggingServers" : [
           "1.2.3.4"
@@ -4088,8 +4088,8 @@
       "cadant_misc" : {
         "configurationFormat" : "CADANT",
         "name" : "cadant_misc",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "ntpServers" : [
           "1.2.3.4",
@@ -4127,19 +4127,19 @@
       "cadant_prefix_list" : {
         "configurationFormat" : "CADANT",
         "name" : "cadant_prefix_list",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "route6FilterLists" : {
           "bar" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "0:0:0:0:0:0:0:0",
                 "lengthRange" : "128-128"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "dead:beef:0:0:0:0:0:0/26",
                 "lengthRange" : "64-64"
               }
@@ -4151,7 +4151,7 @@
           "A+C" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "2.2.0.0/19",
                 "lengthRange" : "24-32"
               }
@@ -4161,12 +4161,12 @@
           "foo" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "1.1.1.1",
                 "lengthRange" : "32-32"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "2.2.0.0/19",
                 "lengthRange" : "24-32"
               }
@@ -4188,8 +4188,8 @@
       "cadant_qos" : {
         "configurationFormat" : "CADANT",
         "name" : "cadant_qos",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -4205,8 +4205,8 @@
       "cadant_rip" : {
         "configurationFormat" : "CADANT",
         "name" : "cadant_rip",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "routingPolicies" : {
           "~RIP_EXPORT_POLICY:default~" : {
@@ -4230,8 +4230,8 @@
       "cadant_route_map" : {
         "configurationFormat" : "CADANT",
         "name" : "cadant_route_map",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "routingPolicies" : {
           "bar" : {
@@ -4267,8 +4267,8 @@
       "cadant_snmp" : {
         "configurationFormat" : "CADANT",
         "name" : "cadant_snmp",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "snmpSourceInterface" : "Loopback0",
         "snmpTrapServers" : [
@@ -4304,8 +4304,8 @@
       "cisco-zone" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco-zone",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -4332,8 +4332,8 @@
       "cisco_aaa" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_aaa",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -4419,15 +4419,15 @@
       "cisco_acl" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_acl",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "ipAccessLists" : {
           "BLAH-BLAH" : {
             "name" : "BLAH-BLAH",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -4448,7 +4448,7 @@
                 "name" : "10 permit icmp any any"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -4469,7 +4469,7 @@
                 "name" : "20 permit ip any any tracked"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -4490,7 +4490,7 @@
                 "name" : "30 permit ospf any any"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -4514,7 +4514,7 @@
                 "name" : "40 permit tcp any any eq bgp"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -4540,7 +4540,7 @@
                 "name" : "50 permit udp any any eq bootps bootpc ntp"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.AndMatchExpr",
                   "conjuncts" : [
@@ -4566,7 +4566,7 @@
                 "name" : "60 permit tcp any any eq mlag ttl eq 255"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.AndMatchExpr",
                   "conjuncts" : [
@@ -4592,7 +4592,7 @@
                 "name" : "70 permit udp any any eq mlag ttl eq 255"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -4613,7 +4613,7 @@
                 "name" : "80 permit vrrp any any"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -4634,7 +4634,7 @@
                 "name" : "90 permit ahp any any"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -4655,7 +4655,7 @@
                 "name" : "100 permit pim any any"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -4676,7 +4676,7 @@
                 "name" : "110 permit igmp any any"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -4700,7 +4700,7 @@
                 "name" : "120 permit tcp any any range 1 10"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -4724,7 +4724,7 @@
                 "name" : "140 permit udp 10.0.0.0/19 any eq snmp"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -4748,7 +4748,7 @@
                 "name" : "180 permit udp host 10.0.0.0 any eq snmp"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -4772,7 +4772,7 @@
                 "name" : "220 permit tcp 10.0.0.0/19 any eq ssh"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -4796,7 +4796,7 @@
                 "name" : "260 permit tcp host 10.0.0.0 any eq ssh"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -4828,7 +4828,7 @@
             "name" : "blah",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -4864,12 +4864,12 @@
           "allowprefix" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "192.0.2.0/24",
                 "lengthRange" : "24-24"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "209.165.201.0/24",
                 "lengthRange" : "24-32"
               }
@@ -4879,12 +4879,12 @@
           "allowprefix-asa" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "192.0.2.0/24",
                 "lengthRange" : "24-32"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "209.165.201.0/24",
                 "lengthRange" : "24-32"
               }
@@ -4909,8 +4909,8 @@
       "cisco_additional_paths" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_additional_paths",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
@@ -4969,8 +4969,8 @@
       "cisco_authentication" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_authentication",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -4993,11 +4993,11 @@
           "10" : {
             "lines" : [
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "regex" : "^65535$"
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "regex" : "(,|\\{|\\}|^|$| )65535(,|\\{|\\}|^|$| )"
               }
             ],
@@ -5006,7 +5006,7 @@
           "20" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "regex" : "^65536$"
               }
             ],
@@ -5015,21 +5015,21 @@
           "30" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "regex" : "^4000$"
               }
             ],
             "name" : "30"
           }
         },
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "routeFilterLists" : {
           "~MATCH_SUPPRESSED_SUMMARY_ONLY:aVrfWithInnerStatements~" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "192.168.0.0/16",
                 "lengthRange" : "17-32"
               }
@@ -5617,8 +5617,8 @@
       "cisco_bgp_confederation" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_bgp_confederation",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
@@ -5677,8 +5677,8 @@
       "cisco_cable" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_cable",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "interfaces" : {
           "Cable1/2/3" : {
@@ -5769,8 +5769,8 @@
       "cisco_callhome" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_callhome",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -5790,8 +5790,8 @@
       "cisco_control_plane" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_control_plane",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -5810,8 +5810,8 @@
       "cisco_controller" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_controller",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -5830,8 +5830,8 @@
       "cisco_crypto" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_crypto",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "ikePhase1Keys" : {
           "VRF:ABC:DEF:GHI:1234" : {
@@ -6020,8 +6020,8 @@
       "cisco_dhcp" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_dhcp",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -6045,8 +6045,8 @@
       "cisco_domain" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_domain",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "dnsServers" : [
           "1.2.3.4",
@@ -6071,8 +6071,8 @@
       "cisco_dot11" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_dot11",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -6091,8 +6091,8 @@
       "cisco_dot1x" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_dot1x",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -6111,8 +6111,8 @@
       "cisco_dspfarm" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_dspfarm",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -6131,8 +6131,8 @@
       "cisco_dynamic_access_policy_record" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_dynamic_access_policy_record",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -6151,8 +6151,8 @@
       "cisco_eigrp" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_eigrp",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "interfaces" : {
           "Ethernet0" : {
@@ -6186,7 +6186,7 @@
             "name" : "bippety",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -6210,7 +6210,7 @@
                 "name" : "permit tcp 30.9.132.0 0.0.1.255 host 1.1.1.1 range 48000 48060"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -6234,7 +6234,7 @@
                 "name" : "permit tcp host 1.1.1.1 any eq 27401"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -6258,7 +6258,7 @@
                 "name" : "permit tcp any host 1.1.1.1 eq 65001"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -6282,7 +6282,7 @@
                 "name" : "permit tcp host 1.1.1.1 any eq 20000"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -6313,7 +6313,7 @@
             "name" : "bloop_blop",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -6558,8 +6558,8 @@
       "cisco_enable" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_enable",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -6579,8 +6579,8 @@
       "cisco_flow" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_flow",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "interfaces" : {
           "GigabitEthernet0/1" : {
@@ -6629,8 +6629,8 @@
       "cisco_hardware" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_hardware",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -6649,8 +6649,8 @@
       "cisco_hsrp" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_hsrp",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "interfaces" : {
           "TenGigabitEthernet0/0/2/2" : {
@@ -6699,8 +6699,8 @@
       "cisco_interface" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_interface",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "interfaces" : {
           "Async1" : {
@@ -7287,7 +7287,7 @@
             "name" : "abc",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -7358,8 +7358,8 @@
       "cisco_ip" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_ip",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -7381,8 +7381,8 @@
       "cisco_ip_nat" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_ip_nat",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -7401,8 +7401,8 @@
       "cisco_ip_route" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_ip_route",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -7536,8 +7536,8 @@
       "cisco_ipsla" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_ipsla",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -7556,8 +7556,8 @@
       "cisco_ipv6" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_ipv6",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -7576,15 +7576,15 @@
       "cisco_ipv6_access_list" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_ipv6_access_list",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "ip6AccessLists" : {
           "RT404888-XO" : {
             "name" : "RT404888-XO",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "dstIps" : [
                   "0:0:0:0:0:0:0:0/0"
                 ],
@@ -7598,7 +7598,7 @@
                 ]
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "dstIps" : [
                   "fe80:0:0:0:0:0:0:0/64"
                 ],
@@ -7612,7 +7612,7 @@
                 ]
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "dstIps" : [
                   "ff02:0:0:0:0:0:0:0/64"
                 ],
@@ -7626,7 +7626,7 @@
                 ]
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "dstIps" : [
                   "0:0:0:0:0:0:0:0"
                 ],
@@ -7640,7 +7640,7 @@
                 ]
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "dstIps" : [
                   "0:0:0:0:0:0:0:0/0"
                 ],
@@ -7654,7 +7654,7 @@
                 ]
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "dstIps" : [
                   "0:0:0:0:0:0:0:0/0"
                 ],
@@ -7668,7 +7668,7 @@
                 ]
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "dstIps" : [
                   "0:0:0:0:0:0:0:0/0"
                 ],
@@ -7682,7 +7682,7 @@
                 ]
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "dstIps" : [
                   "0:0:0:0:0:0:0:0/0"
                 ],
@@ -7696,7 +7696,7 @@
                 ]
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "dstIps" : [
                   "0:0:0:0:0:0:0:0/0"
                 ],
@@ -7710,7 +7710,7 @@
                 ]
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "dstIps" : [
                   "0:0:0:0:0:0:0:0/0"
                 ],
@@ -7724,7 +7724,7 @@
                 ]
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "dstIps" : [
                   "0:0:0:0:0:0:0:0/0"
                 ],
@@ -7738,7 +7738,7 @@
                 ]
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "dstIps" : [
                   "0:0:0:0:0:0:0:0/0"
                 ],
@@ -7757,7 +7757,7 @@
             "name" : "abcdefg",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "dstIps" : [
                   "0:0:0:0:0:0:0:0/0"
                 ],
@@ -7771,7 +7771,7 @@
                 ]
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "dstIps" : [
                   "0:0:0:0:0:0:0:0/0"
                 ],
@@ -7785,7 +7785,7 @@
                 ]
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "dstIps" : [
                   "0:0:0:0:0:0:0:0/0"
                 ],
@@ -7799,7 +7799,7 @@
                 ]
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "dstIps" : [
                   "0:0:0:0:0:0:0:0/0"
                 ],
@@ -7832,8 +7832,8 @@
       "cisco_isis" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_isis",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "interfaces" : {
           "GigabitEthernet0/0" : {
@@ -8081,8 +8081,8 @@
       "cisco_l2tp" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_l2tp",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -8106,8 +8106,8 @@
       "cisco_line" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_line",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -8665,8 +8665,8 @@
       "cisco_logging" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_logging",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "loggingServers" : [
           "1.1.1.1",
@@ -8727,8 +8727,8 @@
       "cisco_mac_acl" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_mac_acl",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -8747,15 +8747,15 @@
       "cisco_misc" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_misc",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "ipAccessLists" : {
           "~SERVICE_OBJECT_GROUP~SVCGRP-ICMP~" : {
             "name" : "~SERVICE_OBJECT_GROUP~SVCGRP-ICMP~",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.OrMatchExpr",
                   "disjuncts" : [
@@ -8818,8 +8818,8 @@
       "cisco_monitor" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_monitor",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -8838,8 +8838,8 @@
       "cisco_mpls" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_mpls",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -8858,8 +8858,8 @@
       "cisco_multicast" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_multicast",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -8878,8 +8878,8 @@
       "cisco_ntp" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_ntp",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "ntpServers" : [
           "1.2.3.4",
@@ -8918,15 +8918,15 @@
       "cisco_nxos" : {
         "configurationFormat" : "CISCO_NX",
         "name" : "cisco_nxos",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "ipAccessLists" : {
           "copp-system-acl-icmp" : {
             "name" : "copp-system-acl-icmp",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -8968,14 +8968,14 @@
       "cisco_nxos_bgp" : {
         "configurationFormat" : "CISCO_NX",
         "name" : "cisco_nxos_bgp",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "route6FilterLists" : {
           "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "fe80:0:0:0:0:0:0:0/120",
                 "lengthRange" : "120-120"
               }
@@ -9166,8 +9166,8 @@
       "cisco_ospf" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_ospf",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "interfaces" : {
           "Ethernet0/0" : {
@@ -9233,12 +9233,12 @@
           "~OSPF_SUMMARY_FILTER:default:0~" : {
             "lines" : [
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "ipWildcard" : "1.2.3.0/24",
                 "lengthRange" : "25-32"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "0.0.0.0/0",
                 "lengthRange" : "0-32"
               }
@@ -9248,12 +9248,12 @@
           "~OSPF_SUMMARY_FILTER:default:16909056~" : {
             "lines" : [
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "ipWildcard" : "1.2.3.0/24",
                 "lengthRange" : "24-32"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "0.0.0.0/0",
                 "lengthRange" : "0-32"
               }
@@ -9429,8 +9429,8 @@
       "cisco_pim" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_pim",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -9449,8 +9449,8 @@
       "cisco_platform" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_platform",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -9469,8 +9469,8 @@
       "cisco_privilege" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_privilege",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -9489,19 +9489,19 @@
       "cisco_qos" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_qos",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "ipAccessLists" : {
           "~INSPECT_POLICY_MAP_ACL~pminspect~" : {
             "name" : "~INSPECT_POLICY_MAP_ACL~pminspect~",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
-                "name" : "class-default action: ACCEPT"
+                "name" : "class-default action: PERMIT"
               }
             ],
             "sourceName" : "pminspect",
@@ -9539,14 +9539,14 @@
             "class" : "org.batfish.datamodel.AclIpSpace",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipSpace" : {
                   "class" : "org.batfish.datamodel.IpWildcardIpSpace",
                   "ipWildcard" : "1.1.1.1"
                 }
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipSpace" : {
                   "class" : "org.batfish.datamodel.IpWildcardIpSpace",
                   "ipWildcard" : "1.1.1.1"
@@ -9576,8 +9576,8 @@
       "cisco_queue_monitor" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_queue_monitor",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -9596,8 +9596,8 @@
       "cisco_redundancy" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_redundancy",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -9616,8 +9616,8 @@
       "cisco_rip" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_rip",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "routingPolicies" : {
           "~RIP_EXPORT_POLICY:default~" : {
@@ -9644,8 +9644,8 @@
       "cisco_role" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_role",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -9668,11 +9668,11 @@
           "AS_PATH_ACL1" : {
             "lines" : [
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "regex" : "^65535$"
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "regex" : "(,|\\{|\\}|^|$| )65535(,|\\{|\\}|^|$| )"
               }
             ],
@@ -9681,7 +9681,7 @@
           "AS_PATH_ACL2" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "regex" : "^65536$"
               }
             ],
@@ -9690,15 +9690,15 @@
           "AS_PATH_ACL_UNUSED" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "regex" : "^4000$"
               }
             ],
             "name" : "AS_PATH_ACL_UNUSED"
           }
         },
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "routingPolicies" : {
           "MAP_NAME1" : {
@@ -9886,8 +9886,8 @@
       "cisco_sccp" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_sccp",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -9906,8 +9906,8 @@
       "cisco_snmp" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_snmp",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "snmpSourceInterface" : "Loopback0",
         "snmpTrapServers" : [
@@ -10046,8 +10046,8 @@
       "cisco_spanning_tree" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_spanning_tree",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -10066,8 +10066,8 @@
       "cisco_ssh" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_ssh",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -10089,8 +10089,8 @@
       "cisco_stcapp" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_stcapp",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -10109,15 +10109,15 @@
       "cisco_style_acl1" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_style_acl1",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "ipAccessLists" : {
           "blah" : {
             "name" : "blah",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -10155,15 +10155,15 @@
       "cisco_style_acl2" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_style_acl2",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "ipAccessLists" : {
           "1" : {
             "name" : "1",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -10201,8 +10201,8 @@
       "cisco_system" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_system",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -10222,8 +10222,8 @@
       "cisco_tacacs" : {
         "configurationFormat" : "CISCO_NX",
         "name" : "cisco_tacacs",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "tacacsServers" : [
           "1.2.3.4",
@@ -10256,8 +10256,8 @@
       "cisco_track" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_track",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "trackingGroups" : {
           "1" : {
@@ -10286,8 +10286,8 @@
       "cisco_username" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_username",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -10322,8 +10322,8 @@
       "cisco_username_without_password" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_username_without_password",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -10353,8 +10353,8 @@
       "cisco_vdc" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_vdc",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -10373,8 +10373,8 @@
       "cisco_vlan" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_vlan",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -10393,8 +10393,8 @@
       "cisco_voice" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_voice",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -10413,8 +10413,8 @@
       "cisco_vpdn" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_vpdn",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -10433,8 +10433,8 @@
       "cisco_vpn" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_vpn",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -10453,8 +10453,8 @@
       "cisco_vrf" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_vrf",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -10487,8 +10487,8 @@
       "cisco_vrrp" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_vrrp",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "interfaces" : {
           "Ethernet0" : {
@@ -10549,8 +10549,8 @@
       "cisco_webvpn" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_webvpn",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -10569,8 +10569,8 @@
       "cisco_wsma" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "cisco_wsma",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -10589,8 +10589,8 @@
       "colon_in_vrf" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "colon_in_vrf",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
@@ -10697,7 +10697,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunity",
                   "community" : 80936723
@@ -10711,7 +10711,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.routing_policy.expr.CommunityHalvesExpr",
                   "left" : {
@@ -10732,7 +10732,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunity",
                   "community" : 141099002
@@ -10746,7 +10746,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.RegexCommunitySet",
                   "regex" : "^52:.*"
@@ -10760,7 +10760,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunity",
                   "community" : 141034138
@@ -10774,7 +10774,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.RegexCommunitySet",
                   "regex" : "2152:*"
@@ -10788,7 +10788,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunity",
                   "community" : 141099674
@@ -10802,7 +10802,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.RegexCommunitySet",
                   "regex" : "2153:*"
@@ -10816,7 +10816,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunity",
                   "community" : 3408538
@@ -10830,7 +10830,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunity",
                   "community" : 3473370
@@ -10844,7 +10844,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunity",
                   "community" : 141098890
@@ -10858,7 +10858,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunity",
                   "community" : 3410025
@@ -10872,7 +10872,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunity",
                   "community" : 141164426
@@ -10882,8 +10882,8 @@
             "name" : "ucla_to_hpr_community_ipv6"
           }
         },
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -10908,7 +10908,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunity",
                   "community" : 655303352
@@ -10918,8 +10918,8 @@
             "name" : "9999-RRR"
           }
         },
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "routingPolicies" : {
           "AAA1-BBB-CCC" : {
@@ -10983,7 +10983,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunity",
                   "community" : 655303352
@@ -10993,8 +10993,8 @@
             "name" : "9999-RRR"
           }
         },
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "routingPolicies" : {
           "AAA1-BBB-CCC" : {
@@ -11058,7 +11058,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunity",
                   "community" : 4915242
@@ -11068,14 +11068,14 @@
             "name" : "COMM_LIST_NAME"
           }
         },
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "routeFilterLists" : {
           "PFX_LIST" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "10.0.0.0/15",
                 "lengthRange" : "15-32"
               }
@@ -11146,7 +11146,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.routing_policy.expr.CommunityHalvesExpr",
                   "left" : {
@@ -11160,7 +11160,7 @@
                 }
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.routing_policy.expr.CommunityHalvesExpr",
                   "left" : {
@@ -11182,8 +11182,8 @@
             "name" : "foo"
           }
         },
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -11202,15 +11202,15 @@
       "foundry_access_list" : {
         "configurationFormat" : "FOUNDRY",
         "name" : "foundry_access_list",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "ip6AccessLists" : {
           "RT404888-Caltech" : {
             "name" : "RT404888-Caltech",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "dstIps" : [
                   "0:0:0:0:0:0:0:0/0"
                 ],
@@ -11224,7 +11224,7 @@
                 ]
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "dstIps" : [
                   "0:0:0:0:0:0:0:0/0"
                 ],
@@ -11238,7 +11238,7 @@
                 ]
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "dstIps" : [
                   "0:0:0:0:0:0:0:0/0"
                 ],
@@ -11252,7 +11252,7 @@
                 ]
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "dstIps" : [
                   "0:0:0:0:0:0:0:0/0"
                 ],
@@ -11266,7 +11266,7 @@
                 ]
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "dstIps" : [
                   "0:0:0:0:0:0:0:0/0"
                 ],
@@ -11280,7 +11280,7 @@
                 ]
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "dstIps" : [
                   "0:0:0:0:0:0:0:0/0"
                 ],
@@ -11294,7 +11294,7 @@
                 ]
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "dstIps" : [
                   "0:0:0:0:0:0:0:0/0"
                 ],
@@ -11308,7 +11308,7 @@
                 ]
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "dstIps" : [
                   "0:0:0:0:0:0:0:0/0"
                 ],
@@ -11322,7 +11322,7 @@
                 ]
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "dstIps" : [
                   "0:0:0:0:0:0:0:0/0"
                 ],
@@ -11352,8 +11352,8 @@
       "foundry_bgp" : {
         "configurationFormat" : "FOUNDRY",
         "name" : "foundry_bgp",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
@@ -11409,8 +11409,8 @@
       "foundry_interface" : {
         "configurationFormat" : "FOUNDRY",
         "name" : "foundry_interface",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "interfaces" : {
           "Ethernet1/15" : {
@@ -11456,8 +11456,8 @@
       "foundry_misc" : {
         "configurationFormat" : "FOUNDRY",
         "name" : "foundry_misc",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -11490,8 +11490,8 @@
       "foundry_vlan_group" : {
         "configurationFormat" : "FOUNDRY",
         "name" : "foundry_vlan_group",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -11507,8 +11507,8 @@
       "host1" : {
         "configurationFormat" : "HOST",
         "name" : "host1",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "HOST",
         "interfaces" : {
           "eth0" : {
@@ -11548,7 +11548,7 @@
             "name" : "filter::INPUT",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -11568,7 +11568,7 @@
                 "name" : "-s 1.2.3.4/32 -p tcp -m tcp --dport 22 -j ACCEPT"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -11588,7 +11588,7 @@
                 "name" : "-s 11.22.33.44/32 -p tcp -m tcp --dport 25 -j ACCEPT"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -11608,7 +11608,7 @@
                 "name" : "-s 111.222.111.222/32 -p tcp -m tcp --dport 80 -j ACCEPT"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -11628,7 +11628,7 @@
                 "name" : "-s 4.3.2.1/32 -p tcp -m tcp --dport 110 -j ACCEPT"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -11648,7 +11648,7 @@
                 "name" : "-s 44.22.33.11/32 -p tcp -m tcp --dport 143 -j ACCEPT"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
@@ -11660,7 +11660,7 @@
             "name" : "filter::OUTPUT",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
@@ -11672,7 +11672,7 @@
             "name" : "mangle::FORWARD",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
@@ -11684,7 +11684,7 @@
             "name" : "mangle::INPUT",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
@@ -11696,7 +11696,7 @@
             "name" : "mangle::OUTPUT",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
@@ -11708,7 +11708,7 @@
             "name" : "mangle::POSTROUTING",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
@@ -11720,7 +11720,7 @@
             "name" : "mangle::PREROUTING",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
@@ -11732,7 +11732,7 @@
             "name" : "nat::OUTPUT",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
@@ -11744,7 +11744,7 @@
             "name" : "nat::POSTROUTING",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
@@ -11756,7 +11756,7 @@
             "name" : "nat::PREROUTING",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
@@ -11789,8 +11789,8 @@
       "host2" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "host2",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "interfaces" : {
           "Ethernet0" : {
@@ -11863,7 +11863,7 @@
             "name" : "iptables_Ethernet0_ingress",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -11877,7 +11877,7 @@
                 "name" : "-s 2.128.0.101/32 -i eth0 -j ACCEPT"
               },
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -11887,7 +11887,7 @@
                 "name" : "-j DROP"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
@@ -11899,7 +11899,7 @@
             "name" : "iptables_Ethernet1_ingress",
             "lines" : [
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -11909,7 +11909,7 @@
                 "name" : "-j DROP"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
@@ -11962,8 +11962,8 @@
       "if_tag_is" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "if_tag_is",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "routingPolicies" : {
           "FOO" : {
@@ -12233,8 +12233,8 @@
       "interface_exit" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "interface_exit",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "interfaces" : {
           "Vlan303" : {
@@ -12323,8 +12323,8 @@
       "interface_name" : {
         "configurationFormat" : "CISCO_IOS_XR",
         "name" : "interface_name",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "interfaces" : {
           "FastEthernet12/13" : {
@@ -12449,8 +12449,8 @@
       "interface_sdr" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "interface_sdr",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "interfaces" : {
           "Loopback0" : {
@@ -12504,8 +12504,8 @@
       "ios_bfd" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "ios_bfd",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -12524,8 +12524,8 @@
       "ios_bgp" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "ios_bgp",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
@@ -12584,8 +12584,8 @@
       "ios_interface" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "ios_interface",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "interfaces" : {
           "GigabitEthernet1/0/1" : {
@@ -12634,8 +12634,8 @@
       "ios_standby" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "ios_standby",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "interfaces" : {
           "Vlan1000" : {
@@ -12703,8 +12703,8 @@
       "ios_template" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "ios_template",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -12723,8 +12723,8 @@
       "ios_xr_acl" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "ios_xr_acl",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -12743,14 +12743,14 @@
       "ios_xr_bgp" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "ios_xr_bgp",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "routeFilterLists" : {
           "~MATCH_SUPPRESSED_SUMMARY_ONLY:default~" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "1.0.0.0/8",
                 "lengthRange" : "9-32"
               }
@@ -12968,8 +12968,8 @@
       "ios_xr_bgp_neighbor_group" : {
         "configurationFormat" : "CISCO_IOS_XR",
         "name" : "ios_xr_bgp_neighbor_group",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
@@ -13168,8 +13168,8 @@
       "ios_xr_class_map" : {
         "configurationFormat" : "CISCO_IOS_XR",
         "name" : "ios_xr_class_map",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -13185,8 +13185,8 @@
       "ios_xr_isis" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "ios_xr_isis",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "interfaces" : {
           "GigabitEthernet0/2/1/6" : {
@@ -13244,8 +13244,8 @@
       "ios_xr_logging" : {
         "configurationFormat" : "CISCO_IOS_XR",
         "name" : "ios_xr_logging",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -13264,8 +13264,8 @@
       "ios_xr_misc" : {
         "configurationFormat" : "CISCO_IOS_XR",
         "name" : "ios_xr_misc",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -13281,8 +13281,8 @@
       "ios_xr_multipart" : {
         "configurationFormat" : "CISCO_IOS_XR",
         "name" : "ios_xr_multipart",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -13301,8 +13301,8 @@
       "ios_xr_ntp" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "ios_xr_ntp",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "ntpServers" : [
           "1.2.3.4"
@@ -13331,8 +13331,8 @@
       "ios_xr_ospf" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "ios_xr_ospf",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "interfaces" : {
           "Bundle-Ethernet101" : {
@@ -13566,12 +13566,12 @@
           "~OSPF_SUMMARY_FILTER:default:0~" : {
             "lines" : [
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "ipWildcard" : "10.0.0.0/15",
                 "lengthRange" : "16-32"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "0.0.0.0/0",
                 "lengthRange" : "0-32"
               }
@@ -13668,8 +13668,8 @@
       "ios_xr_router_static" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "ios_xr_router_static",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -13780,8 +13780,8 @@
       "ios_xr_ssh" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "ios_xr_ssh",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -13800,8 +13800,8 @@
       "ios_xr_taskgroup" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "ios_xr_taskgroup",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -13820,8 +13820,8 @@
       "iosxrmulticast" : {
         "configurationFormat" : "CISCO_IOS_XR",
         "name" : "iosxrmulticast",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -13837,14 +13837,14 @@
       "ip_prefix_list_single_line" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "ip_prefix_list_single_line",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "routeFilterLists" : {
           "DENY-IPV4-ANY-IN" : {
             "lines" : [
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "ipWildcard" : "0.0.0.0/0",
                 "lengthRange" : "0-32"
               }
@@ -13869,8 +13869,8 @@
       "isr_crypto_gdoi" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "isr_crypto_gdoi",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -13889,8 +13889,8 @@
       "isr_voip" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "isr_voip",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -13909,8 +13909,8 @@
       "juniper-ospf" : {
         "configurationFormat" : "FLAT_JUNIPER",
         "name" : "juniper-ospf",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "interfaces" : {
           "xe-0/0/1.0" : {
@@ -13993,7 +13993,7 @@
           "~SUMMARY1_2_0_0_16_RF~" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "1.2.0.0/16",
                 "lengthRange" : "17-32"
               }
@@ -14154,15 +14154,15 @@
       "juniper-tcpflags" : {
         "configurationFormat" : "FLAT_JUNIPER",
         "name" : "juniper-tcpflags",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "ipAccessLists" : {
           "foo" : {
             "name" : "foo",
             "lines" : [
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -14238,8 +14238,8 @@
       "juniper_application" : {
         "configurationFormat" : "FLAT_JUNIPER",
         "name" : "juniper_application",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "juniper" : {
@@ -14283,8 +14283,8 @@
       "juniper_apply_macro" : {
         "configurationFormat" : "FLAT_JUNIPER",
         "name" : "juniper_apply_macro",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "juniper" : {
@@ -14328,8 +14328,8 @@
       "juniper_bgp" : {
         "configurationFormat" : "FLAT_JUNIPER",
         "name" : "juniper_bgp",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "routingPolicies" : {
           "~DEFAULT_BGP_EXPORT_POLICY~" : {
@@ -14683,8 +14683,8 @@
             "tolerance" : 30
           }
         },
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "routingPolicies" : {
           "~DEFAULT_BGP_EXPORT_POLICY~" : {
@@ -15071,8 +15071,8 @@
       "juniper_bgp_remove_private_as" : {
         "configurationFormat" : "FLAT_JUNIPER",
         "name" : "juniper_bgp_remove_private_as",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "routingPolicies" : {
           "~DEFAULT_BGP_EXPORT_POLICY~" : {
@@ -15218,7 +15218,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.RegexCommunitySet",
                   "regex" : "target:123456L:.*$"
@@ -15232,7 +15232,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.RegexCommunitySet",
                   "regex" : "8075:[1][0][0-3,5-9][0-9][0-9]$"
@@ -15246,7 +15246,7 @@
             "invertMatch" : false,
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.RegexCommunitySet",
                   "regex" : "^_200_5?(1-3)*\\?:[^3]+$"
@@ -15256,8 +15256,8 @@
             "name" : "COMM_REGEX"
           }
         },
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "juniper" : {
@@ -15301,15 +15301,15 @@
       "juniper_firewall" : {
         "configurationFormat" : "FLAT_JUNIPER",
         "name" : "juniper_firewall",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "ipAccessLists" : {
           "blah" : {
             "name" : "blah",
             "lines" : [
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -15317,14 +15317,14 @@
                       "class" : "org.batfish.datamodel.AclIpSpace",
                       "lines" : [
                         {
-                          "action" : "ACCEPT",
+                          "action" : "PERMIT",
                           "ipSpace" : {
                             "class" : "org.batfish.datamodel.IpWildcardIpSpace",
                             "ipWildcard" : "1.2.3.4"
                           }
                         },
                         {
-                          "action" : "ACCEPT",
+                          "action" : "PERMIT",
                           "ipSpace" : {
                             "class" : "org.batfish.datamodel.IpWildcardIpSpace",
                             "ipWildcard" : "1.2.3.5"
@@ -15390,8 +15390,8 @@
       "juniper_forwarding_options" : {
         "configurationFormat" : "FLAT_JUNIPER",
         "name" : "juniper_forwarding_options",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "interfaces" : {
           "et-0/0/10.0" : {
@@ -15520,8 +15520,8 @@
       "juniper_interfaces" : {
         "configurationFormat" : "FLAT_JUNIPER",
         "name" : "juniper_interfaces",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "interfaces" : {
           "ae0.0" : {
@@ -15685,8 +15685,8 @@
       "juniper_isis" : {
         "configurationFormat" : "FLAT_JUNIPER",
         "name" : "juniper_isis",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "interfaces" : {
           "ge-0/0/0.0" : {
@@ -15760,8 +15760,8 @@
       "juniper_l2_learning" : {
         "configurationFormat" : "FLAT_JUNIPER",
         "name" : "juniper_l2_learning",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "juniper" : {
@@ -15805,8 +15805,8 @@
       "juniper_misc" : {
         "configurationFormat" : "FLAT_JUNIPER",
         "name" : "juniper_misc",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "domainName" : "my.domain.name",
         "vendorFamily" : {
@@ -15851,8 +15851,8 @@
       "juniper_ntp" : {
         "configurationFormat" : "FLAT_JUNIPER",
         "name" : "juniper_ntp",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "ntpServers" : [
           "1.2.3.4",
@@ -15900,8 +15900,8 @@
       "juniper_ospf_stub_areas" : {
         "configurationFormat" : "FLAT_JUNIPER",
         "name" : "juniper_ospf_stub_areas",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "routingPolicies" : {
           "~OSPF_EXPORT_POLICY:default~" : {
@@ -16011,8 +16011,8 @@
       "juniper_passwords" : {
         "configurationFormat" : "FLAT_JUNIPER",
         "name" : "juniper_passwords",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "tacacsServers" : [
           "1.2.3.4",
@@ -16073,8 +16073,8 @@
       "juniper_policy_statement" : {
         "configurationFormat" : "FLAT_JUNIPER",
         "name" : "juniper_policy_statement",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "routingPolicies" : {
           "POLICY-NAME" : {
@@ -16236,8 +16236,8 @@
       "juniper_relay" : {
         "configurationFormat" : "FLAT_JUNIPER",
         "name" : "juniper_relay",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "interfaces" : {
           "irb.10" : {
@@ -16343,94 +16343,94 @@
       "juniper_route_filter" : {
         "configurationFormat" : "FLAT_JUNIPER",
         "name" : "juniper_route_filter",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "route6FilterLists" : {
           "route-filter-test-v6:t1" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "2001:db8:1234:0:0:0:0:0/48",
                 "lengthRange" : "48-48"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "2001:db8:1235:0:0:0:0:0/58",
                 "lengthRange" : "59-128"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "2001:db8:1236:0:0:0:0:0/68",
                 "lengthRange" : "68-128"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "2001:db8:1237:0:0:0:0:0/78",
                 "lengthRange" : "78-88"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "2001:db8:1238:0:0:0:0:0/88",
                 "lengthRange" : "100-110"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "2001:db8:1239:0:0:0:0:0/98",
                 "lengthRange" : "98-98"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "2001:db8:1239:0:0:0:0:0/99",
                 "lengthRange" : "99-99"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "2001:db8:1239:0:0:0:0:0/100",
                 "lengthRange" : "100-100"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "2001:db8:1239:0:0:0:0:0/101",
                 "lengthRange" : "101-101"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "2001:db8:1239:0:0:0:0:0/102",
                 "lengthRange" : "102-102"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "2001:db8:1239:0:0:0:0:0/103",
                 "lengthRange" : "103-103"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "2001:db8:1239:0:0:0:0:0/104",
                 "lengthRange" : "104-104"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "2001:db8:1239:0:0:0:0:0/105",
                 "lengthRange" : "105-105"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "2001:db8:1239:0:0:0:0:0/106",
                 "lengthRange" : "106-106"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "2001:db8:1239:0:0:0:0:0/107",
                 "lengthRange" : "107-107"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "2001:db8:1239:0:0:0:0:0/108",
                 "lengthRange" : "108-108"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "2001:db8:1239:0:0:0:0:0/109",
                 "lengthRange" : "109-109"
               }
@@ -16442,47 +16442,47 @@
           "route-filter-test-v4:t1" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "1.2.0.0/16",
                 "lengthRange" : "16-16"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "1.3.0.0/17",
                 "lengthRange" : "18-32"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "1.4.0.0/18",
                 "lengthRange" : "18-32"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "1.5.0.0/19",
                 "lengthRange" : "19-24"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "1.6.0.0/20",
                 "lengthRange" : "26-29"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "1.7.0.0/21",
                 "lengthRange" : "21-21"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "1.7.0.0/22",
                 "lengthRange" : "22-22"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "1.7.0.0/23",
                 "lengthRange" : "23-23"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "1.7.0.0/24",
                 "lengthRange" : "24-24"
               }
@@ -16598,14 +16598,14 @@
       "juniper_routing_options" : {
         "configurationFormat" : "FLAT_JUNIPER",
         "name" : "juniper_routing_options",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "routeFilterLists" : {
           "~AGGREGATE_10_0_0_0_8_RF~" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "10.0.0.0/8",
                 "lengthRange" : "9-32"
               }
@@ -16699,8 +16699,8 @@
       "juniper_security" : {
         "configurationFormat" : "FLAT_JUNIPER",
         "name" : "juniper_security",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "ikePhase1Keys" : {
           "~IKE_PHASE1_KEY_1.2.3.4~" : {
@@ -16753,7 +16753,7 @@
             "name" : "~EXISTING_CONNECTION~",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -16771,7 +16771,7 @@
             "name" : "~FROM_ZONE~A~TO_ZONE~B",
             "lines" : [
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.AndMatchExpr",
                   "conjuncts" : [
@@ -16796,7 +16796,7 @@
             "name" : "~GLOBAL_SECURITY_POLICY~",
             "lines" : [
               {
-                "action" : "REJECT",
+                "action" : "DENY",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -16874,8 +16874,8 @@
       "juniper_snmp" : {
         "configurationFormat" : "FLAT_JUNIPER",
         "name" : "juniper_snmp",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "juniper" : {
@@ -16939,8 +16939,8 @@
       "juniper_syslog" : {
         "configurationFormat" : "FLAT_JUNIPER",
         "name" : "juniper_syslog",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "loggingServers" : [
           "1.2.3.4"
@@ -16987,8 +16987,8 @@
       "juniper_system" : {
         "configurationFormat" : "FLAT_JUNIPER",
         "name" : "juniper_system",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "juniper" : {
@@ -17032,8 +17032,8 @@
       "juniper_tacplus" : {
         "configurationFormat" : "FLAT_JUNIPER",
         "name" : "juniper_tacplus",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "tacacsServers" : [
           "1.2.3.4",
@@ -17092,8 +17092,8 @@
       "l2vpn" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "l2vpn",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -17112,8 +17112,8 @@
       "local_v6_addr" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "local_v6_addr",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
@@ -17172,8 +17172,8 @@
       "mac_access_list" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "mac_access_list",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -17192,8 +17192,8 @@
       "mcastrouting" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "mcastrouting",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -17212,8 +17212,8 @@
       "mos_interface" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "mos_interface",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "interfaces" : {
           "Ethernet1" : {
@@ -17340,8 +17340,8 @@
       "mos_misc" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "mos_misc",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "loggingServers" : [
           "1.2.3.4"
@@ -17381,8 +17381,8 @@
       "msdp_originator_id" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "msdp_originator_id",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -17401,8 +17401,8 @@
       "named_and_numbered_lists" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "named_and_numbered_lists",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "routingPolicies" : {
           "foo" : {
@@ -17432,8 +17432,8 @@
       "nat-08c21704416f06046" : {
         "configurationFormat" : "AWS",
         "name" : "nat-08c21704416f06046",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "domainName" : "aws",
         "vendorFamily" : {
@@ -17450,8 +17450,8 @@
       "nat-09fd8f73171d2d9a3" : {
         "configurationFormat" : "AWS",
         "name" : "nat-09fd8f73171d2d9a3",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "domainName" : "aws",
         "vendorFamily" : {
@@ -17468,8 +17468,8 @@
       "neighbor" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "neighbor",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
@@ -17575,8 +17575,8 @@
       "neighbor-name-numbers" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "neighbor-name-numbers",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
@@ -17635,8 +17635,8 @@
       "neighbor_dos" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "neighbor_dos",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
@@ -17742,8 +17742,8 @@
       "neighbor_mix" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "neighbor_mix",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
@@ -18012,8 +18012,8 @@
       "neighbor_nxos" : {
         "configurationFormat" : "CISCO_NX",
         "name" : "neighbor_nxos",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
@@ -18072,14 +18072,14 @@
       "network6" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "network6",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "route6FilterLists" : {
           "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "1a01:111:a100:1001:0:0:0:0/64",
                 "lengthRange" : "64-64"
               }
@@ -18144,8 +18144,8 @@
       "nexus" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "nexus",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -18164,8 +18164,8 @@
       "nexus-arista-router-bgp" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "nexus-arista-router-bgp",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
@@ -18224,14 +18224,14 @@
       "nexus_bgp" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "nexus_bgp",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "route6FilterLists" : {
           "~BGP_NETWORK6_NETWORKS_FILTER:default~" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "0:0:0:0:0:0:102:300/120",
                 "lengthRange" : "120-120"
               }
@@ -18408,8 +18408,8 @@
       "nexus_ntp" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "nexus_ntp",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "ntpServers" : [
           "1.2.3.4",
@@ -18446,8 +18446,8 @@
       "nexus_ssh" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "nexus_ssh",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -18466,8 +18466,8 @@
       "no_aaa_group_server" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "no_aaa_group_server",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -18486,8 +18486,8 @@
       "no_ip_name_server" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "no_ip_name_server",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -18506,8 +18506,8 @@
       "no_mask_reply" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "no_mask_reply",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "interfaces" : {
           "GigabitEthernet1" : {
@@ -18560,8 +18560,8 @@
       "no_snmp_server" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "no_snmp_server",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -18580,8 +18580,8 @@
       "non_nexus_neighbor_af" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "non_nexus_neighbor_af",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
@@ -18757,15 +18757,15 @@
       "nxos_acl" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "nxos_acl",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "ipAccessLists" : {
           "blah" : {
             "name" : "blah",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -18814,8 +18814,8 @@
       "nxos_bgp" : {
         "configurationFormat" : "CISCO_NX",
         "name" : "nxos_bgp",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
@@ -18874,8 +18874,8 @@
       "nxos_interface" : {
         "configurationFormat" : "CISCO_NX",
         "name" : "nxos_interface",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "interfaces" : {
           "Ethernet0/0" : {
@@ -18950,8 +18950,8 @@
       "nxos_misc" : {
         "configurationFormat" : "CISCO_NX",
         "name" : "nxos_misc",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -18970,8 +18970,8 @@
       "nxos_ospf" : {
         "configurationFormat" : "CISCO_NX",
         "name" : "nxos_ospf",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "routingPolicies" : {
           "~OSPF_EXPORT_POLICY:OTHER~" : {
@@ -19107,8 +19107,8 @@
       "nxos_route_map_continue" : {
         "configurationFormat" : "CISCO_NX",
         "name" : "nxos_route_map_continue",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "routingPolicies" : {
           "foobar" : {
@@ -20266,8 +20266,8 @@
       "nxos_system" : {
         "configurationFormat" : "CISCO_NX",
         "name" : "nxos_system",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -20286,8 +20286,8 @@
       "openflow" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "openflow",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -20306,8 +20306,8 @@
       "peer_template" : {
         "configurationFormat" : "CISCO_NX",
         "name" : "peer_template",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
@@ -20746,8 +20746,8 @@
       "pim" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "pim",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "interfaces" : {
           "Loopback1" : {
@@ -20800,8 +20800,8 @@
       "pim_snooping" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "pim_snooping",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -20820,14 +20820,14 @@
       "prefix_list_ipv4" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "prefix_list_ipv4",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "routeFilterLists" : {
           "default" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "0.0.0.0/0",
                 "lengthRange" : "0-0"
               }
@@ -20837,7 +20837,7 @@
           "test" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "192.168.100.2/31",
                 "lengthRange" : "31-31"
               }
@@ -20895,14 +20895,14 @@
       "preset" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "preset",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "routeFilterLists" : {
           "default_route" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "0.0.0.0",
                 "lengthRange" : "32-32"
               }
@@ -20912,42 +20912,42 @@
           "ucla_networks" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "128.97.0.0/16",
                 "lengthRange" : "16-32"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "131.179.0.0/16",
                 "lengthRange" : "16-32"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "149.142.0.0/16",
                 "lengthRange" : "16-32"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "164.67.0.0/16",
                 "lengthRange" : "16-32"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "169.232.0.0/16",
                 "lengthRange" : "16-32"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "192.35.225.0/24",
                 "lengthRange" : "24-32"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "192.154.2.0/24",
                 "lengthRange" : "24-32"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "198.17.109.0/24",
                 "lengthRange" : "24-32"
               }
@@ -20972,14 +20972,14 @@
       "route_maps_in_two_address_families" : {
         "configurationFormat" : "CISCO_NX",
         "name" : "route_maps_in_two_address_families",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "route6FilterLists" : {
           "v6_list" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "0:0:0:0:0:0:0:0",
                 "lengthRange" : "128-128"
               }
@@ -20991,7 +20991,7 @@
           "v4_list" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "ipWildcard" : "0.0.0.0/0",
                 "lengthRange" : "0-0"
               }
@@ -21174,7 +21174,7 @@
           "ama-coe-as-path" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "regex" : "^64666((,|\\{|\\}|^|$| )64666)*$"
               }
             ],
@@ -21183,7 +21183,7 @@
           "ama-coe-as-path2" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "regex" : "^64666((,|\\{|\\}|^|$| )64666)*$"
               }
             ],
@@ -21192,27 +21192,27 @@
           "ama-coe-as-path3" : {
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "regex" : "^64666((,|\\{|\\}|^|$| )64666)*$"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "regex" : "^64666((,|\\{|\\}|^|$| )64666)*$"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "regex" : "^64666((,|\\{|\\}|^|$| )64666)*$"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "regex" : "^$"
               }
             ],
             "name" : "ama-coe-as-path3"
           }
         },
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "routingPolicies" : {
           "erick-test" : {
@@ -21326,49 +21326,49 @@
                                             "invertMatch" : false,
                                             "lines" : [
                                               {
-                                                "action" : "ACCEPT",
+                                                "action" : "PERMIT",
                                                 "matchCondition" : {
                                                   "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunity",
                                                   "community" : 364058035
                                                 }
                                               },
                                               {
-                                                "action" : "ACCEPT",
+                                                "action" : "PERMIT",
                                                 "matchCondition" : {
                                                   "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunity",
                                                   "community" : 364117919
                                                 }
                                               },
                                               {
-                                                "action" : "ACCEPT",
+                                                "action" : "PERMIT",
                                                 "matchCondition" : {
                                                   "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunity",
                                                   "community" : 364117917
                                                 }
                                               },
                                               {
-                                                "action" : "ACCEPT",
+                                                "action" : "PERMIT",
                                                 "matchCondition" : {
                                                   "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunity",
                                                   "community" : 364183434
                                                 }
                                               },
                                               {
-                                                "action" : "ACCEPT",
+                                                "action" : "PERMIT",
                                                 "matchCondition" : {
                                                   "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunity",
                                                   "community" : 364183454
                                                 }
                                               },
                                               {
-                                                "action" : "ACCEPT",
+                                                "action" : "PERMIT",
                                                 "matchCondition" : {
                                                   "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunity",
                                                   "community" : 364183452
                                                 }
                                               },
                                               {
-                                                "action" : "ACCEPT",
+                                                "action" : "PERMIT",
                                                 "matchCondition" : {
                                                   "class" : "org.batfish.datamodel.routing_policy.expr.CommunityHalvesExpr",
                                                   "left" : {
@@ -21456,7 +21456,7 @@
                                             "invertMatch" : false,
                                             "lines" : [
                                               {
-                                                "action" : "ACCEPT",
+                                                "action" : "PERMIT",
                                                 "matchCondition" : {
                                                   "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunity",
                                                   "community" : 364058035
@@ -21533,7 +21533,7 @@
                                         "invertMatch" : false,
                                         "lines" : [
                                           {
-                                            "action" : "ACCEPT",
+                                            "action" : "PERMIT",
                                             "matchCondition" : {
                                               "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunity",
                                               "community" : 920255987
@@ -21600,21 +21600,21 @@
                                 "invertMatch" : false,
                                 "lines" : [
                                   {
-                                    "action" : "ACCEPT",
+                                    "action" : "PERMIT",
                                     "matchCondition" : {
                                       "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunity",
                                       "community" : 364118010
                                     }
                                   },
                                   {
-                                    "action" : "ACCEPT",
+                                    "action" : "PERMIT",
                                     "matchCondition" : {
                                       "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunity",
                                       "community" : 364053147
                                     }
                                   },
                                   {
-                                    "action" : "ACCEPT",
+                                    "action" : "PERMIT",
                                     "matchCondition" : {
                                       "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunity",
                                       "community" : 364116480
@@ -21706,8 +21706,8 @@
       "route_policy_igp_cost" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "route_policy_igp_cost",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "routingPolicies" : {
           "EBGP_CUST_FULL_v4" : {
@@ -21833,8 +21833,8 @@
       "route_policy_metric_type" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "route_policy_metric_type",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "routingPolicies" : {
           "to_csuchico" : {
@@ -21875,7 +21875,7 @@
                             "invertMatch" : false,
                             "lines" : [
                               {
-                                "action" : "ACCEPT",
+                                "action" : "PERMIT",
                                 "matchCondition" : {
                                   "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunity",
                                   "community" : 141035624
@@ -21941,8 +21941,8 @@
       "route_policy_param" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "route_policy_param",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "routingPolicies" : {
           "cust_v4_in" : {
@@ -22006,14 +22006,14 @@
                         "invertMatch" : false,
                         "lines" : [
                           {
-                            "action" : "ACCEPT",
+                            "action" : "PERMIT",
                             "matchCondition" : {
                               "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunity",
                               "community" : 141099007
                             }
                           },
                           {
-                            "action" : "ACCEPT",
+                            "action" : "PERMIT",
                             "matchCondition" : {
                               "class" : "org.batfish.datamodel.routing_policy.expr.CommunityHalvesExpr",
                               "left" : {
@@ -22071,21 +22071,21 @@
                         "invertMatch" : false,
                         "lines" : [
                           {
-                            "action" : "ACCEPT",
+                            "action" : "PERMIT",
                             "matchCondition" : {
                               "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunity",
                               "community" : 141034138
                             }
                           },
                           {
-                            "action" : "ACCEPT",
+                            "action" : "PERMIT",
                             "matchCondition" : {
                               "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunity",
                               "community" : 141098970
                             }
                           },
                           {
-                            "action" : "ACCEPT",
+                            "action" : "PERMIT",
                             "matchCondition" : {
                               "class" : "org.batfish.datamodel.routing_policy.expr.CommunityHalvesExpr",
                               "left" : {
@@ -22175,8 +22175,8 @@
       "router_msdp" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "router_msdp",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -22195,8 +22195,8 @@
       "rp" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "rp",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "routingPolicies" : {
           "EBGP-PEER-AS2828-LAX-PNI-OUT" : {
@@ -22657,21 +22657,21 @@
                         "invertMatch" : false,
                         "lines" : [
                           {
-                            "action" : "ACCEPT",
+                            "action" : "PERMIT",
                             "matchCondition" : {
                               "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunity",
                               "community" : 80872090
                             }
                           },
                           {
-                            "action" : "ACCEPT",
+                            "action" : "PERMIT",
                             "matchCondition" : {
                               "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunity",
                               "community" : 80936922
                             }
                           },
                           {
-                            "action" : "ACCEPT",
+                            "action" : "PERMIT",
                             "matchCondition" : {
                               "class" : "org.batfish.datamodel.routing_policy.expr.CommunityHalvesExpr",
                               "left" : {
@@ -23588,7 +23588,7 @@
                                                                                         "invertMatch" : false,
                                                                                         "lines" : [
                                                                                           {
-                                                                                            "action" : "ACCEPT",
+                                                                                            "action" : "PERMIT",
                                                                                             "matchCondition" : {
                                                                                               "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunity",
                                                                                               "community" : 809107338
@@ -23604,7 +23604,7 @@
                                                                                         "invertMatch" : false,
                                                                                         "lines" : [
                                                                                           {
-                                                                                            "action" : "ACCEPT",
+                                                                                            "action" : "PERMIT",
                                                                                             "matchCondition" : {
                                                                                               "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunity",
                                                                                               "community" : 809107357
@@ -23780,7 +23780,7 @@
                                                                 "invertMatch" : false,
                                                                 "lines" : [
                                                                   {
-                                                                    "action" : "ACCEPT",
+                                                                    "action" : "PERMIT",
                                                                     "matchCondition" : {
                                                                       "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunity",
                                                                       "community" : 141035624
@@ -23796,7 +23796,7 @@
                                                                 "invertMatch" : false,
                                                                 "lines" : [
                                                                   {
-                                                                    "action" : "ACCEPT",
+                                                                    "action" : "PERMIT",
                                                                     "matchCondition" : {
                                                                       "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunity",
                                                                       "community" : 141098770
@@ -23886,14 +23886,14 @@
                                                         "invertMatch" : false,
                                                         "lines" : [
                                                           {
-                                                            "action" : "ACCEPT",
+                                                            "action" : "PERMIT",
                                                             "matchCondition" : {
                                                               "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunity",
                                                               "community" : 141098770
                                                             }
                                                           },
                                                           {
-                                                            "action" : "ACCEPT",
+                                                            "action" : "PERMIT",
                                                             "matchCondition" : {
                                                               "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunity",
                                                               "community" : 141098970
@@ -24022,14 +24022,14 @@
                                     "invertMatch" : false,
                                     "lines" : [
                                       {
-                                        "action" : "ACCEPT",
+                                        "action" : "PERMIT",
                                         "matchCondition" : {
                                           "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunity",
                                           "community" : 2623275007
                                         }
                                       },
                                       {
-                                        "action" : "ACCEPT",
+                                        "action" : "PERMIT",
                                         "matchCondition" : {
                                           "class" : "org.batfish.datamodel.routing_policy.expr.CommunityHalvesExpr",
                                           "left" : {
@@ -24154,8 +24154,8 @@
       "set_inline_community" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "set_inline_community",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "routingPolicies" : {
           "FOOBAR" : {
@@ -24170,7 +24170,7 @@
                     "invertMatch" : false,
                     "lines" : [
                       {
-                        "action" : "ACCEPT",
+                        "action" : "PERMIT",
                         "matchCondition" : {
                           "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunity",
                           "community" : 65538
@@ -24219,8 +24219,8 @@
       "statistics" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "statistics",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -24239,8 +24239,8 @@
       "switchport_range" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "switchport_range",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "interfaces" : {
           "FastEthernet0/1" : {
@@ -24295,8 +24295,8 @@
       "syslog_source_interface" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "syslog_source_interface",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -24315,8 +24315,8 @@
       "taskgroup" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "taskgroup",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -24335,15 +24335,15 @@
       "tcpflags" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "tcpflags",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "ipAccessLists" : {
           "100" : {
             "name" : "100",
             "lines" : [
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -24384,7 +24384,7 @@
                 "name" : "permit tcp 1.2.3.4/31 any ack"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -24425,7 +24425,7 @@
                 "name" : "permit tcp 1.2.3.4/31 any rst"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -24574,7 +24574,7 @@
                 "name" : "permit tcp 1.2.3.4/31 any syn ack urg psh rst ece fin cwr"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -24615,7 +24615,7 @@
                 "name" : "permit tcp 1.2.3.4/31 any fin"
               },
               {
-                "action" : "ACCEPT",
+                "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
@@ -24695,8 +24695,8 @@
       "test" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "test",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -24715,8 +24715,8 @@
       "underscore_variable" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "underscore_variable",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "routingPolicies" : {
           "JKL_MNO_PQR" : {
@@ -24746,8 +24746,8 @@
       "variables" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "variables",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "interfaces" : {
           "FastEthernet0/0" : {
@@ -24796,8 +24796,8 @@
       "variables_dos" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "variables_dos",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "interfaces" : {
           "FastEthernet0/0" : {
@@ -24846,8 +24846,8 @@
       "vlan_access_map4" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "vlan_access_map4",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "routingPolicies" : {
           "EBGP-PEER" : {
@@ -24862,7 +24862,7 @@
                     "invertMatch" : false,
                     "lines" : [
                       {
-                        "action" : "ACCEPT",
+                        "action" : "PERMIT",
                         "matchCondition" : {
                           "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunity",
                           "community" : 529254200
@@ -24968,8 +24968,8 @@
       "vrf_context" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "vrf_context",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {
@@ -25013,8 +25013,8 @@
       "vxlan" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "vxlan",
-        "defaultCrossZoneAction" : "ACCEPT",
-        "defaultInboundAction" : "ACCEPT",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "vendorFamily" : {
           "cisco" : {

--- a/tests/roles/nsRoleConsistency.ref
+++ b/tests/roles/nsRoleConsistency.ref
@@ -17,7 +17,7 @@
           "invertMatch" : false,
           "lines" : [
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.RegexCommunitySet",
                 "regex" : "(,|\\{|\\}|^|$| )1:"
@@ -44,7 +44,7 @@
           "invertMatch" : false,
           "lines" : [
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.RegexCommunitySet",
                 "regex" : "(,|\\{|\\}|^|$| )2:"
@@ -71,7 +71,7 @@
           "invertMatch" : false,
           "lines" : [
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.RegexCommunitySet",
                 "regex" : "(,|\\{|\\}|^|$| )3:"
@@ -109,7 +109,7 @@
           "invertMatch" : false,
           "lines" : [
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.RegexCommunitySet",
                 "regex" : "(,|\\{|\\}|^|$| )2:"
@@ -132,7 +132,7 @@
           "invertMatch" : false,
           "lines" : [
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.RegexCommunitySet",
                 "regex" : "(,|\\{|\\}|^|$| )65001:"

--- a/tests/roles/perRoleOutliers.ref
+++ b/tests/roles/perRoleOutliers.ref
@@ -111,7 +111,7 @@
           "name" : "102",
           "lines" : [
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                 "headerSpace" : {
@@ -129,7 +129,7 @@
               "name" : "permit ip host 2.0.0.0 host 255.0.0.0"
             },
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                 "headerSpace" : {
@@ -169,12 +169,12 @@
         "structDefinition" : {
           "lines" : [
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "ipWildcard" : "2.0.0.0/8",
               "lengthRange" : "8-8"
             },
             {
-              "action" : "ACCEPT",
+              "action" : "PERMIT",
               "ipWildcard" : "2.128.0.0/16",
               "lengthRange" : "16-16"
             }


### PR DESCRIPTION
Conversion to "deny" makes it more consistent with flow dispositions and configuration languages. Also, opposite of deny is permit in ACL language.

Thoughts? Will be a breaking change.