### PR TITLE
Simplify testfilter presentation

### DIFF
--- a/projects/allinone/src/test/java/org/batfish/question/testfilters/TestFiltersTest.java
+++ b/projects/allinone/src/test/java/org/batfish/question/testfilters/TestFiltersTest.java
@@ -99,7 +99,12 @@ public class TestFiltersTest {
     TestFiltersAnswerer answerer = new TestFiltersAnswerer(question, batfish);
     TableAnswerElement answer = answerer.answer();
 
-    /* Trace should be present for referencing acl with two events: being denied by referenced acl, and permited by referencing acl in later line */
+    /*
+     * Trace should be present for referencing acl with one event:
+     * Permitted by referencing acl
+     *
+     * NO event for referenced ACL since it's action was not match (default deny)
+     */
     assertThat(
         answer,
         hasRows(
@@ -110,7 +115,6 @@ public class TestFiltersTest {
                     hasEvents(
                         contains(
                             ImmutableList.of(
-                                isDefaultDeniedByIpAccessListNamed(referencedAcl.getName()),
                                 isPermittedByIpAccessListLineThat(
                                     PermittedByIpAccessListLineMatchers.hasName(acl.getName()))))),
                     Schema.ACL_TRACE))));

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclTracer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclTracer.java
@@ -4,10 +4,12 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import static org.batfish.common.util.CommonUtil.rangesContain;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableList.Builder;
+import com.google.common.graph.Traverser;
+import java.util.ArrayList;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.AclIpSpaceLine;
@@ -47,7 +49,9 @@ public final class AclTracer extends Evaluator {
 
   private final Map<IpSpace, String> _ipSpaceNames;
 
-  private Builder<TraceEvent> _traceEvents;
+  private final TraceEventNode _traceRoot;
+
+  private TraceEventNode _currentTreeNode;
 
   public AclTracer(
       @Nonnull Flow flow,
@@ -58,7 +62,8 @@ public final class AclTracer extends Evaluator {
     super(flow, srcInterface, availableAcls, namedIpSpaces);
     _ipSpaceNames = new IdentityHashMap<>();
     _ipSpaceMetadata = new IdentityHashMap<>();
-    _traceEvents = ImmutableList.builder();
+    _traceRoot = new TraceEventNode(null);
+    _currentTreeNode = _traceRoot;
     namedIpSpaces.forEach((name, ipSpace) -> _ipSpaceNames.put(ipSpace, name));
     namedIpSpaceMetadata.forEach(
         (name, ipSpaceMetadata) -> _ipSpaceMetadata.put(namedIpSpaces.get(name), ipSpaceMetadata));
@@ -89,14 +94,20 @@ public final class AclTracer extends Evaluator {
   }
 
   public @Nonnull AclTrace getTrace() {
-    return new AclTrace(_traceEvents.build());
+    return new AclTrace(
+        ImmutableList.copyOf(
+                Traverser.forTree(TraceEventNode::getChildren).depthFirstPreOrder(_traceRoot))
+            .stream()
+            .map(TraceEventNode::getEvent)
+            .filter(Objects::nonNull)
+            .collect(ImmutableList.toImmutableList()));
   }
 
   public void recordAction(
       @Nonnull IpAccessList ipAccessList, int index, @Nonnull IpAccessListLine line) {
     String lineDescription = firstNonNull(line.getName(), line.toString());
     if (line.getAction() == LineAction.PERMIT) {
-      _traceEvents.add(
+      _currentTreeNode.setEvent(
           new PermittedByIpAccessListLine(
               index,
               lineDescription,
@@ -104,7 +115,7 @@ public final class AclTracer extends Evaluator {
               ipAccessList.getSourceName(),
               ipAccessList.getSourceType()));
     } else {
-      _traceEvents.add(
+      _currentTreeNode.setEvent(
           new DeniedByIpAccessListLine(
               index,
               lineDescription,
@@ -123,7 +134,7 @@ public final class AclTracer extends Evaluator {
       String ipDescription,
       IpSpaceDescriber describer) {
     if (line.getAction() == LineAction.PERMIT) {
-      _traceEvents.add(
+      _currentTreeNode.setEvent(
           new PermittedByAclIpSpaceLine(
               aclIpSpaceName,
               ipSpaceMetadata,
@@ -132,7 +143,7 @@ public final class AclTracer extends Evaluator {
               ip,
               ipDescription));
     } else {
-      _traceEvents.add(
+      _currentTreeNode.setEvent(
           new DeniedByAclIpSpaceLine(
               aclIpSpaceName,
               ipSpaceMetadata,
@@ -144,7 +155,7 @@ public final class AclTracer extends Evaluator {
   }
 
   public void recordDefaultDeny(@Nonnull IpAccessList ipAccessList) {
-    _traceEvents.add(
+    _currentTreeNode.setEvent(
         new DefaultDeniedByIpAccessList(
             ipAccessList.getName(), ipAccessList.getSourceName(), ipAccessList.getSourceType()));
   }
@@ -154,7 +165,7 @@ public final class AclTracer extends Evaluator {
       @Nullable IpSpaceMetadata ipSpaceMetadata,
       Ip ip,
       String ipDescription) {
-    _traceEvents.add(
+    _currentTreeNode.setEvent(
         new DefaultDeniedByAclIpSpace(aclIpSpaceName, ip, ipDescription, ipSpaceMetadata));
   }
 
@@ -166,11 +177,11 @@ public final class AclTracer extends Evaluator {
       Ip ip,
       String ipDescription) {
     if (permit) {
-      _traceEvents.add(
+      _currentTreeNode.setEvent(
           new PermittedByNamedIpSpace(
               ip, ipDescription, ipSpaceDescription, ipSpaceMetadata, name));
     } else {
-      _traceEvents.add(
+      _currentTreeNode.setEvent(
           new DeniedByNamedIpSpace(ip, ipDescription, ipSpaceDescription, ipSpaceMetadata, name));
     }
   }
@@ -361,14 +372,18 @@ public final class AclTracer extends Evaluator {
 
   private boolean trace(@Nonnull IpAccessList ipAccessList) {
     List<IpAccessListLine> lines = ipAccessList.getLines();
+    newTrace();
     for (int i = 0; i < lines.size(); i++) {
       IpAccessListLine line = lines.get(i);
       if (line.getMatchCondition().accept(this)) {
         recordAction(ipAccessList, i, line);
+        endTrace();
         return line.getAction() == LineAction.PERMIT;
       }
+      nextLine();
     }
     recordDefaultDeny(ipAccessList);
+    endTrace();
     return false;
   }
 
@@ -392,5 +407,105 @@ public final class AclTracer extends Evaluator {
   @Override
   public Boolean visitPermittedByAcl(PermittedByAcl permittedByAcl) {
     return trace(_availableAcls.get(permittedByAcl.getAclName()));
+  }
+
+  @Override
+  public Boolean visitAndMatchExpr(AndMatchExpr andMatchExpr) {
+    return andMatchExpr
+        .getConjuncts()
+        .stream()
+        .allMatch(
+            c -> {
+              newTrace();
+              Boolean result = c.accept(this);
+              endTrace();
+              return result;
+            });
+  }
+
+  @Override
+  public Boolean visitOrMatchExpr(OrMatchExpr orMatchExpr) {
+    return orMatchExpr
+        .getDisjuncts()
+        .stream()
+        .anyMatch(
+            d -> {
+              newTrace();
+              Boolean result = d.accept(this);
+              endTrace();
+              return result;
+            });
+  }
+
+  /**
+   * Start a new trace at the current depth level. Indicates jump in a level of indirection to a new
+   * structure (even though said structure can still be part of a single ACL line.
+   */
+  public void newTrace() {
+    // Add new child, set it as current node
+    _currentTreeNode = _currentTreeNode.addChild(new TraceEventNode(_currentTreeNode));
+  }
+
+  /** End a trace: indicates that tracing of a structure is finished. */
+  public void endTrace() {
+    // Go up level of a tree, do not delete children
+    _currentTreeNode = _currentTreeNode.getParent();
+  }
+
+  /**
+   * Indicate we are moving on to the next line in current data structure (i.e., did not match
+   * previous line)
+   */
+  public void nextLine() {
+    // All previous children are of no interest since they resulted in a no-match on previous line
+    _currentTreeNode.clearChildren();
+  }
+
+  /** For building trace event trees */
+  private class TraceEventNode {
+    private @Nullable TraceEvent _event;
+    private @Nullable TraceEventNode _parent;
+    private @Nonnull List<TraceEventNode> _children;
+
+    // This is not a copy constructor, it's a constructor linking this tree node to a parent node
+    @SuppressWarnings("IncompleteCopyConstructor")
+    public TraceEventNode(@Nullable TraceEventNode parent) {
+      _event = null;
+      _parent = parent;
+      _children = new ArrayList<>();
+    }
+
+    @Nonnull
+    public List<TraceEventNode> getChildren() {
+      return _children;
+    }
+
+    @Nullable
+    public TraceEventNode getParent() {
+      return _parent;
+    }
+
+    @Nullable
+    public TraceEvent getEvent() {
+      return _event;
+    }
+
+    public void setParent(@Nullable TraceEventNode parent) {
+      _parent = parent;
+    }
+
+    public void setEvent(@Nonnull TraceEvent event) {
+      _event = event;
+    }
+
+    /** Adds a new child to this node trace node. Returns pointer to given node */
+    TraceEventNode addChild(@Nonnull TraceEventNode node) {
+      _children.add(node);
+      return node;
+    }
+
+    void clearChildren() {
+      _children.clear();
+    }
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclTracer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclTracer.java
@@ -476,37 +476,37 @@ public final class AclTracer extends Evaluator {
       _children = children;
     }
 
-    static TraceEventNode withParent(@Nullable TraceEventNode parent) {
+    private static TraceEventNode withParent(@Nullable TraceEventNode parent) {
       return new TraceEventNode(null, parent, new ArrayList<>());
     }
 
     @Nonnull
-    public List<TraceEventNode> getChildren() {
+    private List<TraceEventNode> getChildren() {
       return _children;
     }
 
     @Nullable
-    public TraceEventNode getParent() {
+    private TraceEventNode getParent() {
       return _parent;
     }
 
     @Nullable
-    public TraceEvent getEvent() {
+    private TraceEvent getEvent() {
       return _event;
     }
 
-    public void setEvent(@Nonnull TraceEvent event) {
+    private void setEvent(@Nonnull TraceEvent event) {
       _event = event;
     }
 
     /** Adds a new child to this node trace node. Returns pointer to given node */
-    TraceEventNode addChild(@Nonnull TraceEventNode node) {
+    private TraceEventNode addChild(@Nonnull TraceEventNode node) {
       _children.add(node);
       return node;
     }
 
     /** Clears all children from this node */
-    void clearChildren() {
+    private void clearChildren() {
       _children.clear();
     }
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/visitors/IpSpaceTracer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/visitors/IpSpaceTracer.java
@@ -46,6 +46,7 @@ public class IpSpaceTracer implements GenericIpSpaceVisitor<Boolean> {
   @Override
   public Boolean visitAclIpSpace(AclIpSpace aclIpSpace) {
     String name = _aclTracer.getIpSpaceNames().get(aclIpSpace);
+    _aclTracer.newTrace();
     List<AclIpSpaceLine> lines = aclIpSpace.getLines();
     for (int i = 0; i < lines.size(); i++) {
       AclIpSpaceLine line = lines.get(i);
@@ -60,13 +61,16 @@ public class IpSpaceTracer implements GenericIpSpaceVisitor<Boolean> {
               _ipDescription,
               _ipSpaceDescriber);
         }
+        _aclTracer.endTrace();
         return line.getAction() == LineAction.PERMIT;
       }
+      _aclTracer.nextLine();
     }
     if (name != null) {
       _aclTracer.recordDefaultDeny(
           name, _aclTracer.getIpSpaceMetadata().get(aclIpSpace), _ip, _ipDescription);
     }
+    _aclTracer.endTrace();
     return false;
   }
 
@@ -85,7 +89,10 @@ public class IpSpaceTracer implements GenericIpSpaceVisitor<Boolean> {
     String name = ipSpaceReference.getName();
     IpSpace ipSpace = _aclTracer.getNamedIpSpaces().get(name);
     if (ipSpace != null) {
-      return ipSpace.accept(this);
+      _aclTracer.newTrace();
+      Boolean accepted = ipSpace.accept(this);
+      _aclTracer.endTrace();
+      return accepted;
     } else {
       return false;
     }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/AclTracerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/AclTracerTest.java
@@ -1,11 +1,8 @@
 package org.batfish.datamodel.acl;
 
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasEvents;
-import static org.batfish.datamodel.matchers.DataModelMatchers.isDefaultDeniedByAclIpSpaceNamed;
 import static org.batfish.datamodel.matchers.DataModelMatchers.isDefaultDeniedByIpAccessListNamed;
-import static org.batfish.datamodel.matchers.DataModelMatchers.isDeniedByAclIpSpaceLineThat;
 import static org.batfish.datamodel.matchers.DataModelMatchers.isDeniedByIpAccessListLineThat;
-import static org.batfish.datamodel.matchers.DataModelMatchers.isDeniedByNamedIpSpace;
 import static org.batfish.datamodel.matchers.DataModelMatchers.isPermittedByAclIpSpaceLineThat;
 import static org.batfish.datamodel.matchers.DataModelMatchers.isPermittedByIpAccessListLineThat;
 import static org.batfish.datamodel.matchers.DataModelMatchers.isPermittedByNamedIpSpace;
@@ -28,7 +25,6 @@ import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.IpSpaceMetadata;
 import org.batfish.datamodel.IpSpaceReference;
 import org.batfish.datamodel.UniverseIpSpace;
-import org.batfish.datamodel.matchers.DeniedByAclIpSpaceLineMatchers;
 import org.batfish.datamodel.matchers.DeniedByIpAccessListLineMatchers;
 import org.batfish.datamodel.matchers.PermittedByAclIpSpaceLineMatchers;
 import org.batfish.datamodel.matchers.PermittedByIpAccessListLineMatchers;
@@ -83,12 +79,7 @@ public class AclTracerTest {
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
     assertThat(
-        trace,
-        hasEvents(
-            contains(
-                ImmutableList.of(
-                    isDefaultDeniedByAclIpSpaceNamed(ACL_IP_SPACE_NAME),
-                    isDefaultDeniedByIpAccessListNamed(ACL_NAME)))));
+        trace, hasEvents(contains(ImmutableList.of(isDefaultDeniedByIpAccessListNamed(ACL_NAME)))));
   }
 
   @Test
@@ -121,14 +112,14 @@ public class AclTracerTest {
         hasEvents(
             contains(
                 ImmutableList.of(
-                    isPermittedByIpAccessListLineThat(
-                        allOf(
-                            PermittedByIpAccessListLineMatchers.hasName(aclIndirectName),
-                            PermittedByIpAccessListLineMatchers.hasIndex(0))),
                     isDeniedByIpAccessListLineThat(
                         allOf(
                             DeniedByIpAccessListLineMatchers.hasName(ACL_NAME),
-                            DeniedByIpAccessListLineMatchers.hasIndex(0)))))));
+                            DeniedByIpAccessListLineMatchers.hasIndex(0))),
+                    isPermittedByIpAccessListLineThat(
+                        allOf(
+                            PermittedByIpAccessListLineMatchers.hasName(aclIndirectName),
+                            PermittedByIpAccessListLineMatchers.hasIndex(0)))))));
   }
 
   @Test
@@ -178,15 +169,7 @@ public class AclTracerTest {
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
     assertThat(
-        trace,
-        hasEvents(
-            contains(
-                ImmutableList.of(
-                    isDeniedByAclIpSpaceLineThat(
-                        allOf(
-                            DeniedByAclIpSpaceLineMatchers.hasName(ACL_IP_SPACE_NAME),
-                            DeniedByAclIpSpaceLineMatchers.hasIndex(0))),
-                    isDefaultDeniedByIpAccessListNamed(ACL_NAME)))));
+        trace, hasEvents(contains(ImmutableList.of(isDefaultDeniedByIpAccessListNamed(ACL_NAME)))));
   }
 
   @Test
@@ -213,12 +196,7 @@ public class AclTracerTest {
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
     assertThat(
-        trace,
-        hasEvents(
-            contains(
-                ImmutableList.of(
-                    isDeniedByNamedIpSpace(ipSpaceName),
-                    isDefaultDeniedByIpAccessListNamed(ACL_NAME)))));
+        trace, hasEvents(contains(ImmutableList.of(isDefaultDeniedByIpAccessListNamed(ACL_NAME)))));
   }
 
   @Test
@@ -313,14 +291,14 @@ public class AclTracerTest {
         hasEvents(
             contains(
                 ImmutableList.of(
-                    isPermittedByAclIpSpaceLineThat(
-                        allOf(
-                            PermittedByAclIpSpaceLineMatchers.hasName(ACL_IP_SPACE_NAME),
-                            PermittedByAclIpSpaceLineMatchers.hasIndex(0))),
                     isPermittedByIpAccessListLineThat(
                         allOf(
                             PermittedByIpAccessListLineMatchers.hasName(ACL_NAME),
-                            PermittedByIpAccessListLineMatchers.hasIndex(0)))))));
+                            PermittedByIpAccessListLineMatchers.hasIndex(0))),
+                    isPermittedByAclIpSpaceLineThat(
+                        allOf(
+                            PermittedByAclIpSpaceLineMatchers.hasName(ACL_IP_SPACE_NAME),
+                            PermittedByAclIpSpaceLineMatchers.hasIndex(0)))))));
   }
 
   @Test
@@ -349,11 +327,11 @@ public class AclTracerTest {
         hasEvents(
             contains(
                 ImmutableList.of(
-                    isPermittedByNamedIpSpace(ipSpaceName),
                     isPermittedByIpAccessListLineThat(
                         allOf(
                             PermittedByIpAccessListLineMatchers.hasName(ACL_NAME),
-                            PermittedByIpAccessListLineMatchers.hasIndex(0)))))));
+                            PermittedByIpAccessListLineMatchers.hasIndex(0))),
+                    isPermittedByNamedIpSpace(ipSpaceName)))));
   }
 
   @Test
@@ -412,6 +390,64 @@ public class AclTracerTest {
                     isPermittedByIpAccessListLineThat(
                         allOf(
                             PermittedByIpAccessListLineMatchers.hasName(ACL_NAME),
+                            PermittedByIpAccessListLineMatchers.hasIndex(0)))))));
+  }
+
+  @Test
+  public void testDeniedByIndirectAndExpr() {
+    String aclIndirectName1 = "aclIndirect1";
+    String aclIndirectName2 = "aclIndirect2";
+    IpAccessList acl =
+        IpAccessList.builder()
+            .setName(ACL_NAME)
+            .setLines(
+                ImmutableList.of(
+                    IpAccessListLine.accepting()
+                        .setMatchCondition(
+                            new AndMatchExpr(
+                                ImmutableList.of(
+                                    new PermittedByAcl(aclIndirectName1),
+                                    new PermittedByAcl(aclIndirectName2))))
+                        .build()))
+            .build();
+    IpAccessList aclIndirect1 =
+        IpAccessList.builder()
+            .setName(aclIndirectName1)
+            .setLines(ImmutableList.of(IpAccessListLine.ACCEPT_ALL))
+            .build();
+    IpAccessList aclIndirect2 =
+        IpAccessList.builder()
+            .setName(aclIndirectName2)
+            .setLines(
+                ImmutableList.of(
+                    IpAccessListLine.acceptingHeaderSpace(
+                        HeaderSpace.builder().setSrcIps(Ip.ZERO.toIpSpace()).build())))
+            .build();
+    Map<String, IpAccessList> availableAcls =
+        ImmutableMap.of(
+            ACL_NAME, acl, aclIndirectName1, aclIndirect1, aclIndirectName2, aclIndirect2);
+    Map<String, IpSpace> namedIpSpaces = ImmutableMap.of();
+    Map<String, IpSpaceMetadata> namedIpSpaceMetadata = ImmutableMap.of();
+    AclTrace trace =
+        AclTracer.trace(
+            acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
+
+    assertThat(
+        trace,
+        hasEvents(
+            contains(
+                ImmutableList.of(
+                    isPermittedByIpAccessListLineThat(
+                        allOf(
+                            PermittedByIpAccessListLineMatchers.hasName(ACL_NAME),
+                            PermittedByIpAccessListLineMatchers.hasIndex(0))),
+                    isPermittedByIpAccessListLineThat(
+                        allOf(
+                            PermittedByIpAccessListLineMatchers.hasName(aclIndirectName2),
+                            PermittedByIpAccessListLineMatchers.hasIndex(0))),
+                    isPermittedByIpAccessListLineThat(
+                        allOf(
+                            PermittedByIpAccessListLineMatchers.hasName(aclIndirectName1),
                             PermittedByIpAccessListLineMatchers.hasIndex(0)))))));
   }
 }


### PR DESCRIPTION
* Keep track of indirection by separating out traces
* Return the last action at each level of indirection
* Ignore the "nothing matched" events unless it's at the top level of the tree.