### PR TITLE
BDD specializers: flag whether to simplify to True/Universe

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/z3/BDDIpAccessListSpecializer.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/BDDIpAccessListSpecializer.java
@@ -14,6 +14,7 @@ import javax.annotation.Nullable;
 import net.sf.javabdd.BDD;
 import org.batfish.datamodel.AclIpSpace;
 import org.batfish.datamodel.HeaderSpace;
+import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.SubRange;
@@ -30,6 +31,26 @@ import org.batfish.symbolic.bdd.BDDPacket;
 import org.batfish.symbolic.bdd.BDDSourceManager;
 import org.batfish.symbolic.bdd.IpSpaceToBDD;
 
+/**
+ * An {@link IpAccessListSpecializer} that uses {@link BDD BDDs} to represent the headerspace of
+ * interest. The intuition of specialization is to remove parts of the ACL that are irrelevant for
+ * the headerspace of interest.
+ *
+ * <p>The superclass {@link IpAccessListSpecializer} walks over the {@link IpAccessList ACL} and its
+ * {@link AclLineMatchExpr match expressions}, downcalling at the match expression leaves. For each
+ * leaf, we compute the space matched by that expression (as a BDD) and compare with the space of
+ * interest. There are three cases:
+ *
+ * <ol>
+ *   <li>The two spaces are disjoint. Then the expression is not relevant to the space of interest,
+ *       and will be replaced by the {@code FalseExpr.INSTANCE}.
+ *   <li>The match expression space contains the space of interest. Then the expression is relevant,
+ *       but we also know that it will always evaluate to {@code true}. We can optionally optimize
+ *       such expressions by replacing them with {@code TrueExpr.INSTANCE}.
+ *   <li>The match expression intersects, but does not contain the space of interest. We preserve
+ *       the expression as-is.
+ * </ol>
+ */
 public final class BDDIpAccessListSpecializer extends IpAccessListSpecializer {
   private final BDDSourceManager _bddSrcManager;
   private final BDDIpSpaceSpecializer _dstIpSpaceSpecializer;
@@ -46,6 +67,16 @@ public final class BDDIpAccessListSpecializer extends IpAccessListSpecializer {
     this(pkt, flowBDD, namedIpSpaces, bddSrcManager, true);
   }
 
+  /**
+   * @param pkt The {@link BDD} variables representing a symbolic packet.
+   * @param flowBDD The representation of the headerspace of interest.
+   * @param namedIpSpaces Definitions of named {@link IpSpace IpSpaces} currently in scope.
+   * @param bddSrcManager Manages constraints for {@link OriginatingFromDevice} and {@link
+   *     MatchSrcInterface} expressions.
+   * @param simplifyToTrue Indicates whether expressions that are always true within the headerspace
+   *     of interest (i.e. the match a space that includes the space of interest) should be
+   *     optimized to the constant {@link TrueExpr}.
+   */
   public BDDIpAccessListSpecializer(
       BDDPacket pkt,
       BDD flowBDD,

--- a/projects/batfish/src/main/java/org/batfish/z3/BDDIpSpaceSpecializer.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/BDDIpSpaceSpecializer.java
@@ -14,9 +14,14 @@ import org.batfish.symbolic.bdd.BDDInteger;
 import org.batfish.symbolic.bdd.BDDUtils;
 import org.batfish.symbolic.bdd.IpSpaceToBDD;
 
+/**
+ * An {@link IpSpaceSpecializer} that uses a {@link BDD} to represent the headerspace to which we
+ * want to specialize.
+ */
 public final class BDDIpSpaceSpecializer extends IpSpaceSpecializer {
   private final BDD _bdd;
   private final IpSpaceToBDD _ipSpaceToBDD;
+  private final boolean _simplifyToUniverse;
 
   public BDDIpSpaceSpecializer(IpSpace ipSpace, Map<String, IpSpace> namedIpSpaces) {
     super(namedIpSpaces);
@@ -25,6 +30,7 @@ public final class BDDIpSpaceSpecializer extends IpSpaceSpecializer {
     BDDInteger ipAddrBdd = BDDInteger.makeFromIndex(factory, 32, 0, true);
     _ipSpaceToBDD = new IpSpaceToBDD(factory, ipAddrBdd, namedIpSpaces);
     _bdd = ipSpace.accept(_ipSpaceToBDD);
+    _simplifyToUniverse = true;
   }
 
   /**
@@ -38,9 +44,18 @@ public final class BDDIpSpaceSpecializer extends IpSpaceSpecializer {
    */
   public BDDIpSpaceSpecializer(
       BDD bdd, Map<String, IpSpace> namedIpSpaces, IpSpaceToBDD ipSpaceToBDD) {
+    this(bdd, namedIpSpaces, ipSpaceToBDD, true);
+  }
+
+  public BDDIpSpaceSpecializer(
+      BDD bdd,
+      Map<String, IpSpace> namedIpSpaces,
+      IpSpaceToBDD ipSpaceToBDD,
+      boolean simplifyToUniverse) {
     super(namedIpSpaces);
     _bdd = bdd;
     _ipSpaceToBDD = ipSpaceToBDD;
+    _simplifyToUniverse = simplifyToUniverse;
   }
 
   @Override
@@ -75,7 +90,7 @@ public final class BDDIpSpaceSpecializer extends IpSpaceSpecializer {
       return EmptyIpSpace.INSTANCE;
     }
 
-    if (ipSpaceBDD.not().and(_bdd).isZero()) {
+    if (_simplifyToUniverse && ipSpaceBDD.not().and(_bdd).isZero()) {
       // _bdd's ip space is a subset of ipSpace.
       return UniverseIpSpace.INSTANCE;
     }


### PR DESCRIPTION
Ordinarily specializers simplify constraints that are always true to UniverseIpSpace (IpSpaceSpecializer) or TrueExpr (IpAccessListSpecializer). 

For headerspace explanation, we want to keep those constraints unmodified. This change adds a flag to the BDD specializers to indicate whether to simplify them or not.