### PR TITLE
 Separate TCP flags from TCP match conditions, make both immutable

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Header6Space.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Header6Space.java
@@ -80,7 +80,7 @@ public class Header6Space implements Serializable {
 
   private Set<State> _states;
 
-  private List<TcpFlags> _tcpFlags;
+  private List<TcpFlagsMatchConditions> _tcpFlags;
 
   public Header6Space() {
     _dscps = new TreeSet<>();
@@ -291,7 +291,7 @@ public class Header6Space implements Serializable {
     return _states;
   }
 
-  public List<TcpFlags> getTcpFlags() {
+  public List<TcpFlagsMatchConditions> getTcpFlags() {
     return _tcpFlags;
   }
 
@@ -474,7 +474,7 @@ public class Header6Space implements Serializable {
     _states = states;
   }
 
-  public void setTcpFlags(List<TcpFlags> tcpFlags) {
+  public void setTcpFlags(List<TcpFlagsMatchConditions> tcpFlags) {
     _tcpFlags = tcpFlags;
   }
 
@@ -524,7 +524,7 @@ public class Header6Space implements Serializable {
         + _notIcmpCodes
         + ", States:"
         + _states
-        + ", TcpFlags:"
+        + ", TcpFlagsMatchConditions:"
         + _tcpFlags
         + "]";
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Header6Space.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Header6Space.java
@@ -35,7 +35,7 @@ public class Header6Space implements Serializable {
   private static final String PROP_SRC_OR_DST_PORTS = "srcOrDstPorts";
   private static final String PROP_SRC_PORTS = "srcPorts";
   private static final String PROP_STATES = "states";
-  private static final String PROP_TCP_FLAGS = "tcpFlags";
+  private static final String PROP_TCP_FLAGS_MATCH_CONDITIONS = "tcpFlagsMatchConditions";
   /** */
   private static final long serialVersionUID = 1L;
 
@@ -340,7 +340,7 @@ public class Header6Space implements Serializable {
     return _states;
   }
 
-  @JsonProperty(PROP_TCP_FLAGS)
+  @JsonProperty(PROP_TCP_FLAGS_MATCH_CONDITIONS)
   public List<TcpFlagsMatchConditions> getTcpFlags() {
     return _tcpFlags;
   }
@@ -548,7 +548,7 @@ public class Header6Space implements Serializable {
     _states = states;
   }
 
-  @JsonProperty(PROP_TCP_FLAGS)
+  @JsonProperty(PROP_TCP_FLAGS_MATCH_CONDITIONS)
   public void setTcpFlags(List<TcpFlagsMatchConditions> tcpFlags) {
     _tcpFlags = tcpFlags;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/HeaderSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/HeaderSpace.java
@@ -551,7 +551,7 @@ public class HeaderSpace implements Serializable, Comparable<HeaderSpace> {
 
   private static final String PROP_STATES = "states";
 
-  private static final String PROP_TCP_FLAGS = "tcpFlags";
+  private static final String PROP_TCP_FLAGS_MATCH_CONDITIONS = "tcpFlagsMatchConditions";
 
   /** */
   private static final long serialVersionUID = 1L;
@@ -921,7 +921,7 @@ public class HeaderSpace implements Serializable, Comparable<HeaderSpace> {
   }
 
   @JsonPropertyDescription("A set of acceptable TCP flag bitmasks for a TCP packet to match")
-  @JsonProperty(PROP_TCP_FLAGS)
+  @JsonProperty(PROP_TCP_FLAGS_MATCH_CONDITIONS)
   public List<TcpFlagsMatchConditions> getTcpFlags() {
     return _tcpFlags;
   }
@@ -1303,7 +1303,7 @@ public class HeaderSpace implements Serializable, Comparable<HeaderSpace> {
     _states = ImmutableSortedSet.copyOf(states);
   }
 
-  @JsonProperty(PROP_TCP_FLAGS)
+  @JsonProperty(PROP_TCP_FLAGS_MATCH_CONDITIONS)
   public void setTcpFlags(Iterable<TcpFlagsMatchConditions> tcpFlags) {
     _tcpFlags = ImmutableList.copyOf(tcpFlags);
   }
@@ -1379,7 +1379,7 @@ public class HeaderSpace implements Serializable, Comparable<HeaderSpace> {
         .add(PROP_SRC_PORTS, nullIfEmpty(_srcPorts))
         .add(PROP_SRC_PROTOCOLS, nullIfEmpty(_srcProtocols))
         .add(PROP_STATES, nullIfEmpty(_states))
-        .add(PROP_TCP_FLAGS, nullIfEmpty(_tcpFlags))
+        .add(PROP_TCP_FLAGS_MATCH_CONDITIONS, nullIfEmpty(_tcpFlags))
         .toString();
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/HeaderSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/HeaderSpace.java
@@ -86,7 +86,7 @@ public class HeaderSpace implements Serializable, Comparable<HeaderSpace> {
 
     private SortedSet<State> _states;
 
-    private List<TcpFlags> _tcpFlags;
+    private List<TcpFlagsMatchConditions> _tcpFlags;
 
     private Builder() {
       _dscps = ImmutableSortedSet.of();
@@ -265,7 +265,7 @@ public class HeaderSpace implements Serializable, Comparable<HeaderSpace> {
       return _states;
     }
 
-    public List<TcpFlags> getTcpFlags() {
+    public List<TcpFlagsMatchConditions> getTcpFlags() {
       return _tcpFlags;
     }
 
@@ -449,7 +449,7 @@ public class HeaderSpace implements Serializable, Comparable<HeaderSpace> {
       return this;
     }
 
-    public Builder setTcpFlags(Iterable<TcpFlags> tcpFlags) {
+    public Builder setTcpFlags(Iterable<TcpFlagsMatchConditions> tcpFlags) {
       _tcpFlags = ImmutableList.copyOf(tcpFlags);
       return this;
     }
@@ -622,7 +622,7 @@ public class HeaderSpace implements Serializable, Comparable<HeaderSpace> {
 
   private SortedSet<State> _states;
 
-  private List<TcpFlags> _tcpFlags;
+  private List<TcpFlagsMatchConditions> _tcpFlags;
 
   public HeaderSpace() {
     _dscps = Collections.emptySortedSet();
@@ -922,7 +922,7 @@ public class HeaderSpace implements Serializable, Comparable<HeaderSpace> {
 
   @JsonPropertyDescription("A set of acceptable TCP flag bitmasks for a TCP packet to match")
   @JsonProperty(PROP_TCP_FLAGS)
-  public List<TcpFlags> getTcpFlags() {
+  public List<TcpFlagsMatchConditions> getTcpFlags() {
     return _tcpFlags;
   }
 
@@ -1304,7 +1304,7 @@ public class HeaderSpace implements Serializable, Comparable<HeaderSpace> {
   }
 
   @JsonProperty(PROP_TCP_FLAGS)
-  public void setTcpFlags(Iterable<TcpFlags> tcpFlags) {
+  public void setTcpFlags(Iterable<TcpFlagsMatchConditions> tcpFlags) {
     _tcpFlags = ImmutableList.copyOf(tcpFlags);
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpProtocol.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpProtocol.java
@@ -2,10 +2,15 @@ package org.batfish.datamodel;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.google.common.collect.ImmutableMap;
-import java.util.Comparator;
 import java.util.Map;
 import org.batfish.common.BatfishException;
 
+/**
+ * List of known IP protocols corresponding to their number as assigned by the Internet Assigned
+ * Numbers Authority (IANA).
+ *
+ * <p>See https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
+ */
 public enum IpProtocol {
   AHP(51),
   AN(107),
@@ -57,6 +62,7 @@ public enum IpProtocol {
   IGMP(2),
   IGP(9),
   IL(40),
+  /** Denotes any IP protocol, not a value defined by IANA */
   IP(256),
   IPComp(108),
   IPCU(71),
@@ -264,9 +270,6 @@ public enum IpProtocol {
   XNET(15),
   XNS_IDP(22),
   XTP(36);
-
-  public static final Comparator<IpProtocol> BY_NUMBER =
-      (p1, p2) -> Integer.compare(p1.number(), p2.number());
 
   private static final Map<Integer, IpProtocol> NUMBER_TO_PROTOCOL_MAP = buildNumberToProtocolMap();
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/TcpFlags.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/TcpFlags.java
@@ -1,472 +1,206 @@
 package org.batfish.datamodel;
 
-import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import java.io.Serializable;
 import java.util.Comparator;
+import java.util.Objects;
+import javax.annotation.Nonnull;
 
+/** Collection of TCP flags. */
 public final class TcpFlags implements Serializable, Comparable<TcpFlags> {
 
-  public static class Builder {
-    private boolean _ack;
+  private static final String PROP_ACK = "ack";
+  private static final String PROP_CWR = "cwr";
+  private static final String PROP_ECE = "ece";
+  private static final String PROP_FIN = "fin";
+  private static final String PROP_PSH = "psh";
+  private static final String PROP_RST = "rst";
+  private static final String PROP_SYN = "syn";
+  private static final String PROP_URG = "urg";
 
-    private boolean _cwr;
+  private final boolean _ack;
+  private final boolean _cwr;
+  private final boolean _ece;
+  private final boolean _fin;
+  private final boolean _psh;
+  private final boolean _rst;
+  private final boolean _syn;
+  private final boolean _urg;
 
-    private boolean _ece;
-
-    private boolean _fin;
-
-    private boolean _psh;
-
-    private boolean _rst;
-
-    private boolean _syn;
-
-    private boolean _urg;
-
-    private boolean _useAck;
-
-    private boolean _useCwr;
-
-    private boolean _useEce;
-
-    private boolean _useFin;
-
-    private boolean _usePsh;
-
-    private boolean _useRst;
-
-    private boolean _useSyn;
-
-    private boolean _useUrg;
-
-    private Builder() {}
-
-    public TcpFlags build() {
-      return new TcpFlags(
-          _ack, _cwr, _ece, _fin, _psh, _rst, _syn, _urg, _useAck, _useCwr, _useEce, _useFin,
-          _usePsh, _useRst, _useSyn, _useUrg);
-    }
-
-    public Builder setAck(boolean ack) {
-      _ack = ack;
-      return this;
-    }
-
-    public Builder setCwr(boolean cwr) {
-      _cwr = cwr;
-      return this;
-    }
-
-    public Builder setEce(boolean ece) {
-      _ece = ece;
-      return this;
-    }
-
-    public Builder setFin(boolean fin) {
-      _fin = fin;
-      return this;
-    }
-
-    public Builder setPsh(boolean psh) {
-      _psh = psh;
-      return this;
-    }
-
-    public Builder setRst(boolean rst) {
-      _rst = rst;
-      return this;
-    }
-
-    public Builder setSyn(boolean syn) {
-      _syn = syn;
-      return this;
-    }
-
-    public Builder setUrg(boolean urg) {
-      _urg = urg;
-      return this;
-    }
-
-    public Builder setUseAck(boolean useAck) {
-      _useAck = useAck;
-      return this;
-    }
-
-    public Builder setUseCwr(boolean useCwr) {
-      _useCwr = useCwr;
-      return this;
-    }
-
-    public Builder setUseEce(boolean useEce) {
-      _useEce = useEce;
-      return this;
-    }
-
-    public Builder setUseFin(boolean useFin) {
-      _useFin = useFin;
-      return this;
-    }
-
-    public Builder setUsePsh(boolean usePsh) {
-      _usePsh = usePsh;
-      return this;
-    }
-
-    public Builder setUseRst(boolean useRst) {
-      _useRst = useRst;
-      return this;
-    }
-
-    public Builder setUseSyn(boolean useSyn) {
-      _useSyn = useSyn;
-      return this;
-    }
-
-    public Builder setUseUrg(boolean useUrg) {
-      _useUrg = useUrg;
-      return this;
-    }
-  }
-
-  public static final int ACK = 0x10;
-
-  public static final TcpFlags ACK_TCP_FLAG = builder().setAck(true).setUseAck(true).build();
-
-  private static final Comparator<TcpFlags> COMPARATOR =
-      Comparator.comparing(TcpFlags::getAck)
-          .thenComparing(TcpFlags::getCwr)
-          .thenComparing(TcpFlags::getEce)
-          .thenComparing(TcpFlags::getFin)
-          .thenComparing(TcpFlags::getPsh)
-          .thenComparing(TcpFlags::getRst)
-          .thenComparing(TcpFlags::getSyn)
-          .thenComparing(TcpFlags::getUrg)
-          .thenComparing(TcpFlags::getUseAck)
-          .thenComparing(TcpFlags::getUseCwr)
-          .thenComparing(TcpFlags::getUseEce)
-          .thenComparing(TcpFlags::getUseFin)
-          .thenComparing(TcpFlags::getUsePsh)
-          .thenComparing(TcpFlags::getUseRst)
-          .thenComparing(TcpFlags::getUseSyn)
-          .thenComparing(TcpFlags::getUseUrg);
-
-  public static final int CWR = 0x80;
-
-  public static final int ECE = 0x40;
-
-  public static final int FIN = 0x01;
-
-  public static final int PSH = 0x08;
-
-  public static final int RST = 0x04;
-
-  /** */
   private static final long serialVersionUID = 1L;
 
-  public static final int SYN = 0x02;
+  @JsonCreator
+  public TcpFlags(
+      @JsonProperty(PROP_ACK) boolean ack,
+      @JsonProperty(PROP_CWR) boolean cwr,
+      @JsonProperty(PROP_ECE) boolean ece,
+      @JsonProperty(PROP_FIN) boolean fin,
+      @JsonProperty(PROP_PSH) boolean psh,
+      @JsonProperty(PROP_RST) boolean rst,
+      @JsonProperty(PROP_SYN) boolean syn,
+      @JsonProperty(PROP_URG) boolean urg) {
+    _ack = ack;
+    _cwr = cwr;
+    _ece = ece;
+    _fin = fin;
+    _psh = psh;
+    _rst = rst;
+    _syn = syn;
+    _urg = urg;
+  }
 
-  public static final int URG = 0x20;
+  @Override
+  public int compareTo(@Nonnull TcpFlags o) {
+    return Comparator.comparing(TcpFlags::getAck)
+        .thenComparing(TcpFlags::getCwr)
+        .thenComparing(TcpFlags::getEce)
+        .thenComparing(TcpFlags::getFin)
+        .thenComparing(TcpFlags::getPsh)
+        .thenComparing(TcpFlags::getRst)
+        .thenComparing(TcpFlags::getUrg)
+        .thenComparing(TcpFlags::getSyn)
+        .compare(this, o);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof TcpFlags)) {
+      return false;
+    }
+    TcpFlags tcpFlags = (TcpFlags) o;
+    return _ack == tcpFlags._ack
+        && _cwr == tcpFlags._cwr
+        && _ece == tcpFlags._ece
+        && _fin == tcpFlags._fin
+        && _psh == tcpFlags._psh
+        && _rst == tcpFlags._rst
+        && _syn == tcpFlags._syn
+        && _urg == tcpFlags._urg;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_ack, _cwr, _ece, _fin, _psh, _rst, _syn, _urg);
+  }
+
+  @JsonProperty(PROP_ACK)
+  public boolean getAck() {
+    return _ack;
+  }
+
+  @JsonProperty(PROP_CWR)
+  public boolean getCwr() {
+    return _cwr;
+  }
+
+  @JsonProperty(PROP_ECE)
+  public boolean getEce() {
+    return _ece;
+  }
+
+  @JsonProperty(PROP_FIN)
+  public boolean getFin() {
+    return _fin;
+  }
+
+  @JsonProperty(PROP_PSH)
+  public boolean getPsh() {
+    return _psh;
+  }
+
+  @JsonProperty(PROP_RST)
+  public boolean getRst() {
+    return _rst;
+  }
+
+  @JsonProperty(PROP_SYN)
+  public boolean getSyn() {
+    return _syn;
+  }
+
+  @JsonProperty(PROP_URG)
+  public boolean getUrg() {
+    return _urg;
+  }
 
   public static Builder builder() {
     return new Builder();
   }
 
-  private boolean _ack;
+  /** Builder for {@link TcpFlags} */
+  public static final class Builder {
+    private boolean _ack;
+    private boolean _cwr;
+    private boolean _ece;
+    private boolean _fin;
+    private boolean _psh;
+    private boolean _rst;
+    private boolean _syn;
+    private boolean _urg;
 
-  private boolean _cwr;
+    private Builder() {}
 
-  private boolean _ece;
-
-  private boolean _fin;
-
-  private boolean _psh;
-
-  private boolean _rst;
-
-  private boolean _syn;
-
-  private boolean _urg;
-
-  private boolean _useAck;
-
-  private boolean _useCwr;
-
-  private boolean _useEce;
-
-  private boolean _useFin;
-
-  private boolean _usePsh;
-
-  private boolean _useRst;
-
-  private boolean _useSyn;
-
-  private boolean _useUrg;
-
-  public TcpFlags() {}
-
-  private TcpFlags(
-      boolean ack,
-      boolean cwr,
-      boolean ece,
-      boolean fin,
-      boolean psh,
-      boolean rst,
-      boolean syn,
-      boolean urg,
-      boolean useAck,
-      boolean useCwr,
-      boolean useEce,
-      boolean useFin,
-      boolean usePsh,
-      boolean useRst,
-      boolean useSyn,
-      boolean useUrg) {
-    _ack = ack;
-    _cwr = cwr;
-    _ece = ece;
-    _fin = fin;
-    _psh = psh;
-    _rst = rst;
-    _syn = syn;
-    _urg = urg;
-    _useAck = useAck;
-    _useCwr = useCwr;
-    _useEce = useEce;
-    _useFin = useFin;
-    _usePsh = usePsh;
-    _useRst = useRst;
-    _useSyn = useSyn;
-    _useUrg = useUrg;
-  }
-
-  public boolean anyUsed() {
-    return _useAck || _useCwr || _useEce || _useFin || _usePsh || _useRst || _useSyn || _useUrg;
-  }
-
-  @Override
-  public int compareTo(TcpFlags o) {
-    return COMPARATOR.compare(this, o);
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    } else if (!(obj instanceof TcpFlags)) {
-      return false;
+    public Builder setAck(boolean ack) {
+      this._ack = ack;
+      return this;
     }
-    TcpFlags other = (TcpFlags) obj;
-    return other.toString().equals(this.toString());
-  }
 
-  @JsonPropertyDescription("Value for ACK bit if used (true->1/false->0)")
-  public boolean getAck() {
-    return _ack;
-  }
+    public Builder setCwr(boolean cwr) {
+      this._cwr = cwr;
+      return this;
+    }
 
-  @JsonPropertyDescription("Value for CWR bit if used (true->1/false->0)")
-  public boolean getCwr() {
-    return _cwr;
-  }
+    public Builder setEce(boolean ece) {
+      this._ece = ece;
+      return this;
+    }
 
-  @JsonPropertyDescription("Value for ECE bit if used (true->1/false->0)")
-  public boolean getEce() {
-    return _ece;
-  }
+    public Builder setFin(boolean fin) {
+      this._fin = fin;
+      return this;
+    }
 
-  @JsonPropertyDescription("Value for FIN bit if used (true->1/false->0)")
-  public boolean getFin() {
-    return _fin;
-  }
+    public Builder setPsh(boolean psh) {
+      this._psh = psh;
+      return this;
+    }
 
-  @JsonPropertyDescription("Value for PSH bit if used (true->1/false->0)")
-  public boolean getPsh() {
-    return _psh;
-  }
+    public Builder setRst(boolean rst) {
+      this._rst = rst;
+      return this;
+    }
 
-  @JsonPropertyDescription("Value for RST bit if used (true->1/false->0)")
-  public boolean getRst() {
-    return _rst;
-  }
+    public Builder setSyn(boolean syn) {
+      this._syn = syn;
+      return this;
+    }
 
-  @JsonPropertyDescription("Value for SYN bit if used (true->1/false->0)")
-  public boolean getSyn() {
-    return _syn;
-  }
+    public Builder setUrg(boolean urg) {
+      this._urg = urg;
+      return this;
+    }
 
-  @JsonPropertyDescription("Value for URG bit if used (true->1/false->0)")
-  public boolean getUrg() {
-    return _urg;
-  }
-
-  @JsonPropertyDescription("Whether or not to match against the ACK bit")
-  public boolean getUseAck() {
-    return _useAck;
-  }
-
-  @JsonPropertyDescription("Whether or not to match against the CWR bit")
-  public boolean getUseCwr() {
-    return _useCwr;
-  }
-
-  @JsonPropertyDescription("Whether or not to match against the ECE bit")
-  public boolean getUseEce() {
-    return _useEce;
-  }
-
-  @JsonPropertyDescription("Whether or not to match against the FIN bit")
-  public boolean getUseFin() {
-    return _useFin;
-  }
-
-  @JsonPropertyDescription("Whether or not to match against the PSH bit")
-  public boolean getUsePsh() {
-    return _usePsh;
-  }
-
-  @JsonPropertyDescription("Whether or not to match against the RST bit")
-  public boolean getUseRst() {
-    return _useRst;
-  }
-
-  @JsonPropertyDescription("Whether or not to match against the SYN bit")
-  public boolean getUseSyn() {
-    return _useSyn;
-  }
-
-  @JsonPropertyDescription("Whether or not to match against the URG bit")
-  public boolean getUseUrg() {
-    return _useUrg;
-  }
-
-  @Override
-  public int hashCode() {
-    // TODO: implement better hashcode
-    return 0;
-  }
-
-  /**
-   * Returns {@code true} iff the TCP flags used in this object (configured via e.g. {@link
-   * #setUseAck}) match the TCP flags in the given {@link Flow}.
-   *
-   * <p>Note this function will return {@code true} if no bits are used.
-   */
-  public boolean match(Flow flow) {
-    return !(_useAck && _ack ^ (flow.getTcpFlagsAck() == 1))
-        && !(_useCwr && _cwr ^ (flow.getTcpFlagsCwr() == 1))
-        && !(_useEce && _ece ^ (flow.getTcpFlagsEce() == 1))
-        && !(_useFin && _fin ^ (flow.getTcpFlagsFin() == 1))
-        && !(_usePsh && _psh ^ (flow.getTcpFlagsPsh() == 1))
-        && !(_useRst && _rst ^ (flow.getTcpFlagsRst() == 1))
-        && !(_useSyn && _syn ^ (flow.getTcpFlagsSyn() == 1))
-        && !(_useUrg && _urg ^ (flow.getTcpFlagsUrg() == 1));
-  }
-
-  /**
-   * Returns {@code true} iff the TCP flags used in this object (configured via e.g. {@link
-   * #setUseAck}) match the TCP flags in the given {@link Flow6}.
-   *
-   * <p>Note this function will return {@code true} if no bits are used.
-   */
-  public boolean match(Flow6 flow6) {
-    return !(_useAck && _ack ^ (flow6.getTcpFlagsAck() == 1))
-        && !(_useCwr && _cwr ^ (flow6.getTcpFlagsCwr() == 1))
-        && !(_useEce && _ece ^ (flow6.getTcpFlagsEce() == 1))
-        && !(_useFin && _fin ^ (flow6.getTcpFlagsFin() == 1))
-        && !(_usePsh && _psh ^ (flow6.getTcpFlagsPsh() == 1))
-        && !(_useRst && _rst ^ (flow6.getTcpFlagsRst() == 1))
-        && !(_useSyn && _syn ^ (flow6.getTcpFlagsSyn() == 1))
-        && !(_useUrg && _urg ^ (flow6.getTcpFlagsUrg() == 1));
-  }
-
-  public void setAck(boolean ack) {
-    _ack = ack;
-  }
-
-  public void setCwr(boolean cwr) {
-    _cwr = cwr;
-  }
-
-  public void setEce(boolean ece) {
-    _ece = ece;
-  }
-
-  public void setFin(boolean fin) {
-    _fin = fin;
-  }
-
-  public void setPsh(boolean psh) {
-    _psh = psh;
-  }
-
-  public void setRst(boolean rst) {
-    _rst = rst;
-  }
-
-  public void setSyn(boolean syn) {
-    _syn = syn;
-  }
-
-  public void setUrg(boolean urg) {
-    _urg = urg;
-  }
-
-  public void setUseAck(boolean useAck) {
-    _useAck = useAck;
-  }
-
-  public void setUseCwr(boolean useCwr) {
-    _useCwr = useCwr;
-  }
-
-  public void setUseEce(boolean useEce) {
-    _useEce = useEce;
-  }
-
-  public void setUseFin(boolean useFin) {
-    _useFin = useFin;
-  }
-
-  public void setUsePsh(boolean usePsh) {
-    _usePsh = usePsh;
-  }
-
-  public void setUseRst(boolean useRst) {
-    _useRst = useRst;
-  }
-
-  public void setUseSyn(boolean useSyn) {
-    _useSyn = useSyn;
-  }
-
-  public void setUseUrg(boolean useUrg) {
-    _useUrg = useUrg;
+    public TcpFlags build() {
+      return new TcpFlags(_ack, _cwr, _ece, _fin, _psh, _rst, _syn, _urg);
+    }
   }
 
   @Override
   public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append(toString(_cwr, _useCwr));
-    sb.append(toString(_ece, _useEce));
-    sb.append(toString(_urg, _useUrg));
-    sb.append(toString(_ack, _useAck));
-    sb.append(toString(_psh, _usePsh));
-    sb.append(toString(_rst, _useRst));
-    sb.append(toString(_syn, _useSyn));
-    sb.append(toString(_fin, _useFin));
-    return sb.toString();
-  }
-
-  private String toString(boolean bit, boolean useBit) {
-    if (useBit) {
-      if (bit) {
-        return "1";
-      } else {
-        return "0";
-      }
-    } else {
-      return "x";
-    }
+    return MoreObjects.toStringHelper(this)
+        .add("_ack", _ack)
+        .add("_cwr", _cwr)
+        .add("_ece", _ece)
+        .add("_fin", _fin)
+        .add("_psh", _psh)
+        .add("_rst", _rst)
+        .add("_syn", _syn)
+        .add("_urg", _urg)
+        .toString();
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/TcpFlagsMatchConditions.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/TcpFlagsMatchConditions.java
@@ -14,14 +14,14 @@ public final class TcpFlagsMatchConditions
     implements Serializable, Comparable<TcpFlagsMatchConditions> {
 
   private static final String PROP_TCP_FLAGS = "tcpFlags";
-  private static final String PROP_USE_ACK = "ack";
-  private static final String PROP_USE_CWR = "cwr";
-  private static final String PROP_USE_ECE = "ece";
-  private static final String PROP_USE_FIN = "fin";
-  private static final String PROP_USE_PSH = "psh";
-  private static final String PROP_USE_RST = "rst";
-  private static final String PROP_USE_SYN = "syn";
-  private static final String PROP_USE_URG = "urg";
+  private static final String PROP_USE_ACK = "useAck";
+  private static final String PROP_USE_CWR = "useCwr";
+  private static final String PROP_USE_ECE = "useEce";
+  private static final String PROP_USE_FIN = "useFin";
+  private static final String PROP_USE_PSH = "usePsh";
+  private static final String PROP_USE_RST = "useRst";
+  private static final String PROP_USE_SYN = "useSyn";
+  private static final String PROP_USE_URG = "useUrg";
 
   private final TcpFlags _tcpFlags;
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/TcpFlagsMatchConditions.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/TcpFlagsMatchConditions.java
@@ -1,0 +1,289 @@
+package org.batfish.datamodel;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import java.io.Serializable;
+import java.util.Comparator;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+
+/** Allows matching flows with specified TCP flags */
+public final class TcpFlagsMatchConditions
+    implements Serializable, Comparable<TcpFlagsMatchConditions> {
+
+  private static final String PROP_TCP_FLAGS = "tcpFlags";
+  private static final String PROP_USE_ACK = "ack";
+  private static final String PROP_USE_CWR = "cwr";
+  private static final String PROP_USE_ECE = "ece";
+  private static final String PROP_USE_FIN = "fin";
+  private static final String PROP_USE_PSH = "psh";
+  private static final String PROP_USE_RST = "rst";
+  private static final String PROP_USE_SYN = "syn";
+  private static final String PROP_USE_URG = "urg";
+
+  private final TcpFlags _tcpFlags;
+
+  /** Builder for {@link TcpFlags} */
+  public static class Builder {
+    private TcpFlags _tcpFlags;
+
+    private boolean _useAck;
+
+    private boolean _useCwr;
+
+    private boolean _useEce;
+
+    private boolean _useFin;
+
+    private boolean _usePsh;
+
+    private boolean _useRst;
+
+    private boolean _useSyn;
+
+    private boolean _useUrg;
+
+    private Builder() {}
+
+    public TcpFlagsMatchConditions build() {
+      return new TcpFlagsMatchConditions(
+          _tcpFlags, _useAck, _useCwr, _useEce, _useFin, _usePsh, _useRst, _useSyn, _useUrg);
+    }
+
+    public Builder setTcpFlags(@Nonnull TcpFlags tcpFlags) {
+      _tcpFlags = tcpFlags;
+      return this;
+    }
+
+    public Builder setUseAck(boolean useAck) {
+      _useAck = useAck;
+      return this;
+    }
+
+    public Builder setUseCwr(boolean useCwr) {
+      _useCwr = useCwr;
+      return this;
+    }
+
+    public Builder setUseEce(boolean useEce) {
+      _useEce = useEce;
+      return this;
+    }
+
+    public Builder setUseFin(boolean useFin) {
+      _useFin = useFin;
+      return this;
+    }
+
+    public Builder setUsePsh(boolean usePsh) {
+      _usePsh = usePsh;
+      return this;
+    }
+
+    public Builder setUseRst(boolean useRst) {
+      _useRst = useRst;
+      return this;
+    }
+
+    public Builder setUseSyn(boolean useSyn) {
+      _useSyn = useSyn;
+      return this;
+    }
+
+    public Builder setUseUrg(boolean useUrg) {
+      _useUrg = useUrg;
+      return this;
+    }
+  }
+
+  /** Shorthand for match conditions for a ACK (acknowledgement) packet */
+  public static final TcpFlagsMatchConditions ACK_TCP_FLAG =
+      builder().setTcpFlags(TcpFlags.builder().setAck(true).build()).setUseAck(true).build();
+
+  private static final Comparator<TcpFlagsMatchConditions> COMPARATOR =
+      Comparator.comparing(TcpFlagsMatchConditions::getTcpFlags)
+          .thenComparing(TcpFlagsMatchConditions::getUseAck)
+          .thenComparing(TcpFlagsMatchConditions::getUseCwr)
+          .thenComparing(TcpFlagsMatchConditions::getUseEce)
+          .thenComparing(TcpFlagsMatchConditions::getUseFin)
+          .thenComparing(TcpFlagsMatchConditions::getUsePsh)
+          .thenComparing(TcpFlagsMatchConditions::getUseRst)
+          .thenComparing(TcpFlagsMatchConditions::getUseSyn)
+          .thenComparing(TcpFlagsMatchConditions::getUseUrg);
+
+  private static final long serialVersionUID = 1L;
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  private final boolean _useAck;
+
+  private final boolean _useCwr;
+
+  private final boolean _useEce;
+
+  private final boolean _useFin;
+
+  private final boolean _usePsh;
+
+  private final boolean _useRst;
+
+  private final boolean _useSyn;
+
+  private final boolean _useUrg;
+
+  private TcpFlagsMatchConditions(
+      @JsonProperty(PROP_TCP_FLAGS) TcpFlags tcpFlags,
+      @JsonProperty(PROP_USE_ACK) boolean useAck,
+      @JsonProperty(PROP_USE_CWR) boolean useCwr,
+      @JsonProperty(PROP_USE_ECE) boolean useEce,
+      @JsonProperty(PROP_USE_FIN) boolean useFin,
+      @JsonProperty(PROP_USE_PSH) boolean usePsh,
+      @JsonProperty(PROP_USE_RST) boolean useRst,
+      @JsonProperty(PROP_USE_SYN) boolean useSyn,
+      @JsonProperty(PROP_USE_URG) boolean useUrg) {
+    _tcpFlags = firstNonNull(tcpFlags, TcpFlags.builder().build());
+    _useAck = useAck;
+    _useCwr = useCwr;
+    _useEce = useEce;
+    _useFin = useFin;
+    _usePsh = usePsh;
+    _useRst = useRst;
+    _useSyn = useSyn;
+    _useUrg = useUrg;
+  }
+
+  /** Check if any flags are using for matching */
+  public boolean anyUsed() {
+    return _useAck || _useCwr || _useEce || _useFin || _usePsh || _useRst || _useSyn || _useUrg;
+  }
+
+  @Override
+  public int compareTo(TcpFlagsMatchConditions o) {
+    return COMPARATOR.compare(this, o);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof TcpFlagsMatchConditions)) {
+      return false;
+    }
+    TcpFlagsMatchConditions other = (TcpFlagsMatchConditions) o;
+    return Objects.equals(_tcpFlags, other._tcpFlags)
+        && _useAck == other._useAck
+        && _useCwr == other._useCwr
+        && _useEce == other._useEce
+        && _useFin == other._useFin
+        && _usePsh == other._usePsh
+        && _useRst == other._useRst
+        && _useSyn == other._useSyn
+        && _useUrg == other._useUrg;
+  }
+
+  @JsonProperty(PROP_TCP_FLAGS)
+  @Nonnull
+  public TcpFlags getTcpFlags() {
+    return _tcpFlags;
+  }
+
+  @JsonProperty(PROP_USE_ACK)
+  public boolean getUseAck() {
+    return _useAck;
+  }
+
+  @JsonProperty(PROP_USE_CWR)
+  public boolean getUseCwr() {
+    return _useCwr;
+  }
+
+  @JsonProperty(PROP_USE_ECE)
+  public boolean getUseEce() {
+    return _useEce;
+  }
+
+  @JsonProperty(PROP_USE_FIN)
+  public boolean getUseFin() {
+    return _useFin;
+  }
+
+  @JsonProperty(PROP_USE_PSH)
+  public boolean getUsePsh() {
+    return _usePsh;
+  }
+
+  @JsonProperty(PROP_USE_RST)
+  public boolean getUseRst() {
+    return _useRst;
+  }
+
+  @JsonProperty(PROP_USE_SYN)
+  public boolean getUseSyn() {
+    return _useSyn;
+  }
+
+  @JsonProperty(PROP_USE_URG)
+  public boolean getUseUrg() {
+    return _useUrg;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        _tcpFlags, _useAck, _useCwr, _useEce, _useFin, _usePsh, _useRst, _useSyn, _useUrg);
+  }
+
+  /**
+   * Returns {@code true} iff the TCP flags for which matching is enabled match the TCP flags in the
+   * given {@link Flow}.
+   *
+   * <p>Note this function will return {@code true} if no bits are used.
+   */
+  public boolean match(Flow flow) {
+    return !(_useAck && _tcpFlags.getAck() ^ (flow.getTcpFlagsAck() == 1))
+        && !(_useCwr && _tcpFlags.getCwr() ^ (flow.getTcpFlagsCwr() == 1))
+        && !(_useEce && _tcpFlags.getEce() ^ (flow.getTcpFlagsEce() == 1))
+        && !(_useFin && _tcpFlags.getFin() ^ (flow.getTcpFlagsFin() == 1))
+        && !(_usePsh && _tcpFlags.getPsh() ^ (flow.getTcpFlagsPsh() == 1))
+        && !(_useRst && _tcpFlags.getRst() ^ (flow.getTcpFlagsRst() == 1))
+        && !(_useSyn && _tcpFlags.getSyn() ^ (flow.getTcpFlagsSyn() == 1))
+        && !(_useUrg && _tcpFlags.getUrg() ^ (flow.getTcpFlagsUrg() == 1));
+  }
+
+  /**
+   * Returns {@code true} iff the TCP flags used for which matching is enabled match the TCP flags
+   * in the given {@link Flow6}.
+   *
+   * <p>Note this function will return {@code true} if no bits are used.
+   */
+  public boolean match(Flow6 flow6) {
+    return !(_useAck && _tcpFlags.getAck() ^ (flow6.getTcpFlagsAck() == 1))
+        && !(_useCwr && _tcpFlags.getCwr() ^ (flow6.getTcpFlagsCwr() == 1))
+        && !(_useEce && _tcpFlags.getEce() ^ (flow6.getTcpFlagsEce() == 1))
+        && !(_useFin && _tcpFlags.getFin() ^ (flow6.getTcpFlagsFin() == 1))
+        && !(_usePsh && _tcpFlags.getPsh() ^ (flow6.getTcpFlagsPsh() == 1))
+        && !(_useRst && _tcpFlags.getRst() ^ (flow6.getTcpFlagsRst() == 1))
+        && !(_useSyn && _tcpFlags.getSyn() ^ (flow6.getTcpFlagsSyn() == 1))
+        && !(_useUrg && _tcpFlags.getUrg() ^ (flow6.getTcpFlagsUrg() == 1));
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("_tcpFlags", _tcpFlags)
+        .add("_useAck", _useAck)
+        .add("_useCwr", _useCwr)
+        .add("_useEce", _useEce)
+        .add("_useFin", _useFin)
+        .add("_usePsh", _usePsh)
+        .add("_useRst", _useRst)
+        .add("_useSyn", _useSyn)
+        .add("_useUrg", _useUrg)
+        .toString();
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/TcpFlagsMatchConditionsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/TcpFlagsMatchConditionsTest.java
@@ -1,0 +1,83 @@
+package org.batfish.datamodel;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests of {@link org.batfish.datamodel.TcpFlagsMatchConditions} */
+@RunWith(JUnit4.class)
+public class TcpFlagsMatchConditionsTest {
+
+  @Test
+  public void testEquals() {
+    TcpFlags flags1 = TcpFlags.builder().setUrg(true).setRst(true).build();
+    TcpFlags flags2 = TcpFlags.builder().setUrg(false).setRst(true).build();
+    new EqualsTester()
+        .addEqualityGroup(
+            TcpFlagsMatchConditions.builder().setTcpFlags(flags1).setUseUrg(true).build(),
+            TcpFlagsMatchConditions.builder().setTcpFlags(flags1).setUseUrg(true).build())
+        .addEqualityGroup(
+            TcpFlagsMatchConditions.builder().setTcpFlags(flags2).setUseUrg(true).build())
+        .addEqualityGroup(
+            TcpFlagsMatchConditions.builder().setTcpFlags(flags1).setUseUrg(false).build())
+        .testEquals();
+  }
+
+  @Test
+  public void testMatchFlow() {
+    TcpFlags flags = TcpFlags.builder().setUrg(true).setRst(true).build();
+    TcpFlagsMatchConditions conditions =
+        TcpFlagsMatchConditions.builder().setTcpFlags(flags).setUseUrg(true).build();
+    assertThat(
+        conditions.match(Flow.builder().setTcpFlagsUrg(1).setIngressNode("n").setTag("t").build()),
+        equalTo(true));
+    assertThat(
+        conditions.match(Flow.builder().setTcpFlagsUrg(0).setIngressNode("n").setTag("t").build()),
+        equalTo(false));
+  }
+
+  @Test
+  public void testMatchFlowIgnoreFields() {
+    TcpFlags flags = TcpFlags.builder().setUrg(true).setRst(true).build();
+    // All fields ignored by default
+    TcpFlagsMatchConditions conditions =
+        TcpFlagsMatchConditions.builder().setTcpFlags(flags).build();
+    assertThat(
+        conditions.match(Flow.builder().setTcpFlagsUrg(1).setIngressNode("n").setTag("t").build()),
+        equalTo(true));
+    // Fields that do not match, but are ignored do not break match
+    conditions =
+        TcpFlagsMatchConditions.builder()
+            .setTcpFlags(flags)
+            .setUseUrg(false)
+            .setUseRst(true)
+            .build();
+    assertThat(
+        conditions.match(
+            Flow.builder()
+                .setTcpFlagsUrg(0)
+                .setTcpFlagsRst(1)
+                .setIngressNode("n")
+                .setTag("t")
+                .build()),
+        equalTo(true));
+  }
+
+  @Test
+  public void testBuilderDefaults() {
+    TcpFlagsMatchConditions conditions = TcpFlagsMatchConditions.builder().build();
+    assertThat(conditions.getTcpFlags(), equalTo(TcpFlags.builder().build()));
+    assertThat(conditions.getUseAck(), equalTo(false));
+    assertThat(conditions.getUseCwr(), equalTo(false));
+    assertThat(conditions.getUseEce(), equalTo(false));
+    assertThat(conditions.getUseFin(), equalTo(false));
+    assertThat(conditions.getUsePsh(), equalTo(false));
+    assertThat(conditions.getUseRst(), equalTo(false));
+    assertThat(conditions.getUseSyn(), equalTo(false));
+    assertThat(conditions.getUseUrg(), equalTo(false));
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/TcpFlagsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/TcpFlagsTest.java
@@ -1,0 +1,35 @@
+package org.batfish.datamodel;
+
+import com.google.common.testing.EqualsTester;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests of {@link org.batfish.datamodel.TcpFlags} */
+@RunWith(JUnit4.class)
+public class TcpFlagsTest {
+  @Test
+  public void testEquality() {
+    new EqualsTester()
+        .addEqualityGroup(
+            TcpFlags.builder().setAck(true).setRst(true).build(),
+            TcpFlags.builder().setAck(true).setRst(true).build())
+        .addEqualityGroup(
+            TcpFlags.builder().setFin(true).setUrg(false).build(),
+            TcpFlags.builder().setFin(true).setUrg(false).build())
+        .testEquals();
+  }
+
+  @Test
+  public void testBuilderDefaults() {
+    TcpFlags flags = TcpFlags.builder().build();
+    assertThat(flags.getAck(), equalTo(false));
+    assertThat(flags.getCwr(), equalTo(false));
+    assertThat(flags.getEce(), equalTo(false));
+    assertThat(flags.getFin(), equalTo(false));
+    assertThat(flags.getPsh(), equalTo(false));
+    assertThat(flags.getRst(), equalTo(false));
+    assertThat(flags.getSyn(), equalTo(false));
+    assertThat(flags.getUrg(), equalTo(false));
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/TcpFlagsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/TcpFlagsTest.java
@@ -1,5 +1,8 @@
 package org.batfish.datamodel;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
 import com.google.common.testing.EqualsTester;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/projects/batfish/src/main/java/org/batfish/dataplane/TracerouteEngineImpl.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/TracerouteEngineImpl.java
@@ -9,6 +9,7 @@ import org.batfish.datamodel.Fib;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowTrace;
 
+/** The default implementation of a traceroute engine */
 public class TracerouteEngineImpl implements ITracerouteEngine {
   private static ITracerouteEngine _instance = new TracerouteEngineImpl();
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -302,6 +302,7 @@ import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.SwitchportEncapsulationType;
 import org.batfish.datamodel.SwitchportMode;
 import org.batfish.datamodel.TcpFlags;
+import org.batfish.datamodel.TcpFlagsMatchConditions;
 import org.batfish.datamodel.eigrp.EigrpMetric;
 import org.batfish.datamodel.eigrp.EigrpProcessMode;
 import org.batfish.datamodel.isis.IsisInterfaceMode;
@@ -4801,26 +4802,28 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
           ctx.alps_dst != null ? toPortRanges(ctx.alps_dst) : Collections.emptyList();
       Integer icmpType = null;
       Integer icmpCode = null;
-      List<TcpFlags> tcpFlags = new ArrayList<>();
+      List<TcpFlagsMatchConditions> tcpFlags = new ArrayList<>();
       Set<Integer> dscps = new TreeSet<>();
       Set<Integer> ecns = new TreeSet<>();
       Set<State> states = EnumSet.noneOf(State.class);
       for (Extended_access_list_additional_featureContext feature : ctx.features) {
         if (feature.ACK() != null) {
-          TcpFlags alt = new TcpFlags();
-          alt.setUseAck(true);
-          alt.setAck(true);
-          tcpFlags.add(alt);
+          tcpFlags.add(
+              TcpFlagsMatchConditions.builder()
+                  .setTcpFlags(TcpFlags.builder().setAck(true).build())
+                  .setUseAck(true)
+                  .build());
         }
         if (feature.DSCP() != null) {
           int dscpType = toDscpType(feature.dscp_type());
           dscps.add(dscpType);
         }
         if (feature.ECE() != null) {
-          TcpFlags alt = new TcpFlags();
-          alt.setUseEce(true);
-          alt.setEce(true);
-          tcpFlags.add(alt);
+          tcpFlags.add(
+              TcpFlagsMatchConditions.builder()
+                  .setTcpFlags(TcpFlags.builder().setEce(true).build())
+                  .setUseEce(true)
+                  .build());
         }
         if (feature.ECHO_REPLY() != null) {
           icmpType = IcmpType.ECHO_REPLY;
@@ -4836,20 +4839,23 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
         }
         if (feature.ESTABLISHED() != null) {
           // must contain ACK or RST
-          TcpFlags alt1 = new TcpFlags();
-          TcpFlags alt2 = new TcpFlags();
-          alt1.setUseAck(true);
-          alt1.setAck(true);
-          alt2.setUseRst(true);
-          alt2.setRst(true);
-          tcpFlags.add(alt1);
-          tcpFlags.add(alt2);
+          tcpFlags.add(
+              TcpFlagsMatchConditions.builder()
+                  .setTcpFlags(TcpFlags.builder().setAck(true).build())
+                  .setUseAck(true)
+                  .build());
+          tcpFlags.add(
+              TcpFlagsMatchConditions.builder()
+                  .setTcpFlags(TcpFlags.builder().setRst(true).build())
+                  .setUseRst(true)
+                  .build());
         }
         if (feature.FIN() != null) {
-          TcpFlags alt = new TcpFlags();
-          alt.setUseFin(true);
-          alt.setFin(true);
-          tcpFlags.add(alt);
+          tcpFlags.add(
+              TcpFlagsMatchConditions.builder()
+                  .setTcpFlags(TcpFlags.builder().setFin(true).build())
+                  .setUseFin(true)
+                  .build());
         }
         if (feature.FRAGMENTS() != null) {
           _w.addWarning(
@@ -4884,29 +4890,32 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
           icmpCode = IcmpCode.DESTINATION_PORT_UNREACHABLE;
         }
         if (feature.PSH() != null) {
-          TcpFlags alt = new TcpFlags();
-          alt.setUsePsh(true);
-          alt.setPsh(true);
-          tcpFlags.add(alt);
+          tcpFlags.add(
+              TcpFlagsMatchConditions.builder()
+                  .setTcpFlags(TcpFlags.builder().setPsh(true).build())
+                  .setUsePsh(true)
+                  .build());
         }
         if (feature.REDIRECT() != null) {
           icmpType = IcmpType.REDIRECT_MESSAGE;
         }
         if (feature.RST() != null) {
-          TcpFlags alt = new TcpFlags();
-          alt.setUseRst(true);
-          alt.setRst(true);
-          tcpFlags.add(alt);
+          tcpFlags.add(
+              TcpFlagsMatchConditions.builder()
+                  .setTcpFlags(TcpFlags.builder().setRst(true).build())
+                  .setUseRst(true)
+                  .build());
         }
         if (feature.SOURCE_QUENCH() != null) {
           icmpType = IcmpType.SOURCE_QUENCH;
           icmpCode = IcmpCode.SOURCE_QUENCH;
         }
         if (feature.SYN() != null) {
-          TcpFlags alt = new TcpFlags();
-          alt.setUseSyn(true);
-          alt.setSyn(true);
-          tcpFlags.add(alt);
+          tcpFlags.add(
+              TcpFlagsMatchConditions.builder()
+                  .setTcpFlags(TcpFlags.builder().setSyn(true).build())
+                  .setUseSyn(true)
+                  .build());
         }
         if (feature.TIME_EXCEEDED() != null) {
           icmpType = IcmpType.TIME_EXCEEDED;
@@ -4930,10 +4939,11 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
           icmpType = IcmpType.DESTINATION_UNREACHABLE;
         }
         if (feature.URG() != null) {
-          TcpFlags alt = new TcpFlags();
-          alt.setUseUrg(true);
-          alt.setUrg(true);
-          tcpFlags.add(alt);
+          tcpFlags.add(
+              TcpFlagsMatchConditions.builder()
+                  .setTcpFlags(TcpFlags.builder().setUrg(true).build())
+                  .setUseUrg(true)
+                  .build());
         }
       }
       return SimpleExtendedAccessListServiceSpecifier.builder()
@@ -5021,26 +5031,28 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
         ctx.alps_dst != null ? toPortRanges(ctx.alps_dst) : Collections.emptyList();
     Integer icmpType = null;
     Integer icmpCode = null;
-    List<TcpFlags> tcpFlags = new ArrayList<>();
+    List<TcpFlagsMatchConditions> tcpFlags = new ArrayList<>();
     Set<Integer> dscps = new TreeSet<>();
     Set<Integer> ecns = new TreeSet<>();
     Set<State> states = EnumSet.noneOf(State.class);
     for (Extended_access_list_additional_featureContext feature : ctx.features) {
       if (feature.ACK() != null) {
-        TcpFlags alt = new TcpFlags();
-        alt.setUseAck(true);
-        alt.setAck(true);
-        tcpFlags.add(alt);
+        tcpFlags.add(
+            TcpFlagsMatchConditions.builder()
+                .setTcpFlags(TcpFlags.builder().setAck(true).build())
+                .setUseAck(true)
+                .build());
       }
       if (feature.DSCP() != null) {
         int dscpType = toDscpType(feature.dscp_type());
         dscps.add(dscpType);
       }
       if (feature.ECE() != null) {
-        TcpFlags alt = new TcpFlags();
-        alt.setUseEce(true);
-        alt.setEce(true);
-        tcpFlags.add(alt);
+        tcpFlags.add(
+            TcpFlagsMatchConditions.builder()
+                .setTcpFlags(TcpFlags.builder().setEce(true).build())
+                .setUseEce(true)
+                .build());
       }
       if (feature.ECHO_REPLY() != null) {
         icmpType = IcmpType.ECHO_REPLY;
@@ -5056,20 +5068,23 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
       }
       if (feature.ESTABLISHED() != null) {
         // must contain ACK or RST
-        TcpFlags alt1 = new TcpFlags();
-        TcpFlags alt2 = new TcpFlags();
-        alt1.setUseAck(true);
-        alt1.setAck(true);
-        alt2.setUseRst(true);
-        alt2.setRst(true);
-        tcpFlags.add(alt1);
-        tcpFlags.add(alt2);
+        tcpFlags.add(
+            TcpFlagsMatchConditions.builder()
+                .setTcpFlags(TcpFlags.builder().setAck(true).build())
+                .setUseAck(true)
+                .build());
+        tcpFlags.add(
+            TcpFlagsMatchConditions.builder()
+                .setTcpFlags(TcpFlags.builder().setRst(true).build())
+                .setUseRst(true)
+                .build());
       }
       if (feature.FIN() != null) {
-        TcpFlags alt = new TcpFlags();
-        alt.setUseFin(true);
-        alt.setFin(true);
-        tcpFlags.add(alt);
+        tcpFlags.add(
+            TcpFlagsMatchConditions.builder()
+                .setTcpFlags(TcpFlags.builder().setFin(true).build())
+                .setUseFin(true)
+                .build());
       }
       if (feature.FRAGMENTS() != null) {
         todo(ctx);
@@ -5102,29 +5117,32 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
         icmpCode = IcmpCode.DESTINATION_PORT_UNREACHABLE;
       }
       if (feature.PSH() != null) {
-        TcpFlags alt = new TcpFlags();
-        alt.setUsePsh(true);
-        alt.setPsh(true);
-        tcpFlags.add(alt);
+        tcpFlags.add(
+            TcpFlagsMatchConditions.builder()
+                .setTcpFlags(TcpFlags.builder().setPsh(true).build())
+                .setUsePsh(true)
+                .build());
       }
       if (feature.REDIRECT() != null) {
         icmpType = IcmpType.REDIRECT_MESSAGE;
       }
       if (feature.RST() != null) {
-        TcpFlags alt = new TcpFlags();
-        alt.setUseRst(true);
-        alt.setRst(true);
-        tcpFlags.add(alt);
+        tcpFlags.add(
+            TcpFlagsMatchConditions.builder()
+                .setTcpFlags(TcpFlags.builder().setRst(true).build())
+                .setUseRst(true)
+                .build());
       }
       if (feature.SOURCE_QUENCH() != null) {
         icmpType = IcmpType.SOURCE_QUENCH;
         icmpCode = IcmpCode.SOURCE_QUENCH;
       }
       if (feature.SYN() != null) {
-        TcpFlags alt = new TcpFlags();
-        alt.setUseSyn(true);
-        alt.setSyn(true);
-        tcpFlags.add(alt);
+        tcpFlags.add(
+            TcpFlagsMatchConditions.builder()
+                .setTcpFlags(TcpFlags.builder().setSyn(true).build())
+                .setUseSyn(true)
+                .build());
       }
       if (feature.TIME_EXCEEDED() != null) {
         icmpType = IcmpType.TIME_EXCEEDED;
@@ -5147,10 +5165,11 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
         icmpType = IcmpType.DESTINATION_UNREACHABLE;
       }
       if (feature.URG() != null) {
-        TcpFlags alt = new TcpFlags();
-        alt.setUseUrg(true);
-        alt.setUrg(true);
-        tcpFlags.add(alt);
+        tcpFlags.add(
+            TcpFlagsMatchConditions.builder()
+                .setTcpFlags(TcpFlags.builder().setUrg(true).build())
+                .setUseUrg(true)
+                .build());
       }
     }
     String name = getFullText(ctx).trim();

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -116,6 +116,7 @@ import org.batfish.datamodel.SnmpServer;
 import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.SwitchportMode;
 import org.batfish.datamodel.TcpFlags;
+import org.batfish.datamodel.TcpFlagsMatchConditions;
 import org.batfish.datamodel.VrrpGroup;
 import org.batfish.datamodel.isis.IsisAuthenticationAlgorithm;
 import org.batfish.datamodel.isis.IsisHelloAuthenticationType;
@@ -1567,46 +1568,47 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
     return new SubRange(low, high);
   }
 
-  private static TcpFlags toTcpFlags(Tcp_flags_alternativeContext ctx) {
-    TcpFlags tcpFlags = new TcpFlags();
+  private static TcpFlagsMatchConditions toTcpFlags(Tcp_flags_alternativeContext ctx) {
+    TcpFlagsMatchConditions.Builder tcpFlagsConditionsBuilder = TcpFlagsMatchConditions.builder();
+    TcpFlags.Builder tcpFlagsBuilder = TcpFlags.builder();
     for (Tcp_flags_literalContext literalCtx : ctx.literals) {
       boolean value = literalCtx.BANG() == null;
       Tcp_flags_atomContext atom = literalCtx.tcp_flags_atom();
       if (atom.ACK() != null) {
-        tcpFlags.setUseAck(true);
-        tcpFlags.setAck(value);
+        tcpFlagsConditionsBuilder.setUseAck(true);
+        tcpFlagsBuilder.setAck(value);
       } else if (atom.CWR() != null) {
-        tcpFlags.setUseCwr(true);
-        tcpFlags.setCwr(value);
+        tcpFlagsConditionsBuilder.setUseCwr(true);
+        tcpFlagsBuilder.setCwr(value);
       } else if (atom.ECE() != null) {
-        tcpFlags.setUseEce(true);
-        tcpFlags.setEce(value);
+        tcpFlagsConditionsBuilder.setUseEce(true);
+        tcpFlagsBuilder.setEce(value);
       } else if (atom.FIN() != null) {
-        tcpFlags.setUseFin(true);
-        tcpFlags.setFin(value);
+        tcpFlagsConditionsBuilder.setUseFin(true);
+        tcpFlagsBuilder.setFin(value);
       } else if (atom.PSH() != null) {
-        tcpFlags.setUsePsh(true);
-        tcpFlags.setPsh(value);
+        tcpFlagsConditionsBuilder.setUsePsh(true);
+        tcpFlagsBuilder.setPsh(value);
       } else if (atom.RST() != null) {
-        tcpFlags.setUseRst(true);
-        tcpFlags.setRst(value);
+        tcpFlagsConditionsBuilder.setUseRst(true);
+        tcpFlagsBuilder.setRst(value);
       } else if (atom.SYN() != null) {
-        tcpFlags.setUseSyn(true);
-        tcpFlags.setSyn(value);
+        tcpFlagsConditionsBuilder.setUseSyn(true);
+        tcpFlagsBuilder.setSyn(value);
       } else if (atom.URG() != null) {
-        tcpFlags.setUseUrg(true);
-        tcpFlags.setUrg(value);
+        tcpFlagsConditionsBuilder.setUseUrg(true);
+        tcpFlagsBuilder.setUrg(value);
       } else {
         throw new BatfishException("Invalid tcp-flags atom: " + atom.getText());
       }
     }
-    return tcpFlags;
+    return tcpFlagsConditionsBuilder.setTcpFlags(tcpFlagsBuilder.build()).build();
   }
 
-  private static List<TcpFlags> toTcpFlags(Tcp_flagsContext ctx) {
-    List<TcpFlags> tcpFlagsList = new ArrayList<>();
+  private static List<TcpFlagsMatchConditions> toTcpFlags(Tcp_flagsContext ctx) {
+    List<TcpFlagsMatchConditions> tcpFlagsList = new ArrayList<>();
     for (Tcp_flags_alternativeContext alternativeCtx : ctx.alternatives) {
-      TcpFlags tcpFlags = toTcpFlags(alternativeCtx);
+      TcpFlagsMatchConditions tcpFlags = toTcpFlags(alternativeCtx);
       tcpFlagsList.add(tcpFlags);
     }
     return tcpFlagsList;
@@ -3319,35 +3321,37 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
 
   @Override
   public void exitFftf_tcp_established(Fftf_tcp_establishedContext ctx) {
-    List<TcpFlags> tcpFlags = new ArrayList<>();
-    TcpFlags alt1 = new TcpFlags();
-    alt1.setUseAck(true);
-    alt1.setAck(true);
-    tcpFlags.add(alt1);
-    TcpFlags alt2 = new TcpFlags();
-    alt2.setUseRst(true);
-    alt2.setRst(true);
-    tcpFlags.add(alt2);
+    List<TcpFlagsMatchConditions> tcpFlags = new ArrayList<>();
+    tcpFlags.add(
+        TcpFlagsMatchConditions.builder()
+            .setTcpFlags(TcpFlags.builder().setAck(true).build())
+            .setUseAck(true)
+            .build());
+    tcpFlags.add(
+        TcpFlagsMatchConditions.builder()
+            .setTcpFlags(TcpFlags.builder().setRst(true).build())
+            .setUseRst(true)
+            .build());
     FwFrom from = new FwFromTcpFlags(tcpFlags);
     _currentFwTerm.getFroms().add(from);
   }
 
   @Override
   public void exitFftf_tcp_flags(Fftf_tcp_flagsContext ctx) {
-    List<TcpFlags> tcpFlags = toTcpFlags(ctx.tcp_flags());
+    List<TcpFlagsMatchConditions> tcpFlags = toTcpFlags(ctx.tcp_flags());
     FwFrom from = new FwFromTcpFlags(tcpFlags);
     _currentFwTerm.getFroms().add(from);
   }
 
   @Override
   public void exitFftf_tcp_initial(Fftf_tcp_initialContext ctx) {
-    List<TcpFlags> tcpFlags = new ArrayList<>();
-    TcpFlags alt1 = new TcpFlags();
-    alt1.setUseAck(true);
-    alt1.setAck(false);
-    alt1.setUseSyn(true);
-    alt1.setSyn(true);
-    tcpFlags.add(alt1);
+    List<TcpFlagsMatchConditions> tcpFlags = new ArrayList<>();
+    tcpFlags.add(
+        TcpFlagsMatchConditions.builder()
+            .setTcpFlags(TcpFlags.builder().setAck(true).setSyn(true).build())
+            .setUseAck(true)
+            .setUseSyn(true)
+            .build());
     FwFrom from = new FwFromTcpFlags(tcpFlags);
     _currentFwTerm.getFroms().add(from);
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/SecurityGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/SecurityGroup.java
@@ -12,7 +12,7 @@ import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.IpAccessListLine;
 import org.batfish.datamodel.IpWildcard;
-import org.batfish.datamodel.TcpFlags;
+import org.batfish.datamodel.TcpFlagsMatchConditions;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.datamodel.visitors.HeaderSpaceConverter;
 import org.codehaus.jettison.json.JSONArray;
@@ -89,7 +89,8 @@ public class SecurityGroup implements AwsVpcEntity, Serializable {
                                   .setIpProtocols(srcHeaderSpace.getIpProtocols())
                                   .setDstIps(srcHeaderSpace.getSrcIps())
                                   .setSrcPorts(srcHeaderSpace.getDstPorts())
-                                  .setTcpFlags(ImmutableSet.of(TcpFlags.ACK_TCP_FLAG))
+                                  .setTcpFlags(
+                                      ImmutableSet.of(TcpFlagsMatchConditions.ACK_TCP_FLAG))
                                   .build()))
                       .setAction(ipAccessListLine.getAction())
                       .build();
@@ -110,7 +111,8 @@ public class SecurityGroup implements AwsVpcEntity, Serializable {
                                   .setIpProtocols(srcHeaderSpace.getIpProtocols())
                                   .setSrcIps(srcHeaderSpace.getDstIps())
                                   .setSrcPorts(srcHeaderSpace.getDstPorts())
-                                  .setTcpFlags(ImmutableSet.of(TcpFlags.ACK_TCP_FLAG))
+                                  .setTcpFlags(
+                                      ImmutableSet.of(TcpFlagsMatchConditions.ACK_TCP_FLAG))
                                   .build()))
                       .setAction(ipAccessListLine.getAction())
                       .build();

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
@@ -74,7 +74,7 @@ import org.batfish.datamodel.RouteFilterList;
 import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.State;
 import org.batfish.datamodel.SubRange;
-import org.batfish.datamodel.TcpFlags;
+import org.batfish.datamodel.TcpFlagsMatchConditions;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.datamodel.acl.AndMatchExpr;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
@@ -537,7 +537,7 @@ class CiscoConversions {
       }
       Set<State> states = fromLine.getStates();
       newLine.getStates().addAll(states);
-      List<TcpFlags> tcpFlags = fromLine.getTcpFlags();
+      List<TcpFlagsMatchConditions> tcpFlags = fromLine.getTcpFlags();
       newLine.getTcpFlags().addAll(tcpFlags);
       Set<Integer> dscps = fromLine.getDscps();
       newLine.getDscps().addAll(dscps);

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/ExtendedIpv6AccessListLine.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/ExtendedIpv6AccessListLine.java
@@ -9,7 +9,7 @@ import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.State;
 import org.batfish.datamodel.SubRange;
-import org.batfish.datamodel.TcpFlags;
+import org.batfish.datamodel.TcpFlagsMatchConditions;
 
 public class ExtendedIpv6AccessListLine implements Serializable {
 
@@ -43,7 +43,7 @@ public class ExtendedIpv6AccessListLine implements Serializable {
 
   private Set<State> _states;
 
-  private final List<TcpFlags> _tcpFlags;
+  private final List<TcpFlagsMatchConditions> _tcpFlags;
 
   public ExtendedIpv6AccessListLine(
       String name,
@@ -60,7 +60,7 @@ public class ExtendedIpv6AccessListLine implements Serializable {
       @Nullable Integer icmpType,
       @Nullable Integer icmpCode,
       Set<State> states,
-      List<TcpFlags> tcpFlags) {
+      List<TcpFlagsMatchConditions> tcpFlags) {
     _name = name;
     _action = action;
     _protocol = protocol;
@@ -134,7 +134,7 @@ public class ExtendedIpv6AccessListLine implements Serializable {
     return _states;
   }
 
-  public List<TcpFlags> getTcpFlags() {
+  public List<TcpFlagsMatchConditions> getTcpFlags() {
     return _tcpFlags;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/SimpleExtendedAccessListServiceSpecifier.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/SimpleExtendedAccessListServiceSpecifier.java
@@ -11,7 +11,7 @@ import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.State;
 import org.batfish.datamodel.SubRange;
-import org.batfish.datamodel.TcpFlags;
+import org.batfish.datamodel.TcpFlagsMatchConditions;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
 
@@ -38,7 +38,7 @@ public class SimpleExtendedAccessListServiceSpecifier implements AccessListServi
 
     private Set<State> _states;
 
-    private List<TcpFlags> _tcpFlags;
+    private List<TcpFlagsMatchConditions> _tcpFlags;
 
     public SimpleExtendedAccessListServiceSpecifier build() {
       return new SimpleExtendedAccessListServiceSpecifier(this);
@@ -84,7 +84,7 @@ public class SimpleExtendedAccessListServiceSpecifier implements AccessListServi
       return this;
     }
 
-    public Builder setTcpFlags(Iterable<TcpFlags> tcpFlags) {
+    public Builder setTcpFlags(Iterable<TcpFlagsMatchConditions> tcpFlags) {
       _tcpFlags = ImmutableList.copyOf(tcpFlags);
       return this;
     }
@@ -110,7 +110,7 @@ public class SimpleExtendedAccessListServiceSpecifier implements AccessListServi
 
   private final Set<State> _states;
 
-  private final List<TcpFlags> _tcpFlags;
+  private final List<TcpFlagsMatchConditions> _tcpFlags;
 
   private SimpleExtendedAccessListServiceSpecifier(Builder builder) {
     _dscps = builder._dscps;

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromTcpFlags.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromTcpFlags.java
@@ -5,16 +5,16 @@ import java.util.List;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.HeaderSpace;
-import org.batfish.datamodel.TcpFlags;
+import org.batfish.datamodel.TcpFlagsMatchConditions;
 
 public final class FwFromTcpFlags extends FwFrom {
 
   /** */
   private static final long serialVersionUID = 1L;
 
-  private List<TcpFlags> _tcpFlags;
+  private List<TcpFlagsMatchConditions> _tcpFlags;
 
-  public FwFromTcpFlags(List<TcpFlags> tcpFlags) {
+  public FwFromTcpFlags(List<TcpFlagsMatchConditions> tcpFlags) {
     _tcpFlags = tcpFlags;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/symbolic/bdd/HeaderSpaceToBDD.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/bdd/HeaderSpaceToBDD.java
@@ -16,7 +16,7 @@ import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.State;
 import org.batfish.datamodel.SubRange;
-import org.batfish.datamodel.TcpFlags;
+import org.batfish.datamodel.TcpFlagsMatchConditions;
 
 /** Convert a {@link HeaderSpace headerspace constraint} to a {@link BDD}. */
 public final class HeaderSpaceToBDD {
@@ -83,7 +83,7 @@ public final class HeaderSpaceToBDD {
   }
 
   @VisibleForTesting
-  BDD toBDD(List<TcpFlags> tcpFlags) {
+  BDD toBDD(List<TcpFlagsMatchConditions> tcpFlags) {
     if (tcpFlags == null || tcpFlags.isEmpty()) {
       return null;
     }
@@ -91,23 +91,23 @@ public final class HeaderSpaceToBDD {
     return _bddOps.or(tcpFlags.stream().map(this::toBDD).collect(ImmutableList.toImmutableList()));
   }
 
-  /** For TcpFlags */
+  /** For TcpFlagsMatchConditions */
   @VisibleForTesting
   static BDD toBDD(boolean useFlag, boolean flagValue, BDD flagBDD) {
     return useFlag ? flagValue ? flagBDD : flagBDD.not() : null;
   }
 
   @VisibleForTesting
-  BDD toBDD(TcpFlags tcpFlags) {
+  BDD toBDD(TcpFlagsMatchConditions tcpFlags) {
     return _bddOps.and(
-        toBDD(tcpFlags.getUseAck(), tcpFlags.getAck(), _bddPacket.getTcpAck()),
-        toBDD(tcpFlags.getUseCwr(), tcpFlags.getCwr(), _bddPacket.getTcpCwr()),
-        toBDD(tcpFlags.getUseEce(), tcpFlags.getEce(), _bddPacket.getTcpEce()),
-        toBDD(tcpFlags.getUseFin(), tcpFlags.getFin(), _bddPacket.getTcpFin()),
-        toBDD(tcpFlags.getUsePsh(), tcpFlags.getPsh(), _bddPacket.getTcpPsh()),
-        toBDD(tcpFlags.getUseRst(), tcpFlags.getRst(), _bddPacket.getTcpRst()),
-        toBDD(tcpFlags.getUseSyn(), tcpFlags.getSyn(), _bddPacket.getTcpSyn()),
-        toBDD(tcpFlags.getUseUrg(), tcpFlags.getUrg(), _bddPacket.getTcpUrg()));
+        toBDD(tcpFlags.getUseAck(), tcpFlags.getTcpFlags().getAck(), _bddPacket.getTcpAck()),
+        toBDD(tcpFlags.getUseCwr(), tcpFlags.getTcpFlags().getCwr(), _bddPacket.getTcpCwr()),
+        toBDD(tcpFlags.getUseEce(), tcpFlags.getTcpFlags().getEce(), _bddPacket.getTcpEce()),
+        toBDD(tcpFlags.getUseFin(), tcpFlags.getTcpFlags().getFin(), _bddPacket.getTcpFin()),
+        toBDD(tcpFlags.getUsePsh(), tcpFlags.getTcpFlags().getPsh(), _bddPacket.getTcpPsh()),
+        toBDD(tcpFlags.getUseRst(), tcpFlags.getTcpFlags().getRst(), _bddPacket.getTcpRst()),
+        toBDD(tcpFlags.getUseSyn(), tcpFlags.getTcpFlags().getSyn(), _bddPacket.getTcpSyn()),
+        toBDD(tcpFlags.getUseUrg(), tcpFlags.getTcpFlags().getUrg(), _bddPacket.getTcpUrg()));
   }
 
   public BDD toBDD(HeaderSpace headerSpace) {

--- a/projects/batfish/src/main/java/org/batfish/symbolic/smt/IpAccessListToBoolExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/smt/IpAccessListToBoolExpr.java
@@ -17,7 +17,7 @@ import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.SubRange;
-import org.batfish.datamodel.TcpFlags;
+import org.batfish.datamodel.TcpFlagsMatchConditions;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.datamodel.acl.AndMatchExpr;
 import org.batfish.datamodel.acl.FalseExpr;
@@ -101,7 +101,7 @@ public class IpAccessListToBoolExpr implements GenericAclLineMatchExprVisitor<Bo
         : _context.mkAnd(_context.mkGe(var, startExpr), _context.mkLe(var, endExpr));
   }
 
-  private BoolExpr toBoolExpr(List<TcpFlags> tcpFlags) {
+  private BoolExpr toBoolExpr(List<TcpFlagsMatchConditions> tcpFlags) {
     if (tcpFlags == null || tcpFlags.isEmpty()) {
       return null;
     }
@@ -109,25 +109,25 @@ public class IpAccessListToBoolExpr implements GenericAclLineMatchExprVisitor<Bo
     return _context.mkOr(tcpFlags.stream().map(this::toBoolExpr).toArray(BoolExpr[]::new));
   }
 
-  /** For TcpFlags */
+  /** For TcpFlagsMatchConditions */
   private BoolExpr toBoolExpr(boolean useFlag, boolean flagValue, BoolExpr flagExpr) {
     return useFlag ? flagValue ? flagExpr : _context.mkNot(flagExpr) : null;
   }
 
-  private BoolExpr toBoolExpr(TcpFlags tcpFlags) {
+  private BoolExpr toBoolExpr(TcpFlagsMatchConditions tcpFlags) {
     if (!tcpFlags.anyUsed()) {
       return null;
     }
 
     return _boolExprOps.and(
-        toBoolExpr(tcpFlags.getUseAck(), tcpFlags.getAck(), _packet.getTcpAck()),
-        toBoolExpr(tcpFlags.getUseCwr(), tcpFlags.getCwr(), _packet.getTcpCwr()),
-        toBoolExpr(tcpFlags.getUseEce(), tcpFlags.getEce(), _packet.getTcpEce()),
-        toBoolExpr(tcpFlags.getUseFin(), tcpFlags.getFin(), _packet.getTcpFin()),
-        toBoolExpr(tcpFlags.getUsePsh(), tcpFlags.getPsh(), _packet.getTcpPsh()),
-        toBoolExpr(tcpFlags.getUseRst(), tcpFlags.getRst(), _packet.getTcpRst()),
-        toBoolExpr(tcpFlags.getUseSyn(), tcpFlags.getSyn(), _packet.getTcpSyn()),
-        toBoolExpr(tcpFlags.getUseUrg(), tcpFlags.getUrg(), _packet.getTcpUrg()));
+        toBoolExpr(tcpFlags.getUseAck(), tcpFlags.getTcpFlags().getAck(), _packet.getTcpAck()),
+        toBoolExpr(tcpFlags.getUseCwr(), tcpFlags.getTcpFlags().getCwr(), _packet.getTcpCwr()),
+        toBoolExpr(tcpFlags.getUseEce(), tcpFlags.getTcpFlags().getEce(), _packet.getTcpEce()),
+        toBoolExpr(tcpFlags.getUseFin(), tcpFlags.getTcpFlags().getFin(), _packet.getTcpFin()),
+        toBoolExpr(tcpFlags.getUsePsh(), tcpFlags.getTcpFlags().getPsh(), _packet.getTcpPsh()),
+        toBoolExpr(tcpFlags.getUseRst(), tcpFlags.getTcpFlags().getRst(), _packet.getTcpRst()),
+        toBoolExpr(tcpFlags.getUseSyn(), tcpFlags.getTcpFlags().getSyn(), _packet.getTcpSyn()),
+        toBoolExpr(tcpFlags.getUseUrg(), tcpFlags.getTcpFlags().getUrg(), _packet.getTcpUrg()));
   }
 
   private static <T> void forbidHeaderSpaceField(String fieldName, Set<T> fieldValue) {

--- a/projects/batfish/src/main/java/org/batfish/z3/BDDIpAccessListSpecializer.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/BDDIpAccessListSpecializer.java
@@ -17,7 +17,7 @@ import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.SubRange;
-import org.batfish.datamodel.TcpFlags;
+import org.batfish.datamodel.TcpFlagsMatchConditions;
 import org.batfish.datamodel.UniverseIpSpace;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.datamodel.acl.FalseExpr;
@@ -175,7 +175,8 @@ public final class BDDIpAccessListSpecializer extends IpAccessListSpecializer {
     return srcIps == null ? null : _srcIpSpaceSpecializer.specialize(srcIps);
   }
 
-  private @Nullable List<TcpFlags> specializeTcpFlags(@Nullable List<TcpFlags> tcpFlags) {
+  private @Nullable List<TcpFlagsMatchConditions> specializeTcpFlags(
+      @Nullable List<TcpFlagsMatchConditions> tcpFlags) {
     return tcpFlags == null
         ? null
         : tcpFlags
@@ -184,13 +185,20 @@ public final class BDDIpAccessListSpecializer extends IpAccessListSpecializer {
                 flags -> {
                   BDD flagsBDD =
                       BDDOps.andNull(
-                          tcpFlagBDD(flags.getUseAck(), flags.getAck(), _pkt.getTcpAck()),
-                          tcpFlagBDD(flags.getUseCwr(), flags.getCwr(), _pkt.getTcpCwr()),
-                          tcpFlagBDD(flags.getUseEce(), flags.getEce(), _pkt.getTcpEce()),
-                          tcpFlagBDD(flags.getUseFin(), flags.getFin(), _pkt.getTcpFin()),
-                          tcpFlagBDD(flags.getUsePsh(), flags.getPsh(), _pkt.getTcpPsh()),
-                          tcpFlagBDD(flags.getUseRst(), flags.getRst(), _pkt.getTcpRst()),
-                          tcpFlagBDD(flags.getUseUrg(), flags.getUrg(), _pkt.getTcpUrg()));
+                          tcpFlagBDD(
+                              flags.getUseAck(), flags.getTcpFlags().getAck(), _pkt.getTcpAck()),
+                          tcpFlagBDD(
+                              flags.getUseCwr(), flags.getTcpFlags().getCwr(), _pkt.getTcpCwr()),
+                          tcpFlagBDD(
+                              flags.getUseEce(), flags.getTcpFlags().getEce(), _pkt.getTcpEce()),
+                          tcpFlagBDD(
+                              flags.getUseFin(), flags.getTcpFlags().getFin(), _pkt.getTcpFin()),
+                          tcpFlagBDD(
+                              flags.getUsePsh(), flags.getTcpFlags().getPsh(), _pkt.getTcpPsh()),
+                          tcpFlagBDD(
+                              flags.getUseRst(), flags.getTcpFlags().getRst(), _pkt.getTcpRst()),
+                          tcpFlagBDD(
+                              flags.getUseUrg(), flags.getTcpFlags().getUrg(), _pkt.getTcpUrg()));
                   return flagsBDD != null && !_flowBDD.and(flagsBDD).isZero();
                 })
             .collect(ImmutableList.toImmutableList());

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/HeaderSpaceMatchExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/HeaderSpaceMatchExpr.java
@@ -19,7 +19,7 @@ import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Protocol;
 import org.batfish.datamodel.State;
 import org.batfish.datamodel.SubRange;
-import org.batfish.datamodel.TcpFlags;
+import org.batfish.datamodel.TcpFlagsMatchConditions;
 import org.batfish.z3.Field;
 import org.batfish.z3.expr.visitors.ExprVisitor;
 import org.batfish.z3.expr.visitors.GenericBooleanExprVisitor;
@@ -243,7 +243,7 @@ public final class HeaderSpaceMatchExpr extends BooleanExpr {
             .collect(ImmutableList.toImmutableList()));
   }
 
-  public static BooleanExpr matchTcpFlags(List<TcpFlags> tcpFlags) {
+  public static BooleanExpr matchTcpFlags(List<TcpFlagsMatchConditions> tcpFlags) {
     LitIntExpr one = new LitIntExpr(1, 1);
     LitIntExpr zero = new LitIntExpr(0, 1);
     return new OrExpr(
@@ -253,42 +253,42 @@ public final class HeaderSpaceMatchExpr extends BooleanExpr {
                 currentTcpFlags -> {
                   ImmutableList.Builder<BooleanExpr> matchCurrentTcpFlags = ImmutableList.builder();
                   if (currentTcpFlags.getUseCwr()) {
-                    LitIntExpr bit = currentTcpFlags.getCwr() ? one : zero;
+                    LitIntExpr bit = currentTcpFlags.getTcpFlags().getCwr() ? one : zero;
                     EqExpr matchFlag = new EqExpr(new VarIntExpr(Field.TCP_FLAGS_CWR), bit);
                     matchCurrentTcpFlags.add(matchFlag);
                   }
                   if (currentTcpFlags.getUseEce()) {
-                    LitIntExpr bit = currentTcpFlags.getEce() ? one : zero;
+                    LitIntExpr bit = currentTcpFlags.getTcpFlags().getEce() ? one : zero;
                     EqExpr matchFlag = new EqExpr(new VarIntExpr(Field.TCP_FLAGS_ECE), bit);
                     matchCurrentTcpFlags.add(matchFlag);
                   }
                   if (currentTcpFlags.getUseUrg()) {
-                    LitIntExpr bit = currentTcpFlags.getUrg() ? one : zero;
+                    LitIntExpr bit = currentTcpFlags.getTcpFlags().getUrg() ? one : zero;
                     EqExpr matchFlag = new EqExpr(new VarIntExpr(Field.TCP_FLAGS_URG), bit);
                     matchCurrentTcpFlags.add(matchFlag);
                   }
                   if (currentTcpFlags.getUseAck()) {
-                    LitIntExpr bit = currentTcpFlags.getAck() ? one : zero;
+                    LitIntExpr bit = currentTcpFlags.getTcpFlags().getAck() ? one : zero;
                     EqExpr matchFlag = new EqExpr(new VarIntExpr(Field.TCP_FLAGS_ACK), bit);
                     matchCurrentTcpFlags.add(matchFlag);
                   }
                   if (currentTcpFlags.getUsePsh()) {
-                    LitIntExpr bit = currentTcpFlags.getPsh() ? one : zero;
+                    LitIntExpr bit = currentTcpFlags.getTcpFlags().getPsh() ? one : zero;
                     EqExpr matchFlag = new EqExpr(new VarIntExpr(Field.TCP_FLAGS_PSH), bit);
                     matchCurrentTcpFlags.add(matchFlag);
                   }
                   if (currentTcpFlags.getUseRst()) {
-                    LitIntExpr bit = currentTcpFlags.getRst() ? one : zero;
+                    LitIntExpr bit = currentTcpFlags.getTcpFlags().getRst() ? one : zero;
                     EqExpr matchFlag = new EqExpr(new VarIntExpr(Field.TCP_FLAGS_RST), bit);
                     matchCurrentTcpFlags.add(matchFlag);
                   }
                   if (currentTcpFlags.getUseSyn()) {
-                    LitIntExpr bit = currentTcpFlags.getSyn() ? one : zero;
+                    LitIntExpr bit = currentTcpFlags.getTcpFlags().getSyn() ? one : zero;
                     EqExpr matchFlag = new EqExpr(new VarIntExpr(Field.TCP_FLAGS_SYN), bit);
                     matchCurrentTcpFlags.add(matchFlag);
                   }
                   if (currentTcpFlags.getUseFin()) {
-                    LitIntExpr bit = currentTcpFlags.getFin() ? one : zero;
+                    LitIntExpr bit = currentTcpFlags.getTcpFlags().getFin() ? one : zero;
                     EqExpr matchFlag = new EqExpr(new VarIntExpr(Field.TCP_FLAGS_FIN), bit);
                     matchCurrentTcpFlags.add(matchFlag);
                   }

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/ElasticsearchDomainTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/ElasticsearchDomainTest.java
@@ -36,7 +36,7 @@ import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.StaticRoute;
 import org.batfish.datamodel.SubRange;
-import org.batfish.datamodel.TcpFlags;
+import org.batfish.datamodel.TcpFlagsMatchConditions;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.main.Batfish;
@@ -182,7 +182,7 @@ public class ElasticsearchDomainTest {
                                       new IpWildcard("1.2.3.4/32"),
                                       new IpWildcard("10.193.16.105/32")))
                               .setSrcPorts(Sets.newHashSet(new SubRange(45, 50)))
-                              .setTcpFlags(ImmutableSet.of(TcpFlags.ACK_TCP_FLAG))
+                              .setTcpFlags(ImmutableSet.of(TcpFlagsMatchConditions.ACK_TCP_FLAG))
                               .build()),
                       IpAccessListLine.acceptingHeaderSpace(
                           HeaderSpace.builder()
@@ -196,7 +196,7 @@ public class ElasticsearchDomainTest {
                       IpAccessListLine.acceptingHeaderSpace(
                           HeaderSpace.builder()
                               .setSrcIps(Sets.newHashSet(new IpWildcard("0.0.0.0/0")))
-                              .setTcpFlags(ImmutableSet.of(TcpFlags.ACK_TCP_FLAG))
+                              .setTcpFlags(ImmutableSet.of(TcpFlagsMatchConditions.ACK_TCP_FLAG))
                               .build()),
                       IpAccessListLine.acceptingHeaderSpace(
                           HeaderSpace.builder()

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/RdsInstanceTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/RdsInstanceTest.java
@@ -40,7 +40,7 @@ import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.StaticRoute;
 import org.batfish.datamodel.SubRange;
-import org.batfish.datamodel.TcpFlags;
+import org.batfish.datamodel.TcpFlagsMatchConditions;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.main.Batfish;
@@ -162,7 +162,7 @@ public class RdsInstanceTest {
                                       new IpWildcard("1.2.3.4/32"),
                                       new IpWildcard("10.193.16.105/32")))
                               .setSrcPorts(Sets.newHashSet(new SubRange(45, 50)))
-                              .setTcpFlags(ImmutableSet.of(TcpFlags.ACK_TCP_FLAG))
+                              .setTcpFlags(ImmutableSet.of(TcpFlagsMatchConditions.ACK_TCP_FLAG))
                               .build()),
                       IpAccessListLine.acceptingHeaderSpace(
                           HeaderSpace.builder()
@@ -176,7 +176,7 @@ public class RdsInstanceTest {
                       IpAccessListLine.acceptingHeaderSpace(
                           HeaderSpace.builder()
                               .setSrcIps(Sets.newHashSet(new IpWildcard("0.0.0.0/0")))
-                              .setTcpFlags(ImmutableSet.of(TcpFlags.ACK_TCP_FLAG))
+                              .setTcpFlags(ImmutableSet.of(TcpFlagsMatchConditions.ACK_TCP_FLAG))
                               .build()),
                       IpAccessListLine.acceptingHeaderSpace(
                           HeaderSpace.builder()

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/SecurityGroupsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/SecurityGroupsTest.java
@@ -21,7 +21,7 @@ import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.SubRange;
-import org.batfish.datamodel.TcpFlags;
+import org.batfish.datamodel.TcpFlagsMatchConditions;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
@@ -48,7 +48,7 @@ public class SecurityGroupsTest {
         IpAccessListLine.acceptingHeaderSpace(
             HeaderSpace.builder()
                 .setSrcIps(Sets.newHashSet(new IpWildcard("0.0.0.0/0")))
-                .setTcpFlags(ImmutableSet.of(TcpFlags.ACK_TCP_FLAG))
+                .setTcpFlags(ImmutableSet.of(TcpFlagsMatchConditions.ACK_TCP_FLAG))
                 .build());
     _region = new Region("test");
     _flowBuilder = new Builder();
@@ -250,7 +250,7 @@ public class SecurityGroupsTest {
                         .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
                         .setSrcIps(Sets.newHashSet(new IpWildcard("5.6.7.8/32")))
                         .setSrcPorts(Sets.newHashSet(new SubRange(80, 80)))
-                        .setTcpFlags(ImmutableSet.of(TcpFlags.ACK_TCP_FLAG))
+                        .setTcpFlags(ImmutableSet.of(TcpFlagsMatchConditions.ACK_TCP_FLAG))
                         .build()),
                 IpAccessListLine.acceptingHeaderSpace(
                     HeaderSpace.builder()
@@ -268,7 +268,7 @@ public class SecurityGroupsTest {
                         .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
                         .setDstIps(Sets.newHashSet(new IpWildcard("1.2.3.4/32")))
                         .setSrcPorts(Sets.newHashSet(new SubRange(22, 22)))
-                        .setTcpFlags(ImmutableSet.of(TcpFlags.ACK_TCP_FLAG))
+                        .setTcpFlags(ImmutableSet.of(TcpFlagsMatchConditions.ACK_TCP_FLAG))
                         .build()),
                 IpAccessListLine.acceptingHeaderSpace(
                     HeaderSpace.builder()

--- a/projects/batfish/src/test/java/org/batfish/symbolic/bdd/HeaderSpaceToBDDTest.java
+++ b/projects/batfish/src/test/java/org/batfish/symbolic/bdd/HeaderSpaceToBDDTest.java
@@ -16,6 +16,7 @@ import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.State;
 import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.TcpFlags;
+import org.batfish.datamodel.TcpFlagsMatchConditions;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -169,10 +170,18 @@ public class HeaderSpaceToBDDTest {
 
   @Test
   public void test_tcpFlags() {
-    TcpFlags flags1 =
-        TcpFlags.builder().setUseAck(true).setAck(true).setUseEce(true).setEce(false).build();
-    TcpFlags flags2 =
-        TcpFlags.builder().setUseCwr(true).setCwr(true).setUseFin(true).setFin(false).build();
+    TcpFlagsMatchConditions flags1 =
+        TcpFlagsMatchConditions.builder()
+            .setUseAck(true)
+            .setUseEce(true)
+            .setTcpFlags(TcpFlags.builder().setAck(true).setEce(false).build())
+            .build();
+    TcpFlagsMatchConditions flags2 =
+        TcpFlagsMatchConditions.builder()
+            .setUseCwr(true)
+            .setUseFin(true)
+            .setTcpFlags(TcpFlags.builder().setCwr(true).setFin(false).build())
+            .build();
     HeaderSpace headerSpace =
         HeaderSpace.builder().setTcpFlags(ImmutableList.of(flags1, flags2)).build();
     BDD bdd = _toBDD.toBDD(headerSpace);

--- a/projects/batfish/src/test/java/org/batfish/z3/BDDIpAccessListSpecializerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/BDDIpAccessListSpecializerTest.java
@@ -24,6 +24,7 @@ import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.TcpFlags;
+import org.batfish.datamodel.TcpFlagsMatchConditions;
 import org.batfish.datamodel.UniverseIpSpace;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
@@ -408,20 +409,29 @@ public class BDDIpAccessListSpecializerTest {
     BDDIpAccessListSpecializer specializer =
         new BDDIpAccessListSpecializer(PKT, headerSpaceBDD, ImmutableMap.of());
 
-    Iterable<TcpFlags> originalFlagsList =
+    Iterable<TcpFlagsMatchConditions> originalFlagsList =
         ImmutableList.of(
-            TcpFlags.builder().setUseAck(true).setAck(true).build(),
-            TcpFlags.builder().setUseAck(true).setAck(true).setUseEce(true).setEce(false).build(),
-            TcpFlags.builder()
+            TcpFlagsMatchConditions.builder()
+                .setUseAck(true)
+                .setTcpFlags(TcpFlags.builder().setAck(true).build())
+                .build(),
+            TcpFlagsMatchConditions.builder()
+                .setUseAck(true)
                 .setUseEce(true)
-                .setEce(true)
+                .setTcpFlags(TcpFlags.builder().setAck(true).setEce(false).build())
+                .build(),
+            TcpFlagsMatchConditions.builder()
+                .setUseEce(true)
                 .setUseFin(true)
-                .setFin(true)
                 .setUseRst(true)
-                .setRst(true)
+                .setTcpFlags(TcpFlags.builder().setEce(true).setFin(true).setRst(true).build())
                 .build());
-    Iterable<TcpFlags> specializedFlagsList =
-        ImmutableList.of(TcpFlags.builder().setUseAck(true).setAck(true).build());
+    Iterable<TcpFlagsMatchConditions> specializedFlagsList =
+        ImmutableList.of(
+            TcpFlagsMatchConditions.builder()
+                .setUseAck(true)
+                .setTcpFlags(TcpFlags.builder().setAck(true).build())
+                .build());
     HeaderSpace original = HeaderSpace.builder().setTcpFlags(originalFlagsList).build();
     HeaderSpace specialized = HeaderSpace.builder().setTcpFlags(specializedFlagsList).build();
     assertThat(specializer.specialize(original), equalTo(specialized));

--- a/projects/batfish/src/test/java/org/batfish/z3/IpAccessListSpecializerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/IpAccessListSpecializerTest.java
@@ -19,7 +19,7 @@ import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.Protocol;
 import org.batfish.datamodel.State;
 import org.batfish.datamodel.SubRange;
-import org.batfish.datamodel.TcpFlags;
+import org.batfish.datamodel.TcpFlagsMatchConditions;
 import org.batfish.datamodel.UniverseIpSpace;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.datamodel.acl.MatchSrcInterface;
@@ -120,7 +120,8 @@ public final class IpAccessListSpecializerTest {
     List<Protocol> protocolList = ImmutableList.of(Protocol.TCP);
     List<State> stateList = ImmutableList.of(State.NEW);
     List<SubRange> subRangeList = ImmutableList.of(new SubRange(0, 0));
-    List<TcpFlags> tcpFlagsList = ImmutableList.of(TcpFlags.ACK_TCP_FLAG);
+    List<TcpFlagsMatchConditions> tcpFlagsList =
+        ImmutableList.of(TcpFlagsMatchConditions.ACK_TCP_FLAG);
     /* If the initial headerspace has non-empty disjunctions that become empty after specialization,
      * the entire match expression is FALSE.
      */

--- a/projects/batfish/src/test/java/org/batfish/z3/expr/visitors/BoolExprTransformerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/expr/visitors/BoolExprTransformerTest.java
@@ -21,6 +21,7 @@ import org.batfish.datamodel.Protocol;
 import org.batfish.datamodel.State;
 import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.TcpFlags;
+import org.batfish.datamodel.TcpFlagsMatchConditions;
 import org.batfish.z3.Field;
 import org.batfish.z3.MockSynthesizerInput;
 import org.batfish.z3.NodContext;
@@ -227,8 +228,11 @@ public class BoolExprTransformerTest {
                 .setStates(ImmutableSet.of(State.ESTABLISHED, State.NEW))
                 .setTcpFlags(
                     ImmutableSet.of(
-                        TcpFlags.builder().setAck(true).setUseAck(true).build(),
-                        TcpFlags.builder().setUseCwr(true).build()))
+                        TcpFlagsMatchConditions.builder()
+                            .setTcpFlags(TcpFlags.builder().setAck(true).build())
+                            .setUseAck(true)
+                            .build(),
+                        TcpFlagsMatchConditions.builder().setUseCwr(true).build()))
                 .build(),
             ImmutableMap.of());
 

--- a/tests/aws/nodes-example-aws.ref
+++ b/tests/aws/nodes-example-aws.ref
@@ -83,15 +83,8 @@
                       ]
                     },
                     "negate" : false,
-                    "tcpFlags" : [
+                    "tcpFlagsMatchConditions" : [
                       {
-                        "ack" : true,
-                        "cwr" : false,
-                        "ece" : false,
-                        "fin" : false,
-                        "psh" : false,
-                        "rst" : false,
-                        "syn" : false,
                         "tcpFlags" : {
                           "ack" : true,
                           "cwr" : false,
@@ -102,7 +95,14 @@
                           "syn" : false,
                           "urg" : false
                         },
-                        "urg" : false
+                        "useAck" : true,
+                        "useCwr" : false,
+                        "useEce" : false,
+                        "useFin" : false,
+                        "usePsh" : false,
+                        "useRst" : false,
+                        "useSyn" : false,
+                        "useUrg" : false
                       }
                     ]
                   }
@@ -140,15 +140,8 @@
                         "0.0.0.0/0"
                       ]
                     },
-                    "tcpFlags" : [
+                    "tcpFlagsMatchConditions" : [
                       {
-                        "ack" : true,
-                        "cwr" : false,
-                        "ece" : false,
-                        "fin" : false,
-                        "psh" : false,
-                        "rst" : false,
-                        "syn" : false,
                         "tcpFlags" : {
                           "ack" : true,
                           "cwr" : false,
@@ -159,7 +152,14 @@
                           "syn" : false,
                           "urg" : false
                         },
-                        "urg" : false
+                        "useAck" : true,
+                        "useCwr" : false,
+                        "useEce" : false,
+                        "useFin" : false,
+                        "usePsh" : false,
+                        "useRst" : false,
+                        "useSyn" : false,
+                        "useUrg" : false
                       }
                     ]
                   }
@@ -3613,15 +3613,8 @@
                     "srcPorts" : [
                       "3306-3306"
                     ],
-                    "tcpFlags" : [
+                    "tcpFlagsMatchConditions" : [
                       {
-                        "ack" : true,
-                        "cwr" : false,
-                        "ece" : false,
-                        "fin" : false,
-                        "psh" : false,
-                        "rst" : false,
-                        "syn" : false,
                         "tcpFlags" : {
                           "ack" : true,
                           "cwr" : false,
@@ -3632,7 +3625,14 @@
                           "syn" : false,
                           "urg" : false
                         },
-                        "urg" : false
+                        "useAck" : true,
+                        "useCwr" : false,
+                        "useEce" : false,
+                        "useFin" : false,
+                        "usePsh" : false,
+                        "useRst" : false,
+                        "useSyn" : false,
+                        "useUrg" : false
                       }
                     ]
                   }
@@ -3670,15 +3670,8 @@
                         "0.0.0.0/0"
                       ]
                     },
-                    "tcpFlags" : [
+                    "tcpFlagsMatchConditions" : [
                       {
-                        "ack" : true,
-                        "cwr" : false,
-                        "ece" : false,
-                        "fin" : false,
-                        "psh" : false,
-                        "rst" : false,
-                        "syn" : false,
                         "tcpFlags" : {
                           "ack" : true,
                           "cwr" : false,
@@ -3689,7 +3682,14 @@
                           "syn" : false,
                           "urg" : false
                         },
-                        "urg" : false
+                        "useAck" : true,
+                        "useCwr" : false,
+                        "useEce" : false,
+                        "useFin" : false,
+                        "usePsh" : false,
+                        "useRst" : false,
+                        "useSyn" : false,
+                        "useUrg" : false
                       }
                     ]
                   }

--- a/tests/aws/nodes-example-aws.ref
+++ b/tests/aws/nodes-example-aws.ref
@@ -92,15 +92,17 @@
                         "psh" : false,
                         "rst" : false,
                         "syn" : false,
-                        "urg" : false,
-                        "useAck" : true,
-                        "useCwr" : false,
-                        "useEce" : false,
-                        "useFin" : false,
-                        "usePsh" : false,
-                        "useRst" : false,
-                        "useSyn" : false,
-                        "useUrg" : false
+                        "tcpFlags" : {
+                          "ack" : true,
+                          "cwr" : false,
+                          "ece" : false,
+                          "fin" : false,
+                          "psh" : false,
+                          "rst" : false,
+                          "syn" : false,
+                          "urg" : false
+                        },
+                        "urg" : false
                       }
                     ]
                   }
@@ -147,15 +149,17 @@
                         "psh" : false,
                         "rst" : false,
                         "syn" : false,
-                        "urg" : false,
-                        "useAck" : true,
-                        "useCwr" : false,
-                        "useEce" : false,
-                        "useFin" : false,
-                        "usePsh" : false,
-                        "useRst" : false,
-                        "useSyn" : false,
-                        "useUrg" : false
+                        "tcpFlags" : {
+                          "ack" : true,
+                          "cwr" : false,
+                          "ece" : false,
+                          "fin" : false,
+                          "psh" : false,
+                          "rst" : false,
+                          "syn" : false,
+                          "urg" : false
+                        },
+                        "urg" : false
                       }
                     ]
                   }
@@ -3618,15 +3622,17 @@
                         "psh" : false,
                         "rst" : false,
                         "syn" : false,
-                        "urg" : false,
-                        "useAck" : true,
-                        "useCwr" : false,
-                        "useEce" : false,
-                        "useFin" : false,
-                        "usePsh" : false,
-                        "useRst" : false,
-                        "useSyn" : false,
-                        "useUrg" : false
+                        "tcpFlags" : {
+                          "ack" : true,
+                          "cwr" : false,
+                          "ece" : false,
+                          "fin" : false,
+                          "psh" : false,
+                          "rst" : false,
+                          "syn" : false,
+                          "urg" : false
+                        },
+                        "urg" : false
                       }
                     ]
                   }
@@ -3673,15 +3679,17 @@
                         "psh" : false,
                         "rst" : false,
                         "syn" : false,
-                        "urg" : false,
-                        "useAck" : true,
-                        "useCwr" : false,
-                        "useEce" : false,
-                        "useFin" : false,
-                        "usePsh" : false,
-                        "useRst" : false,
-                        "useSyn" : false,
-                        "useUrg" : false
+                        "tcpFlags" : {
+                          "ack" : true,
+                          "cwr" : false,
+                          "ece" : false,
+                          "fin" : false,
+                          "psh" : false,
+                          "rst" : false,
+                          "syn" : false,
+                          "urg" : false
+                        },
+                        "urg" : false
                       }
                     ]
                   }

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -14176,15 +14176,17 @@
                         "psh" : false,
                         "rst" : false,
                         "syn" : false,
-                        "urg" : false,
-                        "useAck" : true,
-                        "useCwr" : false,
-                        "useEce" : false,
-                        "useFin" : false,
-                        "usePsh" : false,
-                        "useRst" : false,
-                        "useSyn" : false,
-                        "useUrg" : false
+                        "tcpFlags" : {
+                          "ack" : true,
+                          "cwr" : false,
+                          "ece" : false,
+                          "fin" : false,
+                          "psh" : false,
+                          "rst" : false,
+                          "syn" : false,
+                          "urg" : false
+                        },
+                        "urg" : false
                       }
                     ]
                   }
@@ -24514,15 +24516,17 @@
                         "psh" : false,
                         "rst" : false,
                         "syn" : false,
-                        "urg" : false,
-                        "useAck" : true,
-                        "useCwr" : false,
-                        "useEce" : false,
-                        "useFin" : false,
-                        "usePsh" : false,
-                        "useRst" : false,
-                        "useSyn" : false,
-                        "useUrg" : false
+                        "tcpFlags" : {
+                          "ack" : true,
+                          "cwr" : false,
+                          "ece" : false,
+                          "fin" : false,
+                          "psh" : false,
+                          "rst" : false,
+                          "syn" : false,
+                          "urg" : false
+                        },
+                        "urg" : false
                       }
                     ]
                   }
@@ -24555,15 +24559,17 @@
                         "psh" : false,
                         "rst" : true,
                         "syn" : false,
-                        "urg" : false,
-                        "useAck" : false,
-                        "useCwr" : false,
-                        "useEce" : false,
-                        "useFin" : false,
-                        "usePsh" : false,
-                        "useRst" : true,
-                        "useSyn" : false,
-                        "useUrg" : false
+                        "tcpFlags" : {
+                          "ack" : false,
+                          "cwr" : false,
+                          "ece" : false,
+                          "fin" : false,
+                          "psh" : false,
+                          "rst" : true,
+                          "syn" : false,
+                          "urg" : false
+                        },
+                        "urg" : false
                       }
                     ]
                   }
@@ -24596,15 +24602,17 @@
                         "psh" : false,
                         "rst" : false,
                         "syn" : true,
-                        "urg" : false,
-                        "useAck" : false,
-                        "useCwr" : false,
-                        "useEce" : false,
-                        "useFin" : false,
-                        "usePsh" : false,
-                        "useRst" : false,
-                        "useSyn" : true,
-                        "useUrg" : false
+                        "tcpFlags" : {
+                          "ack" : false,
+                          "cwr" : false,
+                          "ece" : false,
+                          "fin" : false,
+                          "psh" : false,
+                          "rst" : false,
+                          "syn" : true,
+                          "urg" : false
+                        },
+                        "urg" : false
                       },
                       {
                         "ack" : true,
@@ -24614,15 +24622,17 @@
                         "psh" : false,
                         "rst" : false,
                         "syn" : false,
-                        "urg" : false,
-                        "useAck" : true,
-                        "useCwr" : false,
-                        "useEce" : false,
-                        "useFin" : false,
-                        "usePsh" : false,
-                        "useRst" : false,
-                        "useSyn" : false,
-                        "useUrg" : false
+                        "tcpFlags" : {
+                          "ack" : true,
+                          "cwr" : false,
+                          "ece" : false,
+                          "fin" : false,
+                          "psh" : false,
+                          "rst" : false,
+                          "syn" : false,
+                          "urg" : false
+                        },
+                        "urg" : false
                       },
                       {
                         "ack" : false,
@@ -24632,15 +24642,17 @@
                         "psh" : false,
                         "rst" : false,
                         "syn" : false,
-                        "urg" : true,
-                        "useAck" : false,
-                        "useCwr" : false,
-                        "useEce" : false,
-                        "useFin" : false,
-                        "usePsh" : false,
-                        "useRst" : false,
-                        "useSyn" : false,
-                        "useUrg" : true
+                        "tcpFlags" : {
+                          "ack" : false,
+                          "cwr" : false,
+                          "ece" : false,
+                          "fin" : false,
+                          "psh" : false,
+                          "rst" : false,
+                          "syn" : false,
+                          "urg" : true
+                        },
+                        "urg" : true
                       },
                       {
                         "ack" : false,
@@ -24650,15 +24662,17 @@
                         "psh" : true,
                         "rst" : false,
                         "syn" : false,
-                        "urg" : false,
-                        "useAck" : false,
-                        "useCwr" : false,
-                        "useEce" : false,
-                        "useFin" : false,
-                        "usePsh" : true,
-                        "useRst" : false,
-                        "useSyn" : false,
-                        "useUrg" : false
+                        "tcpFlags" : {
+                          "ack" : false,
+                          "cwr" : false,
+                          "ece" : false,
+                          "fin" : false,
+                          "psh" : true,
+                          "rst" : false,
+                          "syn" : false,
+                          "urg" : false
+                        },
+                        "urg" : false
                       },
                       {
                         "ack" : false,
@@ -24668,15 +24682,17 @@
                         "psh" : false,
                         "rst" : true,
                         "syn" : false,
-                        "urg" : false,
-                        "useAck" : false,
-                        "useCwr" : false,
-                        "useEce" : false,
-                        "useFin" : false,
-                        "usePsh" : false,
-                        "useRst" : true,
-                        "useSyn" : false,
-                        "useUrg" : false
+                        "tcpFlags" : {
+                          "ack" : false,
+                          "cwr" : false,
+                          "ece" : false,
+                          "fin" : false,
+                          "psh" : false,
+                          "rst" : true,
+                          "syn" : false,
+                          "urg" : false
+                        },
+                        "urg" : false
                       },
                       {
                         "ack" : false,
@@ -24686,15 +24702,17 @@
                         "psh" : false,
                         "rst" : false,
                         "syn" : false,
-                        "urg" : false,
-                        "useAck" : false,
-                        "useCwr" : false,
-                        "useEce" : true,
-                        "useFin" : false,
-                        "usePsh" : false,
-                        "useRst" : false,
-                        "useSyn" : false,
-                        "useUrg" : false
+                        "tcpFlags" : {
+                          "ack" : false,
+                          "cwr" : false,
+                          "ece" : true,
+                          "fin" : false,
+                          "psh" : false,
+                          "rst" : false,
+                          "syn" : false,
+                          "urg" : false
+                        },
+                        "urg" : false
                       },
                       {
                         "ack" : false,
@@ -24704,15 +24722,17 @@
                         "psh" : false,
                         "rst" : false,
                         "syn" : false,
-                        "urg" : false,
-                        "useAck" : false,
-                        "useCwr" : false,
-                        "useEce" : false,
-                        "useFin" : true,
-                        "usePsh" : false,
-                        "useRst" : false,
-                        "useSyn" : false,
-                        "useUrg" : false
+                        "tcpFlags" : {
+                          "ack" : false,
+                          "cwr" : false,
+                          "ece" : false,
+                          "fin" : true,
+                          "psh" : false,
+                          "rst" : false,
+                          "syn" : false,
+                          "urg" : false
+                        },
+                        "urg" : false
                       }
                     ]
                   }
@@ -24745,15 +24765,17 @@
                         "psh" : false,
                         "rst" : false,
                         "syn" : false,
-                        "urg" : false,
-                        "useAck" : false,
-                        "useCwr" : false,
-                        "useEce" : false,
-                        "useFin" : true,
-                        "usePsh" : false,
-                        "useRst" : false,
-                        "useSyn" : false,
-                        "useUrg" : false
+                        "tcpFlags" : {
+                          "ack" : false,
+                          "cwr" : false,
+                          "ece" : false,
+                          "fin" : true,
+                          "psh" : false,
+                          "rst" : false,
+                          "syn" : false,
+                          "urg" : false
+                        },
+                        "urg" : false
                       }
                     ]
                   }
@@ -24786,15 +24808,17 @@
                         "psh" : false,
                         "rst" : false,
                         "syn" : false,
-                        "urg" : false,
-                        "useAck" : false,
-                        "useCwr" : false,
-                        "useEce" : false,
-                        "useFin" : true,
-                        "usePsh" : false,
-                        "useRst" : false,
-                        "useSyn" : false,
-                        "useUrg" : false
+                        "tcpFlags" : {
+                          "ack" : false,
+                          "cwr" : false,
+                          "ece" : false,
+                          "fin" : true,
+                          "psh" : false,
+                          "rst" : false,
+                          "syn" : false,
+                          "urg" : false
+                        },
+                        "urg" : false
                       },
                       {
                         "ack" : true,
@@ -24804,15 +24828,17 @@
                         "psh" : false,
                         "rst" : false,
                         "syn" : false,
-                        "urg" : false,
-                        "useAck" : true,
-                        "useCwr" : false,
-                        "useEce" : false,
-                        "useFin" : false,
-                        "usePsh" : false,
-                        "useRst" : false,
-                        "useSyn" : false,
-                        "useUrg" : false
+                        "tcpFlags" : {
+                          "ack" : true,
+                          "cwr" : false,
+                          "ece" : false,
+                          "fin" : false,
+                          "psh" : false,
+                          "rst" : false,
+                          "syn" : false,
+                          "urg" : false
+                        },
+                        "urg" : false
                       }
                     ]
                   }

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -14167,15 +14167,8 @@
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
                     "negate" : false,
-                    "tcpFlags" : [
+                    "tcpFlagsMatchConditions" : [
                       {
-                        "ack" : true,
-                        "cwr" : false,
-                        "ece" : false,
-                        "fin" : false,
-                        "psh" : false,
-                        "rst" : false,
-                        "syn" : false,
                         "tcpFlags" : {
                           "ack" : true,
                           "cwr" : false,
@@ -14186,7 +14179,14 @@
                           "syn" : false,
                           "urg" : false
                         },
-                        "urg" : false
+                        "useAck" : true,
+                        "useCwr" : false,
+                        "useEce" : false,
+                        "useFin" : false,
+                        "usePsh" : false,
+                        "useRst" : false,
+                        "useSyn" : false,
+                        "useUrg" : false
                       }
                     ]
                   }
@@ -24507,15 +24507,8 @@
                       "class" : "org.batfish.datamodel.IpWildcardIpSpace",
                       "ipWildcard" : "1.2.3.4/31"
                     },
-                    "tcpFlags" : [
+                    "tcpFlagsMatchConditions" : [
                       {
-                        "ack" : true,
-                        "cwr" : false,
-                        "ece" : false,
-                        "fin" : false,
-                        "psh" : false,
-                        "rst" : false,
-                        "syn" : false,
                         "tcpFlags" : {
                           "ack" : true,
                           "cwr" : false,
@@ -24526,7 +24519,14 @@
                           "syn" : false,
                           "urg" : false
                         },
-                        "urg" : false
+                        "useAck" : true,
+                        "useCwr" : false,
+                        "useEce" : false,
+                        "useFin" : false,
+                        "usePsh" : false,
+                        "useRst" : false,
+                        "useSyn" : false,
+                        "useUrg" : false
                       }
                     ]
                   }
@@ -24550,15 +24550,8 @@
                       "class" : "org.batfish.datamodel.IpWildcardIpSpace",
                       "ipWildcard" : "1.2.3.4/31"
                     },
-                    "tcpFlags" : [
+                    "tcpFlagsMatchConditions" : [
                       {
-                        "ack" : false,
-                        "cwr" : false,
-                        "ece" : false,
-                        "fin" : false,
-                        "psh" : false,
-                        "rst" : true,
-                        "syn" : false,
                         "tcpFlags" : {
                           "ack" : false,
                           "cwr" : false,
@@ -24569,7 +24562,14 @@
                           "syn" : false,
                           "urg" : false
                         },
-                        "urg" : false
+                        "useAck" : false,
+                        "useCwr" : false,
+                        "useEce" : false,
+                        "useFin" : false,
+                        "usePsh" : false,
+                        "useRst" : true,
+                        "useSyn" : false,
+                        "useUrg" : false
                       }
                     ]
                   }
@@ -24593,15 +24593,8 @@
                       "class" : "org.batfish.datamodel.IpWildcardIpSpace",
                       "ipWildcard" : "1.2.3.4/31"
                     },
-                    "tcpFlags" : [
+                    "tcpFlagsMatchConditions" : [
                       {
-                        "ack" : false,
-                        "cwr" : false,
-                        "ece" : false,
-                        "fin" : false,
-                        "psh" : false,
-                        "rst" : false,
-                        "syn" : true,
                         "tcpFlags" : {
                           "ack" : false,
                           "cwr" : false,
@@ -24612,16 +24605,16 @@
                           "syn" : true,
                           "urg" : false
                         },
-                        "urg" : false
+                        "useAck" : false,
+                        "useCwr" : false,
+                        "useEce" : false,
+                        "useFin" : false,
+                        "usePsh" : false,
+                        "useRst" : false,
+                        "useSyn" : true,
+                        "useUrg" : false
                       },
                       {
-                        "ack" : true,
-                        "cwr" : false,
-                        "ece" : false,
-                        "fin" : false,
-                        "psh" : false,
-                        "rst" : false,
-                        "syn" : false,
                         "tcpFlags" : {
                           "ack" : true,
                           "cwr" : false,
@@ -24632,16 +24625,16 @@
                           "syn" : false,
                           "urg" : false
                         },
-                        "urg" : false
+                        "useAck" : true,
+                        "useCwr" : false,
+                        "useEce" : false,
+                        "useFin" : false,
+                        "usePsh" : false,
+                        "useRst" : false,
+                        "useSyn" : false,
+                        "useUrg" : false
                       },
                       {
-                        "ack" : false,
-                        "cwr" : false,
-                        "ece" : false,
-                        "fin" : false,
-                        "psh" : false,
-                        "rst" : false,
-                        "syn" : false,
                         "tcpFlags" : {
                           "ack" : false,
                           "cwr" : false,
@@ -24652,16 +24645,16 @@
                           "syn" : false,
                           "urg" : true
                         },
-                        "urg" : true
+                        "useAck" : false,
+                        "useCwr" : false,
+                        "useEce" : false,
+                        "useFin" : false,
+                        "usePsh" : false,
+                        "useRst" : false,
+                        "useSyn" : false,
+                        "useUrg" : true
                       },
                       {
-                        "ack" : false,
-                        "cwr" : false,
-                        "ece" : false,
-                        "fin" : false,
-                        "psh" : true,
-                        "rst" : false,
-                        "syn" : false,
                         "tcpFlags" : {
                           "ack" : false,
                           "cwr" : false,
@@ -24672,16 +24665,16 @@
                           "syn" : false,
                           "urg" : false
                         },
-                        "urg" : false
+                        "useAck" : false,
+                        "useCwr" : false,
+                        "useEce" : false,
+                        "useFin" : false,
+                        "usePsh" : true,
+                        "useRst" : false,
+                        "useSyn" : false,
+                        "useUrg" : false
                       },
                       {
-                        "ack" : false,
-                        "cwr" : false,
-                        "ece" : false,
-                        "fin" : false,
-                        "psh" : false,
-                        "rst" : true,
-                        "syn" : false,
                         "tcpFlags" : {
                           "ack" : false,
                           "cwr" : false,
@@ -24692,16 +24685,16 @@
                           "syn" : false,
                           "urg" : false
                         },
-                        "urg" : false
+                        "useAck" : false,
+                        "useCwr" : false,
+                        "useEce" : false,
+                        "useFin" : false,
+                        "usePsh" : false,
+                        "useRst" : true,
+                        "useSyn" : false,
+                        "useUrg" : false
                       },
                       {
-                        "ack" : false,
-                        "cwr" : false,
-                        "ece" : true,
-                        "fin" : false,
-                        "psh" : false,
-                        "rst" : false,
-                        "syn" : false,
                         "tcpFlags" : {
                           "ack" : false,
                           "cwr" : false,
@@ -24712,16 +24705,16 @@
                           "syn" : false,
                           "urg" : false
                         },
-                        "urg" : false
+                        "useAck" : false,
+                        "useCwr" : false,
+                        "useEce" : true,
+                        "useFin" : false,
+                        "usePsh" : false,
+                        "useRst" : false,
+                        "useSyn" : false,
+                        "useUrg" : false
                       },
                       {
-                        "ack" : false,
-                        "cwr" : false,
-                        "ece" : false,
-                        "fin" : true,
-                        "psh" : false,
-                        "rst" : false,
-                        "syn" : false,
                         "tcpFlags" : {
                           "ack" : false,
                           "cwr" : false,
@@ -24732,7 +24725,14 @@
                           "syn" : false,
                           "urg" : false
                         },
-                        "urg" : false
+                        "useAck" : false,
+                        "useCwr" : false,
+                        "useEce" : false,
+                        "useFin" : true,
+                        "usePsh" : false,
+                        "useRst" : false,
+                        "useSyn" : false,
+                        "useUrg" : false
                       }
                     ]
                   }
@@ -24756,15 +24756,8 @@
                       "class" : "org.batfish.datamodel.IpWildcardIpSpace",
                       "ipWildcard" : "1.2.3.4/31"
                     },
-                    "tcpFlags" : [
+                    "tcpFlagsMatchConditions" : [
                       {
-                        "ack" : false,
-                        "cwr" : false,
-                        "ece" : false,
-                        "fin" : true,
-                        "psh" : false,
-                        "rst" : false,
-                        "syn" : false,
                         "tcpFlags" : {
                           "ack" : false,
                           "cwr" : false,
@@ -24775,7 +24768,14 @@
                           "syn" : false,
                           "urg" : false
                         },
-                        "urg" : false
+                        "useAck" : false,
+                        "useCwr" : false,
+                        "useEce" : false,
+                        "useFin" : true,
+                        "usePsh" : false,
+                        "useRst" : false,
+                        "useSyn" : false,
+                        "useUrg" : false
                       }
                     ]
                   }
@@ -24799,15 +24799,8 @@
                       "class" : "org.batfish.datamodel.IpWildcardIpSpace",
                       "ipWildcard" : "1.2.3.4/31"
                     },
-                    "tcpFlags" : [
+                    "tcpFlagsMatchConditions" : [
                       {
-                        "ack" : false,
-                        "cwr" : false,
-                        "ece" : false,
-                        "fin" : true,
-                        "psh" : false,
-                        "rst" : false,
-                        "syn" : false,
                         "tcpFlags" : {
                           "ack" : false,
                           "cwr" : false,
@@ -24818,16 +24811,16 @@
                           "syn" : false,
                           "urg" : false
                         },
-                        "urg" : false
+                        "useAck" : false,
+                        "useCwr" : false,
+                        "useEce" : false,
+                        "useFin" : true,
+                        "usePsh" : false,
+                        "useRst" : false,
+                        "useSyn" : false,
+                        "useUrg" : false
                       },
                       {
-                        "ack" : true,
-                        "cwr" : false,
-                        "ece" : false,
-                        "fin" : false,
-                        "psh" : false,
-                        "rst" : false,
-                        "syn" : false,
                         "tcpFlags" : {
                           "ack" : true,
                           "cwr" : false,
@@ -24838,7 +24831,14 @@
                           "syn" : false,
                           "urg" : false
                         },
-                        "urg" : false
+                        "useAck" : true,
+                        "useCwr" : false,
+                        "useEce" : false,
+                        "useFin" : false,
+                        "usePsh" : false,
+                        "useRst" : false,
+                        "useSyn" : false,
+                        "useUrg" : false
                       }
                     ]
                   }


### PR DESCRIPTION
This begins the bottom-up work of cleaner data structures for Flow/headerspace-related data structures.