### PR TITLE
Make ACL reachability template consistent

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AclLines2Rows.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AclLines2Rows.java
@@ -21,12 +21,12 @@ import org.batfish.datamodel.table.Row;
  */
 @ParametersAreNonnullByDefault
 public class AclLines2Rows implements AclLinesAnswerElementInterface {
-  public static final String COL_SOURCES = "aclSources";
-  public static final String COL_LINES = "lines";
-  public static final String COL_BLOCKED_LINE_NUM = "blockedLineNum";
-  public static final String COL_BLOCKING_LINE_NUMS = "blockingLineNums";
-  public static final String COL_DIFF_ACTION = "differentAction";
-  public static final String COL_MESSAGE = "message";
+  public static final String COL_SOURCES = "ACL_Sources";
+  public static final String COL_LINES = "Lines";
+  public static final String COL_BLOCKED_LINE_NUM = "Blocked_Line_Num";
+  public static final String COL_BLOCKING_LINE_NUMS = "Blocking_Line_Nums";
+  public static final String COL_DIFF_ACTION = "Different_Action";
+  public static final String COL_MESSAGE = "Message";
 
   private final Multiset<Row> _rows = HashMultiset.create();
 

--- a/projects/question/src/main/java/org/batfish/question/aclreachability2/AclReachability2Question.java
+++ b/projects/question/src/main/java/org/batfish/question/aclreachability2/AclReachability2Question.java
@@ -26,11 +26,11 @@ public class AclReachability2Question extends Question {
 
   private static final String PROP_FILTER_SPECIFIER_FACTORY = "filterSpecifierFactory";
 
-  private static final String PROP_FILTER_SPECIFIER_INPUT = "filterSpecifierInput";
+  private static final String PROP_FILTER_SPECIFIER_INPUT = "filters";
 
   private static final String PROP_NODE_SPECIFIER_FACTORY = "nodeSpecifierFactory";
 
-  private static final String PROP_NODE_SPECIFIER_INPUT = "nodeSpecifierInput";
+  private static final String PROP_NODE_SPECIFIER_INPUT = "nodes";
 
   private String _filterSpecifierFactory;
 
@@ -72,7 +72,7 @@ public class AclReachability2Question extends Question {
 
   @Override
   public String getName() {
-    return "aclreachability2";
+    return "aclReachability2";
   }
 
   @JsonProperty(PROP_NODE_SPECIFIER_FACTORY)

--- a/questions/experimental/aclReachability.json
+++ b/questions/experimental/aclReachability.json
@@ -1,25 +1,25 @@
 {
     "class": "org.batfish.question.aclreachability2.AclReachability2Question",
     "differential": false,
-    "filterSpecifierInput": "${filterSpecifierInput}",
-    "nodeSpecifierInput": "${nodeSpecifierInput}",
+    "filters": "${filters}",
+    "nodes": "${nodes}",
     "instance": {
-        "description": "Display ACLs/filters with unreachable lines",
+        "description": "Identify ACLs/filters with unreachable lines",
         "instanceName": "aclReachability",
-        "longDescription": "Return ACLs/filters with unreachable lines, along with all of the unreachable lines within each ACL/filter.",
+        "longDescription": "This question finds all unreachable lines in the specified ACLs/filters.",
         "tags": [
             "acl",
             "default"
         ],
         "variables": {
-            "filterSpecifierInput": {
-              "description": "Name or regex identifying the filter(s) to test",
+            "filters": {
+              "description": "Name or regex identifying the filters to test",
               "type": "string",
               "optional": true
             },
-            "nodeSpecifierInput": {
-              "description": "Name or regex identifying the nodes to restrict the test to",
-              "type": "string",
+            "nodes": {
+              "description": "Examine filters on nodes matching this name or regex",
+              "type": "nodeSpec",
               "optional": true
             }
         }

--- a/tests/basic/aclReachability2.ref
+++ b/tests/basic/aclReachability2.ref
@@ -7,79 +7,79 @@
           "description" : "ACL sources",
           "isKey" : true,
           "isValue" : false,
-          "name" : "aclSources",
+          "name" : "ACL_Sources",
           "schema" : "List<String>"
         },
         {
           "description" : "ACL lines",
           "isKey" : false,
           "isValue" : false,
-          "name" : "lines",
+          "name" : "Lines",
           "schema" : "List<String>"
         },
         {
           "description" : "Blocked line number",
           "isKey" : true,
           "isValue" : false,
-          "name" : "blockedLineNum",
+          "name" : "Blocked_Line_Num",
           "schema" : "Integer"
         },
         {
           "description" : "Blocking line numbers",
           "isKey" : false,
           "isValue" : true,
-          "name" : "blockingLineNums",
+          "name" : "Blocking_Line_Nums",
           "schema" : "List<Integer>"
         },
         {
           "description" : "Different action",
           "isKey" : false,
           "isValue" : true,
-          "name" : "differentAction",
+          "name" : "Different_Action",
           "schema" : "Boolean"
         },
         {
           "description" : "Message",
           "isKey" : false,
           "isValue" : false,
-          "name" : "message",
+          "name" : "Message",
           "schema" : "String"
         }
       ],
-      "textDesc" : "${message}"
+      "textDesc" : "${Message}"
     },
     "rows" : [
       {
-        "aclSources" : [
-          "as2dept1: RESTRICT_HOST_TRAFFIC_IN"
-        ],
-        "lines" : [
-          "permit ip 2.128.0.0 0.0.255.255 any",
-          "deny   ip any any",
-          "permit icmp any any"
-        ],
-        "blockedLineNum" : 2,
-        "blockingLineNums" : [
-          1
-        ],
-        "differentAction" : true,
-        "message" : "ACLs { as2dept1: RESTRICT_HOST_TRAFFIC_IN } contain an unreachable line:\n  [index 2] permit icmp any any\nBlocking line(s):\n  [index 1] deny   ip any any"
-      },
-      {
-        "aclSources" : [
+        "ACL_Sources" : [
           "as2dept1: RESTRICT_HOST_TRAFFIC_OUT"
         ],
-        "lines" : [
+        "Lines" : [
           "permit ip any 2.128.0.0 0.0.255.255",
           "deny   ip 1.128.0.0 0.0.255.255 2.128.0.0 0.0.255.255",
           "deny   ip any any"
         ],
-        "blockedLineNum" : 1,
-        "blockingLineNums" : [
+        "Blocked_Line_Num" : 1,
+        "Blocking_Line_Nums" : [
           0
         ],
-        "differentAction" : true,
-        "message" : "ACLs { as2dept1: RESTRICT_HOST_TRAFFIC_OUT } contain an unreachable line:\n  [index 1] deny   ip 1.128.0.0 0.0.255.255 2.128.0.0 0.0.255.255\nBlocking line(s):\n  [index 0] permit ip any 2.128.0.0 0.0.255.255"
+        "Different_Action" : true,
+        "Message" : "ACLs { as2dept1: RESTRICT_HOST_TRAFFIC_OUT } contain an unreachable line:\n  [index 1] deny   ip 1.128.0.0 0.0.255.255 2.128.0.0 0.0.255.255\nBlocking line(s):\n  [index 0] permit ip any 2.128.0.0 0.0.255.255"
+      },
+      {
+        "ACL_Sources" : [
+          "as2dept1: RESTRICT_HOST_TRAFFIC_IN"
+        ],
+        "Lines" : [
+          "permit ip 2.128.0.0 0.0.255.255 any",
+          "deny   ip any any",
+          "permit icmp any any"
+        ],
+        "Blocked_Line_Num" : 2,
+        "Blocking_Line_Nums" : [
+          1
+        ],
+        "Different_Action" : true,
+        "Message" : "ACLs { as2dept1: RESTRICT_HOST_TRAFFIC_IN } contain an unreachable line:\n  [index 2] permit icmp any any\nBlocking line(s):\n  [index 1] deny   ip any any"
       }
     ],
     "summary" : {

--- a/tests/questions/experimental/aclReachability.ref
+++ b/tests/questions/experimental/aclReachability.ref
@@ -1,28 +1,28 @@
 {
   "class" : "org.batfish.question.aclreachability2.AclReachability2Question",
-  "filterSpecifierInput" : ".*",
-  "nodeSpecifierInput" : ".*",
+  "filters" : ".*",
+  "nodes" : ".*",
   "differential" : false,
   "includeOneTableKeys" : true,
   "instance" : {
-    "description" : "Display ACLs/filters with unreachable lines",
+    "description" : "Identify ACLs/filters with unreachable lines",
     "instanceName" : "qname",
-    "longDescription" : "Return ACLs/filters with unreachable lines, along with all of the unreachable lines within each ACL/filter.",
+    "longDescription" : "This question finds all unreachable lines in the specified ACLs/filters.",
     "tags" : [
       "acl",
       "default"
     ],
     "variables" : {
-      "filterSpecifierInput" : {
-        "description" : "Name or regex identifying the filter(s) to test",
+      "filters" : {
+        "description" : "Name or regex identifying the filters to test",
         "optional" : true,
         "type" : "string",
         "value" : ".*"
       },
-      "nodeSpecifierInput" : {
-        "description" : "Name or regex identifying the nodes to restrict the test to",
+      "nodes" : {
+        "description" : "Examine filters on nodes matching this name or regex",
         "optional" : true,
-        "type" : "string",
+        "type" : "nodeSpec",
         "value" : ".*"
       }
     }

--- a/tests/questions/experimental/commands
+++ b/tests/questions/experimental/commands
@@ -1,7 +1,7 @@
 load-questions questions/experimental
 
 # validate aclReachability
-test -raw tests/questions/experimental/aclReachability.ref validate-template aclReachability filterSpecifierInput=".*", nodeSpecifierInput=".*"
+test -raw tests/questions/experimental/aclReachability.ref validate-template aclReachability filters=".*", nodes=".*"
 
 # validate bgpProperties
 test -raw tests/questions/experimental/bgpProperties.ref validate-template bgpProperties nodeRegex=".*", propertySpec="multipath-.*"


### PR DESCRIPTION
- changed question params to `filters` and `nodes`
- changed type of `nodes` to `nodeSpec`
- updated template descriptions for question and parameters
- changed column names to Uppercase_Underscore_Separated_Format
- changed name returned by `getName()` to camel case