### PR TITLE
Bazel: don't kill the user's machine on ref tests

### DIFF
--- a/skylark/ref_tests.bzl
+++ b/skylark/ref_tests.bzl
@@ -30,4 +30,5 @@ def ref_tests(name, commands, allinone = None, extra_deps = None, **kwargs):
             allinone,
             commands,
         ] + extra_deps,
+        tags = [ "exclusive" ],
     )


### PR DESCRIPTION
Run only one ref test at a time.

https://docs.bazel.build/versions/master/be/common-definitions.html#common.tags