### PR TITLE
BatfishStorage refactor and overhaul

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
@@ -311,11 +311,11 @@ public final class FileBasedStorage implements StorageProvider {
   public void storeAnswer(
       String answerStr,
       String network,
-      String baseSnapshot,
-      @Nullable String deltaSnapshot,
-      @Nullable String analysis,
-      String question) {
-    Path answerDir = getAnswerDir(network, baseSnapshot, deltaSnapshot, analysis, question);
+      String snapshot,
+      String question,
+      @Nullable String referenceSnapshot,
+      @Nullable String analysis) {
+    Path answerDir = getAnswerDir(network, snapshot, referenceSnapshot, analysis, question);
     // If settings has neither a question nor an analysis configured, don't write a file
     if (answerDir == null) {
       return;
@@ -329,17 +329,17 @@ public final class FileBasedStorage implements StorageProvider {
   public void storeAnswerMetadata(
       AnswerMetadata answerMetrics,
       String network,
-      @Nullable String analysis,
-      String baseSnapshot,
-      @Nullable String deltaSnapshot,
-      String question) {
+      String snapshot,
+      String question,
+      @Nullable String referenceSnapshot,
+      @Nullable String analysis) {
     String metricsStr;
     try {
       metricsStr = BatfishObjectMapper.writePrettyString(answerMetrics);
     } catch (JsonProcessingException e) {
       throw new BatfishException("Could not write answer metrics", e);
     }
-    Path answerDir = getAnswerDir(network, baseSnapshot, deltaSnapshot, analysis, question);
+    Path answerDir = getAnswerDir(network, snapshot, referenceSnapshot, analysis, question);
     if (answerDir == null) {
       // If settings has neither a question nor an analysis configured, don't write a file
       return;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
@@ -458,9 +458,7 @@ public final class FileBasedStorage implements StorageProvider {
   }
 
   private @Nonnull Path getAnalysisQuestionDir(
-      @Nonnull String network,
-      @Nonnull String analysis,
-      @Nonnull String question) {
+      @Nonnull String network, @Nonnull String analysis, @Nonnull String question) {
     return getNetworkAnalysisDir(network, analysis)
         .resolve(BfConsts.RELPATH_QUESTIONS_DIR)
         .resolve(question);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
@@ -159,6 +159,7 @@ public final class FileBasedStorage implements StorageProvider {
     }
   }
 
+  @Override
   public @Nullable Layer1Topology loadLayer1Topology(
       @Nonnull String network, @Nonnull String snapshot) {
     Path path =
@@ -452,23 +453,20 @@ public final class FileBasedStorage implements StorageProvider {
     }
   }
 
-  private @Nonnull Path getNetworkAnalysisDir(
-      @Nonnull String network, @Nonnull String snapshot, @Nonnull String analysis) {
+  private @Nonnull Path getNetworkAnalysisDir(@Nonnull String network, @Nonnull String analysis) {
     return getNetworkDir(network).resolve(BfConsts.RELPATH_ANALYSES_DIR).resolve(analysis);
   }
 
   private @Nonnull Path getAnalysisQuestionDir(
       @Nonnull String network,
-      @Nonnull String snapshot,
       @Nonnull String analysis,
       @Nonnull String question) {
-    return getNetworkAnalysisDir(network, snapshot, analysis)
+    return getNetworkAnalysisDir(network, analysis)
         .resolve(BfConsts.RELPATH_QUESTIONS_DIR)
         .resolve(question);
   }
 
-  private @Nonnull Path getAdHocQuestionDir(
-      @Nonnull String network, @Nonnull String snapshot, @Nonnull String question) {
+  private @Nonnull Path getAdHocQuestionDir(@Nonnull String network, @Nonnull String question) {
     return getNetworkDir(network).resolve(BfConsts.RELPATH_QUESTIONS_DIR).resolve(question);
   }
 
@@ -486,8 +484,8 @@ public final class FileBasedStorage implements StorageProvider {
       @Nullable String analysis,
       @Nonnull String question) {
     return analysis != null
-        ? getAnalysisQuestionDir(network, snapshot, analysis, question)
-        : getAdHocQuestionDir(network, snapshot, question);
+        ? getAnalysisQuestionDir(network, analysis, question)
+        : getAdHocQuestionDir(network, question);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
@@ -477,10 +477,7 @@ public final class FileBasedStorage implements StorageProvider {
   }
 
   private @Nonnull Path getQuestionDir(
-      @Nonnull String network,
-      @Nonnull String snapshot,
-      @Nullable String analysis,
-      @Nonnull String question) {
+      @Nonnull String network, @Nullable String analysis, @Nonnull String question) {
     return analysis != null
         ? getAnalysisQuestionDir(network, analysis, question)
         : getAdHocQuestionDir(network, question);
@@ -488,13 +485,9 @@ public final class FileBasedStorage implements StorageProvider {
 
   @Override
   public String loadQuestion(
-      @Nonnull String network,
-      @Nonnull String snapshot,
-      @Nullable String analysis,
-      @Nonnull String question) {
+      @Nonnull String network, @Nullable String analysis, @Nonnull String question) {
     Path questionPath =
-        getQuestionDir(network, snapshot, analysis, question)
-            .resolve(BfConsts.RELPATH_QUESTION_FILE);
+        getQuestionDir(network, analysis, question).resolve(BfConsts.RELPATH_QUESTION_FILE);
     return CommonUtil.readFile(questionPath);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
@@ -316,10 +316,6 @@ public final class FileBasedStorage implements StorageProvider {
       @Nullable String referenceSnapshot,
       @Nullable String analysis) {
     Path answerDir = getAnswerDir(network, snapshot, referenceSnapshot, analysis, question);
-    // If settings has neither a question nor an analysis configured, don't write a file
-    if (answerDir == null) {
-      return;
-    }
     Path answerPath = answerDir.resolve(BfConsts.RELPATH_ANSWER_JSON);
     answerDir.toFile().mkdirs();
     CommonUtil.writeFile(answerPath, answerStr);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import net.jpountz.lz4.LZ4FrameInputStream;
 import net.jpountz.lz4.LZ4FrameOutputStream;
 import org.batfish.common.BatfishException;
@@ -43,6 +44,7 @@ import org.batfish.datamodel.answers.AnswerMetadata;
 import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
 
 /** A utility class that abstracts the underlying file system storage used by {@link Batfish}. */
+@ParametersAreNonnullByDefault
 public final class FileBasedStorage implements StorageProvider {
   private final Path _baseDir;
   private final BatfishLogger _logger;
@@ -65,7 +67,7 @@ public final class FileBasedStorage implements StorageProvider {
   @Override
   @Nullable
   public SortedMap<String, Configuration> loadCompressedConfigurations(
-      @Nonnull String network, @Nonnull String snapshot) {
+      String network, String snapshot) {
     Path testrigDir = getSnapshotDir(network, snapshot);
     Path indepDir = testrigDir.resolve(BfConsts.RELPATH_COMPRESSED_CONFIG_DIR);
     return loadConfigurations(network, snapshot, indepDir);
@@ -77,15 +79,14 @@ public final class FileBasedStorage implements StorageProvider {
    */
   @Override
   @Nullable
-  public SortedMap<String, Configuration> loadConfigurations(
-      @Nonnull String network, @Nonnull String snapshot) {
+  public SortedMap<String, Configuration> loadConfigurations(String network, String snapshot) {
     Path testrigDir = getSnapshotDir(network, snapshot);
     Path indepDir = testrigDir.resolve(BfConsts.RELPATH_VENDOR_INDEPENDENT_CONFIG_DIR);
     return loadConfigurations(network, snapshot, indepDir);
   }
 
-  private SortedMap<String, Configuration> loadConfigurations(
-      @Nonnull String network, @Nonnull String snapshot, Path indepDir) {
+  private @Nullable SortedMap<String, Configuration> loadConfigurations(
+      String network, String snapshot, Path indepDir) {
     // If the directory that would contain these configs does not even exist, no cache exists.
     if (!Files.exists(indepDir)) {
       _logger.debugf("Unable to load configs for %s from disk: no cache directory", snapshot);
@@ -120,7 +121,7 @@ public final class FileBasedStorage implements StorageProvider {
 
   @Override
   public @Nullable ConvertConfigurationAnswerElement loadConvertConfigurationAnswerElement(
-      @Nonnull String network, @Nonnull String snapshot) {
+      String network, String snapshot) {
     Path ccaePath = getSnapshotDir(network, snapshot).resolve(BfConsts.RELPATH_CONVERT_ANSWER_PATH);
     if (!Files.exists(ccaePath)) {
       return null;
@@ -136,7 +137,7 @@ public final class FileBasedStorage implements StorageProvider {
   }
 
   @Override
-  public @Nullable Topology loadLegacyTopology(@Nonnull String network, @Nonnull String snapshot) {
+  public @Nullable Topology loadLegacyTopology(String network, String snapshot) {
     Path path =
         getSnapshotDir(network, snapshot)
             .resolve(
@@ -160,8 +161,7 @@ public final class FileBasedStorage implements StorageProvider {
   }
 
   @Override
-  public @Nullable Layer1Topology loadLayer1Topology(
-      @Nonnull String network, @Nonnull String snapshot) {
+  public @Nullable Layer1Topology loadLayer1Topology(String network, String snapshot) {
     Path path =
         getSnapshotDir(network, snapshot)
             .resolve(
@@ -190,9 +190,7 @@ public final class FileBasedStorage implements StorageProvider {
    */
   @Override
   public void storeCompressedConfigurations(
-      @Nonnull Map<String, Configuration> configurations,
-      @Nonnull String network,
-      @Nonnull String snapshot) {
+      Map<String, Configuration> configurations, String network, String snapshot) {
     Path testrigDir = getSnapshotDir(network, snapshot);
 
     if (!testrigDir.toFile().exists() && !testrigDir.toFile().mkdirs()) {
@@ -215,10 +213,10 @@ public final class FileBasedStorage implements StorageProvider {
    */
   @Override
   public void storeConfigurations(
-      @Nonnull Map<String, Configuration> configurations,
-      @Nonnull ConvertConfigurationAnswerElement convertAnswerElement,
-      @Nonnull String network,
-      @Nonnull String snapshot) {
+      Map<String, Configuration> configurations,
+      ConvertConfigurationAnswerElement convertAnswerElement,
+      String network,
+      String snapshot) {
     Path testrigDir = getSnapshotDir(network, snapshot);
     if (!testrigDir.toFile().exists() && !testrigDir.toFile().mkdirs()) {
       throw new BatfishException(
@@ -264,21 +262,18 @@ public final class FileBasedStorage implements StorageProvider {
   }
 
   private @Nonnull Path getAnswerDir(
-      @Nonnull String network,
-      @Nonnull String baseSnapshot,
+      String network,
+      String baseSnapshot,
       @Nullable String deltaSnapshot,
       @Nullable String analysis,
-      @Nonnull String question) {
+      String question) {
     return deltaSnapshot != null
         ? getDeltaAnswerDir(network, baseSnapshot, deltaSnapshot, analysis, question)
         : getStandardAnswerDir(network, baseSnapshot, analysis, question);
   }
 
   private @Nonnull Path getStandardAnswerDir(
-      @Nonnull String network,
-      @Nonnull String snapshot,
-      @Nullable String analysis,
-      @Nonnull String question) {
+      String network, String snapshot, @Nullable String analysis, String question) {
     Path snapshotDir = getSnapshotDir(network, snapshot);
     Path dirWithQuestions =
         analysis != null
@@ -292,11 +287,11 @@ public final class FileBasedStorage implements StorageProvider {
   }
 
   private @Nonnull Path getDeltaAnswerDir(
-      @Nonnull String network,
-      @Nonnull String baseSnapshot,
-      @Nonnull String deltaSnapshot,
+      String network,
+      String baseSnapshot,
+      String deltaSnapshot,
       @Nullable String analysis,
-      @Nonnull String question) {
+      String question) {
     Path snapshotDir = getSnapshotDir(network, baseSnapshot);
     Path dirWithQuestions =
         analysis != null
@@ -314,14 +309,13 @@ public final class FileBasedStorage implements StorageProvider {
 
   @Override
   public void storeAnswer(
-      @Nonnull String answerStr,
-      @Nonnull String network,
-      @Nonnull String baseSnapshotName,
-      @Nullable String deltaSnapshotName,
-      @Nullable String analysisName,
-      @Nonnull String questionName) {
-    Path answerDir =
-        getAnswerDir(network, baseSnapshotName, deltaSnapshotName, analysisName, questionName);
+      String answerStr,
+      String network,
+      String baseSnapshot,
+      @Nullable String deltaSnapshot,
+      @Nullable String analysis,
+      String question) {
+    Path answerDir = getAnswerDir(network, baseSnapshot, deltaSnapshot, analysis, question);
     // If settings has neither a question nor an analysis configured, don't write a file
     if (answerDir == null) {
       return;
@@ -333,20 +327,19 @@ public final class FileBasedStorage implements StorageProvider {
 
   @Override
   public void storeAnswerMetadata(
-      @Nonnull AnswerMetadata answerMetrics,
-      @Nonnull String network,
-      @Nullable String analysisName,
-      @Nonnull String baseSnapshotName,
-      @Nullable String deltaSnapshotName,
-      @Nonnull String questionName) {
+      AnswerMetadata answerMetrics,
+      String network,
+      @Nullable String analysis,
+      String baseSnapshot,
+      @Nullable String deltaSnapshot,
+      String question) {
     String metricsStr;
     try {
       metricsStr = BatfishObjectMapper.writePrettyString(answerMetrics);
     } catch (JsonProcessingException e) {
       throw new BatfishException("Could not write answer metrics", e);
     }
-    Path answerDir =
-        getAnswerDir(network, baseSnapshotName, deltaSnapshotName, analysisName, questionName);
+    Path answerDir = getAnswerDir(network, baseSnapshot, deltaSnapshot, analysis, question);
     if (answerDir == null) {
       // If settings has neither a question nor an analysis configured, don't write a file
       return;
@@ -436,7 +429,7 @@ public final class FileBasedStorage implements StorageProvider {
     }
   }
 
-  private boolean cachedConfigsAreCompatible(@Nonnull String network, @Nonnull String snapshot) {
+  private boolean cachedConfigsAreCompatible(String network, String snapshot) {
     try {
       ConvertConfigurationAnswerElement ccae =
           loadConvertConfigurationAnswerElement(network, snapshot);
@@ -453,39 +446,36 @@ public final class FileBasedStorage implements StorageProvider {
     }
   }
 
-  private @Nonnull Path getNetworkAnalysisDir(@Nonnull String network, @Nonnull String analysis) {
+  private @Nonnull Path getNetworkAnalysisDir(String network, String analysis) {
     return getNetworkDir(network).resolve(BfConsts.RELPATH_ANALYSES_DIR).resolve(analysis);
   }
 
-  private @Nonnull Path getAnalysisQuestionDir(
-      @Nonnull String network, @Nonnull String analysis, @Nonnull String question) {
+  private @Nonnull Path getAnalysisQuestionDir(String network, String analysis, String question) {
     return getNetworkAnalysisDir(network, analysis)
         .resolve(BfConsts.RELPATH_QUESTIONS_DIR)
         .resolve(question);
   }
 
-  private @Nonnull Path getAdHocQuestionDir(@Nonnull String network, @Nonnull String question) {
+  private @Nonnull Path getAdHocQuestionDir(String network, String question) {
     return getNetworkDir(network).resolve(BfConsts.RELPATH_QUESTIONS_DIR).resolve(question);
   }
 
-  private @Nonnull Path getNetworkDir(@Nonnull String network) {
+  private @Nonnull Path getNetworkDir(String network) {
     return _baseDir.resolve(network);
   }
 
-  private @Nonnull Path getSnapshotDir(@Nonnull String network, @Nonnull String snapshot) {
+  private @Nonnull Path getSnapshotDir(String network, String snapshot) {
     return getNetworkDir(network).resolve(BfConsts.RELPATH_TESTRIGS_DIR).resolve(snapshot);
   }
 
-  private @Nonnull Path getQuestionDir(
-      @Nonnull String network, @Nullable String analysis, @Nonnull String question) {
+  private @Nonnull Path getQuestionDir(String network, @Nullable String analysis, String question) {
     return analysis != null
         ? getAnalysisQuestionDir(network, analysis, question)
         : getAdHocQuestionDir(network, question);
   }
 
   @Override
-  public String loadQuestion(
-      @Nonnull String network, @Nullable String analysis, @Nonnull String question) {
+  public @Nonnull String loadQuestion(String network, @Nullable String analysis, String question) {
     Path questionPath =
         getQuestionDir(network, analysis, question).resolve(BfConsts.RELPATH_QUESTION_FILE);
     return CommonUtil.readFile(questionPath);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
@@ -489,4 +489,16 @@ public final class FileBasedStorage implements StorageProvider {
         ? getAnalysisQuestionDir(network, snapshot, analysis, question)
         : getAdHocQuestionDir(network, snapshot, question);
   }
+
+  @Override
+  public String loadQuestion(
+      @Nonnull String network,
+      @Nonnull String snapshot,
+      @Nullable String analysis,
+      @Nonnull String question) {
+    Path questionPath =
+        getQuestionDir(network, snapshot, analysis, question)
+            .resolve(BfConsts.RELPATH_QUESTION_FILE);
+    return CommonUtil.readFile(questionPath);
+  }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
@@ -28,13 +28,32 @@ public interface StorageProvider {
   SortedMap<String, Configuration> loadConfigurations(
       @Nonnull String network, @Nonnull String snapshot);
 
+  /**
+   * Returns the {@link ConvertConfigurationAnswerElement} that is the result of the phase that
+   * converts vendor-specific configurations to vendor-independent configurations.
+   *
+   * @param network The name of the network
+   * @param snapshot Then name of the snapshot
+   */
   @Nullable
   ConvertConfigurationAnswerElement loadConvertConfigurationAnswerElement(
       @Nonnull String network, @Nonnull String snapshot);
 
+  /**
+   * Returns the old-style combined layer-1 through layer-3 topology provided in the given snapshot
+   *
+   * @param network The name of the network
+   * @param snapshot The name of the snapshot
+   */
   @Nullable
   Topology loadLegacyTopology(@Nonnull String network, @Nonnull String snapshot);
 
+  /**
+   * Returns the layer-1 topology of the network provided in the given snapshot
+   *
+   * @param network The name of the network
+   * @param snapshot The name of the snapshot
+   */
   @Nullable
   Layer1Topology loadLayer1Topology(@Nonnull String network, @Nonnull String snapshot);
 
@@ -57,22 +76,55 @@ public interface StorageProvider {
       @Nonnull String network,
       @Nonnull String snapshot);
 
+  /**
+   * Store the answer to an ad-hoc or analysis question.
+   *
+   * @param answerStr The text of the answer
+   * @param network The name of the network
+   * @param baseSnapshot The name of the base snapshot
+   * @param deltaSnapshot (optional) The name of the deltaSnapshot for a differential question, or
+   *     {@code null} for a non-differential question
+   * @param analysis (optional) The name of the analysis for an analysis question, or {@code null}
+   *     for an ad-hoc question
+   * @param question The name of the question
+   */
   void storeAnswer(
       @Nonnull String answerStr,
       @Nonnull String network,
-      @Nonnull String baseSnapshotName,
-      @Nullable String deltaSnapshotName,
-      @Nullable String analysisName,
-      @Nonnull String questionName);
+      @Nonnull String baseSnapshot,
+      @Nullable String deltaSnapshot,
+      @Nullable String analysis,
+      @Nonnull String question);
 
+  /**
+   * Store the metadata for the answer to an ad-hoc or analysis question.
+   *
+   * @param answerStr The text of the answer
+   * @param network The name of the network
+   * @param baseSnapshot The name of the base snapshot
+   * @param deltaSnapshot (optional) The name of the deltaSnapshot for a differential question, or
+   *     {@code null} for a non-differential question
+   * @param analysis (optional) The name of the analysis for an analysis question, or {@code null}
+   *     for an ad-hoc question
+   * @param question The name of the question
+   */
   void storeAnswerMetadata(
       @Nonnull AnswerMetadata answerMetrics,
       @Nonnull String network,
-      @Nullable String analysisName,
-      @Nonnull String baseSnapshotName,
-      @Nullable String deltaSnapshotName,
-      @Nonnull String questionName);
+      @Nullable String analysis,
+      @Nonnull String baseSnapshot,
+      @Nullable String deltaSnapshot,
+      @Nonnull String question);
 
+  /**
+   * Load the text of a JSON-serialized ad-hoc or analysis question
+   *
+   * @param network The name of the network
+   * @param analysis (optional) The name of the analysis for an analysis question, or {@code null}
+   *     for an ad-hoc question
+   * @param question The name of the question
+   * @return
+   */
   @Nonnull
   String loadQuestion(@Nonnull String network, @Nullable String analysis, @Nonnull String question);
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
@@ -74,9 +74,5 @@ public interface StorageProvider {
       @Nonnull String questionName);
 
   @Nonnull
-  String loadQuestion(
-      @Nonnull String network,
-      @Nonnull String snapshot,
-      @Nullable String analysis,
-      @Nonnull String question);
+  String loadQuestion(@Nonnull String network, @Nullable String analysis, @Nonnull String question);
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
@@ -82,8 +82,8 @@ public interface StorageProvider {
    * @param network The name of the network
    * @param snapshot The name of the base snapshot
    * @param question The name of the question
-   * @param referenceSnapshot (optional) The name of the deltaSnapshot for a differential question, or
-   *     {@code null} for a non-differential question
+   * @param referenceSnapshot (optional) The name of the deltaSnapshot for a differential question,
+   *     or {@code null} for a non-differential question
    * @param analysis (optional) The name of the analysis for an analysis question, or {@code null}
    *     for an ad-hoc question
    */

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
@@ -131,8 +131,8 @@ public interface StorageProvider {
    * Return a list of the names of the questions associated with the given analysis of the given
    * network
    *
-   * @param containerName
-   * @param analysisName
+   * @param network The name of the network
+   * @param analysis The name of the analysis
    */
   @Nonnull
   List<String> listAnalysisQuestions(String network, String analysis);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
@@ -4,12 +4,15 @@ import java.util.Map;
 import java.util.SortedMap;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.common.topology.Layer1Topology;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.answers.AnswerMetadata;
 import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
 
+/** Storage backend for loading and storing persistent data used by Batfish */
+@ParametersAreNonnullByDefault
 public interface StorageProvider {
 
   /**
@@ -17,16 +20,14 @@ public interface StorageProvider {
    * these configurations is not already present, then this function returns {@code null}.
    */
   @Nullable
-  SortedMap<String, Configuration> loadCompressedConfigurations(
-      @Nonnull String network, @Nonnull String snapshot);
+  SortedMap<String, Configuration> loadCompressedConfigurations(String network, String snapshot);
 
   /**
    * Returns the configuration files for the given snapshot. If a serialized copy of these
    * configurations is not already present, then this function returns {@code null}.
    */
   @Nullable
-  SortedMap<String, Configuration> loadConfigurations(
-      @Nonnull String network, @Nonnull String snapshot);
+  SortedMap<String, Configuration> loadConfigurations(String network, String snapshot);
 
   /**
    * Returns the {@link ConvertConfigurationAnswerElement} that is the result of the phase that
@@ -37,7 +38,7 @@ public interface StorageProvider {
    */
   @Nullable
   ConvertConfigurationAnswerElement loadConvertConfigurationAnswerElement(
-      @Nonnull String network, @Nonnull String snapshot);
+      String network, String snapshot);
 
   /**
    * Returns the old-style combined layer-1 through layer-3 topology provided in the given snapshot
@@ -46,7 +47,7 @@ public interface StorageProvider {
    * @param snapshot The name of the snapshot
    */
   @Nullable
-  Topology loadLegacyTopology(@Nonnull String network, @Nonnull String snapshot);
+  Topology loadLegacyTopology(String network, String snapshot);
 
   /**
    * Returns the layer-1 topology of the network provided in the given snapshot
@@ -55,75 +56,73 @@ public interface StorageProvider {
    * @param snapshot The name of the snapshot
    */
   @Nullable
-  Layer1Topology loadLayer1Topology(@Nonnull String network, @Nonnull String snapshot);
+  Layer1Topology loadLayer1Topology(String network, String snapshot);
 
   /**
    * Stores the configurations into the compressed config path for the given snapshot. Will replace
    * any previously-stored compressed configurations.
    */
   void storeCompressedConfigurations(
-      @Nonnull Map<String, Configuration> configurations,
-      @Nonnull String network,
-      @Nonnull String snapshot);
+      Map<String, Configuration> configurations, String network, String snapshot);
 
   /**
    * Stores the configuration information into the given snapshot. Will replace any
    * previously-stored configurations.
    */
   void storeConfigurations(
-      @Nonnull Map<String, Configuration> configurations,
-      @Nonnull ConvertConfigurationAnswerElement convertAnswerElement,
-      @Nonnull String network,
-      @Nonnull String snapshot);
+      Map<String, Configuration> configurations,
+      ConvertConfigurationAnswerElement convertAnswerElement,
+      String network,
+      String snapshot);
 
   /**
    * Store the answer to an ad-hoc or analysis question.
    *
    * @param answerStr The text of the answer
    * @param network The name of the network
-   * @param baseSnapshot The name of the base snapshot
-   * @param deltaSnapshot (optional) The name of the deltaSnapshot for a differential question, or
+   * @param snapshot The name of the base snapshot
+   * @param question The name of the question
+   * @param referenceSnapshot (optional) The name of the deltaSnapshot for a differential question, or
    *     {@code null} for a non-differential question
    * @param analysis (optional) The name of the analysis for an analysis question, or {@code null}
    *     for an ad-hoc question
-   * @param question The name of the question
    */
   void storeAnswer(
-      @Nonnull String answerStr,
-      @Nonnull String network,
-      @Nonnull String baseSnapshot,
-      @Nullable String deltaSnapshot,
-      @Nullable String analysis,
-      @Nonnull String question);
+      String answerStr,
+      String network,
+      String snapshot,
+      String question,
+      @Nullable String referenceSnapshot,
+      @Nullable String analysis);
 
   /**
    * Store the metadata for the answer to an ad-hoc or analysis question.
    *
-   * @param answerStr The text of the answer
+   * @param answerMetrics The metadata to store
    * @param network The name of the network
-   * @param baseSnapshot The name of the base snapshot
-   * @param deltaSnapshot (optional) The name of the deltaSnapshot for a differential question, or
-   *     {@code null} for a non-differential question
+   * @param snapshot The name of the base snapshot
+   * @param question The name of the question
+   * @param referenceSnapshot (optional) The name of the deltaSnapshot for a differential question,
+   *     or {@code null} for a non-differential question
    * @param analysis (optional) The name of the analysis for an analysis question, or {@code null}
    *     for an ad-hoc question
-   * @param question The name of the question
    */
   void storeAnswerMetadata(
-      @Nonnull AnswerMetadata answerMetrics,
-      @Nonnull String network,
-      @Nullable String analysis,
-      @Nonnull String baseSnapshot,
-      @Nullable String deltaSnapshot,
-      @Nonnull String question);
+      AnswerMetadata answerMetrics,
+      String network,
+      String snapshot,
+      String question,
+      @Nullable String referenceSnapshot,
+      @Nullable String analysis);
 
   /**
    * Load the text of a JSON-serialized ad-hoc or analysis question
    *
    * @param network The name of the network
+   * @param question The name of the question
    * @param analysis (optional) The name of the analysis for an analysis question, or {@code null}
    *     for an ad-hoc question
-   * @param question The name of the question
    */
   @Nonnull
-  String loadQuestion(@Nonnull String network, @Nullable String analysis, @Nonnull String question);
+  String loadQuestion(String network, String question, @Nullable String analysis);
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
@@ -1,0 +1,75 @@
+package org.batfish.storage;
+
+import java.util.Map;
+import java.util.SortedMap;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.common.topology.Layer1Topology;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.Topology;
+import org.batfish.datamodel.answers.AnswerMetadata;
+import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
+
+public interface StorageProvider {
+
+  /**
+   * Returns the compressed configuration files for the given snapshot. If a serialized copy of
+   * these configurations is not already present, then this function returns {@code null}.
+   */
+  @Nullable
+  SortedMap<String, Configuration> loadCompressedConfigurations(
+      @Nonnull String network, @Nonnull String snapshot);
+
+  /**
+   * Returns the configuration files for the given snapshot. If a serialized copy of these
+   * configurations is not already present, then this function returns {@code null}.
+   */
+  @Nullable
+  SortedMap<String, Configuration> loadConfigurations(
+      @Nonnull String network, @Nonnull String snapshot);
+
+  @Nullable
+  ConvertConfigurationAnswerElement loadConvertConfigurationAnswerElement(
+      @Nonnull String network, @Nonnull String snapshot);
+
+  @Nullable
+  Topology loadLegacyTopology(@Nonnull String network, @Nonnull String snapshot);
+
+  @Nullable
+  Layer1Topology loadLayer1Topology(@Nonnull String network, @Nonnull String snapshot);
+
+  /**
+   * Stores the configurations into the compressed config path for the given snapshot. Will replace
+   * any previously-stored compressed configurations.
+   */
+  void storeCompressedConfigurations(
+      @Nonnull Map<String, Configuration> configurations,
+      @Nonnull String network,
+      @Nonnull String snapshot);
+
+  /**
+   * Stores the configuration information into the given snapshot. Will replace any
+   * previously-stored configurations.
+   */
+  void storeConfigurations(
+      @Nonnull Map<String, Configuration> configurations,
+      @Nonnull ConvertConfigurationAnswerElement convertAnswerElement,
+      @Nonnull String network,
+      @Nonnull String snapshot);
+
+  void storeAnswer(
+      @Nonnull String answerStr,
+      @Nonnull String network,
+      @Nonnull String baseSnapshotName,
+      @Nullable String deltaSnapshotName,
+      @Nullable String analysisName,
+      @Nonnull String questionName);
+
+  void storeAnswerMetadata(
+      @Nonnull AnswerMetadata answerMetrics,
+      @Nonnull String network,
+      @Nullable String analysisName,
+      @Nonnull String baseSnapshotName,
+      @Nullable String deltaSnapshotName,
+      @Nonnull String questionName);
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
@@ -1,5 +1,6 @@
 package org.batfish.storage;
 
+import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
 import javax.annotation.Nonnull;
@@ -125,4 +126,14 @@ public interface StorageProvider {
    */
   @Nonnull
   String loadQuestion(String network, String question, @Nullable String analysis);
+
+  /**
+   * Return a list of the names of the questions associated with the given analysis of the given
+   * network
+   *
+   * @param containerName
+   * @param analysisName
+   */
+  @Nonnull
+  List<String> listAnalysisQuestions(String network, String analysis);
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
@@ -72,4 +72,11 @@ public interface StorageProvider {
       @Nonnull String baseSnapshotName,
       @Nullable String deltaSnapshotName,
       @Nonnull String questionName);
+
+  @Nonnull
+  String loadQuestion(
+      @Nonnull String network,
+      @Nonnull String snapshot,
+      @Nullable String analysis,
+      @Nonnull String question);
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
@@ -123,7 +123,6 @@ public interface StorageProvider {
    * @param analysis (optional) The name of the analysis for an analysis question, or {@code null}
    *     for an ad-hoc question
    * @param question The name of the question
-   * @return
    */
   @Nonnull
   String loadQuestion(@Nonnull String network, @Nullable String analysis, @Nonnull String question);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/storage/TestStorageProvider.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/storage/TestStorageProvider.java
@@ -1,0 +1,91 @@
+package org.batfish.storage;
+
+import java.util.Map;
+import java.util.SortedMap;
+import org.batfish.common.topology.Layer1Topology;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.Topology;
+import org.batfish.datamodel.answers.AnswerMetadata;
+import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
+
+public class TestStorageProvider implements StorageProvider {
+
+  @Override
+  public SortedMap<String, Configuration> loadCompressedConfigurations(
+      String network, String snapshot) {
+    throw new UnsupportedOperationException(
+        "no implementation for generated method"); // TODO Auto-generated method stub
+  }
+
+  @Override
+  public SortedMap<String, Configuration> loadConfigurations(String network, String snapshot) {
+    throw new UnsupportedOperationException(
+        "no implementation for generated method"); // TODO Auto-generated method stub
+  }
+
+  @Override
+  public ConvertConfigurationAnswerElement loadConvertConfigurationAnswerElement(
+      String network, String snapshot) {
+    throw new UnsupportedOperationException(
+        "no implementation for generated method"); // TODO Auto-generated method stub
+  }
+
+  @Override
+  public Topology loadLegacyTopology(String network, String snapshot) {
+    throw new UnsupportedOperationException(
+        "no implementation for generated method"); // TODO Auto-generated method stub
+  }
+
+  @Override
+  public Layer1Topology loadLayer1Topology(String network, String snapshot) {
+    throw new UnsupportedOperationException(
+        "no implementation for generated method"); // TODO Auto-generated method stub
+  }
+
+  @Override
+  public void storeCompressedConfigurations(
+      Map<String, Configuration> configurations, String network, String snapshot) {
+    throw new UnsupportedOperationException(
+        "no implementation for generated method"); // TODO Auto-generated method stub
+  }
+
+  @Override
+  public void storeConfigurations(
+      Map<String, Configuration> configurations,
+      ConvertConfigurationAnswerElement convertAnswerElement,
+      String network,
+      String snapshot) {
+    throw new UnsupportedOperationException(
+        "no implementation for generated method"); // TODO Auto-generated method stub
+  }
+
+  @Override
+  public void storeAnswer(
+      String answerStr,
+      String network,
+      String baseSnapshotName,
+      String deltaSnapshotName,
+      String analysisName,
+      String questionName) {
+    throw new UnsupportedOperationException(
+        "no implementation for generated method"); // TODO Auto-generated method stub
+  }
+
+  @Override
+  public void storeAnswerMetadata(
+      AnswerMetadata answerMetrics,
+      String network,
+      String analysisName,
+      String baseSnapshotName,
+      String deltaSnapshotName,
+      String questionName) {
+    throw new UnsupportedOperationException(
+        "no implementation for generated method"); // TODO Auto-generated method stub
+  }
+
+  @Override
+  public String loadQuestion(String network, String snapshot, String analysis, String question) {
+    throw new UnsupportedOperationException(
+        "no implementation for generated method"); // TODO Auto-generated method stub
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/storage/TestStorageProvider.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/storage/TestStorageProvider.java
@@ -1,5 +1,6 @@
 package org.batfish.storage;
 
+import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
 import org.batfish.common.topology.Layer1Topology;
@@ -85,6 +86,12 @@ public class TestStorageProvider implements StorageProvider {
 
   @Override
   public String loadQuestion(String network, String analysis, String question) {
+    throw new UnsupportedOperationException(
+        "no implementation for generated method"); // TODO Auto-generated method stub
+  }
+
+  @Override
+  public List<String> listAnalysisQuestions(String network, String analysis) {
     throw new UnsupportedOperationException(
         "no implementation for generated method"); // TODO Auto-generated method stub
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/storage/TestStorageProvider.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/storage/TestStorageProvider.java
@@ -84,7 +84,7 @@ public class TestStorageProvider implements StorageProvider {
   }
 
   @Override
-  public String loadQuestion(String network, String snapshot, String analysis, String question) {
+  public String loadQuestion(String network, String analysis, String question) {
     throw new UnsupportedOperationException(
         "no implementation for generated method"); // TODO Auto-generated method stub
   }

--- a/projects/batfish/pom.xml
+++ b/projects/batfish/pom.xml
@@ -268,11 +268,6 @@
       <artifactId>jgrapht-core</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.lz4</groupId>
-      <artifactId>lz4-java</artifactId>
-    </dependency>
-
     <!-- Runtime dependencies to add logging. -->
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/projects/batfish/src/main/java/org/batfish/config/Settings.java
+++ b/projects/batfish/src/main/java/org/batfish/config/Settings.java
@@ -532,8 +532,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
 
   public static final String TASK_ID = "taskid";
 
-  private static final String QUESTION_PATH = "questionpath";
-
   private TestrigSettings _activeTestrigSettings;
 
   private TestrigSettings _baseTestrigSettings;
@@ -814,11 +812,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
 
   public String getQuestionName() {
     return _config.getString(BfConsts.ARG_QUESTION_NAME);
-  }
-
-  @Nullable
-  public Path getQuestionPath() {
-    return nullablePath(_config.getString(QUESTION_PATH));
   }
 
   public boolean getRedFlagRecord() {
@@ -1539,14 +1532,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     _config.setProperty(ARG_PRINT_PARSE_TREE_LINE_NUMS, printParseTreeLineNums);
   }
 
-  public void setQuestionPath(@Nullable Path questionPath) {
-    if (questionPath != null) {
-      _config.setProperty(QUESTION_PATH, questionPath.toString());
-    } else {
-      _config.clearProperty(QUESTION_PATH);
-    }
-  }
-
   public void setReport(boolean report) {
     _config.setProperty(BfConsts.COMMAND_REPORT, report);
   }
@@ -1619,5 +1604,9 @@ public final class Settings extends BaseSettings implements GrammarSettings {
 
   public void setDataplaneEngineName(String name) {
     _config.setProperty(ARG_DATAPLANE_ENGINE_NAME, name);
+  }
+
+  public void setQuestionName(String questionName) {
+    _config.setProperty(BfConsts.ARG_QUESTION_NAME, questionName);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -632,10 +632,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
       try {
         rawQuestionStr =
             _storage.loadQuestion(
-                _settings.getContainer(),
-                _settings.getBaseTestrigSettings().getName(),
-                _settings.getAnalysisName(),
-                _settings.getQuestionName());
+                _settings.getContainer(), _settings.getAnalysisName(), _settings.getQuestionName());
       } catch (Exception e) {
         Answer answer = new Answer();
         BatfishException exception = new BatfishException("Could not read question", e);

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -2768,9 +2768,9 @@ public class Batfish extends PluginConsumer implements IBatfish {
         AnswerMetadataUtil.computeAnswerMetadata(answer, _logger),
         _settings.getContainer(),
         _baseTestrigSettings.getName(),
+        _settings.getQuestionName(),
         deltaSnapshot,
-        _settings.getAnalysisName(),
-        _settings.getQuestionName());
+        _settings.getAnalysisName());
   }
 
   private ParserRuleContext parse(BatfishCombinedParser<?, ?> parser) {
@@ -4764,9 +4764,9 @@ public class Batfish extends PluginConsumer implements IBatfish {
         structuredAnswerString,
         _settings.getContainer(),
         _baseTestrigSettings.getName(),
+        _settings.getQuestionName(),
         deltaSnapshot,
-        _settings.getAnalysisName(),
-        _settings.getQuestionName());
+        _settings.getAnalysisName());
   }
 
   private void writeJsonAnswerWithLog(@Nullable String logString, String structuredAnswerString) {

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -553,71 +553,57 @@ public class Batfish extends PluginConsumer implements IBatfish {
       AnswerSummary summary = new AnswerSummary();
       String analysisName = _settings.getAnalysisName();
       String containerName = _settings.getContainer();
-      Path analysisQuestionsDir =
-          _settings
-              .getStorageBase()
-              .resolve(containerName)
-              .resolve(
-                  Paths.get(
-                          BfConsts.RELPATH_ANALYSES_DIR,
-                          analysisName,
-                          BfConsts.RELPATH_QUESTIONS_DIR)
-                      .toString());
-      if (!Files.exists(analysisQuestionsDir)) {
-        throw new BatfishException(
-            "Analysis questions dir does not exist: '" + analysisQuestionsDir + "'");
-      }
       RunAnalysisAnswerElement ae = new RunAnalysisAnswerElement();
-      try (Stream<Path> questions = CommonUtil.list(analysisQuestionsDir)) {
-        questions.forEach(
-            analysisQuestionDir -> {
-              String questionName = analysisQuestionDir.getFileName().toString();
-              _settings.setQuestionName(questionName);
-              Answer currentAnswer;
-              try (ActiveSpan analysisQuestionSpan =
-                  GlobalTracer.get()
-                      .buildSpan("Getting answer to analysis question")
-                      .startActive()) {
-                assert analysisQuestionSpan != null; // make span not show up as unused
-                analysisQuestionSpan.setTag("analysis-name", analysisName);
-                currentAnswer = answer();
-              }
-              // Ensuring that question was parsed successfully
-              if (currentAnswer.getQuestion() != null) {
-                try {
-                  // TODO: This can be represented much cleanly and easily with a Json
-                  _logger.infof(
-                      "Ran question:%s from analysis:%s in container:%s; work-id:%s, status:%s, "
-                          + "computed dataplane:%s, parameters:%s\n",
-                      questionName,
-                      analysisName,
-                      containerName,
-                      getTaskId(),
-                      currentAnswer.getSummary().getNumFailed() > 0 ? "failed" : "passed",
-                      currentAnswer.getQuestion().getDataPlane(),
-                      BatfishObjectMapper.writeString(
-                          currentAnswer.getQuestion().getInstance().getVariables()));
-                } catch (JsonProcessingException e) {
-                  throw new BatfishException(
-                      String.format(
-                          "Error logging question %s in analysis %s", questionName, analysisName),
-                      e);
+      _storage
+          .listAnalysisQuestions(containerName, analysisName)
+          .forEach(
+              questionName -> {
+                _settings.setQuestionName(questionName);
+                Answer currentAnswer;
+                try (ActiveSpan analysisQuestionSpan =
+                    GlobalTracer.get()
+                        .buildSpan("Getting answer to analysis question")
+                        .startActive()) {
+                  assert analysisQuestionSpan != null; // make span not show up as unused
+                  analysisQuestionSpan.setTag("analysis-name", analysisName);
+                  currentAnswer = answer();
                 }
-              }
-              try {
-                outputAnswer(currentAnswer);
-                outputAnswerMetadata(currentAnswer);
+                // Ensuring that question was parsed successfully
+                if (currentAnswer.getQuestion() != null) {
+                  try {
+                    // TODO: This can be represented much cleanly and easily with a Json
+                    _logger.infof(
+                        "Ran question:%s from analysis:%s in container:%s; work-id:%s, status:%s, "
+                            + "computed dataplane:%s, parameters:%s\n",
+                        questionName,
+                        analysisName,
+                        containerName,
+                        getTaskId(),
+                        currentAnswer.getSummary().getNumFailed() > 0 ? "failed" : "passed",
+                        currentAnswer.getQuestion().getDataPlane(),
+                        BatfishObjectMapper.writeString(
+                            currentAnswer.getQuestion().getInstance().getVariables()));
+                  } catch (JsonProcessingException e) {
+                    throw new BatfishException(
+                        String.format(
+                            "Error logging question %s in analysis %s", questionName, analysisName),
+                        e);
+                  }
+                }
+                try {
+                  outputAnswer(currentAnswer);
+                  outputAnswerMetadata(currentAnswer);
+                  ae.getAnswers().put(questionName, currentAnswer);
+                } catch (Exception e) {
+                  Answer errorAnswer = new Answer();
+                  errorAnswer.addAnswerElement(
+                      new BatfishStackTrace(new BatfishException("Failed to output answer", e)));
+                  ae.getAnswers().put(questionName, errorAnswer);
+                }
                 ae.getAnswers().put(questionName, currentAnswer);
-              } catch (Exception e) {
-                Answer errorAnswer = new Answer();
-                errorAnswer.addAnswerElement(
-                    new BatfishStackTrace(new BatfishException("Failed to output answer", e)));
-                ae.getAnswers().put(questionName, errorAnswer);
-              }
-              ae.getAnswers().put(questionName, currentAnswer);
-              summary.combine(currentAnswer.getSummary());
-            });
-      }
+                summary.combine(currentAnswer.getSummary());
+              });
+
       answer.addAnswerElement(ae);
       answer.setSummary(summary);
       return answer;

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -2763,12 +2763,16 @@ public class Batfish extends PluginConsumer implements IBatfish {
   }
 
   void outputAnswerMetadata(Answer answer) {
+    String question = _settings.getQuestionName();
+    if (question == null) {
+      return;
+    }
     String deltaSnapshot = _settings.getDiffQuestion() ? _deltaTestrigSettings.getName() : null;
     _storage.storeAnswerMetadata(
         AnswerMetadataUtil.computeAnswerMetadata(answer, _logger),
         _settings.getContainer(),
         _baseTestrigSettings.getName(),
-        _settings.getQuestionName(),
+        question,
         deltaSnapshot,
         _settings.getAnalysisName());
   }
@@ -4782,7 +4786,9 @@ public class Batfish extends PluginConsumer implements IBatfish {
       CommonUtil.writeFile(jsonPath, logString);
     }
     // Write answer.json and answer-pretty.json if WorkItem was answering a question
-    writeJsonAnswer(structuredAnswerString);
+    if (_settings.getQuestionName() != null) {
+      writeJsonAnswer(structuredAnswerString);
+    }
   }
 
   private void writeJsonTopology() {

--- a/projects/batfish/src/main/java/org/batfish/main/Driver.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Driver.java
@@ -552,7 +552,8 @@ public class Driver {
               CACHED_COMPRESSED_DATA_PLANES,
               CACHED_DATA_PLANES,
               CACHED_ENVIRONMENT_BGP_TABLES,
-              CACHED_ENVIRONMENT_ROUTING_TABLES);
+              CACHED_ENVIRONMENT_ROUTING_TABLES,
+              null);
 
       @Nullable
       SpanContext runBatfishSpanContext =

--- a/projects/batfish/src/test/java/org/batfish/config/SettingsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/config/SettingsTest.java
@@ -3,10 +3,8 @@ package org.batfish.config;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import java.nio.file.Paths;
 import org.batfish.common.CleanBatfishException;
 import org.batfish.main.Driver.RunMode;
 import org.junit.Test;
@@ -62,21 +60,6 @@ public class SettingsTest {
   public void testRunModeCaseInsensitive() {
     Settings settings = new Settings(new String[] {"-runmode=workservice"});
     assertThat(settings.getRunMode(), equalTo(RunMode.WORKSERVICE));
-  }
-
-  /**
-   * Value of question path is allowed to have null and acts as a special value, ensure that's
-   * supported.
-   */
-  @Test
-  public void testQuestionPathAllowNull() {
-    Settings settings = new Settings(new String[] {});
-    settings.setQuestionPath(Paths.get("test"));
-
-    assertThat(settings.getQuestionPath(), equalTo(Paths.get("test")));
-    // Update to null
-    settings.setQuestionPath(null);
-    assertThat(settings.getQuestionPath(), is(nullValue()));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
@@ -65,8 +65,7 @@ public class BatfishTest {
         BatfishTestUtils.getBatfish(
             new TestStorageProvider() {
               @Override
-              public String loadQuestion(
-                  String network, String snapshot, String analysis, String question) {
+              public String loadQuestion(String network, String analysis, String question) {
                 return "{"
                     + "\"differential\": false,"
                     + "\"instance\": {"

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
@@ -17,8 +17,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -46,6 +44,7 @@ import org.batfish.datamodel.answers.AnswerStatus;
 import org.batfish.datamodel.answers.ParseStatus;
 import org.batfish.datamodel.answers.ParseVendorConfigurationAnswerElement;
 import org.batfish.representation.host.HostConfiguration;
+import org.batfish.storage.TestStorageProvider;
 import org.batfish.vendor.VendorConfiguration;
 import org.junit.Rule;
 import org.junit.Test;
@@ -62,29 +61,31 @@ public class BatfishTest {
   @Test
   public void testAnswerBadQuestion() throws IOException {
     // missing class field
-    String badQuestionStr =
-        "{"
-            + "\"differential\": false,"
-            + "\"instance\": {"
-            + "\"description\": \"Outputs cases where undefined structures (e.g., ACL, routemaps) "
-            + "are referenced.\","
-            + "\"instanceName\": \"undefinedReferences\","
-            + "\"longDescription\": \"Such occurrences indicate configuration errors and can have"
-            + "serious consequences with some vendors.\","
-            + "\"tags\": [\"default\"],"
-            + "\"variables\": {\"nodeRegex\": {"
-            + "\"description\": \"Only check nodes whose name matches this regex\","
-            + "\"type\": \"javaRegex\","
-            + "\"value\": \".*\""
-            + "}}"
-            + "},"
-            + "\"nodeRegex\": \"${nodeRegex}\""
-            + "}";
-
-    Path questionPath = _folder.newFile("testAnswerBadQuestion").toPath();
-    Files.write(questionPath, badQuestionStr.getBytes(StandardCharsets.UTF_8));
-    Batfish batfish = BatfishTestUtils.getBatfish(new TreeMap<>(), _folder);
-    batfish.getSettings().setQuestionPath(questionPath);
+    Batfish batfish =
+        BatfishTestUtils.getBatfish(
+            new TestStorageProvider() {
+              @Override
+              public String loadQuestion(
+                  String network, String snapshot, String analysis, String question) {
+                return "{"
+                    + "\"differential\": false,"
+                    + "\"instance\": {"
+                    + "\"description\": \"Outputs cases where undefined structures (e.g., ACL, routemaps) "
+                    + "are referenced.\","
+                    + "\"instanceName\": \"undefinedReferences\","
+                    + "\"longDescription\": \"Such occurrences indicate configuration errors and can have"
+                    + "serious consequences with some vendors.\","
+                    + "\"tags\": [\"default\"],"
+                    + "\"variables\": {\"nodeRegex\": {"
+                    + "\"description\": \"Only check nodes whose name matches this regex\","
+                    + "\"type\": \"javaRegex\","
+                    + "\"value\": \".*\""
+                    + "}}"
+                    + "},"
+                    + "\"nodeRegex\": \"${nodeRegex}\""
+                    + "}";
+              }
+            });
     Answer answer = batfish.answer();
     assertThat(answer.getQuestion(), is(nullValue()));
     assertEquals(answer.getStatus(), AnswerStatus.FAILURE);

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
@@ -27,6 +27,7 @@ import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.collections.BgpAdvertisementsByVrf;
 import org.batfish.datamodel.collections.RoutesByVrf;
 import org.batfish.dataplane.ibdp.IncrementalDataPlanePlugin;
+import org.batfish.storage.StorageProvider;
 import org.junit.rules.TemporaryFolder;
 
 public class BatfishTestUtils {
@@ -76,7 +77,8 @@ public class BatfishTestUtils {
             makeDataPlaneCache(),
             makeDataPlaneCache(),
             makeEnvBgpCache(),
-            makeEnvRouteCache());
+            makeEnvRouteCache(),
+            null);
     if (!configurations.isEmpty()) {
       Batfish.serializeAsJson(
           settings.getBaseTestrigSettings().getEnvironmentSettings().getSerializedTopologyPath(),
@@ -125,7 +127,8 @@ public class BatfishTestUtils {
             makeDataPlaneCache(),
             makeDataPlaneCache(),
             makeEnvBgpCache(),
-            makeEnvRouteCache());
+            makeEnvRouteCache(),
+            null);
     batfish.getSettings().setDiffQuestion(true);
     if (!baseConfigs.isEmpty()) {
       Batfish.serializeAsJson(
@@ -211,7 +214,8 @@ public class BatfishTestUtils {
             makeDataPlaneCache(),
             makeDataPlaneCache(),
             makeEnvBgpCache(),
-            makeEnvRouteCache());
+            makeEnvRouteCache(),
+            null);
     registerDataPlanePlugins(batfish);
     return batfish;
   }
@@ -245,6 +249,29 @@ public class BatfishTestUtils {
       SortedMap<String, Configuration> configurations, @Nonnull TemporaryFolder tempFolder)
       throws IOException {
     return initBatfish(configurations, tempFolder);
+  }
+
+  /** Get a new Batfish instance with given storage provider */
+  public static Batfish getBatfish(@Nonnull StorageProvider storageProvider) {
+    Settings settings = new Settings(new String[] {});
+    settings.setLogger(new BatfishLogger("debug", false));
+    final Cache<NetworkSnapshot, SortedMap<String, Configuration>> testrigs = makeTestrigCache();
+    final Cache<NetworkSnapshot, SortedMap<String, Configuration>> compressedTestrigs =
+        makeTestrigCache();
+
+    settings.setContainer("tempContainer");
+    Batfish batfish =
+        new Batfish(
+            settings,
+            compressedTestrigs,
+            testrigs,
+            makeDataPlaneCache(),
+            makeDataPlaneCache(),
+            makeEnvBgpCache(),
+            makeEnvRouteCache(),
+            storageProvider);
+    registerDataPlanePlugins(batfish);
+    return batfish;
   }
 
   /**

--- a/projects/batfish/src/test/java/org/batfish/main/FileBasedStorageTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/FileBasedStorageTest.java
@@ -26,7 +26,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
-public class BatfishStorageTest {
+public class FileBasedStorageTest {
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
 
   private Path _containerDir;


### PR DESCRIPTION
- Conduct all worker storage operations through `StorageProvider`
- Move all worker file access to `FileBasedStorage`
- Clean up heinous question path hackery

Follow-on work: make Coordinator use new StorageProvider for storage operations