### PR TITLE
Question consistency properties

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/BgpPropertySpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/BgpPropertySpecifier.java
@@ -80,7 +80,7 @@ public class BgpPropertySpecifier extends PropertySpecifier {
     return JAVA_MAP
         .keySet()
         .stream()
-        .filter(prop -> _pattern.matcher(prop).matches())
+        .filter(prop -> _pattern.matcher(prop.toLowerCase()).matches())
         .collect(Collectors.toSet());
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/BgpPropertySpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/BgpPropertySpecifier.java
@@ -24,35 +24,46 @@ import org.batfish.datamodel.answers.Schema;
  */
 public class BgpPropertySpecifier extends PropertySpecifier {
 
+  public static final String ACTIVE_NEIGHBORS = "Active_Neighbors";
+  public static final String CLUSTER_IDS = "Cluster_IDs";
+  public static final String GENERATED_ROUTES = "Generated_Routes";
+  public static final String MULTIPATH_EQUIVALENT_AS_PATH_MATCH_MODE =
+      "Multipath_Equivalent_AS_Path_Match_Mode";
+  public static final String MULTIPATH_EBGP = "Multipath_EBGP";
+  public static final String MULTIPATH_IBGP = "Multipath_IBGP";
+  public static final String ORIGINATION_SPACE = "Origination_Space";
+  public static final String PASSIVE_NEIGHBORS = "Passive_Neighbors";
+  public static final String TIE_BREAKER = "Tie_Breaker";
+
   public static Map<String, PropertyDescriptor<BgpProcess>> JAVA_MAP =
       new ImmutableMap.Builder<String, PropertyDescriptor<BgpProcess>>()
           .put(
-              "Active_Neighbors",
+              ACTIVE_NEIGHBORS,
               new PropertyDescriptor<>(BgpProcess::getActiveNeighbors, Schema.set(Schema.STRING)))
           .put(
-              "Cluster_Ids",
+              CLUSTER_IDS,
               new PropertyDescriptor<>(BgpProcess::getClusterIds, Schema.set(Schema.STRING)))
           .put(
-              "Generated_Routes",
+              GENERATED_ROUTES,
               new PropertyDescriptor<>(BgpProcess::getGeneratedRoutes, Schema.set(Schema.STRING)))
           .put(
-              "Multipath_Equivalent_Aspath_Match_Mode",
+              MULTIPATH_EQUIVALENT_AS_PATH_MATCH_MODE,
               new PropertyDescriptor<>(
                   BgpProcess::getMultipathEquivalentAsPathMatchMode, Schema.STRING))
           .put(
-              "Multipath_Ebgp",
+              MULTIPATH_EBGP,
               new PropertyDescriptor<>(BgpProcess::getMultipathEbgp, Schema.BOOLEAN))
           .put(
-              "Multipath_Ibgp",
+              MULTIPATH_IBGP,
               new PropertyDescriptor<>(BgpProcess::getMultipathIbgp, Schema.BOOLEAN))
           .put(
-              "Origination_Space",
+              ORIGINATION_SPACE,
               new PropertyDescriptor<>(BgpProcess::getOriginationSpace, Schema.STRING))
           .put(
-              "Passive_Neighbors",
+              PASSIVE_NEIGHBORS,
               new PropertyDescriptor<>(BgpProcess::getPassiveNeighbors, Schema.set(Schema.STRING)))
           // skip router-id; included as part of process identity
-          .put("Tie_Breaker", new PropertyDescriptor<>(BgpProcess::getTieBreaker, Schema.STRING))
+          .put(TIE_BREAKER, new PropertyDescriptor<>(BgpProcess::getTieBreaker, Schema.STRING))
           .build();
 
   public static final BgpPropertySpecifier ALL = new BgpPropertySpecifier(".*");

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/BgpPropertySpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/BgpPropertySpecifier.java
@@ -27,32 +27,32 @@ public class BgpPropertySpecifier extends PropertySpecifier {
   public static Map<String, PropertyDescriptor<BgpProcess>> JAVA_MAP =
       new ImmutableMap.Builder<String, PropertyDescriptor<BgpProcess>>()
           .put(
-              "active-neighbors",
+              "Active_Neighbors",
               new PropertyDescriptor<>(BgpProcess::getActiveNeighbors, Schema.set(Schema.STRING)))
           .put(
-              "cluster-ids",
+              "Cluster_Ids",
               new PropertyDescriptor<>(BgpProcess::getClusterIds, Schema.set(Schema.STRING)))
           .put(
-              "generated-routes",
+              "Generated_Routes",
               new PropertyDescriptor<>(BgpProcess::getGeneratedRoutes, Schema.set(Schema.STRING)))
           .put(
-              "multipath-equivalent-aspath-match-mode",
+              "Multipath_Equivalent_Aspath_Match_Mode",
               new PropertyDescriptor<>(
                   BgpProcess::getMultipathEquivalentAsPathMatchMode, Schema.STRING))
           .put(
-              "multipath-ebgp",
+              "Multipath_Ebgp",
               new PropertyDescriptor<>(BgpProcess::getMultipathEbgp, Schema.BOOLEAN))
           .put(
-              "multipath-ibgp",
+              "Multipath_Ibgp",
               new PropertyDescriptor<>(BgpProcess::getMultipathIbgp, Schema.BOOLEAN))
           .put(
-              "origination-space",
+              "Origination_Space",
               new PropertyDescriptor<>(BgpProcess::getOriginationSpace, Schema.STRING))
           .put(
-              "passive-neighbors",
+              "Passive_Neighbors",
               new PropertyDescriptor<>(BgpProcess::getPassiveNeighbors, Schema.set(Schema.STRING)))
           // skip router-id; included as part of process identity
-          .put("tie-breaker", new PropertyDescriptor<>(BgpProcess::getTieBreaker, Schema.STRING))
+          .put("Tie_Breaker", new PropertyDescriptor<>(BgpProcess::getTieBreaker, Schema.STRING))
           .build();
 
   public static final BgpPropertySpecifier ALL = new BgpPropertySpecifier(".*");

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/InterfacePropertySpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/InterfacePropertySpecifier.java
@@ -26,96 +26,133 @@ import org.batfish.datamodel.answers.Schema;
  */
 public class InterfacePropertySpecifier extends PropertySpecifier {
 
+  public static final String ACCESS_VLAN = "Access_VLAN";
+  public static final String ACTIVE = "Active";
+  public static final String ADDITIONAL_ARP_IPS = "Additional_ARP_IPs";
+  public static final String ALLOWED_VLANS = "Allowed_VLANs";
+  public static final String ALL_PREFIXES = "All_Prefixes";
+  public static final String AUTO_STATE_VLAN = "Auto_State_VLAN";
+  public static final String BANDWIDTH = "Bandwidth";
+  public static final String BLACKLISTED = "Blacklisted";
+  public static final String CHANNEL_GROUP = "Channel_Group";
+  public static final String CHANNEL_GROUP_MEMBERS = "Channel_Group_Members";
+  public static final String DECLARED_NAMES = "Declared_Names";
+  public static final String DESCRIPTION = "Description";
+  public static final String DHCP_RELAY_ADDRESSES = "DHCP_Relay_Addresses";
+  public static final String HSRP_GROUPS = "HSRP_Groups";
+  public static final String HSRP_VERSION = "HSRP_Version";
+  public static final String INBOUND_FILTER_NAME = "Inbound_Filter_Name";
+  public static final String INCOMING_FILTER_NAME = "Incoming_Filter_Name";
+  public static final String INTERFACE_TYPE = "Interface_Type";
+  public static final String MTU = "MTU";
+  public static final String NATIVE_VLAN = "Native_VLAN";
+  public static final String OSPF_AREA_NAME = "OSPF_Area_Name";
+  public static final String OSPF_COST = "OSPF_Cost";
+  public static final String OSPF_ENABLED = "OSPF_Enabled";
+  public static final String OSPF_HELLO_MULTIPLIER = "OSPF_Hello_Multiplier";
+  public static final String OSPF_PASSIVE = "OSPF_Passive";
+  public static final String OSPF_POINT_TO_POINT = "OSPF_Point_To_Point";
+  public static final String OUTGOING_FILTER_NAME = "Outgoing_Filter_Name";
+  public static final String PRIMARY_ADDRESS = "Primary_Address";
+  public static final String PROXY_ARP = "Proxy_ARP";
+  public static final String RIP_ENABLED = "Rip_Enabled";
+  public static final String RIP_PASSIVE = "Rip_Passive";
+  public static final String ROUTING_POLICY_NAME = "Routing_Policy_Name";
+  public static final String SOURCE_NATS = "Source_NATs";
+  public static final String SPANNING_TREE_PORTFAST = "Spanning_Tree_Portfast";
+  public static final String SWITCHPORT = "Switchport";
+  public static final String SWITCHPORT_MODE = "Switchport_Mode";
+  public static final String SWITCHPORT_TRUNK_ENCAPSULATION = "Switchport_Trunk_Encapsulation";
+  public static final String VRF = "VRF";
+  public static final String VRRP_GROUPS = "VRRP_Groups";
+  public static final String ZONE_NAME = "Zone_Name";
+
   public static Map<String, PropertyDescriptor<Interface>> JAVA_MAP =
       new ImmutableMap.Builder<String, PropertyDescriptor<Interface>>()
-          .put("Access_Vlan", new PropertyDescriptor<>(Interface::getAccessVlan, Schema.INTEGER))
-          .put("Active", new PropertyDescriptor<>(Interface::getActive, Schema.BOOLEAN))
+          .put(ACCESS_VLAN, new PropertyDescriptor<>(Interface::getAccessVlan, Schema.INTEGER))
+          .put(ACTIVE, new PropertyDescriptor<>(Interface::getActive, Schema.BOOLEAN))
           .put(
-              "Additional_Arp_Ips",
+              ADDITIONAL_ARP_IPS,
               new PropertyDescriptor<>(Interface::getAdditionalArpIps, Schema.list(Schema.IP)))
           .put(
-              "Allowed_Vlans",
+              ALLOWED_VLANS,
               new PropertyDescriptor<>(Interface::getAllowedVlans, Schema.list(Schema.STRING)))
           .put(
-              "All_Prefixes",
+              ALL_PREFIXES,
               new PropertyDescriptor<>(Interface::getAllAddresses, Schema.list(Schema.STRING)))
-          .put("Auto_State_Vlan", new PropertyDescriptor<>(Interface::getAutoState, Schema.BOOLEAN))
-          .put("Bandwidth", new PropertyDescriptor<>(Interface::getBandwidth, Schema.DOUBLE))
-          .put("Blacklisted", new PropertyDescriptor<>(Interface::getBlacklisted, Schema.BOOLEAN))
-          .put("Channel_Group", new PropertyDescriptor<>(Interface::getChannelGroup, Schema.STRING))
+          .put(AUTO_STATE_VLAN, new PropertyDescriptor<>(Interface::getAutoState, Schema.BOOLEAN))
+          .put(BANDWIDTH, new PropertyDescriptor<>(Interface::getBandwidth, Schema.DOUBLE))
+          .put(BLACKLISTED, new PropertyDescriptor<>(Interface::getBlacklisted, Schema.BOOLEAN))
+          .put(CHANNEL_GROUP, new PropertyDescriptor<>(Interface::getChannelGroup, Schema.STRING))
           .put(
-              "Channel_Group_Members",
+              CHANNEL_GROUP_MEMBERS,
               new PropertyDescriptor<>(
                   Interface::getChannelGroupMembers, Schema.list(Schema.STRING)))
           .put(
-              "Declared_Names",
+              DECLARED_NAMES,
               new PropertyDescriptor<>(Interface::getDeclaredNames, Schema.list(Schema.STRING)))
-          .put("Description", new PropertyDescriptor<>(Interface::getDescription, Schema.STRING))
+          .put(DESCRIPTION, new PropertyDescriptor<>(Interface::getDescription, Schema.STRING))
           .put(
-              "Dhcp_Relay_Addresses",
+              DHCP_RELAY_ADDRESSES,
               new PropertyDescriptor<>(Interface::getDhcpRelayAddresses, Schema.list(Schema.IP)))
           .put(
-              "Hsrp_Groups",
+              HSRP_GROUPS,
               new PropertyDescriptor<>(Interface::getHsrpGroups, Schema.set(Schema.STRING)))
-          .put("Hsrp_Version", new PropertyDescriptor<>(Interface::getHsrpVersion, Schema.STRING))
+          .put(HSRP_VERSION, new PropertyDescriptor<>(Interface::getHsrpVersion, Schema.STRING))
           // skip inbound-filter
           .put(
-              "Inbound_Filter_Name",
+              INBOUND_FILTER_NAME,
               new PropertyDescriptor<>(Interface::getInboundFilterName, Schema.STRING))
           // skip incoming filter
           .put(
-              "Incoming_Filter_Name",
+              INCOMING_FILTER_NAME,
               new PropertyDescriptor<>(Interface::getIncomingFilter, Schema.STRING))
-          .put(
-              "Interface_Type",
-              new PropertyDescriptor<>(Interface::getInterfaceType, Schema.STRING))
-          .put("Mtu", new PropertyDescriptor<>(Interface::getMtu, Schema.INTEGER))
-          .put("Native_Vlan", new PropertyDescriptor<>(Interface::getNativeVlan, Schema.INTEGER))
+          .put(INTERFACE_TYPE, new PropertyDescriptor<>(Interface::getInterfaceType, Schema.STRING))
+          .put(MTU, new PropertyDescriptor<>(Interface::getMtu, Schema.INTEGER))
+          .put(NATIVE_VLAN, new PropertyDescriptor<>(Interface::getNativeVlan, Schema.INTEGER))
           // skip ospf area
+          .put(OSPF_AREA_NAME, new PropertyDescriptor<>(Interface::getOspfAreaName, Schema.INTEGER))
+          .put(OSPF_COST, new PropertyDescriptor<>(Interface::getOspfCost, Schema.INTEGER))
+          .put(OSPF_ENABLED, new PropertyDescriptor<>(Interface::getOspfEnabled, Schema.BOOLEAN))
           .put(
-              "Ospf_Area_Name",
-              new PropertyDescriptor<>(Interface::getOspfAreaName, Schema.INTEGER))
-          .put("Ospf_Cost", new PropertyDescriptor<>(Interface::getOspfCost, Schema.INTEGER))
-          .put("Ospf_Enabled", new PropertyDescriptor<>(Interface::getOspfEnabled, Schema.BOOLEAN))
-          .put(
-              "Ospf_Hello_Multiplier",
+              OSPF_HELLO_MULTIPLIER,
               new PropertyDescriptor<>(Interface::getOspfHelloMultiplier, Schema.INTEGER))
-          .put("Ospf_Passive", new PropertyDescriptor<>(Interface::getOspfPassive, Schema.BOOLEAN))
+          .put(OSPF_PASSIVE, new PropertyDescriptor<>(Interface::getOspfPassive, Schema.BOOLEAN))
           .put(
-              "Ospf_Point_To_Point",
+              OSPF_POINT_TO_POINT,
               new PropertyDescriptor<>(Interface::getOspfPointToPoint, Schema.BOOLEAN))
           // skip outgoing filter
           .put(
-              "Outgoing_Filter_Name",
+              OUTGOING_FILTER_NAME,
               new PropertyDescriptor<>(Interface::getOutgoingFilterName, Schema.STRING))
           // skip getOwner
-          .put("Primary_Address", new PropertyDescriptor<>(Interface::getAddress, Schema.STRING))
-          .put("Proxy_Arp", new PropertyDescriptor<>(Interface::getProxyArp, Schema.BOOLEAN))
-          .put("Rip_Enabled", new PropertyDescriptor<>(Interface::getRipEnabled, Schema.BOOLEAN))
-          .put("Rip_Passive", new PropertyDescriptor<>(Interface::getRipPassive, Schema.BOOLEAN))
+          .put(PRIMARY_ADDRESS, new PropertyDescriptor<>(Interface::getAddress, Schema.STRING))
+          .put(PROXY_ARP, new PropertyDescriptor<>(Interface::getProxyArp, Schema.BOOLEAN))
+          .put(RIP_ENABLED, new PropertyDescriptor<>(Interface::getRipEnabled, Schema.BOOLEAN))
+          .put(RIP_PASSIVE, new PropertyDescriptor<>(Interface::getRipPassive, Schema.BOOLEAN))
           // skip routing policy
           .put(
-              "Routing_Policy_Name",
+              ROUTING_POLICY_NAME,
               new PropertyDescriptor<>(Interface::getRoutingPolicyName, Schema.STRING))
           .put(
-              "Source_Nats",
+              SOURCE_NATS,
               new PropertyDescriptor<>(Interface::getSourceNats, Schema.list(Schema.STRING)))
           .put(
-              "Spanning_Tree_Portfast",
+              SPANNING_TREE_PORTFAST,
               new PropertyDescriptor<>(Interface::getSpanningTreePortfast, Schema.BOOLEAN))
-          .put("Switchport", new PropertyDescriptor<>(Interface::getSwitchport, Schema.BOOLEAN))
+          .put(SWITCHPORT, new PropertyDescriptor<>(Interface::getSwitchport, Schema.BOOLEAN))
           .put(
-              "Switchport_Mode",
+              SWITCHPORT_MODE,
               new PropertyDescriptor<>(Interface::getSwitchportMode, Schema.STRING))
           .put(
-              "Switchport_Trunk_Encapsulation",
+              SWITCHPORT_TRUNK_ENCAPSULATION,
               new PropertyDescriptor<>(Interface::getSwitchportTrunkEncapsulation, Schema.STRING))
-          .put("Vrf", new PropertyDescriptor<>(Interface::getVrf, Schema.STRING))
+          .put(VRF, new PropertyDescriptor<>(Interface::getVrf, Schema.STRING))
           .put(
-              "Vrrp_Groups",
+              VRRP_GROUPS,
               new PropertyDescriptor<>(Interface::getVrrpGroups, Schema.list(Schema.INTEGER)))
           // skip zone
-          .put("Zone_Name", new PropertyDescriptor<>(Interface::getZoneName, Schema.STRING))
+          .put(ZONE_NAME, new PropertyDescriptor<>(Interface::getZoneName, Schema.STRING))
           .build();
 
   public static final InterfacePropertySpecifier ALL = new InterfacePropertySpecifier(".*");

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/InterfacePropertySpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/InterfacePropertySpecifier.java
@@ -28,94 +28,94 @@ public class InterfacePropertySpecifier extends PropertySpecifier {
 
   public static Map<String, PropertyDescriptor<Interface>> JAVA_MAP =
       new ImmutableMap.Builder<String, PropertyDescriptor<Interface>>()
-          .put("access-vlan", new PropertyDescriptor<>(Interface::getAccessVlan, Schema.INTEGER))
-          .put("active", new PropertyDescriptor<>(Interface::getActive, Schema.BOOLEAN))
+          .put("Access_Vlan", new PropertyDescriptor<>(Interface::getAccessVlan, Schema.INTEGER))
+          .put("Active", new PropertyDescriptor<>(Interface::getActive, Schema.BOOLEAN))
           .put(
-              "additional-arp-ips",
+              "Additional_Arp_Ips",
               new PropertyDescriptor<>(Interface::getAdditionalArpIps, Schema.list(Schema.IP)))
           .put(
-              "allowed-vlans",
+              "Allowed_Vlans",
               new PropertyDescriptor<>(Interface::getAllowedVlans, Schema.list(Schema.STRING)))
           .put(
-              "all-prefixes",
+              "All_Prefixes",
               new PropertyDescriptor<>(Interface::getAllAddresses, Schema.list(Schema.STRING)))
-          .put("auto-state-vlan", new PropertyDescriptor<>(Interface::getAutoState, Schema.BOOLEAN))
-          .put("bandwidth", new PropertyDescriptor<>(Interface::getBandwidth, Schema.DOUBLE))
-          .put("blacklisted", new PropertyDescriptor<>(Interface::getBlacklisted, Schema.BOOLEAN))
-          .put("channel-group", new PropertyDescriptor<>(Interface::getChannelGroup, Schema.STRING))
+          .put("Auto_State_Vlan", new PropertyDescriptor<>(Interface::getAutoState, Schema.BOOLEAN))
+          .put("Bandwidth", new PropertyDescriptor<>(Interface::getBandwidth, Schema.DOUBLE))
+          .put("Blacklisted", new PropertyDescriptor<>(Interface::getBlacklisted, Schema.BOOLEAN))
+          .put("Channel_Group", new PropertyDescriptor<>(Interface::getChannelGroup, Schema.STRING))
           .put(
-              "channel-group-members",
+              "Channel_Group_Members",
               new PropertyDescriptor<>(
                   Interface::getChannelGroupMembers, Schema.list(Schema.STRING)))
           .put(
-              "declared-names",
+              "Declared_Names",
               new PropertyDescriptor<>(Interface::getDeclaredNames, Schema.list(Schema.STRING)))
-          .put("description", new PropertyDescriptor<>(Interface::getDescription, Schema.STRING))
+          .put("Description", new PropertyDescriptor<>(Interface::getDescription, Schema.STRING))
           .put(
-              "dhcp-relay-addresses",
+              "Dhcp_Relay_Addresses",
               new PropertyDescriptor<>(Interface::getDhcpRelayAddresses, Schema.list(Schema.IP)))
           .put(
-              "hsrp-groups",
+              "Hsrp_Groups",
               new PropertyDescriptor<>(Interface::getHsrpGroups, Schema.set(Schema.STRING)))
-          .put("hsrp-version", new PropertyDescriptor<>(Interface::getHsrpVersion, Schema.STRING))
+          .put("Hsrp_Version", new PropertyDescriptor<>(Interface::getHsrpVersion, Schema.STRING))
           // skip inbound-filter
           .put(
-              "inbound-filter-name",
+              "Inbound_Filter_Name",
               new PropertyDescriptor<>(Interface::getInboundFilterName, Schema.STRING))
           // skip incoming filter
           .put(
-              "incoming-filter-name",
+              "Incoming_Filter_Name",
               new PropertyDescriptor<>(Interface::getIncomingFilter, Schema.STRING))
           .put(
-              "interface-type",
+              "Interface_Type",
               new PropertyDescriptor<>(Interface::getInterfaceType, Schema.STRING))
-          .put("mtu", new PropertyDescriptor<>(Interface::getMtu, Schema.INTEGER))
-          .put("native-vlan", new PropertyDescriptor<>(Interface::getNativeVlan, Schema.INTEGER))
+          .put("Mtu", new PropertyDescriptor<>(Interface::getMtu, Schema.INTEGER))
+          .put("Native_Vlan", new PropertyDescriptor<>(Interface::getNativeVlan, Schema.INTEGER))
           // skip ospf area
           .put(
-              "ospf-area-name",
+              "Ospf_Area_Name",
               new PropertyDescriptor<>(Interface::getOspfAreaName, Schema.INTEGER))
-          .put("ospf-cost", new PropertyDescriptor<>(Interface::getOspfCost, Schema.INTEGER))
-          .put("ospf-enabled", new PropertyDescriptor<>(Interface::getOspfEnabled, Schema.BOOLEAN))
+          .put("Ospf_Cost", new PropertyDescriptor<>(Interface::getOspfCost, Schema.INTEGER))
+          .put("Ospf_Enabled", new PropertyDescriptor<>(Interface::getOspfEnabled, Schema.BOOLEAN))
           .put(
-              "ospf-hello-multiplier",
+              "Ospf_Hello_Multiplier",
               new PropertyDescriptor<>(Interface::getOspfHelloMultiplier, Schema.INTEGER))
-          .put("ospf-passive", new PropertyDescriptor<>(Interface::getOspfPassive, Schema.BOOLEAN))
+          .put("Ospf_Passive", new PropertyDescriptor<>(Interface::getOspfPassive, Schema.BOOLEAN))
           .put(
-              "ospf-point-to-point",
+              "Ospf_Point_To_Point",
               new PropertyDescriptor<>(Interface::getOspfPointToPoint, Schema.BOOLEAN))
           // skip outgoing filter
           .put(
-              "outgoing-filter-name",
+              "Outgoing_Filter_Name",
               new PropertyDescriptor<>(Interface::getOutgoingFilterName, Schema.STRING))
           // skip getOwner
-          .put("primary-address", new PropertyDescriptor<>(Interface::getAddress, Schema.STRING))
-          .put("proxy-arp", new PropertyDescriptor<>(Interface::getProxyArp, Schema.BOOLEAN))
-          .put("rip-enabled", new PropertyDescriptor<>(Interface::getRipEnabled, Schema.BOOLEAN))
-          .put("rip-passive", new PropertyDescriptor<>(Interface::getRipPassive, Schema.BOOLEAN))
+          .put("Primary_Address", new PropertyDescriptor<>(Interface::getAddress, Schema.STRING))
+          .put("Proxy_Arp", new PropertyDescriptor<>(Interface::getProxyArp, Schema.BOOLEAN))
+          .put("Rip_Enabled", new PropertyDescriptor<>(Interface::getRipEnabled, Schema.BOOLEAN))
+          .put("Rip_Passive", new PropertyDescriptor<>(Interface::getRipPassive, Schema.BOOLEAN))
           // skip routing policy
           .put(
-              "routing-policy-name",
+              "Routing_Policy_Name",
               new PropertyDescriptor<>(Interface::getRoutingPolicyName, Schema.STRING))
           .put(
-              "source-nats",
+              "Source_Nats",
               new PropertyDescriptor<>(Interface::getSourceNats, Schema.list(Schema.STRING)))
           .put(
-              "spanning-tree-portfast",
+              "Spanning_Tree_Portfast",
               new PropertyDescriptor<>(Interface::getSpanningTreePortfast, Schema.BOOLEAN))
-          .put("switchport", new PropertyDescriptor<>(Interface::getSwitchport, Schema.BOOLEAN))
+          .put("Switchport", new PropertyDescriptor<>(Interface::getSwitchport, Schema.BOOLEAN))
           .put(
-              "switchport-mode",
+              "Switchport_Mode",
               new PropertyDescriptor<>(Interface::getSwitchportMode, Schema.STRING))
           .put(
-              "switchport-trunk-encapsulation",
+              "Switchport_Trunk_Encapsulation",
               new PropertyDescriptor<>(Interface::getSwitchportTrunkEncapsulation, Schema.STRING))
-          .put("vrf", new PropertyDescriptor<>(Interface::getVrf, Schema.STRING))
+          .put("Vrf", new PropertyDescriptor<>(Interface::getVrf, Schema.STRING))
           .put(
-              "vrrp-groups",
+              "Vrrp_Groups",
               new PropertyDescriptor<>(Interface::getVrrpGroups, Schema.list(Schema.INTEGER)))
           // skip zone
-          .put("zone-name", new PropertyDescriptor<>(Interface::getZoneName, Schema.STRING))
+          .put("Zone_Name", new PropertyDescriptor<>(Interface::getZoneName, Schema.STRING))
           .build();
 
   public static final InterfacePropertySpecifier ALL = new InterfacePropertySpecifier(".*");

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/InterfacePropertySpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/InterfacePropertySpecifier.java
@@ -143,7 +143,7 @@ public class InterfacePropertySpecifier extends PropertySpecifier {
     return JAVA_MAP
         .keySet()
         .stream()
-        .filter(prop -> _pattern.matcher(prop).matches())
+        .filter(prop -> _pattern.matcher(prop.toLowerCase()).matches())
         .collect(Collectors.toSet());
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/NodePropertySpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/NodePropertySpecifier.java
@@ -29,105 +29,105 @@ public class NodePropertySpecifier extends PropertySpecifier {
   public static Map<String, PropertyDescriptor<Configuration>> JAVA_MAP =
       new ImmutableMap.Builder<String, PropertyDescriptor<Configuration>>()
           .put(
-              "as-path-access-lists",
+              "As_Path_Access_Lists",
               new PropertyDescriptor<>(
                   Configuration::getAsPathAccessLists, Schema.set(Schema.STRING)))
           .put(
-              "authentication-key-chains",
+              "Authentication_Key_Chains",
               new PropertyDescriptor<>(
                   Configuration::getAuthenticationKeyChains, Schema.set(Schema.STRING)))
-          .put("canonical-ip", new PropertyDescriptor<>(Configuration::getCanonicalIp, Schema.IP))
+          .put("canonical_Ip", new PropertyDescriptor<>(Configuration::getCanonicalIp, Schema.IP))
           .put(
-              "community-lists",
+              "community_Lists",
               new PropertyDescriptor<>(Configuration::getCommunityLists, Schema.set(Schema.STRING)))
           .put(
-              "configuration-format",
+              "configuration_Format",
               new PropertyDescriptor<>(Configuration::getConfigurationFormat, Schema.STRING))
           .put(
-              "default-cross-zone-action",
+              "Default_Cross_Zone_Action",
               new PropertyDescriptor<>(Configuration::getDefaultCrossZoneAction, Schema.STRING))
           .put(
-              "default-inbound-action",
+              "Default_Inbound_Action",
               new PropertyDescriptor<>(Configuration::getDefaultInboundAction, Schema.STRING))
-          .put("device-type", new PropertyDescriptor<>(Configuration::getDeviceType, Schema.STRING))
+          .put("Device_Type", new PropertyDescriptor<>(Configuration::getDeviceType, Schema.STRING))
           .put(
-              "dns-servers",
+              "dns_Servers",
               new PropertyDescriptor<>(Configuration::getDnsServers, Schema.set(Schema.STRING)))
           .put(
-              "dns-source-interface",
+              "dns_Source_Interface",
               new PropertyDescriptor<>(Configuration::getDnsSourceInterface, Schema.STRING))
-          .put("domain-name", new PropertyDescriptor<>(Configuration::getDomainName, Schema.STRING))
-          .put("hostname", new PropertyDescriptor<>(Configuration::getHostname, Schema.STRING))
+          .put("domain_Name", new PropertyDescriptor<>(Configuration::getDomainName, Schema.STRING))
+          .put("Hostname", new PropertyDescriptor<>(Configuration::getHostname, Schema.STRING))
           .put(
-              "ike-gateways",
+              "Ike_Gateways",
               new PropertyDescriptor<>(Configuration::getIkeGateways, Schema.set(Schema.STRING)))
           .put(
-              "ike-policies",
+              "Ike_Policies",
               new PropertyDescriptor<>(Configuration::getIkePolicies, Schema.set(Schema.STRING)))
           .put(
-              "interfaces",
+              "Interfaces",
               new PropertyDescriptor<>(Configuration::getInterfaces, Schema.set(Schema.STRING)))
           .put(
-              "ip-access-lists",
+              "Ip_Access_Lists",
               new PropertyDescriptor<>(Configuration::getIpAccessLists, Schema.set(Schema.STRING)))
           .put(
-              "ip-spaces",
+              "Ip_Spaces",
               new PropertyDescriptor<>(Configuration::getIpSpaces, Schema.set(Schema.STRING)))
           .put(
-              "ip6-access-lists",
+              "Ip6_Access_Lists",
               new PropertyDescriptor<>(Configuration::getIp6AccessLists, Schema.set(Schema.STRING)))
           .put(
-              "ipsec-policies",
+              "Ipsec_Policies",
               new PropertyDescriptor<>(Configuration::getIpsecPolicies, Schema.set(Schema.STRING)))
           .put(
-              "ipsec-proposals",
+              "Ipsec_Proposals",
               new PropertyDescriptor<>(Configuration::getIpsecProposals, Schema.set(Schema.STRING)))
           .put(
-              "ipsec-vpns",
+              "Ipsec_Vpns",
               new PropertyDescriptor<>(Configuration::getIpsecVpns, Schema.set(Schema.STRING)))
           .put(
-              "logging-servers",
+              "Logging_Servers",
               new PropertyDescriptor<>(Configuration::getLoggingServers, Schema.set(Schema.STRING)))
           .put(
-              "logging-source-interface",
+              "Logging_Source_Interface",
               new PropertyDescriptor<>(Configuration::getLoggingSourceInterface, Schema.STRING))
           .put(
-              "ntp-servers",
+              "Ntp_Servers",
               new PropertyDescriptor<>(Configuration::getNtpServers, Schema.set(Schema.STRING)))
           .put(
-              "ntp-source-interface",
+              "Ntp_Source_Interface",
               new PropertyDescriptor<>(Configuration::getNtpSourceInterface, Schema.STRING))
           .put(
-              "route-filter-lists",
+              "Route_Filter_Lists",
               new PropertyDescriptor<>(
                   Configuration::getRouteFilterLists, Schema.set(Schema.STRING)))
           .put(
-              "route6-filter-lists",
+              "Route6_Filter_Lists",
               new PropertyDescriptor<>(
                   Configuration::getRoute6FilterLists, Schema.set(Schema.STRING)))
           .put(
-              "routing-policies",
+              "Routing_Policies",
               new PropertyDescriptor<>(
                   Configuration::getRoutingPolicies, Schema.set(Schema.STRING)))
           .put(
-              "snmp-source-interface",
+              "Snmp_Source_Interface",
               new PropertyDescriptor<>(Configuration::getSnmpSourceInterface, Schema.STRING))
           .put(
-              "snmp-trap-servers",
+              "Snmp_Trap_Servers",
               new PropertyDescriptor<>(
                   Configuration::getSnmpTrapServers, Schema.set(Schema.STRING)))
           .put(
-              "tacacs-servers",
+              "Tacacs_Servers",
               new PropertyDescriptor<>(Configuration::getTacacsServers, Schema.set(Schema.STRING)))
           .put(
-              "tacacs-source-interface",
+              "Tacacs_Source_Interface",
               new PropertyDescriptor<>(Configuration::getTacacsSourceInterface, Schema.STRING))
           .put(
-              "vendor-family",
+              "VendorFamily",
               new PropertyDescriptor<>(Configuration::getVendorFamily, Schema.STRING))
-          .put("vrfs", new PropertyDescriptor<>(Configuration::getVrfs, Schema.set(Schema.STRING)))
+          .put("Vrfs", new PropertyDescriptor<>(Configuration::getVrfs, Schema.set(Schema.STRING)))
           .put(
-              "zones", new PropertyDescriptor<>(Configuration::getZones, Schema.set(Schema.STRING)))
+              "Zones", new PropertyDescriptor<>(Configuration::getZones, Schema.set(Schema.STRING)))
           .build();
 
   public static final NodePropertySpecifier ALL = new NodePropertySpecifier(".*");

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/NodePropertySpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/NodePropertySpecifier.java
@@ -36,12 +36,12 @@ public class NodePropertySpecifier extends PropertySpecifier {
               "Authentication_Key_Chains",
               new PropertyDescriptor<>(
                   Configuration::getAuthenticationKeyChains, Schema.set(Schema.STRING)))
-          .put("canonical_Ip", new PropertyDescriptor<>(Configuration::getCanonicalIp, Schema.IP))
+          .put("Canonical_Ip", new PropertyDescriptor<>(Configuration::getCanonicalIp, Schema.IP))
           .put(
-              "community_Lists",
+              "Community_Lists",
               new PropertyDescriptor<>(Configuration::getCommunityLists, Schema.set(Schema.STRING)))
           .put(
-              "configuration_Format",
+              "Configuration_Format",
               new PropertyDescriptor<>(Configuration::getConfigurationFormat, Schema.STRING))
           .put(
               "Default_Cross_Zone_Action",
@@ -51,12 +51,12 @@ public class NodePropertySpecifier extends PropertySpecifier {
               new PropertyDescriptor<>(Configuration::getDefaultInboundAction, Schema.STRING))
           .put("Device_Type", new PropertyDescriptor<>(Configuration::getDeviceType, Schema.STRING))
           .put(
-              "dns_Servers",
+              "Dns_Servers",
               new PropertyDescriptor<>(Configuration::getDnsServers, Schema.set(Schema.STRING)))
           .put(
-              "dns_Source_Interface",
+              "Dns_Source_Interface",
               new PropertyDescriptor<>(Configuration::getDnsSourceInterface, Schema.STRING))
-          .put("domain_Name", new PropertyDescriptor<>(Configuration::getDomainName, Schema.STRING))
+          .put("Domain_Name", new PropertyDescriptor<>(Configuration::getDomainName, Schema.STRING))
           .put("Hostname", new PropertyDescriptor<>(Configuration::getHostname, Schema.STRING))
           .put(
               "Ike_Gateways",
@@ -123,7 +123,7 @@ public class NodePropertySpecifier extends PropertySpecifier {
               "Tacacs_Source_Interface",
               new PropertyDescriptor<>(Configuration::getTacacsSourceInterface, Schema.STRING))
           .put(
-              "VendorFamily",
+              "Vendor_Family",
               new PropertyDescriptor<>(Configuration::getVendorFamily, Schema.STRING))
           .put("Vrfs", new PropertyDescriptor<>(Configuration::getVrfs, Schema.set(Schema.STRING)))
           .put(

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/NodePropertySpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/NodePropertySpecifier.java
@@ -26,108 +26,143 @@ import org.batfish.datamodel.answers.Schema;
  */
 public class NodePropertySpecifier extends PropertySpecifier {
 
+  public static final String AS_PATH_ACCESS_LISTS = "AS_Path_Access_Lists";
+  public static final String AUTHENTICATION_KEY_CHAINS = "Authentication_Key_Chains";
+  public static final String CANONICAL_IP = "Canonical_IP";
+  public static final String COMMUNITY_LISTS = "Community_Lists";
+  public static final String CONFIGURATION_FORMAT = "Configuration_Format";
+  public static final String DEFAULT_CROSS_ZONE_ACTION = "Default_Cross_Zone_Action";
+  public static final String DEFAULT_INBOUND_ACTION = "Default_Inbound_Action";
+  public static final String DEVICE_TYPE = "Device_Type";
+  public static final String DNS_SERVERS = "DNS_Servers";
+  public static final String DNS_SOURCE_INTERFACE = "DNS_Source_Interface";
+  public static final String DOMAIN_NAME = "Domain_Name";
+  public static final String HOSTNAME = "Hostname";
+  public static final String IKE_GATEWAYS = "IKE_Gateways";
+  public static final String IKE_POLICIES = "IKE_Policies";
+  public static final String INTERFACES = "Interfaces";
+  public static final String IP_ACCESS_LISTS = "IP_Access_Lists";
+  public static final String IP_SPACES = "IP_Spaces";
+  public static final String IP_6_ACCESS_LISTS = "IP6_Access_Lists";
+  public static final String IPSEC_POLICIES = "IPSec_Policies";
+  public static final String IPSEC_PROPOSALS = "IPSec_Proposals";
+  public static final String IPSEC_VPNS = "IPSec_Vpns";
+  public static final String LOGGING_SERVERS = "Logging_Servers";
+  public static final String LOGGING_SOURCE_INTERFACE = "Logging_Source_Interface";
+  public static final String NTP_SERVERS = "NTP_Servers";
+  public static final String NTP_SOURCE_INTERFACE = "NTP_Source_Interface";
+  public static final String ROUTE_FILTER_LISTS = "Route_Filter_Lists";
+  public static final String ROUTE_6_FILTER_LISTS = "Route6_Filter_Lists";
+  public static final String ROUTING_POLICIES = "Routing_Policies";
+  public static final String SNMP_SOURCE_INTERFACE = "SNMP_Source_Interface";
+  public static final String SNMP_TRAP_SERVERS = "SNMP_Trap_Servers";
+  public static final String TACACS_SERVERS = "TACACS_Servers";
+  public static final String TACACS_SOURCE_INTERFACE = "TACACS_Source_Interface";
+  public static final String VENDOR_FAMILY = "Vendor_Family";
+  public static final String VRFS = "VRFs";
+  public static final String ZONES = "Zones";
+
   public static Map<String, PropertyDescriptor<Configuration>> JAVA_MAP =
       new ImmutableMap.Builder<String, PropertyDescriptor<Configuration>>()
           .put(
-              "As_Path_Access_Lists",
+              AS_PATH_ACCESS_LISTS,
               new PropertyDescriptor<>(
                   Configuration::getAsPathAccessLists, Schema.set(Schema.STRING)))
           .put(
-              "Authentication_Key_Chains",
+              AUTHENTICATION_KEY_CHAINS,
               new PropertyDescriptor<>(
                   Configuration::getAuthenticationKeyChains, Schema.set(Schema.STRING)))
-          .put("Canonical_Ip", new PropertyDescriptor<>(Configuration::getCanonicalIp, Schema.IP))
+          .put(CANONICAL_IP, new PropertyDescriptor<>(Configuration::getCanonicalIp, Schema.IP))
           .put(
-              "Community_Lists",
+              COMMUNITY_LISTS,
               new PropertyDescriptor<>(Configuration::getCommunityLists, Schema.set(Schema.STRING)))
           .put(
-              "Configuration_Format",
+              CONFIGURATION_FORMAT,
               new PropertyDescriptor<>(Configuration::getConfigurationFormat, Schema.STRING))
           .put(
-              "Default_Cross_Zone_Action",
+              DEFAULT_CROSS_ZONE_ACTION,
               new PropertyDescriptor<>(Configuration::getDefaultCrossZoneAction, Schema.STRING))
           .put(
-              "Default_Inbound_Action",
+              DEFAULT_INBOUND_ACTION,
               new PropertyDescriptor<>(Configuration::getDefaultInboundAction, Schema.STRING))
-          .put("Device_Type", new PropertyDescriptor<>(Configuration::getDeviceType, Schema.STRING))
+          .put(DEVICE_TYPE, new PropertyDescriptor<>(Configuration::getDeviceType, Schema.STRING))
           .put(
-              "Dns_Servers",
+              DNS_SERVERS,
               new PropertyDescriptor<>(Configuration::getDnsServers, Schema.set(Schema.STRING)))
           .put(
-              "Dns_Source_Interface",
+              DNS_SOURCE_INTERFACE,
               new PropertyDescriptor<>(Configuration::getDnsSourceInterface, Schema.STRING))
-          .put("Domain_Name", new PropertyDescriptor<>(Configuration::getDomainName, Schema.STRING))
-          .put("Hostname", new PropertyDescriptor<>(Configuration::getHostname, Schema.STRING))
+          .put(DOMAIN_NAME, new PropertyDescriptor<>(Configuration::getDomainName, Schema.STRING))
+          .put(HOSTNAME, new PropertyDescriptor<>(Configuration::getHostname, Schema.STRING))
           .put(
-              "Ike_Gateways",
+              IKE_GATEWAYS,
               new PropertyDescriptor<>(Configuration::getIkeGateways, Schema.set(Schema.STRING)))
           .put(
-              "Ike_Policies",
+              IKE_POLICIES,
               new PropertyDescriptor<>(Configuration::getIkePolicies, Schema.set(Schema.STRING)))
           .put(
-              "Interfaces",
+              INTERFACES,
               new PropertyDescriptor<>(Configuration::getInterfaces, Schema.set(Schema.STRING)))
           .put(
-              "Ip_Access_Lists",
+              IP_ACCESS_LISTS,
               new PropertyDescriptor<>(Configuration::getIpAccessLists, Schema.set(Schema.STRING)))
           .put(
-              "Ip_Spaces",
+              IP_SPACES,
               new PropertyDescriptor<>(Configuration::getIpSpaces, Schema.set(Schema.STRING)))
           .put(
-              "Ip6_Access_Lists",
+              IP_6_ACCESS_LISTS,
               new PropertyDescriptor<>(Configuration::getIp6AccessLists, Schema.set(Schema.STRING)))
           .put(
-              "Ipsec_Policies",
+              IPSEC_POLICIES,
               new PropertyDescriptor<>(Configuration::getIpsecPolicies, Schema.set(Schema.STRING)))
           .put(
-              "Ipsec_Proposals",
+              IPSEC_PROPOSALS,
               new PropertyDescriptor<>(Configuration::getIpsecProposals, Schema.set(Schema.STRING)))
           .put(
-              "Ipsec_Vpns",
+              IPSEC_VPNS,
               new PropertyDescriptor<>(Configuration::getIpsecVpns, Schema.set(Schema.STRING)))
           .put(
-              "Logging_Servers",
+              LOGGING_SERVERS,
               new PropertyDescriptor<>(Configuration::getLoggingServers, Schema.set(Schema.STRING)))
           .put(
-              "Logging_Source_Interface",
+              LOGGING_SOURCE_INTERFACE,
               new PropertyDescriptor<>(Configuration::getLoggingSourceInterface, Schema.STRING))
           .put(
-              "Ntp_Servers",
+              NTP_SERVERS,
               new PropertyDescriptor<>(Configuration::getNtpServers, Schema.set(Schema.STRING)))
           .put(
-              "Ntp_Source_Interface",
+              NTP_SOURCE_INTERFACE,
               new PropertyDescriptor<>(Configuration::getNtpSourceInterface, Schema.STRING))
           .put(
-              "Route_Filter_Lists",
+              ROUTE_FILTER_LISTS,
               new PropertyDescriptor<>(
                   Configuration::getRouteFilterLists, Schema.set(Schema.STRING)))
           .put(
-              "Route6_Filter_Lists",
+              ROUTE_6_FILTER_LISTS,
               new PropertyDescriptor<>(
                   Configuration::getRoute6FilterLists, Schema.set(Schema.STRING)))
           .put(
-              "Routing_Policies",
+              ROUTING_POLICIES,
               new PropertyDescriptor<>(
                   Configuration::getRoutingPolicies, Schema.set(Schema.STRING)))
           .put(
-              "Snmp_Source_Interface",
+              SNMP_SOURCE_INTERFACE,
               new PropertyDescriptor<>(Configuration::getSnmpSourceInterface, Schema.STRING))
           .put(
-              "Snmp_Trap_Servers",
+              SNMP_TRAP_SERVERS,
               new PropertyDescriptor<>(
                   Configuration::getSnmpTrapServers, Schema.set(Schema.STRING)))
           .put(
-              "Tacacs_Servers",
+              TACACS_SERVERS,
               new PropertyDescriptor<>(Configuration::getTacacsServers, Schema.set(Schema.STRING)))
           .put(
-              "Tacacs_Source_Interface",
+              TACACS_SOURCE_INTERFACE,
               new PropertyDescriptor<>(Configuration::getTacacsSourceInterface, Schema.STRING))
           .put(
-              "Vendor_Family",
+              VENDOR_FAMILY,
               new PropertyDescriptor<>(Configuration::getVendorFamily, Schema.STRING))
-          .put("Vrfs", new PropertyDescriptor<>(Configuration::getVrfs, Schema.set(Schema.STRING)))
-          .put(
-              "Zones", new PropertyDescriptor<>(Configuration::getZones, Schema.set(Schema.STRING)))
+          .put(VRFS, new PropertyDescriptor<>(Configuration::getVrfs, Schema.set(Schema.STRING)))
+          .put(ZONES, new PropertyDescriptor<>(Configuration::getZones, Schema.set(Schema.STRING)))
           .build();
 
   public static final NodePropertySpecifier ALL = new NodePropertySpecifier(".*");

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/NodePropertySpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/NodePropertySpecifier.java
@@ -158,7 +158,7 @@ public class NodePropertySpecifier extends PropertySpecifier {
     return JAVA_MAP
         .keySet()
         .stream()
-        .filter(prop -> _pattern.matcher(prop).matches())
+        .filter(prop -> _pattern.matcher(prop.toLowerCase()).matches())
         .collect(Collectors.toSet());
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/OspfPropertySpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/OspfPropertySpecifier.java
@@ -27,39 +27,39 @@ public class OspfPropertySpecifier extends PropertySpecifier {
   public static Map<String, PropertyDescriptor<OspfProcess>> JAVA_MAP =
       new ImmutableMap.Builder<String, PropertyDescriptor<OspfProcess>>()
           .put(
-              "area-border-router",
+              "Area_Border_Router",
               new PropertyDescriptor<>(OspfProcess::isAreaBorderRouter, Schema.BOOLEAN))
           // will go from Long to String --> area Ids are not integral anyway
-          .put("areas", new PropertyDescriptor<>(OspfProcess::getAreas, Schema.set(Schema.STRING)))
+          .put("Areas", new PropertyDescriptor<>(OspfProcess::getAreas, Schema.set(Schema.STRING)))
           .put(
-              "export-policy",
+              "Export_Policy",
               new PropertyDescriptor<>(OspfProcess::getExportPolicy, Schema.STRING))
           .put(
-              "generated-routes",
+              "Generated_Routes",
               new PropertyDescriptor<>(OspfProcess::getGeneratedRoutes, Schema.set(Schema.STRING)))
           // All max-metrics go from Long to String
           .put(
-              "max-metric-external-networks",
+              "Max_Metric_External_Networks",
               new PropertyDescriptor<>(OspfProcess::getMaxMetricExternalNetworks, Schema.INTEGER))
           .put(
-              "max-metric-stub-networks",
+              "Max_Metric_Stub_Networks",
               new PropertyDescriptor<>(OspfProcess::getMaxMetricStubNetworks, Schema.INTEGER))
           .put(
-              "max-metric-summary-networks",
+              "Max_Metric_Summary_Networks",
               new PropertyDescriptor<>(OspfProcess::getMaxMetricSummaryNetworks, Schema.INTEGER))
           .put(
-              "max-metric-transit-links",
+              "Max_Metric_Transit_Links",
               new PropertyDescriptor<>(OspfProcess::getMaxMetricTransitLinks, Schema.INTEGER))
           .put(
-              "neighbors",
+              "Neighbors",
               new PropertyDescriptor<>(OspfProcess::getOspfNeighbors, Schema.set(Schema.STRING)))
           .put(
-              "reference-bandwidth",
+              "Reference_Bandwidth",
               new PropertyDescriptor<>(OspfProcess::getReferenceBandwidth, Schema.DOUBLE))
           .put(
-              "rfc1583-compatible",
+              "Rfc1583_Compatible",
               new PropertyDescriptor<>(OspfProcess::getRfc1583Compatible, Schema.BOOLEAN))
-          .put("router-id", new PropertyDescriptor<>(OspfProcess::getRouterId, Schema.IP))
+          .put("Router_Id", new PropertyDescriptor<>(OspfProcess::getRouterId, Schema.IP))
           .build();
 
   public static final OspfPropertySpecifier ALL = new OspfPropertySpecifier(".*");

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/OspfPropertySpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/OspfPropertySpecifier.java
@@ -87,7 +87,7 @@ public class OspfPropertySpecifier extends PropertySpecifier {
     return JAVA_MAP
         .keySet()
         .stream()
-        .filter(prop -> _pattern.matcher(prop).matches())
+        .filter(prop -> _pattern.matcher(prop.toLowerCase()).matches())
         .collect(Collectors.toSet());
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/OspfPropertySpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/OspfPropertySpecifier.java
@@ -24,42 +24,53 @@ import org.batfish.datamodel.ospf.OspfProcess;
  */
 public class OspfPropertySpecifier extends PropertySpecifier {
 
+  public static final String AREA_BORDER_ROUTER = "Area_Border_Router";
+  public static final String AREAS = "Areas";
+  public static final String EXPORT_POLICY = "Export_Policy";
+  public static final String GENERATED_ROUTES = "Generated_Routes";
+  public static final String MAX_METRIC_EXTERNAL_NETWORKS = "Max_Metric_External_Networks";
+  public static final String MAX_METRIC_STUB_NETWORKS = "Max_Metric_Stub_Networks";
+  public static final String MAX_METRIC_SUMMARY_NETWORKS = "Max_Metric_Summary_Networks";
+  public static final String MAX_METRIC_TRANSIT_LINKS = "Max_Metric_Transit_Links";
+  public static final String NEIGHBORS = "Neighbors";
+  public static final String REFERENCE_BANDWIDTH = "Reference_Bandwidth";
+  public static final String RFC_1583_COMPATIBLE = "RFC1583_Compatible";
+  public static final String ROUTER_ID = "Router_ID";
+
   public static Map<String, PropertyDescriptor<OspfProcess>> JAVA_MAP =
       new ImmutableMap.Builder<String, PropertyDescriptor<OspfProcess>>()
           .put(
-              "Area_Border_Router",
+              AREA_BORDER_ROUTER,
               new PropertyDescriptor<>(OspfProcess::isAreaBorderRouter, Schema.BOOLEAN))
           // will go from Long to String --> area Ids are not integral anyway
-          .put("Areas", new PropertyDescriptor<>(OspfProcess::getAreas, Schema.set(Schema.STRING)))
+          .put(AREAS, new PropertyDescriptor<>(OspfProcess::getAreas, Schema.set(Schema.STRING)))
+          .put(EXPORT_POLICY, new PropertyDescriptor<>(OspfProcess::getExportPolicy, Schema.STRING))
           .put(
-              "Export_Policy",
-              new PropertyDescriptor<>(OspfProcess::getExportPolicy, Schema.STRING))
-          .put(
-              "Generated_Routes",
+              GENERATED_ROUTES,
               new PropertyDescriptor<>(OspfProcess::getGeneratedRoutes, Schema.set(Schema.STRING)))
           // All max-metrics go from Long to String
           .put(
-              "Max_Metric_External_Networks",
+              MAX_METRIC_EXTERNAL_NETWORKS,
               new PropertyDescriptor<>(OspfProcess::getMaxMetricExternalNetworks, Schema.INTEGER))
           .put(
-              "Max_Metric_Stub_Networks",
+              MAX_METRIC_STUB_NETWORKS,
               new PropertyDescriptor<>(OspfProcess::getMaxMetricStubNetworks, Schema.INTEGER))
           .put(
-              "Max_Metric_Summary_Networks",
+              MAX_METRIC_SUMMARY_NETWORKS,
               new PropertyDescriptor<>(OspfProcess::getMaxMetricSummaryNetworks, Schema.INTEGER))
           .put(
-              "Max_Metric_Transit_Links",
+              MAX_METRIC_TRANSIT_LINKS,
               new PropertyDescriptor<>(OspfProcess::getMaxMetricTransitLinks, Schema.INTEGER))
           .put(
-              "Neighbors",
+              NEIGHBORS,
               new PropertyDescriptor<>(OspfProcess::getOspfNeighbors, Schema.set(Schema.STRING)))
           .put(
-              "Reference_Bandwidth",
+              REFERENCE_BANDWIDTH,
               new PropertyDescriptor<>(OspfProcess::getReferenceBandwidth, Schema.DOUBLE))
           .put(
-              "Rfc1583_Compatible",
+              RFC_1583_COMPATIBLE,
               new PropertyDescriptor<>(OspfProcess::getRfc1583Compatible, Schema.BOOLEAN))
-          .put("Router_Id", new PropertyDescriptor<>(OspfProcess::getRouterId, Schema.IP))
+          .put(ROUTER_ID, new PropertyDescriptor<>(OspfProcess::getRouterId, Schema.IP))
           .build();
 
   public static final OspfPropertySpecifier ALL = new OspfPropertySpecifier(".*");

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/PropertySpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/PropertySpecifier.java
@@ -65,7 +65,7 @@ public abstract class PropertySpecifier {
       List<AutocompleteSuggestion> propertySuggestions =
           allProperties
               .stream()
-              .filter(prop -> queryPattern.matcher(prop).matches())
+              .filter(prop -> queryPattern.matcher(prop.toLowerCase()).matches())
               .map(prop -> new AutocompleteSuggestion(prop, false))
               .collect(Collectors.toList());
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/PropertySpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/PropertySpecifierTest.java
@@ -30,7 +30,7 @@ public class PropertySpecifierTest {
 
   @Test
   public void baseAutoComplete() {
-    Set<String> properties = ImmutableSet.of("abc", "ntp-servers", "ntp-source-interface");
+    Set<String> properties = ImmutableSet.of("abc", "ntp_servers", "ntp_source_interface");
 
     // null or empty string should yield all options, with .* as the first one
     assertThat(
@@ -46,8 +46,8 @@ public class PropertySpecifierTest {
         equalTo(
             ImmutableList.of(
                 new AutocompleteSuggestion(".*ntp.*", false),
-                new AutocompleteSuggestion("ntp-servers", false),
-                new AutocompleteSuggestion("ntp-source-interface", false))));
+                new AutocompleteSuggestion("ntp_servers", false),
+                new AutocompleteSuggestion("ntp_source_interface", false))));
   }
 
   @Test
@@ -94,7 +94,7 @@ public class PropertySpecifierTest {
   public void fillPropertyForcedString() {
     Configuration configuration = new Configuration("hostname", ConfigurationFormat.CISCO_IOS);
     configuration.setDefaultInboundAction(LineAction.PERMIT);
-    String property = "default-inbound-action";
+    String property = "Default_Inbound_Action";
     PropertyDescriptor<Configuration> propertyDescriptor =
         NodePropertySpecifier.JAVA_MAP.get(property);
     RowBuilder row = Row.builder();
@@ -109,7 +109,7 @@ public class PropertySpecifierTest {
   @Test
   public void fillPropertyListEmpty() {
     Configuration configuration = new Configuration("hostname", ConfigurationFormat.CISCO_IOS);
-    String property = "ntp-servers";
+    String property = "Ntp_Servers";
     PropertyDescriptor<Configuration> propertyDescriptor =
         NodePropertySpecifier.JAVA_MAP.get(property);
     RowBuilder row = Row.builder();
@@ -124,7 +124,7 @@ public class PropertySpecifierTest {
   public void fillPropertyListNonEmpty() {
     Configuration configuration = new Configuration("hostname", ConfigurationFormat.CISCO_IOS);
     configuration.setNtpServers(ImmutableSortedSet.of("sa", "sb"));
-    String property = "ntp-servers";
+    String property = "Ntp_Servers";
     PropertyDescriptor<Configuration> propertyDescriptor =
         NodePropertySpecifier.JAVA_MAP.get(property);
     RowBuilder row = Row.builder();
@@ -140,7 +140,7 @@ public class PropertySpecifierTest {
   public void fillPropertyMap() {
     Configuration configuration = new Configuration("hostname", ConfigurationFormat.CISCO_IOS);
     configuration.setInterfaces(ImmutableSortedMap.of("i1", new Interface("i1")));
-    String property = "interfaces";
+    String property = "Interfaces";
     PropertyDescriptor<Configuration> propertyDescriptor =
         NodePropertySpecifier.JAVA_MAP.get(property);
     RowBuilder row = Row.builder();
@@ -154,7 +154,7 @@ public class PropertySpecifierTest {
   @Test
   public void fillPropertyNull() {
     Configuration configuration = new Configuration("hostname", ConfigurationFormat.CISCO_IOS);
-    String property = "ntp-source-interface";
+    String property = "Ntp_Source_Interface";
     PropertyDescriptor<Configuration> propertyDescriptor =
         NodePropertySpecifier.JAVA_MAP.get(property);
     RowBuilder row = Row.builder();

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/PropertySpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/PropertySpecifierTest.java
@@ -1,5 +1,9 @@
 package org.batfish.datamodel.questions;
 
+import static org.batfish.datamodel.questions.NodePropertySpecifier.DEFAULT_INBOUND_ACTION;
+import static org.batfish.datamodel.questions.NodePropertySpecifier.INTERFACES;
+import static org.batfish.datamodel.questions.NodePropertySpecifier.NTP_SERVERS;
+import static org.batfish.datamodel.questions.NodePropertySpecifier.NTP_SOURCE_INTERFACE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 
@@ -30,7 +34,7 @@ public class PropertySpecifierTest {
 
   @Test
   public void baseAutoComplete() {
-    Set<String> properties = ImmutableSet.of("abc", "ntp_servers", "ntp_source_interface");
+    Set<String> properties = ImmutableSet.of("abc", NTP_SERVERS, NTP_SOURCE_INTERFACE);
 
     // null or empty string should yield all options, with .* as the first one
     assertThat(
@@ -46,8 +50,8 @@ public class PropertySpecifierTest {
         equalTo(
             ImmutableList.of(
                 new AutocompleteSuggestion(".*ntp.*", false),
-                new AutocompleteSuggestion("ntp_servers", false),
-                new AutocompleteSuggestion("ntp_source_interface", false))));
+                new AutocompleteSuggestion(NTP_SERVERS, false),
+                new AutocompleteSuggestion(NTP_SOURCE_INTERFACE, false))));
   }
 
   @Test
@@ -94,7 +98,7 @@ public class PropertySpecifierTest {
   public void fillPropertyForcedString() {
     Configuration configuration = new Configuration("hostname", ConfigurationFormat.CISCO_IOS);
     configuration.setDefaultInboundAction(LineAction.PERMIT);
-    String property = "Default_Inbound_Action";
+    String property = DEFAULT_INBOUND_ACTION;
     PropertyDescriptor<Configuration> propertyDescriptor =
         NodePropertySpecifier.JAVA_MAP.get(property);
     RowBuilder row = Row.builder();
@@ -109,7 +113,7 @@ public class PropertySpecifierTest {
   @Test
   public void fillPropertyListEmpty() {
     Configuration configuration = new Configuration("hostname", ConfigurationFormat.CISCO_IOS);
-    String property = "Ntp_Servers";
+    String property = NTP_SERVERS;
     PropertyDescriptor<Configuration> propertyDescriptor =
         NodePropertySpecifier.JAVA_MAP.get(property);
     RowBuilder row = Row.builder();
@@ -124,7 +128,7 @@ public class PropertySpecifierTest {
   public void fillPropertyListNonEmpty() {
     Configuration configuration = new Configuration("hostname", ConfigurationFormat.CISCO_IOS);
     configuration.setNtpServers(ImmutableSortedSet.of("sa", "sb"));
-    String property = "Ntp_Servers";
+    String property = NTP_SERVERS;
     PropertyDescriptor<Configuration> propertyDescriptor =
         NodePropertySpecifier.JAVA_MAP.get(property);
     RowBuilder row = Row.builder();
@@ -140,7 +144,7 @@ public class PropertySpecifierTest {
   public void fillPropertyMap() {
     Configuration configuration = new Configuration("hostname", ConfigurationFormat.CISCO_IOS);
     configuration.setInterfaces(ImmutableSortedMap.of("i1", new Interface("i1")));
-    String property = "Interfaces";
+    String property = INTERFACES;
     PropertyDescriptor<Configuration> propertyDescriptor =
         NodePropertySpecifier.JAVA_MAP.get(property);
     RowBuilder row = Row.builder();
@@ -154,7 +158,7 @@ public class PropertySpecifierTest {
   @Test
   public void fillPropertyNull() {
     Configuration configuration = new Configuration("hostname", ConfigurationFormat.CISCO_IOS);
-    String property = "Ntp_Source_Interface";
+    String property = NTP_SOURCE_INTERFACE;
     PropertyDescriptor<Configuration> propertyDescriptor =
         NodePropertySpecifier.JAVA_MAP.get(property);
     RowBuilder row = Row.builder();

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/PropertySpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/PropertySpecifierTest.java
@@ -1,9 +1,5 @@
 package org.batfish.datamodel.questions;
 
-import static org.batfish.datamodel.questions.NodePropertySpecifier.DEFAULT_INBOUND_ACTION;
-import static org.batfish.datamodel.questions.NodePropertySpecifier.INTERFACES;
-import static org.batfish.datamodel.questions.NodePropertySpecifier.NTP_SERVERS;
-import static org.batfish.datamodel.questions.NodePropertySpecifier.NTP_SOURCE_INTERFACE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 
@@ -34,7 +30,9 @@ public class PropertySpecifierTest {
 
   @Test
   public void baseAutoComplete() {
-    Set<String> properties = ImmutableSet.of("abc", NTP_SERVERS, NTP_SOURCE_INTERFACE);
+    Set<String> properties =
+        ImmutableSet.of(
+            "abc", NodePropertySpecifier.NTP_SERVERS, NodePropertySpecifier.NTP_SOURCE_INTERFACE);
 
     // null or empty string should yield all options, with .* as the first one
     assertThat(
@@ -50,8 +48,8 @@ public class PropertySpecifierTest {
         equalTo(
             ImmutableList.of(
                 new AutocompleteSuggestion(".*ntp.*", false),
-                new AutocompleteSuggestion(NTP_SERVERS, false),
-                new AutocompleteSuggestion(NTP_SOURCE_INTERFACE, false))));
+                new AutocompleteSuggestion(NodePropertySpecifier.NTP_SERVERS, false),
+                new AutocompleteSuggestion(NodePropertySpecifier.NTP_SOURCE_INTERFACE, false))));
   }
 
   @Test
@@ -98,7 +96,7 @@ public class PropertySpecifierTest {
   public void fillPropertyForcedString() {
     Configuration configuration = new Configuration("hostname", ConfigurationFormat.CISCO_IOS);
     configuration.setDefaultInboundAction(LineAction.PERMIT);
-    String property = DEFAULT_INBOUND_ACTION;
+    String property = NodePropertySpecifier.DEFAULT_INBOUND_ACTION;
     PropertyDescriptor<Configuration> propertyDescriptor =
         NodePropertySpecifier.JAVA_MAP.get(property);
     RowBuilder row = Row.builder();
@@ -113,7 +111,7 @@ public class PropertySpecifierTest {
   @Test
   public void fillPropertyListEmpty() {
     Configuration configuration = new Configuration("hostname", ConfigurationFormat.CISCO_IOS);
-    String property = NTP_SERVERS;
+    String property = NodePropertySpecifier.NTP_SERVERS;
     PropertyDescriptor<Configuration> propertyDescriptor =
         NodePropertySpecifier.JAVA_MAP.get(property);
     RowBuilder row = Row.builder();
@@ -128,7 +126,7 @@ public class PropertySpecifierTest {
   public void fillPropertyListNonEmpty() {
     Configuration configuration = new Configuration("hostname", ConfigurationFormat.CISCO_IOS);
     configuration.setNtpServers(ImmutableSortedSet.of("sa", "sb"));
-    String property = NTP_SERVERS;
+    String property = NodePropertySpecifier.NTP_SERVERS;
     PropertyDescriptor<Configuration> propertyDescriptor =
         NodePropertySpecifier.JAVA_MAP.get(property);
     RowBuilder row = Row.builder();
@@ -144,7 +142,7 @@ public class PropertySpecifierTest {
   public void fillPropertyMap() {
     Configuration configuration = new Configuration("hostname", ConfigurationFormat.CISCO_IOS);
     configuration.setInterfaces(ImmutableSortedMap.of("i1", new Interface("i1")));
-    String property = INTERFACES;
+    String property = NodePropertySpecifier.INTERFACES;
     PropertyDescriptor<Configuration> propertyDescriptor =
         NodePropertySpecifier.JAVA_MAP.get(property);
     RowBuilder row = Row.builder();
@@ -158,7 +156,7 @@ public class PropertySpecifierTest {
   @Test
   public void fillPropertyNull() {
     Configuration configuration = new Configuration("hostname", ConfigurationFormat.CISCO_IOS);
-    String property = NTP_SOURCE_INTERFACE;
+    String property = NodePropertySpecifier.NTP_SOURCE_INTERFACE;
     PropertyDescriptor<Configuration> propertyDescriptor =
         NodePropertySpecifier.JAVA_MAP.get(property);
     RowBuilder row = Row.builder();

--- a/projects/question/src/main/java/org/batfish/question/SmtRoleQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/SmtRoleQuestionPlugin.java
@@ -24,7 +24,7 @@ public class SmtRoleQuestionPlugin extends QuestionPlugin {
     public AnswerElement answer() {
       RoleQuestion q = (RoleQuestion) _question;
       return _batfish.smtRoles(q);
-      // return _batfish.smtRoles(q.getType(), q.getNodeRegex());
+      // return _batfish.smtRoles(q.getType(), q.getNodes());
     }
   }
 

--- a/projects/question/src/main/java/org/batfish/question/bgpproperties/BgpPropertiesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/bgpproperties/BgpPropertiesAnswerer.java
@@ -73,21 +73,20 @@ public class BgpPropertiesAnswerer extends Answerer {
     if (dhints != null && dhints.getTextDesc() != null) {
       textDesc = dhints.getTextDesc();
     }
-    return new TableMetadata(createColumnMetadata(question.getPropertySpec()), textDesc);
+    return new TableMetadata(createColumnMetadata(question.getProperties()), textDesc);
   }
 
   @Override
   public AnswerElement answer() {
     BgpPropertiesQuestion question = (BgpPropertiesQuestion) _question;
     Map<String, Configuration> configurations = _batfish.loadConfigurations();
-    Set<String> nodes = question.getNodeRegex().getMatchingNodes(_batfish);
+    Set<String> nodes = question.getNodes().getMatchingNodes(_batfish);
 
     TableMetadata tableMetadata = createTableMetadata(question);
     TableAnswerElement answer = new TableAnswerElement(tableMetadata);
 
     Multiset<Row> propertyRows =
-        getProperties(
-            question.getPropertySpec(), configurations, nodes, tableMetadata.toColumnMap());
+        getProperties(question.getProperties(), configurations, nodes, tableMetadata.toColumnMap());
 
     answer.postProcessAnswer(question, propertyRows);
     return answer;

--- a/projects/question/src/main/java/org/batfish/question/bgpproperties/BgpPropertiesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/bgpproperties/BgpPropertiesAnswerer.java
@@ -29,8 +29,8 @@ import org.batfish.datamodel.table.TableMetadata;
 public class BgpPropertiesAnswerer extends Answerer {
 
   public static final String COL_NODE = "Node";
-  public static final String COL_VRF = "VRF";
-  public static final String COL_ROUTER_ID = "RouterId";
+  public static final String COL_VRF = "Vrf";
+  public static final String COL_ROUTER = "Router";
 
   public BgpPropertiesAnswerer(Question question, IBatfish batfish) {
     super(question, batfish);
@@ -46,8 +46,8 @@ public class BgpPropertiesAnswerer extends Answerer {
   public static List<ColumnMetadata> createColumnMetadata(BgpPropertySpecifier propertySpecifier) {
     return ImmutableList.<ColumnMetadata>builder()
         .add(new ColumnMetadata(COL_NODE, Schema.NODE, "Node", true, false))
-        .add(new ColumnMetadata(COL_VRF, Schema.STRING, "VRF", true, false))
-        .add(new ColumnMetadata(COL_ROUTER_ID, Schema.IP, "RouterId", true, false))
+        .add(new ColumnMetadata(COL_VRF, Schema.STRING, "Vrf", true, false))
+        .add(new ColumnMetadata(COL_ROUTER, Schema.IP, "RouterId", true, false))
         .addAll(
             propertySpecifier
                 .getMatchingProperties()
@@ -68,7 +68,7 @@ public class BgpPropertiesAnswerer extends Answerer {
   static TableMetadata createTableMetadata(BgpPropertiesQuestion question) {
     String textDesc =
         String.format(
-            "Properties of BGP process ${%s}:${%s}:${%s}.", COL_NODE, COL_VRF, COL_ROUTER_ID);
+            "Properties of BGP process ${%s}:${%s}:${%s}.", COL_NODE, COL_VRF, COL_ROUTER);
     DisplayHints dhints = question.getDisplayHints();
     if (dhints != null && dhints.getTextDesc() != null) {
       textDesc = dhints.getTextDesc();
@@ -126,7 +126,7 @@ public class BgpPropertiesAnswerer extends Answerer {
                         Row.builder(columnMetadata)
                             .put(COL_NODE, new Node(nodeName))
                             .put(COL_VRF, vrf.getName())
-                            .put(COL_ROUTER_ID, bgpProcess.getRouterId());
+                            .put(COL_ROUTER, bgpProcess.getRouterId());
 
                     for (String property : propertySpecifier.getMatchingProperties()) {
                       PropertyDescriptor<BgpProcess> propertyDescriptor =

--- a/projects/question/src/main/java/org/batfish/question/bgpproperties/BgpPropertiesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/bgpproperties/BgpPropertiesAnswerer.java
@@ -29,8 +29,8 @@ import org.batfish.datamodel.table.TableMetadata;
 public class BgpPropertiesAnswerer extends Answerer {
 
   public static final String COL_NODE = "Node";
-  public static final String COL_VRF = "Vrf";
-  public static final String COL_ROUTER = "Router";
+  public static final String COL_VRF = "VRF";
+  public static final String COL_ROUTER_ID = "Router_ID";
 
   public BgpPropertiesAnswerer(Question question, IBatfish batfish) {
     super(question, batfish);
@@ -46,8 +46,8 @@ public class BgpPropertiesAnswerer extends Answerer {
   public static List<ColumnMetadata> createColumnMetadata(BgpPropertySpecifier propertySpecifier) {
     return ImmutableList.<ColumnMetadata>builder()
         .add(new ColumnMetadata(COL_NODE, Schema.NODE, "Node", true, false))
-        .add(new ColumnMetadata(COL_VRF, Schema.STRING, "Vrf", true, false))
-        .add(new ColumnMetadata(COL_ROUTER, Schema.IP, "RouterId", true, false))
+        .add(new ColumnMetadata(COL_VRF, Schema.STRING, "VRF", true, false))
+        .add(new ColumnMetadata(COL_ROUTER_ID, Schema.IP, "Router ID", true, false))
         .addAll(
             propertySpecifier
                 .getMatchingProperties()
@@ -68,7 +68,7 @@ public class BgpPropertiesAnswerer extends Answerer {
   static TableMetadata createTableMetadata(BgpPropertiesQuestion question) {
     String textDesc =
         String.format(
-            "Properties of BGP process ${%s}:${%s}:${%s}.", COL_NODE, COL_VRF, COL_ROUTER);
+            "Properties of BGP process ${%s}:${%s}:${%s}.", COL_NODE, COL_VRF, COL_ROUTER_ID);
     DisplayHints dhints = question.getDisplayHints();
     if (dhints != null && dhints.getTextDesc() != null) {
       textDesc = dhints.getTextDesc();
@@ -125,7 +125,7 @@ public class BgpPropertiesAnswerer extends Answerer {
                         Row.builder(columnMetadata)
                             .put(COL_NODE, new Node(nodeName))
                             .put(COL_VRF, vrf.getName())
-                            .put(COL_ROUTER, bgpProcess.getRouterId());
+                            .put(COL_ROUTER_ID, bgpProcess.getRouterId());
 
                     for (String property : propertySpecifier.getMatchingProperties()) {
                       PropertyDescriptor<BgpProcess> propertyDescriptor =

--- a/projects/question/src/main/java/org/batfish/question/bgpproperties/BgpPropertiesQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/bgpproperties/BgpPropertiesQuestion.java
@@ -39,12 +39,12 @@ public class BgpPropertiesQuestion extends Question {
   }
 
   @JsonProperty(PROP_NODES)
-  public NodesSpecifier getNodeRegex() {
+  public NodesSpecifier getNodes() {
     return _nodes;
   }
 
   @JsonProperty(PROP_PROPERTIES)
-  public BgpPropertySpecifier getPropertySpec() {
+  public BgpPropertySpecifier getProperties() {
     return _properties;
   }
 }

--- a/projects/question/src/main/java/org/batfish/question/bgpproperties/BgpPropertiesQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/bgpproperties/BgpPropertiesQuestion.java
@@ -9,23 +9,23 @@ import org.batfish.datamodel.questions.NodesSpecifier;
 import org.batfish.datamodel.questions.Question;
 
 /**
- * A question that returns properties of BGP routing processes. {@link #_nodeRegex} and {@link
- * #_propertySpec} determine which nodes and properties are included. The default is to include
+ * A question that returns properties of BGP routing processes. {@link #_nodes} and {@link
+ * #_properties} determine which nodes and properties are included. The default is to include
  * everything.
  */
 public class BgpPropertiesQuestion extends Question {
 
-  private static final String PROP_NODE_REGEX = "nodeRegex";
-  private static final String PROP_PROPERTY_SPEC = "propertySpec";
+  private static final String PROP_NODES = "nodes";
+  private static final String PROP_PROPERTIES = "properties";
 
-  @Nonnull private NodesSpecifier _nodeRegex;
-  @Nonnull private BgpPropertySpecifier _propertySpec;
+  @Nonnull private NodesSpecifier _nodes;
+  @Nonnull private BgpPropertySpecifier _properties;
 
   public BgpPropertiesQuestion(
-      @JsonProperty(PROP_NODE_REGEX) NodesSpecifier nodeRegex,
-      @JsonProperty(PROP_PROPERTY_SPEC) BgpPropertySpecifier propertySpec) {
-    _nodeRegex = firstNonNull(nodeRegex, NodesSpecifier.ALL);
-    _propertySpec = firstNonNull(propertySpec, BgpPropertySpecifier.ALL);
+      @JsonProperty(PROP_NODES) NodesSpecifier nodeRegex,
+      @JsonProperty(PROP_PROPERTIES) BgpPropertySpecifier propertySpec) {
+    _nodes = firstNonNull(nodeRegex, NodesSpecifier.ALL);
+    _properties = firstNonNull(propertySpec, BgpPropertySpecifier.ALL);
   }
 
   @Override
@@ -38,13 +38,13 @@ public class BgpPropertiesQuestion extends Question {
     return "bgpproperties";
   }
 
-  @JsonProperty(PROP_NODE_REGEX)
+  @JsonProperty(PROP_NODES)
   public NodesSpecifier getNodeRegex() {
-    return _nodeRegex;
+    return _nodes;
   }
 
-  @JsonProperty(PROP_PROPERTY_SPEC)
+  @JsonProperty(PROP_PROPERTIES)
   public BgpPropertySpecifier getPropertySpec() {
-    return _propertySpec;
+    return _properties;
   }
 }

--- a/projects/question/src/main/java/org/batfish/question/interfaceproperties/InterfacePropertiesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/interfaceproperties/InterfacePropertiesAnswerer.java
@@ -29,7 +29,7 @@ import org.batfish.datamodel.table.TableMetadata;
 
 public class InterfacePropertiesAnswerer extends Answerer {
 
-  public static final String COL_INTERFACE = "interface";
+  public static final String COL_INTERFACE = "Interface";
 
   public InterfacePropertiesAnswerer(Question question, IBatfish batfish) {
     super(question, batfish);

--- a/projects/question/src/main/java/org/batfish/question/interfaceproperties/InterfacePropertiesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/interfaceproperties/InterfacePropertiesAnswerer.java
@@ -75,24 +75,24 @@ public class InterfacePropertiesAnswerer extends Answerer {
     if (dhints != null && dhints.getTextDesc() != null) {
       textDesc = dhints.getTextDesc();
     }
-    return new TableMetadata(createColumnMetadata(question.getPropertySpec()), textDesc);
+    return new TableMetadata(createColumnMetadata(question.getProperties()), textDesc);
   }
 
   @Override
   public AnswerElement answer() {
     InterfacePropertiesQuestion question = (InterfacePropertiesQuestion) _question;
     Map<String, Configuration> configurations = _batfish.loadConfigurations();
-    Set<String> nodes = question.getNodeRegex().getMatchingNodes(_batfish);
+    Set<String> nodes = question.getNodes().getMatchingNodes(_batfish);
 
     TableMetadata tableMetadata = createTableMetadata(question);
     TableAnswerElement answer = new TableAnswerElement(tableMetadata);
 
     Multiset<Row> propertyRows =
         getProperties(
-            question.getPropertySpec(),
+            question.getProperties(),
             configurations,
             nodes,
-            question.getInterfaceRegex(),
+            question.getInterfaces(),
             question.getOnlyActive(),
             tableMetadata.toColumnMap());
 

--- a/projects/question/src/main/java/org/batfish/question/interfaceproperties/InterfacePropertiesQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/interfaceproperties/InterfacePropertiesQuestion.java
@@ -10,33 +10,33 @@ import org.batfish.datamodel.questions.NodesSpecifier;
 import org.batfish.datamodel.questions.Question;
 
 /**
- * A question that returns properties of interfaces in a tabular format. {@link #_nodeRegex}, {@link
- * #_interfaceRegex}, and {@link #_propertySpec} determine which nodes, interfaces, and properties
- * are included. The default is to include everything.
+ * A question that returns properties of interfaces in a tabular format. {@link #_nodes}, {@link
+ * #_interfaces}, and {@link #_properties} determine which nodes, interfaces, and properties are
+ * included. The default is to include everything.
  */
 public class InterfacePropertiesQuestion extends Question {
 
   static final boolean DEFAULT_EXCLUDE_SHUT_INTERFACES = false;
 
   private static final String PROP_EXCLUDE_SHUT_INTERFACES = "excludeShutInterfaces";
-  private static final String PROP_INTERFACE_REGEX = "interfaceRegex";
-  private static final String PROP_NODE_REGEX = "nodeRegex";
-  private static final String PROP_PROPERTY_SPEC = "propertySpec";
+  private static final String PROP_INTERFACES = "interfaces";
+  private static final String PROP_NODES = "nodes";
+  private static final String PROP_PROPERTIES = "properties";
 
-  @Nonnull private InterfacesSpecifier _interfaceRegex;
-  @Nonnull private NodesSpecifier _nodeRegex;
+  @Nonnull private InterfacesSpecifier _interfaces;
+  @Nonnull private NodesSpecifier _nodes;
   private boolean _onlyActive;
-  @Nonnull private InterfacePropertySpecifier _propertySpec;
+  @Nonnull private InterfacePropertySpecifier _properties;
 
   public InterfacePropertiesQuestion(
       @JsonProperty(PROP_EXCLUDE_SHUT_INTERFACES) Boolean excludeShutInterfaces,
-      @JsonProperty(PROP_INTERFACE_REGEX) InterfacesSpecifier interfaceRegex,
-      @JsonProperty(PROP_NODE_REGEX) NodesSpecifier nodeRegex,
-      @JsonProperty(PROP_PROPERTY_SPEC) InterfacePropertySpecifier propertySpec) {
+      @JsonProperty(PROP_INTERFACES) InterfacesSpecifier interfaceRegex,
+      @JsonProperty(PROP_NODES) NodesSpecifier nodeRegex,
+      @JsonProperty(PROP_PROPERTIES) InterfacePropertySpecifier propertySpec) {
     _onlyActive = firstNonNull(excludeShutInterfaces, DEFAULT_EXCLUDE_SHUT_INTERFACES);
-    _interfaceRegex = firstNonNull(interfaceRegex, InterfacesSpecifier.ALL);
-    _nodeRegex = firstNonNull(nodeRegex, NodesSpecifier.ALL);
-    _propertySpec = firstNonNull(propertySpec, InterfacePropertySpecifier.ALL);
+    _interfaces = firstNonNull(interfaceRegex, InterfacesSpecifier.ALL);
+    _nodes = firstNonNull(nodeRegex, NodesSpecifier.ALL);
+    _properties = firstNonNull(propertySpec, InterfacePropertySpecifier.ALL);
   }
 
   @Override
@@ -54,18 +54,18 @@ public class InterfacePropertiesQuestion extends Question {
     return _onlyActive;
   }
 
-  @JsonProperty(PROP_INTERFACE_REGEX)
+  @JsonProperty(PROP_INTERFACES)
   public InterfacesSpecifier getInterfaceRegex() {
-    return _interfaceRegex;
+    return _interfaces;
   }
 
-  @JsonProperty(PROP_NODE_REGEX)
+  @JsonProperty(PROP_NODES)
   public NodesSpecifier getNodeRegex() {
-    return _nodeRegex;
+    return _nodes;
   }
 
-  @JsonProperty(PROP_PROPERTY_SPEC)
+  @JsonProperty(PROP_PROPERTIES)
   public InterfacePropertySpecifier getPropertySpec() {
-    return _propertySpec;
+    return _properties;
   }
 }

--- a/projects/question/src/main/java/org/batfish/question/interfaceproperties/InterfacePropertiesQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/interfaceproperties/InterfacePropertiesQuestion.java
@@ -55,17 +55,17 @@ public class InterfacePropertiesQuestion extends Question {
   }
 
   @JsonProperty(PROP_INTERFACES)
-  public InterfacesSpecifier getInterfaceRegex() {
+  public InterfacesSpecifier getInterfaces() {
     return _interfaces;
   }
 
   @JsonProperty(PROP_NODES)
-  public NodesSpecifier getNodeRegex() {
+  public NodesSpecifier getNodes() {
     return _nodes;
   }
 
   @JsonProperty(PROP_PROPERTIES)
-  public InterfacePropertySpecifier getPropertySpec() {
+  public InterfacePropertySpecifier getProperties() {
     return _properties;
   }
 }

--- a/projects/question/src/main/java/org/batfish/question/nodeproperties/NodePropertiesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/nodeproperties/NodePropertiesAnswerer.java
@@ -26,7 +26,7 @@ import org.batfish.datamodel.table.TableMetadata;
 
 public class NodePropertiesAnswerer extends Answerer {
 
-  public static final String COL_NODE = "node";
+  public static final String COL_NODE = "Node";
 
   public NodePropertiesAnswerer(Question question, IBatfish batfish) {
     super(question, batfish);

--- a/projects/question/src/main/java/org/batfish/question/nodeproperties/NodePropertiesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/nodeproperties/NodePropertiesAnswerer.java
@@ -64,20 +64,19 @@ public class NodePropertiesAnswerer extends Answerer {
     if (dhints != null && dhints.getTextDesc() != null) {
       textDesc = dhints.getTextDesc();
     }
-    return new TableMetadata(createColumnMetadata(question.getPropertySpec()), textDesc);
+    return new TableMetadata(createColumnMetadata(question.getProperties()), textDesc);
   }
 
   @Override
   public AnswerElement answer() {
     NodePropertiesQuestion question = (NodePropertiesQuestion) _question;
     Map<String, Configuration> configurations = _batfish.loadConfigurations();
-    Set<String> nodes = question.getNodeRegex().getMatchingNodes(_batfish);
+    Set<String> nodes = question.getNodes().getMatchingNodes(_batfish);
 
     TableMetadata tableMetadata = createTableMetadata(question);
 
     Multiset<Row> propertyRows =
-        getProperties(
-            question.getPropertySpec(), configurations, nodes, tableMetadata.toColumnMap());
+        getProperties(question.getProperties(), configurations, nodes, tableMetadata.toColumnMap());
 
     TableAnswerElement answer = new TableAnswerElement(tableMetadata);
     answer.postProcessAnswer(question, propertyRows);

--- a/projects/question/src/main/java/org/batfish/question/nodeproperties/NodePropertiesQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/nodeproperties/NodePropertiesQuestion.java
@@ -12,23 +12,23 @@ import org.batfish.datamodel.questions.Question;
 
 /**
  * A question that returns properties of nodes in a tabular format. {@link
- * NodePropertiesQuestion#_nodeRegex} determines which nodes are included, and {@link
- * NodePropertiesQuestion#_propertySpec} determines which properties are included.
+ * NodePropertiesQuestion#_nodes} determines which nodes are included, and {@link
+ * NodePropertiesQuestion#_properties} determines which properties are included.
  */
 public class NodePropertiesQuestion extends Question {
 
-  private static final String PROP_NODE_REGEX = "nodeRegex";
-  private static final String PROP_PROPERTY_SPEC = "propertySpec";
+  private static final String PROP_NODES = "nodes";
+  private static final String PROP_PROPERTIES = "properties";
 
-  @Nonnull private NodesSpecifier _nodeRegex;
+  @Nonnull private NodesSpecifier _nodes;
 
-  @Nonnull private NodePropertySpecifier _propertySpec;
+  @Nonnull private NodePropertySpecifier _properties;
 
   public NodePropertiesQuestion(
-      @JsonProperty(PROP_NODE_REGEX) NodesSpecifier nodeRegex,
-      @JsonProperty(PROP_PROPERTY_SPEC) NodePropertySpecifier propertySpec) {
-    _nodeRegex = firstNonNull(nodeRegex, NodesSpecifier.ALL);
-    _propertySpec = firstNonNull(propertySpec, NodePropertySpecifier.ALL);
+      @JsonProperty(PROP_NODES) NodesSpecifier nodeRegex,
+      @JsonProperty(PROP_PROPERTIES) NodePropertySpecifier propertySpec) {
+    _nodes = firstNonNull(nodeRegex, NodesSpecifier.ALL);
+    _properties = firstNonNull(propertySpec, NodePropertySpecifier.ALL);
   }
 
   @Override
@@ -41,19 +41,19 @@ public class NodePropertiesQuestion extends Question {
     return "nodeproperties";
   }
 
-  @JsonProperty(PROP_NODE_REGEX)
+  @JsonProperty(PROP_NODES)
   public NodesSpecifier getNodeRegex() {
-    return _nodeRegex;
+    return _nodes;
   }
 
-  @JsonProperty(PROP_PROPERTY_SPEC)
+  @JsonProperty(PROP_PROPERTIES)
   public NodePropertySpecifier getPropertySpec() {
-    return _propertySpec;
+    return _properties;
   }
 
   @Deprecated // backwards compatibility for older questions
   @JsonProperty("properties")
   void setProperties(List<String> properties) {
-    _propertySpec = new NodePropertySpecifier(StringUtils.join(properties, "|"));
+    _properties = new NodePropertySpecifier(StringUtils.join(properties, "|"));
   }
 }

--- a/projects/question/src/main/java/org/batfish/question/nodeproperties/NodePropertiesQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/nodeproperties/NodePropertiesQuestion.java
@@ -42,12 +42,12 @@ public class NodePropertiesQuestion extends Question {
   }
 
   @JsonProperty(PROP_NODES)
-  public NodesSpecifier getNodeRegex() {
+  public NodesSpecifier getNodes() {
     return _nodes;
   }
 
   @JsonProperty(PROP_PROPERTIES)
-  public NodePropertySpecifier getPropertySpec() {
+  public NodePropertySpecifier getProperties() {
     return _properties;
   }
 

--- a/projects/question/src/main/java/org/batfish/question/ospfproperties/OspfPropertiesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/ospfproperties/OspfPropertiesAnswerer.java
@@ -29,8 +29,8 @@ import org.batfish.datamodel.table.TableMetadata;
 public class OspfPropertiesAnswerer extends Answerer {
 
   public static final String COL_NODE = "Node";
-  public static final String COL_VRF = "VRF";
-  public static final String COL_PROCESS_ID = "ProcessId";
+  public static final String COL_VRF = "Vrf";
+  public static final String COL_PROCESS = "Process";
 
   public OspfPropertiesAnswerer(Question question, IBatfish batfish) {
     super(question, batfish);
@@ -46,8 +46,8 @@ public class OspfPropertiesAnswerer extends Answerer {
   public static List<ColumnMetadata> createColumnMetadata(OspfPropertySpecifier propertySpecifier) {
     return ImmutableList.<ColumnMetadata>builder()
         .add(new ColumnMetadata(COL_NODE, Schema.NODE, "Node", true, false))
-        .add(new ColumnMetadata(COL_VRF, Schema.STRING, "VRF", true, false))
-        .add(new ColumnMetadata(COL_PROCESS_ID, Schema.STRING, "ProcessId", true, false))
+        .add(new ColumnMetadata(COL_VRF, Schema.STRING, "Vrf", true, false))
+        .add(new ColumnMetadata(COL_PROCESS, Schema.STRING, "ProcessId", true, false))
         .addAll(
             propertySpecifier
                 .getMatchingProperties()
@@ -68,7 +68,7 @@ public class OspfPropertiesAnswerer extends Answerer {
   static TableMetadata createTableMetadata(OspfPropertiesQuestion question) {
     String textDesc =
         String.format(
-            "Properties of OSPF process ${%s}:${%s}:${%s}.", COL_NODE, COL_VRF, COL_PROCESS_ID);
+            "Properties of OSPF process ${%s}:${%s}:${%s}.", COL_NODE, COL_VRF, COL_PROCESS);
     DisplayHints dhints = question.getDisplayHints();
     if (dhints != null && dhints.getTextDesc() != null) {
       textDesc = dhints.getTextDesc();
@@ -126,7 +126,7 @@ public class OspfPropertiesAnswerer extends Answerer {
                         Row.builder(columnMetadata)
                             .put(COL_NODE, new Node(nodeName))
                             .put(COL_VRF, vrf.getName())
-                            .put(COL_PROCESS_ID, ospfProcess.getProcessId());
+                            .put(COL_PROCESS, ospfProcess.getProcessId());
 
                     for (String property : propertySpecifier.getMatchingProperties()) {
                       PropertyDescriptor<OspfProcess> propertyDescriptor =

--- a/projects/question/src/main/java/org/batfish/question/ospfproperties/OspfPropertiesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/ospfproperties/OspfPropertiesAnswerer.java
@@ -73,21 +73,20 @@ public class OspfPropertiesAnswerer extends Answerer {
     if (dhints != null && dhints.getTextDesc() != null) {
       textDesc = dhints.getTextDesc();
     }
-    return new TableMetadata(createColumnMetadata(question.getPropertySpec()), textDesc);
+    return new TableMetadata(createColumnMetadata(question.getProperties()), textDesc);
   }
 
   @Override
   public AnswerElement answer() {
     OspfPropertiesQuestion question = (OspfPropertiesQuestion) _question;
     Map<String, Configuration> configurations = _batfish.loadConfigurations();
-    Set<String> nodes = question.getNodeRegex().getMatchingNodes(_batfish);
+    Set<String> nodes = question.getNodes().getMatchingNodes(_batfish);
 
     TableMetadata tableMetadata = createTableMetadata(question);
     TableAnswerElement answer = new TableAnswerElement(tableMetadata);
 
     Multiset<Row> propertyRows =
-        getProperties(
-            question.getPropertySpec(), configurations, nodes, tableMetadata.toColumnMap());
+        getProperties(question.getProperties(), configurations, nodes, tableMetadata.toColumnMap());
 
     answer.postProcessAnswer(question, propertyRows);
     return answer;

--- a/projects/question/src/main/java/org/batfish/question/ospfproperties/OspfPropertiesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/ospfproperties/OspfPropertiesAnswerer.java
@@ -29,8 +29,8 @@ import org.batfish.datamodel.table.TableMetadata;
 public class OspfPropertiesAnswerer extends Answerer {
 
   public static final String COL_NODE = "Node";
-  public static final String COL_VRF = "Vrf";
-  public static final String COL_PROCESS = "Process";
+  public static final String COL_VRF = "VRF";
+  public static final String COL_PROCESS_ID = "Process_ID";
 
   public OspfPropertiesAnswerer(Question question, IBatfish batfish) {
     super(question, batfish);
@@ -46,8 +46,8 @@ public class OspfPropertiesAnswerer extends Answerer {
   public static List<ColumnMetadata> createColumnMetadata(OspfPropertySpecifier propertySpecifier) {
     return ImmutableList.<ColumnMetadata>builder()
         .add(new ColumnMetadata(COL_NODE, Schema.NODE, "Node", true, false))
-        .add(new ColumnMetadata(COL_VRF, Schema.STRING, "Vrf", true, false))
-        .add(new ColumnMetadata(COL_PROCESS, Schema.STRING, "ProcessId", true, false))
+        .add(new ColumnMetadata(COL_VRF, Schema.STRING, "VRF", true, false))
+        .add(new ColumnMetadata(COL_PROCESS_ID, Schema.STRING, "Process ID", true, false))
         .addAll(
             propertySpecifier
                 .getMatchingProperties()
@@ -68,7 +68,7 @@ public class OspfPropertiesAnswerer extends Answerer {
   static TableMetadata createTableMetadata(OspfPropertiesQuestion question) {
     String textDesc =
         String.format(
-            "Properties of OSPF process ${%s}:${%s}:${%s}.", COL_NODE, COL_VRF, COL_PROCESS);
+            "Properties of OSPF process ${%s}:${%s}:${%s}.", COL_NODE, COL_VRF, COL_PROCESS_ID);
     DisplayHints dhints = question.getDisplayHints();
     if (dhints != null && dhints.getTextDesc() != null) {
       textDesc = dhints.getTextDesc();
@@ -125,7 +125,7 @@ public class OspfPropertiesAnswerer extends Answerer {
                         Row.builder(columnMetadata)
                             .put(COL_NODE, new Node(nodeName))
                             .put(COL_VRF, vrf.getName())
-                            .put(COL_PROCESS, ospfProcess.getProcessId());
+                            .put(COL_PROCESS_ID, ospfProcess.getProcessId());
 
                     for (String property : propertySpecifier.getMatchingProperties()) {
                       PropertyDescriptor<OspfProcess> propertyDescriptor =

--- a/projects/question/src/main/java/org/batfish/question/ospfproperties/OspfPropertiesQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/ospfproperties/OspfPropertiesQuestion.java
@@ -39,12 +39,12 @@ public class OspfPropertiesQuestion extends Question {
   }
 
   @JsonProperty(PROP_NODES)
-  public NodesSpecifier getNodeRegex() {
+  public NodesSpecifier getNodes() {
     return _nodes;
   }
 
   @JsonProperty(PROP_PROPERTIES)
-  public OspfPropertySpecifier getPropertySpec() {
+  public OspfPropertySpecifier getProperties() {
     return _properties;
   }
 }

--- a/projects/question/src/main/java/org/batfish/question/ospfproperties/OspfPropertiesQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/ospfproperties/OspfPropertiesQuestion.java
@@ -9,23 +9,23 @@ import org.batfish.datamodel.questions.OspfPropertySpecifier;
 import org.batfish.datamodel.questions.Question;
 
 /**
- * A question that returns properties of OSPF routing processes. {@link #_nodeRegex} and {@link
- * #_propertySpec} determine which nodes and properties are included. The default is to include
+ * A question that returns properties of OSPF routing processes. {@link #_nodes} and {@link
+ * #_properties} determine which nodes and properties are included. The default is to include
  * everything.
  */
 public class OspfPropertiesQuestion extends Question {
 
-  private static final String PROP_NODE_REGEX = "nodeRegex";
-  private static final String PROP_PROPERTY_SPEC = "propertySpec";
+  private static final String PROP_NODES = "nodes";
+  private static final String PROP_PROPERTIES = "properties";
 
-  @Nonnull private NodesSpecifier _nodeRegex;
-  @Nonnull private OspfPropertySpecifier _propertySpec;
+  @Nonnull private NodesSpecifier _nodes;
+  @Nonnull private OspfPropertySpecifier _properties;
 
   public OspfPropertiesQuestion(
-      @JsonProperty(PROP_NODE_REGEX) NodesSpecifier nodeRegex,
-      @JsonProperty(PROP_PROPERTY_SPEC) OspfPropertySpecifier propertySpec) {
-    _nodeRegex = firstNonNull(nodeRegex, NodesSpecifier.ALL);
-    _propertySpec = firstNonNull(propertySpec, OspfPropertySpecifier.ALL);
+      @JsonProperty(PROP_NODES) NodesSpecifier nodeRegex,
+      @JsonProperty(PROP_PROPERTIES) OspfPropertySpecifier propertySpec) {
+    _nodes = firstNonNull(nodeRegex, NodesSpecifier.ALL);
+    _properties = firstNonNull(propertySpec, OspfPropertySpecifier.ALL);
   }
 
   @Override
@@ -38,13 +38,13 @@ public class OspfPropertiesQuestion extends Question {
     return "ospfproperties";
   }
 
-  @JsonProperty(PROP_NODE_REGEX)
+  @JsonProperty(PROP_NODES)
   public NodesSpecifier getNodeRegex() {
-    return _nodeRegex;
+    return _nodes;
   }
 
-  @JsonProperty(PROP_PROPERTY_SPEC)
+  @JsonProperty(PROP_PROPERTIES)
   public OspfPropertySpecifier getPropertySpec() {
-    return _propertySpec;
+    return _properties;
   }
 }

--- a/projects/question/src/test/java/org/batfish/question/bgpproperties/BgpPropertiesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/bgpproperties/BgpPropertiesAnswererTest.java
@@ -45,7 +45,7 @@ public class BgpPropertiesAnswererTest {
 
     Multiset<Row> propertyRows =
         BgpPropertiesAnswerer.getProperties(
-            question.getPropertySpec(),
+            question.getProperties(),
             ImmutableMap.of("node1", conf1),
             ImmutableSet.of("node1"),
             metadata.toColumnMap());

--- a/projects/question/src/test/java/org/batfish/question/bgpproperties/BgpPropertiesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/bgpproperties/BgpPropertiesAnswererTest.java
@@ -35,8 +35,8 @@ public class BgpPropertiesAnswererTest {
     Configuration conf1 = new Configuration("node1", ConfigurationFormat.CISCO_IOS);
     conf1.setVrfs(ImmutableMap.of("vrf1", vrf1));
 
-    String property1 = "Multipath_Ebgp";
-    String property2 = "Tie_Breaker";
+    String property1 = BgpPropertySpecifier.MULTIPATH_EBGP;
+    String property2 = BgpPropertySpecifier.TIE_BREAKER;
 
     BgpPropertiesQuestion question =
         new BgpPropertiesQuestion(null, new BgpPropertySpecifier(property1 + "|" + property2));
@@ -55,7 +55,7 @@ public class BgpPropertiesAnswererTest {
         Row.builder()
             .put(BgpPropertiesAnswerer.COL_NODE, new Node("node1"))
             .put(BgpPropertiesAnswerer.COL_VRF, "vrf1")
-            .put(BgpPropertiesAnswerer.COL_ROUTER, new Ip("1.1.1.1"))
+            .put(BgpPropertiesAnswerer.COL_ROUTER_ID, new Ip("1.1.1.1"))
             .put(property2, BgpTieBreaker.ARRIVAL_ORDER.toString())
             .put(property1, true)
             .build();

--- a/projects/question/src/test/java/org/batfish/question/bgpproperties/BgpPropertiesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/bgpproperties/BgpPropertiesAnswererTest.java
@@ -35,8 +35,8 @@ public class BgpPropertiesAnswererTest {
     Configuration conf1 = new Configuration("node1", ConfigurationFormat.CISCO_IOS);
     conf1.setVrfs(ImmutableMap.of("vrf1", vrf1));
 
-    String property1 = "multipath-ebgp";
-    String property2 = "tie-breaker";
+    String property1 = "Multipath_Ebgp";
+    String property2 = "Tie_Breaker";
 
     BgpPropertiesQuestion question =
         new BgpPropertiesQuestion(null, new BgpPropertySpecifier(property1 + "|" + property2));

--- a/projects/question/src/test/java/org/batfish/question/bgpproperties/BgpPropertiesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/bgpproperties/BgpPropertiesAnswererTest.java
@@ -55,7 +55,7 @@ public class BgpPropertiesAnswererTest {
         Row.builder()
             .put(BgpPropertiesAnswerer.COL_NODE, new Node("node1"))
             .put(BgpPropertiesAnswerer.COL_VRF, "vrf1")
-            .put(BgpPropertiesAnswerer.COL_ROUTER_ID, new Ip("1.1.1.1"))
+            .put(BgpPropertiesAnswerer.COL_ROUTER, new Ip("1.1.1.1"))
             .put(property2, BgpTieBreaker.ARRIVAL_ORDER.toString())
             .put(property1, true)
             .build();

--- a/projects/question/src/test/java/org/batfish/question/interfaceproperties/InterfacePropertiesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/interfaceproperties/InterfacePropertiesAnswererTest.java
@@ -143,7 +143,7 @@ public class InterfacePropertiesAnswererTest {
   @Test
   public void testHsrpGroups() {
     _ib.setHsrpGroups(ImmutableMap.of(1, HsrpGroup.builder().setGroupNumber(1).build())).build();
-    String property = "Hsrp_Groups";
+    String property = InterfacePropertySpecifier.HSRP_GROUPS;
 
     assertThat(getActualValue(property, Schema.set(Schema.STRING)), equalTo(ImmutableSet.of("1")));
   }
@@ -151,7 +151,7 @@ public class InterfacePropertiesAnswererTest {
   @Test
   public void testHsrpGroupsEmpty() {
     _ib.build();
-    String property = "Hsrp_Groups";
+    String property = InterfacePropertySpecifier.HSRP_GROUPS;
 
     assertThat(getActualValue(property, Schema.set(Schema.STRING)), equalTo(ImmutableSet.of()));
   }
@@ -159,7 +159,7 @@ public class InterfacePropertiesAnswererTest {
   @Test
   public void testHsrpVersion() {
     _ib.setHsrpVersion("2").build();
-    String property = "Hsrp_Version";
+    String property = InterfacePropertySpecifier.HSRP_VERSION;
 
     assertThat(getActualValue(property, Schema.STRING), equalTo("2"));
   }
@@ -167,7 +167,7 @@ public class InterfacePropertiesAnswererTest {
   @Test
   public void testHsrpVersionUnset() {
     _ib.build();
-    String property = "Hsrp_Version";
+    String property = InterfacePropertySpecifier.HSRP_VERSION;
 
     assertThat(getActualValue(property, Schema.STRING), nullValue());
   }

--- a/projects/question/src/test/java/org/batfish/question/interfaceproperties/InterfacePropertiesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/interfaceproperties/InterfacePropertiesAnswererTest.java
@@ -55,8 +55,8 @@ public class InterfacePropertiesAnswererTest {
 
     conf1.getInterfaces().putAll(ImmutableMap.of("iface1", iface1, "iface2", iface2));
 
-    String property1 = "description";
-    String property2 = "active";
+    String property1 = "Description";
+    String property2 = "Active";
     InterfacePropertySpecifier propertySpecifier =
         new InterfacePropertySpecifier(property1 + "|" + property2);
 
@@ -90,7 +90,7 @@ public class InterfacePropertiesAnswererTest {
     Interface shut = Interface.builder().setName("shut").setOwner(conf).setActive(false).build();
     conf.getInterfaces().putAll(ImmutableMap.of("active", active, "shut", shut));
 
-    String property = "description";
+    String property = "Description";
     InterfacePropertySpecifier propertySpecifier = new InterfacePropertySpecifier(property);
 
     Multiset<Row> propertyRows =
@@ -143,7 +143,7 @@ public class InterfacePropertiesAnswererTest {
   @Test
   public void testHsrpGroups() {
     _ib.setHsrpGroups(ImmutableMap.of(1, HsrpGroup.builder().setGroupNumber(1).build())).build();
-    String property = "hsrp-groups";
+    String property = "Hsrp_Groups";
 
     assertThat(getActualValue(property, Schema.set(Schema.STRING)), equalTo(ImmutableSet.of("1")));
   }
@@ -151,7 +151,7 @@ public class InterfacePropertiesAnswererTest {
   @Test
   public void testHsrpGroupsEmpty() {
     _ib.build();
-    String property = "hsrp-groups";
+    String property = "Hsrp_Groups";
 
     assertThat(getActualValue(property, Schema.set(Schema.STRING)), equalTo(ImmutableSet.of()));
   }
@@ -159,7 +159,7 @@ public class InterfacePropertiesAnswererTest {
   @Test
   public void testHsrpVersion() {
     _ib.setHsrpVersion("2").build();
-    String property = "hsrp-version";
+    String property = "Hsrp_Version";
 
     assertThat(getActualValue(property, Schema.STRING), equalTo("2"));
   }
@@ -167,7 +167,7 @@ public class InterfacePropertiesAnswererTest {
   @Test
   public void testHsrpVersionUnset() {
     _ib.build();
-    String property = "hsrp-version";
+    String property = "Hsrp_Version";
 
     assertThat(getActualValue(property, Schema.STRING), nullValue());
   }

--- a/projects/question/src/test/java/org/batfish/question/interfaceproperties/InterfacePropertiesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/interfaceproperties/InterfacePropertiesAnswererTest.java
@@ -55,8 +55,8 @@ public class InterfacePropertiesAnswererTest {
 
     conf1.getInterfaces().putAll(ImmutableMap.of("iface1", iface1, "iface2", iface2));
 
-    String property1 = "Description";
-    String property2 = "Active";
+    String property1 = InterfacePropertySpecifier.DESCRIPTION;
+    String property2 = InterfacePropertySpecifier.ACTIVE;
     InterfacePropertySpecifier propertySpecifier =
         new InterfacePropertySpecifier(property1 + "|" + property2);
 
@@ -90,7 +90,7 @@ public class InterfacePropertiesAnswererTest {
     Interface shut = Interface.builder().setName("shut").setOwner(conf).setActive(false).build();
     conf.getInterfaces().putAll(ImmutableMap.of("active", active, "shut", shut));
 
-    String property = "Description";
+    String property = InterfacePropertySpecifier.DESCRIPTION;
     InterfacePropertySpecifier propertySpecifier = new InterfacePropertySpecifier(property);
 
     Multiset<Row> propertyRows =

--- a/projects/question/src/test/java/org/batfish/question/nodeproperties/NodePropertiesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/nodeproperties/NodePropertiesAnswererTest.java
@@ -24,8 +24,8 @@ public class NodePropertiesAnswererTest {
   @Test
   @SuppressWarnings("deprecation") // includes test of deprecated functionality
   public void getProperties() {
-    String property1 = "configuration-format";
-    String property2 = "ntp-servers";
+    String property1 = "Configuration_Format";
+    String property2 = "Ntp_Servers";
     NodePropertySpecifier propertySpec = new NodePropertySpecifier(property1 + "|" + property2);
 
     Configuration conf1 = new Configuration("node1", ConfigurationFormat.CISCO_IOS);

--- a/projects/question/src/test/java/org/batfish/question/nodeproperties/NodePropertiesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/nodeproperties/NodePropertiesAnswererTest.java
@@ -24,8 +24,8 @@ public class NodePropertiesAnswererTest {
   @Test
   @SuppressWarnings("deprecation") // includes test of deprecated functionality
   public void getProperties() {
-    String property1 = "Configuration_Format";
-    String property2 = "Ntp_Servers";
+    String property1 = NodePropertySpecifier.CONFIGURATION_FORMAT;
+    String property2 = NodePropertySpecifier.NTP_SERVERS;
     NodePropertySpecifier propertySpec = new NodePropertySpecifier(property1 + "|" + property2);
 
     Configuration conf1 = new Configuration("node1", ConfigurationFormat.CISCO_IOS);

--- a/projects/question/src/test/java/org/batfish/question/ospfproperties/OspfPropertiesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/ospfproperties/OspfPropertiesAnswererTest.java
@@ -33,8 +33,8 @@ public class OspfPropertiesAnswererTest {
     Configuration conf1 = new Configuration("node1", ConfigurationFormat.CISCO_IOS);
     conf1.setVrfs(ImmutableMap.of("vrf1", vrf1));
 
-    String property1 = "export-policy";
-    String property2 = "reference-bandwidth";
+    String property1 = "Export_Policy";
+    String property2 = "Reference_Bandwidth";
 
     OspfPropertiesQuestion question =
         new OspfPropertiesQuestion(null, new OspfPropertySpecifier(property1 + "|" + property2));

--- a/projects/question/src/test/java/org/batfish/question/ospfproperties/OspfPropertiesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/ospfproperties/OspfPropertiesAnswererTest.java
@@ -33,8 +33,8 @@ public class OspfPropertiesAnswererTest {
     Configuration conf1 = new Configuration("node1", ConfigurationFormat.CISCO_IOS);
     conf1.setVrfs(ImmutableMap.of("vrf1", vrf1));
 
-    String property1 = "Export_Policy";
-    String property2 = "Reference_Bandwidth";
+    String property1 = OspfPropertySpecifier.EXPORT_POLICY;
+    String property2 = OspfPropertySpecifier.REFERENCE_BANDWIDTH;
 
     OspfPropertiesQuestion question =
         new OspfPropertiesQuestion(null, new OspfPropertySpecifier(property1 + "|" + property2));
@@ -53,7 +53,7 @@ public class OspfPropertiesAnswererTest {
         Row.builder()
             .put(OspfPropertiesAnswerer.COL_NODE, new Node("node1"))
             .put(OspfPropertiesAnswerer.COL_VRF, "vrf1")
-            .put(OspfPropertiesAnswerer.COL_PROCESS, "uber-proc")
+            .put(OspfPropertiesAnswerer.COL_PROCESS_ID, "uber-proc")
             .put(property2, 42.0)
             .put(property1, "my-policy")
             .build();

--- a/projects/question/src/test/java/org/batfish/question/ospfproperties/OspfPropertiesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/ospfproperties/OspfPropertiesAnswererTest.java
@@ -53,7 +53,7 @@ public class OspfPropertiesAnswererTest {
         Row.builder()
             .put(OspfPropertiesAnswerer.COL_NODE, new Node("node1"))
             .put(OspfPropertiesAnswerer.COL_VRF, "vrf1")
-            .put(OspfPropertiesAnswerer.COL_PROCESS_ID, "uber-proc")
+            .put(OspfPropertiesAnswerer.COL_PROCESS, "uber-proc")
             .put(property2, 42.0)
             .put(property1, "my-policy")
             .build();

--- a/projects/question/src/test/java/org/batfish/question/ospfproperties/OspfPropertiesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/ospfproperties/OspfPropertiesAnswererTest.java
@@ -43,7 +43,7 @@ public class OspfPropertiesAnswererTest {
 
     Multiset<Row> propertyRows =
         OspfPropertiesAnswerer.getProperties(
-            question.getPropertySpec(),
+            question.getProperties(),
             ImmutableMap.of("node1", conf1),
             ImmutableSet.of("node1"),
             metadata.toColumnMap());

--- a/questions/experimental/bgpProperties.json
+++ b/questions/experimental/bgpProperties.json
@@ -1,8 +1,8 @@
 {
     "class": "org.batfish.question.bgpproperties.BgpPropertiesQuestion",
     "differential": false,
-    "nodeRegex": "${nodes}",
-    "propertySpec": "${properties}",
+    "nodes": "${nodes}",
+    "properties": "${properties}",
     "instance": {
         "description": "Return BGP configuration properties",
         "instanceName": "bgpProperties",
@@ -12,12 +12,12 @@
         ],
         "variables": {
             "nodes": {
-                "description": "Only include nodes that match this regex (default behavior is to include all nodes)",
+                "description": "Only include nodes that match this regex",
                 "type": "nodeSpec",
                 "optional": true
             },
             "properties": {
-                "description": "Only include properties that match this regex (default behavior is to include all properties)",
+                "description": "Only include properties that match this regex",
                 "type": "bgpPropertySpec",
                 "optional": true
             }

--- a/questions/experimental/bgpProperties.json
+++ b/questions/experimental/bgpProperties.json
@@ -1,8 +1,8 @@
 {
     "class": "org.batfish.question.bgpproperties.BgpPropertiesQuestion",
     "differential": false,
-    "nodeRegex": "${nodeRegex}",
-    "propertySpec": "${propertySpec}",
+    "nodeRegex": "${nodes}",
+    "propertySpec": "${properties}",
     "instance": {
         "description": "Return BGP configuration properties",
         "instanceName": "bgpProperties",
@@ -11,13 +11,13 @@
             "configuration"
         ],
         "variables": {
-            "nodeRegex": {
-                "description": "Only include nodes that match this regex",
+            "nodes": {
+                "description": "Only include nodes that match this regex (default behavior is to include all nodes)",
                 "type": "nodeSpec",
                 "optional": true
             },
-            "propertySpec": {
-                "description": "Only include properties that match this regex. Default behavior is to return all properties",
+            "properties": {
+                "description": "Only include properties that match this regex (default behavior is to include all properties)",
                 "type": "bgpPropertySpec",
                 "optional": true
             }

--- a/questions/experimental/interfaceMtu.json
+++ b/questions/experimental/interfaceMtu.json
@@ -6,8 +6,8 @@
     "innerQuestion": {
         "class": "org.batfish.question.interfaceproperties.InterfacePropertiesQuestion",
         "differential": false,
-        "interfaceRegex": "${interfaceRegex}",
-        "nodeRegex": "${nodeRegex}",
+        "interfaces": "${interfaces}",
+        "nodes": "${nodes}",
         "displayHints": {
             "textDesc": "${interface} has MTU ${mtu}"
         }
@@ -26,7 +26,7 @@
               "type": "comparator",
               "value": "<"
             },
-            "interfaceRegex": {
+            "interfaces": {
               "description": "Only evaluate interfaces whose name matches this regex",
               "type": "javaRegex",
               "value": ".*"
@@ -36,7 +36,7 @@
               "type": "integer",
               "value": 1500
             },
-            "nodeRegex": {
+            "nodes": {
               "description": "Only include nodes whose name matches this regex",
               "type": "javaRegex",
               "value": ".*"

--- a/questions/experimental/interfaceProperties.json
+++ b/questions/experimental/interfaceProperties.json
@@ -1,9 +1,9 @@
 {
     "class": "org.batfish.question.interfaceproperties.InterfacePropertiesQuestion",
     "differential": false,
-    "interfaceRegex": "${interfaceRegex}",
-    "nodeRegex": "${nodeRegex}",
-    "propertySpec": "${propertySpec}",
+    "interfaces": "${interfaces}",
+    "nodes": "${nodes}",
+    "properties": "${properties}",
     "instance": {
         "description": "Returns configuration properties of interfaces",
         "instanceName": "interfaceProperties",
@@ -12,18 +12,18 @@
             "interfaces"
         ],
         "variables": {
-            "interfaceRegex": {
-                "description": "Only include interfaces that match this regex",
-                "type": "javaRegex",
+            "interfaces": {
+                "description": "Only include interfaces that match this regex (default behavior is to include all interfaces)",
+                "type": "interfaceSpec",
                 "optional": true
             },
-            "nodeRegex": {
-                "description": "Only include nodes that match this regex",
+            "nodes": {
+                "description": "Only include nodes that match this regex (default behavior is to include all nodes)",
                 "type": "nodeSpec",
                 "optional": true
             },
-            "propertySpec": {
-                "description": "Only include properties that match this regex. Default behavior is to return all properties",
+            "properties": {
+                "description": "Only include properties that match this regex (default behavior is to include all properties)",
                 "type": "interfacePropertySpec",
                 "optional": true
             }

--- a/questions/experimental/interfaceProperties.json
+++ b/questions/experimental/interfaceProperties.json
@@ -13,17 +13,17 @@
         ],
         "variables": {
             "interfaces": {
-                "description": "Only include interfaces that match this regex (default behavior is to include all interfaces)",
-                "type": "interfaceSpec",
+                "description": "Only include interfaces that match this regex",
+                "type": "javaRegex",
                 "optional": true
             },
             "nodes": {
-                "description": "Only include nodes that match this regex (default behavior is to include all nodes)",
+                "description": "Only include nodes that match this regex",
                 "type": "nodeSpec",
                 "optional": true
             },
             "properties": {
-                "description": "Only include properties that match this regex (default behavior is to include all properties)",
+                "description": "Only include properties that match this regex",
                 "type": "interfacePropertySpec",
                 "optional": true
             }

--- a/questions/experimental/nodeProperties.json
+++ b/questions/experimental/nodeProperties.json
@@ -1,21 +1,21 @@
 {
     "class": "org.batfish.question.nodeproperties.NodePropertiesQuestion",
     "differential": false,
-    "nodeRegex": "${nodeRegex}",
-    "propertySpec": "${propertySpec}",
+    "nodes": "${nodes}",
+    "properties": "${properties}",
     "instance": {
         "description": "Return configuration properties of nodes",
         "instanceName": "nodeProperties",
         "tags": [
         ],
         "variables": {
-            "nodeRegex": {
-                "description": "Only include nodes that match this regex",
+            "nodes": {
+                "description": "Only include nodes that match this regex (default behavior is to include all nodes)",
                 "type": "nodeSpec",
                 "optional": true
             },
-            "propertySpec": {
-                "description": "Only include properties that match this regex. Default behavior is to return all properties",
+            "properties": {
+                "description": "Only include properties that match this regex (default behavior is to include all properties)",
                 "type": "nodePropertySpec",
                 "optional": true
             }

--- a/questions/experimental/nodeProperties.json
+++ b/questions/experimental/nodeProperties.json
@@ -10,12 +10,12 @@
         ],
         "variables": {
             "nodes": {
-                "description": "Only include nodes that match this regex (default behavior is to include all nodes)",
+                "description": "Only include nodes that match this regex",
                 "type": "nodeSpec",
                 "optional": true
             },
             "properties": {
-                "description": "Only include properties that match this regex (default behavior is to include all properties)",
+                "description": "Only include properties that match this regex",
                 "type": "nodePropertySpec",
                 "optional": true
             }

--- a/questions/experimental/ospfProperties.json
+++ b/questions/experimental/ospfProperties.json
@@ -1,8 +1,8 @@
 {
     "class": "org.batfish.question.ospfproperties.OspfPropertiesQuestion",
     "differential": false,
-    "nodeRegex": "${nodeRegex}",
-    "propertySpec": "${propertySpec}",
+    "nodes": "${nodes}",
+    "properties": "${properties}",
     "instance": {
         "description": "Return configuration parameters for OSPF routing processes",
         "instanceName": "ospfProperties",
@@ -10,13 +10,13 @@
             "ospf"
         ],
         "variables": {
-            "nodeRegex": {
-                "description": "Only include nodes that match this regex",
+            "nodes": {
+                "description": "Only include nodes that match this regex (default behavior is to include all nodes)",
                 "type": "nodeSpec",
                 "optional": true
             },
-            "propertySpec": {
-                "description": "Only include properties that match this regex. Default behavior is to return all properties",
+            "properties": {
+                "description": "Only include properties that match this regex (default behavior is to return all properties)",
                 "type": "ospfPropertySpec",
                 "optional": true
             }

--- a/questions/experimental/ospfProperties.json
+++ b/questions/experimental/ospfProperties.json
@@ -11,12 +11,12 @@
         ],
         "variables": {
             "nodes": {
-                "description": "Only include nodes that match this regex (default behavior is to include all nodes)",
+                "description": "Only include nodes that match this regex",
                 "type": "nodeSpec",
                 "optional": true
             },
             "properties": {
-                "description": "Only include properties that match this regex (default behavior is to return all properties)",
+                "description": "Only include properties that match this regex",
                 "type": "ospfPropertySpec",
                 "optional": true
             }

--- a/tests/questions/experimental/bgpProperties.ref
+++ b/tests/questions/experimental/bgpProperties.ref
@@ -1,7 +1,7 @@
 {
   "class" : "org.batfish.question.bgpproperties.BgpPropertiesQuestion",
-  "nodeRegex" : ".*",
-  "propertySpec" : "multipath-.*",
+  "nodes" : ".*",
+  "properties" : "multipath-.*",
   "differential" : false,
   "includeOneTableKeys" : true,
   "instance" : {
@@ -12,14 +12,14 @@
       "configuration"
     ],
     "variables" : {
-      "nodeRegex" : {
+      "nodes" : {
         "description" : "Only include nodes that match this regex",
         "optional" : true,
         "type" : "nodeSpec",
         "value" : ".*"
       },
-      "propertySpec" : {
-        "description" : "Only include properties that match this regex. Default behavior is to return all properties",
+      "properties" : {
+        "description" : "Only include properties that match this regex",
         "optional" : true,
         "type" : "bgpPropertySpec",
         "value" : "multipath-.*"

--- a/tests/questions/experimental/commands
+++ b/tests/questions/experimental/commands
@@ -4,7 +4,7 @@ load-questions questions/experimental
 test -raw tests/questions/experimental/aclReachability.ref validate-template aclReachability filterSpecifierInput=".*", nodeSpecifierInput=".*"
 
 # validate bgpProperties
-test -raw tests/questions/experimental/bgpProperties.ref validate-template bgpProperties nodeRegex=".*", propertySpec="multipath-.*"
+test -raw tests/questions/experimental/bgpProperties.ref validate-template bgpProperties nodes=".*", properties="multipath-.*"
 
 # validate bgpSessionStatus
 test -raw tests/questions/experimental/bgpSessionStatus.ref validate-template bgpSessionStatus includeEstablishedCount=true, node1Regex=".*", node2Regex=".*", status=".*", type=".*"
@@ -13,10 +13,10 @@ test -raw tests/questions/experimental/bgpSessionStatus.ref validate-template bg
 test -raw tests/questions/experimental/filterTable.ref validate-template filterTable filter = "mtu == 1500", innerQuestion={"class": "org.batfish.question.interfaceproperties.InterfacePropertiesQuestion"}, columns=["interface", "mtu"]
 
 # validate interfaceMtu
-test -raw tests/questions/experimental/interfaceMtu.ref validate-template interfaceMtu comparator='>', interfaceRegex='Gig.*', mtuBytes=0, nodeRegex='as1core2'
+test -raw tests/questions/experimental/interfaceMtu.ref validate-template interfaceMtu comparator='>', interfaces='Gig.*', mtuBytes=0, nodes='as1core2'
 
 # validate interfaceProperties
-test -raw tests/questions/experimental/interfaceProperties.ref validate-template interfaceProperties nodeRegex=".*", interfaceRegex=".*", propertySpec=".*"
+test -raw tests/questions/experimental/interfaceProperties.ref validate-template interfaceProperties nodes=".*", interfaces=".*", properties=".*"
 
 # validate neighbors
 test -raw tests/questions/experimental/neighbors.ref validate-template neighbors neighborTypes=["ebgp"], node1Regex=".*", node2Regex=".*", style="summary", roleDimension="default"
@@ -25,10 +25,10 @@ test -raw tests/questions/experimental/neighbors.ref validate-template neighbors
 test -raw tests/questions/experimental/nodes.ref validate-template nodes nodeRegex=".*", nodeTypes=["ospf"], summary=true
 
 # validate nodeProperties
-test -raw tests/questions/experimental/nodeProperties.ref validate-template nodeProperties nodeRegex=".*", propertySpec="ntp.*"
+test -raw tests/questions/experimental/nodeProperties.ref validate-template nodeProperties nodes=".*", properties="ntp.*"
 
 # validate ospfProperties
-test -raw tests/questions/experimental/ospfProperties.ref validate-template ospfProperties nodeRegex=".*", propertySpec="maximum-.*"
+test -raw tests/questions/experimental/ospfProperties.ref validate-template ospfProperties nodes=".*", properties="maximum-.*"
 
 # validate prefixTracer
 test -raw tests/questions/experimental/prefixTracer.ref validate-template prefixTracer nodeRegex=".*", prefix="0.0.0.0/0"
@@ -37,7 +37,7 @@ test -raw tests/questions/experimental/prefixTracer.ref validate-template prefix
 test -raw tests/questions/experimental/reachfilter.ref validate-template reachfilter filterRegex=".*", query="matchLine 0", destinationIpSpaceSpecifierFactory="destFactory", dst="2.2.2.2",sourceIpSpaceSpecifierFactory="sourceFactory", src="1.1.1.1", nodeSpecifierInput=".*", nodeSpecifierFactory="nodesFactory"
 
 # validate specifiers
-test -raw tests/questions/experimental/specifiers.ref validate-template specifiers queryType="filter", filterSpecifierFactory="FlexibleFilterSpecifierFactory", filterSpecifierInput="filterSpecifierInput", interfaceSpecifierFactory="FlexibleInterfaceSpecifierFactory", interfaceSpecifierInput="filterSpecifierInput", ipSpaceSpecifierFactory="InferFromLocationIpSpaceSpecifierFactory", ipSpaceSpecifierInput="ipSpaceSpecifierInput", locationSpecifierFactory="FlexibleLocationSpecifierFactory", locationSpecifierInput="locationSpecifierInput", nodeSpecifierFactory="FlexibleNodeSpecifierFactory", nodeSpecifierInput="nodeSpecifierInput" 
+test -raw tests/questions/experimental/specifiers.ref validate-template specifiers queryType="filter", filterSpecifierFactory="FlexibleFilterSpecifierFactory", filterSpecifierInput="filterSpecifierInput", interfaceSpecifierFactory="FlexibleInterfaceSpecifierFactory", interfaceSpecifierInput="filterSpecifierInput", ipSpaceSpecifierFactory="InferFromLocationIpSpaceSpecifierFactory", ipSpaceSpecifierInput="ipSpaceSpecifierInput", locationSpecifierFactory="FlexibleLocationSpecifierFactory", locationSpecifierInput="locationSpecifierInput", nodeSpecifierFactory="FlexibleNodeSpecifierFactory", nodeSpecifierInput="nodeSpecifierInput"
 
 # validate specifiersReachability
 test -raw tests/questions/experimental/specifiersReachability.ref validate-template specifiersReachability actions=["accept"], debug=false, destinationIpSpaceSpecifierFactory="destFactory", dst="destination.*", finalNodesSpecifierFactory="finalNodeFactory", finalNodesSpecifierInput="finalNode", sourceLocationSpecifierFactory="sourceFactory", src="sourceNode"

--- a/tests/questions/experimental/filterTable.ref
+++ b/tests/questions/experimental/filterTable.ref
@@ -8,9 +8,9 @@
   "innerQuestion" : {
     "class" : "org.batfish.question.interfaceproperties.InterfacePropertiesQuestion",
     "excludeShutInterfaces" : false,
-    "interfaceRegex" : ".*",
-    "nodeRegex" : ".*",
-    "propertySpec" : ".*",
+    "interfaces" : ".*",
+    "nodes" : ".*",
+    "properties" : ".*",
     "differential" : false,
     "includeOneTableKeys" : true
   },

--- a/tests/questions/experimental/interfaceMtu.ref
+++ b/tests/questions/experimental/interfaceMtu.ref
@@ -8,9 +8,9 @@
   "innerQuestion" : {
     "class" : "org.batfish.question.interfaceproperties.InterfacePropertiesQuestion",
     "excludeShutInterfaces" : false,
-    "interfaceRegex" : "Gig.*",
-    "nodeRegex" : "as1core2",
-    "propertySpec" : ".*",
+    "interfaces" : "Gig.*",
+    "nodes" : "as1core2",
+    "properties" : ".*",
     "differential" : false,
     "displayHints" : {
       "textDesc" : "${interface} has MTU ${mtu}"
@@ -33,7 +33,7 @@
         "type" : "comparator",
         "value" : ">"
       },
-      "interfaceRegex" : {
+      "interfaces" : {
         "description" : "Only evaluate interfaces whose name matches this regex",
         "optional" : false,
         "type" : "javaRegex",
@@ -45,7 +45,7 @@
         "type" : "integer",
         "value" : 0
       },
-      "nodeRegex" : {
+      "nodes" : {
         "description" : "Only include nodes whose name matches this regex",
         "optional" : false,
         "type" : "javaRegex",

--- a/tests/questions/experimental/interfaceProperties.ref
+++ b/tests/questions/experimental/interfaceProperties.ref
@@ -1,9 +1,9 @@
 {
   "class" : "org.batfish.question.interfaceproperties.InterfacePropertiesQuestion",
   "excludeShutInterfaces" : false,
-  "interfaceRegex" : ".*",
-  "nodeRegex" : ".*",
-  "propertySpec" : ".*",
+  "interfaces" : ".*",
+  "nodes" : ".*",
+  "properties" : ".*",
   "differential" : false,
   "includeOneTableKeys" : true,
   "instance" : {
@@ -14,20 +14,20 @@
       "interfaces"
     ],
     "variables" : {
-      "interfaceRegex" : {
+      "interfaces" : {
         "description" : "Only include interfaces that match this regex",
         "optional" : true,
         "type" : "javaRegex",
         "value" : ".*"
       },
-      "nodeRegex" : {
+      "nodes" : {
         "description" : "Only include nodes that match this regex",
         "optional" : true,
         "type" : "nodeSpec",
         "value" : ".*"
       },
-      "propertySpec" : {
-        "description" : "Only include properties that match this regex. Default behavior is to return all properties",
+      "properties" : {
+        "description" : "Only include properties that match this regex",
         "optional" : true,
         "type" : "interfacePropertySpec",
         "value" : ".*"

--- a/tests/questions/experimental/nodeProperties.ref
+++ b/tests/questions/experimental/nodeProperties.ref
@@ -1,21 +1,21 @@
 {
   "class" : "org.batfish.question.nodeproperties.NodePropertiesQuestion",
-  "nodeRegex" : ".*",
-  "propertySpec" : "ntp.*",
+  "nodes" : ".*",
+  "properties" : "ntp.*",
   "differential" : false,
   "includeOneTableKeys" : true,
   "instance" : {
     "description" : "Return configuration properties of nodes",
     "instanceName" : "qname",
     "variables" : {
-      "nodeRegex" : {
+      "nodes" : {
         "description" : "Only include nodes that match this regex",
         "optional" : true,
         "type" : "nodeSpec",
         "value" : ".*"
       },
-      "propertySpec" : {
-        "description" : "Only include properties that match this regex. Default behavior is to return all properties",
+      "properties" : {
+        "description" : "Only include properties that match this regex",
         "optional" : true,
         "type" : "nodePropertySpec",
         "value" : "ntp.*"

--- a/tests/questions/experimental/ospfProperties.ref
+++ b/tests/questions/experimental/ospfProperties.ref
@@ -1,7 +1,7 @@
 {
   "class" : "org.batfish.question.ospfproperties.OspfPropertiesQuestion",
-  "nodeRegex" : ".*",
-  "propertySpec" : "maximum-.*",
+  "nodes" : ".*",
+  "properties" : "maximum-.*",
   "differential" : false,
   "includeOneTableKeys" : true,
   "instance" : {
@@ -11,14 +11,14 @@
       "ospf"
     ],
     "variables" : {
-      "nodeRegex" : {
+      "nodes" : {
         "description" : "Only include nodes that match this regex",
         "optional" : true,
         "type" : "nodeSpec",
         "value" : ".*"
       },
-      "propertySpec" : {
-        "description" : "Only include properties that match this regex. Default behavior is to return all properties",
+      "properties" : {
+        "description" : "Only include properties that match this regex",
         "optional" : true,
         "type" : "ospfPropertySpec",
         "value" : "maximum-.*"


### PR DESCRIPTION
Make properties questions consistent.  This includes updating:
* table answer column names
* question properties (names, values, getters)
* templates (descriptions, parameters)

Note: also had to propagate some changes to `interfaceMtu` and `filterTable` questions.
