### PR TITLE
Build sets of AclLineMatchExprs conjuncts/disjuncts

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclLineMatchExprs.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclLineMatchExprs.java
@@ -69,6 +69,22 @@ public final class AclLineMatchExprs {
     return matchDst(new Ip(ip).toIpSpace());
   }
 
+  public static MatchHeaderSpace matchSrc(IpSpace ipSpace) {
+    return new MatchHeaderSpace(HeaderSpace.builder().setSrcIps(ipSpace).build());
+  }
+
+  public static MatchHeaderSpace matchSrc(Ip ip) {
+    return matchSrc(ip.toIpSpace());
+  }
+
+  public static MatchHeaderSpace matchSrc(Prefix prefix) {
+    return matchSrc(prefix.toIpSpace());
+  }
+
+  public static MatchHeaderSpace matchSrcIp(String ip) {
+    return matchSrc(new Ip(ip).toIpSpace());
+  }
+
   public static MatchSrcInterface matchSrcInterface(String... iface) {
     return new MatchSrcInterface(ImmutableList.copyOf(iface));
   }

--- a/projects/batfish/src/main/java/org/batfish/datamodel/acl/explanation/AclLineMatchExprSetBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/datamodel/acl/explanation/AclLineMatchExprSetBuilder.java
@@ -11,7 +11,7 @@ import org.batfish.symbolic.bdd.AclLineMatchExprToBDD;
 
 /**
  * Represents a set of {@link AclLineMatchExpr AclLineMatchExprs} -- either a set of conjuncts or a
- * set of disjuncts. Removes
+ * set of disjuncts. Uses {@link BDD BDDs} to detect and remove redundant members.
  */
 public abstract class AclLineMatchExprSetBuilder {
 

--- a/projects/batfish/src/main/java/org/batfish/datamodel/acl/explanation/AclLineMatchExprSetBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/datamodel/acl/explanation/AclLineMatchExprSetBuilder.java
@@ -1,0 +1,85 @@
+package org.batfish.datamodel.acl.explanation;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import net.sf.javabdd.BDD;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.symbolic.bdd.AclLineMatchExprToBDD;
+
+/**
+ * Represents a set of {@link AclLineMatchExpr AclLineMatchExprs} -- either a set of conjuncts or a
+ * set of disjuncts. Removes
+ */
+public abstract class AclLineMatchExprSetBuilder {
+
+  private final AclLineMatchExprToBDD _aclLineMatchExprToBDD;
+  private final Map<AclLineMatchExpr, BDD> _exprs;
+  private BDD _bdd;
+  private BDD _orExprBDDs;
+
+  protected AclLineMatchExprSetBuilder(AclLineMatchExprToBDD aclLineMatchExprToBDD, BDD identity) {
+    _aclLineMatchExprToBDD = aclLineMatchExprToBDD;
+    _exprs = new HashMap<>();
+    _bdd = identity;
+    _orExprBDDs = identity.getFactory().zero();
+  }
+
+  public AclLineMatchExprSetBuilder(AclLineMatchExprSetBuilder other) {
+    _aclLineMatchExprToBDD = other._aclLineMatchExprToBDD;
+    _exprs = new HashMap<>(other._exprs);
+    _bdd = other._bdd;
+    _orExprBDDs = other._orExprBDDs;
+  }
+
+  protected abstract BDD identity();
+
+  protected abstract BDD combinator(BDD bdd1, BDD bdd2);
+
+  protected abstract BDD shortCircuitBDD();
+
+  public abstract AclLineMatchExpr build();
+
+  public void add(AclLineMatchExpr expr) {
+    if (_bdd.equals(shortCircuitBDD()) || _exprs.containsKey(expr)) {
+      return;
+    }
+
+    BDD exprBdd = _aclLineMatchExprToBDD.visit(expr);
+    BDD newBdd = combinator(_bdd, exprBdd);
+    if (newBdd.equals(_bdd)) {
+      // expr contributes nothing to the set; discard
+      return;
+    }
+
+    if (!_exprs.isEmpty() && exprBdd.imp(_orExprBDDs).isOne()) {
+      // can remove something
+      List<AclLineMatchExpr> toRemove = new ArrayList<>();
+      _exprs.forEach(
+          (expr1, bdd1) -> {
+            if (combinator(bdd1, exprBdd).equals(exprBdd)) {
+              // bdd1 is now redundant; remove
+              toRemove.add(expr1);
+            }
+          });
+      assert !toRemove.isEmpty();
+      toRemove.forEach(_exprs::remove);
+
+      _orExprBDDs = _exprs.values().stream().reduce(_bdd.getFactory().zero(), BDD::or);
+    }
+
+    _exprs.put(expr, exprBdd);
+    _bdd = newBdd;
+    _orExprBDDs = _orExprBDDs.or(exprBdd);
+  }
+
+  protected BDD getBdd() {
+    return _bdd;
+  }
+
+  protected Set<AclLineMatchExpr> getExprs() {
+    return _exprs.keySet();
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/datamodel/acl/explanation/ConjunctsBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/datamodel/acl/explanation/ConjunctsBuilder.java
@@ -1,0 +1,61 @@
+package org.batfish.datamodel.acl.explanation;
+
+import static org.batfish.datamodel.acl.AclLineMatchExprs.FALSE;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
+
+import net.sf.javabdd.BDD;
+import net.sf.javabdd.BDDFactory;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.acl.AndMatchExpr;
+import org.batfish.datamodel.acl.OrMatchExpr;
+import org.batfish.symbolic.bdd.AclLineMatchExprToBDD;
+
+/**
+ * A builder for the conjuncts of an {@link AndMatchExpr}. Uses {@link BDD BDDs} to remove redundant
+ * conjuncts and to short-circuit when the set of disjuncts is unsatisfiable.
+ */
+public final class ConjunctsBuilder extends AclLineMatchExprSetBuilder {
+  private final BDD _one;
+  private final BDD _zero;
+
+  public ConjunctsBuilder(AclLineMatchExprToBDD aclLineMatchExprToBDD) {
+    super(aclLineMatchExprToBDD, aclLineMatchExprToBDD.getBDDPacket().getFactory().one());
+    BDDFactory factory = aclLineMatchExprToBDD.getBDDPacket().getFactory();
+    _one = factory.one();
+    _zero = factory.zero();
+  }
+
+  public ConjunctsBuilder(ConjunctsBuilder other) {
+    super(other);
+    _one = other._one;
+    _zero = other._zero;
+  }
+
+  @Override
+  protected BDD identity() {
+    return _one;
+  }
+
+  @Override
+  protected BDD combinator(BDD bdd1, BDD bdd2) {
+    return bdd1.and(bdd2);
+  }
+
+  @Override
+  protected BDD shortCircuitBDD() {
+    return _zero;
+  }
+
+  @Override
+  public AclLineMatchExpr build() {
+    return getBdd().isZero() ? FALSE : and(getExprs());
+  }
+
+  public boolean unsat() {
+    return getBdd().isZero();
+  }
+
+  public boolean containsOrMatchExpr() {
+    return getExprs().stream().anyMatch(OrMatchExpr.class::isInstance);
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/datamodel/acl/explanation/DisjunctsBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/datamodel/acl/explanation/DisjunctsBuilder.java
@@ -1,0 +1,46 @@
+package org.batfish.datamodel.acl.explanation;
+
+import static org.batfish.datamodel.acl.AclLineMatchExprs.TRUE;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.or;
+
+import net.sf.javabdd.BDD;
+import net.sf.javabdd.BDDFactory;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.acl.OrMatchExpr;
+import org.batfish.symbolic.bdd.AclLineMatchExprToBDD;
+
+/**
+ * A builder for the disjuncts of an {@link OrMatchExpr}. Uses {@link BDD BDDs} to remove redundant
+ * disjuncts and to short-circuit when the set of disjuncts is valid.
+ */
+public final class DisjunctsBuilder extends AclLineMatchExprSetBuilder {
+  BDD _zero;
+  BDD _one;
+
+  public DisjunctsBuilder(AclLineMatchExprToBDD aclLineMatchExprToBDD) {
+    super(aclLineMatchExprToBDD, aclLineMatchExprToBDD.getBDDPacket().getFactory().zero());
+    BDDFactory factory = aclLineMatchExprToBDD.getBDDPacket().getFactory();
+    _one = factory.one();
+    _zero = factory.zero();
+  }
+
+  @Override
+  protected BDD identity() {
+    return _zero;
+  }
+
+  @Override
+  protected BDD combinator(BDD bdd1, BDD bdd2) {
+    return bdd1.or(bdd2);
+  }
+
+  @Override
+  protected BDD shortCircuitBDD() {
+    return _one;
+  }
+
+  @Override
+  public AclLineMatchExpr build() {
+    return getBdd().isOne() ? TRUE : or(getExprs());
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/symbolic/bdd/AclLineMatchExprToBDD.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/bdd/AclLineMatchExprToBDD.java
@@ -32,39 +32,43 @@ public class AclLineMatchExprToBDD implements GenericAclLineMatchExprVisitor<BDD
 
   private final BDDOps _bddOps;
 
-  private final BDDFactory _factory;
+  private final BDDFactory _bddFactory;
+
+  private final BDDPacket _bddPacket;
 
   private final BDDSourceManager _bddSrcManager;
 
   private final HeaderSpaceToBDD _headerSpaceToBDD;
 
-  private Map<String, IpSpace> _namedIpSpaces;
-
   public AclLineMatchExprToBDD(
-      BDDFactory factory,
+      BDDFactory bddFactory,
       BDDPacket packet,
       Map<String, Supplier<BDD>> aclEnv,
       Map<String, IpSpace> namedIpSpaces) {
     _aclEnv = ImmutableMap.copyOf(aclEnv);
-    _factory = factory;
-    _bddOps = new BDDOps(factory);
+    _bddFactory = bddFactory;
+    _bddOps = new BDDOps(bddFactory);
+    _bddPacket = packet;
     _bddSrcManager = BDDSourceManager.forInterfaces(packet, ImmutableSet.of());
-    _namedIpSpaces = ImmutableMap.copyOf(namedIpSpaces);
-    _headerSpaceToBDD = new HeaderSpaceToBDD(packet, _namedIpSpaces);
+    _headerSpaceToBDD = new HeaderSpaceToBDD(packet, namedIpSpaces);
   }
 
   public AclLineMatchExprToBDD(
-      BDDFactory factory,
+      BDDFactory bddFactory,
       BDDPacket packet,
       Map<String, Supplier<BDD>> aclEnv,
       Map<String, IpSpace> namedIpSpaces,
       @Nonnull BDDSourceManager bddSrcManager) {
     _aclEnv = ImmutableMap.copyOf(aclEnv);
+    _bddFactory = bddFactory;
+    _bddOps = new BDDOps(bddFactory);
+    _bddPacket = packet;
     _bddSrcManager = bddSrcManager;
-    _factory = factory;
-    _bddOps = new BDDOps(factory);
-    _namedIpSpaces = ImmutableMap.copyOf(namedIpSpaces);
-    _headerSpaceToBDD = new HeaderSpaceToBDD(packet, _namedIpSpaces);
+    _headerSpaceToBDD = new HeaderSpaceToBDD(packet, namedIpSpaces);
+  }
+
+  public BDDPacket getBDDPacket() {
+    return _bddPacket;
   }
 
   @Override
@@ -79,7 +83,7 @@ public class AclLineMatchExprToBDD implements GenericAclLineMatchExprVisitor<BDD
 
   @Override
   public BDD visitFalseExpr(FalseExpr falseExpr) {
-    return _factory.zero();
+    return _bddFactory.zero();
   }
 
   @Override
@@ -131,6 +135,6 @@ public class AclLineMatchExprToBDD implements GenericAclLineMatchExprVisitor<BDD
 
   @Override
   public BDD visitTrueExpr(TrueExpr trueExpr) {
-    return _factory.one();
+    return _bddFactory.one();
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/datamodel/acl/explanation/ConjunctsBuilderTest.java
+++ b/projects/batfish/src/test/java/org/batfish/datamodel/acl/explanation/ConjunctsBuilderTest.java
@@ -1,0 +1,54 @@
+package org.batfish.datamodel.acl.explanation;
+
+import static org.batfish.datamodel.acl.AclLineMatchExprs.FALSE;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.TRUE;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDst;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrc;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrcIp;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.collect.ImmutableMap;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.symbolic.bdd.AclLineMatchExprToBDD;
+import org.batfish.symbolic.bdd.BDDPacket;
+import org.junit.Test;
+
+public class ConjunctsBuilderTest {
+
+  @Test
+  public void testConjunctsBuilder() {
+    BDDPacket pkt = new BDDPacket();
+    AclLineMatchExprToBDD toBDD =
+        new AclLineMatchExprToBDD(pkt.getFactory(), pkt, ImmutableMap.of(), ImmutableMap.of());
+    ConjunctsBuilder andBuilder = new ConjunctsBuilder(toBDD);
+
+    assertThat(andBuilder.build(), equalTo(TRUE));
+
+    AclLineMatchExpr dstIp = matchDst(new Ip("1.2.3.4"));
+    AclLineMatchExpr dstPrefix = matchDst(Prefix.parse("1.2.3.0/24"));
+    AclLineMatchExpr srcIp = matchSrcIp("2.3.4.5");
+    AclLineMatchExpr srcPrefix = matchSrc(Prefix.parse("2.3.4.0/24"));
+
+    andBuilder.add(dstIp);
+    assertThat(andBuilder.build(), equalTo(dstIp));
+
+    // discard redundant conjunct
+    andBuilder.add(dstPrefix);
+    assertThat(andBuilder.build(), equalTo(dstIp));
+
+    andBuilder.add(srcPrefix);
+    assertThat(andBuilder.build(), equalTo(and(dstIp, srcPrefix)));
+
+    // replace conjunct made redundant by the new one
+    andBuilder.add(srcIp);
+    assertThat(andBuilder.build(), equalTo(and(dstIp, srcIp)));
+
+    // short-circuit
+    andBuilder.add(matchSrcIp("1.1.1.1"));
+    assertThat(andBuilder.build(), equalTo(FALSE));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/datamodel/acl/explanation/DisjunctsBuilderTest.java
+++ b/projects/batfish/src/test/java/org/batfish/datamodel/acl/explanation/DisjunctsBuilderTest.java
@@ -1,0 +1,54 @@
+package org.batfish.datamodel.acl.explanation;
+
+import static org.batfish.datamodel.acl.AclLineMatchExprs.FALSE;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.TRUE;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDst;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrc;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrcIp;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.or;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.acl.NotMatchExpr;
+import org.batfish.symbolic.bdd.AclLineMatchExprToBDD;
+import org.batfish.symbolic.bdd.BDDPacket;
+import org.junit.Test;
+
+public class DisjunctsBuilderTest {
+  @Test
+  public void testDisjunctsBuilder() {
+    BDDPacket pkt = new BDDPacket();
+    AclLineMatchExprToBDD toBDD =
+        new AclLineMatchExprToBDD(pkt.getFactory(), pkt, ImmutableMap.of(), ImmutableMap.of());
+    DisjunctsBuilder orBuilder = new DisjunctsBuilder(toBDD);
+
+    assertThat(orBuilder.build(), equalTo(FALSE));
+
+    AclLineMatchExpr dstIp = matchDst(new Ip("1.2.3.4"));
+    AclLineMatchExpr dstPrefix = matchDst(Prefix.parse("1.2.3.0/24"));
+    AclLineMatchExpr srcIp = matchSrcIp("2.3.4.5");
+    AclLineMatchExpr srcPrefix = matchSrc(Prefix.parse("2.3.4.0/24"));
+
+    orBuilder.add(dstPrefix);
+    assertThat(orBuilder.build(), equalTo(dstPrefix));
+
+    // discard redundant conjunct
+    orBuilder.add(dstIp);
+    assertThat(orBuilder.build(), equalTo(dstPrefix));
+
+    orBuilder.add(srcIp);
+    assertThat(orBuilder.build(), equalTo(or(dstPrefix, srcIp)));
+
+    // replace conjunct made redundant by the new one
+    orBuilder.add(srcPrefix);
+    assertThat(orBuilder.build(), equalTo(or(dstPrefix, srcPrefix)));
+
+    // short-circuit
+    orBuilder.add(new NotMatchExpr(dstPrefix));
+    assertThat(orBuilder.build(), equalTo(TRUE));
+  }
+}


### PR DESCRIPTION
The goal of these classes is to build sets of conjuncts/disjuncts that have no redundant members. 
 Most of the logic exists in the abstract base class `AclLineMatchExprSetBuilder`. It uses BDDs to determine which members are redundant and remove them as they are inserted. 