### PR TITLE
Fix NPE bug for layer2 neighbors

### DIFF
--- a/projects/question/src/main/java/org/batfish/question/NeighborsQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/NeighborsQuestionPlugin.java
@@ -23,7 +23,6 @@ import org.batfish.common.plugin.IBatfish;
 import org.batfish.common.plugin.Plugin;
 import org.batfish.common.topology.Layer1Topology;
 import org.batfish.common.topology.Layer2Topology;
-import org.batfish.common.topology.TopologyUtil;
 import org.batfish.common.util.CommonUtil;
 import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpPeerConfigId;
@@ -889,8 +888,7 @@ public class NeighborsQuestionPlugin extends QuestionPlugin {
           answerElement.setLayer1Neighbors(layer1Topology);
         }
         if (layer2) {
-          answerElement.setLayer2Neighbors(
-              TopologyUtil.computeLayer2Topology(layer1Topology, configurations));
+          answerElement.setLayer2Neighbors(_batfish.getLayer2Topology());
         }
       }
       return answerElement;

--- a/tests/basic/commands
+++ b/tests/basic/commands
@@ -12,7 +12,7 @@ test -raw tests/basic/topology.ref get-object testrig_pojo_topology
 test tests/basic/nodes-summary.ref get nodes summary=true
 test tests/basic/nodes.ref get nodes summary=false
 test tests/basic/neighbors-summary.ref get neighbors neighborTypes=["ebgp","ibgp","ospf","layer3"]
-test tests/basic/neighbors.ref get neighbors style=verbose, neighborTypes=["ebgp","ibgp","ospf","layer3"]
+test tests/basic/neighbors.ref get neighbors style=verbose, neighborTypes=["ebgp","ibgp","ospf","layer1","layer2","layer3"]
 test tests/basic/routes.ref get routes
 
 # some ref tests using delta snapshot


### PR DESCRIPTION
The bug: NeighborsAnswerElement was getting `layer2Neighbors` using:
`TopologyUtil.computeLayer2Topology(layer1Topology, configurations)`

`layer1Topology` came from `_batfish.getLayer1Topology()`, whose return value is nullable, but the `layer1Topology` parameter for `computeLayer2Topology` is nonnull.

The bug wasn't caught because our ref test didn't ask for layer2 neighbors. Now it does (current master would fail with the new test), but the neighbors ref didn't change because `layer2Neighbors` ends up null.

It looked like someone had already run into this in some other context, because Batfish already had a `getLayer2Topology` method with a safeguard against null `layer1Topology`.