### PR TITLE
tolerate missing entries in reverse reachable states map

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysis.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysis.java
@@ -275,6 +275,7 @@ public class BDDReachabilityAnalysis {
   }
 
   public Map<IngressLocation, BDD> getIngressLocationAcceptBDDs() {
+    BDD zero = _bddPacket.getFactory().zero();
     return _reverseReachableStates
         .get()
         .entrySet()
@@ -286,7 +287,7 @@ public class BDDReachabilityAnalysis {
         .collect(
             ImmutableMap.toImmutableMap(
                 entry -> toIngressLocation(entry.getKey()),
-                entry -> entry.getValue().get(Accept.INSTANCE)));
+                entry -> entry.getValue().getOrDefault(Accept.INSTANCE, zero)));
   }
 
   private static IngressLocation toIngressLocation(StateExpr stateExpr) {

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysis.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysis.java
@@ -290,7 +290,8 @@ public class BDDReachabilityAnalysis {
                 entry -> entry.getValue().getOrDefault(Accept.INSTANCE, zero)));
   }
 
-  private static IngressLocation toIngressLocation(StateExpr stateExpr) {
+  @VisibleForTesting
+  static IngressLocation toIngressLocation(StateExpr stateExpr) {
     Preconditions.checkArgument(
         stateExpr instanceof OriginateVrf || stateExpr instanceof OriginateInterfaceLink);
 

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisTest.java
@@ -1,5 +1,6 @@
 package org.batfish.bddreachability;
 
+import static org.batfish.bddreachability.BDDReachabilityAnalysis.toIngressLocation;
 import static org.batfish.bddreachability.TestNetwork.DST_PREFIX_1;
 import static org.batfish.bddreachability.TestNetwork.DST_PREFIX_2;
 import static org.batfish.bddreachability.TestNetwork.LINK_1_NETWORK;
@@ -17,6 +18,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.util.List;
@@ -414,5 +416,22 @@ public final class BDDReachabilityAnalysisTest {
 
     Flow flow = graph.multipathInconsistencyToFlow(inconsistency, FLOW_TAG);
     assertThat(flow, hasDstIp(_dstIface2Ip));
+  }
+
+  @Test
+  public void testDefaultAcceptBDD() {
+    BDDPacket pkt = new BDDPacket();
+    OriginateVrf originateVrf = new OriginateVrf("host", "vrf");
+    BDD one = pkt.getFactory().one();
+    BDDReachabilityAnalysis graph =
+        new BDDReachabilityAnalysis(
+            pkt,
+            ImmutableMap.of(originateVrf, one),
+            ImmutableMap.of(
+                originateVrf,
+                ImmutableMap.of(Drop.INSTANCE, new Edge(originateVrf, Drop.INSTANCE, one))));
+    assertThat(
+        graph.getIngressLocationAcceptBDDs(),
+        equalTo(ImmutableMap.of(toIngressLocation(originateVrf), pkt.getFactory().zero())));
   }
 }


### PR DESCRIPTION
`getIngressLocationAcceptBDDs()` returns for each ingress location the `BDD` representing headers that are accepted from that location. For locations that have no such headers, the map may be empty. Rather than crashing, default to `zero` `BDD`.