### PR TITLE
Bring example-with-delta in sync with example

### DIFF
--- a/networks/example-with-delta/configs/as1border2.cfg
+++ b/networks/example-with-delta/configs/as1border2.cfg
@@ -10,6 +10,9 @@ boot-start-marker
 boot-end-marker
 !
 !
+ntp server 18.18.18.18
+ntp server 23.23.23.23
+!
 !
 no aaa new-model
 no ip icmp rate-limit unreachable
@@ -135,7 +138,6 @@ access-list 101 permit ip host 1.0.2.0 host 255.255.255.0
 access-list 102 permit ip host 2.0.0.0 host 255.0.0.0
 access-list 102 permit ip host 2.128.0.0 host 255.255.0.0
 access-list 103 permit ip host 3.0.1.0 host 255.255.255.0
-access-list 103 permit ip host 3.0.2.0 host 255.255.255.0
 !
 route-map as1_to_as2 permit 1
  match ip address 101

--- a/networks/example-with-delta/configs/as1core1.cfg
+++ b/networks/example-with-delta/configs/as1core1.cfg
@@ -10,6 +10,9 @@ boot-start-marker
 boot-end-marker
 !
 !
+logging host 1.1.1.1
+logging host 2.2.2.2
+!
 !
 no aaa new-model
 no ip icmp rate-limit unreachable

--- a/networks/example-with-delta/configs/as2border1.cfg
+++ b/networks/example-with-delta/configs/as2border1.cfg
@@ -10,6 +10,9 @@ boot-start-marker
 boot-end-marker
 !
 !
+ntp server 18.18.18.18
+ntp server 23.23.23.23
+!
 !
 no aaa new-model
 no ip icmp rate-limit unreachable

--- a/networks/example-with-delta/configs/as2border2.cfg
+++ b/networks/example-with-delta/configs/as2border2.cfg
@@ -10,6 +10,8 @@ boot-start-marker
 boot-end-marker
 !
 !
+ntp server 18.18.18.18
+!
 !
 no aaa new-model
 no ip icmp rate-limit unreachable

--- a/networks/example-with-delta/configs/as2core1.cfg
+++ b/networks/example-with-delta/configs/as2core1.cfg
@@ -10,6 +10,9 @@ boot-start-marker
 boot-end-marker
 !
 !
+logging host 1.1.1.1
+logging host 2.1.2.2
+!
 !
 no aaa new-model
 no ip icmp rate-limit unreachable

--- a/networks/example-with-delta/configs/as2core2.cfg
+++ b/networks/example-with-delta/configs/as2core2.cfg
@@ -10,6 +10,9 @@ boot-start-marker
 boot-end-marker
 !
 !
+logging host 1.1.1.1
+logging host 2.2.2.2
+!
 !
 no aaa new-model
 no ip icmp rate-limit unreachable

--- a/networks/example-with-delta/configs/as3border1.cfg
+++ b/networks/example-with-delta/configs/as3border1.cfg
@@ -10,6 +10,9 @@ boot-start-marker
 boot-end-marker
 !
 !
+ntp server 18.18.18.18
+ntp server 23.23.23.23
+!
 !
 no aaa new-model
 no ip icmp rate-limit unreachable

--- a/networks/example-with-delta/configs/as3border2.cfg
+++ b/networks/example-with-delta/configs/as3border2.cfg
@@ -10,6 +10,9 @@ boot-start-marker
 boot-end-marker
 !
 !
+ntp server 18.18.18.18
+ntp server 23.23.23.23
+!
 !
 no aaa new-model
 no ip icmp rate-limit unreachable

--- a/networks/example-with-delta/configs/as3core1.cfg
+++ b/networks/example-with-delta/configs/as3core1.cfg
@@ -10,6 +10,9 @@ boot-start-marker
 boot-end-marker
 !
 !
+logging host 1.1.1.1
+logging host 2.2.2.2
+!
 !
 no aaa new-model
 no ip icmp rate-limit unreachable

--- a/tests/basic/init-delta.ref
+++ b/tests/basic/init-delta.ref
@@ -226,25 +226,25 @@
           "bgp group" : {
             "as1" : {
               "definitionLines" : [
-                82
+                85
               ],
               "numReferrers" : -1
             },
             "as2" : {
               "definitionLines" : [
-                84
+                87
               ],
               "numReferrers" : 0
             },
             "as3" : {
               "definitionLines" : [
-                86
+                89
               ],
               "numReferrers" : -1
             },
             "as4" : {
               "definitionLines" : [
-                88
+                91
               ],
               "numReferrers" : -1
             }
@@ -252,25 +252,25 @@
           "expanded community-list" : {
             "as1_community" : {
               "definitionLines" : [
-                120
+                123
               ],
               "numReferrers" : 0
             },
             "as2_community" : {
               "definitionLines" : [
-                121
+                124
               ],
               "numReferrers" : 1
             },
             "as3_community" : {
               "definitionLines" : [
-                122
+                125
               ],
               "numReferrers" : 1
             },
             "as4_community" : {
               "definitionLines" : [
-                123
+                126
               ],
               "numReferrers" : 1
             }
@@ -278,22 +278,21 @@
           "extended ipv4 access-list" : {
             "101" : {
               "definitionLines" : [
-                133,
-                134
+                136,
+                137
               ],
               "numReferrers" : 2
             },
             "102" : {
               "definitionLines" : [
-                135,
-                136
+                138,
+                139
               ],
               "numReferrers" : 1
             },
             "103" : {
               "definitionLines" : [
-                137,
-                138
+                140
               ],
               "numReferrers" : 1
             }
@@ -301,44 +300,44 @@
           "interface" : {
             "Ethernet0/0" : {
               "definitionLines" : [
-                54,
-                55,
-                56,
-                57
+                57,
+                58,
+                59,
+                60
               ],
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
               "definitionLines" : [
-                59,
-                60,
-                61,
                 62,
                 63,
-                64
+                64,
+                65,
+                66,
+                67
               ],
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
               "definitionLines" : [
-                66,
-                67,
-                68
+                69,
+                70,
+                71
               ],
               "numReferrers" : 1
             },
             "GigabitEthernet2/0" : {
               "definitionLines" : [
-                70,
-                71,
-                72
+                73,
+                74,
+                75
               ],
               "numReferrers" : 1
             },
             "Loopback0" : {
               "definitionLines" : [
-                51,
-                52
+                54,
+                55
               ],
               "numReferrers" : 2
             }
@@ -346,14 +345,14 @@
           "ipv4 prefix-list" : {
             "as4-prefixes" : {
               "definitionLines" : [
-                129
+                132
               ],
               "numReferrers" : 1
             },
             "inbound_route_filter" : {
               "definitionLines" : [
-                131,
-                132
+                134,
+                135
               ],
               "numReferrers" : 0
             }
@@ -361,60 +360,60 @@
           "route-map" : {
             "as1_to_as2" : {
               "definitionLines" : [
-                140,
-                141,
                 142,
                 143,
+                144,
                 145,
-                146,
                 147,
-                148
+                148,
+                149,
+                150
               ],
               "numReferrers" : 1
             },
             "as1_to_as3" : {
               "definitionLines" : [
-                154,
-                155,
                 156,
                 157,
+                158,
                 159,
-                160,
                 161,
-                162
+                162,
+                163,
+                164
               ],
               "numReferrers" : 1
             },
             "as1_to_as4" : {
               "definitionLines" : [
-                168,
-                169,
-                170
+                170,
+                171,
+                172
               ],
               "numReferrers" : 1
             },
             "as2_to_as1" : {
               "definitionLines" : [
-                150,
-                151,
-                152
+                152,
+                153,
+                154
               ],
               "numReferrers" : 1
             },
             "as3_to_as1" : {
               "definitionLines" : [
-                164,
-                165,
-                166
+                166,
+                167,
+                168
               ],
               "numReferrers" : 1
             },
             "as4_to_as1" : {
               "definitionLines" : [
-                172,
-                173,
                 174,
-                175
+                175,
+                176,
+                177
               ],
               "numReferrers" : 1
             }
@@ -424,7 +423,7 @@
           "bgp group" : {
             "as1" : {
               "definitionLines" : [
-                77
+                80
               ],
               "numReferrers" : -1
             }
@@ -432,36 +431,36 @@
           "interface" : {
             "Ethernet0/0" : {
               "definitionLines" : [
-                54,
-                55,
-                56,
-                57
+                57,
+                58,
+                59,
+                60
               ],
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
               "definitionLines" : [
-                59,
-                60,
-                61,
                 62,
                 63,
-                64
+                64,
+                65,
+                66,
+                67
               ],
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
               "definitionLines" : [
-                66,
-                67,
-                68
+                69,
+                70,
+                71
               ],
               "numReferrers" : 1
             },
             "Loopback0" : {
               "definitionLines" : [
-                51,
-                52
+                54,
+                55
               ],
               "numReferrers" : 3
             }
@@ -471,9 +470,193 @@
           "bgp group" : {
             "as1" : {
               "definitionLines" : [
-                86
+                89
               ],
               "numReferrers" : -1
+            },
+            "as2" : {
+              "definitionLines" : [
+                91
+              ],
+              "numReferrers" : -1
+            },
+            "as3" : {
+              "definitionLines" : [
+                93
+              ],
+              "numReferrers" : 0
+            }
+          },
+          "expanded community-list" : {
+            "as1_community" : {
+              "definitionLines" : [
+                123
+              ],
+              "numReferrers" : 1
+            },
+            "as2_community" : {
+              "definitionLines" : [
+                124
+              ],
+              "numReferrers" : 0
+            },
+            "as3_community" : {
+              "definitionLines" : [
+                125
+              ],
+              "numReferrers" : 1
+            }
+          },
+          "extended ipv4 access-list" : {
+            "101" : {
+              "definitionLines" : [
+                144,
+                145
+              ],
+              "numReferrers" : 1
+            },
+            "103" : {
+              "definitionLines" : [
+                146,
+                147
+              ],
+              "numReferrers" : 1
+            },
+            "INSIDE_TO_AS1" : {
+              "definitionLines" : [
+                130,
+                131,
+                132,
+                133
+              ],
+              "numReferrers" : 1
+            },
+            "OUTSIDE_TO_INSIDE" : {
+              "definitionLines" : [
+                134,
+                135,
+                136,
+                137
+              ],
+              "numReferrers" : 1
+            }
+          },
+          "interface" : {
+            "Ethernet0/0" : {
+              "definitionLines" : [
+                59,
+                60,
+                61,
+                62
+              ],
+              "numReferrers" : 1
+            },
+            "GigabitEthernet0/0" : {
+              "definitionLines" : [
+                64,
+                65,
+                66,
+                67,
+                68,
+                69,
+                70,
+                71
+              ],
+              "numReferrers" : 1
+            },
+            "GigabitEthernet1/0" : {
+              "definitionLines" : [
+                73,
+                74,
+                75
+              ],
+              "numReferrers" : 1
+            },
+            "GigabitEthernet2/0" : {
+              "definitionLines" : [
+                77,
+                78,
+                79
+              ],
+              "numReferrers" : 1
+            },
+            "Loopback0" : {
+              "definitionLines" : [
+                56,
+                57
+              ],
+              "numReferrers" : 3
+            }
+          },
+          "ipv4 prefix-list" : {
+            "inbound_route_filter" : {
+              "definitionLines" : [
+                140,
+                141
+              ],
+              "numReferrers" : 0
+            },
+            "outbound_routes" : {
+              "definitionLines" : [
+                143
+              ],
+              "numReferrers" : 2
+            }
+          },
+          "route-map" : {
+            "as1_to_as2" : {
+              "definitionLines" : [
+                159,
+                160,
+                161,
+                162
+              ],
+              "numReferrers" : 1
+            },
+            "as2_to_as1" : {
+              "definitionLines" : [
+                149,
+                150,
+                151,
+                152,
+                154,
+                155,
+                156,
+                157
+              ],
+              "numReferrers" : 1
+            },
+            "as2_to_as3" : {
+              "definitionLines" : [
+                164,
+                165,
+                166,
+                167,
+                169,
+                170,
+                171,
+                172
+              ],
+              "numReferrers" : 1
+            },
+            "as3_to_as2" : {
+              "definitionLines" : [
+                174,
+                175,
+                176,
+                177
+              ],
+              "numReferrers" : 1
+            }
+          }
+        },
+        "configs/as2border2.cfg" : {
+          "bgp group" : {
+            "as1" : {
+              "definitionLines" : [
+                86
+              ],
+              "numReferrers" : 0
             },
             "as2" : {
               "definitionLines" : [
@@ -485,7 +668,7 @@
               "definitionLines" : [
                 90
               ],
-              "numReferrers" : 0
+              "numReferrers" : -1
             }
           },
           "expanded community-list" : {
@@ -511,19 +694,19 @@
           "extended ipv4 access-list" : {
             "101" : {
               "definitionLines" : [
-                141,
-                142
+                140,
+                141
               ],
               "numReferrers" : 1
             },
             "103" : {
               "definitionLines" : [
-                143,
-                144
+                142,
+                143
               ],
               "numReferrers" : 1
             },
-            "INSIDE_TO_AS1" : {
+            "INSIDE_TO_AS3" : {
               "definitionLines" : [
                 127,
                 128,
@@ -536,8 +719,7 @@
               "definitionLines" : [
                 131,
                 132,
-                133,
-                134
+                133
               ],
               "numReferrers" : 1
             }
@@ -592,14 +774,14 @@
           "ipv4 prefix-list" : {
             "inbound_route_filter" : {
               "definitionLines" : [
-                137,
-                138
+                136,
+                137
               ],
               "numReferrers" : 0
             },
             "outbound_routes" : {
               "definitionLines" : [
-                140
+                139
               ],
               "numReferrers" : 2
             }
@@ -607,228 +789,45 @@
           "route-map" : {
             "as1_to_as2" : {
               "definitionLines" : [
+                155,
                 156,
                 157,
-                158,
-                159
+                158
               ],
               "numReferrers" : 1
             },
             "as2_to_as1" : {
               "definitionLines" : [
+                145,
                 146,
                 147,
                 148,
-                149,
+                150,
                 151,
                 152,
-                153,
-                154
+                153
               ],
               "numReferrers" : 1
             },
             "as2_to_as3" : {
               "definitionLines" : [
+                160,
                 161,
                 162,
                 163,
-                164,
+                165,
                 166,
                 167,
-                168,
-                169
+                168
               ],
               "numReferrers" : 1
             },
             "as3_to_as2" : {
               "definitionLines" : [
+                170,
                 171,
                 172,
-                173,
-                174
-              ],
-              "numReferrers" : 1
-            }
-          }
-        },
-        "configs/as2border2.cfg" : {
-          "bgp group" : {
-            "as1" : {
-              "definitionLines" : [
-                84
-              ],
-              "numReferrers" : 0
-            },
-            "as2" : {
-              "definitionLines" : [
-                86
-              ],
-              "numReferrers" : -1
-            },
-            "as3" : {
-              "definitionLines" : [
-                88
-              ],
-              "numReferrers" : -1
-            }
-          },
-          "expanded community-list" : {
-            "as1_community" : {
-              "definitionLines" : [
-                118
-              ],
-              "numReferrers" : 1
-            },
-            "as2_community" : {
-              "definitionLines" : [
-                119
-              ],
-              "numReferrers" : 0
-            },
-            "as3_community" : {
-              "definitionLines" : [
-                120
-              ],
-              "numReferrers" : 1
-            }
-          },
-          "extended ipv4 access-list" : {
-            "101" : {
-              "definitionLines" : [
-                138,
-                139
-              ],
-              "numReferrers" : 1
-            },
-            "103" : {
-              "definitionLines" : [
-                140,
-                141
-              ],
-              "numReferrers" : 1
-            },
-            "INSIDE_TO_AS3" : {
-              "definitionLines" : [
-                125,
-                126,
-                127,
-                128
-              ],
-              "numReferrers" : 1
-            },
-            "OUTSIDE_TO_INSIDE" : {
-              "definitionLines" : [
-                129,
-                130,
-                131
-              ],
-              "numReferrers" : 1
-            }
-          },
-          "interface" : {
-            "Ethernet0/0" : {
-              "definitionLines" : [
-                54,
-                55,
-                56,
-                57
-              ],
-              "numReferrers" : 1
-            },
-            "GigabitEthernet0/0" : {
-              "definitionLines" : [
-                59,
-                60,
-                61,
-                62,
-                63,
-                64,
-                65,
-                66
-              ],
-              "numReferrers" : 1
-            },
-            "GigabitEthernet1/0" : {
-              "definitionLines" : [
-                68,
-                69,
-                70
-              ],
-              "numReferrers" : 1
-            },
-            "GigabitEthernet2/0" : {
-              "definitionLines" : [
-                72,
-                73,
-                74
-              ],
-              "numReferrers" : 1
-            },
-            "Loopback0" : {
-              "definitionLines" : [
-                51,
-                52
-              ],
-              "numReferrers" : 3
-            }
-          },
-          "ipv4 prefix-list" : {
-            "inbound_route_filter" : {
-              "definitionLines" : [
-                134,
-                135
-              ],
-              "numReferrers" : 0
-            },
-            "outbound_routes" : {
-              "definitionLines" : [
-                137
-              ],
-              "numReferrers" : 2
-            }
-          },
-          "route-map" : {
-            "as1_to_as2" : {
-              "definitionLines" : [
-                153,
-                154,
-                155,
-                156
-              ],
-              "numReferrers" : 1
-            },
-            "as2_to_as1" : {
-              "definitionLines" : [
-                143,
-                144,
-                145,
-                146,
-                148,
-                149,
-                150,
-                151
-              ],
-              "numReferrers" : 1
-            },
-            "as2_to_as3" : {
-              "definitionLines" : [
-                158,
-                159,
-                160,
-                161,
-                163,
-                164,
-                165,
-                166
-              ],
-              "numReferrers" : 1
-            },
-            "as3_to_as2" : {
-              "definitionLines" : [
-                168,
-                169,
-                170,
-                171
+                173
               ],
               "numReferrers" : 1
             }
@@ -838,7 +837,7 @@
           "bgp group" : {
             "as2" : {
               "definitionLines" : [
-                87
+                90
               ],
               "numReferrers" : -1
             }
@@ -846,9 +845,9 @@
           "extended ipv4 access-list" : {
             "blocktelnet" : {
               "definitionLines" : [
-                118,
-                119,
-                120
+                121,
+                122,
+                123
               ],
               "numReferrers" : 2
             }
@@ -856,54 +855,54 @@
           "interface" : {
             "Ethernet0/0" : {
               "definitionLines" : [
-                54,
-                55,
-                56,
-                57
+                57,
+                58,
+                59,
+                60
               ],
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
               "definitionLines" : [
-                59,
-                60,
-                61,
                 62,
                 63,
-                64
+                64,
+                65,
+                66,
+                67
               ],
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
               "definitionLines" : [
-                66,
-                67,
-                68
+                69,
+                70,
+                71
               ],
               "numReferrers" : 1
             },
             "GigabitEthernet2/0" : {
               "definitionLines" : [
-                70,
-                71,
-                72,
-                73
+                73,
+                74,
+                75,
+                76
               ],
               "numReferrers" : 1
             },
             "GigabitEthernet3/0" : {
               "definitionLines" : [
-                75,
-                76,
-                77,
-                78
+                78,
+                79,
+                80,
+                81
               ],
               "numReferrers" : 1
             },
             "Loopback0" : {
               "definitionLines" : [
-                51,
-                52
+                54,
+                55
               ],
               "numReferrers" : 5
             }
@@ -913,7 +912,7 @@
           "bgp group" : {
             "as2" : {
               "definitionLines" : [
-                88
+                91
               ],
               "numReferrers" : -1
             }
@@ -921,55 +920,55 @@
           "interface" : {
             "Ethernet0/0" : {
               "definitionLines" : [
-                54,
-                55,
-                56,
-                57
+                57,
+                58,
+                59,
+                60
               ],
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
               "definitionLines" : [
-                59,
-                60,
-                61,
                 62,
                 63,
                 64,
-                65
+                65,
+                66,
+                67,
+                68
               ],
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
               "definitionLines" : [
-                67,
-                68,
-                69,
-                70
+                70,
+                71,
+                72,
+                73
               ],
               "numReferrers" : 1
             },
             "GigabitEthernet2/0" : {
               "definitionLines" : [
-                72,
-                73,
-                74,
-                75
+                75,
+                76,
+                77,
+                78
               ],
               "numReferrers" : 1
             },
             "GigabitEthernet3/0" : {
               "definitionLines" : [
-                77,
-                78,
-                79
+                80,
+                81,
+                82
               ],
               "numReferrers" : 1
             },
             "Loopback0" : {
               "definitionLines" : [
-                51,
-                52
+                54,
+                55
               ],
               "numReferrers" : 5
             }
@@ -1319,19 +1318,19 @@
           "bgp group" : {
             "as1" : {
               "definitionLines" : [
-                78
+                81
               ],
               "numReferrers" : 0
             },
             "as2" : {
               "definitionLines" : [
-                80
+                83
               ],
               "numReferrers" : -1
             },
             "as3" : {
               "definitionLines" : [
-                82
+                85
               ],
               "numReferrers" : -1
             }
@@ -1339,19 +1338,19 @@
           "expanded community-list" : {
             "as1_community" : {
               "definitionLines" : [
-                110
+                113
               ],
               "numReferrers" : 1
             },
             "as2_community" : {
               "definitionLines" : [
-                111
+                114
               ],
               "numReferrers" : 1
             },
             "as3_community" : {
               "definitionLines" : [
-                112
+                115
               ],
               "numReferrers" : 0
             }
@@ -1359,22 +1358,22 @@
           "extended ipv4 access-list" : {
             "101" : {
               "definitionLines" : [
-                122,
-                123
+                125,
+                126
               ],
               "numReferrers" : 1
             },
             "102" : {
               "definitionLines" : [
-                124,
-                125
+                127,
+                128
               ],
               "numReferrers" : 1
             },
             "103" : {
               "definitionLines" : [
-                126,
-                127
+                129,
+                130
               ],
               "numReferrers" : 2
             }
@@ -1382,36 +1381,36 @@
           "interface" : {
             "Ethernet0/0" : {
               "definitionLines" : [
-                54,
-                55,
-                56,
-                57
+                57,
+                58,
+                59,
+                60
               ],
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
               "definitionLines" : [
-                59,
-                60,
-                61,
                 62,
                 63,
-                64
+                64,
+                65,
+                66,
+                67
               ],
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
               "definitionLines" : [
-                66,
-                67,
-                68
+                69,
+                70,
+                71
               ],
               "numReferrers" : 1
             },
             "Loopback0" : {
               "definitionLines" : [
-                51,
-                52
+                54,
+                55
               ],
               "numReferrers" : 2
             }
@@ -1419,14 +1418,14 @@
           "ipv4 prefix-list" : {
             "default_list" : {
               "definitionLines" : [
-                118
+                121
               ],
               "numReferrers" : 1
             },
             "inbound_route_filter" : {
               "definitionLines" : [
-                120,
-                121
+                123,
+                124
               ],
               "numReferrers" : 0
             }
@@ -1434,47 +1433,47 @@
           "route-map" : {
             "as1_to_as3" : {
               "definitionLines" : [
-                139,
-                140,
-                141
+                142,
+                143,
+                144
               ],
               "numReferrers" : 1
             },
             "as2_to_as3" : {
               "definitionLines" : [
-                158,
-                159,
-                160
+                161,
+                162,
+                163
               ],
               "numReferrers" : 1
             },
             "as3_to_as1" : {
               "definitionLines" : [
-                129,
-                130,
-                131,
                 132,
+                133,
                 134,
                 135,
-                136,
-                137
+                137,
+                138,
+                139,
+                140
               ],
               "numReferrers" : 1
             },
             "as3_to_as2" : {
               "definitionLines" : [
-                143,
-                144,
-                145,
                 146,
+                147,
                 148,
                 149,
-                150,
                 151,
+                152,
                 153,
                 154,
-                155,
-                156
+                156,
+                157,
+                158,
+                159
               ],
               "numReferrers" : 1
             }
@@ -1484,19 +1483,19 @@
           "bgp group" : {
             "as1" : {
               "definitionLines" : [
-                78
+                81
               ],
               "numReferrers" : -1
             },
             "as2" : {
               "definitionLines" : [
-                80
+                83
               ],
               "numReferrers" : 0
             },
             "as3" : {
               "definitionLines" : [
-                82
+                85
               ],
               "numReferrers" : -1
             }
@@ -1504,19 +1503,19 @@
           "expanded community-list" : {
             "as1_community" : {
               "definitionLines" : [
-                110
+                113
               ],
               "numReferrers" : 1
             },
             "as2_community" : {
               "definitionLines" : [
-                111
+                114
               ],
               "numReferrers" : 1
             },
             "as3_community" : {
               "definitionLines" : [
-                112
+                115
               ],
               "numReferrers" : 0
             }
@@ -1524,22 +1523,22 @@
           "extended ipv4 access-list" : {
             "101" : {
               "definitionLines" : [
-                120,
-                121
+                123,
+                124
               ],
               "numReferrers" : 1
             },
             "102" : {
               "definitionLines" : [
-                122,
-                123
+                125,
+                126
               ],
               "numReferrers" : 1
             },
             "103" : {
               "definitionLines" : [
-                124,
-                125
+                127,
+                128
               ],
               "numReferrers" : 2
             }
@@ -1547,36 +1546,36 @@
           "interface" : {
             "Ethernet0/0" : {
               "definitionLines" : [
-                54,
-                55,
-                56,
-                57
+                57,
+                58,
+                59,
+                60
               ],
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
               "definitionLines" : [
-                59,
-                60,
-                61,
                 62,
                 63,
-                64
+                64,
+                65,
+                66,
+                67
               ],
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
               "definitionLines" : [
-                66,
-                67,
-                68
+                69,
+                70,
+                71
               ],
               "numReferrers" : 1
             },
             "Loopback0" : {
               "definitionLines" : [
-                51,
-                52
+                54,
+                55
               ],
               "numReferrers" : 2
             }
@@ -1584,8 +1583,8 @@
           "ipv4 prefix-list" : {
             "inbound_route_filter" : {
               "definitionLines" : [
-                118,
-                119
+                121,
+                122
               ],
               "numReferrers" : 0
             }
@@ -1593,43 +1592,43 @@
           "route-map" : {
             "as1_to_as3" : {
               "definitionLines" : [
-                137,
-                138,
-                139
+                140,
+                141,
+                142
               ],
               "numReferrers" : 1
             },
             "as2_to_as3" : {
               "definitionLines" : [
-                151,
-                152,
-                153
+                154,
+                155,
+                156
               ],
               "numReferrers" : 1
             },
             "as3_to_as1" : {
               "definitionLines" : [
-                127,
-                128,
-                129,
                 130,
+                131,
                 132,
                 133,
-                134,
-                135
+                135,
+                136,
+                137,
+                138
               ],
               "numReferrers" : 1
             },
             "as3_to_as2" : {
               "definitionLines" : [
-                141,
-                142,
-                143,
                 144,
+                145,
                 146,
                 147,
-                148,
-                149
+                149,
+                150,
+                151,
+                152
               ],
               "numReferrers" : 1
             }
@@ -1639,7 +1638,7 @@
           "bgp group" : {
             "as3" : {
               "definitionLines" : [
-                84
+                87
               ],
               "numReferrers" : -1
             }
@@ -1647,52 +1646,52 @@
           "interface" : {
             "Ethernet0/0" : {
               "definitionLines" : [
-                54,
-                55,
-                56,
-                57
+                57,
+                58,
+                59,
+                60
               ],
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
               "definitionLines" : [
-                59,
-                60,
-                61,
                 62,
                 63,
-                64
+                64,
+                65,
+                66,
+                67
               ],
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
               "definitionLines" : [
-                66,
-                67,
-                68
+                69,
+                70,
+                71
               ],
               "numReferrers" : 1
             },
             "GigabitEthernet2/0" : {
               "definitionLines" : [
-                70,
-                71,
-                72
+                73,
+                74,
+                75
               ],
               "numReferrers" : 1
             },
             "GigabitEthernet3/0" : {
               "definitionLines" : [
-                74,
-                75,
-                76
+                77,
+                78,
+                79
               ],
               "numReferrers" : 1
             },
             "Loopback0" : {
               "definitionLines" : [
-                51,
-                52
+                54,
+                55
               ],
               "numReferrers" : 3
             }
@@ -1706,7 +1705,7 @@
           "route-map" : {
             "filter-bogons" : {
               "bgp inbound route-map" : [
-                106
+                109
               ]
             }
           }

--- a/tests/basic/nodes-diff.ref
+++ b/tests/basic/nodes-diff.ref
@@ -2,29 +2,6 @@
   {
     "class" : "org.batfish.question.NodesQuestionPlugin$NodesDiffAnswerElement",
     "configDiff" : {
-      "as1border2" : {
-        "class" : "org.batfish.datamodel.ConfigurationDiff",
-        "ipAccessListsDiff" : {
-          "class" : "org.batfish.datamodel.IpAccessListsDiff",
-          "diff" : [
-            "103"
-          ]
-        },
-        "routeFilterListsDiff" : {
-          "class" : "org.batfish.datamodel.RouteFilterListsDiff",
-          "diff" : [
-            "103"
-          ],
-          "diffInfo" : {
-            "103" : {
-              "class" : "org.batfish.datamodel.ConfigDiffElement",
-              "inAfterOnly" : [
-                "PERMIT 3.0.2.0/24 [24,24] "
-              ]
-            }
-          }
-        }
-      },
       "as2dept1" : {
         "class" : "org.batfish.datamodel.ConfigurationDiff",
         "interfacesDiff" : {


### PR DESCRIPTION
Although we discussed and decided to get rid of example-with-delta, I found that apart from the deleted demo script, it is being used in `tests/basic/commands` in some non-trivial tests (like generate-delta-dataplane, differential nodes question etc.). So thought it would be better to not remove it, instead bringing over the changes from example snapshot.