### PR TITLE
Update NamedStructures with standardized parameters

### DIFF
--- a/projects/question/src/main/java/org/batfish/question/namedstructures/NamedStructuresAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/namedstructures/NamedStructuresAnswerer.java
@@ -25,7 +25,7 @@ import org.batfish.datamodel.table.TableMetadata;
 
 public class NamedStructuresAnswerer extends Answerer {
 
-  public static final String COL_NODE = "node";
+  public static final String COL_NODE = "Node";
 
   public NamedStructuresAnswerer(Question question, IBatfish batfish) {
     super(question, batfish);
@@ -47,7 +47,7 @@ public class NamedStructuresAnswerer extends Answerer {
     columnMetadataList.add(new ColumnMetadata(COL_NODE, Schema.NODE, "Node", true, false));
 
     for (String nodeName : nodes) {
-      for (String namedStructure : question.getPropertySpec().getMatchingProperties()) {
+      for (String namedStructure : question.getProperties().getMatchingProperties()) {
         Object namedStructureValues =
             NamedStructureSpecifier.JAVA_MAP
                 .get(namedStructure)
@@ -142,7 +142,7 @@ public class NamedStructuresAnswerer extends Answerer {
   public AnswerElement answer() {
     NamedStructuresQuestion question = (NamedStructuresQuestion) _question;
     Map<String, Configuration> configurations = _batfish.loadConfigurations();
-    Set<String> nodes = question.getNodeRegex().getMatchingNodes(_batfish);
+    Set<String> nodes = question.getNodes().getMatchingNodes(_batfish);
 
     TableMetadata tableMetadata = createNamedStructuresMetadata(question, configurations, nodes);
 

--- a/projects/question/src/main/java/org/batfish/question/namedstructures/NamedStructuresQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/namedstructures/NamedStructuresQuestion.java
@@ -10,23 +10,23 @@ import org.batfish.datamodel.questions.Question;
 
 /**
  * A question that returns named structures of nodes in a tabular format. {@link
- * NamedStructuresQuestion#_nodeRegex} determines which nodes are included, and {@link
- * NamedStructuresQuestion#_propertySpec} determines which named structures are included.
+ * NamedStructuresQuestion#_nodes} determines which nodes are included, and {@link
+ * NamedStructuresQuestion#_properties} determines which named structures are included.
  */
 public class NamedStructuresQuestion extends Question {
 
-  private static final String PROP_NODE_REGEX = "nodeRegex";
-  private static final String PROP_PROPERTY_SPEC = "propertySpec";
+  private static final String PROP_NODES = "nodes";
+  private static final String PROP_PROPERTIES = "properties";
 
-  private final NodesSpecifier _nodeRegex;
+  private final NodesSpecifier _nodes;
 
-  @Nonnull private NamedStructureSpecifier _propertySpec;
+  @Nonnull private NamedStructureSpecifier _properties;
 
   public NamedStructuresQuestion(
-      @JsonProperty(PROP_NODE_REGEX) NodesSpecifier nodeRegex,
-      @JsonProperty(PROP_PROPERTY_SPEC) NamedStructureSpecifier propertySpec) {
-    _nodeRegex = firstNonNull(nodeRegex, NodesSpecifier.ALL);
-    _propertySpec = firstNonNull(propertySpec, NamedStructureSpecifier.ALL);
+      @JsonProperty(PROP_NODES) NodesSpecifier nodes,
+      @JsonProperty(PROP_PROPERTIES) NamedStructureSpecifier properties) {
+    _nodes = firstNonNull(nodes, NodesSpecifier.ALL);
+    _properties = firstNonNull(properties, NamedStructureSpecifier.ALL);
   }
 
   @Override
@@ -36,16 +36,16 @@ public class NamedStructuresQuestion extends Question {
 
   @Override
   public String getName() {
-    return "namedstructures";
+    return "namedStructures";
   }
 
-  @JsonProperty(PROP_NODE_REGEX)
-  public NodesSpecifier getNodeRegex() {
-    return _nodeRegex;
+  @JsonProperty(PROP_NODES)
+  public NodesSpecifier getNodes() {
+    return _nodes;
   }
 
-  @JsonProperty(PROP_PROPERTY_SPEC)
-  public NamedStructureSpecifier getPropertySpec() {
-    return _propertySpec;
+  @JsonProperty(PROP_PROPERTIES)
+  public NamedStructureSpecifier getProperties() {
+    return _properties;
   }
 }

--- a/questions/experimental/namedStructures.json
+++ b/questions/experimental/namedStructures.json
@@ -1,21 +1,21 @@
 {
     "class": "org.batfish.question.namedstructures.NamedStructuresQuestion",
     "differential": false,
-    "nodeRegex": "${nodeRegex}",
-    "propertySpec": "${propertySpec}",
+    "nodes": "${nodes}",
+    "properties": "${properties}",
     "instance": {
         "description": "Return named structure definitions",
         "instanceName": "namedStructures",
         "tags": [
         ],
         "variables": {
-            "nodeRegex": {
-                "description": "Only include nodes that match this regex",
+            "nodes": {
+                "description": "Include nodes matching this name or regex",
                 "type": "nodeSpec",
                 "optional": true
             },
-            "propertySpec": {
-                "description": "Only include properties that match this regex. Default behavior is to return all properties",
+            "properties": {
+                "description": "Include properties matching this regex",
                 "type": "namedStructureSpec",
                 "optional": true
             }

--- a/tests/questions/experimental/commands
+++ b/tests/questions/experimental/commands
@@ -18,6 +18,9 @@ test -raw tests/questions/experimental/interfaceMtu.ref validate-template interf
 # validate interfaceProperties
 test -raw tests/questions/experimental/interfaceProperties.ref validate-template interfaceProperties nodes=".*", interfaces=".*", properties=".*"
 
+# validate namedStructures
+test -raw tests/questions/experimental/namedStructures.ref validate-template namedStructures nodes=".*", properties=".*"
+
 # validate neighbors
 test -raw tests/questions/experimental/neighbors.ref validate-template neighbors neighborTypes=["ebgp"], nodes=".*", remoteNodes=".*", style="summary", roleDimension="default"
 

--- a/tests/questions/experimental/namedStructures.ref
+++ b/tests/questions/experimental/namedStructures.ref
@@ -1,0 +1,25 @@
+{
+  "class" : "org.batfish.question.namedstructures.NamedStructuresQuestion",
+  "nodes" : ".*",
+  "properties" : ".*",
+  "differential" : false,
+  "includeOneTableKeys" : true,
+  "instance" : {
+    "description" : "Return named structure definitions",
+    "instanceName" : "qname",
+    "variables" : {
+      "nodes" : {
+        "description" : "Include nodes matching this name or regex",
+        "optional" : true,
+        "type" : "nodeSpec",
+        "value" : ".*"
+      },
+      "properties" : {
+        "description" : "Include properties matching this regex",
+        "optional" : true,
+        "type" : "namedStructureSpec",
+        "value" : ".*"
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Replace parameters "nodeRegex" and "propertySpec" with "nodes" and "properties"
- Capitalize node column name
- Standardize parameter descriptions
- Camel case java question name