### PR TITLE
Updating peerAS from Int to Long for 32bit private ASNs

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -3052,7 +3052,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
 
   @Override
   public void exitBpa_as(Bpa_asContext ctx) {
-    int peerAs = toInt(ctx.as);
+    long peerAs = toLong(ctx.as);
     _currentBgpGroup.setPeerAs(peerAs);
   }
 


### PR DESCRIPTION
I had a configuration parse error: 

> Caused by: java.lang.NumberFormatException: For input string: "4202002800"

Core of the issue: Private 32-bit ASNs (rfc6996, range 4200000000 - 4294967294) are outside of the range of an Int (upper range 2,147,483,647).

Should use a Long to store these. 