### PR TITLE
detect empty unions of IpSpace

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AclIpSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AclIpSpace.java
@@ -113,17 +113,29 @@ public class AclIpSpace extends IpSpace {
   }
 
   private static @Nullable IpSpace intersection(Spliterator<IpSpace> ipSpaces) {
-    IpSpace[] complements =
+    IpSpace[] concreteSpaces =
         StreamSupport.stream(ipSpaces, false)
             .filter(Objects::nonNull)
-            .map(IpSpace::complement)
+            .filter(ipSpace -> ipSpace != UniverseIpSpace.INSTANCE)
             .toArray(IpSpace[]::new);
 
-    if (complements.length == 0) {
+    if (concreteSpaces.length == 0) {
+      // all null or Universe
       return null;
     }
+    if (concreteSpaces.length == 1) {
+      return concreteSpaces[0];
+    }
 
-    return builder().thenRejecting(complements).thenPermitting(UniverseIpSpace.INSTANCE).build();
+    // complement each concrete space.
+    for (int i = 0; i < concreteSpaces.length; i++) {
+      if (concreteSpaces[i] == EmptyIpSpace.INSTANCE) {
+        return EmptyIpSpace.INSTANCE;
+      }
+      concreteSpaces[i] = concreteSpaces[i].complement();
+    }
+
+    return builder().thenRejecting(concreteSpaces).thenPermitting(UniverseIpSpace.INSTANCE).build();
   }
 
   public static Builder permitting(IpSpace... ipSpaces) {
@@ -151,7 +163,7 @@ public class AclIpSpace extends IpSpace {
    * {@code null} ipSpaces are ignored. If all arguments are {@code null}, returns {@code null}.
    */
   public static @Nullable IpSpace union(IpSpace... ipSpaces) {
-    return unionNonnull(Arrays.stream(ipSpaces).filter(Objects::nonNull).toArray(IpSpace[]::new));
+    return union(Arrays.asList(ipSpaces));
   }
 
   /**
@@ -159,10 +171,19 @@ public class AclIpSpace extends IpSpace {
    * {@code null} ipSpaces are ignored. If all arguments are {@code null}, returns {@code null}.
    */
   public static @Nullable IpSpace union(Iterable<IpSpace> ipSpaces) {
-    return unionNonnull(
+    IpSpace[] nonNullSpaces =
         StreamSupport.stream(ipSpaces.spliterator(), false)
             .filter(Objects::nonNull)
-            .toArray(IpSpace[]::new));
+            .toArray(IpSpace[]::new);
+    if (nonNullSpaces.length == 0) {
+      // no constraint
+      return null;
+    }
+    IpSpace[] nonEmptySpaces =
+        Arrays.stream(nonNullSpaces)
+            .filter(ipSpace -> ipSpace != EmptyIpSpace.INSTANCE)
+            .toArray(IpSpace[]::new);
+    return nonEmptySpaces.length == 0 ? EmptyIpSpace.INSTANCE : unionNonnull(nonEmptySpaces);
   }
 
   private static @Nullable IpSpace unionNonnull(IpSpace... ipSpaces) {

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/AclIpSpaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/AclIpSpaceTest.java
@@ -1,8 +1,12 @@
 package org.batfish.datamodel;
 
+import static org.batfish.datamodel.AclIpSpace.intersection;
+import static org.batfish.datamodel.AclIpSpace.union;
 import static org.batfish.datamodel.matchers.IpSpaceMatchers.containsIp;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 
 import org.junit.Test;
 
@@ -29,5 +33,21 @@ public class AclIpSpaceTest {
     assertThat(notIpSpace, containsIp(new Ip("1.1.1.0")));
     assertThat(notIpSpace, not(containsIp(new Ip("1.1.0.0"))));
     assertThat(notIpSpace, containsIp(new Ip("1.0.0.0")));
+  }
+
+  @Test
+  public void testIntersection() {
+    IpIpSpace ipSpace = new Ip("1.2.3.4").toIpSpace();
+    assertThat(intersection(null, UniverseIpSpace.INSTANCE, null), nullValue());
+    assertThat(intersection(ipSpace, null, UniverseIpSpace.INSTANCE), equalTo(ipSpace));
+    assertThat(intersection(EmptyIpSpace.INSTANCE, ipSpace), equalTo(EmptyIpSpace.INSTANCE));
+  }
+
+  @Test
+  public void testUnion() {
+    IpIpSpace ipSpace = new Ip("1.2.3.4").toIpSpace();
+    assertThat(union(null, null), nullValue());
+    assertThat(union(EmptyIpSpace.INSTANCE), equalTo(EmptyIpSpace.INSTANCE));
+    assertThat(union(EmptyIpSpace.INSTANCE, ipSpace), equalTo(ipSpace));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/AclIpSpaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/AclIpSpaceTest.java
@@ -38,7 +38,9 @@ public class AclIpSpaceTest {
   @Test
   public void testIntersection() {
     IpIpSpace ipSpace = new Ip("1.2.3.4").toIpSpace();
-    assertThat(intersection(null, UniverseIpSpace.INSTANCE, null), nullValue());
+    assertThat(intersection(null, null), nullValue());
+    assertThat(
+        intersection(null, UniverseIpSpace.INSTANCE, null), equalTo(UniverseIpSpace.INSTANCE));
     assertThat(intersection(ipSpace, null, UniverseIpSpace.INSTANCE), equalTo(ipSpace));
     assertThat(intersection(EmptyIpSpace.INSTANCE, ipSpace), equalTo(EmptyIpSpace.INSTANCE));
   }


### PR DESCRIPTION
Fix a bug in union: union of only EmptyIpSpaces is EmptyIpSpace. Previously, we removed those and returned null (interpreted as unconstrained/universe).

Also simplify output of intersection when the intersection has only 1 element or contains EmptyIpSpace, short-circuit.