### PR TITLE
InterfaceProperty: skip inbound-filter-name altogether

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/InterfacePropertySpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/InterfacePropertySpecifier.java
@@ -58,10 +58,6 @@ public class InterfacePropertySpecifier extends PropertySpecifier {
               "hsrp-groups",
               new PropertyDescriptor<>(Interface::getHsrpGroups, Schema.set(Schema.STRING)))
           .put("hsrp-version", new PropertyDescriptor<>(Interface::getHsrpVersion, Schema.STRING))
-          // skip inbound-filter
-          .put(
-              "inbound-filter-name",
-              new PropertyDescriptor<>(Interface::getInboundFilterName, Schema.STRING))
           // skip incoming filter
           .put(
               "incoming-filter-name",


### PR DESCRIPTION
This property is in deletion at #2176, this is a user-facing shortcut
while that one is in progress.