### PR TITLE
Upgrade Guava to latest version

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -59,15 +59,16 @@ antlr4_runtime_compile()
 maven_repository(
     name = "auto_service",
     force = [
-        "com.google.guava:guava:22.0",
+        "com.google.guava:guava:26.0-jre",
     ],
     transitive_deps = [
         "4073ab16ab4aceb9a217273da6442166bf51ae16:com.google.auto:auto-common:0.3",
         "35c5d43b0332b8f94d473f9fee5fb1d74b5e0056:com.google.auto.service:auto-service:1.0-rc3",
-        "40719ea6961c0cb6afaeb6a921eaa1f6afd4cfdf:com.google.code.findbugs:jsr305:1.3.9",
-        "5f65affce1684999e2f4024983835efc3504012e:com.google.errorprone:error_prone_annotations:2.0.18",
-        "3564ef3803de51fb0530a8377ec6100b33b0d073:com.google.guava:guava:22.0",
+        "25ea2e8b0c338a877313bd4672d3fe056ea78f0d:com.google.code.findbugs:jsr305:3.0.2",
+        "39b109f2cd352b2d71b52a3b5a1a9850e1dc304b:com.google.errorprone:error_prone_annotations:2.1.3",
+        "6a806eff209f36f635f943e16d97491f00f6bfab:com.google.guava:guava:26.0-jre",
         "ed28ded51a8b1c6b112568def5f4b455e6809019:com.google.j2objc:j2objc-annotations:1.1",
+        "cea74543d5904a30861a61b4643a5f2bb372efc4:org.checkerframework:checker-qual:2.5.2",
         "775b7e22fb10026eed3f86e8dc556dfafe35f2d5:org.codehaus.mojo:animal-sniffer-annotations:1.14",
     ],
     deps = [
@@ -219,10 +220,10 @@ diffutils_compile()
 maven_repository(
     name = "errorprone_annotations",
     transitive_deps = [
-        "5f65affce1684999e2f4024983835efc3504012e:com.google.errorprone:error_prone_annotations:2.0.18",
+        "39b109f2cd352b2d71b52a3b5a1a9850e1dc304b:com.google.errorprone:error_prone_annotations:2.1.3",
     ],
     deps = [
-        "com.google.errorprone:error_prone_annotations:2.0.18",
+        "com.google.errorprone:error_prone_annotations:2.1.3",
     ],
 )
 
@@ -266,14 +267,15 @@ grizzly_server_compile()
 maven_repository(
     name = "guava",
     transitive_deps = [
-        "40719ea6961c0cb6afaeb6a921eaa1f6afd4cfdf:com.google.code.findbugs:jsr305:1.3.9",
-        "5f65affce1684999e2f4024983835efc3504012e:com.google.errorprone:error_prone_annotations:2.0.18",
-        "3564ef3803de51fb0530a8377ec6100b33b0d073:com.google.guava:guava:22.0",
+        "25ea2e8b0c338a877313bd4672d3fe056ea78f0d:com.google.code.findbugs:jsr305:3.0.2",
+        "39b109f2cd352b2d71b52a3b5a1a9850e1dc304b:com.google.errorprone:error_prone_annotations:2.1.3",
+        "6a806eff209f36f635f943e16d97491f00f6bfab:com.google.guava:guava:26.0-jre",
         "ed28ded51a8b1c6b112568def5f4b455e6809019:com.google.j2objc:j2objc-annotations:1.1",
+        "cea74543d5904a30861a61b4643a5f2bb372efc4:org.checkerframework:checker-qual:2.5.2",
         "775b7e22fb10026eed3f86e8dc556dfafe35f2d5:org.codehaus.mojo:animal-sniffer-annotations:1.14",
     ],
     deps = [
-        "com.google.guava:guava:22.0",
+        "com.google.guava:guava:26.0-jre",
     ],
 )
 
@@ -293,17 +295,18 @@ maven_repository(
         "junit:junit:4.12",
     ],
     transitive_deps = [
-        "40719ea6961c0cb6afaeb6a921eaa1f6afd4cfdf:com.google.code.findbugs:jsr305:1.3.9",
-        "5f65affce1684999e2f4024983835efc3504012e:com.google.errorprone:error_prone_annotations:2.0.18",
-        "3564ef3803de51fb0530a8377ec6100b33b0d073:com.google.guava:guava:22.0",
-        "3be1b88f1cfc6592acbcbfe1f3a420f79eb2b146:com.google.guava:guava-testlib:22.0",
+        "25ea2e8b0c338a877313bd4672d3fe056ea78f0d:com.google.code.findbugs:jsr305:3.0.2",
+        "39b109f2cd352b2d71b52a3b5a1a9850e1dc304b:com.google.errorprone:error_prone_annotations:2.1.3",
+        "6a806eff209f36f635f943e16d97491f00f6bfab:com.google.guava:guava:26.0-jre",
+        "3be1b88f1cfc6592acbcbfe1f3a420f79eb2b146:com.google.guava:guava-testlib:26.0-jre",
         "ed28ded51a8b1c6b112568def5f4b455e6809019:com.google.j2objc:j2objc-annotations:1.1",
         "2973d150c0dc1fefe998f834810d68f278ea58ec:junit:junit:4.12",
+        "cea74543d5904a30861a61b4643a5f2bb372efc4:org.checkerframework:checker-qual:2.5.2",
         "775b7e22fb10026eed3f86e8dc556dfafe35f2d5:org.codehaus.mojo:animal-sniffer-annotations:1.14",
         "0f1c8853ade0ecf707f5a261c830e98893983813:org.hamcrest:java-hamcrest:2.0.0.0",
     ],
     deps = [
-        "com.google.guava:guava-testlib:22.0",
+        "com.google.guava:guava-testlib:26.0-jre",
         "org.hamcrest:java-hamcrest:2.0.0.0",
     ],
 )
@@ -382,17 +385,18 @@ maven_repository(
     name = "jackson_guava",
     force = [
         "com.fasterxml.jackson.core:jackson-annotations:2.9.6",
-        "com.google.guava:guava:22.0",
+        "com.google.guava:guava:26.0-jre",
     ],
     transitive_deps = [
         "6a0f0f154edaba00067772ce02e24f8c0973d84c:com.fasterxml.jackson.core:jackson-annotations:2.9.6",
         "4e393793c37c77e042ccc7be5a914ae39251b365:com.fasterxml.jackson.core:jackson-core:2.9.6",
         "cfa4f316351a91bfd95cb0644c6a2c95f52db1fc:com.fasterxml.jackson.core:jackson-databind:2.9.6",
         "5f111734ca7b3b3321e5dbf7b3502a01d5394f26:com.fasterxml.jackson.datatype:jackson-datatype-guava:2.9.6",
-        "40719ea6961c0cb6afaeb6a921eaa1f6afd4cfdf:com.google.code.findbugs:jsr305:1.3.9",
-        "5f65affce1684999e2f4024983835efc3504012e:com.google.errorprone:error_prone_annotations:2.0.18",
-        "3564ef3803de51fb0530a8377ec6100b33b0d073:com.google.guava:guava:22.0",
+        "25ea2e8b0c338a877313bd4672d3fe056ea78f0d:com.google.code.findbugs:jsr305:3.0.2",
+        "39b109f2cd352b2d71b52a3b5a1a9850e1dc304b:com.google.errorprone:error_prone_annotations:2.1.3",
+        "6a806eff209f36f635f943e16d97491f00f6bfab:com.google.guava:guava:26.0-jre",
         "ed28ded51a8b1c6b112568def5f4b455e6809019:com.google.j2objc:j2objc-annotations:1.1",
+        "cea74543d5904a30861a61b4643a5f2bb372efc4:org.checkerframework:checker-qual:2.5.2",
         "775b7e22fb10026eed3f86e8dc556dfafe35f2d5:org.codehaus.mojo:animal-sniffer-annotations:1.14",
     ],
     deps = [
@@ -939,10 +943,10 @@ jsonpath_compile()
 maven_repository(
     name = "jsr305",
     transitive_deps = [
-        "40719ea6961c0cb6afaeb6a921eaa1f6afd4cfdf:com.google.code.findbugs:jsr305:1.3.9",
+        "25ea2e8b0c338a877313bd4672d3fe056ea78f0d:com.google.code.findbugs:jsr305:3.0.2",
     ],
     deps = [
-        "com.google.code.findbugs:jsr305:1.3.9",
+        "com.google.code.findbugs:jsr305:3.0.2",
     ],
 )
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -2423,13 +2423,16 @@ public class VirtualRouter implements Serializable {
     BGP topology edges not guaranteed to be symmetrical (in case of dynamic neighbors).
     So to get session properties, we might need to flip the src/dst edge
      */
-    BgpSessionProperties tmpSession;
-    try {
-      tmpSession = bgpTopology.edgeValue(edge.src(), edge.dst());
-    } catch (IllegalArgumentException e) {
-      tmpSession = bgpTopology.edgeValue(edge.dst(), edge.src());
+    Optional<BgpSessionProperties> session = bgpTopology.edgeValue(edge.src(), edge.dst());
+    if (session.isPresent()) {
+      return session.get();
     }
-    return tmpSession;
+    return bgpTopology
+        .edgeValue(edge.dst(), edge.src())
+        .orElseThrow(
+            () ->
+                new IllegalArgumentException(
+                    String.format("No BGP edge %s in BGP topology", edge)));
   }
 
   private void queueOutgoingIsisRoutes(

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -2488,7 +2488,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
        * repaired, so we still might need to load it from disk.
        */
       loadDataPlaneAnswerElement(compressed);
-      dp = cache.getIfPresent(_testrigSettings);
+      dp = cache.getIfPresent(snapshot);
       if (dp == null) {
         newBatch("Loading data plane from disk", 0);
         dp = deserializeObject(path, DataPlane.class);

--- a/projects/pom.xml
+++ b/projects/pom.xml
@@ -57,9 +57,9 @@
     <commons-io.version>2.4</commons-io.version>
     <commons-lang3.version>3.7</commons-lang3.version>
     <diffutils.version>2.2</diffutils.version>
-    <errorprone.version>2.0.18</errorprone.version>
+    <errorprone.version>2.1.3</errorprone.version>
     <grizzly.version>2.3.18</grizzly.version>
-    <guava.version>22.0</guava.version>
+    <guava.version>26.0-jre</guava.version>
     <guava-eea.version>0.0.1</guava-eea.version>
     <jackson.version>2.9.6</jackson.version>
     <javabdd.version>2018-07-26-36d0ed6-batfish-internal</javabdd.version>

--- a/projects/question/src/main/java/org/batfish/question/NeighborsQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/NeighborsQuestionPlugin.java
@@ -744,7 +744,16 @@ public class NeighborsQuestionPlugin extends QuestionPlugin {
         for (EndpointPair<BgpPeerConfigId> session : _bgpTopology.edges()) {
           BgpPeerConfigId bgpPeerConfigId = session.source();
           BgpPeerConfigId remoteBgpPeerConfigId = session.target();
-          boolean ebgp = _bgpTopology.edgeValue(bgpPeerConfigId, remoteBgpPeerConfigId).isEbgp();
+          boolean ebgp =
+              _bgpTopology
+                  .edgeValue(bgpPeerConfigId, remoteBgpPeerConfigId)
+                  .orElseThrow(
+                      () ->
+                          new IllegalStateException(
+                              String.format(
+                                  "Edge %s -> %s not in BGP topology",
+                                  bgpPeerConfigId, remoteBgpPeerConfigId)))
+                  .isEbgp();
           if (ebgp) {
             VerboseBgpEdge edge =
                 constructVerboseBgpEdge(
@@ -785,7 +794,14 @@ public class NeighborsQuestionPlugin extends QuestionPlugin {
           BgpPeerConfigId bgpPeerConfigId = session.source();
           BgpPeerConfigId remoteBgpPeerConfigId = session.target();
           BgpSessionProperties sessionProp =
-              _bgpTopology.edgeValue(bgpPeerConfigId, remoteBgpPeerConfigId);
+              _bgpTopology
+                  .edgeValue(bgpPeerConfigId, remoteBgpPeerConfigId)
+                  .orElseThrow(
+                      () ->
+                          new IllegalStateException(
+                              String.format(
+                                  "Edge %s -> %s not in IBGP topology",
+                                  bgpPeerConfigId, remoteBgpPeerConfigId)));
           boolean ibgp = sessionProp.getSessionType() == SessionType.IBGP;
           if (ibgp) {
             VerboseBgpEdge edge =

--- a/skylark/ref_tests.bzl
+++ b/skylark/ref_tests.bzl
@@ -30,5 +30,5 @@ def ref_tests(name, commands, allinone = None, extra_deps = None, **kwargs):
             allinone,
             commands,
         ] + extra_deps,
-        tags = [ "exclusive" ],
+        tags = ["exclusive"],
     )


### PR DESCRIPTION
Minor fixups to match beta Guava APIs, and a new type-inference-caught bugfix enabled by the update.