### PR TITLE
Allinone: e2e test cleanup

### DIFF
--- a/projects/allinone/src/test/java/org/batfish/question/CompareSameNameTest.java
+++ b/projects/allinone/src/test/java/org/batfish/question/CompareSameNameTest.java
@@ -1,4 +1,4 @@
-package org.batfish.allinone;
+package org.batfish.question;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
@@ -13,7 +13,6 @@ import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
-import org.batfish.question.CompareSameNameQuestionPlugin;
 import org.batfish.question.CompareSameNameQuestionPlugin.CompareSameNameAnswerElement;
 import org.batfish.question.CompareSameNameQuestionPlugin.CompareSameNameAnswerer;
 import org.batfish.question.CompareSameNameQuestionPlugin.CompareSameNameQuestion;
@@ -22,6 +21,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+/** End-to-end tests of {@link CompareSameNameQuestion}. */
 public class CompareSameNameTest {
 
   private Configuration.Builder _cb;

--- a/projects/allinone/src/test/java/org/batfish/question/aaaauthenticationlogin/AaaAuthenticationLoginTest.java
+++ b/projects/allinone/src/test/java/org/batfish/question/aaaauthenticationlogin/AaaAuthenticationLoginTest.java
@@ -1,4 +1,4 @@
-package org.batfish.allinone;
+package org.batfish.question.aaaauthenticationlogin;
 
 import static org.batfish.datamodel.matchers.RowMatchers.hasColumn;
 import static org.batfish.datamodel.matchers.RowsMatchers.hasSize;
@@ -20,13 +20,12 @@ import org.batfish.datamodel.questions.NodesSpecifier;
 import org.batfish.datamodel.table.TableAnswerElement;
 import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
-import org.batfish.question.aaaauthenticationlogin.AaaAuthenticationLoginAnswerer;
-import org.batfish.question.aaaauthenticationlogin.AaaAuthenticationLoginQuestion;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-public class AaaAuthenticationTest {
+/** End-to-end tests of {@link AaaAuthenticationLoginQuestion}. */
+public class AaaAuthenticationLoginTest {
 
   private static String TESTCONFIGS_PREFIX = "org/batfish/allinone/testconfigs/";
 

--- a/projects/allinone/src/test/java/org/batfish/question/aclreachability/AclReachabilityTest.java
+++ b/projects/allinone/src/test/java/org/batfish/question/aclreachability/AclReachabilityTest.java
@@ -1,4 +1,4 @@
-package org.batfish.allinone;
+package org.batfish.question.aclreachability;
 
 import static org.batfish.datamodel.IpAccessListLine.acceptingHeaderSpace;
 import static org.batfish.datamodel.IpAccessListLine.rejectingHeaderSpace;
@@ -50,13 +50,12 @@ import org.batfish.datamodel.table.Row;
 import org.batfish.datamodel.table.TableAnswerElement;
 import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
-import org.batfish.question.aclreachability.AclReachabilityAnswerer;
-import org.batfish.question.aclreachability.AclReachabilityQuestion;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+/** End-to-end tests of {@link AclReachabilityQuestion}. */
 public class AclReachabilityTest {
 
   @Rule public TemporaryFolder _folder = new TemporaryFolder();

--- a/projects/allinone/src/test/java/org/batfish/question/multipath/MultipathConsistencyTest.java
+++ b/projects/allinone/src/test/java/org/batfish/question/multipath/MultipathConsistencyTest.java
@@ -25,9 +25,9 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Tests of {@link MultipathConsistencyQuestion}. */
+/** End-to-end tests of {@link MultipathConsistencyQuestion}. */
 @RunWith(JUnit4.class)
-public class MultipathConsistencyQuestionTest {
+public class MultipathConsistencyTest {
   @Rule public TemporaryFolder temp = new TemporaryFolder();
 
   private TestNetwork _testNetwork;

--- a/projects/allinone/src/test/java/org/batfish/question/reachfilter/ReachFilterDifferentialTest.java
+++ b/projects/allinone/src/test/java/org/batfish/question/reachfilter/ReachFilterDifferentialTest.java
@@ -34,7 +34,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-public class ReachFilterAnswererDifferentialTest {
+/** End-to-end tests of {@link ReachFilterQuestion} in differential mode. */
+public class ReachFilterDifferentialTest {
   @Rule public TemporaryFolder _tmp = new TemporaryFolder();
 
   private static final String HOSTNAME = "hostname";

--- a/projects/allinone/src/test/java/org/batfish/question/reachfilter/ReachFilterTest.java
+++ b/projects/allinone/src/test/java/org/batfish/question/reachfilter/ReachFilterTest.java
@@ -66,7 +66,8 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-public final class ReachFilterAnswererTest {
+/** End-to-end tests of {@link ReachFilterQuestion}. */
+public final class ReachFilterTest {
   private static final String IFACE1 = "iface1";
 
   private static final String IFACE2 = "iface2";

--- a/projects/allinone/src/test/java/org/batfish/question/reducedreachability/ReducedReachabilityTest.java
+++ b/projects/allinone/src/test/java/org/batfish/question/reducedreachability/ReducedReachabilityTest.java
@@ -34,7 +34,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-public class ReducedReachabilityQuestionTest {
+/** End-to-end tests of {@link ReducedReachabilityQuestion}. */
+public class ReducedReachabilityTest {
   private static final String LOOPBACK = "Loopback0";
   private static final String NODE1 = "node1";
   private static final String NODE2 = "node2";
@@ -50,7 +51,7 @@ public class ReducedReachabilityQuestionTest {
 
   private org.batfish.datamodel.Vrf.Builder _vb;
 
-  public ReducedReachabilityQuestionTest() {}
+  public ReducedReachabilityTest() {}
 
   @Before
   public void setup() {

--- a/projects/allinone/src/test/java/org/batfish/question/specifiers/SpecifiersReachabilityTest.java
+++ b/projects/allinone/src/test/java/org/batfish/question/specifiers/SpecifiersReachabilityTest.java
@@ -1,4 +1,4 @@
-package org.batfish.allinone;
+package org.batfish.question.specifiers;
 
 import static org.batfish.datamodel.matchers.FlowHistoryInfoMatchers.hasFlow;
 import static org.batfish.datamodel.matchers.FlowMatchers.hasDstIp;
@@ -26,8 +26,6 @@ import org.batfish.datamodel.answers.AnswerElement;
 import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
 import org.batfish.main.TestrigText;
-import org.batfish.question.specifiers.SpecifiersReachabilityAnswerer;
-import org.batfish.question.specifiers.SpecifiersReachabilityQuestion;
 import org.batfish.specifier.AllInterfacesLocationSpecifierFactory;
 import org.batfish.specifier.ConstantUniverseIpSpaceSpecifierFactory;
 import org.batfish.specifier.NameRegexInterfaceLocationSpecifierFactory;
@@ -36,8 +34,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-/** End-to-end SpecifiersReachabilityQuestion tests. */
-public class SpecifiersReachabilityQuestionTest {
+/** End-to-end tests of {@link SpecifiersReachabilityQuestion}. */
+public class SpecifiersReachabilityTest {
   private static final String LOOPBACK = "Loopback0";
   private static final String NODE1 = "node1";
   private static final String NODE2 = "node2";

--- a/projects/allinone/src/test/java/org/batfish/question/specifiers/SpecifiersTest.java
+++ b/projects/allinone/src/test/java/org/batfish/question/specifiers/SpecifiersTest.java
@@ -1,4 +1,4 @@
-package org.batfish.main;
+package org.batfish.question.specifiers;
 
 import static org.batfish.datamodel.matchers.RowMatchers.hasColumn;
 import static org.batfish.question.specifiers.SpecifiersAnswerer.COL_IP_SPACE;
@@ -25,8 +25,8 @@ import org.batfish.datamodel.answers.AnswerElement;
 import org.batfish.datamodel.answers.Schema;
 import org.batfish.datamodel.matchers.TableAnswerElementMatchers;
 import org.batfish.datamodel.table.TableAnswerElement;
-import org.batfish.question.specifiers.SpecifiersAnswerer;
-import org.batfish.question.specifiers.SpecifiersQuestion;
+import org.batfish.main.Batfish;
+import org.batfish.main.BatfishTestUtils;
 import org.batfish.question.specifiers.SpecifiersQuestion.QueryType;
 import org.batfish.specifier.InterfaceLocation;
 import org.hamcrest.Matchers;
@@ -35,7 +35,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-public class SpecifiersQuestionTest {
+/** End-to-end tests of {@link SpecifiersQuestion}. */
+public class SpecifiersTest {
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
 
   private Batfish _batfish;

--- a/projects/allinone/src/test/java/org/batfish/question/testfilters/TestFiltersTest.java
+++ b/projects/allinone/src/test/java/org/batfish/question/testfilters/TestFiltersTest.java
@@ -1,4 +1,4 @@
-package org.batfish.allinone;
+package org.batfish.question.testfilters;
 
 import static org.batfish.datamodel.IpAccessListLine.acceptingHeaderSpace;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasIpAccessLists;
@@ -32,13 +32,12 @@ import org.batfish.datamodel.matchers.PermittedByIpAccessListLineMatchers;
 import org.batfish.datamodel.table.TableAnswerElement;
 import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
-import org.batfish.question.testfilters.TestFiltersAnswerer;
-import org.batfish.question.testfilters.TestFiltersQuestion;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+/** End-to-end tests of {@link TestFiltersQuestion}. */
 public class TestFiltersTest {
 
   private Configuration _c;

--- a/projects/allinone/src/test/java/org/batfish/question/traceroute/TracerouteTest.java
+++ b/projects/allinone/src/test/java/org/batfish/question/traceroute/TracerouteTest.java
@@ -8,12 +8,10 @@ import static org.batfish.datamodel.matchers.FlowMatchers.hasSrcIp;
 import static org.batfish.datamodel.matchers.FlowMatchers.hasTag;
 import static org.batfish.datamodel.matchers.FlowTraceMatchers.hasDisposition;
 import static org.batfish.datamodel.matchers.RowMatchers.hasColumn;
-import static org.batfish.question.traceroute.TracerouteAnswerer.COL_FLOW;
 import static org.batfish.question.traceroute.TracerouteAnswerer.COL_TRACES;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anyOf;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
@@ -35,10 +33,7 @@ import org.batfish.datamodel.IpAccessListLine;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.answers.Schema;
-import org.batfish.datamodel.table.ColumnMetadata;
 import org.batfish.datamodel.table.TableAnswerElement;
-import org.batfish.datamodel.table.TableDiff;
-import org.batfish.datamodel.table.TableMetadata;
 import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
 import org.batfish.main.TestrigText;
@@ -50,7 +45,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-public class TracerouteAnswererTest {
+public class TracerouteTest {
   private static final String TAG = "tag";
 
   private static final String FAST_ETHERNET = "FastEthernet0/0";
@@ -80,54 +75,6 @@ public class TracerouteAnswererTest {
             _folder);
 
     _batfish.computeDataPlane(false);
-  }
-
-  @Test
-  public void testCreateMetadata() {
-    TableMetadata tableMetadata = TracerouteAnswerer.createMetadata(false);
-    List<String> columnNames =
-        tableMetadata
-            .getColumnMetadata()
-            .stream()
-            .map(ColumnMetadata::getName)
-            .collect(ImmutableList.toImmutableList());
-    List<Schema> columnSchemas =
-        tableMetadata
-            .getColumnMetadata()
-            .stream()
-            .map(ColumnMetadata::getSchema)
-            .collect(ImmutableList.toImmutableList());
-
-    assertThat(columnNames, equalTo(ImmutableList.of(COL_FLOW, COL_TRACES)));
-    assertThat(
-        columnSchemas, equalTo(ImmutableList.of(Schema.FLOW, Schema.set(Schema.FLOW_TRACE))));
-
-    TableMetadata diffTableMetadata = TracerouteAnswerer.createMetadata(true);
-    List<String> diffColumnNames =
-        diffTableMetadata
-            .getColumnMetadata()
-            .stream()
-            .map(ColumnMetadata::getName)
-            .collect(ImmutableList.toImmutableList());
-    List<Schema> diffColumnSchemas =
-        diffTableMetadata
-            .getColumnMetadata()
-            .stream()
-            .map(ColumnMetadata::getSchema)
-            .collect(ImmutableList.toImmutableList());
-
-    assertThat(
-        diffColumnNames,
-        equalTo(
-            ImmutableList.of(
-                COL_FLOW,
-                TableDiff.baseColumnName(COL_TRACES),
-                TableDiff.deltaColumnName(COL_TRACES))));
-    assertThat(
-        diffColumnSchemas,
-        equalTo(
-            ImmutableList.of(
-                Schema.FLOW, Schema.set(Schema.FLOW_TRACE), Schema.set(Schema.FLOW_TRACE))));
   }
 
   @Test

--- a/projects/allinone/src/test/java/org/batfish/question/traceroute/TracerouteTest.java
+++ b/projects/allinone/src/test/java/org/batfish/question/traceroute/TracerouteTest.java
@@ -45,6 +45,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+/** End-to-end tests of {@link TracerouteQuestion}. */
 public class TracerouteTest {
   private static final String TAG = "tag";
 

--- a/projects/batfish/src/test/java/org/batfish/dataplane/PathDiffTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/PathDiffTest.java
@@ -1,4 +1,4 @@
-package org.batfish.allinone;
+package org.batfish.dataplane;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;

--- a/projects/question/src/test/java/org/batfish/question/NeighborsAnswerElementTest.java
+++ b/projects/question/src/test/java/org/batfish/question/NeighborsAnswerElementTest.java
@@ -1,4 +1,4 @@
-package org.batfish.question.neighbors;
+package org.batfish.question;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;

--- a/projects/question/src/test/java/org/batfish/question/aclreachability/AclReachabilityAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/aclreachability/AclReachabilityAnswererTest.java
@@ -1,4 +1,4 @@
-package org.batfish.allinone;
+package org.batfish.question.aclreachability;
 
 import static org.batfish.datamodel.IpAccessListLine.acceptingHeaderSpace;
 import static org.batfish.datamodel.IpAccessListLine.rejectingHeaderSpace;
@@ -39,7 +39,6 @@ import org.batfish.datamodel.acl.OrMatchExpr;
 import org.batfish.datamodel.acl.PermittedByAcl;
 import org.batfish.datamodel.answers.AclReachabilityRows;
 import org.batfish.datamodel.answers.AclSpecs;
-import org.batfish.question.aclreachability.AclReachabilityAnswerer;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;

--- a/projects/question/src/test/java/org/batfish/question/traceroute/TracerouteAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/traceroute/TracerouteAnswererTest.java
@@ -10,6 +10,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multiset;
+import java.util.List;
 import java.util.Set;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowDisposition;
@@ -17,12 +18,63 @@ import org.batfish.datamodel.FlowHistory;
 import org.batfish.datamodel.FlowHistory.FlowHistoryInfo;
 import org.batfish.datamodel.FlowTrace;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.answers.Schema;
 import org.batfish.datamodel.pojo.Environment;
+import org.batfish.datamodel.table.ColumnMetadata;
 import org.batfish.datamodel.table.Row;
 import org.batfish.datamodel.table.TableDiff;
+import org.batfish.datamodel.table.TableMetadata;
 import org.junit.Test;
 
 public class TracerouteAnswererTest {
+
+  @Test
+  public void testCreateMetadata() {
+    TableMetadata tableMetadata = TracerouteAnswerer.createMetadata(false);
+    List<String> columnNames =
+        tableMetadata
+            .getColumnMetadata()
+            .stream()
+            .map(ColumnMetadata::getName)
+            .collect(ImmutableList.toImmutableList());
+    List<Schema> columnSchemas =
+        tableMetadata
+            .getColumnMetadata()
+            .stream()
+            .map(ColumnMetadata::getSchema)
+            .collect(ImmutableList.toImmutableList());
+
+    assertThat(columnNames, equalTo(ImmutableList.of(COL_FLOW, COL_TRACES)));
+    assertThat(
+        columnSchemas, equalTo(ImmutableList.of(Schema.FLOW, Schema.set(Schema.FLOW_TRACE))));
+
+    TableMetadata diffTableMetadata = TracerouteAnswerer.createMetadata(true);
+    List<String> diffColumnNames =
+        diffTableMetadata
+            .getColumnMetadata()
+            .stream()
+            .map(ColumnMetadata::getName)
+            .collect(ImmutableList.toImmutableList());
+    List<Schema> diffColumnSchemas =
+        diffTableMetadata
+            .getColumnMetadata()
+            .stream()
+            .map(ColumnMetadata::getSchema)
+            .collect(ImmutableList.toImmutableList());
+
+    assertThat(
+        diffColumnNames,
+        equalTo(
+            ImmutableList.of(
+                COL_FLOW,
+                TableDiff.baseColumnName(COL_TRACES),
+                TableDiff.deltaColumnName(COL_TRACES))));
+    assertThat(
+        diffColumnSchemas,
+        equalTo(
+            ImmutableList.of(
+                Schema.FLOW, Schema.set(Schema.FLOW_TRACE), Schema.set(Schema.FLOW_TRACE))));
+  }
 
   @Test
   public void testDiffFlowHistoryToRows() {


### PR DESCRIPTION
* Unit tests should not be here, so moved a bunch of those next to the code they test
* Test names should make sense and be unique. Specifically, unified on
  `<QuestionName>Test` for e2e tests and `<ClassName>Test` for unit tests of `<ClassName>`.
  `<ClassName>` is typically `FooQuestion`, `FooAnswer`, whereas
  `<QuestionName>` is `Foo`.
* Add trivial javadocs.