### PR TITLE
negate AclMatchExprs

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclLineMatchExprs.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclLineMatchExprs.java
@@ -74,8 +74,8 @@ public final class AclLineMatchExprs {
   }
 
   /**
-   * smart constructor for NotMatchExpr that does constant-time simplifications (i.e. when expr is
-   * {@code TRUE} or {@code FALSE}.
+   * Smart constructor for NotMatchExpr that does constant-time simplifications (i.e. when expr is
+   * {@code TRUE} or {@code FALSE}).
    */
   public static AclLineMatchExpr not(AclLineMatchExpr expr) {
     if (expr == TRUE) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclLineMatchExprs.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclLineMatchExprs.java
@@ -74,8 +74,8 @@ public final class AclLineMatchExprs {
   }
 
   /**
-   * Smart constructor for NotMatchExpr that does constant-time simplifications (i.e. when expr is
-   * {@code TRUE} or {@code FALSE}).
+   * Smart constructor for {@link NotMatchExpr} that does constant-time simplifications (i.e. when
+   * expr is {@link #TRUE} or {@link #FALSE}).
    */
   public static AclLineMatchExpr not(AclLineMatchExpr expr) {
     if (expr == TRUE) {
@@ -83,6 +83,9 @@ public final class AclLineMatchExprs {
     }
     if (expr == FALSE) {
       return TRUE;
+    }
+    if (expr instanceof NotMatchExpr) {
+      return ((NotMatchExpr) expr).getOperand();
     }
     return new NotMatchExpr(expr);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclLineMatchExprs.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclLineMatchExprs.java
@@ -73,7 +73,17 @@ public final class AclLineMatchExprs {
     return new MatchSrcInterface(ImmutableList.copyOf(iface));
   }
 
-  public static NotMatchExpr not(AclLineMatchExpr expr) {
+  /**
+   * smart constructor for NotMatchExpr that does constant-time simplifications (i.e. when expr is
+   * {@code TRUE} or {@code FALSE}.
+   */
+  public static AclLineMatchExpr not(AclLineMatchExpr expr) {
+    if (expr == TRUE) {
+      return FALSE;
+    }
+    if (expr == FALSE) {
+      return TRUE;
+    }
     return new NotMatchExpr(expr);
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/normalize/Negate.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/normalize/Negate.java
@@ -17,9 +17,9 @@ import org.batfish.datamodel.acl.PermittedByAcl;
 import org.batfish.datamodel.acl.TrueExpr;
 
 /**
- * Negate an AclLineMatchExpr. Eliminate double-negation and apply deMorgan's law where possible.
- * Negate shallowly -- rather than recursively negating when applying deMorgan, use a {@link
- * NotMatchExpr}.
+ * Negate an {@link AclLineMatchExpr}. Eliminate double-negation and apply deMorgan's law where
+ * possible. Negate shallowly -- rather than recursively negating when applying deMorgan, use
+ * {@link AclLineMatchExprs#not}.
  */
 public final class Negate implements GenericAclLineMatchExprVisitor<AclLineMatchExpr> {
   private static final Negate INSTANCE = new Negate();

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/normalize/Negate.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/normalize/Negate.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableSortedSet;
 import java.util.Comparator;
 import java.util.SortedSet;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.acl.AclLineMatchExprs;
 import org.batfish.datamodel.acl.AndMatchExpr;
 import org.batfish.datamodel.acl.FalseExpr;
 import org.batfish.datamodel.acl.GenericAclLineMatchExprVisitor;
@@ -32,7 +33,7 @@ public final class Negate implements GenericAclLineMatchExprVisitor<AclLineMatch
   private static SortedSet<AclLineMatchExpr> negate(SortedSet<AclLineMatchExpr> exprs) {
     return exprs
         .stream()
-        .map(NotMatchExpr::new)
+        .map(AclLineMatchExprs::not)
         .collect(ImmutableSortedSet.toImmutableSortedSet(Comparator.naturalOrder()));
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/normalize/Negate.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/normalize/Negate.java
@@ -18,8 +18,8 @@ import org.batfish.datamodel.acl.TrueExpr;
 
 /**
  * Negate an {@link AclLineMatchExpr}. Eliminate double-negation and apply deMorgan's law where
- * possible. Negate shallowly -- rather than recursively negating when applying deMorgan, use
- * {@link AclLineMatchExprs#not}.
+ * possible. Negate shallowly -- rather than recursively negating when applying deMorgan, use {@link
+ * AclLineMatchExprs#not}.
  */
 public final class Negate implements GenericAclLineMatchExprVisitor<AclLineMatchExpr> {
   private static final Negate INSTANCE = new Negate();

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/normalize/Negate.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/normalize/Negate.java
@@ -1,0 +1,84 @@
+package org.batfish.datamodel.acl.normalize;
+
+import com.google.common.collect.ImmutableSortedSet;
+import java.util.Comparator;
+import java.util.SortedSet;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.acl.AndMatchExpr;
+import org.batfish.datamodel.acl.FalseExpr;
+import org.batfish.datamodel.acl.GenericAclLineMatchExprVisitor;
+import org.batfish.datamodel.acl.MatchHeaderSpace;
+import org.batfish.datamodel.acl.MatchSrcInterface;
+import org.batfish.datamodel.acl.NotMatchExpr;
+import org.batfish.datamodel.acl.OrMatchExpr;
+import org.batfish.datamodel.acl.OriginatingFromDevice;
+import org.batfish.datamodel.acl.PermittedByAcl;
+import org.batfish.datamodel.acl.TrueExpr;
+
+/**
+ * Negate an AclLineMatchExpr. Eliminate double-negation and apply deMorgan's law where possible.
+ * Negate shallowly -- rather than recursively negating when applying deMorgan, use a {@link
+ * NotMatchExpr}.
+ */
+public final class Negate implements GenericAclLineMatchExprVisitor<AclLineMatchExpr> {
+  private static final Negate INSTANCE = new Negate();
+
+  private Negate() {}
+
+  public static AclLineMatchExpr negate(AclLineMatchExpr expr) {
+    return expr.accept(INSTANCE);
+  }
+
+  private static SortedSet<AclLineMatchExpr> negate(SortedSet<AclLineMatchExpr> exprs) {
+    return exprs
+        .stream()
+        .map(NotMatchExpr::new)
+        .collect(ImmutableSortedSet.toImmutableSortedSet(Comparator.naturalOrder()));
+  }
+
+  @Override
+  public AclLineMatchExpr visitAndMatchExpr(AndMatchExpr andMatchExpr) {
+    return new OrMatchExpr(negate(andMatchExpr.getConjuncts()));
+  }
+
+  @Override
+  public AclLineMatchExpr visitFalseExpr(FalseExpr falseExpr) {
+    return TrueExpr.INSTANCE;
+  }
+
+  @Override
+  public AclLineMatchExpr visitMatchHeaderSpace(MatchHeaderSpace matchHeaderSpace) {
+    return new NotMatchExpr(matchHeaderSpace);
+  }
+
+  @Override
+  public AclLineMatchExpr visitMatchSrcInterface(MatchSrcInterface matchSrcInterface) {
+    return new NotMatchExpr(matchSrcInterface);
+  }
+
+  @Override
+  public AclLineMatchExpr visitNotMatchExpr(NotMatchExpr notMatchExpr) {
+    // eliminate double-negation
+    return notMatchExpr.getOperand();
+  }
+
+  @Override
+  public AclLineMatchExpr visitOriginatingFromDevice(OriginatingFromDevice originatingFromDevice) {
+    return new NotMatchExpr(originatingFromDevice);
+  }
+
+  @Override
+  public AclLineMatchExpr visitOrMatchExpr(OrMatchExpr orMatchExpr) {
+    return new AndMatchExpr(negate(orMatchExpr.getDisjuncts()));
+  }
+
+  @Override
+  public AclLineMatchExpr visitPermittedByAcl(PermittedByAcl permittedByAcl) {
+    return new NotMatchExpr(permittedByAcl);
+  }
+
+  @Override
+  public AclLineMatchExpr visitTrueExpr(TrueExpr trueExpr) {
+    return FalseExpr.INSTANCE;
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/normalize/NegateTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/normalize/NegateTest.java
@@ -1,0 +1,77 @@
+package org.batfish.datamodel.acl.normalize;
+
+import static org.batfish.datamodel.acl.AclLineMatchExprs.FALSE;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.ORIGINATING_FROM_DEVICE;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.TRUE;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.match;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.not;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.or;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.permittedByAcl;
+import static org.batfish.datamodel.acl.normalize.Negate.negate;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import org.batfish.datamodel.HeaderSpace;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.acl.AclLineMatchExprs;
+import org.batfish.datamodel.acl.MatchSrcInterface;
+import org.batfish.datamodel.acl.PermittedByAcl;
+import org.junit.Test;
+
+public class NegateTest {
+
+  @Test
+  public void visitAndMatchExpr() {
+    assertThat(
+        negate(and(ORIGINATING_FROM_DEVICE, TRUE, FALSE)),
+        equalTo(or(not(ORIGINATING_FROM_DEVICE), FALSE, TRUE)));
+  }
+
+  @Test
+  public void visitFalseExpr() {
+    assertThat(negate(FALSE), equalTo(TRUE));
+  }
+
+  @Test
+  public void visitMatchHeaderSpace() {
+    AclLineMatchExpr matchHeaderSpace = match(HeaderSpace.builder().build());
+    assertThat(negate(matchHeaderSpace), equalTo(not(matchHeaderSpace)));
+  }
+
+  @Test
+  public void visitMatchSrcInterface() {
+    MatchSrcInterface matchSrcInterface = AclLineMatchExprs.matchSrcInterface("foo");
+    assertThat(negate(matchSrcInterface), equalTo(not(matchSrcInterface)));
+  }
+
+  @Test
+  public void visitNotMatchExpr() {
+    assertThat(negate(not(ORIGINATING_FROM_DEVICE)), equalTo(ORIGINATING_FROM_DEVICE));
+    assertThat(negate(not(null)), nullValue());
+  }
+
+  @Test
+  public void visitOriginatingFromDevice() {
+    assertThat(negate(ORIGINATING_FROM_DEVICE), equalTo(not(ORIGINATING_FROM_DEVICE)));
+  }
+
+  @Test
+  public void visitOrMatchExpr() {
+    assertThat(
+        negate(or(ORIGINATING_FROM_DEVICE, TRUE, FALSE)),
+        equalTo(and(not(ORIGINATING_FROM_DEVICE), FALSE, TRUE)));
+  }
+
+  @Test
+  public void visitPermittedByAcl() {
+    PermittedByAcl permittedByFoo = permittedByAcl("foo");
+    assertThat(negate(permittedByFoo), equalTo(not(permittedByFoo)));
+  }
+
+  @Test
+  public void visitTrueExpr() {
+    assertThat(negate(TRUE), equalTo(FALSE));
+  }
+}


### PR DESCRIPTION
Negate an AclLineMatchExpr, applying deMorgan to AndMatchExpr and OrMatchExpr (at most once -- uses NotMatchExpr instead of recursion to negate when applying deMorgan). Everything else is wrapped in a NotMatchExpr (including MatchHeaderSpace, which could also be negated using the flag in HeaderSpace), and double-negation is eliminated.