### PR TITLE
Separate answer metadata from answers

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
@@ -36,7 +36,6 @@ public class BfConsts {
       "/org/batfish/coordinator/config/coordinator.properties";
   public static final String ABSPATH_DEFAULT_SALT = "org/batfish/common/util/salt";
 
-  public static final String ARG_AGGREGATIONS = "aggregations";
   public static final String ARG_ANALYSIS_NAME = "analysisname";
   public static final String ARG_BDP_DETAIL = "bdpdetail";
   public static final String ARG_BDP_MAX_OSCILLATION_RECOVERY_ATTEMPTS =

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
@@ -36,6 +36,7 @@ public class BfConsts {
       "/org/batfish/coordinator/config/coordinator.properties";
   public static final String ABSPATH_DEFAULT_SALT = "org/batfish/common/util/salt";
 
+  public static final String ARG_AGGREGATIONS = "aggregations";
   public static final String ARG_ANALYSIS_NAME = "analysisname";
   public static final String ARG_BDP_DETAIL = "bdpdetail";
   public static final String ARG_BDP_MAX_OSCILLATION_RECOVERY_ATTEMPTS =
@@ -132,6 +133,7 @@ public class BfConsts {
   public static final String RELPATH_ANALYSIS_FILE = "analysis";
   public static final String RELPATH_ANSWER_HTML = "answer.html";
   public static final String RELPATH_ANSWER_JSON = "answer.json";
+  public static final String RELPATH_ANSWER_METADATA = "answer_metadata.json";
   public static final String RELPATH_ANSWERS_DIR = "answers";
   public static final String RELPATH_AWS_CONFIGS_DIR = "aws_configs";
   public static final String RELPATH_AWS_CONFIGS_FILE = "aws_configs";

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AnswerMetadata.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AnswerMetadata.java
@@ -10,20 +10,20 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.common.BfConsts;
 
-public class AnalysisAnswerMetricsResult {
+public class AnswerMetadata {
 
   @JsonCreator
-  private static @Nonnull AnalysisAnswerMetricsResult create(
+  private static @Nonnull AnswerMetadata create(
       @JsonProperty(BfConsts.PROP_METRICS) Metrics metrics,
       @JsonProperty(BfConsts.PROP_STATUS) AnswerStatus status) {
-    return new AnalysisAnswerMetricsResult(metrics, requireNonNull(status));
+    return new AnswerMetadata(metrics, requireNonNull(status));
   }
 
   private final Metrics _metrics;
 
   private final AnswerStatus _status;
 
-  public AnalysisAnswerMetricsResult(@Nullable Metrics metrics, @Nonnull AnswerStatus status) {
+  public AnswerMetadata(@Nullable Metrics metrics, @Nonnull AnswerStatus status) {
     _metrics = metrics;
     _status = status;
   }
@@ -33,10 +33,10 @@ public class AnalysisAnswerMetricsResult {
     if (this == obj) {
       return true;
     }
-    if (!(obj instanceof AnalysisAnswerMetricsResult)) {
+    if (!(obj instanceof AnswerMetadata)) {
       return false;
     }
-    AnalysisAnswerMetricsResult rhs = (AnalysisAnswerMetricsResult) obj;
+    AnswerMetadata rhs = (AnswerMetadata) obj;
     return Objects.equals(_metrics, rhs._metrics) && _status == rhs._status;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AnswerMetadataUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AnswerMetadataUtil.java
@@ -1,0 +1,110 @@
+package org.batfish.datamodel.answers;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.Function;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.common.BatfishLogger;
+import org.batfish.datamodel.table.ColumnMetadata;
+import org.batfish.datamodel.table.Row;
+import org.batfish.datamodel.table.TableAnswerElement;
+
+public final class AnswerMetadataUtil {
+
+  private AnswerMetadataUtil() {}
+
+  public static @Nonnull AnswerMetadata computeAnswerMetadata(
+      @Nonnull Answer answer,
+      @Nonnull List<ColumnAggregation> columnAggregations,
+      BatfishLogger logger) {
+    try {
+      return new AnswerMetadata(
+          computeMetrics(answer, columnAggregations, logger), answer.getStatus());
+    } catch (Exception e) {
+      return new AnswerMetadata(null, AnswerStatus.FAILURE);
+    }
+  }
+
+  @VisibleForTesting
+  static @Nullable Metrics computeMetrics(
+      Answer answer, List<ColumnAggregation> columnAggregations, BatfishLogger logger) {
+    if (answer.getAnswerElements().isEmpty()) {
+      return null;
+    }
+    AnswerElement ae = answer.getAnswerElements().get(0);
+    if (!(ae instanceof TableAnswerElement)) {
+      return null;
+    }
+    TableAnswerElement table = (TableAnswerElement) ae;
+    int numRows = table.getRowsList().size();
+    List<ColumnAggregationResult> columnAggregationResults =
+        computeColumnAggregations(table, columnAggregations, logger);
+    return new Metrics(columnAggregationResults, numRows);
+  }
+
+  @VisibleForTesting
+  @Nonnull
+  static List<ColumnAggregationResult> computeColumnAggregations(
+      @Nonnull TableAnswerElement table,
+      @Nonnull List<ColumnAggregation> aggregations,
+      BatfishLogger logger) {
+    return aggregations
+        .stream()
+        .map(columnAggregation -> computeColumnAggregation(table, columnAggregation, logger))
+        .collect(ImmutableList.toImmutableList());
+  }
+
+  @VisibleForTesting
+  @Nonnull
+  static ColumnAggregationResult computeColumnAggregation(
+      @Nonnull TableAnswerElement table,
+      ColumnAggregation columnAggregation,
+      BatfishLogger logger) {
+    Object value;
+    String column = columnAggregation.getColumn();
+    Aggregation aggregation = columnAggregation.getAggregation();
+    switch (aggregation) {
+      case MAX:
+        value = computeColumnMax(table, column, logger);
+        break;
+      default:
+        logger.errorf("Unhandled aggregation type: %s\n", aggregation);
+        value = null;
+        break;
+    }
+    return new ColumnAggregationResult(aggregation, column, value);
+  }
+
+  @VisibleForTesting
+  @Nullable
+  static Integer computeColumnMax(
+      @Nonnull TableAnswerElement table, @Nonnull String column, BatfishLogger logger) {
+    ColumnMetadata columnMetadata = table.getMetadata().toColumnMap().get(column);
+    if (columnMetadata == null) {
+      String message = String.format("No column named: %s", column);
+      logger.errorf("%s\n", message);
+      throw new IllegalArgumentException(message);
+    }
+    Schema schema = columnMetadata.getSchema();
+    Function<Row, Integer> rowToInteger;
+    if (schema.equals(Schema.INTEGER)) {
+      rowToInteger = r -> r.getInteger(column);
+    } else if (schema.equals(Schema.ISSUE)) {
+      rowToInteger = r -> r.getIssue(column).getSeverity();
+    } else {
+      String message = String.format("Unsupported schema for MAX aggregation: %s", schema);
+      logger.errorf("%s\n", message);
+      throw new UnsupportedOperationException(message);
+    }
+    return table
+        .getRows()
+        .getData()
+        .stream()
+        .map(rowToInteger)
+        .max(Comparator.naturalOrder())
+        .orElse(null);
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/ColumnAggregationResult.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/ColumnAggregationResult.java
@@ -6,6 +6,7 @@ import static java.util.Objects.requireNonNull;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
+import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.common.BfConsts;
@@ -16,18 +17,21 @@ public class ColumnAggregationResult {
   private static @Nonnull ColumnAggregationResult create(
       @JsonProperty(BfConsts.PROP_AGGREGATION) Aggregation aggregation,
       @JsonProperty(BfConsts.PROP_COLUMN) String column,
-      @JsonProperty(BfConsts.PROP_VALUE) Object value) {
-    return new ColumnAggregationResult(requireNonNull(aggregation), requireNonNull(column), value);
+      @JsonProperty(BfConsts.PROP_VALUE) Optional<? extends Object> value) {
+    return new ColumnAggregationResult(
+        requireNonNull(aggregation), requireNonNull(column), requireNonNull(value));
   }
 
   private final Aggregation _aggregation;
 
   private final String _column;
 
-  private final Object _value;
+  private final Optional<? extends Object> _value;
 
   public ColumnAggregationResult(
-      @Nonnull Aggregation aggregation, @Nonnull String column, @Nullable Object value) {
+      @Nonnull Aggregation aggregation,
+      @Nonnull String column,
+      @Nonnull Optional<? extends Object> value) {
     _aggregation = aggregation;
     _column = column;
     _value = value;
@@ -58,7 +62,7 @@ public class ColumnAggregationResult {
   }
 
   @JsonProperty(BfConsts.PROP_VALUE)
-  public @Nullable Object getValue() {
+  public @Nullable Optional<? extends Object> getValue() {
     return _value;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/ColumnAggregationResult.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/ColumnAggregationResult.java
@@ -26,12 +26,10 @@ public class ColumnAggregationResult {
 
   private final String _column;
 
-  private final Optional<? extends Object> _value;
+  private final Object _value;
 
   public ColumnAggregationResult(
-      @Nonnull Aggregation aggregation,
-      @Nonnull String column,
-      @Nonnull Optional<? extends Object> value) {
+      @Nonnull Aggregation aggregation, @Nonnull String column, @Nonnull Object value) {
     _aggregation = aggregation;
     _column = column;
     _value = value;
@@ -62,7 +60,7 @@ public class ColumnAggregationResult {
   }
 
   @JsonProperty(BfConsts.PROP_VALUE)
-  public @Nullable Optional<? extends Object> getValue() {
+  public @Nonnull Object getValue() {
     return _value;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/GetAnalysisAnswerMetricsAnswer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/GetAnalysisAnswerMetricsAnswer.java
@@ -15,13 +15,13 @@ public class GetAnalysisAnswerMetricsAnswer {
 
   @JsonCreator
   private static @Nonnull GetAnalysisAnswerMetricsAnswer create(
-      @JsonProperty(BfConsts.PROP_RESULTS) Map<String, AnalysisAnswerMetricsResult> results) {
+      @JsonProperty(BfConsts.PROP_RESULTS) Map<String, AnswerMetadata> results) {
     return new GetAnalysisAnswerMetricsAnswer(firstNonNull(results, ImmutableMap.of()));
   }
 
-  private final Map<String, AnalysisAnswerMetricsResult> _results;
+  private final Map<String, AnswerMetadata> _results;
 
-  public GetAnalysisAnswerMetricsAnswer(@Nonnull Map<String, AnalysisAnswerMetricsResult> results) {
+  public GetAnalysisAnswerMetricsAnswer(@Nonnull Map<String, AnswerMetadata> results) {
     _results = results;
   }
 
@@ -37,7 +37,7 @@ public class GetAnalysisAnswerMetricsAnswer {
   }
 
   @JsonProperty(BfConsts.PROP_RESULTS)
-  public @Nonnull Map<String, AnalysisAnswerMetricsResult> getResults() {
+  public @Nonnull Map<String, AnswerMetadata> getResults() {
     return _results;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/Metrics.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/Metrics.java
@@ -5,8 +5,8 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableList;
-import java.util.List;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -16,16 +16,16 @@ public class Metrics {
 
   @JsonCreator
   private static @Nonnull Metrics create(
-      @JsonProperty(BfConsts.PROP_AGGREGATIONS) List<ColumnAggregationResult> aggregations,
+      @JsonProperty(BfConsts.PROP_AGGREGATIONS) Map<String, Map<Aggregation, Object>> aggregations,
       @JsonProperty(BfConsts.PROP_NUM_ROWS) int numRows) {
-    return new Metrics(firstNonNull(aggregations, ImmutableList.of()), numRows);
+    return new Metrics(firstNonNull(aggregations, ImmutableMap.of()), numRows);
   }
 
-  private final List<ColumnAggregationResult> _aggregations;
+  private final Map<String, Map<Aggregation, Object>> _aggregations;
 
   private final int _numRows;
 
-  public Metrics(@Nonnull List<ColumnAggregationResult> aggregations, int numRows) {
+  public Metrics(@Nonnull Map<String, Map<Aggregation, Object>> aggregations, int numRows) {
     _aggregations = aggregations;
     _numRows = numRows;
   }
@@ -43,7 +43,7 @@ public class Metrics {
   }
 
   @JsonProperty(BfConsts.PROP_AGGREGATIONS)
-  public @Nonnull List<ColumnAggregationResult> getAggregations() {
+  public @Nonnull Map<String, Map<Aggregation, Object>> getAggregations() {
     return _aggregations;
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/answers/AnswerMetadataUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/answers/AnswerMetadataUtilTest.java
@@ -1,14 +1,13 @@
 package org.batfish.datamodel.answers;
 
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.util.List;
-import java.util.Optional;
 import org.batfish.common.BatfishLogger;
 import org.batfish.datamodel.questions.DisplayHints;
 import org.batfish.datamodel.table.ColumnMetadata;
@@ -81,10 +80,7 @@ public class AnswerMetadataUtilTest {
 
     assertThat(
         AnswerMetadataUtil.computeAnswerMetadata(testAnswer, _logger),
-        equalTo(
-            new AnswerMetadata(
-                new Metrics(ImmutableMap.of(columnName, ImmutableMap.of(Aggregation.MAX)), 1),
-                AnswerStatus.SUCCESS)));
+        equalTo(new AnswerMetadata(new Metrics(ImmutableMap.of(), 1), AnswerStatus.SUCCESS)));
   }
 
   @Test
@@ -103,7 +99,7 @@ public class AnswerMetadataUtilTest {
 
     assertThat(
         AnswerMetadataUtil.computeColumnAggregations(table, aggregations, _logger),
-        equalTo(ImmutableMap.of(columnName, ImmutableMap.of(Aggregation.MAX, Optional.of(value)))));
+        equalTo(ImmutableMap.of(columnName, ImmutableMap.of(Aggregation.MAX, value))));
   }
 
   @Test
@@ -121,7 +117,7 @@ public class AnswerMetadataUtilTest {
 
     assertThat(
         AnswerMetadataUtil.computeColumnAggregation(table, columnAggregation, _logger),
-        equalTo(new ColumnAggregationResult(Aggregation.MAX, columnName, Optional.of(value))));
+        equalTo(new ColumnAggregationResult(Aggregation.MAX, columnName, value)));
   }
 
   @Test
@@ -136,9 +132,7 @@ public class AnswerMetadataUtilTest {
                     new DisplayHints().getTextDesc()))
             .addRow(Row.of(columnName, value));
 
-    assertThat(
-        AnswerMetadataUtil.computeColumnMax(table, columnName, _logger),
-        equalTo(Optional.of(value)));
+    assertThat(AnswerMetadataUtil.computeColumnMax(table, columnName, _logger), equalTo(value));
   }
 
   @Test
@@ -154,9 +148,7 @@ public class AnswerMetadataUtilTest {
                     new DisplayHints().getTextDesc()))
             .addRow(Row.of(columnName, value));
 
-    assertThat(
-        AnswerMetadataUtil.computeColumnMax(table, columnName, _logger),
-        equalTo(Optional.of(severity)));
+    assertThat(AnswerMetadataUtil.computeColumnMax(table, columnName, _logger), equalTo(severity));
   }
 
   @Test
@@ -173,9 +165,7 @@ public class AnswerMetadataUtilTest {
             .addRow(Row.of(columnName, value1))
             .addRow(Row.of(columnName, value2));
 
-    assertThat(
-        AnswerMetadataUtil.computeColumnMax(table, columnName, _logger),
-        equalTo(Optional.of(value2)));
+    assertThat(AnswerMetadataUtil.computeColumnMax(table, columnName, _logger), equalTo(value2));
   }
 
   @Test
@@ -188,8 +178,7 @@ public class AnswerMetadataUtilTest {
                 ImmutableList.of(new ColumnMetadata(columnName, Schema.INTEGER, "foobar")),
                 new DisplayHints().getTextDesc()));
 
-    assertThat(
-        AnswerMetadataUtil.computeColumnMax(table, columnName, _logger), equalTo(Optional.empty()));
+    assertThat(AnswerMetadataUtil.computeColumnMax(table, columnName, _logger), nullValue());
   }
 
   @Test
@@ -221,7 +210,6 @@ public class AnswerMetadataUtilTest {
                     new DisplayHints().getTextDesc()))
             .addRow(Row.of(columnName, value));
 
-    assertThat(
-        AnswerMetadataUtil.computeColumnMax(table, columnName, _logger), equalTo(Optional.empty()));
+    assertThat(AnswerMetadataUtil.computeColumnMax(table, columnName, _logger), nullValue());
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/answers/AnswerMetadataUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/answers/AnswerMetadataUtilTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.util.List;
 import org.batfish.common.BatfishLogger;
@@ -42,52 +43,43 @@ public class AnswerMetadataUtilTest {
                     new DisplayHints().getTextDesc()))
             .addRow(Row.of(columnName, value)));
     testAnswer.setStatus(AnswerStatus.SUCCESS);
-    List<ColumnAggregation> aggregations =
-        ImmutableList.of(new ColumnAggregation(Aggregation.MAX, columnName));
 
     assertThat(
-        AnswerMetadataUtil.computeAnswerMetadata(testAnswer, aggregations, _logger),
+        AnswerMetadataUtil.computeAnswerMetadata(testAnswer, _logger),
         equalTo(
             new AnswerMetadata(
                 new Metrics(
-                    ImmutableList.of(
-                        new ColumnAggregationResult(Aggregation.MAX, columnName, value)),
-                    1),
+                    ImmutableMap.of(columnName, ImmutableMap.of(Aggregation.MAX, value)), 1),
                 AnswerStatus.SUCCESS)));
   }
 
   @Test
   public void testComputeAnswerMetadataUnsuccessfulAnswer() throws IOException {
-    String columnName = "col";
-
     Answer testAnswer = new Answer();
     testAnswer.setStatus(AnswerStatus.FAILURE);
-    List<ColumnAggregation> aggregations =
-        ImmutableList.of(new ColumnAggregation(Aggregation.MAX, columnName));
 
     assertThat(
-        AnswerMetadataUtil.computeAnswerMetadata(testAnswer, aggregations, _logger),
+        AnswerMetadataUtil.computeAnswerMetadata(testAnswer, _logger),
         equalTo(new AnswerMetadata(null, AnswerStatus.FAILURE)));
   }
 
   @Test
-  public void testComputeAnswerMetadataFailedComputation() throws IOException {
+  public void testComputeAnswerMetadataInapplicable() throws IOException {
     String columnName = "col";
-    int value = 5;
+    List<Integer> value = ImmutableList.of(5);
 
     Answer testAnswer = new Answer();
     testAnswer.addAnswerElement(
         new TableAnswerElement(
                 new TableMetadata(
-                    ImmutableList.of(new ColumnMetadata(columnName, Schema.INTEGER, "foobar")),
+                    ImmutableList.of(
+                        new ColumnMetadata(columnName, Schema.list(Schema.INTEGER), "foobar")),
                     new DisplayHints().getTextDesc()))
             .addRow(Row.of(columnName, value)));
     testAnswer.setStatus(AnswerStatus.SUCCESS);
-    List<ColumnAggregation> aggregations =
-        ImmutableList.of(new ColumnAggregation(Aggregation.MAX, "fakeColumn"));
 
     assertThat(
-        AnswerMetadataUtil.computeAnswerMetadata(testAnswer, aggregations, _logger),
+        AnswerMetadataUtil.computeAnswerMetadata(testAnswer, _logger),
         equalTo(new AnswerMetadata(null, AnswerStatus.FAILURE)));
   }
 
@@ -107,7 +99,7 @@ public class AnswerMetadataUtilTest {
 
     assertThat(
         AnswerMetadataUtil.computeColumnAggregations(table, aggregations, _logger),
-        equalTo(ImmutableList.of(new ColumnAggregationResult(Aggregation.MAX, columnName, value))));
+        equalTo(ImmutableMap.of(columnName, ImmutableMap.of(Aggregation.MAX, value))));
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/answers/AnswerMetadataUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/answers/AnswerMetadataUtilTest.java
@@ -8,6 +8,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 import org.batfish.common.BatfishLogger;
 import org.batfish.datamodel.questions.DisplayHints;
 import org.batfish.datamodel.table.ColumnMetadata;
@@ -80,7 +81,10 @@ public class AnswerMetadataUtilTest {
 
     assertThat(
         AnswerMetadataUtil.computeAnswerMetadata(testAnswer, _logger),
-        equalTo(new AnswerMetadata(null, AnswerStatus.FAILURE)));
+        equalTo(
+            new AnswerMetadata(
+                new Metrics(ImmutableMap.of(columnName, ImmutableMap.of(Aggregation.MAX)), 1),
+                AnswerStatus.SUCCESS)));
   }
 
   @Test
@@ -99,7 +103,7 @@ public class AnswerMetadataUtilTest {
 
     assertThat(
         AnswerMetadataUtil.computeColumnAggregations(table, aggregations, _logger),
-        equalTo(ImmutableMap.of(columnName, ImmutableMap.of(Aggregation.MAX, value))));
+        equalTo(ImmutableMap.of(columnName, ImmutableMap.of(Aggregation.MAX, Optional.of(value)))));
   }
 
   @Test
@@ -117,7 +121,7 @@ public class AnswerMetadataUtilTest {
 
     assertThat(
         AnswerMetadataUtil.computeColumnAggregation(table, columnAggregation, _logger),
-        equalTo(new ColumnAggregationResult(Aggregation.MAX, columnName, value)));
+        equalTo(new ColumnAggregationResult(Aggregation.MAX, columnName, Optional.of(value))));
   }
 
   @Test
@@ -132,7 +136,9 @@ public class AnswerMetadataUtilTest {
                     new DisplayHints().getTextDesc()))
             .addRow(Row.of(columnName, value));
 
-    assertThat(AnswerMetadataUtil.computeColumnMax(table, columnName, _logger), equalTo(value));
+    assertThat(
+        AnswerMetadataUtil.computeColumnMax(table, columnName, _logger),
+        equalTo(Optional.of(value)));
   }
 
   @Test
@@ -148,7 +154,9 @@ public class AnswerMetadataUtilTest {
                     new DisplayHints().getTextDesc()))
             .addRow(Row.of(columnName, value));
 
-    assertThat(AnswerMetadataUtil.computeColumnMax(table, columnName, _logger), equalTo(severity));
+    assertThat(
+        AnswerMetadataUtil.computeColumnMax(table, columnName, _logger),
+        equalTo(Optional.of(severity)));
   }
 
   @Test
@@ -165,7 +173,9 @@ public class AnswerMetadataUtilTest {
             .addRow(Row.of(columnName, value1))
             .addRow(Row.of(columnName, value2));
 
-    assertThat(AnswerMetadataUtil.computeColumnMax(table, columnName, _logger), equalTo(value2));
+    assertThat(
+        AnswerMetadataUtil.computeColumnMax(table, columnName, _logger),
+        equalTo(Optional.of(value2)));
   }
 
   @Test
@@ -178,7 +188,8 @@ public class AnswerMetadataUtilTest {
                 ImmutableList.of(new ColumnMetadata(columnName, Schema.INTEGER, "foobar")),
                 new DisplayHints().getTextDesc()));
 
-    assertThat(AnswerMetadataUtil.computeColumnMax(table, columnName, _logger), nullValue());
+    assertThat(
+        AnswerMetadataUtil.computeColumnMax(table, columnName, _logger), equalTo(Optional.empty()));
   }
 
   @Test
@@ -210,7 +221,7 @@ public class AnswerMetadataUtilTest {
                     new DisplayHints().getTextDesc()))
             .addRow(Row.of(columnName, value));
 
-    _thrown.expect(UnsupportedOperationException.class);
-    AnswerMetadataUtil.computeColumnMax(table, columnName, _logger);
+    assertThat(
+        AnswerMetadataUtil.computeColumnMax(table, columnName, _logger), equalTo(Optional.empty()));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/answers/AnswerMetadataUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/answers/AnswerMetadataUtilTest.java
@@ -1,0 +1,224 @@
+package org.batfish.datamodel.answers;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.util.List;
+import org.batfish.common.BatfishLogger;
+import org.batfish.datamodel.questions.DisplayHints;
+import org.batfish.datamodel.table.ColumnMetadata;
+import org.batfish.datamodel.table.Row;
+import org.batfish.datamodel.table.TableAnswerElement;
+import org.batfish.datamodel.table.TableMetadata;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class AnswerMetadataUtilTest {
+
+  @Rule public ExpectedException _thrown = ExpectedException.none();
+
+  private BatfishLogger _logger;
+
+  @Before
+  public void setup() {
+    _logger = new BatfishLogger(BatfishLogger.LEVELSTR_OUTPUT, false);
+  }
+
+  @Test
+  public void testComputeAnswerMetadata() throws IOException {
+    String columnName = "col";
+    int value = 5;
+
+    Answer testAnswer = new Answer();
+    testAnswer.addAnswerElement(
+        new TableAnswerElement(
+                new TableMetadata(
+                    ImmutableList.of(new ColumnMetadata(columnName, Schema.INTEGER, "foobar")),
+                    new DisplayHints().getTextDesc()))
+            .addRow(Row.of(columnName, value)));
+    testAnswer.setStatus(AnswerStatus.SUCCESS);
+    List<ColumnAggregation> aggregations =
+        ImmutableList.of(new ColumnAggregation(Aggregation.MAX, columnName));
+
+    assertThat(
+        AnswerMetadataUtil.computeAnswerMetadata(testAnswer, aggregations, _logger),
+        equalTo(
+            new AnswerMetadata(
+                new Metrics(
+                    ImmutableList.of(
+                        new ColumnAggregationResult(Aggregation.MAX, columnName, value)),
+                    1),
+                AnswerStatus.SUCCESS)));
+  }
+
+  @Test
+  public void testComputeAnswerMetadataUnsuccessfulAnswer() throws IOException {
+    String columnName = "col";
+
+    Answer testAnswer = new Answer();
+    testAnswer.setStatus(AnswerStatus.FAILURE);
+    List<ColumnAggregation> aggregations =
+        ImmutableList.of(new ColumnAggregation(Aggregation.MAX, columnName));
+
+    assertThat(
+        AnswerMetadataUtil.computeAnswerMetadata(testAnswer, aggregations, _logger),
+        equalTo(new AnswerMetadata(null, AnswerStatus.FAILURE)));
+  }
+
+  @Test
+  public void testComputeAnswerMetadataFailedComputation() throws IOException {
+    String columnName = "col";
+    int value = 5;
+
+    Answer testAnswer = new Answer();
+    testAnswer.addAnswerElement(
+        new TableAnswerElement(
+                new TableMetadata(
+                    ImmutableList.of(new ColumnMetadata(columnName, Schema.INTEGER, "foobar")),
+                    new DisplayHints().getTextDesc()))
+            .addRow(Row.of(columnName, value)));
+    testAnswer.setStatus(AnswerStatus.SUCCESS);
+    List<ColumnAggregation> aggregations =
+        ImmutableList.of(new ColumnAggregation(Aggregation.MAX, "fakeColumn"));
+
+    assertThat(
+        AnswerMetadataUtil.computeAnswerMetadata(testAnswer, aggregations, _logger),
+        equalTo(new AnswerMetadata(null, AnswerStatus.FAILURE)));
+  }
+
+  @Test
+  public void testComputeColumnAggregations() {
+    String columnName = "col";
+    int value = 5;
+
+    TableAnswerElement table =
+        new TableAnswerElement(
+                new TableMetadata(
+                    ImmutableList.of(new ColumnMetadata(columnName, Schema.INTEGER, "foobar")),
+                    new DisplayHints().getTextDesc()))
+            .addRow(Row.of(columnName, value));
+    List<ColumnAggregation> aggregations =
+        ImmutableList.of(new ColumnAggregation(Aggregation.MAX, columnName));
+
+    assertThat(
+        AnswerMetadataUtil.computeColumnAggregations(table, aggregations, _logger),
+        equalTo(ImmutableList.of(new ColumnAggregationResult(Aggregation.MAX, columnName, value))));
+  }
+
+  @Test
+  public void testComputeColumnAggregationMax() {
+    String columnName = "col";
+    int value = 5;
+
+    TableAnswerElement table =
+        new TableAnswerElement(
+                new TableMetadata(
+                    ImmutableList.of(new ColumnMetadata(columnName, Schema.INTEGER, "foobar")),
+                    new DisplayHints().getTextDesc()))
+            .addRow(Row.of(columnName, value));
+    ColumnAggregation columnAggregation = new ColumnAggregation(Aggregation.MAX, columnName);
+
+    assertThat(
+        AnswerMetadataUtil.computeColumnAggregation(table, columnAggregation, _logger),
+        equalTo(new ColumnAggregationResult(Aggregation.MAX, columnName, value)));
+  }
+
+  @Test
+  public void testComputeColumnMaxOneRowInteger() {
+    String columnName = "col";
+    int value = 5;
+
+    TableAnswerElement table =
+        new TableAnswerElement(
+                new TableMetadata(
+                    ImmutableList.of(new ColumnMetadata(columnName, Schema.INTEGER, "foobar")),
+                    new DisplayHints().getTextDesc()))
+            .addRow(Row.of(columnName, value));
+
+    assertThat(AnswerMetadataUtil.computeColumnMax(table, columnName, _logger), equalTo(value));
+  }
+
+  @Test
+  public void testComputeColumnMaxOneRowIssue() {
+    String columnName = "col";
+    int severity = 5;
+    Issue value = new Issue("blah", severity, new Issue.Type("1", "2"));
+
+    TableAnswerElement table =
+        new TableAnswerElement(
+                new TableMetadata(
+                    ImmutableList.of(new ColumnMetadata(columnName, Schema.ISSUE, "foobar")),
+                    new DisplayHints().getTextDesc()))
+            .addRow(Row.of(columnName, value));
+
+    assertThat(AnswerMetadataUtil.computeColumnMax(table, columnName, _logger), equalTo(severity));
+  }
+
+  @Test
+  public void testComputeColumnMaxTwoRows() {
+    String columnName = "col";
+    int value1 = 5;
+    int value2 = 10;
+
+    TableAnswerElement table =
+        new TableAnswerElement(
+                new TableMetadata(
+                    ImmutableList.of(new ColumnMetadata(columnName, Schema.INTEGER, "foobar")),
+                    new DisplayHints().getTextDesc()))
+            .addRow(Row.of(columnName, value1))
+            .addRow(Row.of(columnName, value2));
+
+    assertThat(AnswerMetadataUtil.computeColumnMax(table, columnName, _logger), equalTo(value2));
+  }
+
+  @Test
+  public void testComputeColumnMaxNoRows() {
+    String columnName = "col";
+
+    TableAnswerElement table =
+        new TableAnswerElement(
+            new TableMetadata(
+                ImmutableList.of(new ColumnMetadata(columnName, Schema.INTEGER, "foobar")),
+                new DisplayHints().getTextDesc()));
+
+    assertThat(AnswerMetadataUtil.computeColumnMax(table, columnName, _logger), nullValue());
+  }
+
+  @Test
+  public void testComputeColumnMaxInvalidColumn() {
+    String columnName = "col";
+    String invalidColumnName = "invalid";
+    int value = 5;
+
+    TableAnswerElement table =
+        new TableAnswerElement(
+                new TableMetadata(
+                    ImmutableList.of(new ColumnMetadata(columnName, Schema.INTEGER, "foobar")),
+                    new DisplayHints().getTextDesc()))
+            .addRow(Row.of(columnName, value));
+
+    _thrown.expect(IllegalArgumentException.class);
+    AnswerMetadataUtil.computeColumnMax(table, invalidColumnName, _logger);
+  }
+
+  @Test
+  public void testComputeColumnMaxInvalidSchema() {
+    String columnName = "col";
+    String value = "hello";
+
+    TableAnswerElement table =
+        new TableAnswerElement(
+                new TableMetadata(
+                    ImmutableList.of(new ColumnMetadata(columnName, Schema.STRING, "foobar")),
+                    new DisplayHints().getTextDesc()))
+            .addRow(Row.of(columnName, value));
+
+    _thrown.expect(UnsupportedOperationException.class);
+    AnswerMetadataUtil.computeColumnMax(table, columnName, _logger);
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/config/Settings.java
+++ b/projects/batfish/src/main/java/org/batfish/config/Settings.java
@@ -601,10 +601,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     return _activeTestrigSettings;
   }
 
-  public String getAggregations() {
-    return _config.getString(BfConsts.ARG_AGGREGATIONS);
-  }
-
   public String getAnalysisName() {
     return _config.getString(BfConsts.ARG_ANALYSIS_NAME);
   }
@@ -983,7 +979,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
   }
 
   private void initConfigDefaults() {
-    setDefaultProperty(BfConsts.ARG_AGGREGATIONS, null);
     setDefaultProperty(BfConsts.ARG_ANALYSIS_NAME, null);
     setDefaultProperty(BfConsts.ARG_BDP_DETAIL, false);
     setDefaultProperty(BfConsts.ARG_BDP_MAX_OSCILLATION_RECOVERY_ATTEMPTS, 0);
@@ -1079,9 +1074,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
   }
 
   private void initOptions() {
-
-    addOption(
-        BfConsts.ARG_AGGREGATIONS, "aggregations to be performed on table answers", "aggregations");
 
     addOption(BfConsts.ARG_ANALYSIS_NAME, "name of analysis", ARGNAME_NAME);
 
@@ -1372,7 +1364,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     }
 
     // REGULAR OPTIONS
-    getStringOptionValue(BfConsts.ARG_AGGREGATIONS);
     getStringOptionValue(BfConsts.ARG_ANALYSIS_NAME);
     getBooleanOptionValue(BfConsts.COMMAND_ANALYZE);
     getBooleanOptionValue(BfConsts.COMMAND_ANSWER);

--- a/projects/batfish/src/main/java/org/batfish/config/Settings.java
+++ b/projects/batfish/src/main/java/org/batfish/config/Settings.java
@@ -601,6 +601,10 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     return _activeTestrigSettings;
   }
 
+  public String getAggregations() {
+    return _config.getString(BfConsts.ARG_AGGREGATIONS);
+  }
+
   public String getAnalysisName() {
     return _config.getString(BfConsts.ARG_ANALYSIS_NAME);
   }
@@ -979,6 +983,7 @@ public final class Settings extends BaseSettings implements GrammarSettings {
   }
 
   private void initConfigDefaults() {
+    setDefaultProperty(BfConsts.ARG_AGGREGATIONS, null);
     setDefaultProperty(BfConsts.ARG_ANALYSIS_NAME, null);
     setDefaultProperty(BfConsts.ARG_BDP_DETAIL, false);
     setDefaultProperty(BfConsts.ARG_BDP_MAX_OSCILLATION_RECOVERY_ATTEMPTS, 0);
@@ -1074,6 +1079,9 @@ public final class Settings extends BaseSettings implements GrammarSettings {
   }
 
   private void initOptions() {
+
+    addOption(
+        BfConsts.ARG_AGGREGATIONS, "aggregations to be performed on table answers", "aggregations");
 
     addOption(BfConsts.ARG_ANALYSIS_NAME, "name of analysis", ARGNAME_NAME);
 
@@ -1364,6 +1372,7 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     }
 
     // REGULAR OPTIONS
+    getStringOptionValue(BfConsts.ARG_AGGREGATIONS);
     getStringOptionValue(BfConsts.ARG_ANALYSIS_NAME);
     getBooleanOptionValue(BfConsts.COMMAND_ANALYZE);
     getBooleanOptionValue(BfConsts.COMMAND_ANSWER);

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -2770,7 +2770,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
     }
   }
 
-  private void outputAnswerMetadata(Answer answer) {
+  void outputAnswerMetadata(Answer answer) {
     _storage.storeAnswerMetadata(
         AnswerMetadataUtil.computeAnswerMetadata(answer, _aggregations, _logger),
         _settings.getAnalysisName(),

--- a/projects/batfish/src/main/java/org/batfish/main/BatfishStorage.java
+++ b/projects/batfish/src/main/java/org/batfish/main/BatfishStorage.java
@@ -338,6 +338,10 @@ final class BatfishStorage {
     Path answerDir =
         computeAnswerDir(
             analysisName, questionPath, baseSnapshotName, deltaSnapshotName, questionName, diff);
+    if (answerDir == null) {
+      // If settings has neither a question nor an analysis configured, don't write a file
+      return;
+    }
     Path answerMetricsPath = answerDir.resolve(BfConsts.RELPATH_ANSWER_METADATA);
     CommonUtil.writeFile(answerMetricsPath, metricsStr);
   }

--- a/projects/batfish/src/main/java/org/batfish/main/BatfishStorage.java
+++ b/projects/batfish/src/main/java/org/batfish/main/BatfishStorage.java
@@ -3,6 +3,7 @@ package org.batfish.main;
 import static org.batfish.common.plugin.PluginConsumer.DEFAULT_HEADER_LENGTH_BYTES;
 import static org.batfish.common.plugin.PluginConsumer.detectFormat;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.base.Throwables;
 import com.google.common.io.Closer;
 import java.io.FileInputStream;
@@ -38,6 +39,7 @@ import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.common.util.CommonUtil;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Topology;
+import org.batfish.datamodel.answers.AnswerMetadata;
 import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
 
 /** A utility class that abstracts the underlying file system storage used by {@link Batfish}. */
@@ -245,6 +247,99 @@ final class BatfishStorage {
               serializeObject(e.getValue(), currentOutputPath);
               progressCount.incrementAndGet();
             });
+  }
+
+  private @Nullable Path computeAnswerDir(
+      String analysisName,
+      Path questionPath,
+      String baseSnapshotName,
+      String deltaSnapshotName,
+      String questionName,
+      boolean diff) {
+    // TODO: don't pass in questionPath
+    Path answerDir;
+
+    if (questionName != null) {
+      // If settings has a question name, we're answering an adhoc question. Set up path accordingly
+      Path testrigDir = getTestrigDir(baseSnapshotName);
+      answerDir =
+          testrigDir.resolve(
+              Paths.get(
+                  BfConsts.RELPATH_ANSWERS_DIR,
+                  questionName,
+                  BfConsts.RELPATH_DEFAULT_ENVIRONMENT_NAME));
+      if (diff) {
+        answerDir =
+            answerDir.resolve(
+                Paths.get(
+                    BfConsts.RELPATH_DIFF_DIR,
+                    deltaSnapshotName,
+                    BfConsts.RELPATH_DEFAULT_ENVIRONMENT_NAME));
+      } else {
+        answerDir = answerDir.resolve(Paths.get(BfConsts.RELPATH_STANDARD_DIR));
+      }
+    } else if (analysisName != null && questionPath != null) {
+      // If settings has an analysis name and question path, we're answering an analysis question
+      Path questionDir = questionPath.getParent();
+      answerDir =
+          questionDir.resolve(
+              Paths.get(
+                  BfConsts.RELPATH_ENVIRONMENTS_DIR, BfConsts.RELPATH_DEFAULT_ENVIRONMENT_NAME));
+      if (diff) {
+        answerDir =
+            answerDir.resolve(
+                Paths.get(
+                    BfConsts.RELPATH_DELTA,
+                    deltaSnapshotName,
+                    BfConsts.RELPATH_DEFAULT_ENVIRONMENT_NAME));
+      }
+    } else {
+      // If settings has neither a question nor an analysis configured, don't write a file
+      return null;
+    }
+    return answerDir;
+  }
+
+  public void storeAnswer(
+      String answerStr,
+      String analysisName,
+      Path questionPath,
+      String baseSnapshotName,
+      String deltaSnapshotName,
+      String questionName,
+      boolean diff) {
+    Path answerDir =
+        computeAnswerDir(
+            analysisName, questionPath, baseSnapshotName, deltaSnapshotName, questionName, diff);
+    // If settings has neither a question nor an analysis configured, don't write a file
+    if (answerDir == null) {
+      return;
+    }
+    Path answerPath = answerDir.resolve(BfConsts.RELPATH_ANSWER_JSON);
+    answerDir.toFile().mkdirs();
+    CommonUtil.writeFile(answerPath, answerStr);
+  }
+
+  public void storeAnswerMetadata(
+      AnswerMetadata answerMetrics,
+      String analysisName,
+      Path questionPath,
+      String baseSnapshotName,
+      String deltaSnapshotName,
+      String questionName,
+      boolean diff) {
+    // TODO: don't pass in questionPath
+    String metricsStr;
+    try {
+      metricsStr = BatfishObjectMapper.writePrettyString(answerMetrics);
+    } catch (JsonProcessingException e) {
+      throw new BatfishException("Could not write answer metrics", e);
+    }
+    Path answerDir =
+        computeAnswerDir(
+            analysisName, questionPath, baseSnapshotName, deltaSnapshotName, questionName, diff);
+    Path answerMetricsPath = answerDir.resolve(BfConsts.RELPATH_ANSWER_METADATA);
+    CommonUtil.writeFile(answerMetricsPath, metricsStr);
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/main/BatfishStorage.java
+++ b/projects/batfish/src/main/java/org/batfish/main/BatfishStorage.java
@@ -256,7 +256,7 @@ final class BatfishStorage {
       String deltaSnapshotName,
       String questionName,
       boolean diff) {
-    // TODO: don't pass in questionPath
+    // TODO: https://github.com/batfish/batfish/issues/2143 don't pass in questionPath
     Path answerDir;
 
     if (questionName != null) {
@@ -341,6 +341,11 @@ final class BatfishStorage {
     if (answerDir == null) {
       // If settings has neither a question nor an analysis configured, don't write a file
       return;
+    }
+    answerDir.toFile().mkdirs();
+    if (!answerDir.toFile().exists() && !answerDir.toFile().mkdirs()) {
+      throw new BatfishException(
+          String.format("Unable to create a answer metadata directory '%s'", answerDir));
     }
     Path answerMetricsPath = answerDir.resolve(BfConsts.RELPATH_ANSWER_METADATA);
     CommonUtil.writeFile(answerMetricsPath, metricsStr);

--- a/projects/batfish/src/main/java/org/batfish/main/Driver.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Driver.java
@@ -621,6 +621,7 @@ public class Driver {
                       assert outputAnswerSpan != null;
                       if (settings.getTaskId() != null) {
                         batfish.outputAnswerWithLog(answer);
+                        batfish.outputAnswerMetadata(answer);
                       }
                     }
                   }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -11,6 +11,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Sets;
 import io.opentracing.ActiveSpan;
@@ -77,15 +78,11 @@ import org.batfish.coordinator.WorkQueueMgr.QueueType;
 import org.batfish.coordinator.config.Settings;
 import org.batfish.datamodel.AnalysisMetadata;
 import org.batfish.datamodel.TestrigMetadata;
-import org.batfish.datamodel.answers.Aggregation;
-import org.batfish.datamodel.answers.AnalysisAnswerMetricsResult;
 import org.batfish.datamodel.answers.Answer;
+import org.batfish.datamodel.answers.AnswerMetadata;
 import org.batfish.datamodel.answers.AnswerStatus;
 import org.batfish.datamodel.answers.AutocompleteSuggestion;
 import org.batfish.datamodel.answers.AutocompleteSuggestion.CompletionType;
-import org.batfish.datamodel.answers.ColumnAggregation;
-import org.batfish.datamodel.answers.ColumnAggregationResult;
-import org.batfish.datamodel.answers.Metrics;
 import org.batfish.datamodel.answers.ParseVendorConfigurationAnswerElement;
 import org.batfish.datamodel.answers.Schema;
 import org.batfish.datamodel.pojo.Node;
@@ -702,6 +699,68 @@ public class WorkMgr extends AbstractCoordinator {
     return answer;
   }
 
+  public AnswerMetadata getAnalysisAnswerMetadata(
+      String containerName,
+      String baseSnapshot,
+      String deltaSnapshot,
+      String analysisName,
+      String questionName)
+      throws JsonProcessingException {
+    Path analysisDir = getdirContainerAnalysis(containerName, analysisName);
+    Path testrigDir = getdirTestrig(containerName, baseSnapshot);
+
+    Path questionFile =
+        analysisDir.resolve(
+            Paths.get(
+                BfConsts.RELPATH_QUESTIONS_DIR, questionName, BfConsts.RELPATH_QUESTION_FILE));
+    if (!Files.exists(questionFile)) {
+      throw new BatfishException("Question file for question " + questionName + "not found");
+    }
+    Path answerDir =
+        testrigDir.resolve(
+            Paths.get(
+                BfConsts.RELPATH_ANALYSES_DIR,
+                analysisName,
+                BfConsts.RELPATH_QUESTIONS_DIR,
+                questionName,
+                BfConsts.RELPATH_ENVIRONMENTS_DIR,
+                BfConsts.RELPATH_DEFAULT_ENVIRONMENT_NAME));
+    if (deltaSnapshot != null) {
+      answerDir =
+          answerDir.resolve(
+              Paths.get(
+                  BfConsts.RELPATH_DELTA,
+                  deltaSnapshot,
+                  BfConsts.RELPATH_DEFAULT_ENVIRONMENT_NAME));
+    }
+    Path answerMetadataFile = answerDir.resolve(BfConsts.RELPATH_ANSWER_METADATA);
+    AnswerMetadata answerMetadata;
+    if (!Files.exists(answerMetadataFile)) {
+      Answer ans = Answer.failureAnswer("Not answered", null);
+      ans.setStatus(AnswerStatus.NOTFOUND);
+      answerMetadata = new AnswerMetadata(null, AnswerStatus.NOTFOUND);
+    } else {
+      boolean answerIsStale;
+      answerIsStale =
+          CommonUtil.getLastModifiedTime(questionFile)
+                  .compareTo(CommonUtil.getLastModifiedTime(answerMetadataFile))
+              > 0;
+      if (answerIsStale) {
+        answerMetadata = new AnswerMetadata(null, AnswerStatus.STALE);
+      } else {
+        String answerMetadataString = CommonUtil.readFile(answerMetadataFile);
+        try {
+          answerMetadata =
+              BatfishObjectMapper.mapper()
+                  .readValue(answerMetadataString, new TypeReference<AnswerMetadata>() {});
+        } catch (IOException e) {
+          answerMetadata = new AnswerMetadata(null, AnswerStatus.FAILURE);
+        }
+      }
+    }
+    return answerMetadata;
+  }
+
   public Map<String, String> getAnalysisAnswers(
       String containerName,
       String baseTestrig,
@@ -755,6 +814,28 @@ public class WorkMgr extends AbstractCoordinator {
               questionName));
     }
     return retMap;
+  }
+
+  public @Nonnull Map<String, AnswerMetadata> getAnalysisAnswersMetadata(
+      String network,
+      String baseSnapshot,
+      String deltaSnapshot,
+      String analysisName,
+      Set<String> analysisQuestions)
+      throws JsonProcessingException {
+    SortedSet<String> allQuestions = listAnalysisQuestions(network, analysisName);
+    SortedSet<String> questions =
+        analysisQuestions.isEmpty()
+            ? allQuestions
+            : ImmutableSortedSet.copyOf(Sets.intersection(allQuestions, analysisQuestions));
+    ImmutableSortedMap.Builder<String, AnswerMetadata> builder = ImmutableSortedMap.naturalOrder();
+    for (String questionName : questions) {
+      builder.put(
+          questionName,
+          getAnalysisAnswerMetadata(
+              network, baseSnapshot, deltaSnapshot, analysisName, questionName));
+    }
+    return builder.build();
   }
 
   public String getAnalysisQuestion(
@@ -1801,106 +1882,6 @@ public class WorkMgr extends AbstractCoordinator {
   public boolean checkContainerExists(String containerName) {
     Path containerDir = getdirContainer(containerName, false);
     return Files.exists(containerDir);
-  }
-
-  /**
-   * Compute metrics for the answer to each question in an analysis.
-   *
-   * @param answers Mapping from questionName to raw answer JSON string
-   * @param aggregations A list of aggregations to be performed on each answer and returned in the
-   *     order specified in the {@link Metrics} contained in each result within the returned {@link
-   *     AnalysisAnswerMetricsResult}
-   * @return A mapping from questionName to the metrics for that question
-   */
-  public @Nonnull Map<String, AnalysisAnswerMetricsResult> getAnalysisAnswersMetrics(
-      Map<String, String> answers, List<ColumnAggregation> aggregations) {
-    return CommonUtil.toImmutableMap(
-        answers,
-        Entry::getKey,
-        rawAnswerByNameEntry ->
-            toAnalysisAnswerMetricsResult(rawAnswerByNameEntry.getValue(), aggregations));
-  }
-
-  @VisibleForTesting
-  @Nonnull
-  AnalysisAnswerMetricsResult toAnalysisAnswerMetricsResult(
-      @Nonnull String rawAnswer, @Nonnull List<ColumnAggregation> aggregations) {
-    AnswerStatus status;
-    try {
-      Answer answer =
-          BatfishObjectMapper.mapper().readValue(rawAnswer, new TypeReference<Answer>() {});
-      status = answer.getStatus();
-      if (status != AnswerStatus.SUCCESS) {
-        return new AnalysisAnswerMetricsResult(null, status);
-      }
-      TableAnswerElement table = (TableAnswerElement) answer.getAnswerElements().get(0);
-      int numRows = table.getRows().size();
-      List<ColumnAggregationResult> aggregationResults =
-          computeColumnAggregations(table, aggregations);
-      return new AnalysisAnswerMetricsResult(new Metrics(aggregationResults, numRows), status);
-    } catch (Exception e) {
-      _logger.errorf(
-          "Failed to convert answer string to AnalysisAnswerMetricsResult: %s", e.getMessage());
-      return new AnalysisAnswerMetricsResult(null, AnswerStatus.FAILURE);
-    }
-  }
-
-  @VisibleForTesting
-  @Nonnull
-  List<ColumnAggregationResult> computeColumnAggregations(
-      @Nonnull TableAnswerElement table, @Nonnull List<ColumnAggregation> aggregations) {
-    return aggregations
-        .stream()
-        .map(columnAggregation -> computeColumnAggregation(table, columnAggregation))
-        .collect(ImmutableList.toImmutableList());
-  }
-
-  @VisibleForTesting
-  @Nonnull
-  ColumnAggregationResult computeColumnAggregation(
-      @Nonnull TableAnswerElement table, ColumnAggregation columnAggregation) {
-    Object value;
-    String column = columnAggregation.getColumn();
-    Aggregation aggregation = columnAggregation.getAggregation();
-    switch (aggregation) {
-      case MAX:
-        value = computeColumnMax(table, column);
-        break;
-      default:
-        _logger.errorf("Unhandled aggregation type: %s", aggregation);
-        value = null;
-        break;
-    }
-    return new ColumnAggregationResult(aggregation, column, value);
-  }
-
-  @VisibleForTesting
-  @Nullable
-  Integer computeColumnMax(@Nonnull TableAnswerElement table, @Nonnull String column) {
-    ColumnMetadata columnMetadata = table.getMetadata().toColumnMap().get(column);
-    if (columnMetadata == null) {
-      String message = String.format("No column named: %s", column);
-      _logger.error(message);
-      throw new IllegalArgumentException(message);
-    }
-    Schema schema = columnMetadata.getSchema();
-    Function<Row, Integer> rowToInteger;
-    if (schema.equals(Schema.INTEGER)) {
-      rowToInteger = r -> r.getInteger(column);
-    } else if (schema.equals(Schema.ISSUE)) {
-      rowToInteger = r -> r.getIssue(column).getSeverity();
-    } else {
-      String message = String.format("Unsupported schema for MAX aggregation: %s", schema);
-      _logger.error(message);
-      throw new UnsupportedOperationException(message);
-    }
-    return table
-        .getRows()
-        .getData()
-        .stream()
-        .map(rowToInteger)
-        .max(Comparator.naturalOrder())
-        .orElse(null);
   }
 
   /**

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
@@ -45,11 +45,10 @@ import org.batfish.coordinator.AnalysisMetadataMgr.AnalysisType;
 import org.batfish.coordinator.WorkDetails.WorkType;
 import org.batfish.coordinator.WorkQueueMgr.QueueType;
 import org.batfish.datamodel.TestrigMetadata;
-import org.batfish.datamodel.answers.AnalysisAnswerMetricsResult;
 import org.batfish.datamodel.answers.Answer;
+import org.batfish.datamodel.answers.AnswerMetadata;
 import org.batfish.datamodel.answers.AutocompleteSuggestion;
 import org.batfish.datamodel.answers.AutocompleteSuggestion.CompletionType;
-import org.batfish.datamodel.answers.ColumnAggregation;
 import org.batfish.datamodel.answers.GetAnalysisAnswerMetricsAnswer;
 import org.batfish.datamodel.pojo.WorkStatus;
 import org.batfish.datamodel.questions.Question;
@@ -859,26 +858,16 @@ public class WorkMgrService {
         }
       }
 
-      List<ColumnAggregation> aggregations =
-          BatfishObjectMapper.mapper()
-              .readValue(aggregationsStr, new TypeReference<List<ColumnAggregation>>() {});
-
-      Map<String, String> answers =
+      Map<String, AnswerMetadata> answersMetadata =
           Main.getWorkMgr()
-              .getAnalysisAnswers(
+              .getAnalysisAnswersMetadata(
                   networkNameParam,
                   snapshotNameParam,
-                  BfConsts.RELPATH_DEFAULT_ENVIRONMENT_NAME,
                   deltaSnapshotParam,
-                  BfConsts.RELPATH_DEFAULT_ENVIRONMENT_NAME,
                   analysisName,
                   analysisQuestions);
 
-      Map<String, AnalysisAnswerMetricsResult> analysisAnswerMetricsResults =
-          Main.getWorkMgr().getAnalysisAnswersMetrics(answers, aggregations);
-
-      GetAnalysisAnswerMetricsAnswer answer =
-          new GetAnalysisAnswerMetricsAnswer(analysisAnswerMetricsResults);
+      GetAnalysisAnswerMetricsAnswer answer = new GetAnalysisAnswerMetricsAnswer(answersMetadata);
 
       String answerStr = BatfishObjectMapper.writePrettyString(answer);
 

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
@@ -797,7 +797,6 @@ public class WorkMgrService {
    * @param networkName The name of the network in which the analysis resides
    * @param snapshotName The name of the snapshot on which the analysis was run
    * @param deltaSnapshot The name of the delta snapshot on which the analysis was run
-   * @param aggregationsStr A list of aggregations to be computed and returned for each table
    * @param analysisName The name of the analysis
    * @param analysisQuestionsStr The names of the questions for which to retrieve metrics
    * @return TODO: document JSON response
@@ -811,7 +810,6 @@ public class WorkMgrService {
       @FormDataParam(CoordConsts.SVC_KEY_NETWORK_NAME) String networkName,
       @FormDataParam(CoordConsts.SVC_KEY_SNAPSHOT_NAME) String snapshotName,
       @FormDataParam(CoordConsts.SVC_KEY_DELTA_SNAPSHOT_NAME) String deltaSnapshot,
-      @FormDataParam(CoordConsts.SVC_KEY_AGGREGATIONS) String aggregationsStr,
       @FormDataParam(CoordConsts.SVC_KEY_ANALYSIS_NAME) String analysisName,
       @FormDataParam(CoordConsts.SVC_KEY_ANALYSIS_QUESTIONS)
           String analysisQuestionsStr /* optional */,

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrServiceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrServiceTest.java
@@ -19,7 +19,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.ws.rs.core.Response;
@@ -39,7 +38,6 @@ import org.batfish.datamodel.answers.Aggregation;
 import org.batfish.datamodel.answers.Answer;
 import org.batfish.datamodel.answers.AnswerMetadata;
 import org.batfish.datamodel.answers.AnswerStatus;
-import org.batfish.datamodel.answers.ColumnAggregation;
 import org.batfish.datamodel.answers.GetAnalysisAnswerMetricsAnswer;
 import org.batfish.datamodel.answers.Metrics;
 import org.batfish.datamodel.answers.Schema;
@@ -719,10 +717,6 @@ public class WorkMgrServiceTest {
     answerDir.toFile().mkdirs();
     CommonUtil.writeFile(answer1MetadataPath, answerMetadata);
 
-    List<ColumnAggregation> aggregations =
-        ImmutableList.of(new ColumnAggregation(Aggregation.MAX, columnName));
-    String aggregationsStr = BatfishObjectMapper.writePrettyString(aggregations);
-
     JSONArray answerOutput =
         _service.getAnalysisAnswersMetrics(
             CoordConsts.DEFAULT_API_KEY,
@@ -730,7 +724,6 @@ public class WorkMgrServiceTest {
             _networkName,
             _snapshotName,
             null,
-            aggregationsStr,
             analysisName,
             analysisQuestionsStr,
             null);

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrServiceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrServiceTest.java
@@ -40,7 +40,6 @@ import org.batfish.datamodel.answers.Answer;
 import org.batfish.datamodel.answers.AnswerMetadata;
 import org.batfish.datamodel.answers.AnswerStatus;
 import org.batfish.datamodel.answers.ColumnAggregation;
-import org.batfish.datamodel.answers.ColumnAggregationResult;
 import org.batfish.datamodel.answers.GetAnalysisAnswerMetricsAnswer;
 import org.batfish.datamodel.answers.Metrics;
 import org.batfish.datamodel.answers.Schema;
@@ -680,9 +679,7 @@ public class WorkMgrServiceTest {
     int value = 5;
     AnswerMetadata testAnswerMetadata =
         new AnswerMetadata(
-            new Metrics(
-                ImmutableList.of(new ColumnAggregationResult(Aggregation.MAX, columnName, value)),
-                1),
+            new Metrics(ImmutableMap.of(columnName, ImmutableMap.of(Aggregation.MAX, value)), 1),
             AnswerStatus.SUCCESS);
     String answerMetadata = BatfishObjectMapper.writePrettyString(testAnswerMetadata);
 
@@ -753,8 +750,7 @@ public class WorkMgrServiceTest {
                     questionName,
                     new AnswerMetadata(
                         new Metrics(
-                            ImmutableList.of(
-                                new ColumnAggregationResult(Aggregation.MAX, columnName, value)),
+                            ImmutableMap.of(columnName, ImmutableMap.of(Aggregation.MAX, value)),
                             1),
                         AnswerStatus.SUCCESS)))));
   }


### PR DESCRIPTION
Answer metadata for table answers is now stored separately in `answer-metadata.json` file along `answer.json`.

Breaking change:
- no longer able to request aggregations via coordinator `getAnalysisAnswersMetrics`
- instead, pass '-aggregations ...' to batfish work item args when analysis is run

