### PR TITLE
Jackson: add missing annotations in lots of places

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/ParseTreeSentences.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/ParseTreeSentences.java
@@ -1,17 +1,21 @@
 package org.batfish.common;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
 public class ParseTreeSentences implements Serializable {
+  private static final String PROP_SENTENCES = "sentences";
 
   /** */
   private static final long serialVersionUID = 1L;
 
   protected List<String> _sentences;
 
+  @JsonCreator
   public ParseTreeSentences() {
     _sentences = new ArrayList<>();
   }
@@ -26,6 +30,7 @@ public class ParseTreeSentences implements Serializable {
     }
   }
 
+  @JsonProperty(PROP_SENTENCES)
   public List<String> getSentences() {
     return _sentences;
   }
@@ -35,6 +40,7 @@ public class ParseTreeSentences implements Serializable {
     return _sentences.isEmpty();
   }
 
+  @JsonProperty(PROP_SENTENCES)
   public void setSentences(List<String> sentences) {
     _sentences = sentences;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsPathAccessListLine.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsPathAccessListLine.java
@@ -1,17 +1,41 @@
 package org.batfish.datamodel;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDescription;
 import java.io.Serializable;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @JsonSchemaDescription("A line in an AsPathAccessList")
+@ParametersAreNonnullByDefault
 public final class AsPathAccessListLine implements Serializable, Comparable<AsPathAccessListLine> {
+  private static final String PROP_ACTION = "action";
+  private static final String PROP_REGEX = "regex";
 
   private static final long serialVersionUID = 1L;
 
-  private LineAction _action;
+  @Nonnull private LineAction _action;
 
-  private String _regex;
+  @Nonnull private String _regex;
+
+  @JsonCreator
+  private static AsPathAccessListLine jsonCreator(
+      @Nullable @JsonProperty(PROP_ACTION) LineAction action,
+      @Nullable @JsonProperty(PROP_REGEX) String regex) {
+    checkArgument(action != null, "%s must be provided", PROP_ACTION);
+    checkArgument(regex != null, "%s must be provided", PROP_REGEX);
+    return new AsPathAccessListLine(action, regex);
+  }
+
+  public AsPathAccessListLine(LineAction action, String regex) {
+    _action = action;
+    _regex = regex;
+  }
 
   @Override
   public int compareTo(AsPathAccessListLine rhs) {
@@ -27,22 +51,20 @@ public final class AsPathAccessListLine implements Serializable, Comparable<AsPa
       return false;
     }
     AsPathAccessListLine other = (AsPathAccessListLine) o;
-    if (_action != other._action) {
-      return false;
-    }
-    if (!_regex.equals(other._regex)) {
-      return false;
-    }
-    return true;
+    return _action == other._action && _regex.equals(other._regex);
   }
 
   @JsonPropertyDescription(
       "The action the underlying access-list will take when this line matches a route.")
+  @JsonProperty(PROP_ACTION)
+  @Nonnull
   public LineAction getAction() {
     return _action;
   }
 
   @JsonPropertyDescription("The regex against which a route's AS-path will be compared")
+  @JsonProperty(PROP_REGEX)
+  @Nonnull
   public String getRegex() {
     return _regex;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Configuration.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Configuration.java
@@ -130,6 +130,8 @@ public final class Configuration implements Serializable {
 
   private static final String PROP_INTERFACES = "interfaces";
 
+  private static final String PROP_IP6_ACCESS_LISTS = "ip6AccessLists";
+
   private static final String PROP_IP_ACCESS_LISTS = "ipAccessLists";
 
   private static final String PROP_IP_SPACES = "ipSpaces";
@@ -157,6 +159,8 @@ public final class Configuration implements Serializable {
   private static final String PROP_NTP_SERVERS = "ntpServers";
 
   private static final String PROP_NTP_SOURCE_INTERFACE = "ntpSourceInterface";
+
+  private static final String PROP_ROUTE6_FILTER_LISTS = "route6FilterLists";
 
   private static final String PROP_ROUTE_FILTER_LISTS = "routeFilterLists";
 
@@ -530,6 +534,7 @@ public final class Configuration implements Serializable {
   }
 
   @JsonPropertyDescription("Dictionary of all IPV6 access-lists for this node.")
+  @JsonProperty(PROP_IP6_ACCESS_LISTS)
   public NavigableMap<String, Ip6AccessList> getIp6AccessLists() {
     return _ip6AccessLists;
   }
@@ -642,6 +647,7 @@ public final class Configuration implements Serializable {
   }
 
   @JsonPropertyDescription("Dictionary of all IPV6 route filter lists for this node.")
+  @JsonProperty(PROP_ROUTE6_FILTER_LISTS)
   public NavigableMap<String, Route6FilterList> getRoute6FilterLists() {
     return _route6FilterLists;
   }
@@ -826,6 +832,7 @@ public final class Configuration implements Serializable {
     _interfaces = interfaces;
   }
 
+  @JsonProperty(PROP_IP6_ACCESS_LISTS)
   public void setIp6AccessLists(NavigableMap<String, Ip6AccessList> ip6AccessLists) {
     _ip6AccessLists = ip6AccessLists;
   }
@@ -907,6 +914,7 @@ public final class Configuration implements Serializable {
     _ntpSourceInterface = ntpSourceInterface;
   }
 
+  @JsonProperty(PROP_ROUTE6_FILTER_LISTS)
   public void setRoute6FilterLists(NavigableMap<String, Route6FilterList> route6FilterLists) {
     _route6FilterLists = route6FilterLists;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Header6Space.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Header6Space.java
@@ -1,5 +1,6 @@
 package org.batfish.datamodel;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -10,7 +11,31 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 
 public class Header6Space implements Serializable {
-
+  private static final String PROP_DSCPS = "dscps";
+  private static final String PROP_DST_IPS = "dstIps";
+  private static final String PROP_DST_PORTS = "dstPorts";
+  private static final String PROP_ECNS = "ecns";
+  private static final String PROP_FRAGMENT_OFFSETS = "fragmentOffsets";
+  private static final String PROP_ICMP_CODES = "icmpCodes";
+  private static final String PROP_ICMP_TYPES = "icmpTypes";
+  private static final String PROP_IP_PROTOCOLS = "ipProtocols";
+  private static final String PROP_NEGATE = "negate";
+  private static final String PROP_NOT_DSCPS = "notDscps";
+  private static final String PROP_NOT_DST_IPS = "notDstIps";
+  private static final String PROP_NOT_DST_PORTS = "notDstPorts";
+  private static final String PROP_NOT_ECNS = "notEcns";
+  private static final String PROP_NOT_FRAGMENT_OFFSETS = "notFragmentOffsets";
+  private static final String PROP_NOT_ICMP_CODES = "notIcmpCodes";
+  private static final String PROP_NOT_ICMP_TYPES = "notIcmpTypes";
+  private static final String PROP_NOT_IP_PROTOCOLS = "notIpProtocols";
+  private static final String PROP_NOT_SRC_IPS = "notSrcIps";
+  private static final String PROP_NOT_SRC_PORTS = "notSrcPorts";
+  private static final String PROP_SRC_IPS = "srcIps";
+  private static final String PROP_SRC_OR_DST_IPS = "srcOrDstIps";
+  private static final String PROP_SRC_OR_DST_PORTS = "srcOrDstPorts";
+  private static final String PROP_SRC_PORTS = "srcPorts";
+  private static final String PROP_STATES = "states";
+  private static final String PROP_TCP_FLAGS = "tcpFlags";
   /** */
   private static final long serialVersionUID = 1L;
 
@@ -195,102 +220,127 @@ public class Header6Space implements Serializable {
     return true;
   }
 
+  @JsonProperty(PROP_DSCPS)
   public SortedSet<Integer> getDscps() {
     return _dscps;
   }
 
+  @JsonProperty(PROP_DST_IPS)
   public SortedSet<Ip6Wildcard> getDstIps() {
     return _dstIps;
   }
 
+  @JsonProperty(PROP_DST_PORTS)
   public SortedSet<SubRange> getDstPorts() {
     return _dstPorts;
   }
 
+  @JsonProperty(PROP_ECNS)
   public SortedSet<Integer> getEcns() {
     return _ecns;
   }
 
+  @JsonProperty(PROP_FRAGMENT_OFFSETS)
   public SortedSet<SubRange> getFragmentOffsets() {
     return _fragmentOffsets;
   }
 
+  @JsonProperty(PROP_ICMP_CODES)
   public SortedSet<SubRange> getIcmpCodes() {
     return _icmpCodes;
   }
 
+  @JsonProperty(PROP_ICMP_TYPES)
   public SortedSet<SubRange> getIcmpTypes() {
     return _icmpTypes;
   }
 
+  @JsonProperty(PROP_IP_PROTOCOLS)
   public Set<IpProtocol> getIpProtocols() {
     return _ipProtocols;
   }
 
+  @JsonProperty(PROP_NEGATE)
   public boolean getNegate() {
     return _negate;
   }
 
+  @JsonProperty(PROP_NOT_DSCPS)
   public SortedSet<Integer> getNotDscps() {
     return _notDscps;
   }
 
+  @JsonProperty(PROP_NOT_DST_IPS)
   public SortedSet<Ip6Wildcard> getNotDstIps() {
     return _notDstIps;
   }
 
+  @JsonProperty(PROP_NOT_DST_PORTS)
   public SortedSet<SubRange> getNotDstPorts() {
     return _notDstPorts;
   }
 
+  @JsonProperty(PROP_NOT_ECNS)
   public SortedSet<Integer> getNotEcns() {
     return _notEcns;
   }
 
+  @JsonProperty(PROP_NOT_FRAGMENT_OFFSETS)
   public SortedSet<SubRange> getNotFragmentOffsets() {
     return _notFragmentOffsets;
   }
 
+  @JsonProperty(PROP_NOT_ICMP_CODES)
   public SortedSet<SubRange> getNotIcmpCodes() {
     return _notIcmpCodes;
   }
 
+  @JsonProperty(PROP_NOT_ICMP_TYPES)
   public SortedSet<SubRange> getNotIcmpTypes() {
     return _notIcmpTypes;
   }
 
+  @JsonProperty(PROP_NOT_IP_PROTOCOLS)
   public Set<IpProtocol> getNotIpProtocols() {
     return _notIpProtocols;
   }
 
+  @JsonProperty(PROP_NOT_SRC_IPS)
   public SortedSet<Ip6Wildcard> getNotSrcIps() {
     return _notSrcIps;
   }
 
+  @JsonProperty(PROP_NOT_SRC_PORTS)
   public SortedSet<SubRange> getNotSrcPorts() {
     return _notSrcPorts;
   }
 
+  @JsonProperty(PROP_SRC_IPS)
   public SortedSet<Ip6Wildcard> getSrcIps() {
     return _srcIps;
   }
 
+  @JsonProperty(PROP_SRC_OR_DST_IPS)
   public SortedSet<Ip6Wildcard> getSrcOrDstIps() {
     return _srcOrDstIps;
   }
 
+  @JsonProperty(PROP_SRC_OR_DST_PORTS)
   public SortedSet<SubRange> getSrcOrDstPorts() {
     return _srcOrDstPorts;
   }
 
+  @JsonProperty(PROP_SRC_PORTS)
   public SortedSet<SubRange> getSrcPorts() {
     return _srcPorts;
   }
 
+  @JsonProperty(PROP_STATES)
   public Set<State> getStates() {
     return _states;
   }
 
+  @JsonProperty(PROP_TCP_FLAGS)
   public List<TcpFlags> getTcpFlags() {
     return _tcpFlags;
   }
@@ -376,104 +426,129 @@ public class Header6Space implements Serializable {
     return true;
   }
 
+  @JsonProperty(PROP_DSCPS)
   public void setDscps(SortedSet<Integer> dscps) {
     _dscps = dscps;
   }
 
+  @JsonProperty(PROP_DST_IPS)
   public void setDstIps(SortedSet<Ip6Wildcard> dstIps) {
     _dstIps = dstIps;
   }
 
+  @JsonProperty(PROP_DST_PORTS)
   public void setDstPorts(SortedSet<SubRange> dstPorts) {
     _dstPorts = dstPorts;
   }
 
+  @JsonProperty(PROP_ECNS)
   public void setEcns(SortedSet<Integer> ecns) {
     _ecns = ecns;
   }
 
+  @JsonProperty(PROP_FRAGMENT_OFFSETS)
   public void setFragmentOffsets(SortedSet<SubRange> fragmentOffsets) {
     _fragmentOffsets = fragmentOffsets;
   }
 
+  @JsonProperty(PROP_ICMP_CODES)
   public void setIcmpCodes(SortedSet<SubRange> icmpCodes) {
     _icmpCodes = icmpCodes;
   }
 
+  @JsonProperty(PROP_ICMP_TYPES)
   public void setIcmpTypes(SortedSet<SubRange> icmpTypes) {
     _icmpTypes = icmpTypes;
   }
 
+  @JsonProperty(PROP_IP_PROTOCOLS)
   public void setIpProtocols(Set<IpProtocol> ipProtocols) {
     _ipProtocols.clear();
     _ipProtocols.addAll(ipProtocols);
   }
 
+  @JsonProperty(PROP_NEGATE)
   public void setNegate(boolean negate) {
     _negate = negate;
   }
 
+  @JsonProperty(PROP_NOT_DSCPS)
   public void setNotDscps(SortedSet<Integer> notDscps) {
     _notDscps = notDscps;
   }
 
+  @JsonProperty(PROP_NOT_DST_IPS)
   public void setNotDstIps(SortedSet<Ip6Wildcard> notDstIps) {
     _notDstIps = notDstIps;
   }
 
+  @JsonProperty(PROP_NOT_DST_PORTS)
   public void setNotDstPorts(SortedSet<SubRange> notDstPorts) {
     _notDstPorts = notDstPorts;
   }
 
+  @JsonProperty(PROP_NOT_ECNS)
   public void setNotEcns(SortedSet<Integer> notEcns) {
     _notEcns = notEcns;
   }
 
+  @JsonProperty(PROP_NOT_FRAGMENT_OFFSETS)
   public void setNotFragmentOffsets(SortedSet<SubRange> notFragmentOffsets) {
     _notFragmentOffsets = notFragmentOffsets;
   }
 
+  @JsonProperty(PROP_NOT_ICMP_CODES)
   public void setNotIcmpCodes(SortedSet<SubRange> notIcmpCodes) {
     _notIcmpCodes = notIcmpCodes;
   }
 
+  @JsonProperty(PROP_NOT_ICMP_TYPES)
   public void setNotIcmpTypes(SortedSet<SubRange> notIcmpTypes) {
     _notIcmpTypes = notIcmpTypes;
   }
 
+  @JsonProperty(PROP_NOT_IP_PROTOCOLS)
   public void setNotIpProtocols(Set<IpProtocol> notIpProtocols) {
     _notIpProtocols.clear();
     _notIpProtocols.addAll(notIpProtocols);
   }
 
+  @JsonProperty(PROP_NOT_SRC_IPS)
   public void setNotSrcIps(SortedSet<Ip6Wildcard> notSrcIps) {
     _notSrcIps = notSrcIps;
   }
 
+  @JsonProperty(PROP_NOT_SRC_PORTS)
   public void setNotSrcPorts(SortedSet<SubRange> notSrcPorts) {
     _notSrcPorts = notSrcPorts;
   }
 
+  @JsonProperty(PROP_SRC_IPS)
   public void setSrcIps(SortedSet<Ip6Wildcard> srcIps) {
     _srcIps = srcIps;
   }
 
+  @JsonProperty(PROP_SRC_OR_DST_IPS)
   public void setSrcOrDstIps(SortedSet<Ip6Wildcard> srcOrDstIps) {
     _srcOrDstIps = srcOrDstIps;
   }
 
+  @JsonProperty(PROP_SRC_OR_DST_PORTS)
   public void setSrcOrDstPorts(SortedSet<SubRange> srcOrDstPorts) {
     _srcOrDstPorts = srcOrDstPorts;
   }
 
+  @JsonProperty(PROP_SRC_PORTS)
   public void setSrcPorts(SortedSet<SubRange> srcPorts) {
     _srcPorts = srcPorts;
   }
 
+  @JsonProperty(PROP_STATES)
   public void setStates(Set<State> states) {
     _states = states;
   }
 
+  @JsonProperty(PROP_TCP_FLAGS)
   public void setTcpFlags(List<TcpFlags> tcpFlags) {
     _tcpFlags = tcpFlags;
   }
@@ -527,34 +602,5 @@ public class Header6Space implements Serializable {
         + ", TcpFlags:"
         + _tcpFlags
         + "]";
-  }
-
-  public final boolean unrestricted() {
-    boolean ret =
-        _dscps.isEmpty()
-            && _notDscps.isEmpty()
-            && _dstIps.isEmpty()
-            && _notDstIps.isEmpty()
-            && _dstPorts.isEmpty()
-            && _notDstPorts.isEmpty()
-            && _ecns.isEmpty()
-            && _notEcns.isEmpty()
-            && _fragmentOffsets.isEmpty()
-            && _notFragmentOffsets.isEmpty()
-            && _icmpCodes.isEmpty()
-            && _notIcmpCodes.isEmpty()
-            && _icmpTypes.isEmpty()
-            && _notIcmpTypes.isEmpty()
-            && _ipProtocols.isEmpty()
-            && _notIpProtocols.isEmpty()
-            && _srcIps.isEmpty()
-            && _notSrcIps.isEmpty()
-            && _srcOrDstIps.isEmpty()
-            && _srcOrDstPorts.isEmpty()
-            && _srcPorts.isEmpty()
-            && _notSrcPorts.isEmpty()
-            && _states.isEmpty()
-            && _tcpFlags.isEmpty();
-    return ret;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Ip6AccessList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Ip6AccessList.java
@@ -14,26 +14,6 @@ public class Ip6AccessList extends ComparableStructure<String> {
 
   private static final long serialVersionUID = 1L;
 
-  static boolean bothNullOrSameName(Ip6AccessList a, Ip6AccessList b) {
-    if (a == null && b == null) {
-      return true;
-    } else if (a != null && b != null) {
-      return a.getName().equals(b.getName());
-    } else {
-      return false;
-    }
-  }
-
-  static boolean bothNullOrUnorderedEqual(Ip6AccessList a, Ip6AccessList b) {
-    if (a == null && b == null) {
-      return true;
-    } else if (a != null && b != null) {
-      return a.unorderedEqual(b);
-    } else {
-      return false;
-    }
-  }
-
   private List<Ip6AccessListLine> _lines;
 
   @JsonCreator
@@ -73,17 +53,6 @@ public class Ip6AccessList extends ComparableStructure<String> {
     return _lines;
   }
 
-  private boolean noDenyOrLastDeny(Ip6AccessList acl) {
-    int count = 0;
-    for (Ip6AccessListLine line : acl.getLines()) {
-      if (line.getAction() == LineAction.DENY && count < acl.getLines().size() - 1) {
-        return false;
-      }
-      count++;
-    }
-    return true;
-  }
-
   @JsonProperty(PROP_LINES)
   public void setLines(List<Ip6AccessListLine> lines) {
     _lines = lines;
@@ -96,30 +65,5 @@ public class Ip6AccessList extends ComparableStructure<String> {
       output += "\n" + line;
     }
     return output;
-  }
-
-  public boolean unorderedEqual(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (this.equals(obj)) {
-      return true;
-    }
-    Ip6AccessList other = (Ip6AccessList) obj;
-    if (this.getLines().size() != other.getLines().size()) {
-      return false;
-    }
-    // Unordered check is valid only if there is no deny OR if there is only
-    // one, at the
-    // end, in both lists.
-    if (!noDenyOrLastDeny(this) || !noDenyOrLastDeny(other)) {
-      return false;
-    }
-    for (Ip6AccessListLine line : this.getLines()) {
-      if (!other.getLines().contains(line)) {
-        return false;
-      }
-    }
-    return true;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Ip6AccessListLine.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Ip6AccessListLine.java
@@ -1,10 +1,13 @@
 package org.batfish.datamodel;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDescription;
 
 @JsonSchemaDescription("A line in an Ip6AccessList")
 public final class Ip6AccessListLine extends Header6Space {
+  private static final String PROP_ACTION = "action";
+  private static final String PROP_NAME = "name";
 
   private static final long serialVersionUID = 1L;
 
@@ -16,24 +19,22 @@ public final class Ip6AccessListLine extends Header6Space {
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
+    } else if (!(obj instanceof Ip6AccessListLine)) {
+      return false;
     }
     Ip6AccessListLine other = (Ip6AccessListLine) obj;
-    if (!super.equals(obj)) {
-      return false;
-    }
-    if (_action != other._action) {
-      return false;
-    }
-    return true;
+    return super.equals(obj) && _action == other._action;
   }
 
   @JsonPropertyDescription(
       "The action the underlying access-list will take when this line matches an IPV6 packet.")
+  @JsonProperty(PROP_ACTION)
   public LineAction getAction() {
     return _action;
   }
 
   @JsonSchemaDescription("The name of this line in the list")
+  @JsonProperty(PROP_NAME)
   public String getName() {
     return _name;
   }
@@ -44,10 +45,12 @@ public final class Ip6AccessListLine extends Header6Space {
     return 0;
   }
 
+  @JsonProperty(PROP_ACTION)
   public void setAction(LineAction action) {
     _action = action;
   }
 
+  @JsonProperty(PROP_NAME)
   public void setName(String name) {
     _name = name;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Line.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Line.java
@@ -1,19 +1,30 @@
 package org.batfish.datamodel;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.Objects;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.common.util.ComparableStructure;
 
 public class Line extends ComparableStructure<String> {
+  private static final String PROP_EXEC_TIMEOUT_MINUTES = "execTimeoutMinutes";
+  private static final String PROP_EXEC_TIMEOUT_SECONDS = "execTimeoutSeconds";
+  private static final String PROP_INPUT_ACCESS_LIST = "inputAccessList";
+  private static final String PROP_INPUT_IPV6_ACCESS_LIST = "inputIpv6AccessList";
+  private static final String PROP_LINE_TYPE = "lineType";
+  private static final String PROP_LOGIN_AUTHENTICATION = "loginAuthentication";
+  private static final String PROP_OUTPUT_ACCESS_LIST = "outputAccessList";
+  private static final String PROP_OUTPUT_IPV6_ACCESS_LIST = "outputIpv6AccessList";
+  private static final String PROP_TRANSPORT_INPUT = "transportInput";
+  private static final String PROP_TRANSPORT_OUTPUT = "transportOutput";
+  private static final String PROP_TRANSPORT_PREFERRED = "transportPreferred";
 
   /** */
   private static final long serialVersionUID = 1L;
-
-  private static final String PROP_LINE_TYPE = "lineType";
 
   private AaaAuthenticationLoginList _aaaAuthenticationLoginList;
 
@@ -24,9 +35,6 @@ public class Line extends ComparableStructure<String> {
   private String _inputAccessList;
 
   private String _inputIpv6AccessList;
-
-  @JsonProperty(PROP_LINE_TYPE)
-  private LineType _lineType;
 
   private String _loginAuthentication;
 
@@ -41,59 +49,73 @@ public class Line extends ComparableStructure<String> {
   private SortedSet<String> _transportPreferred;
 
   @JsonCreator
-  public Line(@JsonProperty(PROP_NAME) String name) {
+  private static Line jsonCreator(@Nullable @JsonProperty(PROP_NAME) String name) {
+    checkArgument(name != null, "%s must be provided", PROP_NAME);
+    return new Line(name);
+  }
+
+  public Line(@Nonnull String name) {
     super(name);
     _transportInput = new TreeSet<>();
     _transportOutput = new TreeSet<>();
     _transportPreferred = new TreeSet<>();
-    _lineType = LineType.toLineType(Objects.requireNonNull(name));
   }
 
   public AaaAuthenticationLoginList getAaaAuthenticationLoginList() {
     return _aaaAuthenticationLoginList;
   }
 
+  @JsonProperty(PROP_EXEC_TIMEOUT_MINUTES)
   public Integer getExecTimeoutMinutes() {
     return _execTimeoutMinutes;
   }
 
+  @JsonProperty(PROP_EXEC_TIMEOUT_SECONDS)
   public Integer getExecTimeoutSeconds() {
     return _execTimeoutSeconds;
   }
 
+  @JsonProperty(PROP_INPUT_ACCESS_LIST)
   public String getInputAccessList() {
     return _inputAccessList;
   }
 
+  @JsonProperty(PROP_INPUT_IPV6_ACCESS_LIST)
   public String getInputIpv6AccessList() {
     return _inputIpv6AccessList;
   }
 
   @JsonProperty(PROP_LINE_TYPE)
   public LineType getLineType() {
-    return _lineType;
+    return LineType.toLineType(getName());
   }
 
+  @JsonProperty(PROP_LOGIN_AUTHENTICATION)
   public String getLoginAuthentication() {
     return _loginAuthentication;
   }
 
+  @JsonProperty(PROP_OUTPUT_ACCESS_LIST)
   public String getOutputAccessList() {
     return _outputAccessList;
   }
 
+  @JsonProperty(PROP_OUTPUT_IPV6_ACCESS_LIST)
   public String getOutputIpv6AccessList() {
     return _outputIpv6AccessList;
   }
 
+  @JsonProperty(PROP_TRANSPORT_INPUT)
   public SortedSet<String> getTransportInput() {
     return _transportInput;
   }
 
+  @JsonProperty(PROP_TRANSPORT_OUTPUT)
   public SortedSet<String> getTransportOutput() {
     return _transportOutput;
   }
 
+  @JsonProperty(PROP_TRANSPORT_PREFERRED)
   public SortedSet<String> getTransportPreferred() {
     return _transportPreferred;
   }
@@ -123,42 +145,58 @@ public class Line extends ComparableStructure<String> {
     _aaaAuthenticationLoginList = aaaAuthenticationLoginList;
   }
 
+  @JsonProperty(PROP_EXEC_TIMEOUT_MINUTES)
   public void setExecTimeoutMinutes(Integer execTimeoutMinutes) {
     _execTimeoutMinutes = execTimeoutMinutes;
   }
 
+  @JsonProperty(PROP_EXEC_TIMEOUT_SECONDS)
   public void setExecTimeoutSeconds(Integer execTimeoutSeconds) {
     _execTimeoutSeconds = execTimeoutSeconds;
   }
 
+  @JsonProperty(PROP_INPUT_ACCESS_LIST)
   public void setInputAccessList(String inputAccessList) {
     _inputAccessList = inputAccessList;
   }
 
+  @JsonProperty(PROP_INPUT_IPV6_ACCESS_LIST)
   public void setInputIpv6AccessList(String inputIpv6AccessList) {
     _inputIpv6AccessList = inputIpv6AccessList;
   }
 
+  @JsonProperty(PROP_LINE_TYPE)
+  @SuppressWarnings("unused")
+  private void setLineType(String lineType) {
+    /* Ignore this -- it's only used by Jackson to ignore fields. */
+  }
+
+  @JsonProperty(PROP_LOGIN_AUTHENTICATION)
   public void setLoginAuthentication(@Nullable String loginAuthentication) {
     _loginAuthentication = loginAuthentication;
   }
 
+  @JsonProperty(PROP_OUTPUT_ACCESS_LIST)
   public void setOutputAccessList(String outputAccessList) {
     _outputAccessList = outputAccessList;
   }
 
+  @JsonProperty(PROP_OUTPUT_IPV6_ACCESS_LIST)
   public void setOutputIpv6AccessList(String outputIpv6AccessList) {
     _outputIpv6AccessList = outputIpv6AccessList;
   }
 
+  @JsonProperty(PROP_TRANSPORT_INPUT)
   public void setTransportInput(SortedSet<String> transportInput) {
     _transportInput = transportInput;
   }
 
+  @JsonProperty(PROP_TRANSPORT_OUTPUT)
   public void setTransportOutput(SortedSet<String> transportOutput) {
     _transportOutput = transportOutput;
   }
 
+  @JsonProperty(PROP_TRANSPORT_PREFERRED)
   public void setTransportPreferred(SortedSet<String> transportPreferred) {
     _transportPreferred = transportPreferred;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/TcpFlags.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/TcpFlags.java
@@ -1,10 +1,29 @@
 package org.batfish.datamodel;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import java.io.Serializable;
 import java.util.Comparator;
 
 public final class TcpFlags implements Serializable, Comparable<TcpFlags> {
+
+  private static final String PROP_ACK = "ack";
+  private static final String PROP_CWR = "cwr";
+  private static final String PROP_ECE = "ece";
+  private static final String PROP_FIN = "fin";
+  private static final String PROP_PSH = "psh";
+  private static final String PROP_RST = "rst";
+  private static final String PROP_SYN = "syn";
+  private static final String PROP_URG = "urg";
+  private static final String PROP_USE_ACK = "useAck";
+  private static final String PROP_USE_CWR = "useCwr";
+  private static final String PROP_USE_ECE = "useEce";
+  private static final String PROP_USE_FIN = "useFin";
+  private static final String PROP_USE_PSH = "usePsh";
+  private static final String PROP_USE_RST = "useRst";
+  private static final String PROP_USE_SYN = "useSyn";
+  private static final String PROP_USE_URG = "useUrg";
 
   public static class Builder {
     private boolean _ack;
@@ -203,6 +222,7 @@ public final class TcpFlags implements Serializable, Comparable<TcpFlags> {
 
   private boolean _useUrg;
 
+  @JsonCreator
   public TcpFlags() {}
 
   private TcpFlags(
@@ -261,81 +281,97 @@ public final class TcpFlags implements Serializable, Comparable<TcpFlags> {
   }
 
   @JsonPropertyDescription("Value for ACK bit if used (true->1/false->0)")
+  @JsonProperty(PROP_ACK)
   public boolean getAck() {
     return _ack;
   }
 
   @JsonPropertyDescription("Value for CWR bit if used (true->1/false->0)")
+  @JsonProperty(PROP_CWR)
   public boolean getCwr() {
     return _cwr;
   }
 
   @JsonPropertyDescription("Value for ECE bit if used (true->1/false->0)")
+  @JsonProperty(PROP_ECE)
   public boolean getEce() {
     return _ece;
   }
 
   @JsonPropertyDescription("Value for FIN bit if used (true->1/false->0)")
+  @JsonProperty(PROP_FIN)
   public boolean getFin() {
     return _fin;
   }
 
   @JsonPropertyDescription("Value for PSH bit if used (true->1/false->0)")
+  @JsonProperty(PROP_PSH)
   public boolean getPsh() {
     return _psh;
   }
 
   @JsonPropertyDescription("Value for RST bit if used (true->1/false->0)")
+  @JsonProperty(PROP_RST)
   public boolean getRst() {
     return _rst;
   }
 
   @JsonPropertyDescription("Value for SYN bit if used (true->1/false->0)")
+  @JsonProperty(PROP_SYN)
   public boolean getSyn() {
     return _syn;
   }
 
   @JsonPropertyDescription("Value for URG bit if used (true->1/false->0)")
+  @JsonProperty(PROP_URG)
   public boolean getUrg() {
     return _urg;
   }
 
   @JsonPropertyDescription("Whether or not to match against the ACK bit")
+  @JsonProperty(PROP_USE_ACK)
   public boolean getUseAck() {
     return _useAck;
   }
 
   @JsonPropertyDescription("Whether or not to match against the CWR bit")
+  @JsonProperty(PROP_USE_CWR)
   public boolean getUseCwr() {
     return _useCwr;
   }
 
   @JsonPropertyDescription("Whether or not to match against the ECE bit")
+  @JsonProperty(PROP_USE_ECE)
   public boolean getUseEce() {
     return _useEce;
   }
 
   @JsonPropertyDescription("Whether or not to match against the FIN bit")
+  @JsonProperty(PROP_USE_FIN)
   public boolean getUseFin() {
     return _useFin;
   }
 
   @JsonPropertyDescription("Whether or not to match against the PSH bit")
+  @JsonProperty(PROP_USE_PSH)
   public boolean getUsePsh() {
     return _usePsh;
   }
 
   @JsonPropertyDescription("Whether or not to match against the RST bit")
+  @JsonProperty(PROP_USE_RST)
   public boolean getUseRst() {
     return _useRst;
   }
 
   @JsonPropertyDescription("Whether or not to match against the SYN bit")
+  @JsonProperty(PROP_USE_SYN)
   public boolean getUseSyn() {
     return _useSyn;
   }
 
   @JsonPropertyDescription("Whether or not to match against the URG bit")
+  @JsonProperty(PROP_USE_URG)
   public boolean getUseUrg() {
     return _useUrg;
   }
@@ -380,66 +416,82 @@ public final class TcpFlags implements Serializable, Comparable<TcpFlags> {
         && !(_useUrg && _urg ^ (flow6.getTcpFlagsUrg() == 1));
   }
 
+  @JsonProperty(PROP_ACK)
   public void setAck(boolean ack) {
     _ack = ack;
   }
 
+  @JsonProperty(PROP_CWR)
   public void setCwr(boolean cwr) {
     _cwr = cwr;
   }
 
+  @JsonProperty(PROP_ECE)
   public void setEce(boolean ece) {
     _ece = ece;
   }
 
+  @JsonProperty(PROP_FIN)
   public void setFin(boolean fin) {
     _fin = fin;
   }
 
+  @JsonProperty(PROP_PSH)
   public void setPsh(boolean psh) {
     _psh = psh;
   }
 
+  @JsonProperty(PROP_RST)
   public void setRst(boolean rst) {
     _rst = rst;
   }
 
+  @JsonProperty(PROP_SYN)
   public void setSyn(boolean syn) {
     _syn = syn;
   }
 
+  @JsonProperty(PROP_URG)
   public void setUrg(boolean urg) {
     _urg = urg;
   }
 
+  @JsonProperty(PROP_USE_ACK)
   public void setUseAck(boolean useAck) {
     _useAck = useAck;
   }
 
+  @JsonProperty(PROP_USE_CWR)
   public void setUseCwr(boolean useCwr) {
     _useCwr = useCwr;
   }
 
+  @JsonProperty(PROP_USE_ECE)
   public void setUseEce(boolean useEce) {
     _useEce = useEce;
   }
 
+  @JsonProperty(PROP_USE_FIN)
   public void setUseFin(boolean useFin) {
     _useFin = useFin;
   }
 
+  @JsonProperty(PROP_USE_PSH)
   public void setUsePsh(boolean usePsh) {
     _usePsh = usePsh;
   }
 
+  @JsonProperty(PROP_USE_RST)
   public void setUseRst(boolean useRst) {
     _useRst = useRst;
   }
 
+  @JsonProperty(PROP_USE_SYN)
   public void setUseSyn(boolean useSyn) {
     _useSyn = useSyn;
   }
 
+  @JsonProperty(PROP_USE_URG)
   public void setUseUrg(boolean useUrg) {
     _useUrg = useUrg;
   }
@@ -458,7 +510,7 @@ public final class TcpFlags implements Serializable, Comparable<TcpFlags> {
     return sb.toString();
   }
 
-  private String toString(boolean bit, boolean useBit) {
+  private static String toString(boolean bit, boolean useBit) {
     if (useBit) {
       if (bit) {
         return "1";

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfAreaSummary.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfAreaSummary.java
@@ -1,5 +1,6 @@
 package org.batfish.datamodel.ospf;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
 import javax.annotation.Nullable;
@@ -17,6 +18,7 @@ public final class OspfAreaSummary implements Serializable {
   private final boolean _advertised;
   @Nullable private final Long _metric;
 
+  @JsonCreator
   public OspfAreaSummary(
       @JsonProperty(PROP_ADVERTISE) boolean advertised,
       @JsonProperty(PROP_METRIC) @Nullable Long metric) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/BooleanExpr.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/BooleanExpr.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
+import javax.annotation.Nullable;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
@@ -19,11 +20,11 @@ public abstract class BooleanExpr implements Serializable {
   /** */
   private static final long serialVersionUID = 1L;
 
-  private static final String PROP_COMMENT = "comment";
+  protected static final String PROP_COMMENT = "comment";
 
   protected transient BooleanExpr _simplified;
 
-  private String _comment;
+  @Nullable private String _comment;
 
   /**
    * Get all the routing-policies referenced by this expression.
@@ -42,6 +43,7 @@ public abstract class BooleanExpr implements Serializable {
   public abstract Result evaluate(Environment environment);
 
   @JsonProperty(PROP_COMMENT)
+  @Nullable
   public String getComment() {
     return _comment;
   }
@@ -50,7 +52,7 @@ public abstract class BooleanExpr implements Serializable {
   public abstract int hashCode();
 
   @JsonProperty(PROP_COMMENT)
-  public void setComment(String comment) {
+  public void setComment(@Nullable String comment) {
     _comment = comment;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/DestinationNetwork.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/DestinationNetwork.java
@@ -1,5 +1,6 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.routing_policy.Environment;
 
@@ -22,6 +23,7 @@ public final class DestinationNetwork extends PrefixExpr {
     return env.getOriginalRoute().getNetwork();
   }
 
+  @JsonCreator
   public static DestinationNetwork instance() {
     return INSTANCE;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/ExplicitAs.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/ExplicitAs.java
@@ -1,9 +1,16 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.routing_policy.Environment;
 
-public class ExplicitAs extends AsExpr {
+@ParametersAreNonnullByDefault
+public final class ExplicitAs extends AsExpr {
+  private static final String PROP_AS = "as";
 
   /** */
   private static final long serialVersionUID = 1L;
@@ -11,7 +18,10 @@ public class ExplicitAs extends AsExpr {
   private long _as;
 
   @JsonCreator
-  private ExplicitAs() {}
+  private static ExplicitAs jsonCreator(@Nullable @JsonProperty(PROP_AS) Long as) {
+    checkArgument(as != null, "%s must be provided", PROP_AS);
+    return new ExplicitAs(as);
+  }
 
   public ExplicitAs(long as) {
     _as = as;
@@ -21,18 +31,11 @@ public class ExplicitAs extends AsExpr {
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    } else if (!(obj instanceof ExplicitAs)) {
       return false;
     }
     ExplicitAs other = (ExplicitAs) obj;
-    if (_as != other._as) {
-      return false;
-    }
-    return true;
+    return _as == other._as;
   }
 
   @Override
@@ -40,6 +43,7 @@ public class ExplicitAs extends AsExpr {
     return _as;
   }
 
+  @JsonProperty(PROP_AS)
   public long getAs() {
     return _as;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/ExplicitAsPathSet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/ExplicitAsPathSet.java
@@ -1,18 +1,30 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
 import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.routing_policy.Environment;
 
-public class ExplicitAsPathSet extends AsPathSetExpr {
+@ParametersAreNonnullByDefault
+public final class ExplicitAsPathSet extends AsPathSetExpr {
+  private static final String PROP_ELEMS = "elems";
 
   /** */
   private static final long serialVersionUID = 1L;
 
-  private List<AsPathSetElem> _elems;
+  @Nonnull private List<AsPathSetElem> _elems;
 
   @JsonCreator
-  private ExplicitAsPathSet() {}
+  private static ExplicitAsPathSet jsonCreator(
+      @Nullable @JsonProperty(PROP_ELEMS) List<AsPathSetElem> elems) {
+    return new ExplicitAsPathSet(firstNonNull(elems, ImmutableList.of()));
+  }
 
   public ExplicitAsPathSet(List<AsPathSetElem> elems) {
     _elems = elems;
@@ -22,24 +34,15 @@ public class ExplicitAsPathSet extends AsPathSetExpr {
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    } else if (!(obj instanceof ExplicitAsPathSet)) {
       return false;
     }
     ExplicitAsPathSet other = (ExplicitAsPathSet) obj;
-    if (_elems == null) {
-      if (other._elems != null) {
-        return false;
-      }
-    } else if (!_elems.equals(other._elems)) {
-      return false;
-    }
-    return true;
+    return _elems.equals(other._elems);
   }
 
+  @JsonProperty(PROP_ELEMS)
+  @Nonnull
   public List<AsPathSetElem> getElems() {
     return _elems;
   }
@@ -48,7 +51,7 @@ public class ExplicitAsPathSet extends AsPathSetExpr {
   public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + ((_elems == null) ? 0 : _elems.hashCode());
+    result = prime * result + _elems.hashCode();
     return result;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/ExplicitPrefix6Set.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/ExplicitPrefix6Set.java
@@ -1,19 +1,32 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.Prefix6;
 import org.batfish.datamodel.Prefix6Space;
 import org.batfish.datamodel.routing_policy.Environment;
 
-public class ExplicitPrefix6Set extends Prefix6SetExpr {
+@ParametersAreNonnullByDefault
+public final class ExplicitPrefix6Set extends Prefix6SetExpr {
+
+  private static final String PROP_PREFIX6_SPACE = "prefix6Space";
 
   /** */
   private static final long serialVersionUID = 1L;
 
-  private Prefix6Space _prefix6Space;
+  @Nonnull private final Prefix6Space _prefix6Space;
 
   @JsonCreator
-  private ExplicitPrefix6Set() {}
+  private static ExplicitPrefix6Set jsonCreator(
+      @Nullable @JsonProperty(PROP_PREFIX6_SPACE) Prefix6Space prefix6Space) {
+    checkArgument(prefix6Space != null, "%s must be provided", PROP_PREFIX6_SPACE);
+    return new ExplicitPrefix6Set(prefix6Space);
+  }
 
   public ExplicitPrefix6Set(Prefix6Space prefix6Space) {
     _prefix6Space = prefix6Space;
@@ -23,24 +36,15 @@ public class ExplicitPrefix6Set extends Prefix6SetExpr {
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    } else if (!(obj instanceof ExplicitPrefix6Set)) {
       return false;
     }
     ExplicitPrefix6Set other = (ExplicitPrefix6Set) obj;
-    if (_prefix6Space == null) {
-      if (other._prefix6Space != null) {
-        return false;
-      }
-    } else if (!_prefix6Space.equals(other._prefix6Space)) {
-      return false;
-    }
-    return true;
+    return _prefix6Space.equals(other._prefix6Space);
   }
 
+  @JsonProperty(PROP_PREFIX6_SPACE)
+  @Nonnull
   public Prefix6Space getPrefix6Space() {
     return _prefix6Space;
   }
@@ -49,7 +53,7 @@ public class ExplicitPrefix6Set extends Prefix6SetExpr {
   public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + ((_prefix6Space == null) ? 0 : _prefix6Space.hashCode());
+    result = prime * result + _prefix6Space.hashCode();
     return result;
   }
 
@@ -57,9 +61,5 @@ public class ExplicitPrefix6Set extends Prefix6SetExpr {
   public boolean matches(Prefix6 prefix6, Environment environment) {
     throw new UnsupportedOperationException("no implementation for generated method");
     // TODO Auto-generated method stub
-  }
-
-  public void setPrefix6Space(Prefix6Space prefix6Space) {
-    _prefix6Space = prefix6Space;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/HasRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/HasRoute.java
@@ -1,18 +1,29 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
-public class HasRoute extends BooleanExpr {
+@ParametersAreNonnullByDefault
+public final class HasRoute extends BooleanExpr {
+  private static final String PROP_EXPR = "expr";
 
   /** */
   private static final long serialVersionUID = 1L;
 
-  private PrefixSetExpr _expr;
+  @Nonnull private PrefixSetExpr _expr;
 
   @JsonCreator
-  private HasRoute() {}
+  private static HasRoute jsonCreator(@Nullable @JsonProperty(PROP_EXPR) PrefixSetExpr expr) {
+    checkArgument(expr != null, "%s must be provided", PROP_EXPR);
+    return new HasRoute(expr);
+  }
 
   public HasRoute(PrefixSetExpr expr) {
     _expr = expr;
@@ -22,22 +33,14 @@ public class HasRoute extends BooleanExpr {
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
-    }
-    if (obj == null) {
+    } else if (!(obj instanceof HasRoute)) {
       return false;
     }
     if (getClass() != obj.getClass()) {
       return false;
     }
     HasRoute other = (HasRoute) obj;
-    if (_expr == null) {
-      if (other._expr != null) {
-        return false;
-      }
-    } else if (!_expr.equals(other._expr)) {
-      return false;
-    }
-    return true;
+    return _expr.equals(other._expr);
   }
 
   @Override
@@ -46,6 +49,8 @@ public class HasRoute extends BooleanExpr {
     // TODO Auto-generated method stub
   }
 
+  @JsonProperty(PROP_EXPR)
+  @Nonnull
   public PrefixSetExpr getExpr() {
     return _expr;
   }
@@ -54,7 +59,7 @@ public class HasRoute extends BooleanExpr {
   public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + ((_expr == null) ? 0 : _expr.hashCode());
+    result = prime * result + _expr.hashCode();
     return result;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/IncrementMetric.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/IncrementMetric.java
@@ -1,17 +1,28 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.routing_policy.Environment;
 
-public class IncrementMetric extends LongExpr {
+@ParametersAreNonnullByDefault
+public final class IncrementMetric extends LongExpr {
+  private static final String PROP_ADDEND = "addend";
 
   /** */
   private static final long serialVersionUID = 1L;
 
-  private long _addend;
+  @Nonnull private long _addend;
 
   @JsonCreator
-  private IncrementMetric() {}
+  private static IncrementMetric jsonCreator(@Nullable @JsonProperty(PROP_ADDEND) Long addend) {
+    checkArgument(addend != null, "%s must be provided", PROP_ADDEND);
+    return new IncrementMetric(addend);
+  }
 
   public IncrementMetric(long addend) {
     _addend = addend;
@@ -21,18 +32,11 @@ public class IncrementMetric extends LongExpr {
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    } else if (!(obj instanceof IncrementMetric)) {
       return false;
     }
     IncrementMetric other = (IncrementMetric) obj;
-    if (_addend != other._addend) {
-      return false;
-    }
-    return true;
+    return _addend == other._addend;
   }
 
   @Override
@@ -42,6 +46,7 @@ public class IncrementMetric extends LongExpr {
     return newVal;
   }
 
+  @JsonProperty(PROP_ADDEND)
   public long getAddend() {
     return _addend;
   }
@@ -52,9 +57,5 @@ public class IncrementMetric extends LongExpr {
     int result = 1;
     result = prime * result + Long.hashCode(_addend);
     return result;
-  }
-
-  public void setAddend(int addend) {
-    _addend = addend;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/Ip6NextHop.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/Ip6NextHop.java
@@ -1,20 +1,30 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
 import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Ip6;
 import org.batfish.datamodel.routing_policy.Environment;
 
-public class Ip6NextHop extends NextHopExpr {
-
+@ParametersAreNonnullByDefault
+public final class Ip6NextHop extends NextHopExpr {
+  private static final String PROP_IPS = "ips";
   /** */
   private static final long serialVersionUID = 1L;
 
-  private List<Ip6> _ips;
+  @Nonnull private final List<Ip6> _ips;
 
   @JsonCreator
-  private Ip6NextHop() {}
+  private static Ip6NextHop jsonCreator(@Nullable @JsonProperty(PROP_IPS) List<Ip6> ips) {
+    return new Ip6NextHop(firstNonNull(ips, ImmutableList.of()));
+  }
 
   public Ip6NextHop(List<Ip6> ips) {
     _ips = ips;
@@ -24,24 +34,15 @@ public class Ip6NextHop extends NextHopExpr {
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    } else if (!(obj instanceof Ip6NextHop)) {
       return false;
     }
     Ip6NextHop other = (Ip6NextHop) obj;
-    if (_ips == null) {
-      if (other._ips != null) {
-        return false;
-      }
-    } else if (!_ips.equals(other._ips)) {
-      return false;
-    }
-    return true;
+    return _ips.equals(other._ips);
   }
 
+  @JsonProperty(PROP_IPS)
+  @Nonnull
   public List<Ip6> getIps() {
     return _ips;
   }
@@ -56,11 +57,7 @@ public class Ip6NextHop extends NextHopExpr {
   public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + ((_ips == null) ? 0 : _ips.hashCode());
+    result = prime * result + _ips.hashCode();
     return result;
-  }
-
-  public void setIps(List<Ip6> ips) {
-    _ips = ips;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/IpNextHop.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/IpNextHop.java
@@ -1,20 +1,31 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
 import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.common.BatfishException;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.routing_policy.Environment;
 
-public class IpNextHop extends NextHopExpr {
+@ParametersAreNonnullByDefault
+public final class IpNextHop extends NextHopExpr {
+  private static final String PROP_IPS = "ips";
 
   /** */
   private static final long serialVersionUID = 1L;
 
-  private List<Ip> _ips;
+  @Nonnull private final List<Ip> _ips;
 
   @JsonCreator
-  private IpNextHop() {}
+  private static IpNextHop jsonCreator(@Nullable @JsonProperty(PROP_IPS) List<Ip> ips) {
+    return new IpNextHop(firstNonNull(ips, ImmutableList.of()));
+  }
 
   public IpNextHop(List<Ip> ips) {
     _ips = ips;
@@ -24,24 +35,18 @@ public class IpNextHop extends NextHopExpr {
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
-    }
-    if (obj == null) {
+    } else if (!(obj instanceof IpNextHop)) {
       return false;
     }
     if (getClass() != obj.getClass()) {
       return false;
     }
     IpNextHop other = (IpNextHop) obj;
-    if (_ips == null) {
-      if (other._ips != null) {
-        return false;
-      }
-    } else if (!_ips.equals(other._ips)) {
-      return false;
-    }
-    return true;
+    return _ips.equals(other._ips);
   }
 
+  @JsonProperty(PROP_IPS)
+  @Nonnull
   public List<Ip> getIps() {
     return _ips;
   }
@@ -59,11 +64,7 @@ public class IpNextHop extends NextHopExpr {
   public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + ((_ips == null) ? 0 : _ips.hashCode());
+    result = prime * result + _ips.hashCode();
     return result;
-  }
-
-  public void setIps(List<Ip> ips) {
-    _ips = ips;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/IpPrefix.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/IpPrefix.java
@@ -1,20 +1,35 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.routing_policy.Environment;
 
-public class IpPrefix extends PrefixExpr {
+@ParametersAreNonnullByDefault
+public final class IpPrefix extends PrefixExpr {
+  private static final String PROP_IP = "ip";
+  private static final String PROP_PREFIX_LENGTH = "prefixLength";
 
   private static final long serialVersionUID = 1L;
 
-  private IpExpr _ip;
+  @Nonnull private IpExpr _ip;
 
-  private IntExpr _prefixLength;
+  @Nonnull private IntExpr _prefixLength;
 
   @JsonCreator
-  private IpPrefix() {}
+  private static IpPrefix jsonCreator(
+      @Nullable @JsonProperty(PROP_IP) IpExpr ip,
+      @Nullable @JsonProperty(PROP_PREFIX_LENGTH) IntExpr prefixLength) {
+    checkArgument(ip != null, "%s must be provided", PROP_IP);
+    checkArgument(prefixLength != null, "%s must be provided", PROP_PREFIX_LENGTH);
+    return new IpPrefix(ip, prefixLength);
+  }
 
   public IpPrefix(IpExpr ip, IntExpr prefixLength) {
     _ip = ip;
@@ -25,29 +40,11 @@ public class IpPrefix extends PrefixExpr {
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    } else if (!(obj instanceof IpPrefix)) {
       return false;
     }
     IpPrefix other = (IpPrefix) obj;
-    if (_ip == null) {
-      if (other._ip != null) {
-        return false;
-      }
-    } else if (!_ip.equals(other._ip)) {
-      return false;
-    }
-    if (_prefixLength == null) {
-      if (other._prefixLength != null) {
-        return false;
-      }
-    } else if (!_prefixLength.equals(other._prefixLength)) {
-      return false;
-    }
-    return true;
+    return _ip.equals(other._ip) && _prefixLength.equals(other._prefixLength);
   }
 
   @Override
@@ -57,10 +54,14 @@ public class IpPrefix extends PrefixExpr {
     return new Prefix(ip, prefixLength);
   }
 
+  @JsonProperty(PROP_IP)
+  @Nonnull
   public IpExpr getIp() {
     return _ip;
   }
 
+  @JsonProperty(PROP_PREFIX_LENGTH)
+  @Nonnull
   public IntExpr getPrefixLength() {
     return _prefixLength;
   }
@@ -69,8 +70,8 @@ public class IpPrefix extends PrefixExpr {
   public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + ((_ip == null) ? 0 : _ip.hashCode());
-    result = prime * result + ((_prefixLength == null) ? 0 : _prefixLength.hashCode());
+    result = prime * result + _ip.hashCode();
+    result = prime * result + _prefixLength.hashCode();
     return result;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/LiteralAsList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/LiteralAsList.java
@@ -1,19 +1,29 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.routing_policy.Environment;
 
-public class LiteralAsList extends AsPathListExpr {
+@ParametersAreNonnullByDefault
+public final class LiteralAsList extends AsPathListExpr {
+  private static final String PROP_LIST = "list";
 
   /** */
   private static final long serialVersionUID = 1L;
 
-  private List<AsExpr> _list;
+  @Nonnull private List<AsExpr> _list;
 
   @JsonCreator
-  private LiteralAsList() {}
+  private static LiteralAsList jsonCreator(@Nullable @JsonProperty(PROP_LIST) List<AsExpr> list) {
+    return new LiteralAsList(firstNonNull(list, ImmutableList.of()));
+  }
 
   public LiteralAsList(List<AsExpr> list) {
     _list = list;
@@ -31,14 +41,7 @@ public class LiteralAsList extends AsPathListExpr {
       return false;
     }
     LiteralAsList other = (LiteralAsList) obj;
-    if (_list == null) {
-      if (other._list != null) {
-        return false;
-      }
-    } else if (!_list.equals(other._list)) {
-      return false;
-    }
-    return true;
+    return _list.equals(other._list);
   }
 
   @Override
@@ -49,6 +52,8 @@ public class LiteralAsList extends AsPathListExpr {
         .collect(ImmutableList.toImmutableList());
   }
 
+  @JsonProperty(PROP_LIST)
+  @Nonnull
   public List<AsExpr> getList() {
     return _list;
   }
@@ -57,7 +62,7 @@ public class LiteralAsList extends AsPathListExpr {
   public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + ((_list == null) ? 0 : _list.hashCode());
+    result = prime * result + _list.hashCode();
     return result;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/LiteralEigrpMetric.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/LiteralEigrpMetric.java
@@ -1,21 +1,32 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.eigrp.EigrpMetric;
 import org.batfish.datamodel.routing_policy.Environment;
 
-public class LiteralEigrpMetric extends EigrpMetricExpr {
+@ParametersAreNonnullByDefault
+public final class LiteralEigrpMetric extends EigrpMetricExpr {
+  private static final String PROP_METRIC = "metric";
 
   private static final long serialVersionUID = 1L;
 
-  private EigrpMetric _metric;
+  @Nonnull private final EigrpMetric _metric;
 
   @JsonCreator
-  private LiteralEigrpMetric() {}
+  private static LiteralEigrpMetric jsonCreator(
+      @Nullable @JsonProperty(PROP_METRIC) EigrpMetric metric) {
+    checkArgument(metric != null, "%s must be provided", PROP_METRIC);
+    return new LiteralEigrpMetric(metric);
+  }
 
-  public LiteralEigrpMetric(@Nonnull EigrpMetric metric) {
+  public LiteralEigrpMetric(EigrpMetric metric) {
     _metric = metric;
   }
 
@@ -26,7 +37,6 @@ public class LiteralEigrpMetric extends EigrpMetricExpr {
     } else if (!(obj instanceof LiteralEigrpMetric)) {
       return false;
     }
-
     LiteralEigrpMetric rhs = (LiteralEigrpMetric) obj;
     return Objects.equals(_metric, rhs._metric);
   }
@@ -36,12 +46,10 @@ public class LiteralEigrpMetric extends EigrpMetricExpr {
     return _metric;
   }
 
+  @JsonProperty(PROP_METRIC)
+  @Nonnull
   public EigrpMetric getMetric() {
     return _metric;
-  }
-
-  public void setMetric(EigrpMetric metric) {
-    _metric = metric;
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/LiteralInt.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/LiteralInt.java
@@ -1,10 +1,15 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.routing_policy.Environment;
 
-public class LiteralInt extends IntExpr {
+@ParametersAreNonnullByDefault
+public final class LiteralInt extends IntExpr {
 
   private static final String PROP_VALUE = "value";
 
@@ -14,7 +19,10 @@ public class LiteralInt extends IntExpr {
   private int _value;
 
   @JsonCreator
-  private LiteralInt() {}
+  private static LiteralInt jsonCreator(@Nullable @JsonProperty(PROP_VALUE) Integer value) {
+    checkArgument(value != null, "%s must be provided", PROP_VALUE);
+    return new LiteralInt(value);
+  }
 
   public LiteralInt(int value) {
     _value = value;
@@ -24,18 +32,11 @@ public class LiteralInt extends IntExpr {
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    } else if (!(obj instanceof LiteralInt)) {
       return false;
     }
     LiteralInt other = (LiteralInt) obj;
-    if (_value != other._value) {
-      return false;
-    }
-    return true;
+    return _value == other._value;
   }
 
   @Override
@@ -56,7 +57,6 @@ public class LiteralInt extends IntExpr {
     return result;
   }
 
-  @JsonProperty(PROP_VALUE)
   public void setValue(int value) {
     _value = value;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/LiteralIsisLevel.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/LiteralIsisLevel.java
@@ -1,18 +1,28 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.isis.IsisLevel;
 import org.batfish.datamodel.routing_policy.Environment;
 
-public class LiteralIsisLevel extends IsisLevelExpr {
-
+@ParametersAreNonnullByDefault
+public final class LiteralIsisLevel extends IsisLevelExpr {
+  private static final String PROP_LEVEL = "level";
   /** */
   private static final long serialVersionUID = 1L;
 
-  private IsisLevel _level;
+  @Nonnull private IsisLevel _level;
 
   @JsonCreator
-  private LiteralIsisLevel() {}
+  private static LiteralIsisLevel jsonCreator(@Nullable @JsonProperty(PROP_LEVEL) IsisLevel level) {
+    checkArgument(level != null, "%s must be provided", PROP_LEVEL);
+    return new LiteralIsisLevel(level);
+  }
 
   public LiteralIsisLevel(IsisLevel level) {
     _level = level;
@@ -22,18 +32,11 @@ public class LiteralIsisLevel extends IsisLevelExpr {
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    } else if (!(obj instanceof LiteralIsisLevel)) {
       return false;
     }
     LiteralIsisLevel other = (LiteralIsisLevel) obj;
-    if (_level != other._level) {
-      return false;
-    }
-    return true;
+    return _level == other._level;
   }
 
   @Override
@@ -41,6 +44,8 @@ public class LiteralIsisLevel extends IsisLevelExpr {
     return _level;
   }
 
+  @JsonProperty(PROP_LEVEL)
+  @Nonnull
   public IsisLevel getLevel() {
     return _level;
   }
@@ -49,7 +54,7 @@ public class LiteralIsisLevel extends IsisLevelExpr {
   public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + ((_level == null) ? 0 : _level.ordinal());
+    result = prime * result + _level.ordinal();
     return result;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/LiteralRouteType.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/LiteralRouteType.java
@@ -1,17 +1,28 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.routing_policy.Environment;
 
-public class LiteralRouteType extends RouteTypeExpr {
+@ParametersAreNonnullByDefault
+public final class LiteralRouteType extends RouteTypeExpr {
+  private static final String PROP_TYPE = "type";
 
   /** */
   private static final long serialVersionUID = 1L;
 
-  private RouteType _type;
+  @Nonnull private RouteType _type;
 
   @JsonCreator
-  private LiteralRouteType() {}
+  private static LiteralRouteType jsonCreator(@Nullable @JsonProperty(PROP_TYPE) RouteType type) {
+    checkArgument(type != null, "%s must be provided", PROP_TYPE);
+    return new LiteralRouteType(type);
+  }
 
   public LiteralRouteType(RouteType type) {
     _type = type;
@@ -21,18 +32,11 @@ public class LiteralRouteType extends RouteTypeExpr {
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    } else if (!(obj instanceof LiteralRouteType)) {
       return false;
     }
     LiteralRouteType other = (LiteralRouteType) obj;
-    if (_type != other._type) {
-      return false;
-    }
-    return true;
+    return _type == other._type;
   }
 
   @Override
@@ -40,6 +44,8 @@ public class LiteralRouteType extends RouteTypeExpr {
     return _type;
   }
 
+  @JsonProperty(PROP_TYPE)
+  @Nonnull
   public RouteType getType() {
     return _type;
   }
@@ -48,7 +54,7 @@ public class LiteralRouteType extends RouteTypeExpr {
   public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + ((_type == null) ? 0 : _type.ordinal());
+    result = prime * result + _type.ordinal();
     return result;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchLocalPreference.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchLocalPreference.java
@@ -1,20 +1,35 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
-public class MatchLocalPreference extends BooleanExpr {
+@ParametersAreNonnullByDefault
+public final class MatchLocalPreference extends BooleanExpr {
+  private static final String PROP_COMPARATOR = "comparator";
+  private static final String PROP_METRIC = "metric";
 
   /** */
   private static final long serialVersionUID = 1L;
 
-  private IntComparator _comparator;
+  @Nonnull private IntComparator _comparator;
 
-  private IntExpr _metric;
+  @Nonnull private IntExpr _metric;
 
   @JsonCreator
-  private MatchLocalPreference() {}
+  private static MatchLocalPreference jsonCreator(
+      @Nullable @JsonProperty(PROP_COMPARATOR) IntComparator comparator,
+      @Nullable @JsonProperty(PROP_METRIC) IntExpr metric) {
+    checkArgument(comparator != null, "%s must be provided", PROP_COMPARATOR);
+    checkArgument(metric != null, "%s must be provided", PROP_METRIC);
+    return new MatchLocalPreference(comparator, metric);
+  }
 
   public MatchLocalPreference(IntComparator comparator, IntExpr metric) {
     _comparator = comparator;
@@ -25,25 +40,11 @@ public class MatchLocalPreference extends BooleanExpr {
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    } else if (!(obj instanceof MatchLocalPreference)) {
       return false;
     }
     MatchLocalPreference other = (MatchLocalPreference) obj;
-    if (_comparator != other._comparator) {
-      return false;
-    }
-    if (_metric == null) {
-      if (other._metric != null) {
-        return false;
-      }
-    } else if (!_metric.equals(other._metric)) {
-      return false;
-    }
-    return true;
+    return _comparator == other._comparator && _metric.equals(other._metric);
   }
 
   @Override
@@ -52,10 +53,14 @@ public class MatchLocalPreference extends BooleanExpr {
     // TODO Auto-generated method stub
   }
 
+  @JsonProperty(PROP_COMPARATOR)
+  @Nonnull
   public IntComparator getComparator() {
     return _comparator;
   }
 
+  @JsonProperty(PROP_METRIC)
+  @Nonnull
   public IntExpr getMetric() {
     return _metric;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchMetric.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchMetric.java
@@ -1,20 +1,35 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
-public class MatchMetric extends BooleanExpr {
+@ParametersAreNonnullByDefault
+public final class MatchMetric extends BooleanExpr {
+  private static final String PROP_COMPARATOR = "comparator";
+  private static final String PROP_METRIC = "metric";
 
   /** */
   private static final long serialVersionUID = 1L;
 
-  private IntComparator _comparator;
+  @Nonnull private final IntComparator _comparator;
 
-  private IntExpr _metric;
+  @Nonnull private final IntExpr _metric;
 
   @JsonCreator
-  private MatchMetric() {}
+  private static MatchMetric jsonCreator(
+      @Nullable @JsonProperty(PROP_COMPARATOR) IntComparator comparator,
+      @Nullable @JsonProperty(PROP_METRIC) IntExpr metric) {
+    checkArgument(comparator != null, "%s must be provided", PROP_COMPARATOR);
+    checkArgument(metric != null, "%s must be provided", PROP_METRIC);
+    return new MatchMetric(comparator, metric);
+  }
 
   public MatchMetric(IntComparator comparator, IntExpr metric) {
     _comparator = comparator;
@@ -25,25 +40,11 @@ public class MatchMetric extends BooleanExpr {
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    } else if (!(obj instanceof MatchMetric)) {
       return false;
     }
     MatchMetric other = (MatchMetric) obj;
-    if (_comparator != other._comparator) {
-      return false;
-    }
-    if (_metric == null) {
-      if (other._metric != null) {
-        return false;
-      }
-    } else if (!_metric.equals(other._metric)) {
-      return false;
-    }
-    return true;
+    return _comparator == other._comparator && _metric.equals(other._metric);
   }
 
   @Override
@@ -52,10 +53,14 @@ public class MatchMetric extends BooleanExpr {
     // TODO Auto-generated method stub
   }
 
+  @JsonProperty(PROP_COMPARATOR)
+  @Nonnull
   public IntComparator getComparator() {
     return _comparator;
   }
 
+  @JsonProperty(PROP_METRIC)
+  @Nonnull
   public IntExpr getMetric() {
     return _metric;
   }
@@ -64,16 +69,8 @@ public class MatchMetric extends BooleanExpr {
   public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + ((_comparator == null) ? 0 : _comparator.ordinal());
-    result = prime * result + ((_metric == null) ? 0 : _metric.hashCode());
+    result = prime * result + _comparator.ordinal();
+    result = prime * result + _metric.hashCode();
     return result;
-  }
-
-  public void setComparator(IntComparator comparator) {
-    _comparator = comparator;
-  }
-
-  public void setMetric(IntExpr metric) {
-    _metric = metric;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchPrefix6Set.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchPrefix6Set.java
@@ -1,21 +1,35 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.Prefix6;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
-public class MatchPrefix6Set extends BooleanExpr {
-
+@ParametersAreNonnullByDefault
+public final class MatchPrefix6Set extends BooleanExpr {
+  private static final String PROP_PREFIX = "prefix";
+  private static final String PROP_PREFIX_SET = "prefixSet";
   /** */
   private static final long serialVersionUID = 1L;
 
-  private Prefix6Expr _prefix;
+  @Nonnull private Prefix6Expr _prefix;
 
-  private Prefix6SetExpr _prefixSet;
+  @Nonnull private Prefix6SetExpr _prefixSet;
 
   @JsonCreator
-  private MatchPrefix6Set() {}
+  private static MatchPrefix6Set jsonCreator(
+      @Nullable @JsonProperty(PROP_PREFIX) Prefix6Expr prefix,
+      @Nullable @JsonProperty(PROP_PREFIX_SET) Prefix6SetExpr prefixSet) {
+    checkArgument(prefix != null, "%s must be provided", PROP_PREFIX);
+    checkArgument(prefixSet != null, "%s must be provided", PROP_PREFIX_SET);
+    return new MatchPrefix6Set(prefix, prefixSet);
+  }
 
   public MatchPrefix6Set(Prefix6Expr prefix, Prefix6SetExpr prefixSet) {
     _prefix = prefix;
@@ -26,29 +40,11 @@ public class MatchPrefix6Set extends BooleanExpr {
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    } else if (!(obj instanceof MatchPrefix6Set)) {
       return false;
     }
     MatchPrefix6Set other = (MatchPrefix6Set) obj;
-    if (_prefix == null) {
-      if (other._prefix != null) {
-        return false;
-      }
-    } else if (!_prefix.equals(other._prefix)) {
-      return false;
-    }
-    if (_prefixSet == null) {
-      if (other._prefixSet != null) {
-        return false;
-      }
-    } else if (!_prefixSet.equals(other._prefixSet)) {
-      return false;
-    }
-    return true;
+    return _prefix.equals(other._prefix) && _prefixSet.equals(other._prefixSet);
   }
 
   @Override
@@ -60,10 +56,14 @@ public class MatchPrefix6Set extends BooleanExpr {
     return result;
   }
 
+  @JsonProperty(PROP_PREFIX)
+  @Nonnull
   public Prefix6Expr getPrefix() {
     return _prefix;
   }
 
+  @JsonProperty(PROP_PREFIX_SET)
+  @Nonnull
   public Prefix6SetExpr getPrefixSet() {
     return _prefixSet;
   }
@@ -72,16 +72,8 @@ public class MatchPrefix6Set extends BooleanExpr {
   public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + ((_prefix == null) ? 0 : _prefix.hashCode());
-    result = prime * result + ((_prefixSet == null) ? 0 : _prefixSet.hashCode());
+    result = prime * result + _prefix.hashCode();
+    result = prime * result + _prefixSet.hashCode();
     return result;
-  }
-
-  public void setPrefix(Prefix6Expr prefix) {
-    _prefix = prefix;
-  }
-
-  public void setPrefixSet(Prefix6SetExpr prefixSet) {
-    _prefixSet = prefixSet;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchPrefixSet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchPrefixSet.java
@@ -1,28 +1,41 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
-public class MatchPrefixSet extends BooleanExpr {
+@ParametersAreNonnullByDefault
+public final class MatchPrefixSet extends BooleanExpr {
 
   private static final long serialVersionUID = 1L;
 
   private static final String PROP_PREFIX = "prefix";
-
   private static final String PROP_PREFIX_SET = "prefixSet";
 
-  private PrefixExpr _prefix;
+  @Nonnull private PrefixExpr _prefix;
 
-  private PrefixSetExpr _prefixSet;
+  @Nonnull private PrefixSetExpr _prefixSet;
 
   @JsonCreator
-  private MatchPrefixSet() {}
+  private static MatchPrefixSet jsonCreator(
+      @Nullable @JsonProperty(PROP_PREFIX) PrefixExpr prefix,
+      @Nullable @JsonProperty(PROP_PREFIX_SET) PrefixSetExpr prefixSet,
+      @Nullable @JsonProperty(PROP_COMMENT) String comment) {
+    checkArgument(prefix != null, "%s must be provided", PROP_PREFIX);
+    checkArgument(prefixSet != null, "%s must be provided", PROP_PREFIX_SET);
+    MatchPrefixSet ret = new MatchPrefixSet(prefix, prefixSet);
+    ret.setComment(comment);
+    return ret;
+  }
 
-  public MatchPrefixSet(@Nonnull PrefixExpr prefix, @Nonnull PrefixSetExpr prefixSet) {
+  public MatchPrefixSet(PrefixExpr prefix, PrefixSetExpr prefixSet) {
     _prefix = prefix;
     _prefixSet = prefixSet;
   }
@@ -31,29 +44,11 @@ public class MatchPrefixSet extends BooleanExpr {
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    } else if (!(obj instanceof MatchPrefixSet)) {
       return false;
     }
     MatchPrefixSet other = (MatchPrefixSet) obj;
-    if (_prefix == null) {
-      if (other._prefix != null) {
-        return false;
-      }
-    } else if (!_prefix.equals(other._prefix)) {
-      return false;
-    }
-    if (_prefixSet == null) {
-      if (other._prefixSet != null) {
-        return false;
-      }
-    } else if (!_prefixSet.equals(other._prefixSet)) {
-      return false;
-    }
-    return true;
+    return _prefix.equals(other._prefix) && _prefixSet.equals(other._prefixSet);
   }
 
   @Override
@@ -66,11 +61,13 @@ public class MatchPrefixSet extends BooleanExpr {
   }
 
   @JsonProperty(PROP_PREFIX)
+  @Nonnull
   public PrefixExpr getPrefix() {
     return _prefix;
   }
 
   @JsonProperty(PROP_PREFIX_SET)
+  @Nonnull
   public PrefixSetExpr getPrefixSet() {
     return _prefixSet;
   }
@@ -79,19 +76,9 @@ public class MatchPrefixSet extends BooleanExpr {
   public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + ((_prefix == null) ? 0 : _prefix.hashCode());
-    result = prime * result + ((_prefixSet == null) ? 0 : _prefixSet.hashCode());
+    result = prime * result + _prefix.hashCode();
+    result = prime * result + _prefixSet.hashCode();
     return result;
-  }
-
-  @JsonProperty(PROP_PREFIX)
-  public void setPrefix(PrefixExpr prefix) {
-    _prefix = prefix;
-  }
-
-  @JsonProperty(PROP_PREFIX_SET)
-  public void setPrefixSet(PrefixSetExpr prefixSet) {
-    _prefixSet = prefixSet;
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchRouteType.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchRouteType.java
@@ -1,19 +1,30 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.common.BatfishException;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
-public class MatchRouteType extends BooleanExpr {
+@ParametersAreNonnullByDefault
+public final class MatchRouteType extends BooleanExpr {
+  private static final String PROP_TYPE = "type";
 
   /** */
   private static final long serialVersionUID = 1L;
 
-  private RouteTypeExpr _type;
+  @Nonnull private RouteTypeExpr _type;
 
   @JsonCreator
-  private MatchRouteType() {}
+  private static MatchRouteType jsonCreator(@Nullable @JsonProperty(PROP_TYPE) RouteTypeExpr type) {
+    checkArgument(type != null, "%s must be provided", PROP_TYPE);
+    return new MatchRouteType(type);
+  }
 
   public MatchRouteType(RouteTypeExpr type) {
     _type = type;
@@ -23,22 +34,11 @@ public class MatchRouteType extends BooleanExpr {
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    } else if (!(obj instanceof MatchRouteType)) {
       return false;
     }
     MatchRouteType other = (MatchRouteType) obj;
-    if (_type == null) {
-      if (other._type != null) {
-        return false;
-      }
-    } else if (!_type.equals(other._type)) {
-      return false;
-    }
-    return true;
+    return _type.equals(other._type);
   }
 
   @Override
@@ -47,6 +47,8 @@ public class MatchRouteType extends BooleanExpr {
     throw new BatfishException("unimplemented: match route type: " + type.routeTypeName());
   }
 
+  @JsonProperty(PROP_TYPE)
+  @Nonnull
   public RouteTypeExpr getType() {
     return _type;
   }
@@ -55,7 +57,7 @@ public class MatchRouteType extends BooleanExpr {
   public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + ((_type == null) ? 0 : _type.hashCode());
+    result = prime * result + _type.hashCode();
     return result;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchTag.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchTag.java
@@ -1,20 +1,35 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
-public class MatchTag extends BooleanExpr {
+@ParametersAreNonnullByDefault
+public final class MatchTag extends BooleanExpr {
+  private static final String PROP_CMP = "cmp";
+  private static final String PROP_TAG = "tag";
 
   /** */
   private static final long serialVersionUID = 1L;
 
-  private IntComparator _cmp;
+  @Nonnull private IntComparator _cmp;
 
-  private IntExpr _tag;
+  @Nonnull private IntExpr _tag;
 
   @JsonCreator
-  private MatchTag() {}
+  private static MatchTag jsonCreator(
+      @Nullable @JsonProperty(PROP_CMP) IntComparator cmp,
+      @Nullable @JsonProperty(PROP_TAG) IntExpr tag) {
+    checkArgument(cmp != null, "%s must be provided", PROP_CMP);
+    checkArgument(tag != null, "%s must be provided", PROP_TAG);
+    return new MatchTag(cmp, tag);
+  }
 
   public MatchTag(IntComparator cmp, IntExpr tag) {
     _cmp = cmp;
@@ -25,25 +40,11 @@ public class MatchTag extends BooleanExpr {
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    } else if (!(obj instanceof MatchTag)) {
       return false;
     }
     MatchTag other = (MatchTag) obj;
-    if (_cmp != other._cmp) {
-      return false;
-    }
-    if (_tag == null) {
-      if (other._tag != null) {
-        return false;
-      }
-    } else if (!_tag.equals(other._tag)) {
-      return false;
-    }
-    return true;
+    return _cmp == other._cmp && _tag.equals(other._tag);
   }
 
   @Override
@@ -60,10 +61,14 @@ public class MatchTag extends BooleanExpr {
     return _cmp.apply(lhs, rhs);
   }
 
+  @JsonProperty(PROP_CMP)
+  @Nonnull
   public IntComparator getCmp() {
     return _cmp;
   }
 
+  @JsonProperty(PROP_TAG)
+  @Nonnull
   public IntExpr getTag() {
     return _tag;
   }
@@ -72,8 +77,8 @@ public class MatchTag extends BooleanExpr {
   public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + ((_cmp == null) ? 0 : _cmp.ordinal());
-    result = prime * result + ((_tag == null) ? 0 : _tag.hashCode());
+    result = prime * result + _cmp.ordinal();
+    result = prime * result + _tag.hashCode();
     return result;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MultipliedAs.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MultipliedAs.java
@@ -1,21 +1,37 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.routing_policy.Environment;
 
-public class MultipliedAs extends AsPathListExpr {
+@ParametersAreNonnullByDefault
+public final class MultipliedAs extends AsPathListExpr {
+
+  private static final String PROP_EXPR = "expr";
+  private static final String PROP_NUMBER = "number";
 
   /** */
   private static final long serialVersionUID = 1L;
 
-  private AsExpr _expr;
+  @Nonnull private AsExpr _expr;
 
-  private IntExpr _number;
+  @Nonnull private IntExpr _number;
 
   @JsonCreator
-  private MultipliedAs() {}
+  private static MultipliedAs jsonCreator(
+      @Nullable @JsonProperty(PROP_EXPR) AsExpr expr,
+      @Nullable @JsonProperty(PROP_NUMBER) IntExpr number) {
+    checkArgument(expr != null, "%s must be provided", PROP_EXPR);
+    checkArgument(number != null, "%s must be provided", PROP_NUMBER);
+    return new MultipliedAs(expr, number);
+  }
 
   public MultipliedAs(AsExpr expr, IntExpr number) {
     _expr = expr;
@@ -26,29 +42,11 @@ public class MultipliedAs extends AsPathListExpr {
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    } else if (!(obj instanceof MultipliedAs)) {
       return false;
     }
     MultipliedAs other = (MultipliedAs) obj;
-    if (_expr == null) {
-      if (other._expr != null) {
-        return false;
-      }
-    } else if (!_expr.equals(other._expr)) {
-      return false;
-    }
-    if (_number == null) {
-      if (other._number != null) {
-        return false;
-      }
-    } else if (!_number.equals(other._number)) {
-      return false;
-    }
-    return true;
+    return _expr.equals(other._expr) && _number.equals(other._number);
   }
 
   @Override
@@ -62,10 +60,14 @@ public class MultipliedAs extends AsPathListExpr {
     return listBuilder.build();
   }
 
+  @JsonProperty(PROP_EXPR)
+  @Nonnull
   public AsExpr getExpr() {
     return _expr;
   }
 
+  @JsonProperty(PROP_NUMBER)
+  @Nonnull
   public IntExpr getNumber() {
     return _number;
   }
@@ -74,8 +76,8 @@ public class MultipliedAs extends AsPathListExpr {
   public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + ((_expr == null) ? 0 : _expr.hashCode());
-    result = prime * result + ((_number == null) ? 0 : _number.hashCode());
+    result = prime * result + _expr.hashCode();
+    result = prime * result + _number.hashCode();
     return result;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/NamedPrefix6Set.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/NamedPrefix6Set.java
@@ -1,19 +1,30 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.Prefix6;
 import org.batfish.datamodel.Route6FilterList;
 import org.batfish.datamodel.routing_policy.Environment;
 
-public class NamedPrefix6Set extends Prefix6SetExpr {
+@ParametersAreNonnullByDefault
+public final class NamedPrefix6Set extends Prefix6SetExpr {
+  private static final String PROP_NAME = "name";
 
   /** */
   private static final long serialVersionUID = 1L;
 
-  private String _name;
+  @Nonnull private final String _name;
 
   @JsonCreator
-  private NamedPrefix6Set() {}
+  private static NamedPrefix6Set jsonCreator(@Nullable @JsonProperty(PROP_NAME) String name) {
+    checkArgument(name != null, "%s must be provided", PROP_NAME);
+    return new NamedPrefix6Set(name);
+  }
 
   public NamedPrefix6Set(String name) {
     _name = name;
@@ -23,24 +34,15 @@ public class NamedPrefix6Set extends Prefix6SetExpr {
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    } else if (!(obj instanceof NamedPrefix6Set)) {
       return false;
     }
     NamedPrefix6Set other = (NamedPrefix6Set) obj;
-    if (_name == null) {
-      if (other._name != null) {
-        return false;
-      }
-    } else if (!_name.equals(other._name)) {
-      return false;
-    }
-    return true;
+    return _name.equals(other._name);
   }
 
+  @JsonProperty(PROP_NAME)
+  @Nonnull
   public String getName() {
     return _name;
   }
@@ -49,7 +51,7 @@ public class NamedPrefix6Set extends Prefix6SetExpr {
   public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + ((_name == null) ? 0 : _name.hashCode());
+    result = prime * result + _name.hashCode();
     return result;
   }
 
@@ -62,9 +64,5 @@ public class NamedPrefix6Set extends Prefix6SetExpr {
       environment.setError(true);
       return false;
     }
-  }
-
-  public void setName(String name) {
-    _name = name;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/NamedPrefixSet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/NamedPrefixSet.java
@@ -1,17 +1,18 @@
 package org.batfish.datamodel.routing_policy.expr;
 
-import static java.util.Objects.requireNonNull;
+import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.RouteFilterList;
 import org.batfish.datamodel.routing_policy.Environment;
 
 /** Expression for matching a {@link Prefix} against a named {@link RouteFilterList}. */
+@ParametersAreNonnullByDefault
 public final class NamedPrefixSet extends PrefixSetExpr {
 
   private static final String PROP_NAME = "name";
@@ -21,11 +22,12 @@ public final class NamedPrefixSet extends PrefixSetExpr {
   private final String _name;
 
   @JsonCreator
-  private static NamedPrefixSet create(@JsonProperty(PROP_NAME) @Nullable String name) {
-    return new NamedPrefixSet(requireNonNull(name));
+  private static NamedPrefixSet create(@Nullable @JsonProperty(PROP_NAME) String name) {
+    checkArgument(name != null, "%s must be provided", PROP_NAME);
+    return new NamedPrefixSet(name);
   }
 
-  public NamedPrefixSet(@Nonnull String name) {
+  public NamedPrefixSet(String name) {
     _name = name;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/NeighborIsAsPath.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/NeighborIsAsPath.java
@@ -1,21 +1,37 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
 import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
-public class NeighborIsAsPath extends BooleanExpr {
+@ParametersAreNonnullByDefault
+public final class NeighborIsAsPath extends BooleanExpr {
+  private static final String PROP_EXACT = "exact";
+  private static final String PROP_RANGE = "range";
 
   /** */
   private static final long serialVersionUID = 1L;
 
   private boolean _exact;
 
-  private List<SubRangeExpr> _range;
+  @Nonnull private List<SubRangeExpr> _range;
 
   @JsonCreator
-  private NeighborIsAsPath() {}
+  private static NeighborIsAsPath jsonCreator(
+      @Nullable @JsonProperty(PROP_EXACT) Boolean exact,
+      @Nullable @JsonProperty(PROP_RANGE) List<SubRangeExpr> range) {
+    checkArgument(exact != null, "%s must be provided", PROP_EXACT);
+    return new NeighborIsAsPath(firstNonNull(range, ImmutableList.of()), exact);
+  }
 
   public NeighborIsAsPath(List<SubRangeExpr> range, boolean exact) {
     _range = range;
@@ -26,25 +42,11 @@ public class NeighborIsAsPath extends BooleanExpr {
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    } else if (!(obj instanceof NeighborIsAsPath)) {
       return false;
     }
     NeighborIsAsPath other = (NeighborIsAsPath) obj;
-    if (_exact != other._exact) {
-      return false;
-    }
-    if (_range == null) {
-      if (other._range != null) {
-        return false;
-      }
-    } else if (!_range.equals(other._range)) {
-      return false;
-    }
-    return true;
+    return _exact == other._exact && _range.equals(other._range);
   }
 
   @Override
@@ -53,10 +55,13 @@ public class NeighborIsAsPath extends BooleanExpr {
     // TODO Auto-generated method stub
   }
 
+  @JsonProperty(PROP_EXACT)
   public boolean getExact() {
     return _exact;
   }
 
+  @JsonProperty(PROP_RANGE)
+  @Nonnull
   public List<SubRangeExpr> getRange() {
     return _range;
   }
@@ -66,7 +71,7 @@ public class NeighborIsAsPath extends BooleanExpr {
     final int prime = 31;
     int result = 1;
     result = prime * result + (_exact ? 1231 : 1237);
-    result = prime * result + ((_range == null) ? 0 : _range.hashCode());
+    result = prime * result + _range.hashCode();
     return result;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/OriginatesFromAsPath.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/OriginatesFromAsPath.java
@@ -1,21 +1,37 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
 import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
-public class OriginatesFromAsPath extends BooleanExpr {
+@ParametersAreNonnullByDefault
+public final class OriginatesFromAsPath extends BooleanExpr {
+  private static final String PROP_AS_RANGE = "asRange";
+  private static final String PROP_EXACT = "exact";
 
   /** */
   private static final long serialVersionUID = 1L;
 
-  private List<SubRangeExpr> _asRange;
+  @Nonnull private final List<SubRangeExpr> _asRange;
 
-  private boolean _exact;
+  private final boolean _exact;
 
   @JsonCreator
-  private OriginatesFromAsPath() {}
+  private static OriginatesFromAsPath jsonCreator(
+      @Nullable @JsonProperty(PROP_AS_RANGE) List<SubRangeExpr> asRange,
+      @Nullable @JsonProperty(PROP_EXACT) Boolean exact) {
+    checkArgument(exact != null, "%s must be provided", PROP_EXACT);
+    return new OriginatesFromAsPath(firstNonNull(asRange, ImmutableList.of()), exact);
+  }
 
   public OriginatesFromAsPath(List<SubRangeExpr> asRange, boolean exact) {
     _asRange = asRange;
@@ -26,25 +42,12 @@ public class OriginatesFromAsPath extends BooleanExpr {
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
-    }
-    if (obj == null) {
+    } else if (!(obj instanceof OriginatesFromAsPath)) {
       return false;
     }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
+
     OriginatesFromAsPath other = (OriginatesFromAsPath) obj;
-    if (_asRange == null) {
-      if (other._asRange != null) {
-        return false;
-      }
-    } else if (!_asRange.equals(other._asRange)) {
-      return false;
-    }
-    if (_exact != other._exact) {
-      return false;
-    }
-    return true;
+    return _asRange.equals(other._asRange) && _exact == other._exact;
   }
 
   @Override
@@ -53,10 +56,13 @@ public class OriginatesFromAsPath extends BooleanExpr {
     // TODO Auto-generated method stub
   }
 
+  @JsonProperty(PROP_AS_RANGE)
+  @Nonnull
   public List<SubRangeExpr> getAsRange() {
     return _asRange;
   }
 
+  @JsonProperty(PROP_EXACT)
   public boolean getExact() {
     return _exact;
   }
@@ -65,16 +71,8 @@ public class OriginatesFromAsPath extends BooleanExpr {
   public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + ((_asRange == null) ? 0 : _asRange.hashCode());
+    result = prime * result + _asRange.hashCode();
     result = prime * result + (_exact ? 1231 : 1237);
     return result;
-  }
-
-  public void setAsRange(List<SubRangeExpr> asRange) {
-    _asRange = asRange;
-  }
-
-  public void setExact(boolean exact) {
-    _exact = exact;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/PassesThroughAsPath.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/PassesThroughAsPath.java
@@ -1,21 +1,37 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
 import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
-public class PassesThroughAsPath extends BooleanExpr {
+@ParametersAreNonnullByDefault
+public final class PassesThroughAsPath extends BooleanExpr {
+  private static final String PROP_EXACT = "exact";
+  private static final String PROP_RANGE = "range";
 
   /** */
   private static final long serialVersionUID = 1L;
 
   private boolean _exact;
 
-  private List<SubRangeExpr> _range;
+  @Nonnull private List<SubRangeExpr> _range;
 
   @JsonCreator
-  private PassesThroughAsPath() {}
+  private static PassesThroughAsPath jsonCreator(
+      @Nullable @JsonProperty(PROP_EXACT) Boolean exact,
+      @Nullable @JsonProperty(PROP_RANGE) List<SubRangeExpr> range) {
+    checkArgument(exact != null, "%s must be provided", PROP_EXACT);
+    return new PassesThroughAsPath(firstNonNull(range, ImmutableList.of()), exact);
+  }
 
   public PassesThroughAsPath(List<SubRangeExpr> range, boolean exact) {
     _range = range;
@@ -26,25 +42,14 @@ public class PassesThroughAsPath extends BooleanExpr {
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    } else if (!(obj instanceof PassesThroughAsPath)) {
       return false;
     }
     PassesThroughAsPath other = (PassesThroughAsPath) obj;
     if (_exact != other._exact) {
       return false;
     }
-    if (_range == null) {
-      if (other._range != null) {
-        return false;
-      }
-    } else if (!_range.equals(other._range)) {
-      return false;
-    }
-    return true;
+    return _range.equals(other._range);
   }
 
   @Override
@@ -53,10 +58,13 @@ public class PassesThroughAsPath extends BooleanExpr {
     // TODO Auto-generated method stub
   }
 
+  @JsonProperty(PROP_EXACT)
   public boolean getExact() {
     return _exact;
   }
 
+  @JsonProperty(PROP_RANGE)
+  @Nonnull
   public List<SubRangeExpr> getRange() {
     return _range;
   }
@@ -66,7 +74,7 @@ public class PassesThroughAsPath extends BooleanExpr {
     final int prime = 31;
     int result = 1;
     result = prime * result + (_exact ? 1231 : 1237);
-    result = prime * result + ((_range == null) ? 0 : _range.hashCode());
+    result = prime * result + _range.hashCode();
     return result;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/RegexAsPathSetElem.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/RegexAsPathSetElem.java
@@ -1,16 +1,27 @@
 package org.batfish.datamodel.routing_policy.expr;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
+import static com.google.common.base.Preconditions.checkArgument;
 
-public class RegexAsPathSetElem extends AsPathSetElem {
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+public final class RegexAsPathSetElem extends AsPathSetElem {
+  private static final String PROP_REGEX = "regex";
 
   /** */
   private static final long serialVersionUID = 1L;
 
-  private String _regex;
+  @Nonnull private String _regex;
 
   @JsonCreator
-  private RegexAsPathSetElem() {}
+  private static RegexAsPathSetElem jsonCreator(@Nullable @JsonProperty(PROP_REGEX) String regex) {
+    checkArgument(regex != null, "%s must be provided", PROP_REGEX);
+    return new RegexAsPathSetElem(regex);
+  }
 
   public RegexAsPathSetElem(String regex) {
     _regex = regex;
@@ -20,24 +31,15 @@ public class RegexAsPathSetElem extends AsPathSetElem {
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    } else if (!(obj instanceof RegexAsPathSetElem)) {
       return false;
     }
     RegexAsPathSetElem other = (RegexAsPathSetElem) obj;
-    if (_regex == null) {
-      if (other._regex != null) {
-        return false;
-      }
-    } else if (!_regex.equals(other._regex)) {
-      return false;
-    }
-    return true;
+    return _regex.equals(other._regex);
   }
 
+  @JsonProperty(PROP_REGEX)
+  @Nonnull
   public String getRegex() {
     return _regex;
   }
@@ -46,13 +48,13 @@ public class RegexAsPathSetElem extends AsPathSetElem {
   public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + ((_regex == null) ? 0 : _regex.hashCode());
+    result = prime * result + _regex.hashCode();
     return result;
   }
 
   @Override
   public String regex() {
-    return _regex;
+    return getRegex();
   }
 
   public void setRegex(String regex) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/SubRangeExpr.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/SubRangeExpr.java
@@ -1,21 +1,36 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.routing_policy.Environment;
 
-public class SubRangeExpr implements Serializable {
+@ParametersAreNonnullByDefault
+public final class SubRangeExpr implements Serializable {
+  private static final String PROP_FIRST = "first";
+  private static final String PROP_LAST = "last";
 
   /** */
   private static final long serialVersionUID = 1L;
 
-  private IntExpr _first;
+  @Nonnull private IntExpr _first;
 
-  private IntExpr _last;
+  @Nonnull private IntExpr _last;
 
   @JsonCreator
-  private SubRangeExpr() {}
+  private static SubRangeExpr jsonCreator(
+      @Nullable @JsonProperty(PROP_FIRST) IntExpr first,
+      @Nullable @JsonProperty(PROP_LAST) IntExpr last) {
+    checkArgument(first != null, "%s must be provided", PROP_FIRST);
+    checkArgument(last != null, "%s must be provided", PROP_LAST);
+    return new SubRangeExpr(first, last);
+  }
 
   public SubRangeExpr(IntExpr first, IntExpr last) {
     _first = first;
@@ -26,29 +41,11 @@ public class SubRangeExpr implements Serializable {
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    } else if (!(obj instanceof SubRangeExpr)) {
       return false;
     }
     SubRangeExpr other = (SubRangeExpr) obj;
-    if (_first == null) {
-      if (other._first != null) {
-        return false;
-      }
-    } else if (!_first.equals(other._first)) {
-      return false;
-    }
-    if (_last == null) {
-      if (other._last != null) {
-        return false;
-      }
-    } else if (!_last.equals(other._last)) {
-      return false;
-    }
-    return true;
+    return _first.equals(other._first) && _last.equals(other._last);
   }
 
   public SubRange evaluate(Environment env) {
@@ -57,10 +54,14 @@ public class SubRangeExpr implements Serializable {
     return new SubRange(first, last);
   }
 
+  @JsonProperty(PROP_FIRST)
+  @Nonnull
   public IntExpr getFirst() {
     return _first;
   }
 
+  @JsonProperty(PROP_LAST)
+  @Nonnull
   public IntExpr getLast() {
     return _last;
   }
@@ -69,8 +70,8 @@ public class SubRangeExpr implements Serializable {
   public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + ((_first == null) ? 0 : _first.hashCode());
-    result = prime * result + ((_last == null) ? 0 : _last.hashCode());
+    result = prime * result + _first.hashCode();
+    result = prime * result + _last.hashCode();
     return result;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/VarAsPathSet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/VarAsPathSet.java
@@ -1,17 +1,28 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.routing_policy.Environment;
 
-public class VarAsPathSet extends AsPathSetExpr {
+@ParametersAreNonnullByDefault
+public final class VarAsPathSet extends AsPathSetExpr {
+  private static final String PROP_VAR = "var";
 
   /** */
   private static final long serialVersionUID = 1L;
 
-  private String _var;
+  @Nonnull private String _var;
 
   @JsonCreator
-  private VarAsPathSet() {}
+  private static VarAsPathSet jsonCreator(@Nullable @JsonProperty(PROP_VAR) String var) {
+    checkArgument(var != null, "%s must be provided", PROP_VAR);
+    return new VarAsPathSet(var);
+  }
 
   public VarAsPathSet(String var) {
     _var = var;
@@ -21,24 +32,15 @@ public class VarAsPathSet extends AsPathSetExpr {
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    } else if (!(obj instanceof VarAsPathSet)) {
       return false;
     }
     VarAsPathSet other = (VarAsPathSet) obj;
-    if (_var == null) {
-      if (other._var != null) {
-        return false;
-      }
-    } else if (!_var.equals(other._var)) {
-      return false;
-    }
-    return true;
+    return _var.equals(other._var);
   }
 
+  @JsonProperty(PROP_VAR)
+  @Nonnull
   public String getVar() {
     return _var;
   }
@@ -47,7 +49,7 @@ public class VarAsPathSet extends AsPathSetExpr {
   public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + ((_var == null) ? 0 : _var.hashCode());
+    result = prime * result + _var.hashCode();
     return result;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/BufferedStatement.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/BufferedStatement.java
@@ -1,24 +1,35 @@
 package org.batfish.datamodel.routing_policy.statement;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
 
-public class BufferedStatement extends Statement {
+public final class BufferedStatement extends Statement {
+
+  private static final String PROP_STATEMENT = "statement";
 
   /** */
   private static final long serialVersionUID = 1L;
 
-  private Statement _statement;
+  @Nonnull private Statement _statement;
 
   @JsonCreator
-  private BufferedStatement() {}
+  private static BufferedStatement jsonCreator(
+      @Nullable @JsonProperty(PROP_STATEMENT) Statement statement) {
+    checkArgument(statement != null, "%s is required", PROP_STATEMENT);
+    return new BufferedStatement(statement);
+  }
 
-  public BufferedStatement(Statement statement) {
+  public BufferedStatement(@Nonnull Statement statement) {
     _statement = statement;
   }
 
@@ -33,21 +44,11 @@ public class BufferedStatement extends Statement {
     if (this == obj) {
       return true;
     }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    if (!(obj instanceof BufferedStatement)) {
       return false;
     }
     BufferedStatement other = (BufferedStatement) obj;
-    if (_statement == null) {
-      if (other._statement != null) {
-        return false;
-      }
-    } else if (!_statement.equals(other._statement)) {
-      return false;
-    }
-    return true;
+    return _statement.equals(other._statement);
   }
 
   @Override
@@ -57,6 +58,8 @@ public class BufferedStatement extends Statement {
     return result;
   }
 
+  @JsonProperty(PROP_STATEMENT)
+  @Nonnull
   public Statement getStatement() {
     return _statement;
   }
@@ -65,11 +68,11 @@ public class BufferedStatement extends Statement {
   public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + ((_statement == null) ? 0 : _statement.hashCode());
+    result = prime * result + _statement.hashCode();
     return result;
   }
 
-  public void setStatement(Statement statement) {
+  public void setStatement(@Nonnull Statement statement) {
     _statement = statement;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/DeleteCommunity.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/DeleteCommunity.java
@@ -1,21 +1,33 @@
 package org.batfish.datamodel.routing_policy.statement;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.SortedSet;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.BgpRoute;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 import org.batfish.datamodel.routing_policy.expr.CommunitySetExpr;
 
-public class DeleteCommunity extends Statement {
+@ParametersAreNonnullByDefault
+public final class DeleteCommunity extends Statement {
+  private static final String PROP_EXPR = "expr";
 
   /** */
   private static final long serialVersionUID = 1L;
 
-  private CommunitySetExpr _expr;
+  @Nonnull private final CommunitySetExpr _expr;
 
   @JsonCreator
-  private DeleteCommunity() {}
+  private static DeleteCommunity jsonCreator(
+      @Nullable @JsonProperty(PROP_EXPR) CommunitySetExpr expr) {
+    checkArgument(expr != null, "%s must be provided", PROP_EXPR);
+    return new DeleteCommunity(expr);
+  }
 
   public DeleteCommunity(CommunitySetExpr expr) {
     _expr = expr;
@@ -25,22 +37,11 @@ public class DeleteCommunity extends Statement {
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    } else if (!(obj instanceof DeleteCommunity)) {
       return false;
     }
     DeleteCommunity other = (DeleteCommunity) obj;
-    if (_expr == null) {
-      if (other._expr != null) {
-        return false;
-      }
-    } else if (!_expr.equals(other._expr)) {
-      return false;
-    }
-    return true;
+    return _expr.equals(other._expr);
   }
 
   @Override
@@ -53,6 +54,8 @@ public class DeleteCommunity extends Statement {
     return result;
   }
 
+  @JsonProperty(PROP_EXPR)
+  @Nonnull
   public CommunitySetExpr getExpr() {
     return _expr;
   }
@@ -61,11 +64,7 @@ public class DeleteCommunity extends Statement {
   public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + ((_expr == null) ? 0 : _expr.hashCode());
+    result = prime * result + _expr.hashCode();
     return result;
-  }
-
-  public void setExpr(CommunitySetExpr expr) {
-    _expr = expr;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/PrependAsPath.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/PrependAsPath.java
@@ -1,24 +1,35 @@
 package org.batfish.datamodel.routing_policy.statement;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;
 import java.util.List;
 import java.util.SortedSet;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.BgpRoute;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 import org.batfish.datamodel.routing_policy.expr.AsPathListExpr;
 
-public class PrependAsPath extends Statement {
+@ParametersAreNonnullByDefault
+public final class PrependAsPath extends Statement {
+  private static final String PROP_EXPR = "expr";
 
   /** */
   private static final long serialVersionUID = 1L;
 
-  private AsPathListExpr _expr;
+  @Nonnull private AsPathListExpr _expr;
 
   @JsonCreator
-  private PrependAsPath() {}
+  private static PrependAsPath jsonCreator(@Nullable @JsonProperty(PROP_EXPR) AsPathListExpr expr) {
+    checkArgument(expr != null, "%s must be provided", PROP_EXPR);
+    return new PrependAsPath(expr);
+  }
 
   public PrependAsPath(AsPathListExpr expr) {
     _expr = expr;
@@ -28,22 +39,11 @@ public class PrependAsPath extends Statement {
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    } else if (!(obj instanceof PrependAsPath)) {
       return false;
     }
     PrependAsPath other = (PrependAsPath) obj;
-    if (_expr == null) {
-      if (other._expr != null) {
-        return false;
-      }
-    } else if (!_expr.equals(other._expr)) {
-      return false;
-    }
-    return true;
+    return _expr.equals(other._expr);
   }
 
   @Override
@@ -72,6 +72,8 @@ public class PrependAsPath extends Statement {
     return result;
   }
 
+  @JsonProperty(PROP_EXPR)
+  @Nonnull
   public AsPathListExpr getExpr() {
     return _expr;
   }
@@ -80,7 +82,7 @@ public class PrependAsPath extends Statement {
   public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + ((_expr == null) ? 0 : _expr.hashCode());
+    result = prime * result + _expr.hashCode();
     return result;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/SetAdministrativeCost.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/SetAdministrativeCost.java
@@ -1,6 +1,12 @@
 package org.batfish.datamodel.routing_policy.statement;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 import org.batfish.datamodel.routing_policy.expr.IntExpr;
@@ -9,15 +15,21 @@ import org.batfish.datamodel.routing_policy.expr.IntExpr;
  * Type of {@link Statement} to set the administrative cost of output route present in the {@link
  * Environment}
  */
-public class SetAdministrativeCost extends Statement {
+@ParametersAreNonnullByDefault
+public final class SetAdministrativeCost extends Statement {
+  private static final String PROP_ADMIN = "admin";
 
   /** */
   private static final long serialVersionUID = 1L;
 
-  private IntExpr _admin;
+  @Nonnull private final IntExpr _admin;
 
   @JsonCreator
-  private SetAdministrativeCost() {}
+  private static SetAdministrativeCost jsonCreator(
+      @Nullable @JsonProperty(PROP_ADMIN) IntExpr admin) {
+    checkArgument(admin != null, "%s must be provided", PROP_ADMIN);
+    return new SetAdministrativeCost(admin);
+  }
 
   public SetAdministrativeCost(IntExpr admin) {
     _admin = admin;
@@ -27,22 +39,11 @@ public class SetAdministrativeCost extends Statement {
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    } else if (!(obj instanceof SetAdministrativeCost)) {
       return false;
     }
     SetAdministrativeCost other = (SetAdministrativeCost) obj;
-    if (_admin == null) {
-      if (other._admin != null) {
-        return false;
-      }
-    } else if (!_admin.equals(other._admin)) {
-      return false;
-    }
-    return true;
+    return _admin.equals(other._admin);
   }
 
   @Override
@@ -56,6 +57,8 @@ public class SetAdministrativeCost extends Statement {
     return result;
   }
 
+  @JsonProperty(PROP_ADMIN)
+  @Nonnull
   public IntExpr getAdmin() {
     return _admin;
   }
@@ -64,11 +67,7 @@ public class SetAdministrativeCost extends Statement {
   public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + ((_admin == null) ? 0 : _admin.hashCode());
+    result = prime * result + _admin.hashCode();
     return result;
-  }
-
-  public void setAdmin(IntExpr admin) {
-    _admin = admin;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/SetCommunity.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/SetCommunity.java
@@ -1,25 +1,36 @@
 package org.batfish.datamodel.routing_policy.statement;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.SortedSet;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.batfish.datamodel.BgpRoute;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 import org.batfish.datamodel.routing_policy.expr.CommunitySetExpr;
 import org.batfish.datamodel.routing_policy.expr.EmptyCommunitySetExpr;
 
-public class SetCommunity extends Statement {
+public final class SetCommunity extends Statement {
 
   private static final long serialVersionUID = 1L;
 
+  private static final String PROP_EXPR = "expr";
+
   public static final SetCommunity NONE = new SetCommunity(EmptyCommunitySetExpr.INSTANCE);
 
-  private CommunitySetExpr _expr;
+  @Nonnull private CommunitySetExpr _expr;
 
   @JsonCreator
-  private SetCommunity() {}
+  private static SetCommunity jsonCreator(
+      @Nullable @JsonProperty(PROP_EXPR) CommunitySetExpr expr) {
+    checkArgument(expr != null, "%s must be provided", PROP_EXPR);
+    return new SetCommunity(expr);
+  }
 
-  public SetCommunity(CommunitySetExpr expr) {
+  public SetCommunity(@Nonnull CommunitySetExpr expr) {
     _expr = expr;
   }
 
@@ -27,22 +38,11 @@ public class SetCommunity extends Statement {
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    } else if (!(obj instanceof SetCommunity)) {
       return false;
     }
     SetCommunity other = (SetCommunity) obj;
-    if (_expr == null) {
-      if (other._expr != null) {
-        return false;
-      }
-    } else if (!_expr.equals(other._expr)) {
-      return false;
-    }
-    return true;
+    return _expr.equals(other._expr);
   }
 
   @Override
@@ -59,6 +59,7 @@ public class SetCommunity extends Statement {
     return result;
   }
 
+  @JsonProperty(PROP_EXPR)
   public CommunitySetExpr getExpr() {
     return _expr;
   }
@@ -67,11 +68,11 @@ public class SetCommunity extends Statement {
   public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + ((_expr == null) ? 0 : _expr.hashCode());
+    result = prime * result + _expr.hashCode();
     return result;
   }
 
-  public void setExpr(CommunitySetExpr expr) {
+  public void setExpr(@Nonnull CommunitySetExpr expr) {
     _expr = expr;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/SetDefaultPolicy.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/SetDefaultPolicy.java
@@ -1,18 +1,30 @@
 package org.batfish.datamodel.routing_policy.statement;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
-public class SetDefaultPolicy extends Statement {
+@ParametersAreNonnullByDefault
+public final class SetDefaultPolicy extends Statement {
+  private static final String PROP_DEFAULT_POLICY = "defaultPolicy";
 
   /** */
   private static final long serialVersionUID = 1L;
 
-  private String _defaultPolicy;
+  @Nonnull private final String _defaultPolicy;
 
   @JsonCreator
-  private SetDefaultPolicy() {}
+  private static SetDefaultPolicy jsonCreator(
+      @Nullable @JsonProperty(PROP_DEFAULT_POLICY) String defaultPolicy) {
+    checkArgument(defaultPolicy != null, "%s must be provided", PROP_DEFAULT_POLICY);
+    return new SetDefaultPolicy(defaultPolicy);
+  }
 
   public SetDefaultPolicy(String defaultPolicy) {
     _defaultPolicy = defaultPolicy;
@@ -22,22 +34,11 @@ public class SetDefaultPolicy extends Statement {
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    } else if (!(obj instanceof SetDefaultPolicy)) {
       return false;
     }
     SetDefaultPolicy other = (SetDefaultPolicy) obj;
-    if (_defaultPolicy == null) {
-      if (other._defaultPolicy != null) {
-        return false;
-      }
-    } else if (!_defaultPolicy.equals(other._defaultPolicy)) {
-      return false;
-    }
-    return true;
+    return _defaultPolicy.equals(other._defaultPolicy);
   }
 
   @Override
@@ -47,6 +48,8 @@ public class SetDefaultPolicy extends Statement {
     return result;
   }
 
+  @JsonProperty(PROP_DEFAULT_POLICY)
+  @Nonnull
   public String getDefaultPolicy() {
     return _defaultPolicy;
   }
@@ -55,11 +58,7 @@ public class SetDefaultPolicy extends Statement {
   public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + ((_defaultPolicy == null) ? 0 : _defaultPolicy.hashCode());
+    result = prime * result + _defaultPolicy.hashCode();
     return result;
-  }
-
-  public void setDefaultPolicy(String defaultPolicy) {
-    _defaultPolicy = defaultPolicy;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/SetEigrpMetric.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/SetEigrpMetric.java
@@ -1,21 +1,33 @@
 package org.batfish.datamodel.routing_policy.statement;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.EigrpExternalRoute;
 import org.batfish.datamodel.eigrp.EigrpMetric;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 import org.batfish.datamodel.routing_policy.expr.EigrpMetricExpr;
 
-public class SetEigrpMetric extends Statement {
+@ParametersAreNonnullByDefault
+public final class SetEigrpMetric extends Statement {
+  private static final String PROP_METRIC = "metric";
 
   private static final long serialVersionUID = 1L;
 
-  private EigrpMetricExpr _metric;
+  @Nonnull private final EigrpMetricExpr _metric;
 
   @JsonCreator
-  private SetEigrpMetric() {}
+  private static SetEigrpMetric jsonCreator(
+      @Nullable @JsonProperty(PROP_METRIC) EigrpMetricExpr metric) {
+    checkArgument(metric != null, "%s must be provided", PROP_METRIC);
+    return new SetEigrpMetric(metric);
+  }
 
   public SetEigrpMetric(EigrpMetricExpr metric) {
     _metric = metric;
@@ -28,9 +40,8 @@ public class SetEigrpMetric extends Statement {
     } else if (!(obj instanceof SetEigrpMetric)) {
       return false;
     }
-
     SetEigrpMetric rhs = (SetEigrpMetric) obj;
-    return Objects.equals(_metric, rhs._metric);
+    return _metric.equals(rhs._metric);
   }
 
   @Override
@@ -41,12 +52,10 @@ public class SetEigrpMetric extends Statement {
     return result;
   }
 
+  @JsonProperty(PROP_METRIC)
+  @Nonnull
   public EigrpMetricExpr getMetric() {
     return _metric;
-  }
-
-  public void setMetric(EigrpMetricExpr metric) {
-    _metric = metric;
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/SetIsisLevel.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/SetIsisLevel.java
@@ -1,21 +1,32 @@
 package org.batfish.datamodel.routing_policy.statement;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.IsisRoute;
 import org.batfish.datamodel.isis.IsisLevel;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 import org.batfish.datamodel.routing_policy.expr.IsisLevelExpr;
 
-public class SetIsisLevel extends Statement {
+@ParametersAreNonnullByDefault
+public final class SetIsisLevel extends Statement {
+  private static final String PROP_LEVEL = "level";
 
   /** */
   private static final long serialVersionUID = 1L;
 
-  private IsisLevelExpr _level;
+  @Nonnull private IsisLevelExpr _level;
 
   @JsonCreator
-  private SetIsisLevel() {}
+  private static SetIsisLevel jsonCreator(@Nullable @JsonProperty(PROP_LEVEL) IsisLevelExpr level) {
+    checkArgument(level != null, "%s must be provided", level);
+    return new SetIsisLevel(level);
+  }
 
   public SetIsisLevel(IsisLevelExpr level) {
     _level = level;
@@ -25,22 +36,11 @@ public class SetIsisLevel extends Statement {
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    } else if (!(obj instanceof SetIsisLevel)) {
       return false;
     }
     SetIsisLevel other = (SetIsisLevel) obj;
-    if (_level == null) {
-      if (other._level != null) {
-        return false;
-      }
-    } else if (!_level.equals(other._level)) {
-      return false;
-    }
-    return true;
+    return _level.equals(other._level);
   }
 
   @Override
@@ -52,6 +52,8 @@ public class SetIsisLevel extends Statement {
     return result;
   }
 
+  @JsonProperty(PROP_LEVEL)
+  @Nonnull
   public IsisLevelExpr getLevel() {
     return _level;
   }
@@ -60,7 +62,7 @@ public class SetIsisLevel extends Statement {
   public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + ((_level == null) ? 0 : _level.hashCode());
+    result = prime * result + _level.hashCode();
     return result;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/SetIsisMetricType.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/SetIsisMetricType.java
@@ -1,19 +1,30 @@
 package org.batfish.datamodel.routing_policy.statement;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.isis.IsisMetricType;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
-public class SetIsisMetricType extends Statement {
-
+@ParametersAreNonnullByDefault
+public final class SetIsisMetricType extends Statement {
+  private static final String PROP_METRIC_TYPE = "metricType";
   /** */
   private static final long serialVersionUID = 1L;
 
-  private IsisMetricType _metricType;
+  @Nonnull private IsisMetricType _metricType;
 
   @JsonCreator
-  private SetIsisMetricType() {}
+  private static SetIsisMetricType jsonCreator(
+      @Nullable @JsonProperty(PROP_METRIC_TYPE) IsisMetricType type) {
+    checkArgument(type != null, "%s must be provided", PROP_METRIC_TYPE);
+    return new SetIsisMetricType(type);
+  }
 
   public SetIsisMetricType(IsisMetricType metricType) {
     _metricType = metricType;
@@ -23,18 +34,11 @@ public class SetIsisMetricType extends Statement {
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    } else if (!(obj instanceof SetIsisMetricType)) {
       return false;
     }
     SetIsisMetricType other = (SetIsisMetricType) obj;
-    if (_metricType != other._metricType) {
-      return false;
-    }
-    return true;
+    return _metricType == other._metricType;
   }
 
   @Override
@@ -43,6 +47,8 @@ public class SetIsisMetricType extends Statement {
     // TODO Auto-generated method stub
   }
 
+  @JsonProperty(PROP_METRIC_TYPE)
+  @Nonnull
   public IsisMetricType getMetricType() {
     return _metricType;
   }
@@ -51,7 +57,7 @@ public class SetIsisMetricType extends Statement {
   public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + ((_metricType == null) ? 0 : _metricType.ordinal());
+    result = prime * result + _metricType.ordinal();
     return result;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/SetMetric.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/SetMetric.java
@@ -1,22 +1,30 @@
 package org.batfish.datamodel.routing_policy.statement;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 import org.batfish.datamodel.routing_policy.expr.LongExpr;
 
-public class SetMetric extends Statement {
-
+@ParametersAreNonnullByDefault
+public final class SetMetric extends Statement {
   private static final String PROP_METRIC = "metric";
 
   /** */
   private static final long serialVersionUID = 1L;
 
-  private LongExpr _metric;
+  @Nonnull private final LongExpr _metric;
 
   @JsonCreator
-  private SetMetric() {}
+  private static SetMetric jsonCreator(@Nullable @JsonProperty(PROP_METRIC) LongExpr metric) {
+    checkArgument(metric != null, "%s must be provided", PROP_METRIC);
+    return new SetMetric(metric);
+  }
 
   public SetMetric(LongExpr metric) {
     _metric = metric;
@@ -26,22 +34,11 @@ public class SetMetric extends Statement {
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    } else if (!(obj instanceof SetMetric)) {
       return false;
     }
     SetMetric other = (SetMetric) obj;
-    if (_metric == null) {
-      if (other._metric != null) {
-        return false;
-      }
-    } else if (!_metric.equals(other._metric)) {
-      return false;
-    }
-    return true;
+    return _metric.equals(other._metric);
   }
 
   @Override
@@ -56,6 +53,7 @@ public class SetMetric extends Statement {
   }
 
   @JsonProperty(PROP_METRIC)
+  @Nonnull
   public LongExpr getMetric() {
     return _metric;
   }
@@ -64,12 +62,7 @@ public class SetMetric extends Statement {
   public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + ((_metric == null) ? 0 : _metric.hashCode());
+    result = prime * result + _metric.hashCode();
     return result;
-  }
-
-  @JsonProperty(PROP_METRIC)
-  public void setMetric(LongExpr metric) {
-    _metric = metric;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/SetNextHop.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/SetNextHop.java
@@ -1,23 +1,37 @@
 package org.batfish.datamodel.routing_policy.statement;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.BgpRoute;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 import org.batfish.datamodel.routing_policy.expr.NextHopExpr;
 
-public class SetNextHop extends Statement {
-
+@ParametersAreNonnullByDefault
+public final class SetNextHop extends Statement {
+  private static final String PROP_DESTINATION_VRF = "destinationVrf";
+  private static final String PROP_EXPR = "expr";
   /** */
   private static final long serialVersionUID = 1L;
 
   private boolean _destinationVrf;
 
-  private NextHopExpr _expr;
+  @Nonnull private NextHopExpr _expr;
 
   @JsonCreator
-  private SetNextHop() {}
+  private static SetNextHop jsonCreator(
+      @Nullable @JsonProperty(PROP_DESTINATION_VRF) Boolean destinationVrf,
+      @Nullable @JsonProperty(PROP_EXPR) NextHopExpr expr) {
+    checkArgument(destinationVrf != null, "%s must be provided", PROP_DESTINATION_VRF);
+    checkArgument(expr != null, "%s must be provided", PROP_EXPR);
+    return new SetNextHop(expr, destinationVrf);
+  }
 
   public SetNextHop(NextHopExpr expr, boolean destinationVrf) {
     _expr = expr;
@@ -28,25 +42,11 @@ public class SetNextHop extends Statement {
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    } else if (!(obj instanceof SetNextHop)) {
       return false;
     }
     SetNextHop other = (SetNextHop) obj;
-    if (_destinationVrf != other._destinationVrf) {
-      return false;
-    }
-    if (_expr == null) {
-      if (other._expr != null) {
-        return false;
-      }
-    } else if (!_expr.equals(other._expr)) {
-      return false;
-    }
-    return true;
+    return _destinationVrf == other._destinationVrf && _expr.equals(other._expr);
   }
 
   @Override
@@ -64,10 +64,13 @@ public class SetNextHop extends Statement {
     return result;
   }
 
+  @JsonProperty(PROP_DESTINATION_VRF)
   public boolean getDestinationVrf() {
     return _destinationVrf;
   }
 
+  @JsonProperty(PROP_EXPR)
+  @Nonnull
   public NextHopExpr getExpr() {
     return _expr;
   }
@@ -77,15 +80,7 @@ public class SetNextHop extends Statement {
     final int prime = 31;
     int result = 1;
     result = prime * result + (_destinationVrf ? 1231 : 1237);
-    result = prime * result + ((_expr == null) ? 0 : _expr.hashCode());
+    result = prime * result + _expr.hashCode();
     return result;
-  }
-
-  public void setDestinationVrf(boolean destinationVrf) {
-    _destinationVrf = destinationVrf;
-  }
-
-  public void setExpr(NextHopExpr expr) {
-    _expr = expr;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/SetTag.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/SetTag.java
@@ -1,19 +1,29 @@
 package org.batfish.datamodel.routing_policy.statement;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 import org.batfish.datamodel.routing_policy.expr.IntExpr;
 
-public class SetTag extends Statement {
-
+@ParametersAreNonnullByDefault
+public final class SetTag extends Statement {
+  private static final String PROP_TAG = "tag";
   /** */
   private static final long serialVersionUID = 1L;
 
-  private IntExpr _tag;
+  @Nonnull private final IntExpr _tag;
 
   @JsonCreator
-  private SetTag() {}
+  private static SetTag jsonCreator(@Nullable @JsonProperty(PROP_TAG) IntExpr expr) {
+    checkArgument(expr != null, "%s must be provided", PROP_TAG);
+    return new SetTag(expr);
+  }
 
   public SetTag(IntExpr expr) {
     _tag = expr;
@@ -23,22 +33,11 @@ public class SetTag extends Statement {
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    } else if (!(obj instanceof SetTag)) {
       return false;
     }
     SetTag other = (SetTag) obj;
-    if (_tag == null) {
-      if (other._tag != null) {
-        return false;
-      }
-    } else if (!_tag.equals(other._tag)) {
-      return false;
-    }
-    return true;
+    return _tag.equals(other._tag);
   }
 
   @Override
@@ -52,6 +51,8 @@ public class SetTag extends Statement {
     return result;
   }
 
+  @JsonProperty(PROP_TAG)
+  @Nonnull
   public IntExpr getTag() {
     return _tag;
   }
@@ -60,11 +61,7 @@ public class SetTag extends Statement {
   public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + ((_tag == null) ? 0 : _tag.hashCode());
+    result = prime * result + _tag.hashCode();
     return result;
-  }
-
-  public void setTag(IntExpr tag) {
-    _tag = tag;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/SetWeight.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/SetWeight.java
@@ -1,20 +1,30 @@
 package org.batfish.datamodel.routing_policy.statement;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.BgpRoute;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 import org.batfish.datamodel.routing_policy.expr.IntExpr;
 
-public class SetWeight extends Statement {
-
+@ParametersAreNonnullByDefault
+public final class SetWeight extends Statement {
+  private static final String PROP_WEIGHT = "weight";
   /** */
   private static final long serialVersionUID = 1L;
 
-  private IntExpr _weight;
+  @Nonnull private IntExpr _weight;
 
   @JsonCreator
-  private SetWeight() {}
+  private static SetWeight jsonCreator(@Nullable @JsonProperty(PROP_WEIGHT) IntExpr weight) {
+    checkArgument(weight != null, "%s must be provided", PROP_WEIGHT);
+    return new SetWeight(weight);
+  }
 
   public SetWeight(IntExpr weight) {
     _weight = weight;
@@ -24,22 +34,11 @@ public class SetWeight extends Statement {
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    } else if (!(obj instanceof SetWeight)) {
       return false;
     }
     SetWeight other = (SetWeight) obj;
-    if (_weight == null) {
-      if (other._weight != null) {
-        return false;
-      }
-    } else if (!_weight.equals(other._weight)) {
-      return false;
-    }
-    return true;
+    return _weight.equals(other._weight);
   }
 
   @Override
@@ -51,6 +50,8 @@ public class SetWeight extends Statement {
     return result;
   }
 
+  @JsonProperty(PROP_WEIGHT)
+  @Nonnull
   public IntExpr getWeight() {
     return _weight;
   }
@@ -59,7 +60,7 @@ public class SetWeight extends Statement {
   public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + ((_weight == null) ? 0 : _weight.hashCode());
+    result = prime * result + _weight.hashCode();
     return result;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco/Aaa.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco/Aaa.java
@@ -1,8 +1,12 @@
 package org.batfish.datamodel.vendor_family.cisco;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
 
 public class Aaa implements Serializable {
+  private static final String PROP_ACCOUNTING = "accounting";
+  private static final String PROP_AUTHENTICATION = "authentication";
+  private static final String PROP_NEW_MODEL = "newModel";
 
   /** */
   private static final long serialVersionUID = 1L;
@@ -13,26 +17,32 @@ public class Aaa implements Serializable {
 
   private boolean _newModel;
 
+  @JsonProperty(PROP_ACCOUNTING)
   public AaaAccounting getAccounting() {
     return _accounting;
   }
 
+  @JsonProperty(PROP_AUTHENTICATION)
   public AaaAuthentication getAuthentication() {
     return _authentication;
   }
 
+  @JsonProperty(PROP_NEW_MODEL)
   public boolean getNewModel() {
     return _newModel;
   }
 
+  @JsonProperty(PROP_ACCOUNTING)
   public void setAccounting(AaaAccounting accounting) {
     _accounting = accounting;
   }
 
+  @JsonProperty(PROP_AUTHENTICATION)
   public void setAuthentication(AaaAuthentication aaaAuthentication) {
     _authentication = aaaAuthentication;
   }
 
+  @JsonProperty(PROP_NEW_MODEL)
   public void setNewModel(boolean newModel) {
     _newModel = newModel;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco/CiscoFamily.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco/CiscoFamily.java
@@ -1,5 +1,6 @@
 package org.batfish.datamodel.vendor_family.cisco;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -7,6 +8,26 @@ import org.batfish.datamodel.Line;
 import org.batfish.datamodel.SwitchportMode;
 
 public class CiscoFamily implements Serializable {
+
+  private static final String PROP_AAA = "aaa";
+  private static final String PROP_BANNERS = "banners";
+  private static final String PROP_CABLE = "cable";
+  private static final String PROP_DEFAULT_SWITCHPORT_MODE = "defaultSwitchportMode";
+  private static final String PROP_DEPI_CLASSES = "depiClasses";
+  private static final String PROP_DEPI_TUNNELS = "depiTunnels";
+  private static final String PROP_ENABLE_SECRET = "enableSecret";
+  private static final String PROP_FEATURES = "features";
+  private static final String PROP_HOSTNAME = "hostname";
+  private static final String PROP_L2TP_CLASSES = "l2tpClasses";
+  private static final String PROP_LINES = "lines";
+  private static final String PROP_LOGGING = "logging";
+  private static final String PROP_NTP = "ntp";
+  private static final String PROP_PROXY_ARP = "proxyArp";
+  private static final String PROP_SERVICES = "services";
+  private static final String PROP_SNTP = "sntp";
+  private static final String PROP_SOURCE_ROUTE = "sourceRoute";
+  private static final String PROP_SSH = "ssh";
+  private static final String PROP_USERS = "users";
 
   /** */
   private static final long serialVersionUID = 1L;
@@ -60,154 +81,192 @@ public class CiscoFamily implements Serializable {
     _users = new TreeMap<>();
   }
 
+  @JsonProperty(PROP_AAA)
   public Aaa getAaa() {
     return _aaa;
   }
 
+  @JsonProperty(PROP_BANNERS)
   public SortedMap<String, String> getBanners() {
     return _banners;
   }
 
+  @JsonProperty(PROP_CABLE)
   public Cable getCable() {
     return _cable;
   }
 
+  @JsonProperty(PROP_DEFAULT_SWITCHPORT_MODE)
   public SwitchportMode getDefaultSwitchportMode() {
     return _defaultSwitchportMode;
   }
 
+  @JsonProperty(PROP_DEPI_CLASSES)
   public SortedMap<String, DepiClass> getDepiClasses() {
     return _depiClasses;
   }
 
+  @JsonProperty(PROP_DEPI_TUNNELS)
   public SortedMap<String, DepiTunnel> getDepiTunnels() {
     return _depiTunnels;
   }
 
+  @JsonProperty(PROP_ENABLE_SECRET)
   public String getEnableSecret() {
     return _enableSecret;
   }
 
+  @JsonProperty(PROP_FEATURES)
   public SortedMap<String, Boolean> getFeatures() {
     return _features;
   }
 
+  @JsonProperty(PROP_HOSTNAME)
   public String getHostname() {
     return _hostname;
   }
 
+  @JsonProperty(PROP_L2TP_CLASSES)
   public SortedMap<String, L2tpClass> getL2tpClasses() {
     return _l2tpClasses;
   }
 
+  @JsonProperty(PROP_LINES)
   public SortedMap<String, Line> getLines() {
     return _lines;
   }
 
+  @JsonProperty(PROP_LOGGING)
   public Logging getLogging() {
     return _logging;
   }
 
+  @JsonProperty(PROP_NTP)
   public Ntp getNtp() {
     return _ntp;
   }
 
+  @JsonProperty(PROP_PROXY_ARP)
   public Boolean getProxyArp() {
     return _proxyArp;
   }
 
+  @JsonProperty(PROP_SERVICES)
   public SortedMap<String, Service> getServices() {
     return _services;
   }
 
+  @JsonProperty(PROP_SNTP)
   public Sntp getSntp() {
     return _sntp;
   }
 
+  @JsonProperty(PROP_SOURCE_ROUTE)
   public Boolean getSourceRoute() {
     return _sourceRoute;
   }
 
+  @JsonProperty(PROP_SSH)
   public SshSettings getSsh() {
     return _ssh;
   }
 
+  @JsonProperty(PROP_USERS)
   public SortedMap<String, User> getUsers() {
     return _users;
   }
 
+  @JsonProperty(PROP_AAA)
   public void setAaa(Aaa aaa) {
     _aaa = aaa;
   }
 
+  @JsonProperty(PROP_BANNERS)
   public void setBanners(SortedMap<String, String> banners) {
     _banners = banners;
   }
 
+  @JsonProperty(PROP_CABLE)
   public void setCable(Cable cable) {
     _cable = cable;
   }
 
+  @JsonProperty(PROP_DEFAULT_SWITCHPORT_MODE)
   public void setDefaultSwitchportMode(SwitchportMode defaultSwitchportMode) {
     _defaultSwitchportMode = defaultSwitchportMode;
   }
 
+  @JsonProperty(PROP_DEPI_CLASSES)
   public void setDepiClasses(SortedMap<String, DepiClass> depiClasses) {
     _depiClasses = depiClasses;
   }
 
+  @JsonProperty(PROP_DEPI_TUNNELS)
   public void setDepiTunnels(SortedMap<String, DepiTunnel> depiTunnels) {
     _depiTunnels = depiTunnels;
   }
 
+  @JsonProperty(PROP_ENABLE_SECRET)
   public void setEnableSecret(String enableSecret) {
     _enableSecret = enableSecret;
   }
 
+  @JsonProperty(PROP_FEATURES)
   public void setFeatures(SortedMap<String, Boolean> features) {
     _features = features;
   }
 
+  @JsonProperty(PROP_HOSTNAME)
   public void setHostname(String hostname) {
     _hostname = hostname;
   }
 
+  @JsonProperty(PROP_L2TP_CLASSES)
   public void setL2tpClasses(SortedMap<String, L2tpClass> l2tpClasses) {
     _l2tpClasses = l2tpClasses;
   }
 
+  @JsonProperty(PROP_LINES)
   public void setLines(SortedMap<String, Line> lines) {
     _lines = lines;
   }
 
+  @JsonProperty(PROP_LOGGING)
   public void setLogging(Logging logging) {
     _logging = logging;
   }
 
+  @JsonProperty(PROP_NTP)
   public void setNtp(Ntp ntp) {
     _ntp = ntp;
   }
 
+  @JsonProperty(PROP_PROXY_ARP)
   public void setProxyArp(Boolean proxyArp) {
     _proxyArp = proxyArp;
   }
 
+  @JsonProperty(PROP_SERVICES)
   public void setServices(SortedMap<String, Service> services) {
     _services = services;
   }
 
+  @JsonProperty(PROP_SNTP)
   public void setSntp(Sntp sntp) {
     _sntp = sntp;
   }
 
+  @JsonProperty(PROP_SOURCE_ROUTE)
   public void setSourceRoute(Boolean sourceRoute) {
     _sourceRoute = sourceRoute;
   }
 
+  @JsonProperty(PROP_SSH)
   public void setSsh(SshSettings ssh) {
     _ssh = ssh;
   }
 
+  @JsonProperty(PROP_USERS)
   public void setUsers(SortedMap<String, User> users) {
     _users = users;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco/Logging.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco/Logging.java
@@ -1,10 +1,17 @@
 package org.batfish.datamodel.vendor_family.cisco;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
 public class Logging implements Serializable {
+  private static final String PROP_BUFFERED = "buffered";
+  private static final String PROP_CONSOLE = "console";
+  private static final String PROP_HOSTS = "hosts";
+  private static final String PROP_ON = "on";
+  private static final String PROP_SOURCE_INTERFACE = "sourceInterface";
+  private static final String PROP_TRAP = "trap";
 
   public static final int MAX_LOGGING_SEVERITY = 7;
 
@@ -44,50 +51,62 @@ public class Logging implements Serializable {
     _on = true;
   }
 
+  @JsonProperty(PROP_BUFFERED)
   public Buffered getBuffered() {
     return _buffered;
   }
 
+  @JsonProperty(PROP_CONSOLE)
   public LoggingType getConsole() {
     return _console;
   }
 
+  @JsonProperty(PROP_HOSTS)
   public SortedMap<String, LoggingHost> getHosts() {
     return _hosts;
   }
 
+  @JsonProperty(PROP_ON)
   public boolean getOn() {
     return _on;
   }
 
+  @JsonProperty(PROP_SOURCE_INTERFACE)
   public String getSourceInterface() {
     return _sourceInterface;
   }
 
+  @JsonProperty(PROP_TRAP)
   public LoggingType getTrap() {
     return _trap;
   }
 
+  @JsonProperty(PROP_BUFFERED)
   public void setBuffered(Buffered buffered) {
     _buffered = buffered;
   }
 
+  @JsonProperty(PROP_CONSOLE)
   public void setConsole(LoggingType console) {
     _console = console;
   }
 
+  @JsonProperty(PROP_HOSTS)
   public void setHosts(SortedMap<String, LoggingHost> hosts) {
     _hosts = hosts;
   }
 
+  @JsonProperty(PROP_ON)
   public void setOn(boolean on) {
     _on = on;
   }
 
+  @JsonProperty(PROP_SOURCE_INTERFACE)
   public void setSourceInterface(String sourceInterface) {
     _sourceInterface = sourceInterface;
   }
 
+  @JsonProperty(PROP_TRAP)
   public void setTrap(LoggingType trap) {
     _trap = trap;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco/Service.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco/Service.java
@@ -1,18 +1,28 @@
 package org.batfish.datamodel.vendor_family.cisco;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public class Service implements Serializable {
+
+  private static final String PROP_ENABLED = "enabled";
+  private static final String PROP_SUBSERVICES = "subservices";
 
   /** */
   private static final long serialVersionUID = 1L;
 
-  private Boolean _enabled;
+  @Nullable private Boolean _enabled;
 
-  private SortedMap<String, Service> _subservices;
+  @Nonnull private SortedMap<String, Service> _subservices;
 
+  @JsonCreator
   public Service() {
     _subservices = new TreeMap<>();
   }
@@ -24,19 +34,25 @@ public class Service implements Serializable {
     _enabled = false;
   }
 
+  @JsonProperty(PROP_ENABLED)
+  @Nullable
   public Boolean getEnabled() {
     return _enabled;
   }
 
+  @JsonProperty(PROP_SUBSERVICES)
+  @Nonnull
   public SortedMap<String, Service> getSubservices() {
     return _subservices;
   }
 
-  public void setEnabled(Boolean enabled) {
+  @JsonProperty(PROP_ENABLED)
+  public void setEnabled(@Nullable Boolean enabled) {
     _enabled = enabled;
   }
 
-  public void setSubservices(SortedMap<String, Service> subservices) {
-    _subservices = subservices;
+  @JsonProperty(PROP_SUBSERVICES)
+  public void setSubservices(@Nullable SortedMap<String, Service> subservices) {
+    _subservices = firstNonNull(subservices, new TreeMap<>());
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco/User.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco/User.java
@@ -1,6 +1,8 @@
 package org.batfish.datamodel.vendor_family.cisco;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nullable;
 import org.batfish.common.util.ComparableStructure;
 
 public class User extends ComparableStructure<String> {
@@ -8,27 +10,37 @@ public class User extends ComparableStructure<String> {
   /** */
   private static final long serialVersionUID = 1L;
 
-  private String _password;
+  private static final String PROP_PASSWORD = "password";
+  private static final String PROP_ROLE = "role";
 
-  private String _role;
+  @Nullable private String _password;
 
-  public User(@JsonProperty(PROP_NAME) String name) {
+  @Nullable private String _role;
+
+  @JsonCreator
+  public User(@Nullable @JsonProperty(PROP_NAME) String name) {
     super(name);
   }
 
+  @JsonProperty(PROP_PASSWORD)
+  @Nullable
   public String getPassword() {
     return _password;
   }
 
+  @JsonProperty(PROP_ROLE)
+  @Nullable
   public String getRole() {
     return _role;
   }
 
-  public void setPassword(String password) {
+  @JsonProperty(PROP_PASSWORD)
+  public void setPassword(@Nullable String password) {
     _password = password;
   }
 
-  public void setRole(String role) {
+  @JsonProperty(PROP_ROLE)
+  public void setRole(@Nullable String role) {
     _role = role;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/juniper/JuniperFamily.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/juniper/JuniperFamily.java
@@ -1,5 +1,6 @@
 package org.batfish.datamodel.vendor_family.juniper;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.Serializable;
 import java.util.Collections;
@@ -10,7 +11,11 @@ import org.batfish.datamodel.AuthenticationMethod;
 import org.batfish.datamodel.Line;
 
 public class JuniperFamily implements Serializable {
-
+  private static final String PROP_LINES = "lines";
+  private static final String PROP_ROOT_AUTHENTICATION_ENCRYPTED_PASSWORD =
+      "rootAuthenticationEncryptedPassword";
+  private static final String PROP_SYSTEM_AUTHENTICATION_ORDER = "systemAuthenticationOrder";
+  private static final String PROP_TACPLUS_SERVERS = "tacplusServers";
   /** */
   private static final long serialVersionUID = 1L;
 
@@ -42,34 +47,42 @@ public class JuniperFamily implements Serializable {
     _lines.put(AUXILIARY_LINE_NAME, aux);
   }
 
+  @JsonProperty(PROP_LINES)
   public SortedMap<String, Line> getLines() {
     return _lines;
   }
 
+  @JsonProperty(PROP_ROOT_AUTHENTICATION_ENCRYPTED_PASSWORD)
   public String getRootAuthenticationEncryptedPassword() {
     return _rootAuthenticationEncryptedPassword;
   }
 
+  @JsonProperty(PROP_SYSTEM_AUTHENTICATION_ORDER)
   public AaaAuthenticationLoginList getSystemAuthenticationOrder() {
     return _systemAuthenticationOrder;
   }
 
+  @JsonProperty(PROP_TACPLUS_SERVERS)
   public SortedMap<String, TacplusServer> getTacplusServers() {
     return _tacplusServers;
   }
 
+  @JsonProperty(PROP_LINES)
   public void setLines(SortedMap<String, Line> lines) {
     _lines = lines;
   }
 
+  @JsonProperty(PROP_ROOT_AUTHENTICATION_ENCRYPTED_PASSWORD)
   public void setRootAuthenticationEncryptedPassword(String rootAuthenticationEncryptedPassword) {
     _rootAuthenticationEncryptedPassword = rootAuthenticationEncryptedPassword;
   }
 
+  @JsonProperty(PROP_SYSTEM_AUTHENTICATION_ORDER)
   public void setSystemAuthenticationOrder(AaaAuthenticationLoginList authenticationOrder) {
     _systemAuthenticationOrder = authenticationOrder;
   }
 
+  @JsonProperty(PROP_TACPLUS_SERVERS)
   public void setTacplusServers(SortedMap<String, TacplusServer> tacplusServers) {
     _tacplusServers = tacplusServers;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
@@ -1221,9 +1221,7 @@ class CiscoConversions {
 
   private static AsPathAccessListLine toAsPathAccessListLine(AsPathSetElem elem) {
     String regex = CiscoConfiguration.toJavaRegex(elem.regex());
-    AsPathAccessListLine line = new AsPathAccessListLine();
-    line.setAction(LineAction.PERMIT);
-    line.setRegex(regex);
+    AsPathAccessListLine line = new AsPathAccessListLine(LineAction.PERMIT, regex);
     return line;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/IpAsPathAccessListLine.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/IpAsPathAccessListLine.java
@@ -1,16 +1,19 @@
 package org.batfish.representation.cisco;
 
 import java.io.Serializable;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.AsPathAccessListLine;
 import org.batfish.datamodel.LineAction;
 
+@ParametersAreNonnullByDefault
 public class IpAsPathAccessListLine implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
-  private LineAction _action;
+  @Nonnull private LineAction _action;
 
-  private String _regex;
+  @Nonnull private String _regex;
 
   public IpAsPathAccessListLine(LineAction action, String regex) {
     _action = action;
@@ -18,14 +21,7 @@ public class IpAsPathAccessListLine implements Serializable {
   }
 
   public AsPathAccessListLine toAsPathAccessListLine() {
-    AsPathAccessListLine line = new AsPathAccessListLine();
-    line.setAction(_action);
     String regex = CiscoConfiguration.toJavaRegex(_regex);
-    line.setRegex(regex);
-    return line;
-  }
-
-  public LineAction getAction() {
-    return _action;
+    return new AsPathAccessListLine(_action, regex);
   }
 }


### PR DESCRIPTION
Mostly in routing_policy, and a few other places that didn't have it.

Formulaic changes:
* routing_policy: where applicable, make the classes final and with nonnull be default. Make the required parameters final and nonnull, and fix the JsonCreator, equals, hashCode for this.
* delete unused code in classes I touched. Leftovers from before we knew about Guava?