### PR TITLE
Drop node column from edges question to reduce redundancy

### DIFF
--- a/projects/question/src/main/java/org/batfish/question/edges/EdgesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/edges/EdgesAnswerer.java
@@ -325,7 +325,7 @@ public class EdgesAnswerer extends Answerer {
   static Row eigrpEdgeToRow(EigrpEdge eigrpEdge) {
     RowBuilder row = Row.builder();
     row.put(
-        COL_INTERFACE,
+            COL_INTERFACE,
             new NodeInterfacePair(
                 eigrpEdge.getNode1().getHostname(), eigrpEdge.getNode1().getInterfaceName()))
         .put(
@@ -356,7 +356,7 @@ public class EdgesAnswerer extends Answerer {
   static Row isisEdgeToRow(IsisEdge isisEdge) {
     RowBuilder row = Row.builder();
     row.put(
-        COL_INTERFACE,
+            COL_INTERFACE,
             new NodeInterfacePair(
                 isisEdge.getNode1().getHostname(), isisEdge.getNode1().getInterfaceName()))
         .put(
@@ -370,7 +370,7 @@ public class EdgesAnswerer extends Answerer {
   static Row layer1EdgeToRow(Layer1Edge layer1Edge) {
     RowBuilder row = Row.builder();
     row.put(
-        COL_INTERFACE,
+            COL_INTERFACE,
             new NodeInterfacePair(
                 layer1Edge.getNode1().getHostname(), layer1Edge.getNode1().getInterfaceName()))
         .put(
@@ -385,7 +385,7 @@ public class EdgesAnswerer extends Answerer {
   static Row layer2EdgeToRow(Layer2Edge layer2Edge) {
     RowBuilder row = Row.builder();
     row.put(
-        COL_INTERFACE,
+            COL_INTERFACE,
             new NodeInterfacePair(
                 layer2Edge.getNode1().getHostname(), layer2Edge.getNode1().getInterfaceName()))
         .put(COL_VLAN, layer2Edge.getNode1().getVlanId())

--- a/projects/question/src/main/java/org/batfish/question/edges/EdgesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/edges/EdgesAnswerer.java
@@ -54,17 +54,14 @@ import org.batfish.datamodel.table.TableMetadata;
 
 public class EdgesAnswerer extends Answerer {
 
-  // Global (always present) columns
-  static final String COL_NODE = "Node";
-  static final String COL_REMOTE_NODE = "Remote_Node";
-
-  // Present sometime
-  static final String COL_INTERFACE = "Interface";
-  static final String COL_REMOTE_INTERFACE = "Remote_Interface";
+  static final String COL_NODE_INTERFACE = "Node:Interface";
+  static final String COL_REMOTE_NODE_INTERFACE = "Remote_Node:Remote_Interface";
   static final String COL_IPS = "IPs";
   static final String COL_REMOTE_IPS = "Remote_IPs";
 
   // BGP only
+  static final String COL_NODE = "Node";
+  static final String COL_REMOTE_NODE = "Remote_Node";
   static final String COL_AS_NUMBER = "AS_Number";
   static final String COL_REMOTE_AS_NUMBER = "Remote_AS_Number";
   static final String COL_IP = "IP";
@@ -327,14 +324,12 @@ public class EdgesAnswerer extends Answerer {
   @VisibleForTesting
   static Row eigrpEdgeToRow(EigrpEdge eigrpEdge) {
     RowBuilder row = Row.builder();
-    row.put(COL_NODE, new Node(eigrpEdge.getNode1().getHostname()))
-        .put(
-            COL_INTERFACE,
+    row.put(
+            COL_NODE_INTERFACE,
             new NodeInterfacePair(
                 eigrpEdge.getNode1().getHostname(), eigrpEdge.getNode1().getInterfaceName()))
-        .put(COL_REMOTE_NODE, new Node(eigrpEdge.getNode2().getHostname()))
         .put(
-            COL_REMOTE_INTERFACE,
+            COL_REMOTE_NODE_INTERFACE,
             new NodeInterfacePair(
                 eigrpEdge.getNode2().getHostname(), eigrpEdge.getNode2().getInterfaceName()));
     return row.build();
@@ -360,14 +355,12 @@ public class EdgesAnswerer extends Answerer {
 
   static Row isisEdgeToRow(IsisEdge isisEdge) {
     RowBuilder row = Row.builder();
-    row.put(COL_NODE, new Node(isisEdge.getNode1().getHostname()))
-        .put(
-            COL_INTERFACE,
+    row.put(
+            COL_NODE_INTERFACE,
             new NodeInterfacePair(
                 isisEdge.getNode1().getHostname(), isisEdge.getNode1().getInterfaceName()))
-        .put(COL_REMOTE_NODE, new Node(isisEdge.getNode2().getHostname()))
         .put(
-            COL_REMOTE_INTERFACE,
+            COL_REMOTE_NODE_INTERFACE,
             new NodeInterfacePair(
                 isisEdge.getNode2().getHostname(), isisEdge.getNode2().getInterfaceName()));
     return row.build();
@@ -376,14 +369,12 @@ public class EdgesAnswerer extends Answerer {
   @VisibleForTesting
   static Row layer1EdgeToRow(Layer1Edge layer1Edge) {
     RowBuilder row = Row.builder();
-    row.put(COL_NODE, new Node(layer1Edge.getNode1().getHostname()))
-        .put(
-            COL_INTERFACE,
+    row.put(
+            COL_NODE_INTERFACE,
             new NodeInterfacePair(
                 layer1Edge.getNode1().getHostname(), layer1Edge.getNode1().getInterfaceName()))
-        .put(COL_REMOTE_NODE, new Node(layer1Edge.getNode2().getHostname()))
         .put(
-            COL_REMOTE_INTERFACE,
+            COL_REMOTE_NODE_INTERFACE,
             new NodeInterfacePair(
                 layer1Edge.getNode2().getHostname(), layer1Edge.getNode2().getInterfaceName()));
 
@@ -393,15 +384,13 @@ public class EdgesAnswerer extends Answerer {
   @VisibleForTesting
   static Row layer2EdgeToRow(Layer2Edge layer2Edge) {
     RowBuilder row = Row.builder();
-    row.put(COL_NODE, new Node(layer2Edge.getNode1().getHostname()))
-        .put(
-            COL_INTERFACE,
+    row.put(
+            COL_NODE_INTERFACE,
             new NodeInterfacePair(
                 layer2Edge.getNode1().getHostname(), layer2Edge.getNode1().getInterfaceName()))
         .put(COL_VLAN, layer2Edge.getNode1().getVlanId())
-        .put(COL_REMOTE_NODE, new Node(layer2Edge.getNode2().getHostname()))
         .put(
-            COL_REMOTE_INTERFACE,
+            COL_REMOTE_NODE_INTERFACE,
             new NodeInterfacePair(
                 layer2Edge.getNode2().getHostname(), layer2Edge.getNode2().getInterfaceName()))
         .put(COL_REMOTE_VLAN, layer2Edge.getNode2().getVlanId());
@@ -431,11 +420,9 @@ public class EdgesAnswerer extends Answerer {
             .collect(Collectors.toSet());
 
     RowBuilder row = Row.builder();
-    row.put(COL_NODE, new Node(edge.getNode1()))
-        .put(COL_INTERFACE, new NodeInterfacePair(edge.getNode1(), edge.getInt1()))
+    row.put(COL_NODE_INTERFACE, new NodeInterfacePair(edge.getNode1(), edge.getInt1()))
         .put(COL_IPS, ips1)
-        .put(COL_REMOTE_NODE, new Node(edge.getNode2()))
-        .put(COL_REMOTE_INTERFACE, new NodeInterfacePair(edge.getNode2(), edge.getInt2()))
+        .put(COL_REMOTE_NODE_INTERFACE, new NodeInterfacePair(edge.getNode2(), edge.getInt2()))
         .put(COL_REMOTE_IPS, ips2);
 
     return row.build();
@@ -444,19 +431,15 @@ public class EdgesAnswerer extends Answerer {
   @VisibleForTesting
   static Row getOspfEdgeRow(String node, String iface, String remoteNode, String remoteIface) {
     RowBuilder row = Row.builder();
-    row.put(COL_NODE, new Node(node))
-        .put(COL_INTERFACE, new NodeInterfacePair(node, iface))
-        .put(COL_REMOTE_NODE, new Node(remoteNode))
-        .put(COL_REMOTE_INTERFACE, new NodeInterfacePair(remoteNode, remoteIface));
+    row.put(COL_NODE_INTERFACE, new NodeInterfacePair(node, iface))
+        .put(COL_REMOTE_NODE_INTERFACE, new NodeInterfacePair(remoteNode, remoteIface));
     return row.build();
   }
 
   static Row getRipEdgeRow(String node, String iface, String remoteNode, String remoteIface) {
     RowBuilder row = Row.builder();
-    row.put(COL_NODE, new Node(node))
-        .put(COL_INTERFACE, new NodeInterfacePair(node, iface))
-        .put(COL_REMOTE_NODE, new Node(remoteNode))
-        .put(COL_REMOTE_INTERFACE, new NodeInterfacePair(remoteNode, remoteIface));
+    row.put(COL_NODE_INTERFACE, new NodeInterfacePair(node, iface))
+        .put(COL_REMOTE_NODE_INTERFACE, new NodeInterfacePair(remoteNode, remoteIface));
     return row.build();
   }
 
@@ -468,30 +451,17 @@ public class EdgesAnswerer extends Answerer {
       case LAYER3:
         columnBuilder.add(
             new ColumnMetadata(
-                COL_NODE,
-                Schema.NODE,
-                "Node from which the edge originates",
-                Boolean.FALSE,
-                Boolean.TRUE));
-        columnBuilder.add(
-            new ColumnMetadata(
-                COL_INTERFACE,
+                COL_NODE_INTERFACE,
                 Schema.INTERFACE,
                 "Interface from which the edge originates",
                 Boolean.FALSE,
                 Boolean.TRUE));
         columnBuilder.add(
             new ColumnMetadata(COL_IPS, Schema.set(Schema.IP), "IPs", Boolean.FALSE, Boolean.TRUE));
+
         columnBuilder.add(
             new ColumnMetadata(
-                COL_REMOTE_NODE,
-                Schema.NODE,
-                "Node at which the edge terminates",
-                Boolean.FALSE,
-                Boolean.TRUE));
-        columnBuilder.add(
-            new ColumnMetadata(
-                COL_REMOTE_INTERFACE,
+                COL_REMOTE_NODE_INTERFACE,
                 Schema.INTERFACE,
                 "Interface at which the edge terminates",
                 Boolean.FALSE,
@@ -504,14 +474,7 @@ public class EdgesAnswerer extends Answerer {
       case LAYER2:
         columnBuilder.add(
             new ColumnMetadata(
-                COL_NODE,
-                Schema.NODE,
-                "Node from which the edge originates",
-                Boolean.FALSE,
-                Boolean.TRUE));
-        columnBuilder.add(
-            new ColumnMetadata(
-                COL_INTERFACE,
+                COL_NODE_INTERFACE,
                 Schema.INTERFACE,
                 "Interface from which the edge originates",
                 Boolean.FALSE,
@@ -523,16 +486,10 @@ public class EdgesAnswerer extends Answerer {
                 "VLAN containing the originator",
                 Boolean.FALSE,
                 Boolean.TRUE));
+
         columnBuilder.add(
             new ColumnMetadata(
-                COL_REMOTE_NODE,
-                Schema.NODE,
-                "Node at which the edge terminates",
-                Boolean.FALSE,
-                Boolean.TRUE));
-        columnBuilder.add(
-            new ColumnMetadata(
-                COL_REMOTE_INTERFACE,
+                COL_REMOTE_NODE_INTERFACE,
                 Schema.INTERFACE,
                 "Interface at which the edge terminates",
                 Boolean.FALSE,
@@ -593,28 +550,15 @@ public class EdgesAnswerer extends Answerer {
       default:
         columnBuilder.add(
             new ColumnMetadata(
-                COL_NODE,
-                Schema.NODE,
-                "Node from which the edge originates",
-                Boolean.FALSE,
-                Boolean.TRUE));
-        columnBuilder.add(
-            new ColumnMetadata(
-                COL_INTERFACE,
+                COL_NODE_INTERFACE,
                 Schema.INTERFACE,
                 "Interface from which the edge originates",
                 Boolean.FALSE,
                 Boolean.TRUE));
+
         columnBuilder.add(
             new ColumnMetadata(
-                COL_REMOTE_NODE,
-                Schema.NODE,
-                "Node at which the edge terminates",
-                Boolean.FALSE,
-                Boolean.TRUE));
-        columnBuilder.add(
-            new ColumnMetadata(
-                COL_REMOTE_INTERFACE,
+                COL_REMOTE_NODE_INTERFACE,
                 Schema.INTERFACE,
                 "Interface at which the edge terminates",
                 Boolean.FALSE,

--- a/projects/question/src/main/java/org/batfish/question/edges/EdgesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/edges/EdgesAnswerer.java
@@ -54,8 +54,8 @@ import org.batfish.datamodel.table.TableMetadata;
 
 public class EdgesAnswerer extends Answerer {
 
-  static final String COL_NODE_INTERFACE = "Node:Interface";
-  static final String COL_REMOTE_NODE_INTERFACE = "Remote_Node:Remote_Interface";
+  static final String COL_INTERFACE = "Interface";
+  static final String COL_REMOTE_INTERFACE = "Remote_Interface";
   static final String COL_IPS = "IPs";
   static final String COL_REMOTE_IPS = "Remote_IPs";
 
@@ -325,11 +325,11 @@ public class EdgesAnswerer extends Answerer {
   static Row eigrpEdgeToRow(EigrpEdge eigrpEdge) {
     RowBuilder row = Row.builder();
     row.put(
-            COL_NODE_INTERFACE,
+        COL_INTERFACE,
             new NodeInterfacePair(
                 eigrpEdge.getNode1().getHostname(), eigrpEdge.getNode1().getInterfaceName()))
         .put(
-            COL_REMOTE_NODE_INTERFACE,
+            COL_REMOTE_INTERFACE,
             new NodeInterfacePair(
                 eigrpEdge.getNode2().getHostname(), eigrpEdge.getNode2().getInterfaceName()));
     return row.build();
@@ -356,11 +356,11 @@ public class EdgesAnswerer extends Answerer {
   static Row isisEdgeToRow(IsisEdge isisEdge) {
     RowBuilder row = Row.builder();
     row.put(
-            COL_NODE_INTERFACE,
+        COL_INTERFACE,
             new NodeInterfacePair(
                 isisEdge.getNode1().getHostname(), isisEdge.getNode1().getInterfaceName()))
         .put(
-            COL_REMOTE_NODE_INTERFACE,
+            COL_REMOTE_INTERFACE,
             new NodeInterfacePair(
                 isisEdge.getNode2().getHostname(), isisEdge.getNode2().getInterfaceName()));
     return row.build();
@@ -370,11 +370,11 @@ public class EdgesAnswerer extends Answerer {
   static Row layer1EdgeToRow(Layer1Edge layer1Edge) {
     RowBuilder row = Row.builder();
     row.put(
-            COL_NODE_INTERFACE,
+        COL_INTERFACE,
             new NodeInterfacePair(
                 layer1Edge.getNode1().getHostname(), layer1Edge.getNode1().getInterfaceName()))
         .put(
-            COL_REMOTE_NODE_INTERFACE,
+            COL_REMOTE_INTERFACE,
             new NodeInterfacePair(
                 layer1Edge.getNode2().getHostname(), layer1Edge.getNode2().getInterfaceName()));
 
@@ -385,12 +385,12 @@ public class EdgesAnswerer extends Answerer {
   static Row layer2EdgeToRow(Layer2Edge layer2Edge) {
     RowBuilder row = Row.builder();
     row.put(
-            COL_NODE_INTERFACE,
+        COL_INTERFACE,
             new NodeInterfacePair(
                 layer2Edge.getNode1().getHostname(), layer2Edge.getNode1().getInterfaceName()))
         .put(COL_VLAN, layer2Edge.getNode1().getVlanId())
         .put(
-            COL_REMOTE_NODE_INTERFACE,
+            COL_REMOTE_INTERFACE,
             new NodeInterfacePair(
                 layer2Edge.getNode2().getHostname(), layer2Edge.getNode2().getInterfaceName()))
         .put(COL_REMOTE_VLAN, layer2Edge.getNode2().getVlanId());
@@ -420,9 +420,9 @@ public class EdgesAnswerer extends Answerer {
             .collect(Collectors.toSet());
 
     RowBuilder row = Row.builder();
-    row.put(COL_NODE_INTERFACE, new NodeInterfacePair(edge.getNode1(), edge.getInt1()))
+    row.put(COL_INTERFACE, new NodeInterfacePair(edge.getNode1(), edge.getInt1()))
         .put(COL_IPS, ips1)
-        .put(COL_REMOTE_NODE_INTERFACE, new NodeInterfacePair(edge.getNode2(), edge.getInt2()))
+        .put(COL_REMOTE_INTERFACE, new NodeInterfacePair(edge.getNode2(), edge.getInt2()))
         .put(COL_REMOTE_IPS, ips2);
 
     return row.build();
@@ -431,15 +431,15 @@ public class EdgesAnswerer extends Answerer {
   @VisibleForTesting
   static Row getOspfEdgeRow(String node, String iface, String remoteNode, String remoteIface) {
     RowBuilder row = Row.builder();
-    row.put(COL_NODE_INTERFACE, new NodeInterfacePair(node, iface))
-        .put(COL_REMOTE_NODE_INTERFACE, new NodeInterfacePair(remoteNode, remoteIface));
+    row.put(COL_INTERFACE, new NodeInterfacePair(node, iface))
+        .put(COL_REMOTE_INTERFACE, new NodeInterfacePair(remoteNode, remoteIface));
     return row.build();
   }
 
   static Row getRipEdgeRow(String node, String iface, String remoteNode, String remoteIface) {
     RowBuilder row = Row.builder();
-    row.put(COL_NODE_INTERFACE, new NodeInterfacePair(node, iface))
-        .put(COL_REMOTE_NODE_INTERFACE, new NodeInterfacePair(remoteNode, remoteIface));
+    row.put(COL_INTERFACE, new NodeInterfacePair(node, iface))
+        .put(COL_REMOTE_INTERFACE, new NodeInterfacePair(remoteNode, remoteIface));
     return row.build();
   }
 
@@ -451,7 +451,7 @@ public class EdgesAnswerer extends Answerer {
       case LAYER3:
         columnBuilder.add(
             new ColumnMetadata(
-                COL_NODE_INTERFACE,
+                COL_INTERFACE,
                 Schema.INTERFACE,
                 "Interface from which the edge originates",
                 Boolean.FALSE,
@@ -461,7 +461,7 @@ public class EdgesAnswerer extends Answerer {
 
         columnBuilder.add(
             new ColumnMetadata(
-                COL_REMOTE_NODE_INTERFACE,
+                COL_REMOTE_INTERFACE,
                 Schema.INTERFACE,
                 "Interface at which the edge terminates",
                 Boolean.FALSE,
@@ -474,7 +474,7 @@ public class EdgesAnswerer extends Answerer {
       case LAYER2:
         columnBuilder.add(
             new ColumnMetadata(
-                COL_NODE_INTERFACE,
+                COL_INTERFACE,
                 Schema.INTERFACE,
                 "Interface from which the edge originates",
                 Boolean.FALSE,
@@ -489,7 +489,7 @@ public class EdgesAnswerer extends Answerer {
 
         columnBuilder.add(
             new ColumnMetadata(
-                COL_REMOTE_NODE_INTERFACE,
+                COL_REMOTE_INTERFACE,
                 Schema.INTERFACE,
                 "Interface at which the edge terminates",
                 Boolean.FALSE,
@@ -550,7 +550,7 @@ public class EdgesAnswerer extends Answerer {
       default:
         columnBuilder.add(
             new ColumnMetadata(
-                COL_NODE_INTERFACE,
+                COL_INTERFACE,
                 Schema.INTERFACE,
                 "Interface from which the edge originates",
                 Boolean.FALSE,
@@ -558,7 +558,7 @@ public class EdgesAnswerer extends Answerer {
 
         columnBuilder.add(
             new ColumnMetadata(
-                COL_REMOTE_NODE_INTERFACE,
+                COL_REMOTE_INTERFACE,
                 Schema.INTERFACE,
                 "Interface at which the edge terminates",
                 Boolean.FALSE,

--- a/projects/question/src/test/java/org/batfish/question/edges/EdgesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/edges/EdgesAnswererTest.java
@@ -5,12 +5,12 @@ import static org.batfish.question.edges.EdgesAnswerer.COL_AS_NUMBER;
 import static org.batfish.question.edges.EdgesAnswerer.COL_IP;
 import static org.batfish.question.edges.EdgesAnswerer.COL_IPS;
 import static org.batfish.question.edges.EdgesAnswerer.COL_NODE;
-import static org.batfish.question.edges.EdgesAnswerer.COL_NODE_INTERFACE;
+import static org.batfish.question.edges.EdgesAnswerer.COL_INTERFACE;
 import static org.batfish.question.edges.EdgesAnswerer.COL_REMOTE_AS_NUMBER;
 import static org.batfish.question.edges.EdgesAnswerer.COL_REMOTE_IP;
 import static org.batfish.question.edges.EdgesAnswerer.COL_REMOTE_IPS;
 import static org.batfish.question.edges.EdgesAnswerer.COL_REMOTE_NODE;
-import static org.batfish.question.edges.EdgesAnswerer.COL_REMOTE_NODE_INTERFACE;
+import static org.batfish.question.edges.EdgesAnswerer.COL_REMOTE_INTERFACE;
 import static org.batfish.question.edges.EdgesAnswerer.COL_REMOTE_VLAN;
 import static org.batfish.question.edges.EdgesAnswerer.COL_VLAN;
 import static org.batfish.question.edges.EdgesAnswerer.eigrpEdgeToRow;
@@ -145,11 +145,11 @@ public class EdgesAnswererTest {
         contains(
             allOf(
                 hasColumn(
-                    COL_NODE_INTERFACE,
+                    COL_INTERFACE,
                     equalTo(new NodeInterfacePair("host1", "int1")),
                     Schema.INTERFACE),
                 hasColumn(
-                    COL_REMOTE_NODE_INTERFACE,
+                    COL_REMOTE_INTERFACE,
                     equalTo(new NodeInterfacePair("host2", "int2")),
                     Schema.INTERFACE))));
   }
@@ -229,11 +229,11 @@ public class EdgesAnswererTest {
         contains(
             allOf(
                 hasColumn(
-                    COL_NODE_INTERFACE,
+                    COL_INTERFACE,
                     equalTo(new NodeInterfacePair("host1", "int1")),
                     Schema.INTERFACE),
                 hasColumn(
-                    COL_REMOTE_NODE_INTERFACE,
+                    COL_REMOTE_INTERFACE,
                     equalTo(new NodeInterfacePair("host2", "int2")),
                     Schema.INTERFACE))));
   }
@@ -272,20 +272,20 @@ public class EdgesAnswererTest {
             ImmutableList.of(
                 allOf(
                     hasColumn(
-                        COL_NODE_INTERFACE,
+                        COL_INTERFACE,
                         equalTo(new NodeInterfacePair("host1", "int1")),
                         Schema.INTERFACE),
                     hasColumn(
-                        COL_REMOTE_NODE_INTERFACE,
+                        COL_REMOTE_INTERFACE,
                         equalTo(new NodeInterfacePair("host2", "int2")),
                         Schema.INTERFACE)),
                 allOf(
                     hasColumn(
-                        COL_NODE_INTERFACE,
+                        COL_INTERFACE,
                         equalTo(new NodeInterfacePair("host2", "int2")),
                         Schema.INTERFACE),
                     hasColumn(
-                        COL_REMOTE_NODE_INTERFACE,
+                        COL_REMOTE_INTERFACE,
                         equalTo(new NodeInterfacePair("host1", "int1")),
                         Schema.INTERFACE)))));
   }
@@ -307,11 +307,11 @@ public class EdgesAnswererTest {
         contains(
             allOf(
                 hasColumn(
-                    COL_NODE_INTERFACE,
+                    COL_INTERFACE,
                     equalTo(new NodeInterfacePair("host1", "int1")),
                     Schema.INTERFACE),
                 hasColumn(
-                    COL_REMOTE_NODE_INTERFACE,
+                    COL_REMOTE_INTERFACE,
                     equalTo(new NodeInterfacePair("host2", "int2")),
                     Schema.INTERFACE))));
   }
@@ -331,11 +331,11 @@ public class EdgesAnswererTest {
         contains(
             allOf(
                 hasColumn(
-                    COL_NODE_INTERFACE,
+                    COL_INTERFACE,
                     equalTo(new NodeInterfacePair("host1", "int1")),
                     Schema.INTERFACE),
                 hasColumn(
-                    COL_REMOTE_NODE_INTERFACE,
+                    COL_REMOTE_INTERFACE,
                     equalTo(new NodeInterfacePair("host2", "int2")),
                     Schema.INTERFACE))));
   }
@@ -356,12 +356,12 @@ public class EdgesAnswererTest {
         contains(
             allOf(
                 hasColumn(
-                    COL_NODE_INTERFACE,
+                    COL_INTERFACE,
                     equalTo(new NodeInterfacePair("host1", "int1")),
                     Schema.INTERFACE),
                 hasColumn(COL_VLAN, equalTo("1"), Schema.STRING),
                 hasColumn(
-                    COL_REMOTE_NODE_INTERFACE,
+                    COL_REMOTE_INTERFACE,
                     equalTo(new NodeInterfacePair("host2", "int2")),
                     Schema.INTERFACE),
                 hasColumn(COL_REMOTE_VLAN, equalTo("2"), Schema.STRING))));
@@ -380,13 +380,13 @@ public class EdgesAnswererTest {
         contains(
             allOf(
                 hasColumn(
-                    COL_NODE_INTERFACE,
+                    COL_INTERFACE,
                     equalTo(new NodeInterfacePair("host1", "int1")),
                     Schema.INTERFACE),
                 hasColumn(
                     COL_IPS, equalTo(ImmutableSet.of(new Ip("1.1.1.1"))), Schema.set(Schema.IP)),
                 hasColumn(
-                    COL_REMOTE_NODE_INTERFACE,
+                    COL_REMOTE_INTERFACE,
                     equalTo(new NodeInterfacePair("host2", "int2")),
                     Schema.INTERFACE),
                 hasColumn(
@@ -407,11 +407,11 @@ public class EdgesAnswererTest {
         row,
         allOf(
             hasColumn(
-                COL_NODE_INTERFACE,
+                COL_INTERFACE,
                 equalTo(new NodeInterfacePair("host1", "int1")),
                 Schema.INTERFACE),
             hasColumn(
-                COL_REMOTE_NODE_INTERFACE,
+                COL_REMOTE_INTERFACE,
                 equalTo(new NodeInterfacePair("host2", "int2")),
                 Schema.INTERFACE)));
   }
@@ -424,11 +424,11 @@ public class EdgesAnswererTest {
         row,
         allOf(
             hasColumn(
-                COL_NODE_INTERFACE,
+                COL_INTERFACE,
                 equalTo(new NodeInterfacePair("host1", "int1")),
                 Schema.INTERFACE),
             hasColumn(
-                COL_REMOTE_NODE_INTERFACE,
+                COL_REMOTE_INTERFACE,
                 equalTo(new NodeInterfacePair("host2", "int2")),
                 Schema.INTERFACE)));
   }
@@ -444,11 +444,11 @@ public class EdgesAnswererTest {
         row,
         allOf(
             hasColumn(
-                COL_NODE_INTERFACE,
+                COL_INTERFACE,
                 equalTo(new NodeInterfacePair("host1", "int1")),
                 Schema.INTERFACE),
             hasColumn(
-                COL_REMOTE_NODE_INTERFACE,
+                COL_REMOTE_INTERFACE,
                 equalTo(new NodeInterfacePair("host2", "int2")),
                 Schema.INTERFACE)));
   }
@@ -461,11 +461,11 @@ public class EdgesAnswererTest {
         row,
         allOf(
             hasColumn(
-                COL_NODE_INTERFACE,
+                COL_INTERFACE,
                 equalTo(new NodeInterfacePair("host1", "int1")),
                 Schema.INTERFACE),
             hasColumn(
-                COL_REMOTE_NODE_INTERFACE,
+                COL_REMOTE_INTERFACE,
                 equalTo(new NodeInterfacePair("host2", "int2")),
                 Schema.INTERFACE)));
   }
@@ -491,11 +491,11 @@ public class EdgesAnswererTest {
         row,
         allOf(
             hasColumn(
-                COL_NODE_INTERFACE,
+                COL_INTERFACE,
                 equalTo(new NodeInterfacePair("host1", "int1")),
                 Schema.INTERFACE),
             hasColumn(
-                COL_REMOTE_NODE_INTERFACE,
+                COL_REMOTE_INTERFACE,
                 equalTo(new NodeInterfacePair("host2", "int2")),
                 Schema.INTERFACE)));
   }
@@ -507,12 +507,12 @@ public class EdgesAnswererTest {
         row,
         allOf(
             hasColumn(
-                COL_NODE_INTERFACE,
+                COL_INTERFACE,
                 equalTo(new NodeInterfacePair("host1", "int1")),
                 Schema.INTERFACE),
             hasColumn(COL_VLAN, equalTo("1"), Schema.STRING),
             hasColumn(
-                COL_REMOTE_NODE_INTERFACE,
+                COL_REMOTE_INTERFACE,
                 equalTo(new NodeInterfacePair("host2", "int2")),
                 Schema.INTERFACE),
             hasColumn(COL_REMOTE_VLAN, equalTo("2"), Schema.STRING)));
@@ -527,12 +527,12 @@ public class EdgesAnswererTest {
         row,
         allOf(
             hasColumn(
-                COL_NODE_INTERFACE,
+                COL_INTERFACE,
                 equalTo(new NodeInterfacePair("host1", "int1")),
                 Schema.INTERFACE),
             hasColumn(COL_IPS, equalTo(ImmutableSet.of(new Ip("1.1.1.1"))), Schema.set(Schema.IP)),
             hasColumn(
-                COL_REMOTE_NODE_INTERFACE,
+                COL_REMOTE_INTERFACE,
                 equalTo(new NodeInterfacePair("host2", "int2")),
                 Schema.INTERFACE),
             hasColumn(
@@ -549,7 +549,7 @@ public class EdgesAnswererTest {
             .stream()
             .map(ColumnMetadata::getName)
             .collect(ImmutableList.toImmutableList()),
-        contains(COL_NODE_INTERFACE, COL_IPS, COL_REMOTE_NODE_INTERFACE, COL_REMOTE_IPS));
+        contains(COL_INTERFACE, COL_IPS, COL_REMOTE_INTERFACE, COL_REMOTE_IPS));
 
     assertThat(
         columnMetadata
@@ -567,7 +567,7 @@ public class EdgesAnswererTest {
             .stream()
             .map(ColumnMetadata::getName)
             .collect(ImmutableList.toImmutableList()),
-        contains(COL_NODE_INTERFACE, COL_VLAN, COL_REMOTE_NODE_INTERFACE, COL_REMOTE_VLAN));
+        contains(COL_INTERFACE, COL_VLAN, COL_REMOTE_INTERFACE, COL_REMOTE_VLAN));
 
     assertThat(
         columnMetadata
@@ -604,7 +604,7 @@ public class EdgesAnswererTest {
             .stream()
             .map(ColumnMetadata::getName)
             .collect(ImmutableList.toImmutableList()),
-        contains(COL_NODE_INTERFACE, COL_REMOTE_NODE_INTERFACE));
+        contains(COL_INTERFACE, COL_REMOTE_INTERFACE));
 
     assertThat(
         columnMetadata

--- a/projects/question/src/test/java/org/batfish/question/edges/EdgesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/edges/EdgesAnswererTest.java
@@ -2,15 +2,15 @@ package org.batfish.question.edges;
 
 import static org.batfish.datamodel.matchers.RowMatchers.hasColumn;
 import static org.batfish.question.edges.EdgesAnswerer.COL_AS_NUMBER;
-import static org.batfish.question.edges.EdgesAnswerer.COL_INTERFACE;
 import static org.batfish.question.edges.EdgesAnswerer.COL_IP;
 import static org.batfish.question.edges.EdgesAnswerer.COL_IPS;
 import static org.batfish.question.edges.EdgesAnswerer.COL_NODE;
+import static org.batfish.question.edges.EdgesAnswerer.COL_NODE_INTERFACE;
 import static org.batfish.question.edges.EdgesAnswerer.COL_REMOTE_AS_NUMBER;
-import static org.batfish.question.edges.EdgesAnswerer.COL_REMOTE_INTERFACE;
 import static org.batfish.question.edges.EdgesAnswerer.COL_REMOTE_IP;
 import static org.batfish.question.edges.EdgesAnswerer.COL_REMOTE_IPS;
 import static org.batfish.question.edges.EdgesAnswerer.COL_REMOTE_NODE;
+import static org.batfish.question.edges.EdgesAnswerer.COL_REMOTE_NODE_INTERFACE;
 import static org.batfish.question.edges.EdgesAnswerer.COL_REMOTE_VLAN;
 import static org.batfish.question.edges.EdgesAnswerer.COL_VLAN;
 import static org.batfish.question.edges.EdgesAnswerer.eigrpEdgeToRow;
@@ -144,14 +144,12 @@ public class EdgesAnswererTest {
         rows,
         contains(
             allOf(
-                hasColumn(COL_NODE, equalTo(new Node("host1")), Schema.NODE),
                 hasColumn(
-                    COL_INTERFACE,
+                    COL_NODE_INTERFACE,
                     equalTo(new NodeInterfacePair("host1", "int1")),
                     Schema.INTERFACE),
-                hasColumn(COL_REMOTE_NODE, equalTo(new Node("host2")), Schema.NODE),
                 hasColumn(
-                    COL_REMOTE_INTERFACE,
+                    COL_REMOTE_NODE_INTERFACE,
                     equalTo(new NodeInterfacePair("host2", "int2")),
                     Schema.INTERFACE))));
   }
@@ -230,14 +228,12 @@ public class EdgesAnswererTest {
         rows,
         contains(
             allOf(
-                hasColumn(COL_NODE, equalTo(new Node("host1")), Schema.NODE),
                 hasColumn(
-                    COL_INTERFACE,
+                    COL_NODE_INTERFACE,
                     equalTo(new NodeInterfacePair("host1", "int1")),
                     Schema.INTERFACE),
-                hasColumn(COL_REMOTE_NODE, equalTo(new Node("host2")), Schema.NODE),
                 hasColumn(
-                    COL_REMOTE_INTERFACE,
+                    COL_REMOTE_NODE_INTERFACE,
                     equalTo(new NodeInterfacePair("host2", "int2")),
                     Schema.INTERFACE))));
   }
@@ -275,25 +271,21 @@ public class EdgesAnswererTest {
         containsInAnyOrder(
             ImmutableList.of(
                 allOf(
-                    hasColumn(COL_NODE, equalTo(new Node("host1")), Schema.NODE),
                     hasColumn(
-                        COL_INTERFACE,
+                        COL_NODE_INTERFACE,
                         equalTo(new NodeInterfacePair("host1", "int1")),
                         Schema.INTERFACE),
-                    hasColumn(COL_REMOTE_NODE, equalTo(new Node("host2")), Schema.NODE),
                     hasColumn(
-                        COL_REMOTE_INTERFACE,
+                        COL_REMOTE_NODE_INTERFACE,
                         equalTo(new NodeInterfacePair("host2", "int2")),
                         Schema.INTERFACE)),
                 allOf(
-                    hasColumn(COL_NODE, equalTo(new Node("host2")), Schema.NODE),
                     hasColumn(
-                        COL_INTERFACE,
+                        COL_NODE_INTERFACE,
                         equalTo(new NodeInterfacePair("host2", "int2")),
                         Schema.INTERFACE),
-                    hasColumn(COL_REMOTE_NODE, equalTo(new Node("host1")), Schema.NODE),
                     hasColumn(
-                        COL_REMOTE_INTERFACE,
+                        COL_REMOTE_NODE_INTERFACE,
                         equalTo(new NodeInterfacePair("host1", "int1")),
                         Schema.INTERFACE)))));
   }
@@ -314,14 +306,12 @@ public class EdgesAnswererTest {
         rows,
         contains(
             allOf(
-                hasColumn(COL_NODE, equalTo(new Node("host1")), Schema.NODE),
                 hasColumn(
-                    COL_INTERFACE,
+                    COL_NODE_INTERFACE,
                     equalTo(new NodeInterfacePair("host1", "int1")),
                     Schema.INTERFACE),
-                hasColumn(COL_REMOTE_NODE, equalTo(new Node("host2")), Schema.NODE),
                 hasColumn(
-                    COL_REMOTE_INTERFACE,
+                    COL_REMOTE_NODE_INTERFACE,
                     equalTo(new NodeInterfacePair("host2", "int2")),
                     Schema.INTERFACE))));
   }
@@ -340,14 +330,12 @@ public class EdgesAnswererTest {
         rows,
         contains(
             allOf(
-                hasColumn(COL_NODE, equalTo(new Node("host1")), Schema.NODE),
                 hasColumn(
-                    COL_INTERFACE,
+                    COL_NODE_INTERFACE,
                     equalTo(new NodeInterfacePair("host1", "int1")),
                     Schema.INTERFACE),
-                hasColumn(COL_REMOTE_NODE, equalTo(new Node("host2")), Schema.NODE),
                 hasColumn(
-                    COL_REMOTE_INTERFACE,
+                    COL_REMOTE_NODE_INTERFACE,
                     equalTo(new NodeInterfacePair("host2", "int2")),
                     Schema.INTERFACE))));
   }
@@ -367,15 +355,13 @@ public class EdgesAnswererTest {
         rows,
         contains(
             allOf(
-                hasColumn(COL_NODE, equalTo(new Node("host1")), Schema.NODE),
                 hasColumn(
-                    COL_INTERFACE,
+                    COL_NODE_INTERFACE,
                     equalTo(new NodeInterfacePair("host1", "int1")),
                     Schema.INTERFACE),
                 hasColumn(COL_VLAN, equalTo("1"), Schema.STRING),
-                hasColumn(COL_REMOTE_NODE, equalTo(new Node("host2")), Schema.NODE),
                 hasColumn(
-                    COL_REMOTE_INTERFACE,
+                    COL_REMOTE_NODE_INTERFACE,
                     equalTo(new NodeInterfacePair("host2", "int2")),
                     Schema.INTERFACE),
                 hasColumn(COL_REMOTE_VLAN, equalTo("2"), Schema.STRING))));
@@ -393,16 +379,14 @@ public class EdgesAnswererTest {
         rows,
         contains(
             allOf(
-                hasColumn(COL_NODE, equalTo(new Node("host1")), Schema.NODE),
                 hasColumn(
-                    COL_INTERFACE,
+                    COL_NODE_INTERFACE,
                     equalTo(new NodeInterfacePair("host1", "int1")),
                     Schema.INTERFACE),
                 hasColumn(
                     COL_IPS, equalTo(ImmutableSet.of(new Ip("1.1.1.1"))), Schema.set(Schema.IP)),
-                hasColumn(COL_REMOTE_NODE, equalTo(new Node("host2")), Schema.NODE),
                 hasColumn(
-                    COL_REMOTE_INTERFACE,
+                    COL_REMOTE_NODE_INTERFACE,
                     equalTo(new NodeInterfacePair("host2", "int2")),
                     Schema.INTERFACE),
                 hasColumn(
@@ -422,12 +406,12 @@ public class EdgesAnswererTest {
     assertThat(
         row,
         allOf(
-            hasColumn(COL_NODE, equalTo(new Node("host1")), Schema.NODE),
             hasColumn(
-                COL_INTERFACE, equalTo(new NodeInterfacePair("host1", "int1")), Schema.INTERFACE),
-            hasColumn(COL_REMOTE_NODE, equalTo(new Node("host2")), Schema.NODE),
+                COL_NODE_INTERFACE,
+                equalTo(new NodeInterfacePair("host1", "int1")),
+                Schema.INTERFACE),
             hasColumn(
-                COL_REMOTE_INTERFACE,
+                COL_REMOTE_NODE_INTERFACE,
                 equalTo(new NodeInterfacePair("host2", "int2")),
                 Schema.INTERFACE)));
   }
@@ -439,12 +423,12 @@ public class EdgesAnswererTest {
     assertThat(
         row,
         allOf(
-            hasColumn(COL_NODE, equalTo(new Node("host1")), Schema.NODE),
             hasColumn(
-                COL_INTERFACE, equalTo(new NodeInterfacePair("host1", "int1")), Schema.INTERFACE),
-            hasColumn(COL_REMOTE_NODE, equalTo(new Node("host2")), Schema.NODE),
+                COL_NODE_INTERFACE,
+                equalTo(new NodeInterfacePair("host1", "int1")),
+                Schema.INTERFACE),
             hasColumn(
-                COL_REMOTE_INTERFACE,
+                COL_REMOTE_NODE_INTERFACE,
                 equalTo(new NodeInterfacePair("host2", "int2")),
                 Schema.INTERFACE)));
   }
@@ -459,12 +443,12 @@ public class EdgesAnswererTest {
     assertThat(
         row,
         allOf(
-            hasColumn(COL_NODE, equalTo(new Node("host1")), Schema.NODE),
             hasColumn(
-                COL_INTERFACE, equalTo(new NodeInterfacePair("host1", "int1")), Schema.INTERFACE),
-            hasColumn(COL_REMOTE_NODE, equalTo(new Node("host2")), Schema.NODE),
+                COL_NODE_INTERFACE,
+                equalTo(new NodeInterfacePair("host1", "int1")),
+                Schema.INTERFACE),
             hasColumn(
-                COL_REMOTE_INTERFACE,
+                COL_REMOTE_NODE_INTERFACE,
                 equalTo(new NodeInterfacePair("host2", "int2")),
                 Schema.INTERFACE)));
   }
@@ -476,12 +460,12 @@ public class EdgesAnswererTest {
     assertThat(
         row,
         allOf(
-            hasColumn(COL_NODE, equalTo(new Node("host1")), Schema.NODE),
             hasColumn(
-                COL_INTERFACE, equalTo(new NodeInterfacePair("host1", "int1")), Schema.INTERFACE),
-            hasColumn(COL_REMOTE_NODE, equalTo(new Node("host2")), Schema.NODE),
+                COL_NODE_INTERFACE,
+                equalTo(new NodeInterfacePair("host1", "int1")),
+                Schema.INTERFACE),
             hasColumn(
-                COL_REMOTE_INTERFACE,
+                COL_REMOTE_NODE_INTERFACE,
                 equalTo(new NodeInterfacePair("host2", "int2")),
                 Schema.INTERFACE)));
   }
@@ -506,12 +490,12 @@ public class EdgesAnswererTest {
     assertThat(
         row,
         allOf(
-            hasColumn(COL_NODE, equalTo(new Node("host1")), Schema.NODE),
             hasColumn(
-                COL_INTERFACE, equalTo(new NodeInterfacePair("host1", "int1")), Schema.INTERFACE),
-            hasColumn(COL_REMOTE_NODE, equalTo(new Node("host2")), Schema.NODE),
+                COL_NODE_INTERFACE,
+                equalTo(new NodeInterfacePair("host1", "int1")),
+                Schema.INTERFACE),
             hasColumn(
-                COL_REMOTE_INTERFACE,
+                COL_REMOTE_NODE_INTERFACE,
                 equalTo(new NodeInterfacePair("host2", "int2")),
                 Schema.INTERFACE)));
   }
@@ -522,13 +506,13 @@ public class EdgesAnswererTest {
     assertThat(
         row,
         allOf(
-            hasColumn(COL_NODE, equalTo(new Node("host1")), Schema.NODE),
             hasColumn(
-                COL_INTERFACE, equalTo(new NodeInterfacePair("host1", "int1")), Schema.INTERFACE),
+                COL_NODE_INTERFACE,
+                equalTo(new NodeInterfacePair("host1", "int1")),
+                Schema.INTERFACE),
             hasColumn(COL_VLAN, equalTo("1"), Schema.STRING),
-            hasColumn(COL_REMOTE_NODE, equalTo(new Node("host2")), Schema.NODE),
             hasColumn(
-                COL_REMOTE_INTERFACE,
+                COL_REMOTE_NODE_INTERFACE,
                 equalTo(new NodeInterfacePair("host2", "int2")),
                 Schema.INTERFACE),
             hasColumn(COL_REMOTE_VLAN, equalTo("2"), Schema.STRING)));
@@ -542,13 +526,13 @@ public class EdgesAnswererTest {
     assertThat(
         row,
         allOf(
-            hasColumn(COL_NODE, equalTo(new Node("host1")), Schema.NODE),
             hasColumn(
-                COL_INTERFACE, equalTo(new NodeInterfacePair("host1", "int1")), Schema.INTERFACE),
+                COL_NODE_INTERFACE,
+                equalTo(new NodeInterfacePair("host1", "int1")),
+                Schema.INTERFACE),
             hasColumn(COL_IPS, equalTo(ImmutableSet.of(new Ip("1.1.1.1"))), Schema.set(Schema.IP)),
-            hasColumn(COL_REMOTE_NODE, equalTo(new Node("host2")), Schema.NODE),
             hasColumn(
-                COL_REMOTE_INTERFACE,
+                COL_REMOTE_NODE_INTERFACE,
                 equalTo(new NodeInterfacePair("host2", "int2")),
                 Schema.INTERFACE),
             hasColumn(
@@ -565,26 +549,14 @@ public class EdgesAnswererTest {
             .stream()
             .map(ColumnMetadata::getName)
             .collect(ImmutableList.toImmutableList()),
-        contains(
-            COL_NODE,
-            COL_INTERFACE,
-            COL_IPS,
-            COL_REMOTE_NODE,
-            COL_REMOTE_INTERFACE,
-            COL_REMOTE_IPS));
+        contains(COL_NODE_INTERFACE, COL_IPS, COL_REMOTE_NODE_INTERFACE, COL_REMOTE_IPS));
 
     assertThat(
         columnMetadata
             .stream()
             .map(ColumnMetadata::getSchema)
             .collect(ImmutableList.toImmutableList()),
-        contains(
-            Schema.NODE,
-            Schema.INTERFACE,
-            Schema.set(Schema.IP),
-            Schema.NODE,
-            Schema.INTERFACE,
-            Schema.set(Schema.IP)));
+        contains(Schema.INTERFACE, Schema.set(Schema.IP), Schema.INTERFACE, Schema.set(Schema.IP)));
   }
 
   @Test
@@ -595,26 +567,14 @@ public class EdgesAnswererTest {
             .stream()
             .map(ColumnMetadata::getName)
             .collect(ImmutableList.toImmutableList()),
-        contains(
-            COL_NODE,
-            COL_INTERFACE,
-            COL_VLAN,
-            COL_REMOTE_NODE,
-            COL_REMOTE_INTERFACE,
-            COL_REMOTE_VLAN));
+        contains(COL_NODE_INTERFACE, COL_VLAN, COL_REMOTE_NODE_INTERFACE, COL_REMOTE_VLAN));
 
     assertThat(
         columnMetadata
             .stream()
             .map(ColumnMetadata::getSchema)
             .collect(ImmutableList.toImmutableList()),
-        contains(
-            Schema.NODE,
-            Schema.INTERFACE,
-            Schema.STRING,
-            Schema.NODE,
-            Schema.INTERFACE,
-            Schema.STRING));
+        contains(Schema.INTERFACE, Schema.STRING, Schema.INTERFACE, Schema.STRING));
   }
 
   @Test
@@ -644,13 +604,13 @@ public class EdgesAnswererTest {
             .stream()
             .map(ColumnMetadata::getName)
             .collect(ImmutableList.toImmutableList()),
-        contains(COL_NODE, COL_INTERFACE, COL_REMOTE_NODE, COL_REMOTE_INTERFACE));
+        contains(COL_NODE_INTERFACE, COL_REMOTE_NODE_INTERFACE));
 
     assertThat(
         columnMetadata
             .stream()
             .map(ColumnMetadata::getSchema)
             .collect(ImmutableList.toImmutableList()),
-        contains(Schema.NODE, Schema.INTERFACE, Schema.NODE, Schema.INTERFACE));
+        contains(Schema.INTERFACE, Schema.INTERFACE));
   }
 }

--- a/projects/question/src/test/java/org/batfish/question/edges/EdgesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/edges/EdgesAnswererTest.java
@@ -2,15 +2,15 @@ package org.batfish.question.edges;
 
 import static org.batfish.datamodel.matchers.RowMatchers.hasColumn;
 import static org.batfish.question.edges.EdgesAnswerer.COL_AS_NUMBER;
+import static org.batfish.question.edges.EdgesAnswerer.COL_INTERFACE;
 import static org.batfish.question.edges.EdgesAnswerer.COL_IP;
 import static org.batfish.question.edges.EdgesAnswerer.COL_IPS;
 import static org.batfish.question.edges.EdgesAnswerer.COL_NODE;
-import static org.batfish.question.edges.EdgesAnswerer.COL_INTERFACE;
 import static org.batfish.question.edges.EdgesAnswerer.COL_REMOTE_AS_NUMBER;
+import static org.batfish.question.edges.EdgesAnswerer.COL_REMOTE_INTERFACE;
 import static org.batfish.question.edges.EdgesAnswerer.COL_REMOTE_IP;
 import static org.batfish.question.edges.EdgesAnswerer.COL_REMOTE_IPS;
 import static org.batfish.question.edges.EdgesAnswerer.COL_REMOTE_NODE;
-import static org.batfish.question.edges.EdgesAnswerer.COL_REMOTE_INTERFACE;
 import static org.batfish.question.edges.EdgesAnswerer.COL_REMOTE_VLAN;
 import static org.batfish.question.edges.EdgesAnswerer.COL_VLAN;
 import static org.batfish.question.edges.EdgesAnswerer.eigrpEdgeToRow;
@@ -407,9 +407,7 @@ public class EdgesAnswererTest {
         row,
         allOf(
             hasColumn(
-                COL_INTERFACE,
-                equalTo(new NodeInterfacePair("host1", "int1")),
-                Schema.INTERFACE),
+                COL_INTERFACE, equalTo(new NodeInterfacePair("host1", "int1")), Schema.INTERFACE),
             hasColumn(
                 COL_REMOTE_INTERFACE,
                 equalTo(new NodeInterfacePair("host2", "int2")),
@@ -424,9 +422,7 @@ public class EdgesAnswererTest {
         row,
         allOf(
             hasColumn(
-                COL_INTERFACE,
-                equalTo(new NodeInterfacePair("host1", "int1")),
-                Schema.INTERFACE),
+                COL_INTERFACE, equalTo(new NodeInterfacePair("host1", "int1")), Schema.INTERFACE),
             hasColumn(
                 COL_REMOTE_INTERFACE,
                 equalTo(new NodeInterfacePair("host2", "int2")),
@@ -444,9 +440,7 @@ public class EdgesAnswererTest {
         row,
         allOf(
             hasColumn(
-                COL_INTERFACE,
-                equalTo(new NodeInterfacePair("host1", "int1")),
-                Schema.INTERFACE),
+                COL_INTERFACE, equalTo(new NodeInterfacePair("host1", "int1")), Schema.INTERFACE),
             hasColumn(
                 COL_REMOTE_INTERFACE,
                 equalTo(new NodeInterfacePair("host2", "int2")),
@@ -461,9 +455,7 @@ public class EdgesAnswererTest {
         row,
         allOf(
             hasColumn(
-                COL_INTERFACE,
-                equalTo(new NodeInterfacePair("host1", "int1")),
-                Schema.INTERFACE),
+                COL_INTERFACE, equalTo(new NodeInterfacePair("host1", "int1")), Schema.INTERFACE),
             hasColumn(
                 COL_REMOTE_INTERFACE,
                 equalTo(new NodeInterfacePair("host2", "int2")),
@@ -491,9 +483,7 @@ public class EdgesAnswererTest {
         row,
         allOf(
             hasColumn(
-                COL_INTERFACE,
-                equalTo(new NodeInterfacePair("host1", "int1")),
-                Schema.INTERFACE),
+                COL_INTERFACE, equalTo(new NodeInterfacePair("host1", "int1")), Schema.INTERFACE),
             hasColumn(
                 COL_REMOTE_INTERFACE,
                 equalTo(new NodeInterfacePair("host2", "int2")),
@@ -507,9 +497,7 @@ public class EdgesAnswererTest {
         row,
         allOf(
             hasColumn(
-                COL_INTERFACE,
-                equalTo(new NodeInterfacePair("host1", "int1")),
-                Schema.INTERFACE),
+                COL_INTERFACE, equalTo(new NodeInterfacePair("host1", "int1")), Schema.INTERFACE),
             hasColumn(COL_VLAN, equalTo("1"), Schema.STRING),
             hasColumn(
                 COL_REMOTE_INTERFACE,
@@ -527,9 +515,7 @@ public class EdgesAnswererTest {
         row,
         allOf(
             hasColumn(
-                COL_INTERFACE,
-                equalTo(new NodeInterfacePair("host1", "int1")),
-                Schema.INTERFACE),
+                COL_INTERFACE, equalTo(new NodeInterfacePair("host1", "int1")), Schema.INTERFACE),
             hasColumn(COL_IPS, equalTo(ImmutableSet.of(new Ip("1.1.1.1"))), Schema.set(Schema.IP)),
             hasColumn(
                 COL_REMOTE_INTERFACE,


### PR DESCRIPTION
- interface column already has this information, rename it `(Remote_)Node:(Remote_)Interface`