### PR TITLE
Handle PAN structure names in quotes

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -239,7 +239,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
 
   @Override
   public void enterS_zone(S_zoneContext ctx) {
-    String name = ctx.name.getText();
+    String name = getText(ctx.name);
     _currentZone = _currentVsys.getZones().computeIfAbsent(name, n -> new Zone(n, _currentVsys));
 
     // Use constructed zone name so same-named zone defs across vsys are unique
@@ -254,7 +254,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
 
   @Override
   public void exitSds_hostname(Sds_hostnameContext ctx) {
-    _configuration.setHostname(ctx.name.getText());
+    _configuration.setHostname(getText(ctx.name));
   }
 
   @Override
@@ -296,7 +296,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
   @Override
   public void enterSn_virtual_router(Sn_virtual_routerContext ctx) {
     _currentVirtualRouter =
-        _configuration.getVirtualRouters().computeIfAbsent(ctx.name.getText(), VirtualRouter::new);
+        _configuration.getVirtualRouters().computeIfAbsent(getText(ctx.name), VirtualRouter::new);
   }
 
   @Override
@@ -359,7 +359,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
     _currentStaticRoute =
         _currentVirtualRouter
             .getStaticRoutes()
-            .computeIfAbsent(ctx.name.getText(), StaticRoute::new);
+            .computeIfAbsent(getText(ctx.name), StaticRoute::new);
   }
 
   @Override
@@ -404,7 +404,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
 
   @Override
   public void enterSr_security(Sr_securityContext ctx) {
-    String name = ctx.name.getText();
+    String name = getText(ctx.name);
     _currentRule = _currentVsys.getRules().computeIfAbsent(name, n -> new Rule(n, _currentVsys));
 
     // Use constructed name so same-named defs across vsys are unique
@@ -430,7 +430,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
   @Override
   public void exitSrs_application(Srs_applicationContext ctx) {
     for (Variable_list_itemContext var : ctx.variable_list().variable_list_item()) {
-      String name = var.getText();
+      String name = getText(var);
       if (!name.equals(CATCHALL_APPLICATION_NAME)) {
         _w.redFlag("Unhandled application: " + name);
       }
@@ -499,7 +499,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
   @Override
   public void exitSrs_to(Srs_toContext ctx) {
     for (Variable_list_itemContext var : ctx.variable_list().variable_list_item()) {
-      String zoneName = var.getText();
+      String zoneName = getText(var);
       _currentRule.getTo().add(zoneName);
 
       if (!zoneName.equals(CATCHALL_ZONE_NAME)) {
@@ -512,7 +512,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
 
   @Override
   public void enterS_service(S_serviceContext ctx) {
-    String name = ctx.name.getText();
+    String name = getText(ctx.name);
     _currentService = _currentVsys.getServices().computeIfAbsent(name, Service::new);
 
     // Use constructed service name so same-named defs across vsys are unique
@@ -557,7 +557,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
 
   @Override
   public void enterS_service_group(S_service_groupContext ctx) {
-    String name = ctx.name.getText();
+    String name = getText(ctx.name);
     _currentServiceGroup = _currentVsys.getServiceGroups().computeIfAbsent(name, ServiceGroup::new);
 
     // Use constructed service-group name so same-named defs across vsys are unique

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -529,9 +529,9 @@ public class PaloAltoGrammarTest {
     String service1Name = computeObjectName(DEFAULT_VSYS_NAME, "SERVICE1");
     String service2Name = computeObjectName(DEFAULT_VSYS_NAME, "SERVICE2");
     String service3Name = computeObjectName(DEFAULT_VSYS_NAME, "SERVICE3");
-    String service4Name = computeObjectName(DEFAULT_VSYS_NAME, "SERVICE4");
+    String service4Name = computeObjectName(DEFAULT_VSYS_NAME, "SERVICE 4");
     String serviceGroup1Name = computeObjectName(DEFAULT_VSYS_NAME, "SG1");
-    String serviceGroup2Name = computeObjectName(DEFAULT_VSYS_NAME, "SG2");
+    String serviceGroup2Name = computeObjectName(DEFAULT_VSYS_NAME, "SG 2");
 
     // Confirm structure definitions are tracked
     assertThat(ccae, hasDefinedStructure(filename, SERVICE, service1Name));

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -482,9 +482,9 @@ public class PaloAltoGrammarTest {
     String service1AclName = computeServiceGroupMemberAclName(DEFAULT_VSYS_NAME, "SERVICE1");
     String service2AclName = computeServiceGroupMemberAclName(DEFAULT_VSYS_NAME, "SERVICE2");
     String service3AclName = computeServiceGroupMemberAclName(DEFAULT_VSYS_NAME, "SERVICE3");
-    String service4AclName = computeServiceGroupMemberAclName(DEFAULT_VSYS_NAME, "SERVICE4");
+    String service4AclName = computeServiceGroupMemberAclName(DEFAULT_VSYS_NAME, "SERVICE 4");
     String serviceGroup1AclName = computeServiceGroupMemberAclName(DEFAULT_VSYS_NAME, "SG1");
-    String serviceGroup2AclName = computeServiceGroupMemberAclName(DEFAULT_VSYS_NAME, "SG2");
+    String serviceGroup2AclName = computeServiceGroupMemberAclName(DEFAULT_VSYS_NAME, "SG 2");
 
     Flow service1Flow = createFlow(IpProtocol.TCP, 999, 1);
     Flow service2Flow = createFlow(IpProtocol.UDP, 4, 999);
@@ -561,7 +561,7 @@ public class PaloAltoGrammarTest {
 
     assertThat(c, hasVrf("default", hasInterfaces(hasItem("ethernet1/1"))));
     assertThat(c, hasVrf("somename", hasInterfaces(hasItems("ethernet1/2", "ethernet1/3"))));
-    assertThat(c, hasVrf("someothername", hasInterfaces(emptyIterable())));
+    assertThat(c, hasVrf("some other name", hasInterfaces(emptyIterable())));
   }
 
   @Test
@@ -677,7 +677,7 @@ public class PaloAltoGrammarTest {
     ConvertConfigurationAnswerElement ccae =
         batfish.loadConvertConfigurationAnswerElementOrReparse();
 
-    String z1Name = computeObjectName(DEFAULT_VSYS_NAME, "z1");
+    String z1Name = computeObjectName(DEFAULT_VSYS_NAME, "zone 1");
     String zEmptyName = computeObjectName(DEFAULT_VSYS_NAME, "zempty");
 
     // Confirm zone definitions are recorded properly
@@ -694,8 +694,8 @@ public class PaloAltoGrammarTest {
     assertThat(c, hasZone(zEmptyName, hasMemberInterfaces(empty())));
 
     // Confirm interfaces are associated with the correct zones
-    assertThat(c, hasInterface("ethernet1/1", hasZoneName(equalTo("z1"))));
-    assertThat(c, hasInterface("ethernet1/2", hasZoneName(equalTo("z1"))));
+    assertThat(c, hasInterface("ethernet1/1", hasZoneName(equalTo("zone 1"))));
+    assertThat(c, hasInterface("ethernet1/2", hasZoneName(equalTo("zone 1"))));
     assertThat(c, hasInterface("ethernet1/3", hasZoneName(is(nullValue()))));
   }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/rulebase
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/rulebase
@@ -9,14 +9,14 @@ set zone z2 network layer3 ethernet1/4
 set service SERVICE1 protocol tcp port 999
 
 # Block all rule is disabled, so should have no impact
-set rulebase security rules RULE0 disabled yes
-set rulebase security rules RULE0 from [ any ZONE_UNDEF ]
-set rulebase security rules RULE0 to any
-set rulebase security rules RULE0 source any
-set rulebase security rules RULE0 destination any
-set rulebase security rules RULE0 service [ any SERVICE_UNDEF ]
-set rulebase security rules RULE0 application any
-set rulebase security rules RULE0 action drop
+set rulebase security rules "disabled rule" disabled yes
+set rulebase security rules "disabled rule" from [ any ZONE_UNDEF ]
+set rulebase security rules "disabled rule" to any
+set rulebase security rules "disabled rule" source any
+set rulebase security rules "disabled rule" destination any
+set rulebase security rules "disabled rule" service [ any SERVICE_UNDEF ]
+set rulebase security rules "disabled rule" application any
+set rulebase security rules "disabled rule" action drop
 
 set rulebase security rules RULE1 from any
 set rulebase security rules RULE1 to [ z1 z2 ]

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/service
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/service
@@ -3,7 +3,7 @@ set service SERVICE1 description "long description"
 set service SERVICE1 protocol tcp port 1
 set service SERVICE2 protocol udp source-port 4
 set service SERVICE3 protocol udp port 5,6 source-port 9,10
-set service SERVICE4 protocol sctp
+set service "SERVICE 4" protocol sctp
 
 set service-group SG1 members [ SERVICE1 SERVICE2 ]
-set service-group SG2 members [ SG1 SERVICE_UNDEFINED ]
+set service-group "SG 2" members [ SG1 SERVICE_UNDEFINED ]

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/virtual-router-interfaces
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/virtual-router-interfaces
@@ -1,7 +1,7 @@
 set deviceconfig system hostname virtual-router-interfaces
 set network virtual-router default interface ethernet1/1
 set network virtual-router somename interface [ ethernet1/2 ethernet1/3 ]
-set network virtual-router someothername interface [ ]
+set network virtual-router "some other name" interface [ ]
 set network interface ethernet ethernet1/1 layer3 ip 1.1.1.1/24
 set network interface ethernet ethernet1/2 layer3 ip 1.1.2.1/24
 set network interface ethernet ethernet1/3 layer3 ip 1.1.3.1/24

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/zones
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/zones
@@ -2,5 +2,5 @@ set deviceconfig system hostname zones
 set network interface ethernet ethernet1/1 layer3 ip 1.1.1.1/24
 set network interface ethernet ethernet1/2 layer3 ip 1.1.2.1/24
 set network interface ethernet ethernet1/3 layer3 ip 1.1.3.1/24
-set zone z1 network layer3 [ ethernet1/1 ethernet1/2 ]
+set zone "zone 1" network layer3 [ ethernet1/1 ethernet1/2 ]
 set zone zempty network layer3


### PR DESCRIPTION
Palo Alto Networks devices allow spaces in the names for many structures, e.g.:
```
set service "service name with spaces" protocol tcp
set service-group "service group name with spaces" members "service name with spaces"
```

This PR updates configuration building for PAN to extract struct names from quotes where applicable.
