### PR TITLE
Remove duplicate vsys conversion call

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -445,9 +445,6 @@ public final class PaloAltoConfiguration extends VendorConfiguration {
       _c.getVrfs().put(nullVrf.getName(), nullVrf);
     }
 
-    // Handle converting items within virtual systems
-    convertVirtualSystems();
-
     // Count and mark simple structure usages and identify undefined references
     markConcreteStructure(
         PaloAltoStructureType.INTERFACE,


### PR DESCRIPTION
Looks like `convertVirtualSystems` is called twice (duplicated in a previous merge - called near the beginning and end of the `toVendorIndependentConfiguration` method).

This only needs to be called once to put vsys sub-components into the vendor independent model.
