### PR TITLE
CiscoControlPlaneExtractor: null guard

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -6653,6 +6653,10 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
 
   @Override
   public void exitRe_network(Re_networkContext ctx) {
+    if (_currentEigrpProcess == null) {
+      _w.addWarning(ctx, getFullText(ctx), _parser, "No eigrp process available");
+      return;
+    }
     // In process context
     Ip address = toIp(ctx.address);
     Ip mask = (ctx.mask != null) ? toIp(ctx.mask) : address.getClassMask().inverted();


### PR DESCRIPTION
Crash is not happening, but was present in every other variant that I saw and
I was getting IDE warnings for it.

cc @mkremerbbn fyi, but nothing needed.