### PR TITLE
OSPF: fix default route propagation for stub areas

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/OspfProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/OspfProtocolHelper.java
@@ -65,7 +65,7 @@ public class OspfProtocolHelper {
       OspfProcess process, OspfProcess neighborProc, OspfArea area, OspfArea neighborArea) {
     return neighborProc.isAreaBorderRouter()
         && !process.isAreaBorderRouter()
-        && area.getInjectDefaultRoute()
+        && neighborArea.getInjectDefaultRoute()
         && (neighborArea.getStubType() == StubType.STUB
             || (neighborArea.getStubType() == StubType.NSSA
                 && neighborArea.getNssa().getDefaultOriginateType()

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/OspfProtocolHelperTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/OspfProtocolHelperTest.java
@@ -95,8 +95,8 @@ public class OspfProtocolHelperTest {
     assertThat(
         isOspfInterAreaDefaultOriginationAllowed(proc, neighborProc, area0, area1), equalTo(true));
 
-    // Area does not inject the default route
-    area0.setInjectDefaultRoute(false);
+    // Area1 is stub without default route injection
+    area1.setInjectDefaultRoute(false);
     assertThat(
         isOspfInterAreaDefaultOriginationAllowed(proc, neighborProc, area0, area1), equalTo(false));
 


### PR DESCRIPTION
There is a lot of confusion between who is receiver/sender in our OSPF code (we both missed this originally)

There is a more general fix that needs to be applied here, with better design patterns and terminology; but for now let's just unblock correct functionality.