### PR TITLE
Track original line numbers for lines using Juniper applicators

### DIFF
--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/ConvertConfigurationAnswerElementMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/ConvertConfigurationAnswerElementMatchers.java
@@ -302,6 +302,86 @@ final class ConvertConfigurationAnswerElementMatchers {
     }
   }
 
+  static final class HasUndefinedReferenceWithReferenceLines
+      extends TypeSafeDiagnosingMatcher<ConvertConfigurationAnswerElement> {
+
+    private final Matcher<? super Set<Integer>> _subMatcher;
+
+    private final String _filename;
+
+    private final String _structureName;
+
+    private final String _type;
+
+    private final String _usage;
+
+    HasUndefinedReferenceWithReferenceLines(
+        @Nonnull String filename,
+        @Nonnull StructureType type,
+        @Nonnull String structureName,
+        @Nonnull StructureUsage usage,
+        @Nonnull Matcher<? super Set<Integer>> subMatcher) {
+      _subMatcher = subMatcher;
+      _filename = filename;
+      _type = type.getDescription();
+      _structureName = structureName;
+      _usage = usage.getDescription();
+    }
+
+    @Override
+    public void describeTo(Description description) {
+      description.appendText(
+          String.format(
+              "A ConvertConfigurationAnswerElement for which file '%s' has an undefined reference "
+                  + "of type '%s' named '%s' with reference lines '%s'",
+              _filename, _type, _structureName, _subMatcher));
+    }
+
+    @Override
+    protected boolean matchesSafely(
+        ConvertConfigurationAnswerElement item, Description mismatchDescription) {
+      SortedMap<String, SortedMap<String, SortedMap<String, SortedMap<String, SortedSet<Integer>>>>>
+          byFile = item.getUndefinedReferences();
+      if (!byFile.containsKey(_filename)) {
+        mismatchDescription.appendText(
+            String.format("File '%s' has no undefined references", _filename));
+        return false;
+      }
+      SortedMap<String, SortedMap<String, SortedMap<String, SortedSet<Integer>>>> byType =
+          byFile.get(_filename);
+      if (!byType.containsKey(_type)) {
+        mismatchDescription.appendText(
+            String.format("File '%s' has no undefined reference of type '%s'", _filename, _type));
+        return false;
+      }
+      SortedMap<String, SortedMap<String, SortedSet<Integer>>> byStructureName = byType.get(_type);
+      if (!byStructureName.containsKey(_structureName)) {
+        mismatchDescription.appendText(
+            String.format(
+                "File '%s' has no undefined reference of type '%s' named '%s'",
+                _filename, _type, _structureName));
+        return false;
+      }
+      SortedMap<String, SortedSet<Integer>> byUsage = byStructureName.get(_structureName);
+      if (!byUsage.containsKey(_usage)) {
+        mismatchDescription.appendText(
+            String.format(
+                "File '%s' has no undefined references to structures of type '%s' named '%s' of "
+                    + "usage '%s'",
+                _filename, _type, _structureName, _usage));
+        return false;
+      }
+      if (!_subMatcher.matches(byUsage.get(_usage))) {
+        mismatchDescription.appendText(
+            String.format(
+                "File '%s' has no undefined reference of type '%s' named '%s' of usage '%s' matching reference lines '%s'",
+                _filename, _type, _structureName, _usage, _subMatcher));
+        return false;
+      }
+      return true;
+    }
+  }
+
   static final class HasNumReferrers
       extends TypeSafeDiagnosingMatcher<ConvertConfigurationAnswerElement> {
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/DataModelMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/DataModelMatchers.java
@@ -318,6 +318,23 @@ public final class DataModelMatchers {
 
   /**
    * Provides a matcher that matches if the provided {@link ConvertConfigurationAnswerElement} has
+   * an undefined reference in {@code hostname} to a structure of type {@code type} named {@code
+   * structureName} of usage type {@code usage} with reference lines matching the provided {@code
+   * subMatcher}.
+   */
+  public static @Nonnull Matcher<ConvertConfigurationAnswerElement>
+      hasUndefinedReferenceWithReferenceLines(
+          @Nonnull String hostname,
+          @Nonnull StructureType type,
+          @Nonnull String structureName,
+          @Nonnull StructureUsage usage,
+          @Nonnull Matcher<? super Set<Integer>> subMatcher) {
+    return new ConvertConfigurationAnswerElementMatchers.HasUndefinedReferenceWithReferenceLines(
+        hostname, type, structureName, usage, subMatcher);
+  }
+
+  /**
+   * Provides a matcher that matches if the provided {@link ConvertConfigurationAnswerElement} has
    * an unused structure for {@code hostname} of type {@code type} named {@code structureName}.
    */
   public static @Nonnull Matcher<ConvertConfigurationAnswerElement> hasNumReferrers(

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -4,11 +4,16 @@ options {
    superClass = 'org.batfish.grammar.BatfishLexer';
 }
 
+@header {
+import static com.google.common.base.MoreObjects.firstNonNull;
+}
+
 @members {
 boolean enableIPV6_ADDRESS = true;
 boolean enableIP_ADDRESS = true;
 boolean enableDEC = true;
 boolean _markWildcards = false;
+private Integer _overrideTokenStartLine;
 
 public boolean isPrefix() {
    char nextChar = (char)this.getInputStream().LA(1);
@@ -16,6 +21,14 @@ public boolean isPrefix() {
       return false;
     }
     return true;
+}
+
+@Override
+public Token emit() {
+  Token t = _factory.create(_tokenFactorySourcePair, _type, _text, _channel, _tokenStartCharIndex, getCharIndex()-1,
+    firstNonNull(_overrideTokenStartLine, _tokenStartLine), _tokenStartCharPositionInLine);
+  emit(t);
+  return t;
 }
 
 @Override
@@ -30,6 +43,10 @@ public String printStateVariables() {
 
 public void setMarkWildcards(boolean markWildcards) {
    _markWildcards = markWildcards;
+}
+
+public void setOverrideTokenStartLine(Integer overrideTokenStartLine) {
+  _overrideTokenStartLine = overrideTokenStartLine;
 }
 
 private void setWildcard() {

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ApplyGroupsApplicator.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ApplyGroupsApplicator.java
@@ -113,7 +113,7 @@ public class ApplyGroupsApplicator extends FlatJuniperParserBaseListener {
       _enablePathRecording = false;
       _reenablePathRecording = true;
       String text = ctx.getText();
-      _currentPath.addNode(text);
+      _currentPath.addNode(text, ctx.getStart().getLine());
     }
   }
 
@@ -177,10 +177,11 @@ public class ApplyGroupsApplicator extends FlatJuniperParserBaseListener {
   public void visitTerminal(TerminalNode node) {
     if (_enablePathRecording) {
       String text = node.getText();
+      int line = node.getSymbol().getLine();
       if (node.getSymbol().getType() == FlatJuniperLexer.WILDCARD) {
-        _currentPath.addWildcardNode(text);
+        _currentPath.addWildcardNode(text, line);
       } else {
-        _currentPath.addNode(text);
+        _currentPath.addNode(text, line);
       }
     }
   }

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ApplyPathApplicator.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ApplyPathApplicator.java
@@ -49,7 +49,7 @@ public class ApplyPathApplicator extends FlatJuniperParserBaseListener {
       _enablePathRecording = false;
       _reenablePathRecording = true;
       String text = ctx.getText();
-      _currentPath.addNode(text);
+      _currentPath.addNode(text, ctx.getStart().getLine());
     }
   }
 
@@ -57,14 +57,15 @@ public class ApplyPathApplicator extends FlatJuniperParserBaseListener {
   public void enterPoplt_apply_path(Poplt_apply_pathContext ctx) {
     HierarchyPath applyPathPath = new HierarchyPath();
     String pathQuoted = ctx.path.getText();
+    int line = ctx.path.getLine();
     String pathWithoutQuotes = pathQuoted.substring(1, pathQuoted.length() - 1);
     String[] pathComponents = pathWithoutQuotes.split("\\s+");
     for (String pathComponent : pathComponents) {
       boolean isWildcard = pathComponent.charAt(0) == '<';
       if (isWildcard) {
-        applyPathPath.addWildcardNode(pathComponent);
+        applyPathPath.addWildcardNode(pathComponent, line);
       } else {
-        applyPathPath.addNode(pathComponent);
+        applyPathPath.addNode(pathComponent, line);
       }
     }
     int insertionIndex = _newConfigurationLines.indexOf(_currentSetLine);
@@ -122,10 +123,11 @@ public class ApplyPathApplicator extends FlatJuniperParserBaseListener {
   public void visitTerminal(TerminalNode node) {
     if (_enablePathRecording) {
       String text = node.getText();
+      int line = node.getSymbol().getLine();
       if (node.getSymbol().getType() == FlatJuniperLexer.WILDCARD) {
-        _currentPath.addWildcardNode(text);
+        _currentPath.addWildcardNode(text, line);
       } else {
-        _currentPath.addNode(text);
+        _currentPath.addNode(text, line);
       }
     }
   }

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/DeactivateTreeBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/DeactivateTreeBuilder.java
@@ -39,7 +39,7 @@ public class DeactivateTreeBuilder extends FlatJuniperParserBaseListener {
       _enablePathRecording = false;
       _reenablePathRecording = true;
       String text = ctx.getText();
-      _currentPath.addNode(text);
+      _currentPath.addNode(text, ctx.getStart().getLine());
     }
   }
 
@@ -72,7 +72,7 @@ public class DeactivateTreeBuilder extends FlatJuniperParserBaseListener {
   public void visitTerminal(TerminalNode node) {
     if (_enablePathRecording) {
       String text = node.getText();
-      _currentPath.addNode(text);
+      _currentPath.addNode(text, node.getSymbol().getLine());
     }
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/DeactivatedLinePruner.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/DeactivatedLinePruner.java
@@ -43,7 +43,7 @@ public class DeactivatedLinePruner extends FlatJuniperParserBaseListener {
       _enablePathRecording = false;
       _reenablePathRecording = true;
       String text = ctx.getText();
-      _currentPath.addNode(text);
+      _currentPath.addNode(text, ctx.getStart().getLine());
     }
   }
 
@@ -94,7 +94,7 @@ public class DeactivatedLinePruner extends FlatJuniperParserBaseListener {
   public void visitTerminal(TerminalNode node) {
     if (_enablePathRecording) {
       String text = node.getText();
-      _currentPath.addNode(text);
+      _currentPath.addNode(text, node.getSymbol().getLine());
     }
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/GroupTreeBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/GroupTreeBuilder.java
@@ -54,7 +54,7 @@ public class GroupTreeBuilder extends FlatJuniperParserBaseListener {
       _enablePathRecording = false;
       _reenablePathRecording = true;
       String text = ctx.getText();
-      _currentPath.addNode(text);
+      _currentPath.addNode(text, ctx.getStart().getLine());
     }
   }
 
@@ -99,10 +99,11 @@ public class GroupTreeBuilder extends FlatJuniperParserBaseListener {
     for (Token currentToken : unfilteredTokens) {
       if (currentToken.getChannel() != Lexer.HIDDEN) {
         String text = currentToken.getText();
+        int line = currentToken.getLine();
         if (currentToken.getType() == FlatJuniperLexer.WILDCARD) {
-          path.addWildcardNode(text);
+          path.addWildcardNode(text, line);
         } else {
-          path.addNode(text);
+          path.addNode(text, line);
         }
       }
     }
@@ -125,10 +126,11 @@ public class GroupTreeBuilder extends FlatJuniperParserBaseListener {
   public void visitTerminal(TerminalNode node) {
     if (_enablePathRecording) {
       String text = node.getText();
+      int line = node.getSymbol().getLine();
       if (node.getSymbol().getType() == FlatJuniperLexer.WILDCARD) {
-        _currentPath.addWildcardNode(text);
+        _currentPath.addWildcardNode(text, line);
       } else {
-        _currentPath.addNode(text);
+        _currentPath.addNode(text, line);
       }
     }
   }

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/Hierarchy.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/Hierarchy.java
@@ -60,12 +60,14 @@ public class Hierarchy {
     private abstract static class HierarchyChildNode extends HierarchyNode {
 
       private Set_lineContext _line;
+      protected int _lineNumber;
       protected String _sourceGroup;
       public List<String> _sourceWildcards;
       protected String _text;
 
-      private HierarchyChildNode(String text) {
+      private HierarchyChildNode(String text, int lineNumber) {
         _text = text;
+        _lineNumber = lineNumber;
       }
 
       public abstract HierarchyChildNode copy();
@@ -79,13 +81,13 @@ public class Hierarchy {
 
     private static final class HierarchyLiteralNode extends HierarchyChildNode {
 
-      private HierarchyLiteralNode(String text) {
-        super(text);
+      private HierarchyLiteralNode(String text, int lineNumber) {
+        super(text, lineNumber);
       }
 
       @Override
       public HierarchyChildNode copy() {
-        return new HierarchyLiteralNode(_text);
+        return new HierarchyLiteralNode(_text, _lineNumber);
       }
 
       @Override
@@ -170,14 +172,14 @@ public class Hierarchy {
         _nodes = new ArrayList<>();
       }
 
-      public void addNode(String text) {
-        HierarchyChildNode newNode = new HierarchyLiteralNode(text);
+      public void addNode(String text, int lineNumber) {
+        HierarchyChildNode newNode = new HierarchyLiteralNode(text, lineNumber);
         _nodes.add(newNode);
       }
 
-      public void addWildcardNode(String text) {
+      public void addWildcardNode(String text, int lineNumber) {
         _containsWildcard = true;
-        HierarchyChildNode newNode = new HierarchyWildcardNode(text);
+        HierarchyChildNode newNode = new HierarchyWildcardNode(text, lineNumber);
         _nodes.add(newNode);
       }
 
@@ -210,8 +212,8 @@ public class Hierarchy {
 
       private String _wildcard;
 
-      private HierarchyWildcardNode(String text) {
-        super(text);
+      private HierarchyWildcardNode(String text, int lineNumber) {
+        super(text, lineNumber);
         if (text.charAt(0) != '<' || text.charAt(text.length() - 1) != '>') {
           throw new BatfishException("Improperly-formatted wildcard: " + text);
         }
@@ -220,7 +222,7 @@ public class Hierarchy {
 
       @Override
       public HierarchyChildNode copy() {
-        return new HierarchyWildcardNode(_text);
+        return new HierarchyWildcardNode(_text, _lineNumber);
       }
 
       @Override
@@ -275,41 +277,13 @@ public class Hierarchy {
         Flat_juniper_configurationContext configurationContext,
         boolean clusterGroup) {
       if (groupLine != null) {
+        int overrideLine = groupLine.getStart().getLine();
         Set_lineContext setLine = new Set_lineContext(configurationContext, -1);
         if (masterTree.addPath(path, setLine, _groupName) == AddPathResult.BLACKLISTED) {
           return;
         }
-        StringBuilder sb = new StringBuilder();
-        for (HierarchyChildNode pathNode : path._nodes) {
-          sb.append(pathNode._text + " ");
-        }
-        String newStatementText = sb.toString();
-        // get rid of last " ", which matters for tokens where whitespace is
-        // not ignored
-        newStatementText =
-            "set " + newStatementText.substring(0, newStatementText.length() - 1) + "\n";
-        TerminalNode set = new TerminalNodeImpl(new CommonToken(FlatJuniperLexer.SET, "set"));
-        Set_line_tailContext setLineTail = new Set_line_tailContext(setLine, -1);
-        TerminalNode newline =
-            new TerminalNodeImpl(new CommonToken(FlatJuniperLexer.NEWLINE, "\n"));
-        setLine.children = new ArrayList<>();
-        setLine.children.add(set);
-        setLine.children.add(setLineTail);
-        setLine.children.add(newline);
-        Settings settings = parserSettings();
-        FlatJuniperCombinedParser parser =
-            new FlatJuniperCombinedParser(newStatementText, settings);
-        parser.setMarkWildcards(true);
-        Flat_juniper_configurationContext newConfiguration =
-            parser.getParser().flat_juniper_configuration();
-        parser.setMarkWildcards(false);
-        // StatementContext newStatement = parser.getParser().statement();
-        StatementContext newStatement = newConfiguration.set_line(0).set_line_tail().statement();
-        newStatement.parent = setLineTail;
-
-        setLineTail.children = new ArrayList<>();
-        if (!clusterGroup || !IsHostnameStatement.isHostnameStatement(newStatement)) {
-          setLineTail.children.add(newStatement);
+        StatementContext newStatement = setLineHelper(setLine, path, overrideLine, true);
+        if (!(clusterGroup && IsHostnameStatement.isHostnameStatement(newStatement))) {
           lines.add(setLine);
         }
       }
@@ -355,9 +329,11 @@ public class Hierarchy {
       HierarchyChildNode wildcardNode = findExactPathMatchNode(path);
       String sourceGroup = wildcardNode._sourceGroup;
       int remainingWildcards = 0;
+      int lineNumber = -1;
       for (HierarchyChildNode node : path._nodes) {
         if (node.isWildcard()) {
           remainingWildcards++;
+          lineNumber = node._lineNumber;
         }
       }
       List<String> appliedWildcards = new ArrayList<>();
@@ -372,7 +348,8 @@ public class Hierarchy {
           remainingWildcards,
           appliedWildcards,
           newPath,
-          lines);
+          lines,
+          lineNumber);
       return lines;
     }
 
@@ -385,7 +362,8 @@ public class Hierarchy {
         int remainingWildcards,
         List<String> appliedWildcards,
         HierarchyPath newPath,
-        List<ParseTree> lines) {
+        List<ParseTree> lines,
+        int overrideLineNumber) {
       if (destinationTreeRoot._blacklistedGroups.contains(sourceGroup)) {
         return;
       }
@@ -408,7 +386,8 @@ public class Hierarchy {
         if (startingIndex == path._nodes.size() - 1) {
           newDestinationTreeRoot._sourceWildcards = new ArrayList<>();
           newDestinationTreeRoot._sourceWildcards.addAll(appliedWildcards);
-          newDestinationTreeRoot._line = generateSetLine(newPath, configurationContext);
+          newDestinationTreeRoot._line =
+              generateSetLine(newPath, configurationContext, overrideLineNumber);
           lines.add(newDestinationTreeRoot._line);
         } else {
           applyWildcardPath(
@@ -420,7 +399,8 @@ public class Hierarchy {
               remainingWildcards,
               appliedWildcards,
               newPath,
-              lines);
+              lines,
+              overrideLineNumber);
         }
         newPath._nodes.remove(newPath._nodes.size() - 1);
       } else {
@@ -440,7 +420,8 @@ public class Hierarchy {
                   remainingWildcards - 1,
                   appliedWildcards,
                   newPath,
-                  lines);
+                  lines,
+                  overrideLineNumber);
               newPath._nodes.remove(newPath._nodes.size() - 1);
             }
           }
@@ -477,18 +458,23 @@ public class Hierarchy {
       return matchNode;
     }
 
-    private Set_lineContext generateSetLine(
-        HierarchyPath path, Flat_juniper_configurationContext configurationContext) {
-      Set_lineContext setLine = new Set_lineContext(configurationContext, -1);
+    /**
+     * Populate the specified setLine's children with the supplied path and return the generated set
+     * statement
+     */
+    private static StatementContext setLineHelper(
+        Set_lineContext setLine, HierarchyPath path, int overrideLine, boolean markWildcards) {
+      Set_line_tailContext setLineTail = new Set_line_tailContext(setLine, -1);
       StringBuilder sb = new StringBuilder();
       for (HierarchyChildNode pathNode : path._nodes) {
-        sb.append(pathNode._text + " ");
+        sb.append(pathNode._text);
+        sb.append(" ");
       }
       String newStatementText = sb.toString();
+      // Get rid of last " ", which matters for tokens where whitespace is not ignored
       newStatementText =
           "set " + newStatementText.substring(0, newStatementText.length() - 1) + "\n";
       TerminalNode set = new TerminalNodeImpl(new CommonToken(FlatJuniperLexer.SET, "set"));
-      Set_line_tailContext setLineTail = new Set_line_tailContext(setLine, -1);
       TerminalNode newline = new TerminalNodeImpl(new CommonToken(FlatJuniperLexer.NEWLINE, "\n"));
       setLine.children = new ArrayList<>();
       setLine.children.add(set);
@@ -496,14 +482,29 @@ public class Hierarchy {
       setLine.children.add(newline);
       Settings settings = parserSettings();
       FlatJuniperCombinedParser parser = new FlatJuniperCombinedParser(newStatementText, settings);
+      parser.getLexer().setOverrideTokenStartLine(overrideLine);
+      if (markWildcards) {
+        parser.setMarkWildcards(true);
+      }
       Flat_juniper_configurationContext newConfiguration =
           parser.getParser().flat_juniper_configuration();
+      if (markWildcards) {
+        parser.setMarkWildcards(false);
+      }
       StatementContext newStatement = newConfiguration.set_line(0).set_line_tail().statement();
       newStatement.parent = setLineTail;
 
       setLineTail.children = new ArrayList<>();
       setLineTail.children.add(newStatement);
+      return newStatement;
+    }
 
+    private Set_lineContext generateSetLine(
+        HierarchyPath path,
+        Flat_juniper_configurationContext configurationContext,
+        int overrideLine) {
+      Set_lineContext setLine = new Set_lineContext(configurationContext, -1);
+      setLineHelper(setLine, path, overrideLine, false);
       return setLine;
     }
 
@@ -563,8 +564,10 @@ public class Hierarchy {
         HierarchyPath applyPathPath,
         Flat_juniper_configurationContext configurationContext) {
       List<ParseTree> lines = new ArrayList<>();
-      List<String> candidatePrefixes = getApplyPathPrefixes(applyPathPath);
-      for (String candidatePrefix : candidatePrefixes) {
+      List<HierarchyChildNode> candidateNodes = getApplyPathPrefixes(applyPathPath);
+      for (HierarchyChildNode candidateNode : candidateNodes) {
+        String candidatePrefix = candidateNode._text;
+        int candidateLineNumber = candidateNode._lineNumber;
         String finalPrefixStr;
         boolean ipv6 = candidatePrefix.contains(":");
         boolean isPrefix = candidatePrefix.contains("/");
@@ -590,26 +593,30 @@ public class Hierarchy {
           throw new BatfishException(
               "Invalid ip(v6) address or prefix: \"" + candidatePrefix + "\"", e);
         }
-        basePath.addNode(finalPrefixStr);
-        Set_lineContext setLine = generateSetLine(basePath, configurationContext);
+        basePath.addNode(finalPrefixStr, candidateLineNumber);
+        Set_lineContext setLine =
+            generateSetLine(basePath, configurationContext, candidateLineNumber);
         lines.add(setLine);
         basePath._nodes.remove(basePath._nodes.size() - 1);
       }
       return lines;
     }
 
-    private List<String> getApplyPathPrefixes(HierarchyPath path) {
-      List<String> prefixes = new ArrayList<>();
+    private List<HierarchyChildNode> getApplyPathPrefixes(HierarchyPath path) {
+      List<HierarchyChildNode> prefixes = new ArrayList<>();
       getApplyPathPrefixes(path, _root, 0, prefixes);
       return prefixes;
     }
 
     private void getApplyPathPrefixes(
-        HierarchyPath path, HierarchyNode currentNode, int currentDepth, List<String> prefixes) {
+        HierarchyPath path,
+        HierarchyNode currentNode,
+        int currentDepth,
+        List<HierarchyChildNode> prefixes) {
       if (currentDepth == path._nodes.size() - 1) {
         for (HierarchyChildNode currentChild : currentNode.getChildren().values()) {
           if (!currentChild.isWildcard()) {
-            prefixes.add(currentChild._text);
+            prefixes.add(currentChild);
           }
         }
       } else {

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/Hierarchy.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/Hierarchy.java
@@ -464,7 +464,6 @@ public class Hierarchy {
      */
     private static StatementContext setLineHelper(
         Set_lineContext setLine, HierarchyPath path, int overrideLine, boolean markWildcards) {
-      Set_line_tailContext setLineTail = new Set_line_tailContext(setLine, -1);
       StringBuilder sb = new StringBuilder();
       for (HierarchyChildNode pathNode : path._nodes) {
         sb.append(pathNode._text);
@@ -475,6 +474,7 @@ public class Hierarchy {
       newStatementText =
           "set " + newStatementText.substring(0, newStatementText.length() - 1) + "\n";
       TerminalNode set = new TerminalNodeImpl(new CommonToken(FlatJuniperLexer.SET, "set"));
+      Set_line_tailContext setLineTail = new Set_line_tailContext(setLine, -1);
       TerminalNode newline = new TerminalNodeImpl(new CommonToken(FlatJuniperLexer.NEWLINE, "\n"));
       setLine.children = new ArrayList<>();
       setLine.children.add(set);
@@ -482,6 +482,7 @@ public class Hierarchy {
       setLine.children.add(newline);
       Settings settings = parserSettings();
       FlatJuniperCombinedParser parser = new FlatJuniperCombinedParser(newStatementText, settings);
+      // Use the supplied line number for the constructed nodes
       parser.getLexer().setOverrideTokenStartLine(overrideLine);
       if (markWildcards) {
         parser.setMarkWildcards(true);

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/InitialTreeBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/InitialTreeBuilder.java
@@ -38,7 +38,7 @@ public class InitialTreeBuilder extends FlatJuniperParserBaseListener {
       _enablePathRecording = false;
       _reenablePathRecording = true;
       String text = ctx.getText();
-      _currentPath.addNode(text);
+      _currentPath.addNode(text, ctx.getStart().getLine());
     }
   }
 
@@ -89,10 +89,11 @@ public class InitialTreeBuilder extends FlatJuniperParserBaseListener {
   public void visitTerminal(TerminalNode node) {
     if (_enablePathRecording) {
       String text = node.getText();
+      int line = node.getSymbol().getLine();
       if (node.getSymbol().getType() == FlatJuniperLexer.WILDCARD) {
-        _currentPath.addWildcardNode(text);
+        _currentPath.addWildcardNode(text, line);
       } else {
-        _currentPath.addNode(text);
+        _currentPath.addNode(text, line);
       }
     }
   }

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/WildcardApplicator.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/WildcardApplicator.java
@@ -67,9 +67,9 @@ public class WildcardApplicator extends FlatJuniperParserBaseListener {
   @Override
   public void exitSet_line(Set_lineContext ctx) {
     if (_currentPath.containsWildcard()) {
-      int insertionIndex = _newConfigurationLines.indexOf(ctx);
       List<ParseTree> lines =
           _hierarchy.getMasterTree().applyWildcardPath(_currentPath, _configurationContext);
+      int insertionIndex = _newConfigurationLines.indexOf(ctx);
       _newConfigurationLines.addAll(insertionIndex, lines);
     }
     _currentPath = null;

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/WildcardApplicator.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/WildcardApplicator.java
@@ -41,7 +41,7 @@ public class WildcardApplicator extends FlatJuniperParserBaseListener {
       _enablePathRecording = false;
       _reenablePathRecording = true;
       String text = ctx.getText();
-      _currentPath.addNode(text);
+      _currentPath.addNode(text, ctx.getStart().getLine());
     }
   }
 
@@ -67,9 +67,9 @@ public class WildcardApplicator extends FlatJuniperParserBaseListener {
   @Override
   public void exitSet_line(Set_lineContext ctx) {
     if (_currentPath.containsWildcard()) {
+      int insertionIndex = _newConfigurationLines.indexOf(ctx);
       List<ParseTree> lines =
           _hierarchy.getMasterTree().applyWildcardPath(_currentPath, _configurationContext);
-      int insertionIndex = _newConfigurationLines.indexOf(ctx);
       _newConfigurationLines.addAll(insertionIndex, lines);
     }
     _currentPath = null;
@@ -84,10 +84,11 @@ public class WildcardApplicator extends FlatJuniperParserBaseListener {
   public void visitTerminal(TerminalNode node) {
     if (_enablePathRecording) {
       String text = node.getText();
+      int line = node.getSymbol().getLine();
       if (node.getSymbol().getType() == FlatJuniperLexer.WILDCARD_ARTIFACT) {
-        _currentPath.addWildcardNode(text);
+        _currentPath.addWildcardNode(text, line);
       } else {
-        _currentPath.addNode(text);
+        _currentPath.addNode(text, line);
       }
     }
   }

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/WildcardPruner.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/WildcardPruner.java
@@ -54,10 +54,11 @@ public class WildcardPruner extends FlatJuniperParserBaseListener {
   public void visitTerminal(TerminalNode node) {
     if (_enablePathRecording) {
       String text = node.getText();
+      int line = node.getSymbol().getLine();
       if (node.getSymbol().getType() == FlatJuniperLexer.WILDCARD_ARTIFACT) {
-        _currentPath.addWildcardNode(text);
+        _currentPath.addWildcardNode(text, line);
       } else {
-        _currentPath.addNode(text);
+        _currentPath.addNode(text, line);
       }
     }
   }

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -2097,7 +2097,6 @@ public class FlatJuniperGrammarTest {
   public void testJuniperWildcardsReference() throws IOException {
     String hostname = "juniper-wildcards";
     String filename = "configs/" + hostname;
-    Configuration c = parseConfig(hostname);
     Batfish batfish = getBatfishForConfigurationNames(hostname);
     ConvertConfigurationAnswerElement ccae =
         batfish.loadConvertConfigurationAnswerElementOrReparse();

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -35,6 +35,7 @@ import static org.batfish.datamodel.matchers.DataModelMatchers.hasReferenceBandw
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasRouteFilterList;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasRouteFilterLists;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasUndefinedReference;
+import static org.batfish.datamodel.matchers.DataModelMatchers.hasUndefinedReferenceWithReferenceLines;
 import static org.batfish.datamodel.matchers.GeneratedRouteMatchers.isDiscard;
 import static org.batfish.datamodel.matchers.IkePhase1PolicyMatchers.hasIkePhase1Key;
 import static org.batfish.datamodel.matchers.IkePhase1PolicyMatchers.hasIkePhase1Proposals;
@@ -113,6 +114,7 @@ import static org.batfish.representation.juniper.JuniperStructureType.VLAN;
 import static org.batfish.representation.juniper.JuniperStructureUsage.APPLICATION_SET_MEMBER_APPLICATION;
 import static org.batfish.representation.juniper.JuniperStructureUsage.APPLICATION_SET_MEMBER_APPLICATION_SET;
 import static org.batfish.representation.juniper.JuniperStructureUsage.INTERFACE_VLAN;
+import static org.batfish.representation.juniper.JuniperStructureUsage.OSPF_AREA_INTERFACE;
 import static org.batfish.representation.juniper.JuniperStructureUsage.SECURITY_POLICY_MATCH_APPLICATION;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.Matchers.allOf;
@@ -2105,14 +2107,24 @@ public class FlatJuniperGrammarTest {
     assertThat(
         ccae,
         hasDefinedStructureWithDefinitionLines(
-            filename, INTERFACE, "lo0", containsInAnyOrder(4, 7)));
+            filename, INTERFACE, "lo0", containsInAnyOrder(4, 8)));
     assertThat(
         ccae,
         hasDefinedStructureWithDefinitionLines(
-            filename, PREFIX_LIST, "p1", containsInAnyOrder(4, 8)));
+            filename, PREFIX_LIST, "p1", containsInAnyOrder(4, 9)));
     assertThat(
         ccae,
         hasDefinedStructureWithDefinitionLines(filename, PREFIX_LIST, "p2", containsInAnyOrder(5)));
+
+    // Confirm undefined references are also tracked properly for apply-groups related references
+    assertThat(
+        ccae,
+        hasUndefinedReferenceWithReferenceLines(
+            filename,
+            INTERFACE,
+            "iface_undefined",
+            OSPF_AREA_INTERFACE,
+            containsInAnyOrder(6, 14)));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -107,6 +107,7 @@ import static org.batfish.representation.juniper.JuniperStructureType.APPLICATIO
 import static org.batfish.representation.juniper.JuniperStructureType.APPLICATION_SET;
 import static org.batfish.representation.juniper.JuniperStructureType.AUTHENTICATION_KEY_CHAIN;
 import static org.batfish.representation.juniper.JuniperStructureType.FIREWALL_FILTER;
+import static org.batfish.representation.juniper.JuniperStructureType.INTERFACE;
 import static org.batfish.representation.juniper.JuniperStructureType.PREFIX_LIST;
 import static org.batfish.representation.juniper.JuniperStructureType.VLAN;
 import static org.batfish.representation.juniper.JuniperStructureUsage.APPLICATION_SET_MEMBER_APPLICATION;
@@ -2090,6 +2091,29 @@ public class FlatJuniperGrammarTest {
 
     /* The wildcard-looking BGP group name should not be pruned since its parse-tree node was not created via preprocessor. */
     assertThat(c, hasDefaultVrf(hasBgpProcess(hasNeighbors(hasKey(neighborPrefix)))));
+  }
+
+  @Test
+  public void testJuniperWildcardsReference() throws IOException {
+    String hostname = "juniper-wildcards";
+    String filename = "configs/" + hostname;
+    Configuration c = parseConfig(hostname);
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse();
+
+    // Confirm definitions are tracked properly for structures defined by apply-groups/apply-path
+    assertThat(
+        ccae,
+        hasDefinedStructureWithDefinitionLines(
+            filename, INTERFACE, "lo0", containsInAnyOrder(4, 7)));
+    assertThat(
+        ccae,
+        hasDefinedStructureWithDefinitionLines(
+            filename, PREFIX_LIST, "p1", containsInAnyOrder(4, 8)));
+    assertThat(
+        ccae,
+        hasDefinedStructureWithDefinitionLines(filename, PREFIX_LIST, "p2", containsInAnyOrder(5)));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-wildcards
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-wildcards
@@ -3,10 +3,13 @@ set system host-name juniper-wildcards
 #
 set groups g1 interfaces <*> unit <*> family inet address 1.1.1.1/32
 set groups g2 policy-options prefix-list <*> 3.3.3.3/32
+set groups g3 protocols ospf area <*> interface <*> authentication md5 0 key "foo"
 set interfaces lo0 unit 0 apply-groups g1
 set interfaces lo0 unit 0 description <SCRUBBED>
 set policy-options prefix-list p1 apply-path "interfaces <*> unit <*> family inet address <*>"
 set policy-options prefix-list p2 apply-groups g2
 set routing-options autonomous-system 1
 set protocols bgp group <SCRUBBED> neighbor 2.2.2.2 peer-as 2
+set protocols ospf apply-groups g3
+set protocols ospf area 0.0.0.1 interface iface_undefined passive
 #


### PR DESCRIPTION
**Context:**
Previously, Juniper lines created by apply-groups (or related applicators) had bogus line numbers associated with them.  This made line tracking incorrect for these structures.

For example, the following config:
```
set system host-name example
set groups g1 interfaces <*> unit <*> family inet address 1.1.1.1/32
set interfaces lo0 unit 0 apply-groups g1
```
Would produce a node with interface named `lo0` with a definition line of `1` regardless of what line the structure was actually defined on.

**Changes:**
* Preserve original line numbers for constructed set lines in Juniper `Hierarchy`
  * Add ability to override token line numbers in lexer
  * Track original line numbers in `HierarchyChildNodes`
  * Update set-line-construction calls in `Hierarchy` to supply original line numbers
* Factor out common set line helper code
