### PR TITLE
Add VI Model question and tests

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/isis/IsisEdge.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/isis/IsisEdge.java
@@ -1,11 +1,14 @@
 package org.batfish.datamodel.isis;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
 import static java.util.Optional.empty;
 import static org.batfish.datamodel.isis.IsisLevel.LEVEL_1;
 import static org.batfish.datamodel.isis.IsisLevel.LEVEL_1_2;
 import static org.batfish.datamodel.isis.IsisLevel.LEVEL_2;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Map;
@@ -130,6 +133,12 @@ public final class IsisEdge implements Comparable<IsisEdge> {
     return LEVEL_2;
   }
 
+  private static final String PROP_CIRCUIT_TYPE = "circuitType";
+
+  private static final String PROP_NODE1 = "node1";
+
+  private static final String PROP_NODE2 = "node2";
+
   private final IsisLevel _circuitType;
 
   private final IsisNode _node1;
@@ -141,6 +150,14 @@ public final class IsisEdge implements Comparable<IsisEdge> {
     _circuitType = circuitType;
     _node1 = node1;
     _node2 = node2;
+  }
+
+  @JsonCreator
+  private static @Nonnull IsisEdge create(
+      @JsonProperty(PROP_CIRCUIT_TYPE) IsisLevel circuitType,
+      @JsonProperty(PROP_NODE1) IsisNode node1,
+      @JsonProperty(PROP_NODE2) IsisNode node2) {
+    return new IsisEdge(requireNonNull(circuitType), requireNonNull(node1), requireNonNull(node2));
   }
 
   @Override
@@ -165,16 +182,19 @@ public final class IsisEdge implements Comparable<IsisEdge> {
         && _node2.equals(rhs._node2);
   }
 
+  @JsonProperty(PROP_CIRCUIT_TYPE)
   @Nonnull
   public IsisLevel getCircuitType() {
     return _circuitType;
   }
 
+  @JsonProperty(PROP_NODE1)
   @Nonnull
   public IsisNode getNode1() {
     return _node1;
   }
 
+  @JsonProperty(PROP_NODE2)
   @Nonnull
   public IsisNode getNode2() {
     return _node2;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/isis/IsisNode.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/isis/IsisNode.java
@@ -13,7 +13,7 @@ import org.batfish.datamodel.NetworkConfigurations;
 
 public final class IsisNode implements Comparable<IsisNode> {
 
-  private static final String PROP_HOSTNAME = "hostname";
+  private static final String PROP_NODE = "node";
 
   private static final String PROP_INTERFACE = "interface";
 
@@ -28,7 +28,7 @@ public final class IsisNode implements Comparable<IsisNode> {
 
   @JsonCreator
   private static @Nonnull IsisNode create(
-      @JsonProperty(PROP_HOSTNAME) String hostname,
+      @JsonProperty(PROP_NODE) String hostname,
       @JsonProperty(PROP_INTERFACE) String interfaceName) {
     return new IsisNode(hostname, interfaceName);
   }
@@ -52,7 +52,7 @@ public final class IsisNode implements Comparable<IsisNode> {
     return _hostname.equals(rhs._hostname) && _interfaceName.equals(rhs._interfaceName);
   }
 
-  @JsonProperty(PROP_HOSTNAME)
+  @JsonProperty(PROP_NODE)
   public @Nonnull String getHostname() {
     return _hostname;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/isis/IsisNode.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/isis/IsisNode.java
@@ -2,6 +2,8 @@ package org.batfish.datamodel.isis;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Comparator;
 import java.util.Objects;
 import javax.annotation.Nonnull;
@@ -11,6 +13,10 @@ import org.batfish.datamodel.NetworkConfigurations;
 
 public final class IsisNode implements Comparable<IsisNode> {
 
+  private static final String PROP_HOSTNAME = "hostname";
+
+  private static final String PROP_INTERFACE = "interface";
+
   private final String _hostname;
 
   private final String _interfaceName;
@@ -18,6 +24,13 @@ public final class IsisNode implements Comparable<IsisNode> {
   public IsisNode(@Nonnull String hostname, @Nonnull String interfaceName) {
     _hostname = hostname;
     _interfaceName = interfaceName;
+  }
+
+  @JsonCreator
+  private static @Nonnull IsisNode create(
+      @JsonProperty(PROP_HOSTNAME) String hostname,
+      @JsonProperty(PROP_INTERFACE) String interfaceName) {
+    return new IsisNode(hostname, interfaceName);
   }
 
   @Override
@@ -39,6 +52,7 @@ public final class IsisNode implements Comparable<IsisNode> {
     return _hostname.equals(rhs._hostname) && _interfaceName.equals(rhs._interfaceName);
   }
 
+  @JsonProperty(PROP_HOSTNAME)
   public @Nonnull String getHostname() {
     return _hostname;
   }
@@ -47,6 +61,7 @@ public final class IsisNode implements Comparable<IsisNode> {
     return nc.getInterface(_hostname, _interfaceName);
   }
 
+  @JsonProperty(PROP_INTERFACE)
   public @Nonnull String getInterfaceName() {
     return _interfaceName;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/isis/IsisNode.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/isis/IsisNode.java
@@ -17,25 +17,24 @@ public final class IsisNode implements Comparable<IsisNode> {
 
   private static final String PROP_INTERFACE = "interface";
 
-  private final String _hostname;
+  private final String _node;
 
   private final String _interfaceName;
 
-  public IsisNode(@Nonnull String hostname, @Nonnull String interfaceName) {
-    _hostname = hostname;
+  public IsisNode(@Nonnull String node, @Nonnull String interfaceName) {
+    _node = node;
     _interfaceName = interfaceName;
   }
 
   @JsonCreator
   private static @Nonnull IsisNode create(
-      @JsonProperty(PROP_NODE) String hostname,
-      @JsonProperty(PROP_INTERFACE) String interfaceName) {
-    return new IsisNode(hostname, interfaceName);
+      @JsonProperty(PROP_NODE) String node, @JsonProperty(PROP_INTERFACE) String interfaceName) {
+    return new IsisNode(node, interfaceName);
   }
 
   @Override
   public int compareTo(IsisNode o) {
-    return Comparator.comparing(IsisNode::getHostname)
+    return Comparator.comparing(IsisNode::getNode)
         .thenComparing(IsisNode::getInterfaceName)
         .compare(this, o);
   }
@@ -49,16 +48,16 @@ public final class IsisNode implements Comparable<IsisNode> {
       return false;
     }
     IsisNode rhs = (IsisNode) o;
-    return _hostname.equals(rhs._hostname) && _interfaceName.equals(rhs._interfaceName);
+    return _node.equals(rhs._node) && _interfaceName.equals(rhs._interfaceName);
   }
 
   @JsonProperty(PROP_NODE)
-  public @Nonnull String getHostname() {
-    return _hostname;
+  public @Nonnull String getNode() {
+    return _node;
   }
 
   public @Nullable Interface getInterface(@Nonnull NetworkConfigurations nc) {
-    return nc.getInterface(_hostname, _interfaceName);
+    return nc.getInterface(_node, _interfaceName);
   }
 
   @JsonProperty(PROP_INTERFACE)
@@ -76,13 +75,13 @@ public final class IsisNode implements Comparable<IsisNode> {
 
   @Override
   public int hashCode() {
-    return Objects.hash(_hostname, _interfaceName);
+    return Objects.hash(_node, _interfaceName);
   }
 
   @Override
   public String toString() {
     return toStringHelper(getClass())
-        .add("hostname", _hostname)
+        .add("node", _node)
         .add("interfaceName", _interfaceName)
         .toString();
   }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -2452,7 +2452,7 @@ public class VirtualRouter implements Serializable {
             edge -> {
               VirtualRouter remoteVr =
                   allNodes
-                      .get(edge.getNode1().getHostname())
+                      .get(edge.getNode1().getNode())
                       .getVirtualRouters()
                       .get(edge.getNode1().getInterface(nc).getVrfName());
               Queue<RouteAdvertisement<IsisRoute>> queue =

--- a/projects/question/src/main/java/org/batfish/question/VIModelQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/VIModelQuestionPlugin.java
@@ -1,0 +1,312 @@
+package org.batfish.question;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.service.AutoService;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.graph.EndpointPair;
+import com.google.common.graph.Network;
+import com.google.common.graph.ValueGraph;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import org.batfish.common.Answerer;
+import org.batfish.common.plugin.IBatfish;
+import org.batfish.common.plugin.Plugin;
+import org.batfish.common.topology.Layer1Topology;
+import org.batfish.common.topology.Layer2Topology;
+import org.batfish.common.util.CommonUtil;
+import org.batfish.datamodel.BgpPeerConfig;
+import org.batfish.datamodel.BgpPeerConfigId;
+import org.batfish.datamodel.BgpSessionProperties;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.Edge;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.NetworkConfigurations;
+import org.batfish.datamodel.RipNeighbor;
+import org.batfish.datamodel.RipProcess;
+import org.batfish.datamodel.Topology;
+import org.batfish.datamodel.VerboseEdge;
+import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.answers.AnswerElement;
+import org.batfish.datamodel.collections.IpEdge;
+import org.batfish.datamodel.collections.VerboseBgpEdge;
+import org.batfish.datamodel.collections.VerboseEigrpEdge;
+import org.batfish.datamodel.collections.VerboseOspfEdge;
+import org.batfish.datamodel.collections.VerboseRipEdge;
+import org.batfish.datamodel.eigrp.EigrpEdge;
+import org.batfish.datamodel.eigrp.EigrpInterface;
+import org.batfish.datamodel.eigrp.EigrpTopology;
+import org.batfish.datamodel.ospf.OspfNeighbor;
+import org.batfish.datamodel.ospf.OspfProcess;
+import org.batfish.datamodel.questions.Question;
+
+@AutoService(Plugin.class)
+public class VIModelQuestionPlugin extends QuestionPlugin {
+
+  private static final Comparator<VerboseBgpEdge> VERBOSE_BGP_EDGE_COMPARATOR =
+      Comparator.nullsFirst(
+          Comparator.comparing(VerboseBgpEdge::getEdgeSummary)
+              .thenComparing(VerboseBgpEdge::getSession1Id)
+              .thenComparing(VerboseBgpEdge::getSession2Id));
+
+  public static class VIModelAnswerElement extends AnswerElement {
+    private static final String PROP_NODES = "nodes";
+
+    private static final String PROP_BGP_EDGES = "bgpEdges";
+
+    private static final String PROP_LAYER1_EDGES = "layer1Edges";
+
+    private static final String PROP_LAYER2_EDGES = "layer2Edges";
+
+    private static final String PROP_LAYER3_EDGES = "layer3Edges";
+
+    private static final String PROP_EIGRP_EDGES = "eigrpEdges";
+
+    private static final String PROP_OSPF_EDGES = "ospfEdges";
+
+    private static final String PROP_RIP_EDGES = "ripEdges";
+
+    private final SortedMap<String, Configuration> _nodes;
+
+    private SortedSet<VerboseBgpEdge> _bgpEdges;
+
+    private SortedSet<VerboseEigrpEdge> _eigrpEdges;
+
+    private Layer1Topology _layer1Edges;
+
+    private Layer2Topology _layer2Edges;
+
+    private SortedSet<VerboseEdge> _layer3Edges;
+
+    private SortedSet<VerboseOspfEdge> _ospfEdges;
+
+    private SortedSet<VerboseRipEdge> _ripEdges;
+
+    @JsonCreator
+    public VIModelAnswerElement(
+        @JsonProperty(PROP_NODES) SortedMap<String, Configuration> nodes,
+        @JsonProperty(PROP_BGP_EDGES) Set<VerboseBgpEdge> bgpEdges,
+        @JsonProperty(PROP_EIGRP_EDGES) SortedSet<VerboseEigrpEdge> eigrpEdges,
+        @JsonProperty(PROP_LAYER1_EDGES) Layer1Topology layer1Edges,
+        @JsonProperty(PROP_LAYER2_EDGES) Layer2Topology layer2Edges,
+        @JsonProperty(PROP_LAYER3_EDGES) SortedSet<VerboseEdge> layer3Edges,
+        @JsonProperty(PROP_OSPF_EDGES) SortedSet<VerboseOspfEdge> ospfEdges,
+        @JsonProperty(PROP_RIP_EDGES) SortedSet<VerboseRipEdge> ripEdges) {
+      _nodes = nodes;
+      _bgpEdges = new TreeSet<>(VERBOSE_BGP_EDGE_COMPARATOR);
+      _bgpEdges.addAll(bgpEdges);
+      _eigrpEdges = eigrpEdges;
+      _layer1Edges = layer1Edges;
+      _layer2Edges = layer2Edges;
+      _layer3Edges = layer3Edges;
+      _ospfEdges = ospfEdges;
+      _ripEdges = ripEdges;
+    }
+
+    @JsonProperty(PROP_NODES)
+    public SortedMap<String, Configuration> getNodes() {
+      return _nodes;
+    }
+
+    @JsonProperty(PROP_BGP_EDGES)
+    public SortedSet<VerboseBgpEdge> getBgpEdges() {
+      return _bgpEdges;
+    }
+
+    @JsonProperty(PROP_EIGRP_EDGES)
+    public SortedSet<VerboseEigrpEdge> getEigrpEdges() {
+      return _eigrpEdges;
+    }
+
+    @JsonProperty(PROP_LAYER1_EDGES)
+    public Layer1Topology getLayer1Edges() {
+      return _layer1Edges;
+    }
+
+    @JsonProperty(PROP_LAYER2_EDGES)
+    public Layer2Topology getLayer2Edges() {
+      return _layer2Edges;
+    }
+
+    @JsonProperty(PROP_LAYER3_EDGES)
+    public SortedSet<VerboseEdge> getLayer3Edges() {
+      return _layer3Edges;
+    }
+
+    @JsonProperty(PROP_OSPF_EDGES)
+    public SortedSet<VerboseOspfEdge> getOspfEdges() {
+      return _ospfEdges;
+    }
+
+    @JsonProperty(PROP_RIP_EDGES)
+    public SortedSet<VerboseRipEdge> getRipEdges() {
+      return _ripEdges;
+    }
+  }
+
+  public static class VIModelAnswerer extends Answerer {
+
+    public VIModelAnswerer(Question question, IBatfish batfish) {
+      super(question, batfish);
+    }
+
+    @Override
+    public VIModelAnswerElement answer() {
+      SortedMap<String, Configuration> configs = _batfish.loadConfigurations();
+      Topology topology = _batfish.getEnvironmentTopology();
+      Map<Ip, Set<String>> ipOwners = CommonUtil.computeIpNodeOwners(configs, true);
+      CommonUtil.initRemoteOspfNeighbors(configs, ipOwners, topology);
+      _batfish.initRemoteRipNeighbors(configs, ipOwners, topology);
+
+      return new VIModelAnswerElement(
+          configs,
+          getBgpEdges(configs, ipOwners),
+          getEigrpEdges(configs, topology),
+          _batfish.getLayer1Topology(),
+          _batfish.getLayer2Topology(),
+          getLayer3Edges(configs, topology),
+          getOspfEdges(configs),
+          getRipEdges(configs));
+    }
+
+    private static SortedSet<VerboseBgpEdge> getBgpEdges(
+        Map<String, Configuration> configs, Map<Ip, Set<String>> ipOwners) {
+      ValueGraph<BgpPeerConfigId, BgpSessionProperties> bgpTopology =
+          CommonUtil.initBgpTopology(configs, ipOwners, false, false, null, null);
+      SortedSet<VerboseBgpEdge> bgpEdges = new TreeSet<>(VERBOSE_BGP_EDGE_COMPARATOR);
+      for (EndpointPair<BgpPeerConfigId> session : bgpTopology.edges()) {
+        BgpPeerConfigId bgpPeerConfigId = session.source();
+        BgpPeerConfigId remoteBgpPeerConfigId = session.target();
+        NetworkConfigurations nc = NetworkConfigurations.of(configs);
+        String hostname = bgpPeerConfigId.getHostname();
+        String remoteHostname = remoteBgpPeerConfigId.getHostname();
+        BgpPeerConfig bgpPeerConfig = nc.getBgpPeerConfig(bgpPeerConfigId);
+        BgpPeerConfig remoteBgpPeerConfig = nc.getBgpPeerConfig(remoteBgpPeerConfigId);
+
+        if (bgpPeerConfig != null && remoteBgpPeerConfig != null) {
+          Ip localIp = bgpPeerConfig.getLocalIp();
+          Ip remoteIp = remoteBgpPeerConfig.getLocalIp();
+          IpEdge ipEdge = new IpEdge(hostname, localIp, remoteHostname, remoteIp);
+          bgpEdges.add(
+              new VerboseBgpEdge(
+                  bgpPeerConfig,
+                  remoteBgpPeerConfig,
+                  bgpPeerConfigId,
+                  remoteBgpPeerConfigId,
+                  ipEdge));
+        }
+      }
+      return bgpEdges;
+    }
+
+    private static SortedSet<VerboseEigrpEdge> getEigrpEdges(
+        Map<String, Configuration> configs, Topology topology) {
+      Network<EigrpInterface, EigrpEdge> eigrpTopology =
+          EigrpTopology.initEigrpTopology(configs, topology);
+      NetworkConfigurations nc = NetworkConfigurations.of(configs);
+      SortedSet<VerboseEigrpEdge> eigrpEdges = new TreeSet<>();
+      for (Configuration c : configs.values()) {
+        String hostname = c.getHostname();
+        for (Vrf vrf : c.getVrfs().values()) {
+          eigrpEdges.addAll(
+              vrf.getInterfaceNames()
+                  .stream()
+                  .map(ifaceName -> new EigrpInterface(hostname, ifaceName, vrf.getName()))
+                  .filter(eigrpTopology.nodes()::contains)
+                  .flatMap(n -> eigrpTopology.inEdges(n).stream())
+                  .map(edge -> new VerboseEigrpEdge(edge, edge.toIpEdge(nc)))
+                  .collect(ImmutableSortedSet.toImmutableSortedSet(Comparator.naturalOrder())));
+        }
+      }
+      return eigrpEdges;
+    }
+
+    private static SortedSet<VerboseEdge> getLayer3Edges(
+        Map<String, Configuration> configs, Topology topology) {
+      SortedSet<VerboseEdge> layer3Edges = new TreeSet<>();
+      for (Edge edge : topology.getEdges()) {
+        Configuration n1 = configs.get(edge.getNode1());
+        Interface i1 = n1.getAllInterfaces().get(edge.getInt1());
+        Configuration n2 = configs.get(edge.getNode2());
+        Interface i2 = n2.getAllInterfaces().get(edge.getInt2());
+        layer3Edges.add(new VerboseEdge(i1, i2, edge));
+      }
+      return layer3Edges;
+    }
+
+    private static SortedSet<VerboseOspfEdge> getOspfEdges(Map<String, Configuration> configs) {
+      SortedSet<VerboseOspfEdge> ospfEdges = new TreeSet<>();
+      for (Configuration c : configs.values()) {
+        String hostname = c.getHostname();
+        for (Vrf vrf : c.getVrfs().values()) {
+          OspfProcess proc = vrf.getOspfProcess();
+          if (proc != null) {
+            for (OspfNeighbor ospfNeighbor : proc.getOspfNeighbors().values()) {
+              OspfNeighbor remoteOspfNeighbor = ospfNeighbor.getRemoteOspfNeighbor();
+              if (remoteOspfNeighbor != null) {
+                Configuration remoteHost = remoteOspfNeighbor.getOwner();
+                String remoteHostname = remoteHost.getHostname();
+                Ip localIp = ospfNeighbor.getLocalIp();
+                Ip remoteIp = remoteOspfNeighbor.getLocalIp();
+                IpEdge edge = new IpEdge(hostname, localIp, remoteHostname, remoteIp);
+                ospfEdges.add(new VerboseOspfEdge(ospfNeighbor, remoteOspfNeighbor, edge));
+              }
+            }
+          }
+        }
+      }
+      return ospfEdges;
+    }
+
+    private static SortedSet<VerboseRipEdge> getRipEdges(Map<String, Configuration> configs) {
+      SortedSet<VerboseRipEdge> ripEdges = new TreeSet<>();
+      for (Configuration c : configs.values()) {
+        String hostname = c.getHostname();
+        for (Vrf vrf : c.getVrfs().values()) {
+          RipProcess proc = vrf.getRipProcess();
+          if (proc != null) {
+            for (RipNeighbor ripNeighbor : proc.getRipNeighbors().values()) {
+              RipNeighbor remoteRipNeighbor = ripNeighbor.getRemoteRipNeighbor();
+              if (remoteRipNeighbor != null) {
+                Configuration remoteHost = remoteRipNeighbor.getOwner();
+                String remoteHostname = remoteHost.getHostname();
+                Ip localIp = ripNeighbor.getLocalIp();
+                Ip remoteIp = remoteRipNeighbor.getLocalIp();
+                IpEdge edge = new IpEdge(hostname, localIp, remoteHostname, remoteIp);
+                ripEdges.add(new VerboseRipEdge(ripNeighbor, remoteRipNeighbor, edge));
+              }
+            }
+          }
+        }
+      }
+      return ripEdges;
+    }
+  }
+
+  public static class VIModelQuestion extends Question {
+    @Override
+    public boolean getDataPlane() {
+      return false;
+    }
+
+    @Override
+    public String getName() {
+      return "viModel";
+    }
+  }
+
+  @Override
+  protected Answerer createAnswerer(Question question, IBatfish batfish) {
+    return new VIModelAnswerer(question, batfish);
+  }
+
+  @Override
+  protected Question createQuestion() {
+    return new VIModelQuestion();
+  }
+}

--- a/projects/question/src/main/java/org/batfish/question/VIModelQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/VIModelQuestionPlugin.java
@@ -1,8 +1,12 @@
 package org.batfish.question;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.service.AutoService;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.graph.EndpointPair;
 import com.google.common.graph.Network;
@@ -13,6 +17,8 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.batfish.common.Answerer;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.common.plugin.Plugin;
@@ -97,54 +103,54 @@ public class VIModelQuestionPlugin extends QuestionPlugin {
         @JsonProperty(PROP_LAYER3_EDGES) SortedSet<VerboseEdge> layer3Edges,
         @JsonProperty(PROP_OSPF_EDGES) SortedSet<VerboseOspfEdge> ospfEdges,
         @JsonProperty(PROP_RIP_EDGES) SortedSet<VerboseRipEdge> ripEdges) {
-      _nodes = nodes;
+      _nodes = firstNonNull(nodes, ImmutableSortedMap.of());
       _bgpEdges = new TreeSet<>(VERBOSE_BGP_EDGE_COMPARATOR);
-      _bgpEdges.addAll(bgpEdges);
-      _eigrpEdges = eigrpEdges;
+      _bgpEdges.addAll(firstNonNull(bgpEdges, ImmutableSet.of()));
+      _eigrpEdges = firstNonNull(eigrpEdges, ImmutableSortedSet.of());
       _layer1Edges = layer1Edges;
       _layer2Edges = layer2Edges;
-      _layer3Edges = layer3Edges;
-      _ospfEdges = ospfEdges;
-      _ripEdges = ripEdges;
+      _layer3Edges = firstNonNull(layer3Edges, ImmutableSortedSet.of());
+      _ospfEdges = firstNonNull(ospfEdges, ImmutableSortedSet.of());
+      _ripEdges = firstNonNull(ripEdges, ImmutableSortedSet.of());
     }
 
     @JsonProperty(PROP_NODES)
-    public SortedMap<String, Configuration> getNodes() {
+    public @Nonnull SortedMap<String, Configuration> getNodes() {
       return _nodes;
     }
 
     @JsonProperty(PROP_BGP_EDGES)
-    public SortedSet<VerboseBgpEdge> getBgpEdges() {
+    public @Nonnull SortedSet<VerboseBgpEdge> getBgpEdges() {
       return _bgpEdges;
     }
 
     @JsonProperty(PROP_EIGRP_EDGES)
-    public SortedSet<VerboseEigrpEdge> getEigrpEdges() {
+    public @Nonnull SortedSet<VerboseEigrpEdge> getEigrpEdges() {
       return _eigrpEdges;
     }
 
     @JsonProperty(PROP_LAYER1_EDGES)
-    public Layer1Topology getLayer1Edges() {
+    public @Nullable Layer1Topology getLayer1Edges() {
       return _layer1Edges;
     }
 
     @JsonProperty(PROP_LAYER2_EDGES)
-    public Layer2Topology getLayer2Edges() {
+    public @Nullable Layer2Topology getLayer2Edges() {
       return _layer2Edges;
     }
 
     @JsonProperty(PROP_LAYER3_EDGES)
-    public SortedSet<VerboseEdge> getLayer3Edges() {
+    public @Nonnull SortedSet<VerboseEdge> getLayer3Edges() {
       return _layer3Edges;
     }
 
     @JsonProperty(PROP_OSPF_EDGES)
-    public SortedSet<VerboseOspfEdge> getOspfEdges() {
+    public @Nonnull SortedSet<VerboseOspfEdge> getOspfEdges() {
       return _ospfEdges;
     }
 
     @JsonProperty(PROP_RIP_EDGES)
-    public SortedSet<VerboseRipEdge> getRipEdges() {
+    public @Nonnull SortedSet<VerboseRipEdge> getRipEdges() {
       return _ripEdges;
     }
   }

--- a/projects/question/src/main/java/org/batfish/question/edges/EdgesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/edges/EdgesAnswerer.java
@@ -190,8 +190,8 @@ public class EdgesAnswerer extends Answerer {
         .filter(Objects::nonNull)
         .filter(
             isisEdge ->
-                includeNodes.contains(isisEdge.getNode1().getHostname())
-                    && includeRemoteNodes.contains(isisEdge.getNode2().getHostname()))
+                includeNodes.contains(isisEdge.getNode1().getNode())
+                    && includeRemoteNodes.contains(isisEdge.getNode2().getNode()))
         .map(EdgesAnswerer::isisEdgeToRow)
         .collect(Collectors.toCollection(HashMultiset::create));
   }
@@ -358,11 +358,11 @@ public class EdgesAnswerer extends Answerer {
     row.put(
             COL_INTERFACE,
             new NodeInterfacePair(
-                isisEdge.getNode1().getHostname(), isisEdge.getNode1().getInterfaceName()))
+                isisEdge.getNode1().getNode(), isisEdge.getNode1().getInterfaceName()))
         .put(
             COL_REMOTE_INTERFACE,
             new NodeInterfacePair(
-                isisEdge.getNode2().getHostname(), isisEdge.getNode2().getInterfaceName()));
+                isisEdge.getNode2().getNode(), isisEdge.getNode2().getInterfaceName()));
     return row.build();
   }
 

--- a/questions/experimental/viModel.json
+++ b/questions/experimental/viModel.json
@@ -1,0 +1,13 @@
+{
+    "class": "org.batfish.question.VIModelQuestionPlugin$VIModelQuestion",
+    "differential": false,
+    "instance": {
+        "description": "Lists configuration attributes of nodes and edges in the network",
+        "instanceName": "viModel",
+        "longDescription": "Returns a JSON dictionary with all of the configuration parameters and neighbor relations stored in the vendor independent data-model.",
+        "tags": [
+            "dataModel"
+        ],
+        "variables": {}
+    }
+}

--- a/tests/basic/commands
+++ b/tests/basic/commands
@@ -9,6 +9,7 @@ test -compareall tests/basic/init.ref init-snapshot networks/example basic-examp
 test tests/basic/parse-status.ref get fileparsestatus
 test -compareall tests/basic/genDp.ref generate-dataplane
 test -raw tests/basic/topology.ref get-object testrig_pojo_topology
+test tests/basic/viModel.ref get viModel
 test tests/basic/nodes-summary.ref get nodes summary=true
 test tests/basic/nodes.ref get nodes summary=false
 test tests/basic/neighbors-summary.ref get neighbors neighborTypes=["ebgp","ibgp","ospf","layer3"]

--- a/tests/basic/viModel.ref
+++ b/tests/basic/viModel.ref
@@ -1,5086 +1,7158 @@
 [
   {
     "class" : "org.batfish.question.VIModelQuestionPlugin$VIModelAnswerElement",
-    "bgpEdges" : [
-      {
-        "edgeSummary" : {
-          "ip1" : "1.1.1.1",
-          "ip2" : "1.10.1.1",
-          "node1" : "as1border1",
-          "node2" : "as1core1"
-        },
-        "node1Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 16843009,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:1.10.1.1~",
-          "group" : "as1",
-          "localAs" : 1,
-          "localIp" : "1.1.1.1",
-          "peerAddress" : "1.10.1.1",
-          "remoteAs" : 1,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node1SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as1border1",
-          "prefix" : "1.10.1.1/32",
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 17432833,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:1.1.1.1~",
-          "group" : "as1",
-          "localAs" : 1,
-          "localIp" : "1.10.1.1",
-          "peerAddress" : "1.1.1.1",
-          "remoteAs" : 1,
-          "routeReflectorClient" : true,
-          "sendCommunity" : true
-        },
-        "node2SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as1core1",
-          "prefix" : "1.1.1.1/32",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "10.12.11.1",
-          "ip2" : "10.12.11.2",
-          "node1" : "as1border1",
-          "node2" : "as2border1"
-        },
-        "node1Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 16843009,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.12.11.2~",
-          "exportPolicySources" : [
-            "as1_to_as2"
-          ],
-          "group" : "as2",
-          "importPolicy" : "as2_to_as1",
-          "importPolicySources" : [
-            "as2_to_as1"
-          ],
-          "localAs" : 1,
-          "localIp" : "10.12.11.1",
-          "peerAddress" : "10.12.11.2",
-          "remoteAs" : 2,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node1SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as1border1",
-          "prefix" : "10.12.11.2/32",
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620225,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.12.11.1~",
-          "exportPolicySources" : [
-            "as2_to_as1"
-          ],
-          "group" : "as1",
-          "importPolicy" : "as1_to_as2",
-          "importPolicySources" : [
-            "as1_to_as2"
-          ],
-          "localAs" : 2,
-          "localIp" : "10.12.11.2",
-          "peerAddress" : "10.12.11.1",
-          "remoteAs" : 1,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node2SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2border1",
-          "prefix" : "10.12.11.1/32",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "1.2.2.2",
-          "ip2" : "1.10.1.1",
-          "node1" : "as1border2",
-          "node2" : "as1core1"
-        },
-        "node1Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 16908802,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:1.10.1.1~",
-          "group" : "as1",
-          "localAs" : 1,
-          "localIp" : "1.2.2.2",
-          "peerAddress" : "1.10.1.1",
-          "remoteAs" : 1,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node1SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as1border2",
-          "prefix" : "1.10.1.1/32",
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 17432833,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:1.2.2.2~",
-          "group" : "as1",
-          "localAs" : 1,
-          "localIp" : "1.10.1.1",
-          "peerAddress" : "1.2.2.2",
-          "remoteAs" : 1,
-          "routeReflectorClient" : true,
-          "sendCommunity" : true
-        },
-        "node2SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as1core1",
-          "prefix" : "1.2.2.2/32",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "10.13.22.1",
-          "ip2" : "10.13.22.3",
-          "node1" : "as1border2",
-          "node2" : "as3border2"
-        },
-        "node1Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 16908802,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.13.22.3~",
-          "exportPolicySources" : [
-            "as1_to_as3"
-          ],
-          "group" : "as3",
-          "importPolicy" : "as3_to_as1",
-          "importPolicySources" : [
-            "as3_to_as1"
-          ],
-          "localAs" : 1,
-          "localIp" : "10.13.22.1",
-          "peerAddress" : "10.13.22.3",
-          "remoteAs" : 3,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node1SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as1border2",
-          "prefix" : "10.13.22.3/32",
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 50463234,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.13.22.1~",
-          "exportPolicySources" : [
-            "as3_to_as1"
-          ],
-          "group" : "as1",
-          "importPolicy" : "as1_to_as3",
-          "importPolicySources" : [
-            "as1_to_as3"
-          ],
-          "localAs" : 3,
-          "localIp" : "10.13.22.3",
-          "peerAddress" : "10.13.22.1",
-          "remoteAs" : 1,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node2SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as3border2",
-          "prefix" : "10.13.22.1/32",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "1.10.1.1",
-          "ip2" : "1.1.1.1",
-          "node1" : "as1core1",
-          "node2" : "as1border1"
-        },
-        "node1Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 17432833,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:1.1.1.1~",
-          "group" : "as1",
-          "localAs" : 1,
-          "localIp" : "1.10.1.1",
-          "peerAddress" : "1.1.1.1",
-          "remoteAs" : 1,
-          "routeReflectorClient" : true,
-          "sendCommunity" : true
-        },
-        "node1SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as1core1",
-          "prefix" : "1.1.1.1/32",
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 16843009,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:1.10.1.1~",
-          "group" : "as1",
-          "localAs" : 1,
-          "localIp" : "1.1.1.1",
-          "peerAddress" : "1.10.1.1",
-          "remoteAs" : 1,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node2SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as1border1",
-          "prefix" : "1.10.1.1/32",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "1.10.1.1",
-          "ip2" : "1.2.2.2",
-          "node1" : "as1core1",
-          "node2" : "as1border2"
-        },
-        "node1Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 17432833,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:1.2.2.2~",
-          "group" : "as1",
-          "localAs" : 1,
-          "localIp" : "1.10.1.1",
-          "peerAddress" : "1.2.2.2",
-          "remoteAs" : 1,
-          "routeReflectorClient" : true,
-          "sendCommunity" : true
-        },
-        "node1SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as1core1",
-          "prefix" : "1.2.2.2/32",
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 16908802,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:1.10.1.1~",
-          "group" : "as1",
-          "localAs" : 1,
-          "localIp" : "1.2.2.2",
-          "peerAddress" : "1.10.1.1",
-          "remoteAs" : 1,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node2SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as1border2",
-          "prefix" : "1.10.1.1/32",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "2.1.1.1",
-          "ip2" : "2.1.2.1",
-          "node1" : "as2border1",
-          "node2" : "as2core1"
-        },
-        "node1Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620225,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~",
-          "group" : "as2",
-          "localAs" : 2,
-          "localIp" : "2.1.1.1",
-          "peerAddress" : "2.1.2.1",
-          "remoteAs" : 2,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node1SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2border1",
-          "prefix" : "2.1.2.1/32",
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620481,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.1.1~",
-          "group" : "as2",
-          "localAs" : 2,
-          "localIp" : "2.1.2.1",
-          "peerAddress" : "2.1.1.1",
-          "remoteAs" : 2,
-          "routeReflectorClient" : true,
-          "sendCommunity" : true
-        },
-        "node2SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2core1",
-          "prefix" : "2.1.1.1/32",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "2.1.1.1",
-          "ip2" : "2.1.2.2",
-          "node1" : "as2border1",
-          "node2" : "as2core2"
-        },
-        "node1Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620225,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~",
-          "group" : "as2",
-          "localAs" : 2,
-          "localIp" : "2.1.1.1",
-          "peerAddress" : "2.1.2.2",
-          "remoteAs" : 2,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node1SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2border1",
-          "prefix" : "2.1.2.2/32",
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620482,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.1.1~",
-          "group" : "as2",
-          "localAs" : 2,
-          "localIp" : "2.1.2.2",
-          "peerAddress" : "2.1.1.1",
-          "remoteAs" : 2,
-          "routeReflectorClient" : true,
-          "sendCommunity" : true
-        },
-        "node2SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2core2",
-          "prefix" : "2.1.1.1/32",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "10.12.11.2",
-          "ip2" : "10.12.11.1",
-          "node1" : "as2border1",
-          "node2" : "as1border1"
-        },
-        "node1Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620225,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.12.11.1~",
-          "exportPolicySources" : [
-            "as2_to_as1"
-          ],
-          "group" : "as1",
-          "importPolicy" : "as1_to_as2",
-          "importPolicySources" : [
-            "as1_to_as2"
-          ],
-          "localAs" : 2,
-          "localIp" : "10.12.11.2",
-          "peerAddress" : "10.12.11.1",
-          "remoteAs" : 1,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node1SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2border1",
-          "prefix" : "10.12.11.1/32",
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 16843009,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.12.11.2~",
-          "exportPolicySources" : [
-            "as1_to_as2"
-          ],
-          "group" : "as2",
-          "importPolicy" : "as2_to_as1",
-          "importPolicySources" : [
-            "as2_to_as1"
-          ],
-          "localAs" : 1,
-          "localIp" : "10.12.11.1",
-          "peerAddress" : "10.12.11.2",
-          "remoteAs" : 2,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node2SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as1border1",
-          "prefix" : "10.12.11.2/32",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "2.1.1.2",
-          "ip2" : "2.1.2.1",
-          "node1" : "as2border2",
-          "node2" : "as2core1"
-        },
-        "node1Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620226,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~",
-          "group" : "as2",
-          "localAs" : 2,
-          "localIp" : "2.1.1.2",
-          "peerAddress" : "2.1.2.1",
-          "remoteAs" : 2,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node1SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2border2",
-          "prefix" : "2.1.2.1/32",
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620481,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.1.2~",
-          "group" : "as2",
-          "localAs" : 2,
-          "localIp" : "2.1.2.1",
-          "peerAddress" : "2.1.1.2",
-          "remoteAs" : 2,
-          "routeReflectorClient" : true,
-          "sendCommunity" : true
-        },
-        "node2SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2core1",
-          "prefix" : "2.1.1.2/32",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "2.1.1.2",
-          "ip2" : "2.1.2.2",
-          "node1" : "as2border2",
-          "node2" : "as2core2"
-        },
-        "node1Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620226,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~",
-          "group" : "as2",
-          "localAs" : 2,
-          "localIp" : "2.1.1.2",
-          "peerAddress" : "2.1.2.2",
-          "remoteAs" : 2,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node1SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2border2",
-          "prefix" : "2.1.2.2/32",
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620482,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.1.2~",
-          "group" : "as2",
-          "localAs" : 2,
-          "localIp" : "2.1.2.2",
-          "peerAddress" : "2.1.1.2",
-          "remoteAs" : 2,
-          "routeReflectorClient" : true,
-          "sendCommunity" : true
-        },
-        "node2SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2core2",
-          "prefix" : "2.1.1.2/32",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "10.23.21.2",
-          "ip2" : "10.23.21.3",
-          "node1" : "as2border2",
-          "node2" : "as3border1"
-        },
-        "node1Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620226,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.23.21.3~",
-          "exportPolicySources" : [
-            "as2_to_as3"
-          ],
-          "group" : "as3",
-          "importPolicy" : "as3_to_as2",
-          "importPolicySources" : [
-            "as3_to_as2"
-          ],
-          "localAs" : 2,
-          "localIp" : "10.23.21.2",
-          "peerAddress" : "10.23.21.3",
-          "remoteAs" : 3,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node1SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2border2",
-          "prefix" : "10.23.21.3/32",
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 50397441,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.23.21.2~",
-          "exportPolicySources" : [
-            "as3_to_as2"
-          ],
-          "group" : "as2",
-          "importPolicy" : "as2_to_as3",
-          "importPolicySources" : [
-            "as2_to_as3"
-          ],
-          "localAs" : 3,
-          "localIp" : "10.23.21.3",
-          "peerAddress" : "10.23.21.2",
-          "remoteAs" : 2,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node2SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as3border1",
-          "prefix" : "10.23.21.2/32",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "2.1.2.1",
-          "ip2" : "2.1.1.1",
-          "node1" : "as2core1",
-          "node2" : "as2border1"
-        },
-        "node1Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620481,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.1.1~",
-          "group" : "as2",
-          "localAs" : 2,
-          "localIp" : "2.1.2.1",
-          "peerAddress" : "2.1.1.1",
-          "remoteAs" : 2,
-          "routeReflectorClient" : true,
-          "sendCommunity" : true
-        },
-        "node1SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2core1",
-          "prefix" : "2.1.1.1/32",
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620225,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~",
-          "group" : "as2",
-          "localAs" : 2,
-          "localIp" : "2.1.1.1",
-          "peerAddress" : "2.1.2.1",
-          "remoteAs" : 2,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node2SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2border1",
-          "prefix" : "2.1.2.1/32",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "2.1.2.1",
-          "ip2" : "2.1.1.2",
-          "node1" : "as2core1",
-          "node2" : "as2border2"
-        },
-        "node1Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620481,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.1.2~",
-          "group" : "as2",
-          "localAs" : 2,
-          "localIp" : "2.1.2.1",
-          "peerAddress" : "2.1.1.2",
-          "remoteAs" : 2,
-          "routeReflectorClient" : true,
-          "sendCommunity" : true
-        },
-        "node1SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2core1",
-          "prefix" : "2.1.1.2/32",
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620226,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~",
-          "group" : "as2",
-          "localAs" : 2,
-          "localIp" : "2.1.1.2",
-          "peerAddress" : "2.1.2.1",
-          "remoteAs" : 2,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node2SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2border2",
-          "prefix" : "2.1.2.1/32",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "2.1.2.1",
-          "ip2" : "2.1.3.1",
-          "node1" : "as2core1",
-          "node2" : "as2dist1"
-        },
-        "node1Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620481,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.3.1~",
-          "group" : "as2",
-          "localAs" : 2,
-          "localIp" : "2.1.2.1",
-          "peerAddress" : "2.1.3.1",
-          "remoteAs" : 2,
-          "routeReflectorClient" : true,
-          "sendCommunity" : true
-        },
-        "node1SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2core1",
-          "prefix" : "2.1.3.1/32",
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620737,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~",
-          "group" : "as2",
-          "localAs" : 2,
-          "localIp" : "2.1.3.1",
-          "peerAddress" : "2.1.2.1",
-          "remoteAs" : 2,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node2SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2dist1",
-          "prefix" : "2.1.2.1/32",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "2.1.2.1",
-          "ip2" : "2.1.3.2",
-          "node1" : "as2core1",
-          "node2" : "as2dist2"
-        },
-        "node1Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620481,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.3.2~",
-          "group" : "as2",
-          "localAs" : 2,
-          "localIp" : "2.1.2.1",
-          "peerAddress" : "2.1.3.2",
-          "remoteAs" : 2,
-          "routeReflectorClient" : true,
-          "sendCommunity" : true
-        },
-        "node1SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2core1",
-          "prefix" : "2.1.3.2/32",
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620738,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~",
-          "group" : "as2",
-          "localAs" : 2,
-          "localIp" : "2.1.3.2",
-          "peerAddress" : "2.1.2.1",
-          "remoteAs" : 2,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node2SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2dist2",
-          "prefix" : "2.1.2.1/32",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "2.1.2.2",
-          "ip2" : "2.1.1.1",
-          "node1" : "as2core2",
-          "node2" : "as2border1"
-        },
-        "node1Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620482,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.1.1~",
-          "group" : "as2",
-          "localAs" : 2,
-          "localIp" : "2.1.2.2",
-          "peerAddress" : "2.1.1.1",
-          "remoteAs" : 2,
-          "routeReflectorClient" : true,
-          "sendCommunity" : true
-        },
-        "node1SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2core2",
-          "prefix" : "2.1.1.1/32",
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620225,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~",
-          "group" : "as2",
-          "localAs" : 2,
-          "localIp" : "2.1.1.1",
-          "peerAddress" : "2.1.2.2",
-          "remoteAs" : 2,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node2SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2border1",
-          "prefix" : "2.1.2.2/32",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "2.1.2.2",
-          "ip2" : "2.1.1.2",
-          "node1" : "as2core2",
-          "node2" : "as2border2"
-        },
-        "node1Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620482,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.1.2~",
-          "group" : "as2",
-          "localAs" : 2,
-          "localIp" : "2.1.2.2",
-          "peerAddress" : "2.1.1.2",
-          "remoteAs" : 2,
-          "routeReflectorClient" : true,
-          "sendCommunity" : true
-        },
-        "node1SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2core2",
-          "prefix" : "2.1.1.2/32",
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620226,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~",
-          "group" : "as2",
-          "localAs" : 2,
-          "localIp" : "2.1.1.2",
-          "peerAddress" : "2.1.2.2",
-          "remoteAs" : 2,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node2SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2border2",
-          "prefix" : "2.1.2.2/32",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "2.1.2.2",
-          "ip2" : "2.1.3.1",
-          "node1" : "as2core2",
-          "node2" : "as2dist1"
-        },
-        "node1Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620482,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.3.1~",
-          "group" : "as2",
-          "localAs" : 2,
-          "localIp" : "2.1.2.2",
-          "peerAddress" : "2.1.3.1",
-          "remoteAs" : 2,
-          "routeReflectorClient" : true,
-          "sendCommunity" : true
-        },
-        "node1SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2core2",
-          "prefix" : "2.1.3.1/32",
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620737,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~",
-          "group" : "as2",
-          "localAs" : 2,
-          "localIp" : "2.1.3.1",
-          "peerAddress" : "2.1.2.2",
-          "remoteAs" : 2,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node2SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2dist1",
-          "prefix" : "2.1.2.2/32",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "2.1.2.2",
-          "ip2" : "2.1.3.2",
-          "node1" : "as2core2",
-          "node2" : "as2dist2"
-        },
-        "node1Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620482,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.3.2~",
-          "group" : "as2",
-          "localAs" : 2,
-          "localIp" : "2.1.2.2",
-          "peerAddress" : "2.1.3.2",
-          "remoteAs" : 2,
-          "routeReflectorClient" : true,
-          "sendCommunity" : true
-        },
-        "node1SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2core2",
-          "prefix" : "2.1.3.2/32",
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620738,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~",
-          "group" : "as2",
-          "localAs" : 2,
-          "localIp" : "2.1.3.2",
-          "peerAddress" : "2.1.2.2",
-          "remoteAs" : 2,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node2SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2dist2",
-          "prefix" : "2.1.2.2/32",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "2.34.101.4",
-          "ip2" : "2.34.101.3",
-          "node1" : "as2dept1",
-          "node2" : "as2dist1"
-        },
-        "node1Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620993,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.34.101.3~",
-          "exportPolicySources" : [
-            "dept_to_as2"
-          ],
-          "group" : "as2",
-          "importPolicy" : "as2_to_dept",
-          "importPolicySources" : [
-            "as2_to_dept"
-          ],
-          "localAs" : 65001,
-          "localIp" : "2.34.101.4",
-          "peerAddress" : "2.34.101.3",
-          "remoteAs" : 2,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node1SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2dept1",
-          "prefix" : "2.34.101.3/32",
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620737,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.34.101.4~",
-          "exportPolicySources" : [
-            "as2dist_to_dept"
-          ],
-          "group" : "dept",
-          "importPolicy" : "dept_to_as2dist",
-          "importPolicySources" : [
-            "dept_to_as2dist"
-          ],
-          "localAs" : 2,
-          "localIp" : "2.34.101.3",
-          "peerAddress" : "2.34.101.4",
-          "remoteAs" : 65001,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node2SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2dist1",
-          "prefix" : "2.34.101.4/32",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "2.34.201.4",
-          "ip2" : "2.34.201.3",
-          "node1" : "as2dept1",
-          "node2" : "as2dist2"
-        },
-        "node1Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620993,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.34.201.3~",
-          "exportPolicySources" : [
-            "dept_to_as2"
-          ],
-          "group" : "as2",
-          "importPolicy" : "as2_to_dept",
-          "importPolicySources" : [
-            "as2_to_dept"
-          ],
-          "localAs" : 65001,
-          "localIp" : "2.34.201.4",
-          "peerAddress" : "2.34.201.3",
-          "remoteAs" : 2,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node1SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2dept1",
-          "prefix" : "2.34.201.3/32",
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620738,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.34.201.4~",
-          "exportPolicySources" : [
-            "as2dist_to_dept"
-          ],
-          "group" : "dept",
-          "importPolicy" : "dept_to_as2dist",
-          "importPolicySources" : [
-            "dept_to_as2dist"
-          ],
-          "localAs" : 2,
-          "localIp" : "2.34.201.3",
-          "peerAddress" : "2.34.201.4",
-          "remoteAs" : 65001,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node2SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2dist2",
-          "prefix" : "2.34.201.4/32",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "2.1.3.1",
-          "ip2" : "2.1.2.1",
-          "node1" : "as2dist1",
-          "node2" : "as2core1"
-        },
-        "node1Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620737,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~",
-          "group" : "as2",
-          "localAs" : 2,
-          "localIp" : "2.1.3.1",
-          "peerAddress" : "2.1.2.1",
-          "remoteAs" : 2,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node1SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2dist1",
-          "prefix" : "2.1.2.1/32",
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620481,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.3.1~",
-          "group" : "as2",
-          "localAs" : 2,
-          "localIp" : "2.1.2.1",
-          "peerAddress" : "2.1.3.1",
-          "remoteAs" : 2,
-          "routeReflectorClient" : true,
-          "sendCommunity" : true
-        },
-        "node2SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2core1",
-          "prefix" : "2.1.3.1/32",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "2.1.3.1",
-          "ip2" : "2.1.2.2",
-          "node1" : "as2dist1",
-          "node2" : "as2core2"
-        },
-        "node1Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620737,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~",
-          "group" : "as2",
-          "localAs" : 2,
-          "localIp" : "2.1.3.1",
-          "peerAddress" : "2.1.2.2",
-          "remoteAs" : 2,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node1SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2dist1",
-          "prefix" : "2.1.2.2/32",
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620482,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.3.1~",
-          "group" : "as2",
-          "localAs" : 2,
-          "localIp" : "2.1.2.2",
-          "peerAddress" : "2.1.3.1",
-          "remoteAs" : 2,
-          "routeReflectorClient" : true,
-          "sendCommunity" : true
-        },
-        "node2SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2core2",
-          "prefix" : "2.1.3.1/32",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "2.34.101.3",
-          "ip2" : "2.34.101.4",
-          "node1" : "as2dist1",
-          "node2" : "as2dept1"
-        },
-        "node1Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620737,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.34.101.4~",
-          "exportPolicySources" : [
-            "as2dist_to_dept"
-          ],
-          "group" : "dept",
-          "importPolicy" : "dept_to_as2dist",
-          "importPolicySources" : [
-            "dept_to_as2dist"
-          ],
-          "localAs" : 2,
-          "localIp" : "2.34.101.3",
-          "peerAddress" : "2.34.101.4",
-          "remoteAs" : 65001,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node1SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2dist1",
-          "prefix" : "2.34.101.4/32",
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620993,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.34.101.3~",
-          "exportPolicySources" : [
-            "dept_to_as2"
-          ],
-          "group" : "as2",
-          "importPolicy" : "as2_to_dept",
-          "importPolicySources" : [
-            "as2_to_dept"
-          ],
-          "localAs" : 65001,
-          "localIp" : "2.34.101.4",
-          "peerAddress" : "2.34.101.3",
-          "remoteAs" : 2,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node2SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2dept1",
-          "prefix" : "2.34.101.3/32",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "2.1.3.2",
-          "ip2" : "2.1.2.1",
-          "node1" : "as2dist2",
-          "node2" : "as2core1"
-        },
-        "node1Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620738,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~",
-          "group" : "as2",
-          "localAs" : 2,
-          "localIp" : "2.1.3.2",
-          "peerAddress" : "2.1.2.1",
-          "remoteAs" : 2,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node1SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2dist2",
-          "prefix" : "2.1.2.1/32",
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620481,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.3.2~",
-          "group" : "as2",
-          "localAs" : 2,
-          "localIp" : "2.1.2.1",
-          "peerAddress" : "2.1.3.2",
-          "remoteAs" : 2,
-          "routeReflectorClient" : true,
-          "sendCommunity" : true
-        },
-        "node2SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2core1",
-          "prefix" : "2.1.3.2/32",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "2.1.3.2",
-          "ip2" : "2.1.2.2",
-          "node1" : "as2dist2",
-          "node2" : "as2core2"
-        },
-        "node1Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620738,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~",
-          "group" : "as2",
-          "localAs" : 2,
-          "localIp" : "2.1.3.2",
-          "peerAddress" : "2.1.2.2",
-          "remoteAs" : 2,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node1SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2dist2",
-          "prefix" : "2.1.2.2/32",
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620482,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.3.2~",
-          "group" : "as2",
-          "localAs" : 2,
-          "localIp" : "2.1.2.2",
-          "peerAddress" : "2.1.3.2",
-          "remoteAs" : 2,
-          "routeReflectorClient" : true,
-          "sendCommunity" : true
-        },
-        "node2SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2core2",
-          "prefix" : "2.1.3.2/32",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "2.34.201.3",
-          "ip2" : "2.34.201.4",
-          "node1" : "as2dist2",
-          "node2" : "as2dept1"
-        },
-        "node1Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620738,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.34.201.4~",
-          "exportPolicySources" : [
-            "as2dist_to_dept"
-          ],
-          "group" : "dept",
-          "importPolicy" : "dept_to_as2dist",
-          "importPolicySources" : [
-            "dept_to_as2dist"
-          ],
-          "localAs" : 2,
-          "localIp" : "2.34.201.3",
-          "peerAddress" : "2.34.201.4",
-          "remoteAs" : 65001,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node1SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2dist2",
-          "prefix" : "2.34.201.4/32",
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620993,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.34.201.3~",
-          "exportPolicySources" : [
-            "dept_to_as2"
-          ],
-          "group" : "as2",
-          "importPolicy" : "as2_to_dept",
-          "importPolicySources" : [
-            "as2_to_dept"
-          ],
-          "localAs" : 65001,
-          "localIp" : "2.34.201.4",
-          "peerAddress" : "2.34.201.3",
-          "remoteAs" : 2,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node2SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2dept1",
-          "prefix" : "2.34.201.3/32",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "3.1.1.1",
-          "ip2" : "3.10.1.1",
-          "node1" : "as3border1",
-          "node2" : "as3core1"
-        },
-        "node1Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 50397441,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:3.10.1.1~",
-          "group" : "as3",
-          "localAs" : 3,
-          "localIp" : "3.1.1.1",
-          "peerAddress" : "3.10.1.1",
-          "remoteAs" : 3,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node1SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as3border1",
-          "prefix" : "3.10.1.1/32",
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 50987265,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:3.1.1.1~",
-          "group" : "as3",
-          "localAs" : 3,
-          "localIp" : "3.10.1.1",
-          "peerAddress" : "3.1.1.1",
-          "remoteAs" : 3,
-          "routeReflectorClient" : true,
-          "sendCommunity" : true
-        },
-        "node2SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as3core1",
-          "prefix" : "3.1.1.1/32",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "10.23.21.3",
-          "ip2" : "10.23.21.2",
-          "node1" : "as3border1",
-          "node2" : "as2border2"
-        },
-        "node1Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 50397441,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.23.21.2~",
-          "exportPolicySources" : [
-            "as3_to_as2"
-          ],
-          "group" : "as2",
-          "importPolicy" : "as2_to_as3",
-          "importPolicySources" : [
-            "as2_to_as3"
-          ],
-          "localAs" : 3,
-          "localIp" : "10.23.21.3",
-          "peerAddress" : "10.23.21.2",
-          "remoteAs" : 2,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node1SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as3border1",
-          "prefix" : "10.23.21.2/32",
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 33620226,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.23.21.3~",
-          "exportPolicySources" : [
-            "as2_to_as3"
-          ],
-          "group" : "as3",
-          "importPolicy" : "as3_to_as2",
-          "importPolicySources" : [
-            "as3_to_as2"
-          ],
-          "localAs" : 2,
-          "localIp" : "10.23.21.2",
-          "peerAddress" : "10.23.21.3",
-          "remoteAs" : 3,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node2SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as2border2",
-          "prefix" : "10.23.21.3/32",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "3.2.2.2",
-          "ip2" : "3.10.1.1",
-          "node1" : "as3border2",
-          "node2" : "as3core1"
-        },
-        "node1Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 50463234,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:3.10.1.1~",
-          "group" : "as3",
-          "localAs" : 3,
-          "localIp" : "3.2.2.2",
-          "peerAddress" : "3.10.1.1",
-          "remoteAs" : 3,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node1SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as3border2",
-          "prefix" : "3.10.1.1/32",
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 50987265,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:3.2.2.2~",
-          "group" : "as3",
-          "localAs" : 3,
-          "localIp" : "3.10.1.1",
-          "peerAddress" : "3.2.2.2",
-          "remoteAs" : 3,
-          "routeReflectorClient" : true,
-          "sendCommunity" : true
-        },
-        "node2SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as3core1",
-          "prefix" : "3.2.2.2/32",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "10.13.22.3",
-          "ip2" : "10.13.22.1",
-          "node1" : "as3border2",
-          "node2" : "as1border2"
-        },
-        "node1Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 50463234,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.13.22.1~",
-          "exportPolicySources" : [
-            "as3_to_as1"
-          ],
-          "group" : "as1",
-          "importPolicy" : "as1_to_as3",
-          "importPolicySources" : [
-            "as1_to_as3"
-          ],
-          "localAs" : 3,
-          "localIp" : "10.13.22.3",
-          "peerAddress" : "10.13.22.1",
-          "remoteAs" : 1,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node1SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as3border2",
-          "prefix" : "10.13.22.1/32",
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 16908802,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.13.22.3~",
-          "exportPolicySources" : [
-            "as1_to_as3"
-          ],
-          "group" : "as3",
-          "importPolicy" : "as3_to_as1",
-          "importPolicySources" : [
-            "as3_to_as1"
-          ],
-          "localAs" : 1,
-          "localIp" : "10.13.22.1",
-          "peerAddress" : "10.13.22.3",
-          "remoteAs" : 3,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node2SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as1border2",
-          "prefix" : "10.13.22.3/32",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "3.10.1.1",
-          "ip2" : "3.1.1.1",
-          "node1" : "as3core1",
-          "node2" : "as3border1"
-        },
-        "node1Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 50987265,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:3.1.1.1~",
-          "group" : "as3",
-          "localAs" : 3,
-          "localIp" : "3.10.1.1",
-          "peerAddress" : "3.1.1.1",
-          "remoteAs" : 3,
-          "routeReflectorClient" : true,
-          "sendCommunity" : true
-        },
-        "node1SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as3core1",
-          "prefix" : "3.1.1.1/32",
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 50397441,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:3.10.1.1~",
-          "group" : "as3",
-          "localAs" : 3,
-          "localIp" : "3.1.1.1",
-          "peerAddress" : "3.10.1.1",
-          "remoteAs" : 3,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node2SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as3border1",
-          "prefix" : "3.10.1.1/32",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "3.10.1.1",
-          "ip2" : "3.2.2.2",
-          "node1" : "as3core1",
-          "node2" : "as3border2"
-        },
-        "node1Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 50987265,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:3.2.2.2~",
-          "group" : "as3",
-          "localAs" : 3,
-          "localIp" : "3.10.1.1",
-          "peerAddress" : "3.2.2.2",
-          "remoteAs" : 3,
-          "routeReflectorClient" : true,
-          "sendCommunity" : true
-        },
-        "node1SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as3core1",
-          "prefix" : "3.2.2.2/32",
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-          "additionalPathsReceive" : true,
-          "additionalPathsSelectAll" : true,
-          "additionalPathsSend" : true,
-          "advertiseExternal" : false,
-          "advertiseInactive" : true,
-          "allowLocalAsIn" : false,
-          "allowRemoteAsOut" : true,
-          "clusterId" : 50463234,
-          "defaultMetric" : 0,
-          "ebgpMultihop" : false,
-          "enforceFirstAs" : false,
-          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:3.10.1.1~",
-          "group" : "as3",
-          "localAs" : 3,
-          "localIp" : "3.2.2.2",
-          "peerAddress" : "3.10.1.1",
-          "remoteAs" : 3,
-          "routeReflectorClient" : false,
-          "sendCommunity" : true
-        },
-        "node2SessionId" : {
-          "dynamic" : false,
-          "hostname" : "as3border2",
-          "prefix" : "3.10.1.1/32",
-          "vrf" : "default"
-        }
-      }
-    ],
-    "layer3Edges" : [
-      {
-        "edgeSummary" : {
-          "node1" : "as1border1",
-          "node1interface" : "GigabitEthernet0/0",
-          "node2" : "as1core1",
-          "node2interface" : "GigabitEthernet1/0"
-        },
-        "node1Interface" : {
-          "name" : "GigabitEthernet0/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "1.0.1.1/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet0/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "1.0.1.1/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        },
-        "node2Interface" : {
-          "name" : "GigabitEthernet1/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "1.0.1.2/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet1/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "1.0.1.2/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "node1" : "as1border1",
-          "node1interface" : "GigabitEthernet1/0",
-          "node2" : "as2border1",
-          "node2interface" : "GigabitEthernet0/0"
-        },
-        "node1Interface" : {
-          "name" : "GigabitEthernet1/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "10.12.11.1/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet1/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : false,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "10.12.11.1/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        },
-        "node2Interface" : {
-          "name" : "GigabitEthernet0/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "10.12.11.2/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet0/0"
-          ],
-          "incomingFilter" : "OUTSIDE_TO_INSIDE",
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : false,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "outgoingFilter" : "INSIDE_TO_AS1",
-          "prefix" : "10.12.11.2/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "node1" : "as1border2",
-          "node1interface" : "GigabitEthernet0/0",
-          "node2" : "as3border2",
-          "node2interface" : "GigabitEthernet0/0"
-        },
-        "node1Interface" : {
-          "name" : "GigabitEthernet0/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "10.13.22.1/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet0/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : false,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "10.13.22.1/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        },
-        "node2Interface" : {
-          "name" : "GigabitEthernet0/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "10.13.22.3/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet0/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : false,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "10.13.22.3/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "node1" : "as1border2",
-          "node1interface" : "GigabitEthernet1/0",
-          "node2" : "as1core1",
-          "node2interface" : "GigabitEthernet0/0"
-        },
-        "node1Interface" : {
-          "name" : "GigabitEthernet1/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "1.0.2.1/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet1/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "1.0.2.1/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        },
-        "node2Interface" : {
-          "name" : "GigabitEthernet0/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "1.0.2.2/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet0/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "1.0.2.2/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "node1" : "as1core1",
-          "node1interface" : "GigabitEthernet0/0",
-          "node2" : "as1border2",
-          "node2interface" : "GigabitEthernet1/0"
-        },
-        "node1Interface" : {
-          "name" : "GigabitEthernet0/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "1.0.2.2/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet0/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "1.0.2.2/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        },
-        "node2Interface" : {
-          "name" : "GigabitEthernet1/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "1.0.2.1/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet1/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "1.0.2.1/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "node1" : "as1core1",
-          "node1interface" : "GigabitEthernet1/0",
-          "node2" : "as1border1",
-          "node2interface" : "GigabitEthernet0/0"
-        },
-        "node1Interface" : {
-          "name" : "GigabitEthernet1/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "1.0.1.2/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet1/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "1.0.1.2/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        },
-        "node2Interface" : {
-          "name" : "GigabitEthernet0/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "1.0.1.1/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet0/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "1.0.1.1/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "node1" : "as2border1",
-          "node1interface" : "GigabitEthernet0/0",
-          "node2" : "as1border1",
-          "node2interface" : "GigabitEthernet1/0"
-        },
-        "node1Interface" : {
-          "name" : "GigabitEthernet0/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "10.12.11.2/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet0/0"
-          ],
-          "incomingFilter" : "OUTSIDE_TO_INSIDE",
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : false,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "outgoingFilter" : "INSIDE_TO_AS1",
-          "prefix" : "10.12.11.2/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        },
-        "node2Interface" : {
-          "name" : "GigabitEthernet1/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "10.12.11.1/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet1/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : false,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "10.12.11.1/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "node1" : "as2border1",
-          "node1interface" : "GigabitEthernet1/0",
-          "node2" : "as2core1",
-          "node2interface" : "GigabitEthernet0/0"
-        },
-        "node1Interface" : {
-          "name" : "GigabitEthernet1/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.12.11.1/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet1/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.12.11.1/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        },
-        "node2Interface" : {
-          "name" : "GigabitEthernet0/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.12.11.2/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet0/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.12.11.2/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "node1" : "as2border1",
-          "node1interface" : "GigabitEthernet2/0",
-          "node2" : "as2core2",
-          "node2interface" : "GigabitEthernet1/0"
-        },
-        "node1Interface" : {
-          "name" : "GigabitEthernet2/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.12.12.1/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet2/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.12.12.1/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        },
-        "node2Interface" : {
-          "name" : "GigabitEthernet1/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.12.12.2/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet1/0"
-          ],
-          "mtu" : 1600,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.12.12.2/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "node1" : "as2border2",
-          "node1interface" : "GigabitEthernet0/0",
-          "node2" : "as3border1",
-          "node2interface" : "GigabitEthernet1/0"
-        },
-        "node1Interface" : {
-          "name" : "GigabitEthernet0/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "10.23.21.2/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet0/0"
-          ],
-          "incomingFilter" : "OUTSIDE_TO_INSIDE",
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : false,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "outgoingFilter" : "INSIDE_TO_AS3",
-          "prefix" : "10.23.21.2/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        },
-        "node2Interface" : {
-          "name" : "GigabitEthernet1/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "10.23.21.3/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet1/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : false,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "10.23.21.3/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "node1" : "as2border2",
-          "node1interface" : "GigabitEthernet1/0",
-          "node2" : "as2core2",
-          "node2interface" : "GigabitEthernet0/0"
-        },
-        "node1Interface" : {
-          "name" : "GigabitEthernet1/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.12.22.1/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet1/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.12.22.1/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        },
-        "node2Interface" : {
-          "name" : "GigabitEthernet0/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.12.22.2/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet0/0"
-          ],
-          "mtu" : 1800,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.12.22.2/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "node1" : "as2border2",
-          "node1interface" : "GigabitEthernet2/0",
-          "node2" : "as2core1",
-          "node2interface" : "GigabitEthernet1/0"
-        },
-        "node1Interface" : {
-          "name" : "GigabitEthernet2/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.12.21.1/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet2/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.12.21.1/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        },
-        "node2Interface" : {
-          "name" : "GigabitEthernet1/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.12.21.2/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet1/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.12.21.2/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "node1" : "as2core1",
-          "node1interface" : "GigabitEthernet0/0",
-          "node2" : "as2border1",
-          "node2interface" : "GigabitEthernet1/0"
-        },
-        "node1Interface" : {
-          "name" : "GigabitEthernet0/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.12.11.2/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet0/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.12.11.2/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        },
-        "node2Interface" : {
-          "name" : "GigabitEthernet1/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.12.11.1/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet1/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.12.11.1/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "node1" : "as2core1",
-          "node1interface" : "GigabitEthernet1/0",
-          "node2" : "as2border2",
-          "node2interface" : "GigabitEthernet2/0"
-        },
-        "node1Interface" : {
-          "name" : "GigabitEthernet1/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.12.21.2/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet1/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.12.21.2/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        },
-        "node2Interface" : {
-          "name" : "GigabitEthernet2/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.12.21.1/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet2/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.12.21.1/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "node1" : "as2core1",
-          "node1interface" : "GigabitEthernet2/0",
-          "node2" : "as2dist1",
-          "node2interface" : "GigabitEthernet0/0"
-        },
-        "node1Interface" : {
-          "name" : "GigabitEthernet2/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.23.11.2/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet2/0"
-          ],
-          "incomingFilter" : "blocktelnet",
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.23.11.2/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        },
-        "node2Interface" : {
-          "name" : "GigabitEthernet0/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.23.11.3/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet0/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.23.11.3/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "node1" : "as2core1",
-          "node1interface" : "GigabitEthernet3/0",
-          "node2" : "as2dist2",
-          "node2interface" : "GigabitEthernet1/0"
-        },
-        "node1Interface" : {
-          "name" : "GigabitEthernet3/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.23.12.2/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet3/0"
-          ],
-          "incomingFilter" : "blocktelnet",
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.23.12.2/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        },
-        "node2Interface" : {
-          "name" : "GigabitEthernet1/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.23.12.3/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet1/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.23.12.3/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "node1" : "as2core2",
-          "node1interface" : "GigabitEthernet0/0",
-          "node2" : "as2border2",
-          "node2interface" : "GigabitEthernet1/0"
-        },
-        "node1Interface" : {
-          "name" : "GigabitEthernet0/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.12.22.2/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet0/0"
-          ],
-          "mtu" : 1800,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.12.22.2/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        },
-        "node2Interface" : {
-          "name" : "GigabitEthernet1/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.12.22.1/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet1/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.12.22.1/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "node1" : "as2core2",
-          "node1interface" : "GigabitEthernet1/0",
-          "node2" : "as2border1",
-          "node2interface" : "GigabitEthernet2/0"
-        },
-        "node1Interface" : {
-          "name" : "GigabitEthernet1/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.12.12.2/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet1/0"
-          ],
-          "mtu" : 1600,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.12.12.2/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        },
-        "node2Interface" : {
-          "name" : "GigabitEthernet2/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.12.12.1/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet2/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.12.12.1/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "node1" : "as2core2",
-          "node1interface" : "GigabitEthernet2/0",
-          "node2" : "as2dist2",
-          "node2interface" : "GigabitEthernet0/0"
-        },
-        "node1Interface" : {
-          "name" : "GigabitEthernet2/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.23.22.2/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet2/0"
-          ],
-          "mtu" : 1700,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.23.22.2/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        },
-        "node2Interface" : {
-          "name" : "GigabitEthernet0/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.23.22.3/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet0/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.23.22.3/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "node1" : "as2core2",
-          "node1interface" : "GigabitEthernet3/0",
-          "node2" : "as2dist1",
-          "node2interface" : "GigabitEthernet1/0"
-        },
-        "node1Interface" : {
-          "name" : "GigabitEthernet3/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.23.21.2/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet3/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.23.21.2/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        },
-        "node2Interface" : {
-          "name" : "GigabitEthernet1/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.23.21.3/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet1/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.23.21.3/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "node1" : "as2dept1",
-          "node1interface" : "GigabitEthernet0/0",
-          "node2" : "as2dist1",
-          "node2interface" : "GigabitEthernet2/0"
-        },
-        "node1Interface" : {
-          "name" : "GigabitEthernet0/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.34.101.4/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet0/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : false,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.34.101.4/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        },
-        "node2Interface" : {
-          "name" : "GigabitEthernet2/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.34.101.3/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet2/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : false,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.34.101.3/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "node1" : "as2dept1",
-          "node1interface" : "GigabitEthernet1/0",
-          "node2" : "as2dist2",
-          "node2interface" : "GigabitEthernet2/0"
-        },
-        "node1Interface" : {
-          "name" : "GigabitEthernet1/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.34.201.4/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet1/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : false,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.34.201.4/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        },
-        "node2Interface" : {
-          "name" : "GigabitEthernet2/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.34.201.3/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet2/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : false,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.34.201.3/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "node1" : "as2dept1",
-          "node1interface" : "GigabitEthernet2/0",
-          "node2" : "host1",
-          "node2interface" : "eth0"
-        },
-        "node1Interface" : {
-          "name" : "GigabitEthernet2/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.128.0.1/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet2/0"
-          ],
-          "incomingFilter" : "RESTRICT_HOST_TRAFFIC_IN",
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : false,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.128.0.1/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        },
-        "node2Interface" : {
-          "name" : "eth0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.128.0.101/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "eth0"
-          ],
-          "incomingFilter" : "filter::INPUT",
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : false,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "outgoingFilter" : "filter::OUTPUT",
-          "prefix" : "2.128.0.101/24",
-          "proxyArp" : false,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "node1" : "as2dept1",
-          "node1interface" : "GigabitEthernet3/0",
-          "node2" : "host2",
-          "node2interface" : "eth0"
-        },
-        "node1Interface" : {
-          "name" : "GigabitEthernet3/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.128.1.1/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet3/0"
-          ],
-          "incomingFilter" : "RESTRICT_HOST_TRAFFIC_IN",
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : false,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.128.1.1/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        },
-        "node2Interface" : {
-          "name" : "eth0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.128.1.101/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "eth0"
-          ],
-          "incomingFilter" : "filter::INPUT",
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : false,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "outgoingFilter" : "filter::OUTPUT",
-          "prefix" : "2.128.1.101/24",
-          "proxyArp" : false,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "node1" : "as2dist1",
-          "node1interface" : "GigabitEthernet0/0",
-          "node2" : "as2core1",
-          "node2interface" : "GigabitEthernet2/0"
-        },
-        "node1Interface" : {
-          "name" : "GigabitEthernet0/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.23.11.3/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet0/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.23.11.3/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        },
-        "node2Interface" : {
-          "name" : "GigabitEthernet2/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.23.11.2/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet2/0"
-          ],
-          "incomingFilter" : "blocktelnet",
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.23.11.2/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "node1" : "as2dist1",
-          "node1interface" : "GigabitEthernet1/0",
-          "node2" : "as2core2",
-          "node2interface" : "GigabitEthernet3/0"
-        },
-        "node1Interface" : {
-          "name" : "GigabitEthernet1/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.23.21.3/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet1/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.23.21.3/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        },
-        "node2Interface" : {
-          "name" : "GigabitEthernet3/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.23.21.2/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet3/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.23.21.2/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "node1" : "as2dist1",
-          "node1interface" : "GigabitEthernet2/0",
-          "node2" : "as2dept1",
-          "node2interface" : "GigabitEthernet0/0"
-        },
-        "node1Interface" : {
-          "name" : "GigabitEthernet2/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.34.101.3/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet2/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : false,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.34.101.3/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        },
-        "node2Interface" : {
-          "name" : "GigabitEthernet0/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.34.101.4/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet0/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : false,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.34.101.4/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "node1" : "as2dist2",
-          "node1interface" : "GigabitEthernet0/0",
-          "node2" : "as2core2",
-          "node2interface" : "GigabitEthernet2/0"
-        },
-        "node1Interface" : {
-          "name" : "GigabitEthernet0/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.23.22.3/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet0/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.23.22.3/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        },
-        "node2Interface" : {
-          "name" : "GigabitEthernet2/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.23.22.2/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet2/0"
-          ],
-          "mtu" : 1700,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.23.22.2/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "node1" : "as2dist2",
-          "node1interface" : "GigabitEthernet1/0",
-          "node2" : "as2core1",
-          "node2interface" : "GigabitEthernet3/0"
-        },
-        "node1Interface" : {
-          "name" : "GigabitEthernet1/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.23.12.3/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet1/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.23.12.3/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        },
-        "node2Interface" : {
-          "name" : "GigabitEthernet3/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.23.12.2/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet3/0"
-          ],
-          "incomingFilter" : "blocktelnet",
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.23.12.2/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "node1" : "as2dist2",
-          "node1interface" : "GigabitEthernet2/0",
-          "node2" : "as2dept1",
-          "node2interface" : "GigabitEthernet1/0"
-        },
-        "node1Interface" : {
-          "name" : "GigabitEthernet2/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.34.201.3/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet2/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : false,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.34.201.3/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        },
-        "node2Interface" : {
-          "name" : "GigabitEthernet1/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.34.201.4/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet1/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : false,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.34.201.4/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "node1" : "as3border1",
-          "node1interface" : "GigabitEthernet0/0",
-          "node2" : "as3core1",
-          "node2interface" : "GigabitEthernet1/0"
-        },
-        "node1Interface" : {
-          "name" : "GigabitEthernet0/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "3.0.1.1/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet0/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "3.0.1.1/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        },
-        "node2Interface" : {
-          "name" : "GigabitEthernet1/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "3.0.1.2/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet1/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "3.0.1.2/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "node1" : "as3border1",
-          "node1interface" : "GigabitEthernet1/0",
-          "node2" : "as2border2",
-          "node2interface" : "GigabitEthernet0/0"
-        },
-        "node1Interface" : {
-          "name" : "GigabitEthernet1/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "10.23.21.3/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet1/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : false,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "10.23.21.3/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        },
-        "node2Interface" : {
-          "name" : "GigabitEthernet0/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "10.23.21.2/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet0/0"
-          ],
-          "incomingFilter" : "OUTSIDE_TO_INSIDE",
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : false,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "outgoingFilter" : "INSIDE_TO_AS3",
-          "prefix" : "10.23.21.2/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "node1" : "as3border2",
-          "node1interface" : "GigabitEthernet0/0",
-          "node2" : "as1border2",
-          "node2interface" : "GigabitEthernet0/0"
-        },
-        "node1Interface" : {
-          "name" : "GigabitEthernet0/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "10.13.22.3/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet0/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : false,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "10.13.22.3/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        },
-        "node2Interface" : {
-          "name" : "GigabitEthernet0/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "10.13.22.1/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet0/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : false,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "10.13.22.1/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "node1" : "as3border2",
-          "node1interface" : "GigabitEthernet1/0",
-          "node2" : "as3core1",
-          "node2interface" : "GigabitEthernet0/0"
-        },
-        "node1Interface" : {
-          "name" : "GigabitEthernet1/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "3.0.2.1/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet1/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "3.0.2.1/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        },
-        "node2Interface" : {
-          "name" : "GigabitEthernet0/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "3.0.2.2/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet0/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "3.0.2.2/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "node1" : "as3core1",
-          "node1interface" : "GigabitEthernet0/0",
-          "node2" : "as3border2",
-          "node2interface" : "GigabitEthernet1/0"
-        },
-        "node1Interface" : {
-          "name" : "GigabitEthernet0/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "3.0.2.2/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet0/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "3.0.2.2/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        },
-        "node2Interface" : {
-          "name" : "GigabitEthernet1/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "3.0.2.1/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet1/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "3.0.2.1/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "node1" : "as3core1",
-          "node1interface" : "GigabitEthernet1/0",
-          "node2" : "as3border1",
-          "node2interface" : "GigabitEthernet0/0"
-        },
-        "node1Interface" : {
-          "name" : "GigabitEthernet1/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "3.0.1.2/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet1/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "3.0.1.2/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        },
-        "node2Interface" : {
-          "name" : "GigabitEthernet0/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "3.0.1.1/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet0/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfArea" : 1,
-          "ospfCost" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : true,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "3.0.1.1/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "node1" : "as3core1",
-          "node1interface" : "GigabitEthernet2/0",
-          "node2" : "as3core1",
-          "node2interface" : "GigabitEthernet3/0"
-        },
-        "node1Interface" : {
-          "name" : "GigabitEthernet2/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "90.90.90.1/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet2/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : false,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "90.90.90.1/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        },
-        "node2Interface" : {
-          "name" : "GigabitEthernet3/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "90.90.90.2/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet3/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : false,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "90.90.90.2/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "node1" : "as3core1",
-          "node1interface" : "GigabitEthernet3/0",
-          "node2" : "as3core1",
-          "node2interface" : "GigabitEthernet2/0"
-        },
-        "node1Interface" : {
-          "name" : "GigabitEthernet3/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "90.90.90.2/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet3/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : false,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "90.90.90.2/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        },
-        "node2Interface" : {
-          "name" : "GigabitEthernet2/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "90.90.90.1/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet2/0"
-          ],
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : false,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "90.90.90.1/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "node1" : "host1",
-          "node1interface" : "eth0",
-          "node2" : "as2dept1",
-          "node2interface" : "GigabitEthernet2/0"
-        },
-        "node1Interface" : {
-          "name" : "eth0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.128.0.101/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "eth0"
-          ],
-          "incomingFilter" : "filter::INPUT",
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : false,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "outgoingFilter" : "filter::OUTPUT",
-          "prefix" : "2.128.0.101/24",
-          "proxyArp" : false,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        },
-        "node2Interface" : {
-          "name" : "GigabitEthernet2/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.128.0.1/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet2/0"
-          ],
-          "incomingFilter" : "RESTRICT_HOST_TRAFFIC_IN",
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : false,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.128.0.1/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "node1" : "host2",
-          "node1interface" : "eth0",
-          "node2" : "as2dept1",
-          "node2interface" : "GigabitEthernet3/0"
-        },
-        "node1Interface" : {
-          "name" : "eth0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.128.1.101/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "eth0"
-          ],
-          "incomingFilter" : "filter::INPUT",
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : false,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "outgoingFilter" : "filter::OUTPUT",
-          "prefix" : "2.128.1.101/24",
-          "proxyArp" : false,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        },
-        "node2Interface" : {
-          "name" : "GigabitEthernet3/0",
-          "accessVlan" : 0,
-          "active" : true,
-          "allPrefixes" : [
-            "2.128.1.1/24"
-          ],
-          "autostate" : true,
-          "bandwidth" : 1.0E9,
-          "declaredNames" : [
-            "GigabitEthernet3/0"
-          ],
-          "incomingFilter" : "RESTRICT_HOST_TRAFFIC_IN",
-          "mtu" : 1500,
-          "nativeVlan" : 1,
-          "ospfDeadInterval" : 0,
-          "ospfEnabled" : false,
-          "ospfHelloMultiplier" : 0,
-          "ospfPassive" : false,
-          "ospfPointToPoint" : false,
-          "prefix" : "2.128.1.1/24",
-          "proxyArp" : true,
-          "ripEnabled" : false,
-          "ripPassive" : false,
-          "spanningTreePortfast" : false,
-          "switchportMode" : "NONE",
-          "switchportTrunkEncapsulation" : "DOT1Q",
-          "type" : "PHYSICAL",
-          "vrf" : "default"
-        }
-      }
-    ],
+    "edges" : {
+      "bgp" : [
+        {
+          "edgeSummary" : {
+            "ip1" : "1.1.1.1",
+            "ip2" : "1.10.1.1",
+            "node1" : "as1border1",
+            "node2" : "as1core1"
+          },
+          "node1Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 16843009,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:1.10.1.1~",
+            "group" : "as1",
+            "localAs" : 1,
+            "localIp" : "1.1.1.1",
+            "peerAddress" : "1.10.1.1",
+            "remoteAs" : 1,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node1SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as1border1",
+            "prefix" : "1.10.1.1/32",
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 17432833,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:1.1.1.1~",
+            "group" : "as1",
+            "localAs" : 1,
+            "localIp" : "1.10.1.1",
+            "peerAddress" : "1.1.1.1",
+            "remoteAs" : 1,
+            "routeReflectorClient" : true,
+            "sendCommunity" : true
+          },
+          "node2SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as1core1",
+            "prefix" : "1.1.1.1/32",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "10.12.11.1",
+            "ip2" : "10.12.11.2",
+            "node1" : "as1border1",
+            "node2" : "as2border1"
+          },
+          "node1Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 16843009,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.12.11.2~",
+            "exportPolicySources" : [
+              "as1_to_as2"
+            ],
+            "group" : "as2",
+            "importPolicy" : "as2_to_as1",
+            "importPolicySources" : [
+              "as2_to_as1"
+            ],
+            "localAs" : 1,
+            "localIp" : "10.12.11.1",
+            "peerAddress" : "10.12.11.2",
+            "remoteAs" : 2,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node1SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as1border1",
+            "prefix" : "10.12.11.2/32",
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620225,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.12.11.1~",
+            "exportPolicySources" : [
+              "as2_to_as1"
+            ],
+            "group" : "as1",
+            "importPolicy" : "as1_to_as2",
+            "importPolicySources" : [
+              "as1_to_as2"
+            ],
+            "localAs" : 2,
+            "localIp" : "10.12.11.2",
+            "peerAddress" : "10.12.11.1",
+            "remoteAs" : 1,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node2SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2border1",
+            "prefix" : "10.12.11.1/32",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "1.2.2.2",
+            "ip2" : "1.10.1.1",
+            "node1" : "as1border2",
+            "node2" : "as1core1"
+          },
+          "node1Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 16908802,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:1.10.1.1~",
+            "group" : "as1",
+            "localAs" : 1,
+            "localIp" : "1.2.2.2",
+            "peerAddress" : "1.10.1.1",
+            "remoteAs" : 1,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node1SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as1border2",
+            "prefix" : "1.10.1.1/32",
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 17432833,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:1.2.2.2~",
+            "group" : "as1",
+            "localAs" : 1,
+            "localIp" : "1.10.1.1",
+            "peerAddress" : "1.2.2.2",
+            "remoteAs" : 1,
+            "routeReflectorClient" : true,
+            "sendCommunity" : true
+          },
+          "node2SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as1core1",
+            "prefix" : "1.2.2.2/32",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "10.13.22.1",
+            "ip2" : "10.13.22.3",
+            "node1" : "as1border2",
+            "node2" : "as3border2"
+          },
+          "node1Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 16908802,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.13.22.3~",
+            "exportPolicySources" : [
+              "as1_to_as3"
+            ],
+            "group" : "as3",
+            "importPolicy" : "as3_to_as1",
+            "importPolicySources" : [
+              "as3_to_as1"
+            ],
+            "localAs" : 1,
+            "localIp" : "10.13.22.1",
+            "peerAddress" : "10.13.22.3",
+            "remoteAs" : 3,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node1SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as1border2",
+            "prefix" : "10.13.22.3/32",
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 50463234,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.13.22.1~",
+            "exportPolicySources" : [
+              "as3_to_as1"
+            ],
+            "group" : "as1",
+            "importPolicy" : "as1_to_as3",
+            "importPolicySources" : [
+              "as1_to_as3"
+            ],
+            "localAs" : 3,
+            "localIp" : "10.13.22.3",
+            "peerAddress" : "10.13.22.1",
+            "remoteAs" : 1,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node2SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as3border2",
+            "prefix" : "10.13.22.1/32",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "1.10.1.1",
+            "ip2" : "1.1.1.1",
+            "node1" : "as1core1",
+            "node2" : "as1border1"
+          },
+          "node1Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 17432833,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:1.1.1.1~",
+            "group" : "as1",
+            "localAs" : 1,
+            "localIp" : "1.10.1.1",
+            "peerAddress" : "1.1.1.1",
+            "remoteAs" : 1,
+            "routeReflectorClient" : true,
+            "sendCommunity" : true
+          },
+          "node1SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as1core1",
+            "prefix" : "1.1.1.1/32",
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 16843009,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:1.10.1.1~",
+            "group" : "as1",
+            "localAs" : 1,
+            "localIp" : "1.1.1.1",
+            "peerAddress" : "1.10.1.1",
+            "remoteAs" : 1,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node2SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as1border1",
+            "prefix" : "1.10.1.1/32",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "1.10.1.1",
+            "ip2" : "1.2.2.2",
+            "node1" : "as1core1",
+            "node2" : "as1border2"
+          },
+          "node1Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 17432833,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:1.2.2.2~",
+            "group" : "as1",
+            "localAs" : 1,
+            "localIp" : "1.10.1.1",
+            "peerAddress" : "1.2.2.2",
+            "remoteAs" : 1,
+            "routeReflectorClient" : true,
+            "sendCommunity" : true
+          },
+          "node1SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as1core1",
+            "prefix" : "1.2.2.2/32",
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 16908802,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:1.10.1.1~",
+            "group" : "as1",
+            "localAs" : 1,
+            "localIp" : "1.2.2.2",
+            "peerAddress" : "1.10.1.1",
+            "remoteAs" : 1,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node2SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as1border2",
+            "prefix" : "1.10.1.1/32",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "2.1.1.1",
+            "ip2" : "2.1.2.1",
+            "node1" : "as2border1",
+            "node2" : "as2core1"
+          },
+          "node1Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620225,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~",
+            "group" : "as2",
+            "localAs" : 2,
+            "localIp" : "2.1.1.1",
+            "peerAddress" : "2.1.2.1",
+            "remoteAs" : 2,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node1SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2border1",
+            "prefix" : "2.1.2.1/32",
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620481,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.1.1~",
+            "group" : "as2",
+            "localAs" : 2,
+            "localIp" : "2.1.2.1",
+            "peerAddress" : "2.1.1.1",
+            "remoteAs" : 2,
+            "routeReflectorClient" : true,
+            "sendCommunity" : true
+          },
+          "node2SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2core1",
+            "prefix" : "2.1.1.1/32",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "2.1.1.1",
+            "ip2" : "2.1.2.2",
+            "node1" : "as2border1",
+            "node2" : "as2core2"
+          },
+          "node1Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620225,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~",
+            "group" : "as2",
+            "localAs" : 2,
+            "localIp" : "2.1.1.1",
+            "peerAddress" : "2.1.2.2",
+            "remoteAs" : 2,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node1SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2border1",
+            "prefix" : "2.1.2.2/32",
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620482,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.1.1~",
+            "group" : "as2",
+            "localAs" : 2,
+            "localIp" : "2.1.2.2",
+            "peerAddress" : "2.1.1.1",
+            "remoteAs" : 2,
+            "routeReflectorClient" : true,
+            "sendCommunity" : true
+          },
+          "node2SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2core2",
+            "prefix" : "2.1.1.1/32",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "10.12.11.2",
+            "ip2" : "10.12.11.1",
+            "node1" : "as2border1",
+            "node2" : "as1border1"
+          },
+          "node1Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620225,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.12.11.1~",
+            "exportPolicySources" : [
+              "as2_to_as1"
+            ],
+            "group" : "as1",
+            "importPolicy" : "as1_to_as2",
+            "importPolicySources" : [
+              "as1_to_as2"
+            ],
+            "localAs" : 2,
+            "localIp" : "10.12.11.2",
+            "peerAddress" : "10.12.11.1",
+            "remoteAs" : 1,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node1SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2border1",
+            "prefix" : "10.12.11.1/32",
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 16843009,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.12.11.2~",
+            "exportPolicySources" : [
+              "as1_to_as2"
+            ],
+            "group" : "as2",
+            "importPolicy" : "as2_to_as1",
+            "importPolicySources" : [
+              "as2_to_as1"
+            ],
+            "localAs" : 1,
+            "localIp" : "10.12.11.1",
+            "peerAddress" : "10.12.11.2",
+            "remoteAs" : 2,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node2SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as1border1",
+            "prefix" : "10.12.11.2/32",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "2.1.1.2",
+            "ip2" : "2.1.2.1",
+            "node1" : "as2border2",
+            "node2" : "as2core1"
+          },
+          "node1Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620226,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~",
+            "group" : "as2",
+            "localAs" : 2,
+            "localIp" : "2.1.1.2",
+            "peerAddress" : "2.1.2.1",
+            "remoteAs" : 2,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node1SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2border2",
+            "prefix" : "2.1.2.1/32",
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620481,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.1.2~",
+            "group" : "as2",
+            "localAs" : 2,
+            "localIp" : "2.1.2.1",
+            "peerAddress" : "2.1.1.2",
+            "remoteAs" : 2,
+            "routeReflectorClient" : true,
+            "sendCommunity" : true
+          },
+          "node2SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2core1",
+            "prefix" : "2.1.1.2/32",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "2.1.1.2",
+            "ip2" : "2.1.2.2",
+            "node1" : "as2border2",
+            "node2" : "as2core2"
+          },
+          "node1Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620226,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~",
+            "group" : "as2",
+            "localAs" : 2,
+            "localIp" : "2.1.1.2",
+            "peerAddress" : "2.1.2.2",
+            "remoteAs" : 2,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node1SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2border2",
+            "prefix" : "2.1.2.2/32",
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620482,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.1.2~",
+            "group" : "as2",
+            "localAs" : 2,
+            "localIp" : "2.1.2.2",
+            "peerAddress" : "2.1.1.2",
+            "remoteAs" : 2,
+            "routeReflectorClient" : true,
+            "sendCommunity" : true
+          },
+          "node2SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2core2",
+            "prefix" : "2.1.1.2/32",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "10.23.21.2",
+            "ip2" : "10.23.21.3",
+            "node1" : "as2border2",
+            "node2" : "as3border1"
+          },
+          "node1Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620226,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.23.21.3~",
+            "exportPolicySources" : [
+              "as2_to_as3"
+            ],
+            "group" : "as3",
+            "importPolicy" : "as3_to_as2",
+            "importPolicySources" : [
+              "as3_to_as2"
+            ],
+            "localAs" : 2,
+            "localIp" : "10.23.21.2",
+            "peerAddress" : "10.23.21.3",
+            "remoteAs" : 3,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node1SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2border2",
+            "prefix" : "10.23.21.3/32",
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 50397441,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.23.21.2~",
+            "exportPolicySources" : [
+              "as3_to_as2"
+            ],
+            "group" : "as2",
+            "importPolicy" : "as2_to_as3",
+            "importPolicySources" : [
+              "as2_to_as3"
+            ],
+            "localAs" : 3,
+            "localIp" : "10.23.21.3",
+            "peerAddress" : "10.23.21.2",
+            "remoteAs" : 2,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node2SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as3border1",
+            "prefix" : "10.23.21.2/32",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "2.1.2.1",
+            "ip2" : "2.1.1.1",
+            "node1" : "as2core1",
+            "node2" : "as2border1"
+          },
+          "node1Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620481,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.1.1~",
+            "group" : "as2",
+            "localAs" : 2,
+            "localIp" : "2.1.2.1",
+            "peerAddress" : "2.1.1.1",
+            "remoteAs" : 2,
+            "routeReflectorClient" : true,
+            "sendCommunity" : true
+          },
+          "node1SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2core1",
+            "prefix" : "2.1.1.1/32",
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620225,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~",
+            "group" : "as2",
+            "localAs" : 2,
+            "localIp" : "2.1.1.1",
+            "peerAddress" : "2.1.2.1",
+            "remoteAs" : 2,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node2SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2border1",
+            "prefix" : "2.1.2.1/32",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "2.1.2.1",
+            "ip2" : "2.1.1.2",
+            "node1" : "as2core1",
+            "node2" : "as2border2"
+          },
+          "node1Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620481,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.1.2~",
+            "group" : "as2",
+            "localAs" : 2,
+            "localIp" : "2.1.2.1",
+            "peerAddress" : "2.1.1.2",
+            "remoteAs" : 2,
+            "routeReflectorClient" : true,
+            "sendCommunity" : true
+          },
+          "node1SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2core1",
+            "prefix" : "2.1.1.2/32",
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620226,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~",
+            "group" : "as2",
+            "localAs" : 2,
+            "localIp" : "2.1.1.2",
+            "peerAddress" : "2.1.2.1",
+            "remoteAs" : 2,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node2SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2border2",
+            "prefix" : "2.1.2.1/32",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "2.1.2.1",
+            "ip2" : "2.1.3.1",
+            "node1" : "as2core1",
+            "node2" : "as2dist1"
+          },
+          "node1Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620481,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.3.1~",
+            "group" : "as2",
+            "localAs" : 2,
+            "localIp" : "2.1.2.1",
+            "peerAddress" : "2.1.3.1",
+            "remoteAs" : 2,
+            "routeReflectorClient" : true,
+            "sendCommunity" : true
+          },
+          "node1SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2core1",
+            "prefix" : "2.1.3.1/32",
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620737,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~",
+            "group" : "as2",
+            "localAs" : 2,
+            "localIp" : "2.1.3.1",
+            "peerAddress" : "2.1.2.1",
+            "remoteAs" : 2,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node2SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2dist1",
+            "prefix" : "2.1.2.1/32",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "2.1.2.1",
+            "ip2" : "2.1.3.2",
+            "node1" : "as2core1",
+            "node2" : "as2dist2"
+          },
+          "node1Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620481,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.3.2~",
+            "group" : "as2",
+            "localAs" : 2,
+            "localIp" : "2.1.2.1",
+            "peerAddress" : "2.1.3.2",
+            "remoteAs" : 2,
+            "routeReflectorClient" : true,
+            "sendCommunity" : true
+          },
+          "node1SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2core1",
+            "prefix" : "2.1.3.2/32",
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620738,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~",
+            "group" : "as2",
+            "localAs" : 2,
+            "localIp" : "2.1.3.2",
+            "peerAddress" : "2.1.2.1",
+            "remoteAs" : 2,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node2SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2dist2",
+            "prefix" : "2.1.2.1/32",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "2.1.2.2",
+            "ip2" : "2.1.1.1",
+            "node1" : "as2core2",
+            "node2" : "as2border1"
+          },
+          "node1Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620482,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.1.1~",
+            "group" : "as2",
+            "localAs" : 2,
+            "localIp" : "2.1.2.2",
+            "peerAddress" : "2.1.1.1",
+            "remoteAs" : 2,
+            "routeReflectorClient" : true,
+            "sendCommunity" : true
+          },
+          "node1SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2core2",
+            "prefix" : "2.1.1.1/32",
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620225,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~",
+            "group" : "as2",
+            "localAs" : 2,
+            "localIp" : "2.1.1.1",
+            "peerAddress" : "2.1.2.2",
+            "remoteAs" : 2,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node2SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2border1",
+            "prefix" : "2.1.2.2/32",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "2.1.2.2",
+            "ip2" : "2.1.1.2",
+            "node1" : "as2core2",
+            "node2" : "as2border2"
+          },
+          "node1Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620482,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.1.2~",
+            "group" : "as2",
+            "localAs" : 2,
+            "localIp" : "2.1.2.2",
+            "peerAddress" : "2.1.1.2",
+            "remoteAs" : 2,
+            "routeReflectorClient" : true,
+            "sendCommunity" : true
+          },
+          "node1SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2core2",
+            "prefix" : "2.1.1.2/32",
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620226,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~",
+            "group" : "as2",
+            "localAs" : 2,
+            "localIp" : "2.1.1.2",
+            "peerAddress" : "2.1.2.2",
+            "remoteAs" : 2,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node2SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2border2",
+            "prefix" : "2.1.2.2/32",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "2.1.2.2",
+            "ip2" : "2.1.3.1",
+            "node1" : "as2core2",
+            "node2" : "as2dist1"
+          },
+          "node1Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620482,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.3.1~",
+            "group" : "as2",
+            "localAs" : 2,
+            "localIp" : "2.1.2.2",
+            "peerAddress" : "2.1.3.1",
+            "remoteAs" : 2,
+            "routeReflectorClient" : true,
+            "sendCommunity" : true
+          },
+          "node1SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2core2",
+            "prefix" : "2.1.3.1/32",
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620737,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~",
+            "group" : "as2",
+            "localAs" : 2,
+            "localIp" : "2.1.3.1",
+            "peerAddress" : "2.1.2.2",
+            "remoteAs" : 2,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node2SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2dist1",
+            "prefix" : "2.1.2.2/32",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "2.1.2.2",
+            "ip2" : "2.1.3.2",
+            "node1" : "as2core2",
+            "node2" : "as2dist2"
+          },
+          "node1Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620482,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.3.2~",
+            "group" : "as2",
+            "localAs" : 2,
+            "localIp" : "2.1.2.2",
+            "peerAddress" : "2.1.3.2",
+            "remoteAs" : 2,
+            "routeReflectorClient" : true,
+            "sendCommunity" : true
+          },
+          "node1SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2core2",
+            "prefix" : "2.1.3.2/32",
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620738,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~",
+            "group" : "as2",
+            "localAs" : 2,
+            "localIp" : "2.1.3.2",
+            "peerAddress" : "2.1.2.2",
+            "remoteAs" : 2,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node2SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2dist2",
+            "prefix" : "2.1.2.2/32",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "2.34.101.4",
+            "ip2" : "2.34.101.3",
+            "node1" : "as2dept1",
+            "node2" : "as2dist1"
+          },
+          "node1Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620993,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.34.101.3~",
+            "exportPolicySources" : [
+              "dept_to_as2"
+            ],
+            "group" : "as2",
+            "importPolicy" : "as2_to_dept",
+            "importPolicySources" : [
+              "as2_to_dept"
+            ],
+            "localAs" : 65001,
+            "localIp" : "2.34.101.4",
+            "peerAddress" : "2.34.101.3",
+            "remoteAs" : 2,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node1SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2dept1",
+            "prefix" : "2.34.101.3/32",
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620737,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.34.101.4~",
+            "exportPolicySources" : [
+              "as2dist_to_dept"
+            ],
+            "group" : "dept",
+            "importPolicy" : "dept_to_as2dist",
+            "importPolicySources" : [
+              "dept_to_as2dist"
+            ],
+            "localAs" : 2,
+            "localIp" : "2.34.101.3",
+            "peerAddress" : "2.34.101.4",
+            "remoteAs" : 65001,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node2SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2dist1",
+            "prefix" : "2.34.101.4/32",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "2.34.201.4",
+            "ip2" : "2.34.201.3",
+            "node1" : "as2dept1",
+            "node2" : "as2dist2"
+          },
+          "node1Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620993,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.34.201.3~",
+            "exportPolicySources" : [
+              "dept_to_as2"
+            ],
+            "group" : "as2",
+            "importPolicy" : "as2_to_dept",
+            "importPolicySources" : [
+              "as2_to_dept"
+            ],
+            "localAs" : 65001,
+            "localIp" : "2.34.201.4",
+            "peerAddress" : "2.34.201.3",
+            "remoteAs" : 2,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node1SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2dept1",
+            "prefix" : "2.34.201.3/32",
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620738,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.34.201.4~",
+            "exportPolicySources" : [
+              "as2dist_to_dept"
+            ],
+            "group" : "dept",
+            "importPolicy" : "dept_to_as2dist",
+            "importPolicySources" : [
+              "dept_to_as2dist"
+            ],
+            "localAs" : 2,
+            "localIp" : "2.34.201.3",
+            "peerAddress" : "2.34.201.4",
+            "remoteAs" : 65001,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node2SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2dist2",
+            "prefix" : "2.34.201.4/32",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "2.1.3.1",
+            "ip2" : "2.1.2.1",
+            "node1" : "as2dist1",
+            "node2" : "as2core1"
+          },
+          "node1Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620737,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~",
+            "group" : "as2",
+            "localAs" : 2,
+            "localIp" : "2.1.3.1",
+            "peerAddress" : "2.1.2.1",
+            "remoteAs" : 2,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node1SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2dist1",
+            "prefix" : "2.1.2.1/32",
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620481,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.3.1~",
+            "group" : "as2",
+            "localAs" : 2,
+            "localIp" : "2.1.2.1",
+            "peerAddress" : "2.1.3.1",
+            "remoteAs" : 2,
+            "routeReflectorClient" : true,
+            "sendCommunity" : true
+          },
+          "node2SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2core1",
+            "prefix" : "2.1.3.1/32",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "2.1.3.1",
+            "ip2" : "2.1.2.2",
+            "node1" : "as2dist1",
+            "node2" : "as2core2"
+          },
+          "node1Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620737,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~",
+            "group" : "as2",
+            "localAs" : 2,
+            "localIp" : "2.1.3.1",
+            "peerAddress" : "2.1.2.2",
+            "remoteAs" : 2,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node1SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2dist1",
+            "prefix" : "2.1.2.2/32",
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620482,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.3.1~",
+            "group" : "as2",
+            "localAs" : 2,
+            "localIp" : "2.1.2.2",
+            "peerAddress" : "2.1.3.1",
+            "remoteAs" : 2,
+            "routeReflectorClient" : true,
+            "sendCommunity" : true
+          },
+          "node2SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2core2",
+            "prefix" : "2.1.3.1/32",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "2.34.101.3",
+            "ip2" : "2.34.101.4",
+            "node1" : "as2dist1",
+            "node2" : "as2dept1"
+          },
+          "node1Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620737,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.34.101.4~",
+            "exportPolicySources" : [
+              "as2dist_to_dept"
+            ],
+            "group" : "dept",
+            "importPolicy" : "dept_to_as2dist",
+            "importPolicySources" : [
+              "dept_to_as2dist"
+            ],
+            "localAs" : 2,
+            "localIp" : "2.34.101.3",
+            "peerAddress" : "2.34.101.4",
+            "remoteAs" : 65001,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node1SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2dist1",
+            "prefix" : "2.34.101.4/32",
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620993,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.34.101.3~",
+            "exportPolicySources" : [
+              "dept_to_as2"
+            ],
+            "group" : "as2",
+            "importPolicy" : "as2_to_dept",
+            "importPolicySources" : [
+              "as2_to_dept"
+            ],
+            "localAs" : 65001,
+            "localIp" : "2.34.101.4",
+            "peerAddress" : "2.34.101.3",
+            "remoteAs" : 2,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node2SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2dept1",
+            "prefix" : "2.34.101.3/32",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "2.1.3.2",
+            "ip2" : "2.1.2.1",
+            "node1" : "as2dist2",
+            "node2" : "as2core1"
+          },
+          "node1Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620738,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~",
+            "group" : "as2",
+            "localAs" : 2,
+            "localIp" : "2.1.3.2",
+            "peerAddress" : "2.1.2.1",
+            "remoteAs" : 2,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node1SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2dist2",
+            "prefix" : "2.1.2.1/32",
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620481,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.3.2~",
+            "group" : "as2",
+            "localAs" : 2,
+            "localIp" : "2.1.2.1",
+            "peerAddress" : "2.1.3.2",
+            "remoteAs" : 2,
+            "routeReflectorClient" : true,
+            "sendCommunity" : true
+          },
+          "node2SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2core1",
+            "prefix" : "2.1.3.2/32",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "2.1.3.2",
+            "ip2" : "2.1.2.2",
+            "node1" : "as2dist2",
+            "node2" : "as2core2"
+          },
+          "node1Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620738,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~",
+            "group" : "as2",
+            "localAs" : 2,
+            "localIp" : "2.1.3.2",
+            "peerAddress" : "2.1.2.2",
+            "remoteAs" : 2,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node1SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2dist2",
+            "prefix" : "2.1.2.2/32",
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620482,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.3.2~",
+            "group" : "as2",
+            "localAs" : 2,
+            "localIp" : "2.1.2.2",
+            "peerAddress" : "2.1.3.2",
+            "remoteAs" : 2,
+            "routeReflectorClient" : true,
+            "sendCommunity" : true
+          },
+          "node2SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2core2",
+            "prefix" : "2.1.3.2/32",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "2.34.201.3",
+            "ip2" : "2.34.201.4",
+            "node1" : "as2dist2",
+            "node2" : "as2dept1"
+          },
+          "node1Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620738,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.34.201.4~",
+            "exportPolicySources" : [
+              "as2dist_to_dept"
+            ],
+            "group" : "dept",
+            "importPolicy" : "dept_to_as2dist",
+            "importPolicySources" : [
+              "dept_to_as2dist"
+            ],
+            "localAs" : 2,
+            "localIp" : "2.34.201.3",
+            "peerAddress" : "2.34.201.4",
+            "remoteAs" : 65001,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node1SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2dist2",
+            "prefix" : "2.34.201.4/32",
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620993,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.34.201.3~",
+            "exportPolicySources" : [
+              "dept_to_as2"
+            ],
+            "group" : "as2",
+            "importPolicy" : "as2_to_dept",
+            "importPolicySources" : [
+              "as2_to_dept"
+            ],
+            "localAs" : 65001,
+            "localIp" : "2.34.201.4",
+            "peerAddress" : "2.34.201.3",
+            "remoteAs" : 2,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node2SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2dept1",
+            "prefix" : "2.34.201.3/32",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "3.1.1.1",
+            "ip2" : "3.10.1.1",
+            "node1" : "as3border1",
+            "node2" : "as3core1"
+          },
+          "node1Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 50397441,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:3.10.1.1~",
+            "group" : "as3",
+            "localAs" : 3,
+            "localIp" : "3.1.1.1",
+            "peerAddress" : "3.10.1.1",
+            "remoteAs" : 3,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node1SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as3border1",
+            "prefix" : "3.10.1.1/32",
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 50987265,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:3.1.1.1~",
+            "group" : "as3",
+            "localAs" : 3,
+            "localIp" : "3.10.1.1",
+            "peerAddress" : "3.1.1.1",
+            "remoteAs" : 3,
+            "routeReflectorClient" : true,
+            "sendCommunity" : true
+          },
+          "node2SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as3core1",
+            "prefix" : "3.1.1.1/32",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "10.23.21.3",
+            "ip2" : "10.23.21.2",
+            "node1" : "as3border1",
+            "node2" : "as2border2"
+          },
+          "node1Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 50397441,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.23.21.2~",
+            "exportPolicySources" : [
+              "as3_to_as2"
+            ],
+            "group" : "as2",
+            "importPolicy" : "as2_to_as3",
+            "importPolicySources" : [
+              "as2_to_as3"
+            ],
+            "localAs" : 3,
+            "localIp" : "10.23.21.3",
+            "peerAddress" : "10.23.21.2",
+            "remoteAs" : 2,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node1SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as3border1",
+            "prefix" : "10.23.21.2/32",
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 33620226,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.23.21.3~",
+            "exportPolicySources" : [
+              "as2_to_as3"
+            ],
+            "group" : "as3",
+            "importPolicy" : "as3_to_as2",
+            "importPolicySources" : [
+              "as3_to_as2"
+            ],
+            "localAs" : 2,
+            "localIp" : "10.23.21.2",
+            "peerAddress" : "10.23.21.3",
+            "remoteAs" : 3,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node2SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as2border2",
+            "prefix" : "10.23.21.3/32",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "3.2.2.2",
+            "ip2" : "3.10.1.1",
+            "node1" : "as3border2",
+            "node2" : "as3core1"
+          },
+          "node1Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 50463234,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:3.10.1.1~",
+            "group" : "as3",
+            "localAs" : 3,
+            "localIp" : "3.2.2.2",
+            "peerAddress" : "3.10.1.1",
+            "remoteAs" : 3,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node1SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as3border2",
+            "prefix" : "3.10.1.1/32",
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 50987265,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:3.2.2.2~",
+            "group" : "as3",
+            "localAs" : 3,
+            "localIp" : "3.10.1.1",
+            "peerAddress" : "3.2.2.2",
+            "remoteAs" : 3,
+            "routeReflectorClient" : true,
+            "sendCommunity" : true
+          },
+          "node2SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as3core1",
+            "prefix" : "3.2.2.2/32",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "10.13.22.3",
+            "ip2" : "10.13.22.1",
+            "node1" : "as3border2",
+            "node2" : "as1border2"
+          },
+          "node1Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 50463234,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.13.22.1~",
+            "exportPolicySources" : [
+              "as3_to_as1"
+            ],
+            "group" : "as1",
+            "importPolicy" : "as1_to_as3",
+            "importPolicySources" : [
+              "as1_to_as3"
+            ],
+            "localAs" : 3,
+            "localIp" : "10.13.22.3",
+            "peerAddress" : "10.13.22.1",
+            "remoteAs" : 1,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node1SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as3border2",
+            "prefix" : "10.13.22.1/32",
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 16908802,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.13.22.3~",
+            "exportPolicySources" : [
+              "as1_to_as3"
+            ],
+            "group" : "as3",
+            "importPolicy" : "as3_to_as1",
+            "importPolicySources" : [
+              "as3_to_as1"
+            ],
+            "localAs" : 1,
+            "localIp" : "10.13.22.1",
+            "peerAddress" : "10.13.22.3",
+            "remoteAs" : 3,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node2SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as1border2",
+            "prefix" : "10.13.22.3/32",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "3.10.1.1",
+            "ip2" : "3.1.1.1",
+            "node1" : "as3core1",
+            "node2" : "as3border1"
+          },
+          "node1Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 50987265,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:3.1.1.1~",
+            "group" : "as3",
+            "localAs" : 3,
+            "localIp" : "3.10.1.1",
+            "peerAddress" : "3.1.1.1",
+            "remoteAs" : 3,
+            "routeReflectorClient" : true,
+            "sendCommunity" : true
+          },
+          "node1SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as3core1",
+            "prefix" : "3.1.1.1/32",
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 50397441,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:3.10.1.1~",
+            "group" : "as3",
+            "localAs" : 3,
+            "localIp" : "3.1.1.1",
+            "peerAddress" : "3.10.1.1",
+            "remoteAs" : 3,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node2SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as3border1",
+            "prefix" : "3.10.1.1/32",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "3.10.1.1",
+            "ip2" : "3.2.2.2",
+            "node1" : "as3core1",
+            "node2" : "as3border2"
+          },
+          "node1Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 50987265,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:3.2.2.2~",
+            "group" : "as3",
+            "localAs" : 3,
+            "localIp" : "3.10.1.1",
+            "peerAddress" : "3.2.2.2",
+            "remoteAs" : 3,
+            "routeReflectorClient" : true,
+            "sendCommunity" : true
+          },
+          "node1SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as3core1",
+            "prefix" : "3.2.2.2/32",
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+            "additionalPathsReceive" : true,
+            "additionalPathsSelectAll" : true,
+            "additionalPathsSend" : true,
+            "advertiseExternal" : false,
+            "advertiseInactive" : true,
+            "allowLocalAsIn" : false,
+            "allowRemoteAsOut" : true,
+            "clusterId" : 50463234,
+            "defaultMetric" : 0,
+            "ebgpMultihop" : false,
+            "enforceFirstAs" : false,
+            "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:3.10.1.1~",
+            "group" : "as3",
+            "localAs" : 3,
+            "localIp" : "3.2.2.2",
+            "peerAddress" : "3.10.1.1",
+            "remoteAs" : 3,
+            "routeReflectorClient" : false,
+            "sendCommunity" : true
+          },
+          "node2SessionId" : {
+            "dynamic" : false,
+            "hostname" : "as3border2",
+            "prefix" : "3.10.1.1/32",
+            "vrf" : "default"
+          }
+        }
+      ],
+      "layer3" : [
+        {
+          "edgeSummary" : {
+            "node1" : "as1border1",
+            "node1interface" : "GigabitEthernet0/0",
+            "node2" : "as1core1",
+            "node2interface" : "GigabitEthernet1/0"
+          },
+          "node1Interface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "1.0.1.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "1.0.1.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "node2Interface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "1.0.1.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "1.0.1.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "node1" : "as1border1",
+            "node1interface" : "GigabitEthernet1/0",
+            "node2" : "as2border1",
+            "node2interface" : "GigabitEthernet0/0"
+          },
+          "node1Interface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "10.12.11.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "10.12.11.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "node2Interface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "10.12.11.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "incomingFilter" : "OUTSIDE_TO_INSIDE",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "outgoingFilter" : "INSIDE_TO_AS1",
+            "prefix" : "10.12.11.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "node1" : "as1border2",
+            "node1interface" : "GigabitEthernet0/0",
+            "node2" : "as3border2",
+            "node2interface" : "GigabitEthernet0/0"
+          },
+          "node1Interface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "10.13.22.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "10.13.22.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "node2Interface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "10.13.22.3/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "10.13.22.3/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "node1" : "as1border2",
+            "node1interface" : "GigabitEthernet1/0",
+            "node2" : "as1core1",
+            "node2interface" : "GigabitEthernet0/0"
+          },
+          "node1Interface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "1.0.2.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "1.0.2.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "node2Interface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "1.0.2.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "1.0.2.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "node1" : "as1core1",
+            "node1interface" : "GigabitEthernet0/0",
+            "node2" : "as1border2",
+            "node2interface" : "GigabitEthernet1/0"
+          },
+          "node1Interface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "1.0.2.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "1.0.2.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "node2Interface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "1.0.2.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "1.0.2.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "node1" : "as1core1",
+            "node1interface" : "GigabitEthernet1/0",
+            "node2" : "as1border1",
+            "node2interface" : "GigabitEthernet0/0"
+          },
+          "node1Interface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "1.0.1.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "1.0.1.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "node2Interface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "1.0.1.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "1.0.1.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "node1" : "as2border1",
+            "node1interface" : "GigabitEthernet0/0",
+            "node2" : "as1border1",
+            "node2interface" : "GigabitEthernet1/0"
+          },
+          "node1Interface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "10.12.11.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "incomingFilter" : "OUTSIDE_TO_INSIDE",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "outgoingFilter" : "INSIDE_TO_AS1",
+            "prefix" : "10.12.11.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "node2Interface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "10.12.11.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "10.12.11.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "node1" : "as2border1",
+            "node1interface" : "GigabitEthernet1/0",
+            "node2" : "as2core1",
+            "node2interface" : "GigabitEthernet0/0"
+          },
+          "node1Interface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.11.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.11.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "node2Interface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.11.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.11.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "node1" : "as2border1",
+            "node1interface" : "GigabitEthernet2/0",
+            "node2" : "as2core2",
+            "node2interface" : "GigabitEthernet1/0"
+          },
+          "node1Interface" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.12.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.12.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "node2Interface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.12.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1600,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.12.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "node1" : "as2border2",
+            "node1interface" : "GigabitEthernet0/0",
+            "node2" : "as3border1",
+            "node2interface" : "GigabitEthernet1/0"
+          },
+          "node1Interface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "10.23.21.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "incomingFilter" : "OUTSIDE_TO_INSIDE",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "outgoingFilter" : "INSIDE_TO_AS3",
+            "prefix" : "10.23.21.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "node2Interface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "10.23.21.3/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "10.23.21.3/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "node1" : "as2border2",
+            "node1interface" : "GigabitEthernet1/0",
+            "node2" : "as2core2",
+            "node2interface" : "GigabitEthernet0/0"
+          },
+          "node1Interface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.22.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.22.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "node2Interface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.22.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1800,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.22.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "node1" : "as2border2",
+            "node1interface" : "GigabitEthernet2/0",
+            "node2" : "as2core1",
+            "node2interface" : "GigabitEthernet1/0"
+          },
+          "node1Interface" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.21.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.21.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "node2Interface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.21.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.21.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "node1" : "as2core1",
+            "node1interface" : "GigabitEthernet0/0",
+            "node2" : "as2border1",
+            "node2interface" : "GigabitEthernet1/0"
+          },
+          "node1Interface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.11.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.11.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "node2Interface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.11.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.11.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "node1" : "as2core1",
+            "node1interface" : "GigabitEthernet1/0",
+            "node2" : "as2border2",
+            "node2interface" : "GigabitEthernet2/0"
+          },
+          "node1Interface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.21.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.21.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "node2Interface" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.21.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.21.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "node1" : "as2core1",
+            "node1interface" : "GigabitEthernet2/0",
+            "node2" : "as2dist1",
+            "node2interface" : "GigabitEthernet0/0"
+          },
+          "node1Interface" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.11.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "incomingFilter" : "blocktelnet",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.11.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "node2Interface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.11.3/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.11.3/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "node1" : "as2core1",
+            "node1interface" : "GigabitEthernet3/0",
+            "node2" : "as2dist2",
+            "node2interface" : "GigabitEthernet1/0"
+          },
+          "node1Interface" : {
+            "name" : "GigabitEthernet3/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.12.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet3/0"
+            ],
+            "incomingFilter" : "blocktelnet",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.12.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "node2Interface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.12.3/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.12.3/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "node1" : "as2core2",
+            "node1interface" : "GigabitEthernet0/0",
+            "node2" : "as2border2",
+            "node2interface" : "GigabitEthernet1/0"
+          },
+          "node1Interface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.22.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1800,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.22.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "node2Interface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.22.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.22.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "node1" : "as2core2",
+            "node1interface" : "GigabitEthernet1/0",
+            "node2" : "as2border1",
+            "node2interface" : "GigabitEthernet2/0"
+          },
+          "node1Interface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.12.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1600,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.12.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "node2Interface" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.12.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.12.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "node1" : "as2core2",
+            "node1interface" : "GigabitEthernet2/0",
+            "node2" : "as2dist2",
+            "node2interface" : "GigabitEthernet0/0"
+          },
+          "node1Interface" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.22.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "mtu" : 1700,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.22.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "node2Interface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.22.3/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.22.3/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "node1" : "as2core2",
+            "node1interface" : "GigabitEthernet3/0",
+            "node2" : "as2dist1",
+            "node2interface" : "GigabitEthernet1/0"
+          },
+          "node1Interface" : {
+            "name" : "GigabitEthernet3/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.21.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet3/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.21.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "node2Interface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.21.3/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.21.3/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "node1" : "as2dept1",
+            "node1interface" : "GigabitEthernet0/0",
+            "node2" : "as2dist1",
+            "node2interface" : "GigabitEthernet2/0"
+          },
+          "node1Interface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.34.101.4/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.34.101.4/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "node2Interface" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.34.101.3/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.34.101.3/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "node1" : "as2dept1",
+            "node1interface" : "GigabitEthernet1/0",
+            "node2" : "as2dist2",
+            "node2interface" : "GigabitEthernet2/0"
+          },
+          "node1Interface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.34.201.4/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.34.201.4/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "node2Interface" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.34.201.3/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.34.201.3/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "node1" : "as2dept1",
+            "node1interface" : "GigabitEthernet2/0",
+            "node2" : "host1",
+            "node2interface" : "eth0"
+          },
+          "node1Interface" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.128.0.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "incomingFilter" : "RESTRICT_HOST_TRAFFIC_IN",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.128.0.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "node2Interface" : {
+            "name" : "eth0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.128.0.101/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "eth0"
+            ],
+            "incomingFilter" : "filter::INPUT",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "outgoingFilter" : "filter::OUTPUT",
+            "prefix" : "2.128.0.101/24",
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "node1" : "as2dept1",
+            "node1interface" : "GigabitEthernet3/0",
+            "node2" : "host2",
+            "node2interface" : "eth0"
+          },
+          "node1Interface" : {
+            "name" : "GigabitEthernet3/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.128.1.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet3/0"
+            ],
+            "incomingFilter" : "RESTRICT_HOST_TRAFFIC_IN",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.128.1.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "node2Interface" : {
+            "name" : "eth0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.128.1.101/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "eth0"
+            ],
+            "incomingFilter" : "filter::INPUT",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "outgoingFilter" : "filter::OUTPUT",
+            "prefix" : "2.128.1.101/24",
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "node1" : "as2dist1",
+            "node1interface" : "GigabitEthernet0/0",
+            "node2" : "as2core1",
+            "node2interface" : "GigabitEthernet2/0"
+          },
+          "node1Interface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.11.3/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.11.3/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "node2Interface" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.11.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "incomingFilter" : "blocktelnet",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.11.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "node1" : "as2dist1",
+            "node1interface" : "GigabitEthernet1/0",
+            "node2" : "as2core2",
+            "node2interface" : "GigabitEthernet3/0"
+          },
+          "node1Interface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.21.3/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.21.3/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "node2Interface" : {
+            "name" : "GigabitEthernet3/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.21.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet3/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.21.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "node1" : "as2dist1",
+            "node1interface" : "GigabitEthernet2/0",
+            "node2" : "as2dept1",
+            "node2interface" : "GigabitEthernet0/0"
+          },
+          "node1Interface" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.34.101.3/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.34.101.3/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "node2Interface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.34.101.4/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.34.101.4/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "node1" : "as2dist2",
+            "node1interface" : "GigabitEthernet0/0",
+            "node2" : "as2core2",
+            "node2interface" : "GigabitEthernet2/0"
+          },
+          "node1Interface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.22.3/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.22.3/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "node2Interface" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.22.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "mtu" : 1700,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.22.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "node1" : "as2dist2",
+            "node1interface" : "GigabitEthernet1/0",
+            "node2" : "as2core1",
+            "node2interface" : "GigabitEthernet3/0"
+          },
+          "node1Interface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.12.3/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.12.3/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "node2Interface" : {
+            "name" : "GigabitEthernet3/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.12.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet3/0"
+            ],
+            "incomingFilter" : "blocktelnet",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.12.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "node1" : "as2dist2",
+            "node1interface" : "GigabitEthernet2/0",
+            "node2" : "as2dept1",
+            "node2interface" : "GigabitEthernet1/0"
+          },
+          "node1Interface" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.34.201.3/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.34.201.3/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "node2Interface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.34.201.4/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.34.201.4/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "node1" : "as3border1",
+            "node1interface" : "GigabitEthernet0/0",
+            "node2" : "as3core1",
+            "node2interface" : "GigabitEthernet1/0"
+          },
+          "node1Interface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "3.0.1.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "3.0.1.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "node2Interface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "3.0.1.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "3.0.1.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "node1" : "as3border1",
+            "node1interface" : "GigabitEthernet1/0",
+            "node2" : "as2border2",
+            "node2interface" : "GigabitEthernet0/0"
+          },
+          "node1Interface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "10.23.21.3/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "10.23.21.3/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "node2Interface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "10.23.21.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "incomingFilter" : "OUTSIDE_TO_INSIDE",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "outgoingFilter" : "INSIDE_TO_AS3",
+            "prefix" : "10.23.21.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "node1" : "as3border2",
+            "node1interface" : "GigabitEthernet0/0",
+            "node2" : "as1border2",
+            "node2interface" : "GigabitEthernet0/0"
+          },
+          "node1Interface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "10.13.22.3/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "10.13.22.3/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "node2Interface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "10.13.22.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "10.13.22.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "node1" : "as3border2",
+            "node1interface" : "GigabitEthernet1/0",
+            "node2" : "as3core1",
+            "node2interface" : "GigabitEthernet0/0"
+          },
+          "node1Interface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "3.0.2.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "3.0.2.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "node2Interface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "3.0.2.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "3.0.2.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "node1" : "as3core1",
+            "node1interface" : "GigabitEthernet0/0",
+            "node2" : "as3border2",
+            "node2interface" : "GigabitEthernet1/0"
+          },
+          "node1Interface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "3.0.2.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "3.0.2.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "node2Interface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "3.0.2.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "3.0.2.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "node1" : "as3core1",
+            "node1interface" : "GigabitEthernet1/0",
+            "node2" : "as3border1",
+            "node2interface" : "GigabitEthernet0/0"
+          },
+          "node1Interface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "3.0.1.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "3.0.1.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "node2Interface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "3.0.1.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "3.0.1.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "node1" : "as3core1",
+            "node1interface" : "GigabitEthernet2/0",
+            "node2" : "as3core1",
+            "node2interface" : "GigabitEthernet3/0"
+          },
+          "node1Interface" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "90.90.90.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "90.90.90.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "node2Interface" : {
+            "name" : "GigabitEthernet3/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "90.90.90.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet3/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "90.90.90.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "node1" : "as3core1",
+            "node1interface" : "GigabitEthernet3/0",
+            "node2" : "as3core1",
+            "node2interface" : "GigabitEthernet2/0"
+          },
+          "node1Interface" : {
+            "name" : "GigabitEthernet3/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "90.90.90.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet3/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "90.90.90.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "node2Interface" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "90.90.90.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "90.90.90.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "node1" : "host1",
+            "node1interface" : "eth0",
+            "node2" : "as2dept1",
+            "node2interface" : "GigabitEthernet2/0"
+          },
+          "node1Interface" : {
+            "name" : "eth0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.128.0.101/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "eth0"
+            ],
+            "incomingFilter" : "filter::INPUT",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "outgoingFilter" : "filter::OUTPUT",
+            "prefix" : "2.128.0.101/24",
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "node2Interface" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.128.0.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "incomingFilter" : "RESTRICT_HOST_TRAFFIC_IN",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.128.0.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "node1" : "host2",
+            "node1interface" : "eth0",
+            "node2" : "as2dept1",
+            "node2interface" : "GigabitEthernet3/0"
+          },
+          "node1Interface" : {
+            "name" : "eth0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.128.1.101/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "eth0"
+            ],
+            "incomingFilter" : "filter::INPUT",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "outgoingFilter" : "filter::OUTPUT",
+            "prefix" : "2.128.1.101/24",
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "node2Interface" : {
+            "name" : "GigabitEthernet3/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.128.1.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet3/0"
+            ],
+            "incomingFilter" : "RESTRICT_HOST_TRAFFIC_IN",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.128.1.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        }
+      ],
+      "ospf" : [
+        {
+          "edgeSummary" : {
+            "ip1" : "1.0.1.1",
+            "ip2" : "1.0.1.2",
+            "node1" : "as1border1",
+            "node2" : "as1core1"
+          },
+          "node1Session" : {
+            "name" : {
+              "ip1" : "1.0.1.1",
+              "ip2" : "1.0.1.2"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet0/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "1.0.1.1/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet0/0"
+              ],
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "1.0.1.1/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "name" : {
+              "ip1" : "1.0.1.2",
+              "ip2" : "1.0.1.1"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet1/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "1.0.1.2/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet1/0"
+              ],
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "1.0.1.2/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "1.0.2.1",
+            "ip2" : "1.0.2.2",
+            "node1" : "as1border2",
+            "node2" : "as1core1"
+          },
+          "node1Session" : {
+            "name" : {
+              "ip1" : "1.0.2.1",
+              "ip2" : "1.0.2.2"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet1/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "1.0.2.1/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet1/0"
+              ],
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "1.0.2.1/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "name" : {
+              "ip1" : "1.0.2.2",
+              "ip2" : "1.0.2.1"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet0/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "1.0.2.2/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet0/0"
+              ],
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "1.0.2.2/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "1.0.1.2",
+            "ip2" : "1.0.1.1",
+            "node1" : "as1core1",
+            "node2" : "as1border1"
+          },
+          "node1Session" : {
+            "name" : {
+              "ip1" : "1.0.1.2",
+              "ip2" : "1.0.1.1"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet1/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "1.0.1.2/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet1/0"
+              ],
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "1.0.1.2/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "name" : {
+              "ip1" : "1.0.1.1",
+              "ip2" : "1.0.1.2"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet0/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "1.0.1.1/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet0/0"
+              ],
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "1.0.1.1/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "1.0.2.2",
+            "ip2" : "1.0.2.1",
+            "node1" : "as1core1",
+            "node2" : "as1border2"
+          },
+          "node1Session" : {
+            "name" : {
+              "ip1" : "1.0.2.2",
+              "ip2" : "1.0.2.1"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet0/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "1.0.2.2/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet0/0"
+              ],
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "1.0.2.2/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "name" : {
+              "ip1" : "1.0.2.1",
+              "ip2" : "1.0.2.2"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet1/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "1.0.2.1/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet1/0"
+              ],
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "1.0.2.1/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "2.12.11.1",
+            "ip2" : "2.12.11.2",
+            "node1" : "as2border1",
+            "node2" : "as2core1"
+          },
+          "node1Session" : {
+            "name" : {
+              "ip1" : "2.12.11.1",
+              "ip2" : "2.12.11.2"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet1/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "2.12.11.1/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet1/0"
+              ],
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "2.12.11.1/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "name" : {
+              "ip1" : "2.12.11.2",
+              "ip2" : "2.12.11.1"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet0/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "2.12.11.2/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet0/0"
+              ],
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "2.12.11.2/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "2.12.12.1",
+            "ip2" : "2.12.12.2",
+            "node1" : "as2border1",
+            "node2" : "as2core2"
+          },
+          "node1Session" : {
+            "name" : {
+              "ip1" : "2.12.12.1",
+              "ip2" : "2.12.12.2"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet2/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "2.12.12.1/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet2/0"
+              ],
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "2.12.12.1/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "name" : {
+              "ip1" : "2.12.12.2",
+              "ip2" : "2.12.12.1"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet1/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "2.12.12.2/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet1/0"
+              ],
+              "mtu" : 1600,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "2.12.12.2/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "2.12.21.1",
+            "ip2" : "2.12.21.2",
+            "node1" : "as2border2",
+            "node2" : "as2core1"
+          },
+          "node1Session" : {
+            "name" : {
+              "ip1" : "2.12.21.1",
+              "ip2" : "2.12.21.2"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet2/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "2.12.21.1/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet2/0"
+              ],
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "2.12.21.1/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "name" : {
+              "ip1" : "2.12.21.2",
+              "ip2" : "2.12.21.1"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet1/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "2.12.21.2/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet1/0"
+              ],
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "2.12.21.2/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "2.12.22.1",
+            "ip2" : "2.12.22.2",
+            "node1" : "as2border2",
+            "node2" : "as2core2"
+          },
+          "node1Session" : {
+            "name" : {
+              "ip1" : "2.12.22.1",
+              "ip2" : "2.12.22.2"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet1/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "2.12.22.1/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet1/0"
+              ],
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "2.12.22.1/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "name" : {
+              "ip1" : "2.12.22.2",
+              "ip2" : "2.12.22.1"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet0/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "2.12.22.2/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet0/0"
+              ],
+              "mtu" : 1800,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "2.12.22.2/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "2.12.11.2",
+            "ip2" : "2.12.11.1",
+            "node1" : "as2core1",
+            "node2" : "as2border1"
+          },
+          "node1Session" : {
+            "name" : {
+              "ip1" : "2.12.11.2",
+              "ip2" : "2.12.11.1"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet0/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "2.12.11.2/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet0/0"
+              ],
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "2.12.11.2/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "name" : {
+              "ip1" : "2.12.11.1",
+              "ip2" : "2.12.11.2"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet1/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "2.12.11.1/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet1/0"
+              ],
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "2.12.11.1/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "2.12.21.2",
+            "ip2" : "2.12.21.1",
+            "node1" : "as2core1",
+            "node2" : "as2border2"
+          },
+          "node1Session" : {
+            "name" : {
+              "ip1" : "2.12.21.2",
+              "ip2" : "2.12.21.1"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet1/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "2.12.21.2/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet1/0"
+              ],
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "2.12.21.2/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "name" : {
+              "ip1" : "2.12.21.1",
+              "ip2" : "2.12.21.2"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet2/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "2.12.21.1/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet2/0"
+              ],
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "2.12.21.1/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "2.23.11.2",
+            "ip2" : "2.23.11.3",
+            "node1" : "as2core1",
+            "node2" : "as2dist1"
+          },
+          "node1Session" : {
+            "name" : {
+              "ip1" : "2.23.11.2",
+              "ip2" : "2.23.11.3"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet2/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "2.23.11.2/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet2/0"
+              ],
+              "incomingFilter" : "blocktelnet",
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "2.23.11.2/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "name" : {
+              "ip1" : "2.23.11.3",
+              "ip2" : "2.23.11.2"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet0/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "2.23.11.3/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet0/0"
+              ],
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "2.23.11.3/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "2.23.12.2",
+            "ip2" : "2.23.12.3",
+            "node1" : "as2core1",
+            "node2" : "as2dist2"
+          },
+          "node1Session" : {
+            "name" : {
+              "ip1" : "2.23.12.2",
+              "ip2" : "2.23.12.3"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet3/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "2.23.12.2/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet3/0"
+              ],
+              "incomingFilter" : "blocktelnet",
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "2.23.12.2/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "name" : {
+              "ip1" : "2.23.12.3",
+              "ip2" : "2.23.12.2"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet1/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "2.23.12.3/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet1/0"
+              ],
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "2.23.12.3/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "2.12.12.2",
+            "ip2" : "2.12.12.1",
+            "node1" : "as2core2",
+            "node2" : "as2border1"
+          },
+          "node1Session" : {
+            "name" : {
+              "ip1" : "2.12.12.2",
+              "ip2" : "2.12.12.1"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet1/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "2.12.12.2/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet1/0"
+              ],
+              "mtu" : 1600,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "2.12.12.2/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "name" : {
+              "ip1" : "2.12.12.1",
+              "ip2" : "2.12.12.2"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet2/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "2.12.12.1/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet2/0"
+              ],
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "2.12.12.1/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "2.12.22.2",
+            "ip2" : "2.12.22.1",
+            "node1" : "as2core2",
+            "node2" : "as2border2"
+          },
+          "node1Session" : {
+            "name" : {
+              "ip1" : "2.12.22.2",
+              "ip2" : "2.12.22.1"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet0/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "2.12.22.2/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet0/0"
+              ],
+              "mtu" : 1800,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "2.12.22.2/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "name" : {
+              "ip1" : "2.12.22.1",
+              "ip2" : "2.12.22.2"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet1/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "2.12.22.1/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet1/0"
+              ],
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "2.12.22.1/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "2.23.21.2",
+            "ip2" : "2.23.21.3",
+            "node1" : "as2core2",
+            "node2" : "as2dist1"
+          },
+          "node1Session" : {
+            "name" : {
+              "ip1" : "2.23.21.2",
+              "ip2" : "2.23.21.3"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet3/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "2.23.21.2/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet3/0"
+              ],
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "2.23.21.2/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "name" : {
+              "ip1" : "2.23.21.3",
+              "ip2" : "2.23.21.2"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet1/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "2.23.21.3/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet1/0"
+              ],
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "2.23.21.3/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "2.23.22.2",
+            "ip2" : "2.23.22.3",
+            "node1" : "as2core2",
+            "node2" : "as2dist2"
+          },
+          "node1Session" : {
+            "name" : {
+              "ip1" : "2.23.22.2",
+              "ip2" : "2.23.22.3"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet2/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "2.23.22.2/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet2/0"
+              ],
+              "mtu" : 1700,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "2.23.22.2/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "name" : {
+              "ip1" : "2.23.22.3",
+              "ip2" : "2.23.22.2"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet0/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "2.23.22.3/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet0/0"
+              ],
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "2.23.22.3/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "2.23.11.3",
+            "ip2" : "2.23.11.2",
+            "node1" : "as2dist1",
+            "node2" : "as2core1"
+          },
+          "node1Session" : {
+            "name" : {
+              "ip1" : "2.23.11.3",
+              "ip2" : "2.23.11.2"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet0/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "2.23.11.3/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet0/0"
+              ],
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "2.23.11.3/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "name" : {
+              "ip1" : "2.23.11.2",
+              "ip2" : "2.23.11.3"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet2/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "2.23.11.2/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet2/0"
+              ],
+              "incomingFilter" : "blocktelnet",
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "2.23.11.2/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "2.23.21.3",
+            "ip2" : "2.23.21.2",
+            "node1" : "as2dist1",
+            "node2" : "as2core2"
+          },
+          "node1Session" : {
+            "name" : {
+              "ip1" : "2.23.21.3",
+              "ip2" : "2.23.21.2"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet1/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "2.23.21.3/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet1/0"
+              ],
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "2.23.21.3/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "name" : {
+              "ip1" : "2.23.21.2",
+              "ip2" : "2.23.21.3"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet3/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "2.23.21.2/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet3/0"
+              ],
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "2.23.21.2/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "2.23.12.3",
+            "ip2" : "2.23.12.2",
+            "node1" : "as2dist2",
+            "node2" : "as2core1"
+          },
+          "node1Session" : {
+            "name" : {
+              "ip1" : "2.23.12.3",
+              "ip2" : "2.23.12.2"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet1/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "2.23.12.3/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet1/0"
+              ],
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "2.23.12.3/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "name" : {
+              "ip1" : "2.23.12.2",
+              "ip2" : "2.23.12.3"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet3/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "2.23.12.2/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet3/0"
+              ],
+              "incomingFilter" : "blocktelnet",
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "2.23.12.2/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "2.23.22.3",
+            "ip2" : "2.23.22.2",
+            "node1" : "as2dist2",
+            "node2" : "as2core2"
+          },
+          "node1Session" : {
+            "name" : {
+              "ip1" : "2.23.22.3",
+              "ip2" : "2.23.22.2"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet0/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "2.23.22.3/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet0/0"
+              ],
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "2.23.22.3/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "name" : {
+              "ip1" : "2.23.22.2",
+              "ip2" : "2.23.22.3"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet2/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "2.23.22.2/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet2/0"
+              ],
+              "mtu" : 1700,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "2.23.22.2/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "3.0.1.1",
+            "ip2" : "3.0.1.2",
+            "node1" : "as3border1",
+            "node2" : "as3core1"
+          },
+          "node1Session" : {
+            "name" : {
+              "ip1" : "3.0.1.1",
+              "ip2" : "3.0.1.2"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet0/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "3.0.1.1/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet0/0"
+              ],
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "3.0.1.1/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "name" : {
+              "ip1" : "3.0.1.2",
+              "ip2" : "3.0.1.1"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet1/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "3.0.1.2/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet1/0"
+              ],
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "3.0.1.2/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "3.0.2.1",
+            "ip2" : "3.0.2.2",
+            "node1" : "as3border2",
+            "node2" : "as3core1"
+          },
+          "node1Session" : {
+            "name" : {
+              "ip1" : "3.0.2.1",
+              "ip2" : "3.0.2.2"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet1/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "3.0.2.1/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet1/0"
+              ],
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "3.0.2.1/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "name" : {
+              "ip1" : "3.0.2.2",
+              "ip2" : "3.0.2.1"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet0/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "3.0.2.2/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet0/0"
+              ],
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "3.0.2.2/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "3.0.1.2",
+            "ip2" : "3.0.1.1",
+            "node1" : "as3core1",
+            "node2" : "as3border1"
+          },
+          "node1Session" : {
+            "name" : {
+              "ip1" : "3.0.1.2",
+              "ip2" : "3.0.1.1"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet1/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "3.0.1.2/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet1/0"
+              ],
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "3.0.1.2/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "name" : {
+              "ip1" : "3.0.1.1",
+              "ip2" : "3.0.1.2"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet0/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "3.0.1.1/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet0/0"
+              ],
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "3.0.1.1/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          }
+        },
+        {
+          "edgeSummary" : {
+            "ip1" : "3.0.2.2",
+            "ip2" : "3.0.2.1",
+            "node1" : "as3core1",
+            "node2" : "as3border2"
+          },
+          "node1Session" : {
+            "name" : {
+              "ip1" : "3.0.2.2",
+              "ip2" : "3.0.2.1"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet0/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "3.0.2.2/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet0/0"
+              ],
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "3.0.2.2/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          },
+          "node2Session" : {
+            "name" : {
+              "ip1" : "3.0.2.1",
+              "ip2" : "3.0.2.2"
+            },
+            "area" : 1,
+            "iface" : {
+              "name" : "GigabitEthernet1/0",
+              "accessVlan" : 0,
+              "active" : true,
+              "allPrefixes" : [
+                "3.0.2.1/24"
+              ],
+              "autostate" : true,
+              "bandwidth" : 1.0E9,
+              "declaredNames" : [
+                "GigabitEthernet1/0"
+              ],
+              "mtu" : 1500,
+              "nativeVlan" : 1,
+              "ospfArea" : 1,
+              "ospfCost" : 1,
+              "ospfDeadInterval" : 0,
+              "ospfEnabled" : true,
+              "ospfHelloMultiplier" : 0,
+              "ospfPassive" : false,
+              "ospfPointToPoint" : false,
+              "prefix" : "3.0.2.1/24",
+              "proxyArp" : true,
+              "ripEnabled" : false,
+              "ripPassive" : false,
+              "spanningTreePortfast" : false,
+              "switchportMode" : "NONE",
+              "switchportTrunkEncapsulation" : "DOT1Q",
+              "type" : "PHYSICAL",
+              "vrf" : "default"
+            },
+            "vrf" : "default"
+          }
+        }
+      ]
+    },
     "nodes" : {
       "as1border1" : {
         "configurationFormat" : "CISCO_IOS",
@@ -17290,2076 +19362,6 @@
           }
         }
       }
-    },
-    "ospfEdges" : [
-      {
-        "edgeSummary" : {
-          "ip1" : "1.0.1.1",
-          "ip2" : "1.0.1.2",
-          "node1" : "as1border1",
-          "node2" : "as1core1"
-        },
-        "node1Session" : {
-          "name" : {
-            "ip1" : "1.0.1.1",
-            "ip2" : "1.0.1.2"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet0/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "1.0.1.1/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet0/0"
-            ],
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "1.0.1.1/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "name" : {
-            "ip1" : "1.0.1.2",
-            "ip2" : "1.0.1.1"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet1/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "1.0.1.2/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet1/0"
-            ],
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "1.0.1.2/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "1.0.2.1",
-          "ip2" : "1.0.2.2",
-          "node1" : "as1border2",
-          "node2" : "as1core1"
-        },
-        "node1Session" : {
-          "name" : {
-            "ip1" : "1.0.2.1",
-            "ip2" : "1.0.2.2"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet1/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "1.0.2.1/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet1/0"
-            ],
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "1.0.2.1/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "name" : {
-            "ip1" : "1.0.2.2",
-            "ip2" : "1.0.2.1"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet0/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "1.0.2.2/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet0/0"
-            ],
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "1.0.2.2/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "1.0.1.2",
-          "ip2" : "1.0.1.1",
-          "node1" : "as1core1",
-          "node2" : "as1border1"
-        },
-        "node1Session" : {
-          "name" : {
-            "ip1" : "1.0.1.2",
-            "ip2" : "1.0.1.1"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet1/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "1.0.1.2/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet1/0"
-            ],
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "1.0.1.2/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "name" : {
-            "ip1" : "1.0.1.1",
-            "ip2" : "1.0.1.2"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet0/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "1.0.1.1/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet0/0"
-            ],
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "1.0.1.1/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "1.0.2.2",
-          "ip2" : "1.0.2.1",
-          "node1" : "as1core1",
-          "node2" : "as1border2"
-        },
-        "node1Session" : {
-          "name" : {
-            "ip1" : "1.0.2.2",
-            "ip2" : "1.0.2.1"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet0/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "1.0.2.2/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet0/0"
-            ],
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "1.0.2.2/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "name" : {
-            "ip1" : "1.0.2.1",
-            "ip2" : "1.0.2.2"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet1/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "1.0.2.1/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet1/0"
-            ],
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "1.0.2.1/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "2.12.11.1",
-          "ip2" : "2.12.11.2",
-          "node1" : "as2border1",
-          "node2" : "as2core1"
-        },
-        "node1Session" : {
-          "name" : {
-            "ip1" : "2.12.11.1",
-            "ip2" : "2.12.11.2"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet1/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "2.12.11.1/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet1/0"
-            ],
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "2.12.11.1/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "name" : {
-            "ip1" : "2.12.11.2",
-            "ip2" : "2.12.11.1"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet0/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "2.12.11.2/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet0/0"
-            ],
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "2.12.11.2/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "2.12.12.1",
-          "ip2" : "2.12.12.2",
-          "node1" : "as2border1",
-          "node2" : "as2core2"
-        },
-        "node1Session" : {
-          "name" : {
-            "ip1" : "2.12.12.1",
-            "ip2" : "2.12.12.2"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet2/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "2.12.12.1/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet2/0"
-            ],
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "2.12.12.1/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "name" : {
-            "ip1" : "2.12.12.2",
-            "ip2" : "2.12.12.1"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet1/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "2.12.12.2/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet1/0"
-            ],
-            "mtu" : 1600,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "2.12.12.2/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "2.12.21.1",
-          "ip2" : "2.12.21.2",
-          "node1" : "as2border2",
-          "node2" : "as2core1"
-        },
-        "node1Session" : {
-          "name" : {
-            "ip1" : "2.12.21.1",
-            "ip2" : "2.12.21.2"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet2/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "2.12.21.1/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet2/0"
-            ],
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "2.12.21.1/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "name" : {
-            "ip1" : "2.12.21.2",
-            "ip2" : "2.12.21.1"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet1/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "2.12.21.2/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet1/0"
-            ],
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "2.12.21.2/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "2.12.22.1",
-          "ip2" : "2.12.22.2",
-          "node1" : "as2border2",
-          "node2" : "as2core2"
-        },
-        "node1Session" : {
-          "name" : {
-            "ip1" : "2.12.22.1",
-            "ip2" : "2.12.22.2"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet1/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "2.12.22.1/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet1/0"
-            ],
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "2.12.22.1/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "name" : {
-            "ip1" : "2.12.22.2",
-            "ip2" : "2.12.22.1"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet0/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "2.12.22.2/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet0/0"
-            ],
-            "mtu" : 1800,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "2.12.22.2/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "2.12.11.2",
-          "ip2" : "2.12.11.1",
-          "node1" : "as2core1",
-          "node2" : "as2border1"
-        },
-        "node1Session" : {
-          "name" : {
-            "ip1" : "2.12.11.2",
-            "ip2" : "2.12.11.1"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet0/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "2.12.11.2/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet0/0"
-            ],
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "2.12.11.2/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "name" : {
-            "ip1" : "2.12.11.1",
-            "ip2" : "2.12.11.2"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet1/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "2.12.11.1/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet1/0"
-            ],
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "2.12.11.1/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "2.12.21.2",
-          "ip2" : "2.12.21.1",
-          "node1" : "as2core1",
-          "node2" : "as2border2"
-        },
-        "node1Session" : {
-          "name" : {
-            "ip1" : "2.12.21.2",
-            "ip2" : "2.12.21.1"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet1/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "2.12.21.2/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet1/0"
-            ],
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "2.12.21.2/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "name" : {
-            "ip1" : "2.12.21.1",
-            "ip2" : "2.12.21.2"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet2/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "2.12.21.1/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet2/0"
-            ],
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "2.12.21.1/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "2.23.11.2",
-          "ip2" : "2.23.11.3",
-          "node1" : "as2core1",
-          "node2" : "as2dist1"
-        },
-        "node1Session" : {
-          "name" : {
-            "ip1" : "2.23.11.2",
-            "ip2" : "2.23.11.3"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet2/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "2.23.11.2/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet2/0"
-            ],
-            "incomingFilter" : "blocktelnet",
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "2.23.11.2/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "name" : {
-            "ip1" : "2.23.11.3",
-            "ip2" : "2.23.11.2"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet0/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "2.23.11.3/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet0/0"
-            ],
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "2.23.11.3/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "2.23.12.2",
-          "ip2" : "2.23.12.3",
-          "node1" : "as2core1",
-          "node2" : "as2dist2"
-        },
-        "node1Session" : {
-          "name" : {
-            "ip1" : "2.23.12.2",
-            "ip2" : "2.23.12.3"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet3/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "2.23.12.2/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet3/0"
-            ],
-            "incomingFilter" : "blocktelnet",
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "2.23.12.2/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "name" : {
-            "ip1" : "2.23.12.3",
-            "ip2" : "2.23.12.2"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet1/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "2.23.12.3/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet1/0"
-            ],
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "2.23.12.3/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "2.12.12.2",
-          "ip2" : "2.12.12.1",
-          "node1" : "as2core2",
-          "node2" : "as2border1"
-        },
-        "node1Session" : {
-          "name" : {
-            "ip1" : "2.12.12.2",
-            "ip2" : "2.12.12.1"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet1/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "2.12.12.2/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet1/0"
-            ],
-            "mtu" : 1600,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "2.12.12.2/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "name" : {
-            "ip1" : "2.12.12.1",
-            "ip2" : "2.12.12.2"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet2/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "2.12.12.1/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet2/0"
-            ],
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "2.12.12.1/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "2.12.22.2",
-          "ip2" : "2.12.22.1",
-          "node1" : "as2core2",
-          "node2" : "as2border2"
-        },
-        "node1Session" : {
-          "name" : {
-            "ip1" : "2.12.22.2",
-            "ip2" : "2.12.22.1"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet0/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "2.12.22.2/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet0/0"
-            ],
-            "mtu" : 1800,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "2.12.22.2/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "name" : {
-            "ip1" : "2.12.22.1",
-            "ip2" : "2.12.22.2"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet1/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "2.12.22.1/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet1/0"
-            ],
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "2.12.22.1/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "2.23.21.2",
-          "ip2" : "2.23.21.3",
-          "node1" : "as2core2",
-          "node2" : "as2dist1"
-        },
-        "node1Session" : {
-          "name" : {
-            "ip1" : "2.23.21.2",
-            "ip2" : "2.23.21.3"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet3/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "2.23.21.2/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet3/0"
-            ],
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "2.23.21.2/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "name" : {
-            "ip1" : "2.23.21.3",
-            "ip2" : "2.23.21.2"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet1/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "2.23.21.3/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet1/0"
-            ],
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "2.23.21.3/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "2.23.22.2",
-          "ip2" : "2.23.22.3",
-          "node1" : "as2core2",
-          "node2" : "as2dist2"
-        },
-        "node1Session" : {
-          "name" : {
-            "ip1" : "2.23.22.2",
-            "ip2" : "2.23.22.3"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet2/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "2.23.22.2/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet2/0"
-            ],
-            "mtu" : 1700,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "2.23.22.2/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "name" : {
-            "ip1" : "2.23.22.3",
-            "ip2" : "2.23.22.2"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet0/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "2.23.22.3/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet0/0"
-            ],
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "2.23.22.3/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "2.23.11.3",
-          "ip2" : "2.23.11.2",
-          "node1" : "as2dist1",
-          "node2" : "as2core1"
-        },
-        "node1Session" : {
-          "name" : {
-            "ip1" : "2.23.11.3",
-            "ip2" : "2.23.11.2"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet0/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "2.23.11.3/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet0/0"
-            ],
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "2.23.11.3/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "name" : {
-            "ip1" : "2.23.11.2",
-            "ip2" : "2.23.11.3"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet2/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "2.23.11.2/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet2/0"
-            ],
-            "incomingFilter" : "blocktelnet",
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "2.23.11.2/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "2.23.21.3",
-          "ip2" : "2.23.21.2",
-          "node1" : "as2dist1",
-          "node2" : "as2core2"
-        },
-        "node1Session" : {
-          "name" : {
-            "ip1" : "2.23.21.3",
-            "ip2" : "2.23.21.2"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet1/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "2.23.21.3/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet1/0"
-            ],
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "2.23.21.3/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "name" : {
-            "ip1" : "2.23.21.2",
-            "ip2" : "2.23.21.3"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet3/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "2.23.21.2/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet3/0"
-            ],
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "2.23.21.2/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "2.23.12.3",
-          "ip2" : "2.23.12.2",
-          "node1" : "as2dist2",
-          "node2" : "as2core1"
-        },
-        "node1Session" : {
-          "name" : {
-            "ip1" : "2.23.12.3",
-            "ip2" : "2.23.12.2"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet1/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "2.23.12.3/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet1/0"
-            ],
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "2.23.12.3/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "name" : {
-            "ip1" : "2.23.12.2",
-            "ip2" : "2.23.12.3"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet3/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "2.23.12.2/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet3/0"
-            ],
-            "incomingFilter" : "blocktelnet",
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "2.23.12.2/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "2.23.22.3",
-          "ip2" : "2.23.22.2",
-          "node1" : "as2dist2",
-          "node2" : "as2core2"
-        },
-        "node1Session" : {
-          "name" : {
-            "ip1" : "2.23.22.3",
-            "ip2" : "2.23.22.2"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet0/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "2.23.22.3/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet0/0"
-            ],
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "2.23.22.3/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "name" : {
-            "ip1" : "2.23.22.2",
-            "ip2" : "2.23.22.3"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet2/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "2.23.22.2/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet2/0"
-            ],
-            "mtu" : 1700,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "2.23.22.2/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "3.0.1.1",
-          "ip2" : "3.0.1.2",
-          "node1" : "as3border1",
-          "node2" : "as3core1"
-        },
-        "node1Session" : {
-          "name" : {
-            "ip1" : "3.0.1.1",
-            "ip2" : "3.0.1.2"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet0/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "3.0.1.1/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet0/0"
-            ],
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "3.0.1.1/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "name" : {
-            "ip1" : "3.0.1.2",
-            "ip2" : "3.0.1.1"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet1/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "3.0.1.2/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet1/0"
-            ],
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "3.0.1.2/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "3.0.2.1",
-          "ip2" : "3.0.2.2",
-          "node1" : "as3border2",
-          "node2" : "as3core1"
-        },
-        "node1Session" : {
-          "name" : {
-            "ip1" : "3.0.2.1",
-            "ip2" : "3.0.2.2"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet1/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "3.0.2.1/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet1/0"
-            ],
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "3.0.2.1/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "name" : {
-            "ip1" : "3.0.2.2",
-            "ip2" : "3.0.2.1"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet0/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "3.0.2.2/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet0/0"
-            ],
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "3.0.2.2/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "3.0.1.2",
-          "ip2" : "3.0.1.1",
-          "node1" : "as3core1",
-          "node2" : "as3border1"
-        },
-        "node1Session" : {
-          "name" : {
-            "ip1" : "3.0.1.2",
-            "ip2" : "3.0.1.1"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet1/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "3.0.1.2/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet1/0"
-            ],
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "3.0.1.2/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "name" : {
-            "ip1" : "3.0.1.1",
-            "ip2" : "3.0.1.2"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet0/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "3.0.1.1/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet0/0"
-            ],
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "3.0.1.1/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        }
-      },
-      {
-        "edgeSummary" : {
-          "ip1" : "3.0.2.2",
-          "ip2" : "3.0.2.1",
-          "node1" : "as3core1",
-          "node2" : "as3border2"
-        },
-        "node1Session" : {
-          "name" : {
-            "ip1" : "3.0.2.2",
-            "ip2" : "3.0.2.1"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet0/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "3.0.2.2/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet0/0"
-            ],
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "3.0.2.2/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        },
-        "node2Session" : {
-          "name" : {
-            "ip1" : "3.0.2.1",
-            "ip2" : "3.0.2.2"
-          },
-          "area" : 1,
-          "iface" : {
-            "name" : "GigabitEthernet1/0",
-            "accessVlan" : 0,
-            "active" : true,
-            "allPrefixes" : [
-              "3.0.2.1/24"
-            ],
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "GigabitEthernet1/0"
-            ],
-            "mtu" : 1500,
-            "nativeVlan" : 1,
-            "ospfArea" : 1,
-            "ospfCost" : 1,
-            "ospfDeadInterval" : 0,
-            "ospfEnabled" : true,
-            "ospfHelloMultiplier" : 0,
-            "ospfPassive" : false,
-            "ospfPointToPoint" : false,
-            "prefix" : "3.0.2.1/24",
-            "proxyArp" : true,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vrf" : "default"
-        }
-      }
-    ]
+    }
   }
 ]

--- a/tests/basic/viModel.ref
+++ b/tests/basic/viModel.ref
@@ -1,0 +1,19365 @@
+[
+  {
+    "class" : "org.batfish.question.VIModelQuestionPlugin$VIModelAnswerElement",
+    "bgpEdges" : [
+      {
+        "edgeSummary" : {
+          "ip1" : "1.1.1.1",
+          "ip2" : "1.10.1.1",
+          "node1" : "as1border1",
+          "node2" : "as1core1"
+        },
+        "node1Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 16843009,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:1.10.1.1~",
+          "group" : "as1",
+          "localAs" : 1,
+          "localIp" : "1.1.1.1",
+          "peerAddress" : "1.10.1.1",
+          "remoteAs" : 1,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node1SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as1border1",
+          "prefix" : "1.10.1.1/32",
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 17432833,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:1.1.1.1~",
+          "group" : "as1",
+          "localAs" : 1,
+          "localIp" : "1.10.1.1",
+          "peerAddress" : "1.1.1.1",
+          "remoteAs" : 1,
+          "routeReflectorClient" : true,
+          "sendCommunity" : true
+        },
+        "node2SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as1core1",
+          "prefix" : "1.1.1.1/32",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "10.12.11.1",
+          "ip2" : "10.12.11.2",
+          "node1" : "as1border1",
+          "node2" : "as2border1"
+        },
+        "node1Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 16843009,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.12.11.2~",
+          "exportPolicySources" : [
+            "as1_to_as2"
+          ],
+          "group" : "as2",
+          "importPolicy" : "as2_to_as1",
+          "importPolicySources" : [
+            "as2_to_as1"
+          ],
+          "localAs" : 1,
+          "localIp" : "10.12.11.1",
+          "peerAddress" : "10.12.11.2",
+          "remoteAs" : 2,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node1SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as1border1",
+          "prefix" : "10.12.11.2/32",
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620225,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.12.11.1~",
+          "exportPolicySources" : [
+            "as2_to_as1"
+          ],
+          "group" : "as1",
+          "importPolicy" : "as1_to_as2",
+          "importPolicySources" : [
+            "as1_to_as2"
+          ],
+          "localAs" : 2,
+          "localIp" : "10.12.11.2",
+          "peerAddress" : "10.12.11.1",
+          "remoteAs" : 1,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node2SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2border1",
+          "prefix" : "10.12.11.1/32",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "1.2.2.2",
+          "ip2" : "1.10.1.1",
+          "node1" : "as1border2",
+          "node2" : "as1core1"
+        },
+        "node1Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 16908802,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:1.10.1.1~",
+          "group" : "as1",
+          "localAs" : 1,
+          "localIp" : "1.2.2.2",
+          "peerAddress" : "1.10.1.1",
+          "remoteAs" : 1,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node1SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as1border2",
+          "prefix" : "1.10.1.1/32",
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 17432833,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:1.2.2.2~",
+          "group" : "as1",
+          "localAs" : 1,
+          "localIp" : "1.10.1.1",
+          "peerAddress" : "1.2.2.2",
+          "remoteAs" : 1,
+          "routeReflectorClient" : true,
+          "sendCommunity" : true
+        },
+        "node2SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as1core1",
+          "prefix" : "1.2.2.2/32",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "10.13.22.1",
+          "ip2" : "10.13.22.3",
+          "node1" : "as1border2",
+          "node2" : "as3border2"
+        },
+        "node1Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 16908802,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.13.22.3~",
+          "exportPolicySources" : [
+            "as1_to_as3"
+          ],
+          "group" : "as3",
+          "importPolicy" : "as3_to_as1",
+          "importPolicySources" : [
+            "as3_to_as1"
+          ],
+          "localAs" : 1,
+          "localIp" : "10.13.22.1",
+          "peerAddress" : "10.13.22.3",
+          "remoteAs" : 3,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node1SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as1border2",
+          "prefix" : "10.13.22.3/32",
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 50463234,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.13.22.1~",
+          "exportPolicySources" : [
+            "as3_to_as1"
+          ],
+          "group" : "as1",
+          "importPolicy" : "as1_to_as3",
+          "importPolicySources" : [
+            "as1_to_as3"
+          ],
+          "localAs" : 3,
+          "localIp" : "10.13.22.3",
+          "peerAddress" : "10.13.22.1",
+          "remoteAs" : 1,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node2SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as3border2",
+          "prefix" : "10.13.22.1/32",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "1.10.1.1",
+          "ip2" : "1.1.1.1",
+          "node1" : "as1core1",
+          "node2" : "as1border1"
+        },
+        "node1Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 17432833,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:1.1.1.1~",
+          "group" : "as1",
+          "localAs" : 1,
+          "localIp" : "1.10.1.1",
+          "peerAddress" : "1.1.1.1",
+          "remoteAs" : 1,
+          "routeReflectorClient" : true,
+          "sendCommunity" : true
+        },
+        "node1SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as1core1",
+          "prefix" : "1.1.1.1/32",
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 16843009,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:1.10.1.1~",
+          "group" : "as1",
+          "localAs" : 1,
+          "localIp" : "1.1.1.1",
+          "peerAddress" : "1.10.1.1",
+          "remoteAs" : 1,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node2SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as1border1",
+          "prefix" : "1.10.1.1/32",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "1.10.1.1",
+          "ip2" : "1.2.2.2",
+          "node1" : "as1core1",
+          "node2" : "as1border2"
+        },
+        "node1Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 17432833,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:1.2.2.2~",
+          "group" : "as1",
+          "localAs" : 1,
+          "localIp" : "1.10.1.1",
+          "peerAddress" : "1.2.2.2",
+          "remoteAs" : 1,
+          "routeReflectorClient" : true,
+          "sendCommunity" : true
+        },
+        "node1SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as1core1",
+          "prefix" : "1.2.2.2/32",
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 16908802,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:1.10.1.1~",
+          "group" : "as1",
+          "localAs" : 1,
+          "localIp" : "1.2.2.2",
+          "peerAddress" : "1.10.1.1",
+          "remoteAs" : 1,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node2SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as1border2",
+          "prefix" : "1.10.1.1/32",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "2.1.1.1",
+          "ip2" : "2.1.2.1",
+          "node1" : "as2border1",
+          "node2" : "as2core1"
+        },
+        "node1Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620225,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.1.1",
+          "peerAddress" : "2.1.2.1",
+          "remoteAs" : 2,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node1SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2border1",
+          "prefix" : "2.1.2.1/32",
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620481,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.1.1~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.2.1",
+          "peerAddress" : "2.1.1.1",
+          "remoteAs" : 2,
+          "routeReflectorClient" : true,
+          "sendCommunity" : true
+        },
+        "node2SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2core1",
+          "prefix" : "2.1.1.1/32",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "2.1.1.1",
+          "ip2" : "2.1.2.2",
+          "node1" : "as2border1",
+          "node2" : "as2core2"
+        },
+        "node1Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620225,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.1.1",
+          "peerAddress" : "2.1.2.2",
+          "remoteAs" : 2,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node1SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2border1",
+          "prefix" : "2.1.2.2/32",
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620482,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.1.1~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.2.2",
+          "peerAddress" : "2.1.1.1",
+          "remoteAs" : 2,
+          "routeReflectorClient" : true,
+          "sendCommunity" : true
+        },
+        "node2SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2core2",
+          "prefix" : "2.1.1.1/32",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "10.12.11.2",
+          "ip2" : "10.12.11.1",
+          "node1" : "as2border1",
+          "node2" : "as1border1"
+        },
+        "node1Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620225,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.12.11.1~",
+          "exportPolicySources" : [
+            "as2_to_as1"
+          ],
+          "group" : "as1",
+          "importPolicy" : "as1_to_as2",
+          "importPolicySources" : [
+            "as1_to_as2"
+          ],
+          "localAs" : 2,
+          "localIp" : "10.12.11.2",
+          "peerAddress" : "10.12.11.1",
+          "remoteAs" : 1,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node1SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2border1",
+          "prefix" : "10.12.11.1/32",
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 16843009,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.12.11.2~",
+          "exportPolicySources" : [
+            "as1_to_as2"
+          ],
+          "group" : "as2",
+          "importPolicy" : "as2_to_as1",
+          "importPolicySources" : [
+            "as2_to_as1"
+          ],
+          "localAs" : 1,
+          "localIp" : "10.12.11.1",
+          "peerAddress" : "10.12.11.2",
+          "remoteAs" : 2,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node2SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as1border1",
+          "prefix" : "10.12.11.2/32",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "2.1.1.2",
+          "ip2" : "2.1.2.1",
+          "node1" : "as2border2",
+          "node2" : "as2core1"
+        },
+        "node1Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620226,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.1.2",
+          "peerAddress" : "2.1.2.1",
+          "remoteAs" : 2,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node1SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2border2",
+          "prefix" : "2.1.2.1/32",
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620481,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.1.2~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.2.1",
+          "peerAddress" : "2.1.1.2",
+          "remoteAs" : 2,
+          "routeReflectorClient" : true,
+          "sendCommunity" : true
+        },
+        "node2SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2core1",
+          "prefix" : "2.1.1.2/32",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "2.1.1.2",
+          "ip2" : "2.1.2.2",
+          "node1" : "as2border2",
+          "node2" : "as2core2"
+        },
+        "node1Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620226,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.1.2",
+          "peerAddress" : "2.1.2.2",
+          "remoteAs" : 2,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node1SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2border2",
+          "prefix" : "2.1.2.2/32",
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620482,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.1.2~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.2.2",
+          "peerAddress" : "2.1.1.2",
+          "remoteAs" : 2,
+          "routeReflectorClient" : true,
+          "sendCommunity" : true
+        },
+        "node2SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2core2",
+          "prefix" : "2.1.1.2/32",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "10.23.21.2",
+          "ip2" : "10.23.21.3",
+          "node1" : "as2border2",
+          "node2" : "as3border1"
+        },
+        "node1Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620226,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.23.21.3~",
+          "exportPolicySources" : [
+            "as2_to_as3"
+          ],
+          "group" : "as3",
+          "importPolicy" : "as3_to_as2",
+          "importPolicySources" : [
+            "as3_to_as2"
+          ],
+          "localAs" : 2,
+          "localIp" : "10.23.21.2",
+          "peerAddress" : "10.23.21.3",
+          "remoteAs" : 3,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node1SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2border2",
+          "prefix" : "10.23.21.3/32",
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 50397441,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.23.21.2~",
+          "exportPolicySources" : [
+            "as3_to_as2"
+          ],
+          "group" : "as2",
+          "importPolicy" : "as2_to_as3",
+          "importPolicySources" : [
+            "as2_to_as3"
+          ],
+          "localAs" : 3,
+          "localIp" : "10.23.21.3",
+          "peerAddress" : "10.23.21.2",
+          "remoteAs" : 2,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node2SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as3border1",
+          "prefix" : "10.23.21.2/32",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "2.1.2.1",
+          "ip2" : "2.1.1.1",
+          "node1" : "as2core1",
+          "node2" : "as2border1"
+        },
+        "node1Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620481,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.1.1~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.2.1",
+          "peerAddress" : "2.1.1.1",
+          "remoteAs" : 2,
+          "routeReflectorClient" : true,
+          "sendCommunity" : true
+        },
+        "node1SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2core1",
+          "prefix" : "2.1.1.1/32",
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620225,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.1.1",
+          "peerAddress" : "2.1.2.1",
+          "remoteAs" : 2,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node2SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2border1",
+          "prefix" : "2.1.2.1/32",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "2.1.2.1",
+          "ip2" : "2.1.1.2",
+          "node1" : "as2core1",
+          "node2" : "as2border2"
+        },
+        "node1Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620481,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.1.2~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.2.1",
+          "peerAddress" : "2.1.1.2",
+          "remoteAs" : 2,
+          "routeReflectorClient" : true,
+          "sendCommunity" : true
+        },
+        "node1SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2core1",
+          "prefix" : "2.1.1.2/32",
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620226,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.1.2",
+          "peerAddress" : "2.1.2.1",
+          "remoteAs" : 2,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node2SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2border2",
+          "prefix" : "2.1.2.1/32",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "2.1.2.1",
+          "ip2" : "2.1.3.1",
+          "node1" : "as2core1",
+          "node2" : "as2dist1"
+        },
+        "node1Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620481,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.3.1~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.2.1",
+          "peerAddress" : "2.1.3.1",
+          "remoteAs" : 2,
+          "routeReflectorClient" : true,
+          "sendCommunity" : true
+        },
+        "node1SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2core1",
+          "prefix" : "2.1.3.1/32",
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620737,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.3.1",
+          "peerAddress" : "2.1.2.1",
+          "remoteAs" : 2,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node2SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2dist1",
+          "prefix" : "2.1.2.1/32",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "2.1.2.1",
+          "ip2" : "2.1.3.2",
+          "node1" : "as2core1",
+          "node2" : "as2dist2"
+        },
+        "node1Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620481,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.3.2~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.2.1",
+          "peerAddress" : "2.1.3.2",
+          "remoteAs" : 2,
+          "routeReflectorClient" : true,
+          "sendCommunity" : true
+        },
+        "node1SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2core1",
+          "prefix" : "2.1.3.2/32",
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620738,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.3.2",
+          "peerAddress" : "2.1.2.1",
+          "remoteAs" : 2,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node2SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2dist2",
+          "prefix" : "2.1.2.1/32",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "2.1.2.2",
+          "ip2" : "2.1.1.1",
+          "node1" : "as2core2",
+          "node2" : "as2border1"
+        },
+        "node1Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620482,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.1.1~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.2.2",
+          "peerAddress" : "2.1.1.1",
+          "remoteAs" : 2,
+          "routeReflectorClient" : true,
+          "sendCommunity" : true
+        },
+        "node1SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2core2",
+          "prefix" : "2.1.1.1/32",
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620225,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.1.1",
+          "peerAddress" : "2.1.2.2",
+          "remoteAs" : 2,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node2SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2border1",
+          "prefix" : "2.1.2.2/32",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "2.1.2.2",
+          "ip2" : "2.1.1.2",
+          "node1" : "as2core2",
+          "node2" : "as2border2"
+        },
+        "node1Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620482,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.1.2~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.2.2",
+          "peerAddress" : "2.1.1.2",
+          "remoteAs" : 2,
+          "routeReflectorClient" : true,
+          "sendCommunity" : true
+        },
+        "node1SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2core2",
+          "prefix" : "2.1.1.2/32",
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620226,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.1.2",
+          "peerAddress" : "2.1.2.2",
+          "remoteAs" : 2,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node2SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2border2",
+          "prefix" : "2.1.2.2/32",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "2.1.2.2",
+          "ip2" : "2.1.3.1",
+          "node1" : "as2core2",
+          "node2" : "as2dist1"
+        },
+        "node1Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620482,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.3.1~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.2.2",
+          "peerAddress" : "2.1.3.1",
+          "remoteAs" : 2,
+          "routeReflectorClient" : true,
+          "sendCommunity" : true
+        },
+        "node1SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2core2",
+          "prefix" : "2.1.3.1/32",
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620737,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.3.1",
+          "peerAddress" : "2.1.2.2",
+          "remoteAs" : 2,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node2SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2dist1",
+          "prefix" : "2.1.2.2/32",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "2.1.2.2",
+          "ip2" : "2.1.3.2",
+          "node1" : "as2core2",
+          "node2" : "as2dist2"
+        },
+        "node1Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620482,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.3.2~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.2.2",
+          "peerAddress" : "2.1.3.2",
+          "remoteAs" : 2,
+          "routeReflectorClient" : true,
+          "sendCommunity" : true
+        },
+        "node1SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2core2",
+          "prefix" : "2.1.3.2/32",
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620738,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.3.2",
+          "peerAddress" : "2.1.2.2",
+          "remoteAs" : 2,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node2SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2dist2",
+          "prefix" : "2.1.2.2/32",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "2.34.101.4",
+          "ip2" : "2.34.101.3",
+          "node1" : "as2dept1",
+          "node2" : "as2dist1"
+        },
+        "node1Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620993,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.34.101.3~",
+          "exportPolicySources" : [
+            "dept_to_as2"
+          ],
+          "group" : "as2",
+          "importPolicy" : "as2_to_dept",
+          "importPolicySources" : [
+            "as2_to_dept"
+          ],
+          "localAs" : 65001,
+          "localIp" : "2.34.101.4",
+          "peerAddress" : "2.34.101.3",
+          "remoteAs" : 2,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node1SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2dept1",
+          "prefix" : "2.34.101.3/32",
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620737,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.34.101.4~",
+          "exportPolicySources" : [
+            "as2dist_to_dept"
+          ],
+          "group" : "dept",
+          "importPolicy" : "dept_to_as2dist",
+          "importPolicySources" : [
+            "dept_to_as2dist"
+          ],
+          "localAs" : 2,
+          "localIp" : "2.34.101.3",
+          "peerAddress" : "2.34.101.4",
+          "remoteAs" : 65001,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node2SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2dist1",
+          "prefix" : "2.34.101.4/32",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "2.34.201.4",
+          "ip2" : "2.34.201.3",
+          "node1" : "as2dept1",
+          "node2" : "as2dist2"
+        },
+        "node1Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620993,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.34.201.3~",
+          "exportPolicySources" : [
+            "dept_to_as2"
+          ],
+          "group" : "as2",
+          "importPolicy" : "as2_to_dept",
+          "importPolicySources" : [
+            "as2_to_dept"
+          ],
+          "localAs" : 65001,
+          "localIp" : "2.34.201.4",
+          "peerAddress" : "2.34.201.3",
+          "remoteAs" : 2,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node1SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2dept1",
+          "prefix" : "2.34.201.3/32",
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620738,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.34.201.4~",
+          "exportPolicySources" : [
+            "as2dist_to_dept"
+          ],
+          "group" : "dept",
+          "importPolicy" : "dept_to_as2dist",
+          "importPolicySources" : [
+            "dept_to_as2dist"
+          ],
+          "localAs" : 2,
+          "localIp" : "2.34.201.3",
+          "peerAddress" : "2.34.201.4",
+          "remoteAs" : 65001,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node2SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2dist2",
+          "prefix" : "2.34.201.4/32",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "2.1.3.1",
+          "ip2" : "2.1.2.1",
+          "node1" : "as2dist1",
+          "node2" : "as2core1"
+        },
+        "node1Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620737,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.3.1",
+          "peerAddress" : "2.1.2.1",
+          "remoteAs" : 2,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node1SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2dist1",
+          "prefix" : "2.1.2.1/32",
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620481,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.3.1~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.2.1",
+          "peerAddress" : "2.1.3.1",
+          "remoteAs" : 2,
+          "routeReflectorClient" : true,
+          "sendCommunity" : true
+        },
+        "node2SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2core1",
+          "prefix" : "2.1.3.1/32",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "2.1.3.1",
+          "ip2" : "2.1.2.2",
+          "node1" : "as2dist1",
+          "node2" : "as2core2"
+        },
+        "node1Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620737,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.3.1",
+          "peerAddress" : "2.1.2.2",
+          "remoteAs" : 2,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node1SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2dist1",
+          "prefix" : "2.1.2.2/32",
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620482,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.3.1~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.2.2",
+          "peerAddress" : "2.1.3.1",
+          "remoteAs" : 2,
+          "routeReflectorClient" : true,
+          "sendCommunity" : true
+        },
+        "node2SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2core2",
+          "prefix" : "2.1.3.1/32",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "2.34.101.3",
+          "ip2" : "2.34.101.4",
+          "node1" : "as2dist1",
+          "node2" : "as2dept1"
+        },
+        "node1Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620737,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.34.101.4~",
+          "exportPolicySources" : [
+            "as2dist_to_dept"
+          ],
+          "group" : "dept",
+          "importPolicy" : "dept_to_as2dist",
+          "importPolicySources" : [
+            "dept_to_as2dist"
+          ],
+          "localAs" : 2,
+          "localIp" : "2.34.101.3",
+          "peerAddress" : "2.34.101.4",
+          "remoteAs" : 65001,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node1SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2dist1",
+          "prefix" : "2.34.101.4/32",
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620993,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.34.101.3~",
+          "exportPolicySources" : [
+            "dept_to_as2"
+          ],
+          "group" : "as2",
+          "importPolicy" : "as2_to_dept",
+          "importPolicySources" : [
+            "as2_to_dept"
+          ],
+          "localAs" : 65001,
+          "localIp" : "2.34.101.4",
+          "peerAddress" : "2.34.101.3",
+          "remoteAs" : 2,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node2SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2dept1",
+          "prefix" : "2.34.101.3/32",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "2.1.3.2",
+          "ip2" : "2.1.2.1",
+          "node1" : "as2dist2",
+          "node2" : "as2core1"
+        },
+        "node1Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620738,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.3.2",
+          "peerAddress" : "2.1.2.1",
+          "remoteAs" : 2,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node1SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2dist2",
+          "prefix" : "2.1.2.1/32",
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620481,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.3.2~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.2.1",
+          "peerAddress" : "2.1.3.2",
+          "remoteAs" : 2,
+          "routeReflectorClient" : true,
+          "sendCommunity" : true
+        },
+        "node2SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2core1",
+          "prefix" : "2.1.3.2/32",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "2.1.3.2",
+          "ip2" : "2.1.2.2",
+          "node1" : "as2dist2",
+          "node2" : "as2core2"
+        },
+        "node1Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620738,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.3.2",
+          "peerAddress" : "2.1.2.2",
+          "remoteAs" : 2,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node1SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2dist2",
+          "prefix" : "2.1.2.2/32",
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620482,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.3.2~",
+          "group" : "as2",
+          "localAs" : 2,
+          "localIp" : "2.1.2.2",
+          "peerAddress" : "2.1.3.2",
+          "remoteAs" : 2,
+          "routeReflectorClient" : true,
+          "sendCommunity" : true
+        },
+        "node2SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2core2",
+          "prefix" : "2.1.3.2/32",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "2.34.201.3",
+          "ip2" : "2.34.201.4",
+          "node1" : "as2dist2",
+          "node2" : "as2dept1"
+        },
+        "node1Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620738,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.34.201.4~",
+          "exportPolicySources" : [
+            "as2dist_to_dept"
+          ],
+          "group" : "dept",
+          "importPolicy" : "dept_to_as2dist",
+          "importPolicySources" : [
+            "dept_to_as2dist"
+          ],
+          "localAs" : 2,
+          "localIp" : "2.34.201.3",
+          "peerAddress" : "2.34.201.4",
+          "remoteAs" : 65001,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node1SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2dist2",
+          "prefix" : "2.34.201.4/32",
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620993,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.34.201.3~",
+          "exportPolicySources" : [
+            "dept_to_as2"
+          ],
+          "group" : "as2",
+          "importPolicy" : "as2_to_dept",
+          "importPolicySources" : [
+            "as2_to_dept"
+          ],
+          "localAs" : 65001,
+          "localIp" : "2.34.201.4",
+          "peerAddress" : "2.34.201.3",
+          "remoteAs" : 2,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node2SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2dept1",
+          "prefix" : "2.34.201.3/32",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "3.1.1.1",
+          "ip2" : "3.10.1.1",
+          "node1" : "as3border1",
+          "node2" : "as3core1"
+        },
+        "node1Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 50397441,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:3.10.1.1~",
+          "group" : "as3",
+          "localAs" : 3,
+          "localIp" : "3.1.1.1",
+          "peerAddress" : "3.10.1.1",
+          "remoteAs" : 3,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node1SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as3border1",
+          "prefix" : "3.10.1.1/32",
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 50987265,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:3.1.1.1~",
+          "group" : "as3",
+          "localAs" : 3,
+          "localIp" : "3.10.1.1",
+          "peerAddress" : "3.1.1.1",
+          "remoteAs" : 3,
+          "routeReflectorClient" : true,
+          "sendCommunity" : true
+        },
+        "node2SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as3core1",
+          "prefix" : "3.1.1.1/32",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "10.23.21.3",
+          "ip2" : "10.23.21.2",
+          "node1" : "as3border1",
+          "node2" : "as2border2"
+        },
+        "node1Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 50397441,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.23.21.2~",
+          "exportPolicySources" : [
+            "as3_to_as2"
+          ],
+          "group" : "as2",
+          "importPolicy" : "as2_to_as3",
+          "importPolicySources" : [
+            "as2_to_as3"
+          ],
+          "localAs" : 3,
+          "localIp" : "10.23.21.3",
+          "peerAddress" : "10.23.21.2",
+          "remoteAs" : 2,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node1SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as3border1",
+          "prefix" : "10.23.21.2/32",
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 33620226,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.23.21.3~",
+          "exportPolicySources" : [
+            "as2_to_as3"
+          ],
+          "group" : "as3",
+          "importPolicy" : "as3_to_as2",
+          "importPolicySources" : [
+            "as3_to_as2"
+          ],
+          "localAs" : 2,
+          "localIp" : "10.23.21.2",
+          "peerAddress" : "10.23.21.3",
+          "remoteAs" : 3,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node2SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as2border2",
+          "prefix" : "10.23.21.3/32",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "3.2.2.2",
+          "ip2" : "3.10.1.1",
+          "node1" : "as3border2",
+          "node2" : "as3core1"
+        },
+        "node1Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 50463234,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:3.10.1.1~",
+          "group" : "as3",
+          "localAs" : 3,
+          "localIp" : "3.2.2.2",
+          "peerAddress" : "3.10.1.1",
+          "remoteAs" : 3,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node1SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as3border2",
+          "prefix" : "3.10.1.1/32",
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 50987265,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:3.2.2.2~",
+          "group" : "as3",
+          "localAs" : 3,
+          "localIp" : "3.10.1.1",
+          "peerAddress" : "3.2.2.2",
+          "remoteAs" : 3,
+          "routeReflectorClient" : true,
+          "sendCommunity" : true
+        },
+        "node2SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as3core1",
+          "prefix" : "3.2.2.2/32",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "10.13.22.3",
+          "ip2" : "10.13.22.1",
+          "node1" : "as3border2",
+          "node2" : "as1border2"
+        },
+        "node1Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 50463234,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.13.22.1~",
+          "exportPolicySources" : [
+            "as3_to_as1"
+          ],
+          "group" : "as1",
+          "importPolicy" : "as1_to_as3",
+          "importPolicySources" : [
+            "as1_to_as3"
+          ],
+          "localAs" : 3,
+          "localIp" : "10.13.22.3",
+          "peerAddress" : "10.13.22.1",
+          "remoteAs" : 1,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node1SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as3border2",
+          "prefix" : "10.13.22.1/32",
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 16908802,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.13.22.3~",
+          "exportPolicySources" : [
+            "as1_to_as3"
+          ],
+          "group" : "as3",
+          "importPolicy" : "as3_to_as1",
+          "importPolicySources" : [
+            "as3_to_as1"
+          ],
+          "localAs" : 1,
+          "localIp" : "10.13.22.1",
+          "peerAddress" : "10.13.22.3",
+          "remoteAs" : 3,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node2SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as1border2",
+          "prefix" : "10.13.22.3/32",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "3.10.1.1",
+          "ip2" : "3.1.1.1",
+          "node1" : "as3core1",
+          "node2" : "as3border1"
+        },
+        "node1Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 50987265,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:3.1.1.1~",
+          "group" : "as3",
+          "localAs" : 3,
+          "localIp" : "3.10.1.1",
+          "peerAddress" : "3.1.1.1",
+          "remoteAs" : 3,
+          "routeReflectorClient" : true,
+          "sendCommunity" : true
+        },
+        "node1SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as3core1",
+          "prefix" : "3.1.1.1/32",
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 50397441,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:3.10.1.1~",
+          "group" : "as3",
+          "localAs" : 3,
+          "localIp" : "3.1.1.1",
+          "peerAddress" : "3.10.1.1",
+          "remoteAs" : 3,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node2SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as3border1",
+          "prefix" : "3.10.1.1/32",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "3.10.1.1",
+          "ip2" : "3.2.2.2",
+          "node1" : "as3core1",
+          "node2" : "as3border2"
+        },
+        "node1Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 50987265,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:3.2.2.2~",
+          "group" : "as3",
+          "localAs" : 3,
+          "localIp" : "3.10.1.1",
+          "peerAddress" : "3.2.2.2",
+          "remoteAs" : 3,
+          "routeReflectorClient" : true,
+          "sendCommunity" : true
+        },
+        "node1SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as3core1",
+          "prefix" : "3.2.2.2/32",
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+          "additionalPathsReceive" : true,
+          "additionalPathsSelectAll" : true,
+          "additionalPathsSend" : true,
+          "advertiseExternal" : false,
+          "advertiseInactive" : true,
+          "allowLocalAsIn" : false,
+          "allowRemoteAsOut" : true,
+          "clusterId" : 50463234,
+          "defaultMetric" : 0,
+          "ebgpMultihop" : false,
+          "enforceFirstAs" : false,
+          "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:3.10.1.1~",
+          "group" : "as3",
+          "localAs" : 3,
+          "localIp" : "3.2.2.2",
+          "peerAddress" : "3.10.1.1",
+          "remoteAs" : 3,
+          "routeReflectorClient" : false,
+          "sendCommunity" : true
+        },
+        "node2SessionId" : {
+          "dynamic" : false,
+          "hostname" : "as3border2",
+          "prefix" : "3.10.1.1/32",
+          "vrf" : "default"
+        }
+      }
+    ],
+    "layer3Edges" : [
+      {
+        "edgeSummary" : {
+          "node1" : "as1border1",
+          "node1interface" : "GigabitEthernet0/0",
+          "node2" : "as1core1",
+          "node2interface" : "GigabitEthernet1/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "1.0.1.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "1.0.1.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "1.0.1.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "1.0.1.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "node1" : "as1border1",
+          "node1interface" : "GigabitEthernet1/0",
+          "node2" : "as2border1",
+          "node2interface" : "GigabitEthernet0/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "10.12.11.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "10.12.11.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "10.12.11.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "incomingFilter" : "OUTSIDE_TO_INSIDE",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "outgoingFilter" : "INSIDE_TO_AS1",
+          "prefix" : "10.12.11.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "node1" : "as1border2",
+          "node1interface" : "GigabitEthernet0/0",
+          "node2" : "as3border2",
+          "node2interface" : "GigabitEthernet0/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "10.13.22.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "10.13.22.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "10.13.22.3/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "10.13.22.3/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "node1" : "as1border2",
+          "node1interface" : "GigabitEthernet1/0",
+          "node2" : "as1core1",
+          "node2interface" : "GigabitEthernet0/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "1.0.2.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "1.0.2.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "1.0.2.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "1.0.2.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "node1" : "as1core1",
+          "node1interface" : "GigabitEthernet0/0",
+          "node2" : "as1border2",
+          "node2interface" : "GigabitEthernet1/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "1.0.2.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "1.0.2.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "1.0.2.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "1.0.2.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "node1" : "as1core1",
+          "node1interface" : "GigabitEthernet1/0",
+          "node2" : "as1border1",
+          "node2interface" : "GigabitEthernet0/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "1.0.1.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "1.0.1.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "1.0.1.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "1.0.1.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "node1" : "as2border1",
+          "node1interface" : "GigabitEthernet0/0",
+          "node2" : "as1border1",
+          "node2interface" : "GigabitEthernet1/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "10.12.11.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "incomingFilter" : "OUTSIDE_TO_INSIDE",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "outgoingFilter" : "INSIDE_TO_AS1",
+          "prefix" : "10.12.11.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "10.12.11.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "10.12.11.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "node1" : "as2border1",
+          "node1interface" : "GigabitEthernet1/0",
+          "node2" : "as2core1",
+          "node2interface" : "GigabitEthernet0/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.12.11.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.12.11.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.12.11.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.12.11.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "node1" : "as2border1",
+          "node1interface" : "GigabitEthernet2/0",
+          "node2" : "as2core2",
+          "node2interface" : "GigabitEthernet1/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet2/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.12.12.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet2/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.12.12.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.12.12.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "mtu" : 1600,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.12.12.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "node1" : "as2border2",
+          "node1interface" : "GigabitEthernet0/0",
+          "node2" : "as3border1",
+          "node2interface" : "GigabitEthernet1/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "10.23.21.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "incomingFilter" : "OUTSIDE_TO_INSIDE",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "outgoingFilter" : "INSIDE_TO_AS3",
+          "prefix" : "10.23.21.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "10.23.21.3/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "10.23.21.3/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "node1" : "as2border2",
+          "node1interface" : "GigabitEthernet1/0",
+          "node2" : "as2core2",
+          "node2interface" : "GigabitEthernet0/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.12.22.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.12.22.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.12.22.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "mtu" : 1800,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.12.22.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "node1" : "as2border2",
+          "node1interface" : "GigabitEthernet2/0",
+          "node2" : "as2core1",
+          "node2interface" : "GigabitEthernet1/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet2/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.12.21.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet2/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.12.21.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.12.21.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.12.21.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "node1" : "as2core1",
+          "node1interface" : "GigabitEthernet0/0",
+          "node2" : "as2border1",
+          "node2interface" : "GigabitEthernet1/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.12.11.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.12.11.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.12.11.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.12.11.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "node1" : "as2core1",
+          "node1interface" : "GigabitEthernet1/0",
+          "node2" : "as2border2",
+          "node2interface" : "GigabitEthernet2/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.12.21.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.12.21.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet2/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.12.21.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet2/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.12.21.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "node1" : "as2core1",
+          "node1interface" : "GigabitEthernet2/0",
+          "node2" : "as2dist1",
+          "node2interface" : "GigabitEthernet0/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet2/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.23.11.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet2/0"
+          ],
+          "incomingFilter" : "blocktelnet",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.23.11.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.23.11.3/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.23.11.3/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "node1" : "as2core1",
+          "node1interface" : "GigabitEthernet3/0",
+          "node2" : "as2dist2",
+          "node2interface" : "GigabitEthernet1/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet3/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.23.12.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet3/0"
+          ],
+          "incomingFilter" : "blocktelnet",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.23.12.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.23.12.3/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.23.12.3/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "node1" : "as2core2",
+          "node1interface" : "GigabitEthernet0/0",
+          "node2" : "as2border2",
+          "node2interface" : "GigabitEthernet1/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.12.22.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "mtu" : 1800,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.12.22.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.12.22.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.12.22.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "node1" : "as2core2",
+          "node1interface" : "GigabitEthernet1/0",
+          "node2" : "as2border1",
+          "node2interface" : "GigabitEthernet2/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.12.12.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "mtu" : 1600,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.12.12.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet2/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.12.12.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet2/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.12.12.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "node1" : "as2core2",
+          "node1interface" : "GigabitEthernet2/0",
+          "node2" : "as2dist2",
+          "node2interface" : "GigabitEthernet0/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet2/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.23.22.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet2/0"
+          ],
+          "mtu" : 1700,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.23.22.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.23.22.3/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.23.22.3/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "node1" : "as2core2",
+          "node1interface" : "GigabitEthernet3/0",
+          "node2" : "as2dist1",
+          "node2interface" : "GigabitEthernet1/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet3/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.23.21.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet3/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.23.21.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.23.21.3/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.23.21.3/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "node1" : "as2dept1",
+          "node1interface" : "GigabitEthernet0/0",
+          "node2" : "as2dist1",
+          "node2interface" : "GigabitEthernet2/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.34.101.4/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.34.101.4/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet2/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.34.101.3/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet2/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.34.101.3/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "node1" : "as2dept1",
+          "node1interface" : "GigabitEthernet1/0",
+          "node2" : "as2dist2",
+          "node2interface" : "GigabitEthernet2/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.34.201.4/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.34.201.4/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet2/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.34.201.3/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet2/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.34.201.3/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "node1" : "as2dept1",
+          "node1interface" : "GigabitEthernet2/0",
+          "node2" : "host1",
+          "node2interface" : "eth0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet2/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.128.0.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet2/0"
+          ],
+          "incomingFilter" : "RESTRICT_HOST_TRAFFIC_IN",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.128.0.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "eth0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.128.0.101/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "eth0"
+          ],
+          "incomingFilter" : "filter::INPUT",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "outgoingFilter" : "filter::OUTPUT",
+          "prefix" : "2.128.0.101/24",
+          "proxyArp" : false,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "node1" : "as2dept1",
+          "node1interface" : "GigabitEthernet3/0",
+          "node2" : "host2",
+          "node2interface" : "eth0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet3/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.128.1.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet3/0"
+          ],
+          "incomingFilter" : "RESTRICT_HOST_TRAFFIC_IN",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.128.1.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "eth0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.128.1.101/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "eth0"
+          ],
+          "incomingFilter" : "filter::INPUT",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "outgoingFilter" : "filter::OUTPUT",
+          "prefix" : "2.128.1.101/24",
+          "proxyArp" : false,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "node1" : "as2dist1",
+          "node1interface" : "GigabitEthernet0/0",
+          "node2" : "as2core1",
+          "node2interface" : "GigabitEthernet2/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.23.11.3/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.23.11.3/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet2/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.23.11.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet2/0"
+          ],
+          "incomingFilter" : "blocktelnet",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.23.11.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "node1" : "as2dist1",
+          "node1interface" : "GigabitEthernet1/0",
+          "node2" : "as2core2",
+          "node2interface" : "GigabitEthernet3/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.23.21.3/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.23.21.3/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet3/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.23.21.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet3/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.23.21.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "node1" : "as2dist1",
+          "node1interface" : "GigabitEthernet2/0",
+          "node2" : "as2dept1",
+          "node2interface" : "GigabitEthernet0/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet2/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.34.101.3/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet2/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.34.101.3/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.34.101.4/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.34.101.4/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "node1" : "as2dist2",
+          "node1interface" : "GigabitEthernet0/0",
+          "node2" : "as2core2",
+          "node2interface" : "GigabitEthernet2/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.23.22.3/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.23.22.3/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet2/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.23.22.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet2/0"
+          ],
+          "mtu" : 1700,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.23.22.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "node1" : "as2dist2",
+          "node1interface" : "GigabitEthernet1/0",
+          "node2" : "as2core1",
+          "node2interface" : "GigabitEthernet3/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.23.12.3/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.23.12.3/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet3/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.23.12.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet3/0"
+          ],
+          "incomingFilter" : "blocktelnet",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.23.12.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "node1" : "as2dist2",
+          "node1interface" : "GigabitEthernet2/0",
+          "node2" : "as2dept1",
+          "node2interface" : "GigabitEthernet1/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet2/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.34.201.3/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet2/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.34.201.3/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.34.201.4/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.34.201.4/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "node1" : "as3border1",
+          "node1interface" : "GigabitEthernet0/0",
+          "node2" : "as3core1",
+          "node2interface" : "GigabitEthernet1/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "3.0.1.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "3.0.1.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "3.0.1.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "3.0.1.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "node1" : "as3border1",
+          "node1interface" : "GigabitEthernet1/0",
+          "node2" : "as2border2",
+          "node2interface" : "GigabitEthernet0/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "10.23.21.3/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "10.23.21.3/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "10.23.21.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "incomingFilter" : "OUTSIDE_TO_INSIDE",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "outgoingFilter" : "INSIDE_TO_AS3",
+          "prefix" : "10.23.21.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "node1" : "as3border2",
+          "node1interface" : "GigabitEthernet0/0",
+          "node2" : "as1border2",
+          "node2interface" : "GigabitEthernet0/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "10.13.22.3/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "10.13.22.3/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "10.13.22.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "10.13.22.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "node1" : "as3border2",
+          "node1interface" : "GigabitEthernet1/0",
+          "node2" : "as3core1",
+          "node2interface" : "GigabitEthernet0/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "3.0.2.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "3.0.2.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "3.0.2.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "3.0.2.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "node1" : "as3core1",
+          "node1interface" : "GigabitEthernet0/0",
+          "node2" : "as3border2",
+          "node2interface" : "GigabitEthernet1/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "3.0.2.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "3.0.2.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "3.0.2.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "3.0.2.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "node1" : "as3core1",
+          "node1interface" : "GigabitEthernet1/0",
+          "node2" : "as3border1",
+          "node2interface" : "GigabitEthernet0/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet1/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "3.0.1.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet1/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "3.0.1.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet0/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "3.0.1.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet0/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfArea" : 1,
+          "ospfCost" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : true,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "3.0.1.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "node1" : "as3core1",
+          "node1interface" : "GigabitEthernet2/0",
+          "node2" : "as3core1",
+          "node2interface" : "GigabitEthernet3/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet2/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "90.90.90.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet2/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "90.90.90.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet3/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "90.90.90.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet3/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "90.90.90.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "node1" : "as3core1",
+          "node1interface" : "GigabitEthernet3/0",
+          "node2" : "as3core1",
+          "node2interface" : "GigabitEthernet2/0"
+        },
+        "node1Interface" : {
+          "name" : "GigabitEthernet3/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "90.90.90.2/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet3/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "90.90.90.2/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet2/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "90.90.90.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet2/0"
+          ],
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "90.90.90.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "node1" : "host1",
+          "node1interface" : "eth0",
+          "node2" : "as2dept1",
+          "node2interface" : "GigabitEthernet2/0"
+        },
+        "node1Interface" : {
+          "name" : "eth0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.128.0.101/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "eth0"
+          ],
+          "incomingFilter" : "filter::INPUT",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "outgoingFilter" : "filter::OUTPUT",
+          "prefix" : "2.128.0.101/24",
+          "proxyArp" : false,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet2/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.128.0.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet2/0"
+          ],
+          "incomingFilter" : "RESTRICT_HOST_TRAFFIC_IN",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.128.0.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "node1" : "host2",
+          "node1interface" : "eth0",
+          "node2" : "as2dept1",
+          "node2interface" : "GigabitEthernet3/0"
+        },
+        "node1Interface" : {
+          "name" : "eth0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.128.1.101/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "eth0"
+          ],
+          "incomingFilter" : "filter::INPUT",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "outgoingFilter" : "filter::OUTPUT",
+          "prefix" : "2.128.1.101/24",
+          "proxyArp" : false,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        },
+        "node2Interface" : {
+          "name" : "GigabitEthernet3/0",
+          "accessVlan" : 0,
+          "active" : true,
+          "allPrefixes" : [
+            "2.128.1.1/24"
+          ],
+          "autostate" : true,
+          "bandwidth" : 1.0E9,
+          "declaredNames" : [
+            "GigabitEthernet3/0"
+          ],
+          "incomingFilter" : "RESTRICT_HOST_TRAFFIC_IN",
+          "mtu" : 1500,
+          "nativeVlan" : 1,
+          "ospfDeadInterval" : 0,
+          "ospfEnabled" : false,
+          "ospfHelloMultiplier" : 0,
+          "ospfPassive" : false,
+          "ospfPointToPoint" : false,
+          "prefix" : "2.128.1.1/24",
+          "proxyArp" : true,
+          "ripEnabled" : false,
+          "ripPassive" : false,
+          "spanningTreePortfast" : false,
+          "switchportMode" : "NONE",
+          "switchportTrunkEncapsulation" : "DOT1Q",
+          "type" : "PHYSICAL",
+          "vrf" : "default"
+        }
+      }
+    ],
+    "nodes" : {
+      "as1border1" : {
+        "configurationFormat" : "CISCO_IOS",
+        "name" : "as1border1",
+        "communityLists" : {
+          "as1_community" : {
+            "class" : "org.batfish.datamodel.CommunityList",
+            "invertMatch" : false,
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.RegexCommunitySet",
+                  "regex" : "(,|\\{|\\}|^|$| )1:"
+                }
+              }
+            ],
+            "name" : "as1_community"
+          },
+          "as2_community" : {
+            "class" : "org.batfish.datamodel.CommunityList",
+            "invertMatch" : false,
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.RegexCommunitySet",
+                  "regex" : "(,|\\{|\\}|^|$| )2:"
+                }
+              }
+            ],
+            "name" : "as2_community"
+          },
+          "as3_community" : {
+            "class" : "org.batfish.datamodel.CommunityList",
+            "invertMatch" : false,
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.RegexCommunitySet",
+                  "regex" : "(,|\\{|\\}|^|$| )3:"
+                }
+              }
+            ],
+            "name" : "as3_community"
+          }
+        },
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
+        "deviceType" : "ROUTER",
+        "domainName" : "lab.local",
+        "interfaces" : {
+          "Ethernet0/0" : {
+            "name" : "Ethernet0/0",
+            "accessVlan" : 0,
+            "active" : false,
+            "autostate" : true,
+            "bandwidth" : 1.0E7,
+            "declaredNames" : [
+              "Ethernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "GigabitEthernet0/0" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "1.0.1.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "1.0.1.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "GigabitEthernet1/0" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "10.12.11.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "10.12.11.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "Loopback0" : {
+            "name" : "Loopback0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "1.1.1.1/32"
+            ],
+            "autostate" : true,
+            "bandwidth" : 8.0E9,
+            "declaredNames" : [
+              "Loopback0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : true,
+            "ospfPointToPoint" : false,
+            "prefix" : "1.1.1.1/32",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "LOOPBACK",
+            "vrf" : "default"
+          }
+        },
+        "ipAccessLists" : {
+          "101" : {
+            "name" : "101",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.255.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "1.0.1.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 1.0.1.0 host 255.255.255.0"
+              },
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.255.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "1.0.2.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 1.0.2.0 host 255.255.255.0"
+              }
+            ],
+            "sourceName" : "101",
+            "sourceType" : "extended ipv4 access-list"
+          },
+          "102" : {
+            "name" : "102",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.0.0.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "2.0.0.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 2.0.0.0 host 255.0.0.0"
+              },
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.0.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "2.128.0.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 2.128.0.0 host 255.255.0.0"
+              }
+            ],
+            "sourceName" : "102",
+            "sourceType" : "extended ipv4 access-list"
+          },
+          "103" : {
+            "name" : "103",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.255.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "3.0.1.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 3.0.1.0 host 255.255.255.0"
+              },
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.255.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "3.0.2.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 3.0.2.0 host 255.255.255.0"
+              }
+            ],
+            "sourceName" : "103",
+            "sourceType" : "extended ipv4 access-list"
+          }
+        },
+        "routeFilterLists" : {
+          "101" : {
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "1.0.1.0/24",
+                "lengthRange" : "24-24"
+              },
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "1.0.2.0/24",
+                "lengthRange" : "24-24"
+              }
+            ],
+            "name" : "101"
+          },
+          "102" : {
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "2.0.0.0/8",
+                "lengthRange" : "8-8"
+              },
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "2.128.0.0/16",
+                "lengthRange" : "16-16"
+              }
+            ],
+            "name" : "102"
+          },
+          "103" : {
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "3.0.1.0/24",
+                "lengthRange" : "24-24"
+              },
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "3.0.2.0/24",
+                "lengthRange" : "24-24"
+              }
+            ],
+            "name" : "103"
+          },
+          "default_list" : {
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "0.0.0.0/0",
+                "lengthRange" : "0-0"
+              }
+            ],
+            "name" : "default_list"
+          },
+          "inbound_route_filter" : {
+            "lines" : [
+              {
+                "action" : "DENY",
+                "ipWildcard" : "1.0.0.0/8",
+                "lengthRange" : "8-32"
+              },
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "0.0.0.0/0",
+                "lengthRange" : "0-32"
+              }
+            ],
+            "name" : "inbound_route_filter"
+          }
+        },
+        "routingPolicies" : {
+          "as1_to_as2" : {
+            "name" : "as1_to_as2",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as1_to_as2~1~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                    "comment" : "~RMCLAUSE~as1_to_as2~3~",
+                    "falseStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                        "comment" : "~RMCLAUSE~as1_to_as2~5~",
+                        "falseStatements" : [
+                          {
+                            "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                            "type" : "ReturnLocalDefaultAction"
+                          }
+                        ],
+                        "guard" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                          "prefix" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                          },
+                          "prefixSet" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                            "name" : "default_list"
+                          }
+                        },
+                        "trueStatements" : [
+                          {
+                            "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                            "metric" : {
+                              "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                              "value" : 50
+                            }
+                          },
+                          {
+                            "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                            "expr" : {
+                              "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySet",
+                              "communities" : [
+                                65538
+                              ]
+                            }
+                          },
+                          {
+                            "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                            "type" : "ReturnTrue"
+                          }
+                        ]
+                      }
+                    ],
+                    "guard" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                      "prefix" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                      },
+                      "prefixSet" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                        "name" : "103"
+                      }
+                    },
+                    "trueStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                        "metric" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                          "value" : 50
+                        }
+                      },
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                        "expr" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySet",
+                          "communities" : [
+                            65538
+                          ]
+                        }
+                      },
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                        "type" : "ReturnTrue"
+                      }
+                    ]
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                    "name" : "101"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                    "metric" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                      "value" : 50
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                    "expr" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySet",
+                      "communities" : [
+                        65538
+                      ]
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
+          "as1_to_as3" : {
+            "name" : "as1_to_as3",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as1_to_as3~1~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                    "comment" : "~RMCLAUSE~as1_to_as3~2~",
+                    "falseStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                        "type" : "ReturnLocalDefaultAction"
+                      }
+                    ],
+                    "guard" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                      "prefix" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                      },
+                      "prefixSet" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                        "name" : "102"
+                      }
+                    },
+                    "trueStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                        "metric" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                          "value" : 50
+                        }
+                      },
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                        "expr" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySet",
+                          "communities" : [
+                            65539
+                          ]
+                        }
+                      },
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                        "type" : "ReturnTrue"
+                      }
+                    ]
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                    "name" : "101"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                    "metric" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                      "value" : 50
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                    "expr" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySet",
+                      "communities" : [
+                        65539
+                      ]
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
+          "as2_to_as1" : {
+            "name" : "as2_to_as1",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as2_to_as1~100~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnLocalDefaultAction"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchCommunitySet",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedCommunitySet",
+                    "name" : "as2_community"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetLocalPreference",
+                    "localPreference" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralInt",
+                      "value" : 350
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
+          "as3_to_as1" : {
+            "name" : "as3_to_as1",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as3_to_as1~100~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnLocalDefaultAction"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchCommunitySet",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedCommunitySet",
+                    "name" : "as3_community"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetLocalPreference",
+                    "localPreference" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralInt",
+                      "value" : 350
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
+          "~BGP_COMMON_EXPORT_POLICY:default~" : {
+            "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
+                  "disjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                      "conjuncts" : [
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                          "prefix" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                          },
+                          "prefixSet" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                            "prefixSpace" : [
+                              "1.0.1.0/24"
+                            ]
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                            "protocol" : "bgp"
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                            "protocol" : "ibgp"
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                            "protocol" : "aggregate"
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.WithEnvironmentExpr",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.BooleanExprs$StaticBooleanExpr",
+                            "type" : "True"
+                          },
+                          "postStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "UnsetWriteIntermediateBgpAttributes"
+                            }
+                          ],
+                          "postTrueStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "SetReadIntermediateBgpAttributes"
+                            },
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.SetOrigin",
+                              "originType" : {
+                                "class" : "org.batfish.datamodel.routing_policy.expr.LiteralOrigin",
+                                "originType" : "igp"
+                              }
+                            }
+                          ],
+                          "preStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "SetWriteIntermediateBgpAttributes"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                      "conjuncts" : [
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                          "prefix" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                          },
+                          "prefixSet" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                            "prefixSpace" : [
+                              "1.0.2.0/24"
+                            ]
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                            "protocol" : "bgp"
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                            "protocol" : "ibgp"
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                            "protocol" : "aggregate"
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.WithEnvironmentExpr",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.BooleanExprs$StaticBooleanExpr",
+                            "type" : "True"
+                          },
+                          "postStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "UnsetWriteIntermediateBgpAttributes"
+                            }
+                          ],
+                          "postTrueStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "SetReadIntermediateBgpAttributes"
+                            },
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.SetOrigin",
+                              "originType" : {
+                                "class" : "org.batfish.datamodel.routing_policy.expr.LiteralOrigin",
+                                "originType" : "igp"
+                              }
+                            }
+                          ],
+                          "preStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "SetWriteIntermediateBgpAttributes"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "bgp"
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "ibgp"
+                    }
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              },
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                "type" : "ReturnFalse"
+              }
+            ]
+          },
+          "~BGP_PEER_EXPORT_POLICY:default:1.10.1.1~" : {
+            "name" : "~BGP_PEER_EXPORT_POLICY:default:1.10.1.1~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          },
+          "~BGP_PEER_EXPORT_POLICY:default:10.12.11.2~" : {
+            "name" : "~BGP_PEER_EXPORT_POLICY:default:10.12.11.2~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                  "conjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                      "calledPolicyName" : "as1_to_as2"
+                    }
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          },
+          "~BGP_PEER_EXPORT_POLICY:default:3.2.2.2~" : {
+            "name" : "~BGP_PEER_EXPORT_POLICY:default:3.2.2.2~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          },
+          "~BGP_PEER_EXPORT_POLICY:default:5.6.7.8~" : {
+            "name" : "~BGP_PEER_EXPORT_POLICY:default:5.6.7.8~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          },
+          "~OSPF_EXPORT_POLICY:default~" : {
+            "name" : "~OSPF_EXPORT_POLICY:default~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "OSPF export routes for connected",
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                  "conjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "connected"
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                      "expr" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                        "comment" : "match default route",
+                        "prefix" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                        },
+                        "prefixSet" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                          "prefixSpace" : [
+                            "0.0.0.0/0"
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetOspfMetricType",
+                    "metricType" : "E2"
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                    "metric" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                      "value" : 20
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "vendorFamily" : {
+          "cisco" : {
+            "aaa" : {
+              "newModel" : false
+            },
+            "hostname" : "as1border1",
+            "lines" : {
+              "aux0" : {
+                "name" : "aux0",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "AUX"
+              },
+              "con0" : {
+                "name" : "con0",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "CON"
+              },
+              "vty0" : {
+                "name" : "vty0",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty1" : {
+                "name" : "vty1",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty2" : {
+                "name" : "vty2",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty3" : {
+                "name" : "vty3",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty4" : {
+                "name" : "vty4",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              }
+            },
+            "logging" : {
+              "on" : true
+            },
+            "services" : {
+              "timestamps" : {
+                "enabled" : true,
+                "subservices" : {
+                  "debug" : {
+                    "enabled" : true,
+                    "subservices" : {
+                      "datetime" : {
+                        "enabled" : true,
+                        "subservices" : {
+                          "msec" : {
+                            "enabled" : true
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "log" : {
+                    "enabled" : true,
+                    "subservices" : {
+                      "datetime" : {
+                        "enabled" : true,
+                        "subservices" : {
+                          "msec" : {
+                            "enabled" : true
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "vrfs" : {
+          "default" : {
+            "name" : "default",
+            "bgpProcess" : {
+              "multipathEbgp" : true,
+              "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
+              "multipathIbgp" : true,
+              "neighbors" : {
+                "1.10.1.1/32" : {
+                  "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "additionalPathsReceive" : true,
+                  "additionalPathsSelectAll" : true,
+                  "additionalPathsSend" : true,
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : false,
+                  "allowRemoteAsOut" : true,
+                  "clusterId" : 16843009,
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:1.10.1.1~",
+                  "group" : "as1",
+                  "localAs" : 1,
+                  "localIp" : "1.1.1.1",
+                  "peerAddress" : "1.10.1.1",
+                  "remoteAs" : 1,
+                  "routeReflectorClient" : false,
+                  "sendCommunity" : true
+                },
+                "3.2.2.2/32" : {
+                  "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "additionalPathsReceive" : true,
+                  "additionalPathsSelectAll" : true,
+                  "additionalPathsSend" : true,
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : false,
+                  "allowRemoteAsOut" : true,
+                  "clusterId" : 16843009,
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:3.2.2.2~",
+                  "group" : "bad-ebgp",
+                  "localAs" : 1,
+                  "peerAddress" : "3.2.2.2",
+                  "remoteAs" : 666,
+                  "routeReflectorClient" : false,
+                  "sendCommunity" : false
+                },
+                "5.6.7.8/32" : {
+                  "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "additionalPathsReceive" : true,
+                  "additionalPathsSelectAll" : true,
+                  "additionalPathsSend" : true,
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : false,
+                  "allowRemoteAsOut" : true,
+                  "clusterId" : 16843009,
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:5.6.7.8~",
+                  "group" : "xanadu",
+                  "localAs" : 1,
+                  "peerAddress" : "5.6.7.8",
+                  "remoteAs" : 555,
+                  "routeReflectorClient" : false,
+                  "sendCommunity" : false
+                },
+                "10.12.11.2/32" : {
+                  "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "additionalPathsReceive" : true,
+                  "additionalPathsSelectAll" : true,
+                  "additionalPathsSend" : true,
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : false,
+                  "allowRemoteAsOut" : true,
+                  "clusterId" : 16843009,
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.12.11.2~",
+                  "exportPolicySources" : [
+                    "as1_to_as2"
+                  ],
+                  "group" : "as2",
+                  "importPolicy" : "as2_to_as1",
+                  "importPolicySources" : [
+                    "as2_to_as1"
+                  ],
+                  "localAs" : 1,
+                  "localIp" : "10.12.11.1",
+                  "peerAddress" : "10.12.11.2",
+                  "remoteAs" : 2,
+                  "routeReflectorClient" : false,
+                  "sendCommunity" : true
+                }
+              },
+              "routerId" : "1.1.1.1",
+              "tieBreaker" : "ARRIVAL_ORDER"
+            },
+            "interfaces" : [
+              "Ethernet0/0",
+              "GigabitEthernet0/0",
+              "GigabitEthernet1/0",
+              "Loopback0"
+            ],
+            "ospfProcess" : {
+              "areas" : {
+                "1" : {
+                  "name" : 1,
+                  "injectDefaultRoute" : true,
+                  "interfaces" : [
+                    "GigabitEthernet0/0",
+                    "Loopback0"
+                  ],
+                  "metricOfDefaultRoute" : 0,
+                  "stubType" : "NONE"
+                }
+              },
+              "exportPolicy" : "~OSPF_EXPORT_POLICY:default~",
+              "processId" : "1",
+              "referenceBandwidth" : 1.0E8,
+              "routerId" : "1.1.1.1"
+            }
+          }
+        }
+      },
+      "as1border2" : {
+        "configurationFormat" : "CISCO_IOS",
+        "name" : "as1border2",
+        "communityLists" : {
+          "as1_community" : {
+            "class" : "org.batfish.datamodel.CommunityList",
+            "invertMatch" : false,
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.RegexCommunitySet",
+                  "regex" : "(,|\\{|\\}|^|$| )1:"
+                }
+              }
+            ],
+            "name" : "as1_community"
+          },
+          "as2_community" : {
+            "class" : "org.batfish.datamodel.CommunityList",
+            "invertMatch" : false,
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.RegexCommunitySet",
+                  "regex" : "(,|\\{|\\}|^|$| )2:"
+                }
+              }
+            ],
+            "name" : "as2_community"
+          },
+          "as3_community" : {
+            "class" : "org.batfish.datamodel.CommunityList",
+            "invertMatch" : false,
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.RegexCommunitySet",
+                  "regex" : "(,|\\{|\\}|^|$| )3:"
+                }
+              }
+            ],
+            "name" : "as3_community"
+          },
+          "as4_community" : {
+            "class" : "org.batfish.datamodel.CommunityList",
+            "invertMatch" : false,
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.RegexCommunitySet",
+                  "regex" : "(,|\\{|\\}|^|$| )4:"
+                }
+              }
+            ],
+            "name" : "as4_community"
+          }
+        },
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
+        "deviceType" : "ROUTER",
+        "domainName" : "lab.local",
+        "interfaces" : {
+          "Ethernet0/0" : {
+            "name" : "Ethernet0/0",
+            "accessVlan" : 0,
+            "active" : false,
+            "autostate" : true,
+            "bandwidth" : 1.0E7,
+            "declaredNames" : [
+              "Ethernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "GigabitEthernet0/0" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "10.13.22.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "10.13.22.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "GigabitEthernet1/0" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "1.0.2.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "1.0.2.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "GigabitEthernet2/0" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "10.14.22.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "10.14.22.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "Loopback0" : {
+            "name" : "Loopback0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "1.2.2.2/32"
+            ],
+            "autostate" : true,
+            "bandwidth" : 8.0E9,
+            "declaredNames" : [
+              "Loopback0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "1.2.2.2/32",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "LOOPBACK",
+            "vrf" : "default"
+          }
+        },
+        "ipAccessLists" : {
+          "101" : {
+            "name" : "101",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.255.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "1.0.1.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 1.0.1.0 host 255.255.255.0"
+              },
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.255.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "1.0.2.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 1.0.2.0 host 255.255.255.0"
+              }
+            ],
+            "sourceName" : "101",
+            "sourceType" : "extended ipv4 access-list"
+          },
+          "102" : {
+            "name" : "102",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.0.0.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "2.0.0.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 2.0.0.0 host 255.0.0.0"
+              },
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.0.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "2.128.0.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 2.128.0.0 host 255.255.0.0"
+              }
+            ],
+            "sourceName" : "102",
+            "sourceType" : "extended ipv4 access-list"
+          },
+          "103" : {
+            "name" : "103",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.255.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "3.0.1.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 3.0.1.0 host 255.255.255.0"
+              }
+            ],
+            "sourceName" : "103",
+            "sourceType" : "extended ipv4 access-list"
+          }
+        },
+        "ntpServers" : [
+          "18.18.18.18",
+          "23.23.23.23"
+        ],
+        "routeFilterLists" : {
+          "101" : {
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "1.0.1.0/24",
+                "lengthRange" : "24-24"
+              },
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "1.0.2.0/24",
+                "lengthRange" : "24-24"
+              }
+            ],
+            "name" : "101"
+          },
+          "102" : {
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "2.0.0.0/8",
+                "lengthRange" : "8-8"
+              },
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "2.128.0.0/16",
+                "lengthRange" : "16-16"
+              }
+            ],
+            "name" : "102"
+          },
+          "103" : {
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "3.0.1.0/24",
+                "lengthRange" : "24-24"
+              }
+            ],
+            "name" : "103"
+          },
+          "as4-prefixes" : {
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "4.0.0.0/8",
+                "lengthRange" : "8-32"
+              }
+            ],
+            "name" : "as4-prefixes"
+          },
+          "inbound_route_filter" : {
+            "lines" : [
+              {
+                "action" : "DENY",
+                "ipWildcard" : "1.0.0.0/8",
+                "lengthRange" : "8-32"
+              },
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "0.0.0.0/0",
+                "lengthRange" : "0-32"
+              }
+            ],
+            "name" : "inbound_route_filter"
+          }
+        },
+        "routingPolicies" : {
+          "as1_to_as2" : {
+            "name" : "as1_to_as2",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as1_to_as2~1~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                    "comment" : "~RMCLAUSE~as1_to_as2~3~",
+                    "falseStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                        "type" : "ReturnLocalDefaultAction"
+                      }
+                    ],
+                    "guard" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                      "prefix" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                      },
+                      "prefixSet" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                        "name" : "103"
+                      }
+                    },
+                    "trueStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                        "metric" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                          "value" : 50
+                        }
+                      },
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                        "expr" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySet",
+                          "communities" : [
+                            65538
+                          ]
+                        }
+                      },
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                        "type" : "ReturnTrue"
+                      }
+                    ]
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                    "name" : "101"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                    "metric" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                      "value" : 50
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                    "expr" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySet",
+                      "communities" : [
+                        65538
+                      ]
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
+          "as1_to_as3" : {
+            "name" : "as1_to_as3",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as1_to_as3~1~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                    "comment" : "~RMCLAUSE~as1_to_as3~2~",
+                    "falseStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                        "type" : "ReturnLocalDefaultAction"
+                      }
+                    ],
+                    "guard" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                      "prefix" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                      },
+                      "prefixSet" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                        "name" : "102"
+                      }
+                    },
+                    "trueStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                        "metric" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                          "value" : 50
+                        }
+                      },
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                        "expr" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySet",
+                          "communities" : [
+                            65539
+                          ]
+                        }
+                      },
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                        "type" : "ReturnTrue"
+                      }
+                    ]
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                    "name" : "101"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                    "metric" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                      "value" : 50
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                    "expr" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySet",
+                      "communities" : [
+                        65539
+                      ]
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
+          "as1_to_as4" : {
+            "name" : "as1_to_as4",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                "metric" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                  "value" : 50
+                }
+              },
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                "expr" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySet",
+                  "communities" : [
+                    65540
+                  ]
+                }
+              },
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                "type" : "ReturnTrue"
+              }
+            ]
+          },
+          "as2_to_as1" : {
+            "name" : "as2_to_as1",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as2_to_as1~100~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnLocalDefaultAction"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchCommunitySet",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedCommunitySet",
+                    "name" : "as2_community"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetLocalPreference",
+                    "localPreference" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralInt",
+                      "value" : 350
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
+          "as3_to_as1" : {
+            "name" : "as3_to_as1",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as3_to_as1~100~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnLocalDefaultAction"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchCommunitySet",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedCommunitySet",
+                    "name" : "as3_community"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetLocalPreference",
+                    "localPreference" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralInt",
+                      "value" : 350
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
+          "as4_to_as1" : {
+            "name" : "as4_to_as1",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as4_to_as1~100~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnLocalDefaultAction"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                  "conjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchCommunitySet",
+                      "expr" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.NamedCommunitySet",
+                        "name" : "as4_community"
+                      }
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                      "prefix" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                      },
+                      "prefixSet" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                        "name" : "as4-prefixes"
+                      }
+                    }
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetLocalPreference",
+                    "localPreference" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralInt",
+                      "value" : 350
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
+          "~BGP_COMMON_EXPORT_POLICY:default~" : {
+            "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
+                  "disjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                      "conjuncts" : [
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                          "prefix" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                          },
+                          "prefixSet" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                            "prefixSpace" : [
+                              "1.0.1.0/24"
+                            ]
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                            "protocol" : "bgp"
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                            "protocol" : "ibgp"
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                            "protocol" : "aggregate"
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.WithEnvironmentExpr",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.BooleanExprs$StaticBooleanExpr",
+                            "type" : "True"
+                          },
+                          "postStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "UnsetWriteIntermediateBgpAttributes"
+                            }
+                          ],
+                          "postTrueStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "SetReadIntermediateBgpAttributes"
+                            },
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.SetOrigin",
+                              "originType" : {
+                                "class" : "org.batfish.datamodel.routing_policy.expr.LiteralOrigin",
+                                "originType" : "igp"
+                              }
+                            }
+                          ],
+                          "preStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "SetWriteIntermediateBgpAttributes"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                      "conjuncts" : [
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                          "prefix" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                          },
+                          "prefixSet" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                            "prefixSpace" : [
+                              "1.0.2.0/24"
+                            ]
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                            "protocol" : "bgp"
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                            "protocol" : "ibgp"
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                            "protocol" : "aggregate"
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.WithEnvironmentExpr",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.BooleanExprs$StaticBooleanExpr",
+                            "type" : "True"
+                          },
+                          "postStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "UnsetWriteIntermediateBgpAttributes"
+                            }
+                          ],
+                          "postTrueStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "SetReadIntermediateBgpAttributes"
+                            },
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.SetOrigin",
+                              "originType" : {
+                                "class" : "org.batfish.datamodel.routing_policy.expr.LiteralOrigin",
+                                "originType" : "igp"
+                              }
+                            }
+                          ],
+                          "preStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "SetWriteIntermediateBgpAttributes"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "bgp"
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "ibgp"
+                    }
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              },
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                "type" : "ReturnFalse"
+              }
+            ]
+          },
+          "~BGP_PEER_EXPORT_POLICY:default:1.10.1.1~" : {
+            "name" : "~BGP_PEER_EXPORT_POLICY:default:1.10.1.1~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          },
+          "~BGP_PEER_EXPORT_POLICY:default:10.13.22.3~" : {
+            "name" : "~BGP_PEER_EXPORT_POLICY:default:10.13.22.3~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                  "conjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                      "calledPolicyName" : "as1_to_as3"
+                    }
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          },
+          "~BGP_PEER_EXPORT_POLICY:default:10.14.22.4~" : {
+            "name" : "~BGP_PEER_EXPORT_POLICY:default:10.14.22.4~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                  "conjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                      "calledPolicyName" : "as1_to_as4"
+                    }
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          },
+          "~OSPF_EXPORT_POLICY:default~" : {
+            "name" : "~OSPF_EXPORT_POLICY:default~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "OSPF export routes for connected",
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                  "conjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "connected"
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                      "expr" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                        "comment" : "match default route",
+                        "prefix" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                        },
+                        "prefixSet" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                          "prefixSpace" : [
+                            "0.0.0.0/0"
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetOspfMetricType",
+                    "metricType" : "E2"
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                    "metric" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                      "value" : 20
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "vendorFamily" : {
+          "cisco" : {
+            "aaa" : {
+              "newModel" : false
+            },
+            "hostname" : "as1border2",
+            "lines" : {
+              "aux0" : {
+                "name" : "aux0",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "AUX"
+              },
+              "con0" : {
+                "name" : "con0",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "CON"
+              },
+              "vty0" : {
+                "name" : "vty0",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty1" : {
+                "name" : "vty1",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty2" : {
+                "name" : "vty2",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty3" : {
+                "name" : "vty3",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty4" : {
+                "name" : "vty4",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              }
+            },
+            "logging" : {
+              "on" : true
+            },
+            "ntp" : {
+              "servers" : {
+                "18.18.18.18" : {
+                  "name" : "18.18.18.18"
+                },
+                "23.23.23.23" : {
+                  "name" : "23.23.23.23"
+                }
+              }
+            },
+            "services" : {
+              "timestamps" : {
+                "enabled" : true,
+                "subservices" : {
+                  "debug" : {
+                    "enabled" : true,
+                    "subservices" : {
+                      "datetime" : {
+                        "enabled" : true,
+                        "subservices" : {
+                          "msec" : {
+                            "enabled" : true
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "log" : {
+                    "enabled" : true,
+                    "subservices" : {
+                      "datetime" : {
+                        "enabled" : true,
+                        "subservices" : {
+                          "msec" : {
+                            "enabled" : true
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "vrfs" : {
+          "default" : {
+            "name" : "default",
+            "bgpProcess" : {
+              "multipathEbgp" : true,
+              "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
+              "multipathIbgp" : true,
+              "neighbors" : {
+                "1.10.1.1/32" : {
+                  "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "additionalPathsReceive" : true,
+                  "additionalPathsSelectAll" : true,
+                  "additionalPathsSend" : true,
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : false,
+                  "allowRemoteAsOut" : true,
+                  "clusterId" : 16908802,
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:1.10.1.1~",
+                  "group" : "as1",
+                  "localAs" : 1,
+                  "localIp" : "1.2.2.2",
+                  "peerAddress" : "1.10.1.1",
+                  "remoteAs" : 1,
+                  "routeReflectorClient" : false,
+                  "sendCommunity" : true
+                },
+                "10.13.22.3/32" : {
+                  "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "additionalPathsReceive" : true,
+                  "additionalPathsSelectAll" : true,
+                  "additionalPathsSend" : true,
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : false,
+                  "allowRemoteAsOut" : true,
+                  "clusterId" : 16908802,
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.13.22.3~",
+                  "exportPolicySources" : [
+                    "as1_to_as3"
+                  ],
+                  "group" : "as3",
+                  "importPolicy" : "as3_to_as1",
+                  "importPolicySources" : [
+                    "as3_to_as1"
+                  ],
+                  "localAs" : 1,
+                  "localIp" : "10.13.22.1",
+                  "peerAddress" : "10.13.22.3",
+                  "remoteAs" : 3,
+                  "routeReflectorClient" : false,
+                  "sendCommunity" : true
+                },
+                "10.14.22.4/32" : {
+                  "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "additionalPathsReceive" : true,
+                  "additionalPathsSelectAll" : true,
+                  "additionalPathsSend" : true,
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : false,
+                  "allowRemoteAsOut" : true,
+                  "clusterId" : 16908802,
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.14.22.4~",
+                  "exportPolicySources" : [
+                    "as1_to_as4"
+                  ],
+                  "group" : "as4",
+                  "importPolicy" : "as4_to_as1",
+                  "importPolicySources" : [
+                    "as4_to_as1"
+                  ],
+                  "localAs" : 1,
+                  "localIp" : "10.14.22.1",
+                  "peerAddress" : "10.14.22.4",
+                  "remoteAs" : 4,
+                  "routeReflectorClient" : false,
+                  "sendCommunity" : false
+                }
+              },
+              "routerId" : "1.2.2.2",
+              "tieBreaker" : "ARRIVAL_ORDER"
+            },
+            "interfaces" : [
+              "Ethernet0/0",
+              "GigabitEthernet0/0",
+              "GigabitEthernet1/0",
+              "GigabitEthernet2/0",
+              "Loopback0"
+            ],
+            "ospfProcess" : {
+              "areas" : {
+                "1" : {
+                  "name" : 1,
+                  "injectDefaultRoute" : true,
+                  "interfaces" : [
+                    "GigabitEthernet1/0",
+                    "Loopback0"
+                  ],
+                  "metricOfDefaultRoute" : 0,
+                  "stubType" : "NONE"
+                }
+              },
+              "exportPolicy" : "~OSPF_EXPORT_POLICY:default~",
+              "processId" : "1",
+              "referenceBandwidth" : 1.0E8,
+              "routerId" : "1.2.2.2"
+            }
+          }
+        }
+      },
+      "as1core1" : {
+        "configurationFormat" : "CISCO_IOS",
+        "name" : "as1core1",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
+        "deviceType" : "ROUTER",
+        "domainName" : "lab.local",
+        "interfaces" : {
+          "Ethernet0/0" : {
+            "name" : "Ethernet0/0",
+            "accessVlan" : 0,
+            "active" : false,
+            "autostate" : true,
+            "bandwidth" : 1.0E7,
+            "declaredNames" : [
+              "Ethernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "GigabitEthernet0/0" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "1.0.2.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "1.0.2.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "GigabitEthernet1/0" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "1.0.1.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "1.0.1.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "Loopback0" : {
+            "name" : "Loopback0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "1.10.1.1/32"
+            ],
+            "autostate" : true,
+            "bandwidth" : 8.0E9,
+            "declaredNames" : [
+              "Loopback0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "1.10.1.1/32",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "LOOPBACK",
+            "vrf" : "default"
+          }
+        },
+        "loggingServers" : [
+          "1.1.1.1",
+          "2.2.2.2"
+        ],
+        "routingPolicies" : {
+          "~BGP_COMMON_EXPORT_POLICY:default~" : {
+            "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
+                  "disjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "bgp"
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "ibgp"
+                    }
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              },
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                "type" : "ReturnFalse"
+              }
+            ]
+          },
+          "~BGP_PEER_EXPORT_POLICY:default:1.1.1.1~" : {
+            "name" : "~BGP_PEER_EXPORT_POLICY:default:1.1.1.1~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          },
+          "~BGP_PEER_EXPORT_POLICY:default:1.2.2.2~" : {
+            "name" : "~BGP_PEER_EXPORT_POLICY:default:1.2.2.2~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          },
+          "~OSPF_EXPORT_POLICY:default~" : {
+            "name" : "~OSPF_EXPORT_POLICY:default~"
+          }
+        },
+        "vendorFamily" : {
+          "cisco" : {
+            "aaa" : {
+              "newModel" : false
+            },
+            "hostname" : "as1core1",
+            "lines" : {
+              "aux0" : {
+                "name" : "aux0",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "AUX"
+              },
+              "con0" : {
+                "name" : "con0",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "CON"
+              },
+              "vty0" : {
+                "name" : "vty0",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty1" : {
+                "name" : "vty1",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty2" : {
+                "name" : "vty2",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty3" : {
+                "name" : "vty3",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty4" : {
+                "name" : "vty4",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              }
+            },
+            "logging" : {
+              "hosts" : {
+                "1.1.1.1" : {
+                  "name" : "1.1.1.1"
+                },
+                "2.2.2.2" : {
+                  "name" : "2.2.2.2"
+                }
+              },
+              "on" : true
+            },
+            "services" : {
+              "timestamps" : {
+                "enabled" : true,
+                "subservices" : {
+                  "debug" : {
+                    "enabled" : true,
+                    "subservices" : {
+                      "datetime" : {
+                        "enabled" : true,
+                        "subservices" : {
+                          "msec" : {
+                            "enabled" : true
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "log" : {
+                    "enabled" : true,
+                    "subservices" : {
+                      "datetime" : {
+                        "enabled" : true,
+                        "subservices" : {
+                          "msec" : {
+                            "enabled" : true
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "vrfs" : {
+          "default" : {
+            "name" : "default",
+            "bgpProcess" : {
+              "multipathEbgp" : true,
+              "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
+              "multipathIbgp" : true,
+              "neighbors" : {
+                "1.1.1.1/32" : {
+                  "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "additionalPathsReceive" : true,
+                  "additionalPathsSelectAll" : true,
+                  "additionalPathsSend" : true,
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : false,
+                  "allowRemoteAsOut" : true,
+                  "clusterId" : 17432833,
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:1.1.1.1~",
+                  "group" : "as1",
+                  "localAs" : 1,
+                  "localIp" : "1.10.1.1",
+                  "peerAddress" : "1.1.1.1",
+                  "remoteAs" : 1,
+                  "routeReflectorClient" : true,
+                  "sendCommunity" : true
+                },
+                "1.2.2.2/32" : {
+                  "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "additionalPathsReceive" : true,
+                  "additionalPathsSelectAll" : true,
+                  "additionalPathsSend" : true,
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : false,
+                  "allowRemoteAsOut" : true,
+                  "clusterId" : 17432833,
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:1.2.2.2~",
+                  "group" : "as1",
+                  "localAs" : 1,
+                  "localIp" : "1.10.1.1",
+                  "peerAddress" : "1.2.2.2",
+                  "remoteAs" : 1,
+                  "routeReflectorClient" : true,
+                  "sendCommunity" : true
+                }
+              },
+              "routerId" : "1.10.1.1",
+              "tieBreaker" : "ARRIVAL_ORDER"
+            },
+            "interfaces" : [
+              "Ethernet0/0",
+              "GigabitEthernet0/0",
+              "GigabitEthernet1/0",
+              "Loopback0"
+            ],
+            "ospfProcess" : {
+              "areas" : {
+                "1" : {
+                  "name" : 1,
+                  "injectDefaultRoute" : true,
+                  "interfaces" : [
+                    "GigabitEthernet0/0",
+                    "GigabitEthernet1/0",
+                    "Loopback0"
+                  ],
+                  "metricOfDefaultRoute" : 0,
+                  "stubType" : "NONE"
+                }
+              },
+              "exportPolicy" : "~OSPF_EXPORT_POLICY:default~",
+              "processId" : "1",
+              "referenceBandwidth" : 1.0E8,
+              "routerId" : "1.10.1.1"
+            }
+          }
+        }
+      },
+      "as2border1" : {
+        "configurationFormat" : "CISCO_IOS",
+        "name" : "as2border1",
+        "communityLists" : {
+          "as1_community" : {
+            "class" : "org.batfish.datamodel.CommunityList",
+            "invertMatch" : false,
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.RegexCommunitySet",
+                  "regex" : "(,|\\{|\\}|^|$| )1:"
+                }
+              }
+            ],
+            "name" : "as1_community"
+          },
+          "as2_community" : {
+            "class" : "org.batfish.datamodel.CommunityList",
+            "invertMatch" : false,
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.RegexCommunitySet",
+                  "regex" : "(,|\\{|\\}|^|$| )2:"
+                }
+              }
+            ],
+            "name" : "as2_community"
+          },
+          "as3_community" : {
+            "class" : "org.batfish.datamodel.CommunityList",
+            "invertMatch" : false,
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.RegexCommunitySet",
+                  "regex" : "(,|\\{|\\}|^|$| )3:"
+                }
+              }
+            ],
+            "name" : "as3_community"
+          }
+        },
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
+        "deviceType" : "ROUTER",
+        "domainName" : "lab.local",
+        "interfaces" : {
+          "Ethernet0/0" : {
+            "name" : "Ethernet0/0",
+            "accessVlan" : 0,
+            "active" : false,
+            "autostate" : true,
+            "bandwidth" : 1.0E7,
+            "declaredNames" : [
+              "Ethernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "GigabitEthernet0/0" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "10.12.11.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "incomingFilter" : "OUTSIDE_TO_INSIDE",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "outgoingFilter" : "INSIDE_TO_AS1",
+            "prefix" : "10.12.11.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "GigabitEthernet1/0" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.11.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.11.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "GigabitEthernet2/0" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.12.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.12.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "Loopback0" : {
+            "name" : "Loopback0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.1.1.1/32"
+            ],
+            "autostate" : true,
+            "bandwidth" : 8.0E9,
+            "declaredNames" : [
+              "Loopback0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.1.1.1/32",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "LOOPBACK",
+            "vrf" : "default"
+          }
+        },
+        "ipAccessLists" : {
+          "101" : {
+            "name" : "101",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.255.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "1.0.1.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 1.0.1.0 host 255.255.255.0"
+              },
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.255.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "1.0.2.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 1.0.2.0 host 255.255.255.0"
+              }
+            ],
+            "sourceName" : "101",
+            "sourceType" : "extended ipv4 access-list"
+          },
+          "103" : {
+            "name" : "103",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.255.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "3.0.1.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 3.0.1.0 host 255.255.255.0"
+              },
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.255.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "3.0.2.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 3.0.2.0 host 255.255.255.0"
+              }
+            ],
+            "sourceName" : "103",
+            "sourceType" : "extended ipv4 access-list"
+          },
+          "INSIDE_TO_AS1" : {
+            "name" : "INSIDE_TO_AS1",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "1.0.0.0/8"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "2.0.0.0/8"
+                    }
+                  }
+                },
+                "name" : "permit ip 2.0.0.0 0.255.255.255 1.0.0.0 0.255.255.255"
+              },
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "10.12.11.1"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "10.12.11.2"
+                    }
+                  }
+                },
+                "name" : "permit ip 10.12.11.2 0.0.0.0 10.12.11.1 0.0.0.0"
+              },
+              {
+                "action" : "DENY",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "0.0.0.0/0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "0.0.0.0/0"
+                    }
+                  }
+                },
+                "name" : "deny   ip any any"
+              }
+            ],
+            "sourceName" : "INSIDE_TO_AS1",
+            "sourceType" : "extended ipv4 access-list"
+          },
+          "OUTSIDE_TO_INSIDE" : {
+            "name" : "OUTSIDE_TO_INSIDE",
+            "lines" : [
+              {
+                "action" : "DENY",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "0.0.0.0/0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "2.0.0.0/8"
+                    }
+                  }
+                },
+                "name" : "deny   ip 2.0.0.0 0.255.255.255 any"
+              },
+              {
+                "action" : "DENY",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "2.128.1.101"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "0.0.0.0/0"
+                    }
+                  }
+                },
+                "name" : "deny   ip any host 2.128.1.101"
+              },
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "0.0.0.0/0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "0.0.0.0/0"
+                    }
+                  }
+                },
+                "name" : "permit ip any any"
+              }
+            ],
+            "sourceName" : "OUTSIDE_TO_INSIDE",
+            "sourceType" : "extended ipv4 access-list"
+          }
+        },
+        "ntpServers" : [
+          "18.18.18.18",
+          "23.23.23.23"
+        ],
+        "routeFilterLists" : {
+          "101" : {
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "1.0.1.0/24",
+                "lengthRange" : "24-24"
+              },
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "1.0.2.0/24",
+                "lengthRange" : "24-24"
+              }
+            ],
+            "name" : "101"
+          },
+          "103" : {
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "3.0.1.0/24",
+                "lengthRange" : "24-24"
+              },
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "3.0.2.0/24",
+                "lengthRange" : "24-24"
+              }
+            ],
+            "name" : "103"
+          },
+          "inbound_route_filter" : {
+            "lines" : [
+              {
+                "action" : "DENY",
+                "ipWildcard" : "2.0.0.0/8",
+                "lengthRange" : "8-32"
+              },
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "0.0.0.0/0",
+                "lengthRange" : "0-32"
+              }
+            ],
+            "name" : "inbound_route_filter"
+          },
+          "outbound_routes" : {
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "2.128.0.0/9",
+                "lengthRange" : "16-32"
+              }
+            ],
+            "name" : "outbound_routes"
+          },
+          "~MATCH_SUPPRESSED_SUMMARY_ONLY:default~" : {
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "2.128.0.0/16",
+                "lengthRange" : "17-32"
+              }
+            ],
+            "name" : "~MATCH_SUPPRESSED_SUMMARY_ONLY:default~"
+          }
+        },
+        "routingPolicies" : {
+          "as1_to_as2" : {
+            "name" : "as1_to_as2",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as1_to_as2~100~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnLocalDefaultAction"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchCommunitySet",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedCommunitySet",
+                    "name" : "as1_community"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetLocalPreference",
+                    "localPreference" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralInt",
+                      "value" : 350
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                    "expr" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySet",
+                      "communities" : [
+                        65538
+                      ]
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
+          "as2_to_as1" : {
+            "name" : "as2_to_as1",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as2_to_as1~2~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                    "comment" : "~RMCLAUSE~as2_to_as1~3~",
+                    "falseStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                        "type" : "ReturnLocalDefaultAction"
+                      }
+                    ],
+                    "guard" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                      "prefix" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                      },
+                      "prefixSet" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                        "name" : "103"
+                      }
+                    },
+                    "trueStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                        "metric" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                          "value" : 50
+                        }
+                      },
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                        "expr" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySet",
+                          "communities" : [
+                            131073
+                          ]
+                        }
+                      },
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                        "type" : "ReturnTrue"
+                      }
+                    ]
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                    "name" : "outbound_routes"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                    "metric" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                      "value" : 50
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                    "expr" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySet",
+                      "communities" : [
+                        131073
+                      ]
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
+          "as2_to_as3" : {
+            "name" : "as2_to_as3",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as2_to_as3~1~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                    "comment" : "~RMCLAUSE~as2_to_as3~2~",
+                    "falseStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                        "type" : "ReturnLocalDefaultAction"
+                      }
+                    ],
+                    "guard" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                      "prefix" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                      },
+                      "prefixSet" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                        "name" : "outbound_routes"
+                      }
+                    },
+                    "trueStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                        "metric" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                          "value" : 50
+                        }
+                      },
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                        "expr" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySet",
+                          "communities" : [
+                            131075
+                          ]
+                        }
+                      },
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                        "type" : "ReturnTrue"
+                      }
+                    ]
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                    "name" : "101"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                    "metric" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                      "value" : 50
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                    "expr" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySet",
+                      "communities" : [
+                        131075
+                      ]
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
+          "as3_to_as2" : {
+            "name" : "as3_to_as2",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as3_to_as2~100~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnLocalDefaultAction"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchCommunitySet",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedCommunitySet",
+                    "name" : "as3_community"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetLocalPreference",
+                    "localPreference" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralInt",
+                      "value" : 350
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                    "expr" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySet",
+                      "communities" : [
+                        196610
+                      ]
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
+          "~AGGREGATE_ROUTE_GEN:default:2.128.0.0/16~" : {
+            "name" : "~AGGREGATE_ROUTE_GEN:default:2.128.0.0/16~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                    "prefixSpace" : [
+                      "2.128.0.0/16:17-32"
+                    ]
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
+          "~BGP_COMMON_EXPORT_POLICY:default~" : {
+            "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "Suppress more specific networks for summary-only aggregate-address networks",
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                    "name" : "~MATCH_SUPPRESSED_SUMMARY_ONLY:default~"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "Suppress"
+                  }
+                ]
+              },
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
+                  "disjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                      "conjuncts" : [
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                          "prefix" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                          },
+                          "prefixSet" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                            "prefixSpace" : [
+                              "2.128.0.0/16"
+                            ]
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                          "protocol" : "aggregate"
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.WithEnvironmentExpr",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.BooleanExprs$StaticBooleanExpr",
+                            "type" : "True"
+                          },
+                          "postStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "UnsetWriteIntermediateBgpAttributes"
+                            }
+                          ],
+                          "postTrueStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "SetReadIntermediateBgpAttributes"
+                            },
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.SetOrigin",
+                              "originType" : {
+                                "class" : "org.batfish.datamodel.routing_policy.expr.LiteralOrigin",
+                                "originType" : "igp"
+                              }
+                            }
+                          ],
+                          "preStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "SetWriteIntermediateBgpAttributes"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "bgp"
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "ibgp"
+                    }
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              },
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                "type" : "ReturnFalse"
+              }
+            ]
+          },
+          "~BGP_PEER_EXPORT_POLICY:default:10.12.11.1~" : {
+            "name" : "~BGP_PEER_EXPORT_POLICY:default:10.12.11.1~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                  "conjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                      "calledPolicyName" : "as2_to_as1"
+                    }
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          },
+          "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~" : {
+            "name" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          },
+          "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~" : {
+            "name" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          },
+          "~OSPF_EXPORT_POLICY:default~" : {
+            "name" : "~OSPF_EXPORT_POLICY:default~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "OSPF export routes for connected",
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                  "conjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "connected"
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                      "expr" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                        "comment" : "match default route",
+                        "prefix" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                        },
+                        "prefixSet" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                          "prefixSpace" : [
+                            "0.0.0.0/0"
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetOspfMetricType",
+                    "metricType" : "E2"
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                    "metric" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                      "value" : 20
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "vendorFamily" : {
+          "cisco" : {
+            "aaa" : {
+              "authentication" : {
+                "login" : {
+                  "privilegeMode" : true
+                }
+              },
+              "newModel" : true
+            },
+            "hostname" : "as2border1",
+            "lines" : {
+              "aux0" : {
+                "name" : "aux0",
+                "aaaAuthenticationLoginList" : {
+                  "methods" : [
+                    "LOCAL"
+                  ]
+                },
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "AUX"
+              },
+              "con0" : {
+                "name" : "con0",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "CON"
+              },
+              "vty0" : {
+                "name" : "vty0",
+                "aaaAuthenticationLoginList" : {
+                  "methods" : [
+                    "LOCAL"
+                  ]
+                },
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty1" : {
+                "name" : "vty1",
+                "aaaAuthenticationLoginList" : {
+                  "methods" : [
+                    "LOCAL"
+                  ]
+                },
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty2" : {
+                "name" : "vty2",
+                "aaaAuthenticationLoginList" : {
+                  "methods" : [
+                    "LOCAL"
+                  ]
+                },
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty3" : {
+                "name" : "vty3",
+                "aaaAuthenticationLoginList" : {
+                  "methods" : [
+                    "LOCAL"
+                  ]
+                },
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty4" : {
+                "name" : "vty4",
+                "aaaAuthenticationLoginList" : {
+                  "methods" : [
+                    "LOCAL"
+                  ]
+                },
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              }
+            },
+            "logging" : {
+              "on" : true
+            },
+            "ntp" : {
+              "servers" : {
+                "18.18.18.18" : {
+                  "name" : "18.18.18.18"
+                },
+                "23.23.23.23" : {
+                  "name" : "23.23.23.23"
+                }
+              }
+            },
+            "services" : {
+              "timestamps" : {
+                "enabled" : true,
+                "subservices" : {
+                  "debug" : {
+                    "enabled" : true,
+                    "subservices" : {
+                      "datetime" : {
+                        "enabled" : true,
+                        "subservices" : {
+                          "msec" : {
+                            "enabled" : true
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "log" : {
+                    "enabled" : true,
+                    "subservices" : {
+                      "datetime" : {
+                        "enabled" : true,
+                        "subservices" : {
+                          "msec" : {
+                            "enabled" : true
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "vrfs" : {
+          "default" : {
+            "name" : "default",
+            "aggregateRoutes" : [
+              {
+                "class" : "org.batfish.datamodel.GeneratedRoute",
+                "administrativeCost" : 200,
+                "asPath" : [ ],
+                "discard" : true,
+                "generationPolicy" : "~AGGREGATE_ROUTE_GEN:default:2.128.0.0/16~",
+                "metric" : 0,
+                "network" : "2.128.0.0/16",
+                "nextHopIp" : "AUTO/NONE(-1l)"
+              }
+            ],
+            "bgpProcess" : {
+              "multipathEbgp" : true,
+              "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
+              "multipathIbgp" : true,
+              "neighbors" : {
+                "2.1.2.1/32" : {
+                  "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "additionalPathsReceive" : true,
+                  "additionalPathsSelectAll" : true,
+                  "additionalPathsSend" : true,
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : false,
+                  "allowRemoteAsOut" : true,
+                  "clusterId" : 33620225,
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~",
+                  "group" : "as2",
+                  "localAs" : 2,
+                  "localIp" : "2.1.1.1",
+                  "peerAddress" : "2.1.2.1",
+                  "remoteAs" : 2,
+                  "routeReflectorClient" : false,
+                  "sendCommunity" : true
+                },
+                "2.1.2.2/32" : {
+                  "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "additionalPathsReceive" : true,
+                  "additionalPathsSelectAll" : true,
+                  "additionalPathsSend" : true,
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : false,
+                  "allowRemoteAsOut" : true,
+                  "clusterId" : 33620225,
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~",
+                  "group" : "as2",
+                  "localAs" : 2,
+                  "localIp" : "2.1.1.1",
+                  "peerAddress" : "2.1.2.2",
+                  "remoteAs" : 2,
+                  "routeReflectorClient" : false,
+                  "sendCommunity" : true
+                },
+                "10.12.11.1/32" : {
+                  "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "additionalPathsReceive" : true,
+                  "additionalPathsSelectAll" : true,
+                  "additionalPathsSend" : true,
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : false,
+                  "allowRemoteAsOut" : true,
+                  "clusterId" : 33620225,
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.12.11.1~",
+                  "exportPolicySources" : [
+                    "as2_to_as1"
+                  ],
+                  "group" : "as1",
+                  "importPolicy" : "as1_to_as2",
+                  "importPolicySources" : [
+                    "as1_to_as2"
+                  ],
+                  "localAs" : 2,
+                  "localIp" : "10.12.11.2",
+                  "peerAddress" : "10.12.11.1",
+                  "remoteAs" : 1,
+                  "routeReflectorClient" : false,
+                  "sendCommunity" : true
+                }
+              },
+              "routerId" : "2.1.1.1",
+              "tieBreaker" : "ARRIVAL_ORDER"
+            },
+            "interfaces" : [
+              "Ethernet0/0",
+              "GigabitEthernet0/0",
+              "GigabitEthernet1/0",
+              "GigabitEthernet2/0",
+              "Loopback0"
+            ],
+            "ospfProcess" : {
+              "areas" : {
+                "1" : {
+                  "name" : 1,
+                  "injectDefaultRoute" : true,
+                  "interfaces" : [
+                    "GigabitEthernet1/0",
+                    "GigabitEthernet2/0",
+                    "Loopback0"
+                  ],
+                  "metricOfDefaultRoute" : 0,
+                  "stubType" : "NONE"
+                }
+              },
+              "exportPolicy" : "~OSPF_EXPORT_POLICY:default~",
+              "processId" : "1",
+              "referenceBandwidth" : 1.0E8,
+              "routerId" : "2.1.1.1"
+            }
+          }
+        }
+      },
+      "as2border2" : {
+        "configurationFormat" : "CISCO_IOS",
+        "name" : "as2border2",
+        "communityLists" : {
+          "as1_community" : {
+            "class" : "org.batfish.datamodel.CommunityList",
+            "invertMatch" : false,
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.RegexCommunitySet",
+                  "regex" : "(,|\\{|\\}|^|$| )1:"
+                }
+              }
+            ],
+            "name" : "as1_community"
+          },
+          "as2_community" : {
+            "class" : "org.batfish.datamodel.CommunityList",
+            "invertMatch" : false,
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.RegexCommunitySet",
+                  "regex" : "(,|\\{|\\}|^|$| )2:"
+                }
+              }
+            ],
+            "name" : "as2_community"
+          },
+          "as3_community" : {
+            "class" : "org.batfish.datamodel.CommunityList",
+            "invertMatch" : false,
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.RegexCommunitySet",
+                  "regex" : "(,|\\{|\\}|^|$| )3:"
+                }
+              }
+            ],
+            "name" : "as3_community"
+          }
+        },
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
+        "deviceType" : "ROUTER",
+        "domainName" : "lab.local",
+        "interfaces" : {
+          "Ethernet0/0" : {
+            "name" : "Ethernet0/0",
+            "accessVlan" : 0,
+            "active" : false,
+            "autostate" : true,
+            "bandwidth" : 1.0E7,
+            "declaredNames" : [
+              "Ethernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "GigabitEthernet0/0" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "10.23.21.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "incomingFilter" : "OUTSIDE_TO_INSIDE",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "outgoingFilter" : "INSIDE_TO_AS3",
+            "prefix" : "10.23.21.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "GigabitEthernet1/0" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.22.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.22.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "GigabitEthernet2/0" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.21.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.21.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "Loopback0" : {
+            "name" : "Loopback0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.1.1.2/32"
+            ],
+            "autostate" : true,
+            "bandwidth" : 8.0E9,
+            "declaredNames" : [
+              "Loopback0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.1.1.2/32",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "LOOPBACK",
+            "vrf" : "default"
+          }
+        },
+        "ipAccessLists" : {
+          "101" : {
+            "name" : "101",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.255.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "1.0.1.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 1.0.1.0 host 255.255.255.0"
+              },
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.255.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "1.0.2.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 1.0.2.0 host 255.255.255.0"
+              }
+            ],
+            "sourceName" : "101",
+            "sourceType" : "extended ipv4 access-list"
+          },
+          "103" : {
+            "name" : "103",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.255.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "3.0.1.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 3.0.1.0 host 255.255.255.0"
+              },
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.255.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "3.0.2.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 3.0.2.0 host 255.255.255.0"
+              }
+            ],
+            "sourceName" : "103",
+            "sourceType" : "extended ipv4 access-list"
+          },
+          "INSIDE_TO_AS3" : {
+            "name" : "INSIDE_TO_AS3",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "3.0.0.0/8"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "2.0.0.0/8"
+                    }
+                  }
+                },
+                "name" : "permit ip 2.0.0.0 0.255.255.255 3.0.0.0 0.255.255.255"
+              },
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "10.23.21.3"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "10.23.21.2"
+                    }
+                  }
+                },
+                "name" : "permit ip 10.23.21.2 0.0.0.0 10.23.21.3 0.0.0.0"
+              },
+              {
+                "action" : "DENY",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "0.0.0.0/0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "0.0.0.0/0"
+                    }
+                  }
+                },
+                "name" : "deny   ip any any"
+              }
+            ],
+            "sourceName" : "INSIDE_TO_AS3",
+            "sourceType" : "extended ipv4 access-list"
+          },
+          "OUTSIDE_TO_INSIDE" : {
+            "name" : "OUTSIDE_TO_INSIDE",
+            "lines" : [
+              {
+                "action" : "DENY",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "0.0.0.0/0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "2.0.0.0/8"
+                    }
+                  }
+                },
+                "name" : "deny   ip 2.0.0.0 0.255.255.255 any"
+              },
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "0.0.0.0/0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "0.0.0.0/0"
+                    }
+                  }
+                },
+                "name" : "permit ip any any"
+              }
+            ],
+            "sourceName" : "OUTSIDE_TO_INSIDE",
+            "sourceType" : "extended ipv4 access-list"
+          }
+        },
+        "ntpServers" : [
+          "18.18.18.18"
+        ],
+        "routeFilterLists" : {
+          "101" : {
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "1.0.1.0/24",
+                "lengthRange" : "24-24"
+              },
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "1.0.2.0/24",
+                "lengthRange" : "24-24"
+              }
+            ],
+            "name" : "101"
+          },
+          "103" : {
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "3.0.1.0/24",
+                "lengthRange" : "24-24"
+              },
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "3.0.2.0/24",
+                "lengthRange" : "24-24"
+              }
+            ],
+            "name" : "103"
+          },
+          "inbound_route_filter" : {
+            "lines" : [
+              {
+                "action" : "DENY",
+                "ipWildcard" : "2.0.0.0/8",
+                "lengthRange" : "8-32"
+              },
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "0.0.0.0/0",
+                "lengthRange" : "0-32"
+              }
+            ],
+            "name" : "inbound_route_filter"
+          },
+          "outbound_routes" : {
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "2.128.0.0/9",
+                "lengthRange" : "16-32"
+              }
+            ],
+            "name" : "outbound_routes"
+          },
+          "~MATCH_SUPPRESSED_SUMMARY_ONLY:default~" : {
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "2.128.0.0/16",
+                "lengthRange" : "17-32"
+              }
+            ],
+            "name" : "~MATCH_SUPPRESSED_SUMMARY_ONLY:default~"
+          }
+        },
+        "routingPolicies" : {
+          "as1_to_as2" : {
+            "name" : "as1_to_as2",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as1_to_as2~100~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnLocalDefaultAction"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchCommunitySet",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedCommunitySet",
+                    "name" : "as1_community"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetLocalPreference",
+                    "localPreference" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralInt",
+                      "value" : 350
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                    "expr" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySet",
+                      "communities" : [
+                        65538
+                      ]
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
+          "as2_to_as1" : {
+            "name" : "as2_to_as1",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as2_to_as1~2~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                    "comment" : "~RMCLAUSE~as2_to_as1~3~",
+                    "falseStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                        "type" : "ReturnLocalDefaultAction"
+                      }
+                    ],
+                    "guard" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                      "prefix" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                      },
+                      "prefixSet" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                        "name" : "103"
+                      }
+                    },
+                    "trueStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                        "metric" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                          "value" : 50
+                        }
+                      },
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                        "expr" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySet",
+                          "communities" : [
+                            131073
+                          ]
+                        }
+                      },
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                        "type" : "ReturnTrue"
+                      }
+                    ]
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                    "name" : "outbound_routes"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                    "metric" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                      "value" : 50
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                    "expr" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySet",
+                      "communities" : [
+                        131073
+                      ]
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
+          "as2_to_as3" : {
+            "name" : "as2_to_as3",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as2_to_as3~1~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                    "comment" : "~RMCLAUSE~as2_to_as3~2~",
+                    "falseStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                        "type" : "ReturnLocalDefaultAction"
+                      }
+                    ],
+                    "guard" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                      "prefix" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                      },
+                      "prefixSet" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                        "name" : "outbound_routes"
+                      }
+                    },
+                    "trueStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                        "metric" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                          "value" : 50
+                        }
+                      },
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                        "expr" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySet",
+                          "communities" : [
+                            131075
+                          ]
+                        }
+                      },
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                        "type" : "ReturnTrue"
+                      }
+                    ]
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                    "name" : "101"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                    "metric" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                      "value" : 50
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                    "expr" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySet",
+                      "communities" : [
+                        131075
+                      ]
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
+          "as3_to_as2" : {
+            "name" : "as3_to_as2",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as3_to_as2~100~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnLocalDefaultAction"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchCommunitySet",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedCommunitySet",
+                    "name" : "as3_community"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetLocalPreference",
+                    "localPreference" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralInt",
+                      "value" : 350
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                    "expr" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySet",
+                      "communities" : [
+                        196610
+                      ]
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
+          "~AGGREGATE_ROUTE_GEN:default:2.128.0.0/16~" : {
+            "name" : "~AGGREGATE_ROUTE_GEN:default:2.128.0.0/16~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                    "prefixSpace" : [
+                      "2.128.0.0/16:17-32"
+                    ]
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
+          "~BGP_COMMON_EXPORT_POLICY:default~" : {
+            "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "Suppress more specific networks for summary-only aggregate-address networks",
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                    "name" : "~MATCH_SUPPRESSED_SUMMARY_ONLY:default~"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "Suppress"
+                  }
+                ]
+              },
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
+                  "disjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                      "conjuncts" : [
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                          "prefix" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                          },
+                          "prefixSet" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                            "prefixSpace" : [
+                              "2.128.0.0/16"
+                            ]
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                          "protocol" : "aggregate"
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.WithEnvironmentExpr",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.BooleanExprs$StaticBooleanExpr",
+                            "type" : "True"
+                          },
+                          "postStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "UnsetWriteIntermediateBgpAttributes"
+                            }
+                          ],
+                          "postTrueStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "SetReadIntermediateBgpAttributes"
+                            },
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.SetOrigin",
+                              "originType" : {
+                                "class" : "org.batfish.datamodel.routing_policy.expr.LiteralOrigin",
+                                "originType" : "igp"
+                              }
+                            }
+                          ],
+                          "preStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "SetWriteIntermediateBgpAttributes"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "bgp"
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "ibgp"
+                    }
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              },
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                "type" : "ReturnFalse"
+              }
+            ]
+          },
+          "~BGP_PEER_EXPORT_POLICY:default:10.23.21.3~" : {
+            "name" : "~BGP_PEER_EXPORT_POLICY:default:10.23.21.3~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                  "conjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                      "calledPolicyName" : "as2_to_as3"
+                    }
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          },
+          "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~" : {
+            "name" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          },
+          "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~" : {
+            "name" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          },
+          "~OSPF_EXPORT_POLICY:default~" : {
+            "name" : "~OSPF_EXPORT_POLICY:default~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "OSPF export routes for connected",
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                  "conjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "connected"
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                      "expr" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                        "comment" : "match default route",
+                        "prefix" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                        },
+                        "prefixSet" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                          "prefixSpace" : [
+                            "0.0.0.0/0"
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetOspfMetricType",
+                    "metricType" : "E2"
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                    "metric" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                      "value" : 20
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "vendorFamily" : {
+          "cisco" : {
+            "aaa" : {
+              "newModel" : false
+            },
+            "hostname" : "as2border2",
+            "lines" : {
+              "aux0" : {
+                "name" : "aux0",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "AUX"
+              },
+              "con0" : {
+                "name" : "con0",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "CON"
+              },
+              "vty0" : {
+                "name" : "vty0",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty1" : {
+                "name" : "vty1",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty2" : {
+                "name" : "vty2",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty3" : {
+                "name" : "vty3",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty4" : {
+                "name" : "vty4",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              }
+            },
+            "logging" : {
+              "on" : true
+            },
+            "ntp" : {
+              "servers" : {
+                "18.18.18.18" : {
+                  "name" : "18.18.18.18"
+                }
+              }
+            },
+            "services" : {
+              "timestamps" : {
+                "enabled" : true,
+                "subservices" : {
+                  "debug" : {
+                    "enabled" : true,
+                    "subservices" : {
+                      "datetime" : {
+                        "enabled" : true,
+                        "subservices" : {
+                          "msec" : {
+                            "enabled" : true
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "log" : {
+                    "enabled" : true,
+                    "subservices" : {
+                      "datetime" : {
+                        "enabled" : true,
+                        "subservices" : {
+                          "msec" : {
+                            "enabled" : true
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "vrfs" : {
+          "default" : {
+            "name" : "default",
+            "aggregateRoutes" : [
+              {
+                "class" : "org.batfish.datamodel.GeneratedRoute",
+                "administrativeCost" : 200,
+                "asPath" : [ ],
+                "discard" : true,
+                "generationPolicy" : "~AGGREGATE_ROUTE_GEN:default:2.128.0.0/16~",
+                "metric" : 0,
+                "network" : "2.128.0.0/16",
+                "nextHopIp" : "AUTO/NONE(-1l)"
+              }
+            ],
+            "bgpProcess" : {
+              "multipathEbgp" : true,
+              "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
+              "multipathIbgp" : true,
+              "neighbors" : {
+                "2.1.2.1/32" : {
+                  "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "additionalPathsReceive" : true,
+                  "additionalPathsSelectAll" : true,
+                  "additionalPathsSend" : true,
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : false,
+                  "allowRemoteAsOut" : true,
+                  "clusterId" : 33620226,
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~",
+                  "group" : "as2",
+                  "localAs" : 2,
+                  "localIp" : "2.1.1.2",
+                  "peerAddress" : "2.1.2.1",
+                  "remoteAs" : 2,
+                  "routeReflectorClient" : false,
+                  "sendCommunity" : true
+                },
+                "2.1.2.2/32" : {
+                  "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "additionalPathsReceive" : true,
+                  "additionalPathsSelectAll" : true,
+                  "additionalPathsSend" : true,
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : false,
+                  "allowRemoteAsOut" : true,
+                  "clusterId" : 33620226,
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~",
+                  "group" : "as2",
+                  "localAs" : 2,
+                  "localIp" : "2.1.1.2",
+                  "peerAddress" : "2.1.2.2",
+                  "remoteAs" : 2,
+                  "routeReflectorClient" : false,
+                  "sendCommunity" : true
+                },
+                "10.23.21.3/32" : {
+                  "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "additionalPathsReceive" : true,
+                  "additionalPathsSelectAll" : true,
+                  "additionalPathsSend" : true,
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : false,
+                  "allowRemoteAsOut" : true,
+                  "clusterId" : 33620226,
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.23.21.3~",
+                  "exportPolicySources" : [
+                    "as2_to_as3"
+                  ],
+                  "group" : "as3",
+                  "importPolicy" : "as3_to_as2",
+                  "importPolicySources" : [
+                    "as3_to_as2"
+                  ],
+                  "localAs" : 2,
+                  "localIp" : "10.23.21.2",
+                  "peerAddress" : "10.23.21.3",
+                  "remoteAs" : 3,
+                  "routeReflectorClient" : false,
+                  "sendCommunity" : true
+                }
+              },
+              "routerId" : "2.1.1.2",
+              "tieBreaker" : "ARRIVAL_ORDER"
+            },
+            "interfaces" : [
+              "Ethernet0/0",
+              "GigabitEthernet0/0",
+              "GigabitEthernet1/0",
+              "GigabitEthernet2/0",
+              "Loopback0"
+            ],
+            "ospfProcess" : {
+              "areas" : {
+                "1" : {
+                  "name" : 1,
+                  "injectDefaultRoute" : true,
+                  "interfaces" : [
+                    "GigabitEthernet1/0",
+                    "GigabitEthernet2/0",
+                    "Loopback0"
+                  ],
+                  "metricOfDefaultRoute" : 0,
+                  "stubType" : "NONE"
+                }
+              },
+              "exportPolicy" : "~OSPF_EXPORT_POLICY:default~",
+              "processId" : "1",
+              "referenceBandwidth" : 1.0E8,
+              "routerId" : "2.1.1.2"
+            }
+          }
+        }
+      },
+      "as2core1" : {
+        "configurationFormat" : "CISCO_IOS",
+        "name" : "as2core1",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
+        "deviceType" : "ROUTER",
+        "domainName" : "lab.local",
+        "interfaces" : {
+          "Ethernet0/0" : {
+            "name" : "Ethernet0/0",
+            "accessVlan" : 0,
+            "active" : false,
+            "autostate" : true,
+            "bandwidth" : 1.0E7,
+            "declaredNames" : [
+              "Ethernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "GigabitEthernet0/0" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.11.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.11.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "GigabitEthernet1/0" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.21.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.21.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "GigabitEthernet2/0" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.11.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "incomingFilter" : "blocktelnet",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.11.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "GigabitEthernet3/0" : {
+            "name" : "GigabitEthernet3/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.12.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet3/0"
+            ],
+            "incomingFilter" : "blocktelnet",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.12.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "Loopback0" : {
+            "name" : "Loopback0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.1.2.1/32"
+            ],
+            "autostate" : true,
+            "bandwidth" : 8.0E9,
+            "declaredNames" : [
+              "Loopback0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.1.2.1/32",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "LOOPBACK",
+            "vrf" : "default"
+          }
+        },
+        "ipAccessLists" : {
+          "blocktelnet" : {
+            "name" : "blocktelnet",
+            "lines" : [
+              {
+                "action" : "DENY",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "0.0.0.0/0"
+                    },
+                    "dstPorts" : [
+                      "23-23"
+                    ],
+                    "ipProtocols" : [
+                      "TCP"
+                    ],
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "0.0.0.0/0"
+                    }
+                  }
+                },
+                "name" : "deny   tcp any any eq telnet"
+              },
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "0.0.0.0/0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "0.0.0.0/0"
+                    }
+                  }
+                },
+                "name" : "permit ip any any"
+              }
+            ],
+            "sourceName" : "blocktelnet",
+            "sourceType" : "extended ipv4 access-list"
+          }
+        },
+        "loggingServers" : [
+          "1.1.1.1",
+          "2.1.2.2"
+        ],
+        "routingPolicies" : {
+          "~BGP_COMMON_EXPORT_POLICY:default~" : {
+            "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
+                  "disjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "bgp"
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "ibgp"
+                    }
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              },
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                "type" : "ReturnFalse"
+              }
+            ]
+          },
+          "~BGP_PEER_EXPORT_POLICY:default:2.1.1.1~" : {
+            "name" : "~BGP_PEER_EXPORT_POLICY:default:2.1.1.1~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          },
+          "~BGP_PEER_EXPORT_POLICY:default:2.1.1.2~" : {
+            "name" : "~BGP_PEER_EXPORT_POLICY:default:2.1.1.2~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          },
+          "~BGP_PEER_EXPORT_POLICY:default:2.1.3.1~" : {
+            "name" : "~BGP_PEER_EXPORT_POLICY:default:2.1.3.1~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          },
+          "~BGP_PEER_EXPORT_POLICY:default:2.1.3.2~" : {
+            "name" : "~BGP_PEER_EXPORT_POLICY:default:2.1.3.2~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          },
+          "~OSPF_EXPORT_POLICY:default~" : {
+            "name" : "~OSPF_EXPORT_POLICY:default~"
+          }
+        },
+        "vendorFamily" : {
+          "cisco" : {
+            "aaa" : {
+              "newModel" : false
+            },
+            "hostname" : "as2core1",
+            "lines" : {
+              "aux0" : {
+                "name" : "aux0",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "AUX"
+              },
+              "con0" : {
+                "name" : "con0",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "CON"
+              },
+              "vty0" : {
+                "name" : "vty0",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty1" : {
+                "name" : "vty1",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty2" : {
+                "name" : "vty2",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty3" : {
+                "name" : "vty3",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty4" : {
+                "name" : "vty4",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              }
+            },
+            "logging" : {
+              "hosts" : {
+                "1.1.1.1" : {
+                  "name" : "1.1.1.1"
+                },
+                "2.1.2.2" : {
+                  "name" : "2.1.2.2"
+                }
+              },
+              "on" : true
+            },
+            "services" : {
+              "timestamps" : {
+                "enabled" : true,
+                "subservices" : {
+                  "debug" : {
+                    "enabled" : true,
+                    "subservices" : {
+                      "datetime" : {
+                        "enabled" : true,
+                        "subservices" : {
+                          "msec" : {
+                            "enabled" : true
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "log" : {
+                    "enabled" : true,
+                    "subservices" : {
+                      "datetime" : {
+                        "enabled" : true,
+                        "subservices" : {
+                          "msec" : {
+                            "enabled" : true
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "vrfs" : {
+          "default" : {
+            "name" : "default",
+            "bgpProcess" : {
+              "multipathEbgp" : true,
+              "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
+              "multipathIbgp" : true,
+              "neighbors" : {
+                "2.1.1.1/32" : {
+                  "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "additionalPathsReceive" : true,
+                  "additionalPathsSelectAll" : true,
+                  "additionalPathsSend" : true,
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : false,
+                  "allowRemoteAsOut" : true,
+                  "clusterId" : 33620481,
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.1.1~",
+                  "group" : "as2",
+                  "localAs" : 2,
+                  "localIp" : "2.1.2.1",
+                  "peerAddress" : "2.1.1.1",
+                  "remoteAs" : 2,
+                  "routeReflectorClient" : true,
+                  "sendCommunity" : true
+                },
+                "2.1.1.2/32" : {
+                  "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "additionalPathsReceive" : true,
+                  "additionalPathsSelectAll" : true,
+                  "additionalPathsSend" : true,
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : false,
+                  "allowRemoteAsOut" : true,
+                  "clusterId" : 33620481,
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.1.2~",
+                  "group" : "as2",
+                  "localAs" : 2,
+                  "localIp" : "2.1.2.1",
+                  "peerAddress" : "2.1.1.2",
+                  "remoteAs" : 2,
+                  "routeReflectorClient" : true,
+                  "sendCommunity" : true
+                },
+                "2.1.3.1/32" : {
+                  "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "additionalPathsReceive" : true,
+                  "additionalPathsSelectAll" : true,
+                  "additionalPathsSend" : true,
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : false,
+                  "allowRemoteAsOut" : true,
+                  "clusterId" : 33620481,
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.3.1~",
+                  "group" : "as2",
+                  "localAs" : 2,
+                  "localIp" : "2.1.2.1",
+                  "peerAddress" : "2.1.3.1",
+                  "remoteAs" : 2,
+                  "routeReflectorClient" : true,
+                  "sendCommunity" : true
+                },
+                "2.1.3.2/32" : {
+                  "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "additionalPathsReceive" : true,
+                  "additionalPathsSelectAll" : true,
+                  "additionalPathsSend" : true,
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : false,
+                  "allowRemoteAsOut" : true,
+                  "clusterId" : 33620481,
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.3.2~",
+                  "group" : "as2",
+                  "localAs" : 2,
+                  "localIp" : "2.1.2.1",
+                  "peerAddress" : "2.1.3.2",
+                  "remoteAs" : 2,
+                  "routeReflectorClient" : true,
+                  "sendCommunity" : true
+                }
+              },
+              "routerId" : "2.1.2.1",
+              "tieBreaker" : "ARRIVAL_ORDER"
+            },
+            "interfaces" : [
+              "Ethernet0/0",
+              "GigabitEthernet0/0",
+              "GigabitEthernet1/0",
+              "GigabitEthernet2/0",
+              "GigabitEthernet3/0",
+              "Loopback0"
+            ],
+            "ospfProcess" : {
+              "areas" : {
+                "1" : {
+                  "name" : 1,
+                  "injectDefaultRoute" : true,
+                  "interfaces" : [
+                    "GigabitEthernet0/0",
+                    "GigabitEthernet1/0",
+                    "GigabitEthernet2/0",
+                    "GigabitEthernet3/0",
+                    "Loopback0"
+                  ],
+                  "metricOfDefaultRoute" : 0,
+                  "stubType" : "NONE"
+                }
+              },
+              "exportPolicy" : "~OSPF_EXPORT_POLICY:default~",
+              "processId" : "1",
+              "referenceBandwidth" : 1.0E8,
+              "routerId" : "2.1.2.1"
+            }
+          }
+        }
+      },
+      "as2core2" : {
+        "configurationFormat" : "CISCO_IOS",
+        "name" : "as2core2",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
+        "deviceType" : "ROUTER",
+        "domainName" : "lab.local",
+        "interfaces" : {
+          "Ethernet0/0" : {
+            "name" : "Ethernet0/0",
+            "accessVlan" : 0,
+            "active" : false,
+            "autostate" : true,
+            "bandwidth" : 1.0E7,
+            "declaredNames" : [
+              "Ethernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "GigabitEthernet0/0" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.22.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1800,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.22.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "GigabitEthernet1/0" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.12.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1600,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.12.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "GigabitEthernet2/0" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.22.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "mtu" : 1700,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.22.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "GigabitEthernet3/0" : {
+            "name" : "GigabitEthernet3/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.21.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet3/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.21.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "Loopback0" : {
+            "name" : "Loopback0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.1.2.2/32"
+            ],
+            "autostate" : true,
+            "bandwidth" : 8.0E9,
+            "declaredNames" : [
+              "Loopback0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.1.2.2/32",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "LOOPBACK",
+            "vrf" : "default"
+          }
+        },
+        "loggingServers" : [
+          "1.1.1.1",
+          "2.2.2.2"
+        ],
+        "routingPolicies" : {
+          "~BGP_COMMON_EXPORT_POLICY:default~" : {
+            "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
+                  "disjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "bgp"
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "ibgp"
+                    }
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              },
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                "type" : "ReturnFalse"
+              }
+            ]
+          },
+          "~BGP_PEER_EXPORT_POLICY:default:2.1.1.1~" : {
+            "name" : "~BGP_PEER_EXPORT_POLICY:default:2.1.1.1~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          },
+          "~BGP_PEER_EXPORT_POLICY:default:2.1.1.2~" : {
+            "name" : "~BGP_PEER_EXPORT_POLICY:default:2.1.1.2~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          },
+          "~BGP_PEER_EXPORT_POLICY:default:2.1.3.1~" : {
+            "name" : "~BGP_PEER_EXPORT_POLICY:default:2.1.3.1~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          },
+          "~BGP_PEER_EXPORT_POLICY:default:2.1.3.2~" : {
+            "name" : "~BGP_PEER_EXPORT_POLICY:default:2.1.3.2~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          },
+          "~OSPF_EXPORT_POLICY:default~" : {
+            "name" : "~OSPF_EXPORT_POLICY:default~"
+          }
+        },
+        "vendorFamily" : {
+          "cisco" : {
+            "aaa" : {
+              "newModel" : false
+            },
+            "hostname" : "as2core2",
+            "lines" : {
+              "aux0" : {
+                "name" : "aux0",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "AUX"
+              },
+              "con0" : {
+                "name" : "con0",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "CON"
+              },
+              "vty0" : {
+                "name" : "vty0",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty1" : {
+                "name" : "vty1",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty2" : {
+                "name" : "vty2",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty3" : {
+                "name" : "vty3",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty4" : {
+                "name" : "vty4",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              }
+            },
+            "logging" : {
+              "hosts" : {
+                "1.1.1.1" : {
+                  "name" : "1.1.1.1"
+                },
+                "2.2.2.2" : {
+                  "name" : "2.2.2.2"
+                }
+              },
+              "on" : true
+            },
+            "services" : {
+              "timestamps" : {
+                "enabled" : true,
+                "subservices" : {
+                  "debug" : {
+                    "enabled" : true,
+                    "subservices" : {
+                      "datetime" : {
+                        "enabled" : true,
+                        "subservices" : {
+                          "msec" : {
+                            "enabled" : true
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "log" : {
+                    "enabled" : true,
+                    "subservices" : {
+                      "datetime" : {
+                        "enabled" : true,
+                        "subservices" : {
+                          "msec" : {
+                            "enabled" : true
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "vrfs" : {
+          "default" : {
+            "name" : "default",
+            "bgpProcess" : {
+              "multipathEbgp" : true,
+              "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
+              "multipathIbgp" : true,
+              "neighbors" : {
+                "2.1.1.1/32" : {
+                  "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "additionalPathsReceive" : true,
+                  "additionalPathsSelectAll" : true,
+                  "additionalPathsSend" : true,
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : false,
+                  "allowRemoteAsOut" : true,
+                  "clusterId" : 33620482,
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.1.1~",
+                  "group" : "as2",
+                  "localAs" : 2,
+                  "localIp" : "2.1.2.2",
+                  "peerAddress" : "2.1.1.1",
+                  "remoteAs" : 2,
+                  "routeReflectorClient" : true,
+                  "sendCommunity" : true
+                },
+                "2.1.1.2/32" : {
+                  "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "additionalPathsReceive" : true,
+                  "additionalPathsSelectAll" : true,
+                  "additionalPathsSend" : true,
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : false,
+                  "allowRemoteAsOut" : true,
+                  "clusterId" : 33620482,
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.1.2~",
+                  "group" : "as2",
+                  "localAs" : 2,
+                  "localIp" : "2.1.2.2",
+                  "peerAddress" : "2.1.1.2",
+                  "remoteAs" : 2,
+                  "routeReflectorClient" : true,
+                  "sendCommunity" : true
+                },
+                "2.1.3.1/32" : {
+                  "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "additionalPathsReceive" : true,
+                  "additionalPathsSelectAll" : true,
+                  "additionalPathsSend" : true,
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : false,
+                  "allowRemoteAsOut" : true,
+                  "clusterId" : 33620482,
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.3.1~",
+                  "group" : "as2",
+                  "localAs" : 2,
+                  "localIp" : "2.1.2.2",
+                  "peerAddress" : "2.1.3.1",
+                  "remoteAs" : 2,
+                  "routeReflectorClient" : true,
+                  "sendCommunity" : true
+                },
+                "2.1.3.2/32" : {
+                  "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "additionalPathsReceive" : true,
+                  "additionalPathsSelectAll" : true,
+                  "additionalPathsSend" : true,
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : false,
+                  "allowRemoteAsOut" : true,
+                  "clusterId" : 33620482,
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.3.2~",
+                  "group" : "as2",
+                  "localAs" : 2,
+                  "localIp" : "2.1.2.2",
+                  "peerAddress" : "2.1.3.2",
+                  "remoteAs" : 2,
+                  "routeReflectorClient" : true,
+                  "sendCommunity" : true
+                }
+              },
+              "routerId" : "2.1.2.2",
+              "tieBreaker" : "ARRIVAL_ORDER"
+            },
+            "interfaces" : [
+              "Ethernet0/0",
+              "GigabitEthernet0/0",
+              "GigabitEthernet1/0",
+              "GigabitEthernet2/0",
+              "GigabitEthernet3/0",
+              "Loopback0"
+            ],
+            "ospfProcess" : {
+              "areas" : {
+                "1" : {
+                  "name" : 1,
+                  "injectDefaultRoute" : true,
+                  "interfaces" : [
+                    "GigabitEthernet0/0",
+                    "GigabitEthernet1/0",
+                    "GigabitEthernet2/0",
+                    "GigabitEthernet3/0",
+                    "Loopback0"
+                  ],
+                  "metricOfDefaultRoute" : 0,
+                  "stubType" : "NONE"
+                }
+              },
+              "exportPolicy" : "~OSPF_EXPORT_POLICY:default~",
+              "processId" : "1",
+              "referenceBandwidth" : 1.0E8,
+              "routerId" : "2.1.2.2"
+            }
+          }
+        }
+      },
+      "as2dept1" : {
+        "configurationFormat" : "CISCO_IOS",
+        "name" : "as2dept1",
+        "communityLists" : {
+          "as2_community" : {
+            "class" : "org.batfish.datamodel.CommunityList",
+            "invertMatch" : false,
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.RegexCommunitySet",
+                  "regex" : "(,|\\{|\\}|^|$| )2:"
+                }
+              }
+            ],
+            "name" : "as2_community"
+          }
+        },
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
+        "deviceType" : "ROUTER",
+        "domainName" : "lab.local",
+        "interfaces" : {
+          "Ethernet0/0" : {
+            "name" : "Ethernet0/0",
+            "accessVlan" : 0,
+            "active" : false,
+            "autostate" : true,
+            "bandwidth" : 1.0E7,
+            "declaredNames" : [
+              "Ethernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "GigabitEthernet0/0" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.34.101.4/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.34.101.4/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "GigabitEthernet1/0" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.34.201.4/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.34.201.4/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "GigabitEthernet2/0" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.128.0.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "incomingFilter" : "RESTRICT_HOST_TRAFFIC_IN",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.128.0.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "GigabitEthernet3/0" : {
+            "name" : "GigabitEthernet3/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.128.1.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet3/0"
+            ],
+            "incomingFilter" : "RESTRICT_HOST_TRAFFIC_IN",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.128.1.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "Loopback0" : {
+            "name" : "Loopback0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.1.1.2/32"
+            ],
+            "autostate" : true,
+            "bandwidth" : 8.0E9,
+            "declaredNames" : [
+              "Loopback0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.1.1.2/32",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "LOOPBACK",
+            "vrf" : "default"
+          }
+        },
+        "ipAccessLists" : {
+          "102" : {
+            "name" : "102",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.255.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "2.128.0.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 2.128.0.0 host 255.255.255.0"
+              },
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.255.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "2.128.1.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 2.128.1.0 host 255.255.255.0"
+              }
+            ],
+            "sourceName" : "102",
+            "sourceType" : "extended ipv4 access-list"
+          },
+          "105" : {
+            "name" : "105",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.255.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "1.0.1.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 1.0.1.0 host 255.255.255.0"
+              },
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.255.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "1.0.2.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 1.0.2.0 host 255.255.255.0"
+              },
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.255.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "3.0.1.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 3.0.1.0 host 255.255.255.0"
+              },
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.255.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "3.0.2.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 3.0.2.0 host 255.255.255.0"
+              }
+            ],
+            "sourceName" : "105",
+            "sourceType" : "extended ipv4 access-list"
+          },
+          "RESTRICT_HOST_TRAFFIC_IN" : {
+            "name" : "RESTRICT_HOST_TRAFFIC_IN",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "0.0.0.0/0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "2.128.0.0/16"
+                    }
+                  }
+                },
+                "name" : "permit ip 2.128.0.0 0.0.255.255 any"
+              },
+              {
+                "action" : "DENY",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "0.0.0.0/0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "0.0.0.0/0"
+                    }
+                  }
+                },
+                "name" : "deny   ip any any"
+              },
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "0.0.0.0/0"
+                    },
+                    "ipProtocols" : [
+                      "ICMP"
+                    ],
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "0.0.0.0/0"
+                    }
+                  }
+                },
+                "name" : "permit icmp any any"
+              }
+            ],
+            "sourceName" : "RESTRICT_HOST_TRAFFIC_IN",
+            "sourceType" : "extended ipv4 access-list"
+          },
+          "RESTRICT_HOST_TRAFFIC_OUT" : {
+            "name" : "RESTRICT_HOST_TRAFFIC_OUT",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "2.128.0.0/16"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "0.0.0.0/0"
+                    }
+                  }
+                },
+                "name" : "permit ip any 2.128.0.0 0.0.255.255"
+              },
+              {
+                "action" : "DENY",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "2.128.0.0/16"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "1.128.0.0/16"
+                    }
+                  }
+                },
+                "name" : "deny   ip 1.128.0.0 0.0.255.255 2.128.0.0 0.0.255.255"
+              },
+              {
+                "action" : "DENY",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "0.0.0.0/0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "0.0.0.0/0"
+                    }
+                  }
+                },
+                "name" : "deny   ip any any"
+              }
+            ],
+            "sourceName" : "RESTRICT_HOST_TRAFFIC_OUT",
+            "sourceType" : "extended ipv4 access-list"
+          }
+        },
+        "routeFilterLists" : {
+          "102" : {
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "2.128.0.0/24",
+                "lengthRange" : "24-24"
+              },
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "2.128.1.0/24",
+                "lengthRange" : "24-24"
+              }
+            ],
+            "name" : "102"
+          }
+        },
+        "routingPolicies" : {
+          "as2_to_dept" : {
+            "name" : "as2_to_dept",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as2_to_dept~100~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnLocalDefaultAction"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchCommunitySet",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedCommunitySet",
+                    "name" : "as2_community"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetLocalPreference",
+                    "localPreference" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralInt",
+                      "value" : 350
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
+          "dept_to_as2" : {
+            "name" : "dept_to_as2",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~dept_to_as2~100~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnLocalDefaultAction"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                    "name" : "102"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                    "metric" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                      "value" : 50
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                    "expr" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySet",
+                      "communities" : [
+                        4259905538
+                      ]
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
+          "~BGP_COMMON_EXPORT_POLICY:default~" : {
+            "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
+                  "disjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                      "conjuncts" : [
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                          "prefix" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                          },
+                          "prefixSet" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                            "prefixSpace" : [
+                              "2.128.0.0/24"
+                            ]
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                            "protocol" : "bgp"
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                            "protocol" : "ibgp"
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                            "protocol" : "aggregate"
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.WithEnvironmentExpr",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.BooleanExprs$StaticBooleanExpr",
+                            "type" : "True"
+                          },
+                          "postStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "UnsetWriteIntermediateBgpAttributes"
+                            }
+                          ],
+                          "postTrueStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "SetReadIntermediateBgpAttributes"
+                            },
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.SetOrigin",
+                              "originType" : {
+                                "class" : "org.batfish.datamodel.routing_policy.expr.LiteralOrigin",
+                                "originType" : "igp"
+                              }
+                            }
+                          ],
+                          "preStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "SetWriteIntermediateBgpAttributes"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                      "conjuncts" : [
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                          "prefix" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                          },
+                          "prefixSet" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                            "prefixSpace" : [
+                              "2.128.1.0/24"
+                            ]
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                            "protocol" : "bgp"
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                            "protocol" : "ibgp"
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                            "protocol" : "aggregate"
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.WithEnvironmentExpr",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.BooleanExprs$StaticBooleanExpr",
+                            "type" : "True"
+                          },
+                          "postStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "UnsetWriteIntermediateBgpAttributes"
+                            }
+                          ],
+                          "postTrueStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "SetReadIntermediateBgpAttributes"
+                            },
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.SetOrigin",
+                              "originType" : {
+                                "class" : "org.batfish.datamodel.routing_policy.expr.LiteralOrigin",
+                                "originType" : "igp"
+                              }
+                            }
+                          ],
+                          "preStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "SetWriteIntermediateBgpAttributes"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "bgp"
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "ibgp"
+                    }
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              },
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                "type" : "ReturnFalse"
+              }
+            ]
+          },
+          "~BGP_PEER_EXPORT_POLICY:default:2.34.101.3~" : {
+            "name" : "~BGP_PEER_EXPORT_POLICY:default:2.34.101.3~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                  "conjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                      "calledPolicyName" : "dept_to_as2"
+                    }
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          },
+          "~BGP_PEER_EXPORT_POLICY:default:2.34.201.3~" : {
+            "name" : "~BGP_PEER_EXPORT_POLICY:default:2.34.201.3~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                  "conjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                      "calledPolicyName" : "dept_to_as2"
+                    }
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "vendorFamily" : {
+          "cisco" : {
+            "aaa" : {
+              "newModel" : false
+            },
+            "hostname" : "as2dept1",
+            "lines" : {
+              "aux0" : {
+                "name" : "aux0",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "AUX"
+              },
+              "con0" : {
+                "name" : "con0",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "CON"
+              },
+              "vty0" : {
+                "name" : "vty0",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty1" : {
+                "name" : "vty1",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty2" : {
+                "name" : "vty2",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty3" : {
+                "name" : "vty3",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty4" : {
+                "name" : "vty4",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              }
+            },
+            "logging" : {
+              "on" : true
+            },
+            "services" : {
+              "timestamps" : {
+                "enabled" : true,
+                "subservices" : {
+                  "debug" : {
+                    "enabled" : true,
+                    "subservices" : {
+                      "datetime" : {
+                        "enabled" : true,
+                        "subservices" : {
+                          "msec" : {
+                            "enabled" : true
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "log" : {
+                    "enabled" : true,
+                    "subservices" : {
+                      "datetime" : {
+                        "enabled" : true,
+                        "subservices" : {
+                          "msec" : {
+                            "enabled" : true
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "vrfs" : {
+          "default" : {
+            "name" : "default",
+            "bgpProcess" : {
+              "multipathEbgp" : true,
+              "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
+              "multipathIbgp" : true,
+              "neighbors" : {
+                "2.34.101.3/32" : {
+                  "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "additionalPathsReceive" : true,
+                  "additionalPathsSelectAll" : true,
+                  "additionalPathsSend" : true,
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : false,
+                  "allowRemoteAsOut" : true,
+                  "clusterId" : 33620993,
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.34.101.3~",
+                  "exportPolicySources" : [
+                    "dept_to_as2"
+                  ],
+                  "group" : "as2",
+                  "importPolicy" : "as2_to_dept",
+                  "importPolicySources" : [
+                    "as2_to_dept"
+                  ],
+                  "localAs" : 65001,
+                  "localIp" : "2.34.101.4",
+                  "peerAddress" : "2.34.101.3",
+                  "remoteAs" : 2,
+                  "routeReflectorClient" : false,
+                  "sendCommunity" : true
+                },
+                "2.34.201.3/32" : {
+                  "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "additionalPathsReceive" : true,
+                  "additionalPathsSelectAll" : true,
+                  "additionalPathsSend" : true,
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : false,
+                  "allowRemoteAsOut" : true,
+                  "clusterId" : 33620993,
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.34.201.3~",
+                  "exportPolicySources" : [
+                    "dept_to_as2"
+                  ],
+                  "group" : "as2",
+                  "importPolicy" : "as2_to_dept",
+                  "importPolicySources" : [
+                    "as2_to_dept"
+                  ],
+                  "localAs" : 65001,
+                  "localIp" : "2.34.201.4",
+                  "peerAddress" : "2.34.201.3",
+                  "remoteAs" : 2,
+                  "routeReflectorClient" : false,
+                  "sendCommunity" : true
+                }
+              },
+              "routerId" : "2.1.4.1",
+              "tieBreaker" : "ARRIVAL_ORDER"
+            },
+            "interfaces" : [
+              "Ethernet0/0",
+              "GigabitEthernet0/0",
+              "GigabitEthernet1/0",
+              "GigabitEthernet2/0",
+              "GigabitEthernet3/0",
+              "Loopback0"
+            ]
+          }
+        }
+      },
+      "as2dist1" : {
+        "configurationFormat" : "CISCO_IOS",
+        "name" : "as2dist1",
+        "communityLists" : {
+          "dept_community" : {
+            "class" : "org.batfish.datamodel.CommunityList",
+            "invertMatch" : false,
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.RegexCommunitySet",
+                  "regex" : "(,|\\{|\\}|^|$| )65001:"
+                }
+              }
+            ],
+            "name" : "dept_community"
+          }
+        },
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
+        "deviceType" : "ROUTER",
+        "domainName" : "lab.local",
+        "interfaces" : {
+          "Ethernet0/0" : {
+            "name" : "Ethernet0/0",
+            "accessVlan" : 0,
+            "active" : false,
+            "autostate" : true,
+            "bandwidth" : 1.0E7,
+            "declaredNames" : [
+              "Ethernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "GigabitEthernet0/0" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.11.3/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.11.3/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "GigabitEthernet1/0" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.21.3/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.21.3/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "GigabitEthernet2/0" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.34.101.3/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.34.101.3/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "Loopback0" : {
+            "name" : "Loopback0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.1.3.1/32"
+            ],
+            "autostate" : true,
+            "bandwidth" : 8.0E9,
+            "declaredNames" : [
+              "Loopback0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.1.3.1/32",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "LOOPBACK",
+            "vrf" : "default"
+          }
+        },
+        "ipAccessLists" : {
+          "102" : {
+            "name" : "102",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.0.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "2.128.0.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 2.128.0.0 host 255.255.0.0"
+              }
+            ],
+            "sourceName" : "102",
+            "sourceType" : "extended ipv4 access-list"
+          },
+          "105" : {
+            "name" : "105",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.255.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "1.0.1.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 1.0.1.0 host 255.255.255.0"
+              },
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.255.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "1.0.2.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 1.0.2.0 host 255.255.255.0"
+              },
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.255.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "3.0.1.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 3.0.1.0 host 255.255.255.0"
+              },
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.255.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "3.0.2.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 3.0.2.0 host 255.255.255.0"
+              }
+            ],
+            "sourceName" : "105",
+            "sourceType" : "extended ipv4 access-list"
+          }
+        },
+        "routeFilterLists" : {
+          "105" : {
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "1.0.1.0/24",
+                "lengthRange" : "24-24"
+              },
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "1.0.2.0/24",
+                "lengthRange" : "24-24"
+              },
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "3.0.1.0/24",
+                "lengthRange" : "24-24"
+              },
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "3.0.2.0/24",
+                "lengthRange" : "24-24"
+              }
+            ],
+            "name" : "105"
+          }
+        },
+        "routingPolicies" : {
+          "as2dist_to_dept" : {
+            "name" : "as2dist_to_dept",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as2dist_to_dept~100~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnLocalDefaultAction"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                    "name" : "105"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                    "metric" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                      "value" : 50
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                    "expr" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySet",
+                      "communities" : [
+                        196073
+                      ]
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
+          "dept_to_as2dist" : {
+            "name" : "dept_to_as2dist",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~dept_to_as2dist~100~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnLocalDefaultAction"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchCommunitySet",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedCommunitySet",
+                    "name" : "dept_community"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetLocalPreference",
+                    "localPreference" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralInt",
+                      "value" : 350
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
+          "~BGP_COMMON_EXPORT_POLICY:default~" : {
+            "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
+                  "disjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "bgp"
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "ibgp"
+                    }
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              },
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                "type" : "ReturnFalse"
+              }
+            ]
+          },
+          "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~" : {
+            "name" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          },
+          "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~" : {
+            "name" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          },
+          "~BGP_PEER_EXPORT_POLICY:default:2.34.101.4~" : {
+            "name" : "~BGP_PEER_EXPORT_POLICY:default:2.34.101.4~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                  "conjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                      "calledPolicyName" : "as2dist_to_dept"
+                    }
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          },
+          "~OSPF_EXPORT_POLICY:default~" : {
+            "name" : "~OSPF_EXPORT_POLICY:default~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "OSPF export routes for connected",
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                  "conjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "connected"
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                      "expr" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                        "comment" : "match default route",
+                        "prefix" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                        },
+                        "prefixSet" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                          "prefixSpace" : [
+                            "0.0.0.0/0"
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetOspfMetricType",
+                    "metricType" : "E2"
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                    "metric" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                      "value" : 20
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "vendorFamily" : {
+          "cisco" : {
+            "aaa" : {
+              "newModel" : false
+            },
+            "hostname" : "as2dist1",
+            "lines" : {
+              "aux0" : {
+                "name" : "aux0",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "AUX"
+              },
+              "con0" : {
+                "name" : "con0",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "CON"
+              },
+              "vty0" : {
+                "name" : "vty0",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty1" : {
+                "name" : "vty1",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty2" : {
+                "name" : "vty2",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty3" : {
+                "name" : "vty3",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty4" : {
+                "name" : "vty4",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              }
+            },
+            "logging" : {
+              "on" : true
+            },
+            "services" : {
+              "timestamps" : {
+                "enabled" : true,
+                "subservices" : {
+                  "debug" : {
+                    "enabled" : true,
+                    "subservices" : {
+                      "datetime" : {
+                        "enabled" : true,
+                        "subservices" : {
+                          "msec" : {
+                            "enabled" : true
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "log" : {
+                    "enabled" : true,
+                    "subservices" : {
+                      "datetime" : {
+                        "enabled" : true,
+                        "subservices" : {
+                          "msec" : {
+                            "enabled" : true
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "vrfs" : {
+          "default" : {
+            "name" : "default",
+            "bgpProcess" : {
+              "multipathEbgp" : true,
+              "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
+              "multipathIbgp" : true,
+              "neighbors" : {
+                "2.1.2.1/32" : {
+                  "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "additionalPathsReceive" : true,
+                  "additionalPathsSelectAll" : true,
+                  "additionalPathsSend" : true,
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : false,
+                  "allowRemoteAsOut" : true,
+                  "clusterId" : 33620737,
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~",
+                  "group" : "as2",
+                  "localAs" : 2,
+                  "localIp" : "2.1.3.1",
+                  "peerAddress" : "2.1.2.1",
+                  "remoteAs" : 2,
+                  "routeReflectorClient" : false,
+                  "sendCommunity" : true
+                },
+                "2.1.2.2/32" : {
+                  "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "additionalPathsReceive" : true,
+                  "additionalPathsSelectAll" : true,
+                  "additionalPathsSend" : true,
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : false,
+                  "allowRemoteAsOut" : true,
+                  "clusterId" : 33620737,
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~",
+                  "group" : "as2",
+                  "localAs" : 2,
+                  "localIp" : "2.1.3.1",
+                  "peerAddress" : "2.1.2.2",
+                  "remoteAs" : 2,
+                  "routeReflectorClient" : false,
+                  "sendCommunity" : true
+                },
+                "2.34.101.4/32" : {
+                  "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "additionalPathsReceive" : true,
+                  "additionalPathsSelectAll" : true,
+                  "additionalPathsSend" : true,
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : false,
+                  "allowRemoteAsOut" : true,
+                  "clusterId" : 33620737,
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.34.101.4~",
+                  "exportPolicySources" : [
+                    "as2dist_to_dept"
+                  ],
+                  "group" : "dept",
+                  "importPolicy" : "dept_to_as2dist",
+                  "importPolicySources" : [
+                    "dept_to_as2dist"
+                  ],
+                  "localAs" : 2,
+                  "localIp" : "2.34.101.3",
+                  "peerAddress" : "2.34.101.4",
+                  "remoteAs" : 65001,
+                  "routeReflectorClient" : false,
+                  "sendCommunity" : true
+                }
+              },
+              "routerId" : "2.1.3.1",
+              "tieBreaker" : "ARRIVAL_ORDER"
+            },
+            "interfaces" : [
+              "Ethernet0/0",
+              "GigabitEthernet0/0",
+              "GigabitEthernet1/0",
+              "GigabitEthernet2/0",
+              "Loopback0"
+            ],
+            "ospfProcess" : {
+              "areas" : {
+                "1" : {
+                  "name" : 1,
+                  "injectDefaultRoute" : true,
+                  "interfaces" : [
+                    "GigabitEthernet0/0",
+                    "GigabitEthernet1/0",
+                    "Loopback0"
+                  ],
+                  "metricOfDefaultRoute" : 0,
+                  "stubType" : "NONE"
+                }
+              },
+              "exportPolicy" : "~OSPF_EXPORT_POLICY:default~",
+              "processId" : "1",
+              "referenceBandwidth" : 1.0E8,
+              "routerId" : "2.1.3.1"
+            }
+          }
+        }
+      },
+      "as2dist2" : {
+        "configurationFormat" : "CISCO_IOS",
+        "name" : "as2dist2",
+        "communityLists" : {
+          "dept_community" : {
+            "class" : "org.batfish.datamodel.CommunityList",
+            "invertMatch" : false,
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.RegexCommunitySet",
+                  "regex" : "(,|\\{|\\}|^|$| )65001:"
+                }
+              }
+            ],
+            "name" : "dept_community"
+          }
+        },
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
+        "deviceType" : "ROUTER",
+        "domainName" : "lab.local",
+        "interfaces" : {
+          "Ethernet0/0" : {
+            "name" : "Ethernet0/0",
+            "accessVlan" : 0,
+            "active" : false,
+            "autostate" : true,
+            "bandwidth" : 1.0E7,
+            "declaredNames" : [
+              "Ethernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "GigabitEthernet0/0" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.22.3/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.22.3/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "GigabitEthernet1/0" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.12.3/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.12.3/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "GigabitEthernet2/0" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.34.201.3/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.34.201.3/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "Loopback0" : {
+            "name" : "Loopback0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.1.3.2/32"
+            ],
+            "autostate" : true,
+            "bandwidth" : 8.0E9,
+            "declaredNames" : [
+              "Loopback0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.1.3.2/32",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "LOOPBACK",
+            "vrf" : "default"
+          }
+        },
+        "ipAccessLists" : {
+          "102" : {
+            "name" : "102",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.0.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "2.128.0.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 2.128.0.0 host 255.255.0.0"
+              }
+            ],
+            "sourceName" : "102",
+            "sourceType" : "extended ipv4 access-list"
+          },
+          "105" : {
+            "name" : "105",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.255.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "1.0.1.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 1.0.1.0 host 255.255.255.0"
+              },
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.255.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "1.0.2.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 1.0.2.0 host 255.255.255.0"
+              },
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.255.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "3.0.1.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 3.0.1.0 host 255.255.255.0"
+              },
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.255.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "3.0.2.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 3.0.2.0 host 255.255.255.0"
+              }
+            ],
+            "sourceName" : "105",
+            "sourceType" : "extended ipv4 access-list"
+          }
+        },
+        "routeFilterLists" : {
+          "105" : {
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "1.0.1.0/24",
+                "lengthRange" : "24-24"
+              },
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "1.0.2.0/24",
+                "lengthRange" : "24-24"
+              },
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "3.0.1.0/24",
+                "lengthRange" : "24-24"
+              },
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "3.0.2.0/24",
+                "lengthRange" : "24-24"
+              }
+            ],
+            "name" : "105"
+          }
+        },
+        "routingPolicies" : {
+          "as2dist_to_dept" : {
+            "name" : "as2dist_to_dept",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as2dist_to_dept~100~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnLocalDefaultAction"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                    "name" : "105"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                    "metric" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                      "value" : 50
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                    "expr" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySet",
+                      "communities" : [
+                        196073
+                      ]
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
+          "dept_to_as2dist" : {
+            "name" : "dept_to_as2dist",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~dept_to_as2dist~100~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnLocalDefaultAction"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchCommunitySet",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedCommunitySet",
+                    "name" : "dept_community"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetLocalPreference",
+                    "localPreference" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralInt",
+                      "value" : 350
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
+          "~BGP_COMMON_EXPORT_POLICY:default~" : {
+            "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
+                  "disjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "bgp"
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "ibgp"
+                    }
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              },
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                "type" : "ReturnFalse"
+              }
+            ]
+          },
+          "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~" : {
+            "name" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          },
+          "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~" : {
+            "name" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          },
+          "~BGP_PEER_EXPORT_POLICY:default:2.34.201.4~" : {
+            "name" : "~BGP_PEER_EXPORT_POLICY:default:2.34.201.4~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                  "conjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                      "calledPolicyName" : "as2dist_to_dept"
+                    }
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          },
+          "~OSPF_EXPORT_POLICY:default~" : {
+            "name" : "~OSPF_EXPORT_POLICY:default~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "OSPF export routes for connected",
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                  "conjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "connected"
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                      "expr" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                        "comment" : "match default route",
+                        "prefix" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                        },
+                        "prefixSet" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                          "prefixSpace" : [
+                            "0.0.0.0/0"
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetOspfMetricType",
+                    "metricType" : "E2"
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                    "metric" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                      "value" : 20
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "vendorFamily" : {
+          "cisco" : {
+            "aaa" : {
+              "newModel" : false
+            },
+            "hostname" : "as2dist2",
+            "lines" : {
+              "aux0" : {
+                "name" : "aux0",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "AUX"
+              },
+              "con0" : {
+                "name" : "con0",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "CON"
+              },
+              "vty0" : {
+                "name" : "vty0",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty1" : {
+                "name" : "vty1",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty2" : {
+                "name" : "vty2",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty3" : {
+                "name" : "vty3",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty4" : {
+                "name" : "vty4",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              }
+            },
+            "logging" : {
+              "on" : true
+            },
+            "services" : {
+              "timestamps" : {
+                "enabled" : true,
+                "subservices" : {
+                  "debug" : {
+                    "enabled" : true,
+                    "subservices" : {
+                      "datetime" : {
+                        "enabled" : true,
+                        "subservices" : {
+                          "msec" : {
+                            "enabled" : true
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "log" : {
+                    "enabled" : true,
+                    "subservices" : {
+                      "datetime" : {
+                        "enabled" : true,
+                        "subservices" : {
+                          "msec" : {
+                            "enabled" : true
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "vrfs" : {
+          "default" : {
+            "name" : "default",
+            "bgpProcess" : {
+              "multipathEbgp" : true,
+              "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
+              "multipathIbgp" : true,
+              "neighbors" : {
+                "2.1.2.1/32" : {
+                  "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "additionalPathsReceive" : true,
+                  "additionalPathsSelectAll" : true,
+                  "additionalPathsSend" : true,
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : false,
+                  "allowRemoteAsOut" : true,
+                  "clusterId" : 33620738,
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.1~",
+                  "group" : "as2",
+                  "localAs" : 2,
+                  "localIp" : "2.1.3.2",
+                  "peerAddress" : "2.1.2.1",
+                  "remoteAs" : 2,
+                  "routeReflectorClient" : false,
+                  "sendCommunity" : true
+                },
+                "2.1.2.2/32" : {
+                  "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "additionalPathsReceive" : true,
+                  "additionalPathsSelectAll" : true,
+                  "additionalPathsSend" : true,
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : false,
+                  "allowRemoteAsOut" : true,
+                  "clusterId" : 33620738,
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.1.2.2~",
+                  "group" : "as2",
+                  "localAs" : 2,
+                  "localIp" : "2.1.3.2",
+                  "peerAddress" : "2.1.2.2",
+                  "remoteAs" : 2,
+                  "routeReflectorClient" : false,
+                  "sendCommunity" : true
+                },
+                "2.34.201.4/32" : {
+                  "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "additionalPathsReceive" : true,
+                  "additionalPathsSelectAll" : true,
+                  "additionalPathsSend" : true,
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : false,
+                  "allowRemoteAsOut" : true,
+                  "clusterId" : 33620738,
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:2.34.201.4~",
+                  "exportPolicySources" : [
+                    "as2dist_to_dept"
+                  ],
+                  "group" : "dept",
+                  "importPolicy" : "dept_to_as2dist",
+                  "importPolicySources" : [
+                    "dept_to_as2dist"
+                  ],
+                  "localAs" : 2,
+                  "localIp" : "2.34.201.3",
+                  "peerAddress" : "2.34.201.4",
+                  "remoteAs" : 65001,
+                  "routeReflectorClient" : false,
+                  "sendCommunity" : true
+                }
+              },
+              "routerId" : "2.1.3.2",
+              "tieBreaker" : "ARRIVAL_ORDER"
+            },
+            "interfaces" : [
+              "Ethernet0/0",
+              "GigabitEthernet0/0",
+              "GigabitEthernet1/0",
+              "GigabitEthernet2/0",
+              "Loopback0"
+            ],
+            "ospfProcess" : {
+              "areas" : {
+                "1" : {
+                  "name" : 1,
+                  "injectDefaultRoute" : true,
+                  "interfaces" : [
+                    "GigabitEthernet0/0",
+                    "GigabitEthernet1/0",
+                    "Loopback0"
+                  ],
+                  "metricOfDefaultRoute" : 0,
+                  "stubType" : "NONE"
+                }
+              },
+              "exportPolicy" : "~OSPF_EXPORT_POLICY:default~",
+              "processId" : "1",
+              "referenceBandwidth" : 1.0E8,
+              "routerId" : "2.1.3.2"
+            }
+          }
+        }
+      },
+      "as3border1" : {
+        "configurationFormat" : "CISCO_IOS",
+        "name" : "as3border1",
+        "communityLists" : {
+          "as1_community" : {
+            "class" : "org.batfish.datamodel.CommunityList",
+            "invertMatch" : false,
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.RegexCommunitySet",
+                  "regex" : "(,|\\{|\\}|^|$| )1:"
+                }
+              }
+            ],
+            "name" : "as1_community"
+          },
+          "as2_community" : {
+            "class" : "org.batfish.datamodel.CommunityList",
+            "invertMatch" : false,
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.RegexCommunitySet",
+                  "regex" : "(,|\\{|\\}|^|$| )2:"
+                }
+              }
+            ],
+            "name" : "as2_community"
+          },
+          "as3_community" : {
+            "class" : "org.batfish.datamodel.CommunityList",
+            "invertMatch" : false,
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.RegexCommunitySet",
+                  "regex" : "(,|\\{|\\}|^|$| )3:"
+                }
+              }
+            ],
+            "name" : "as3_community"
+          }
+        },
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
+        "deviceType" : "ROUTER",
+        "domainName" : "lab.local",
+        "interfaces" : {
+          "Ethernet0/0" : {
+            "name" : "Ethernet0/0",
+            "accessVlan" : 0,
+            "active" : false,
+            "autostate" : true,
+            "bandwidth" : 1.0E7,
+            "declaredNames" : [
+              "Ethernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "GigabitEthernet0/0" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "3.0.1.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "3.0.1.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "GigabitEthernet1/0" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "10.23.21.3/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "10.23.21.3/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "Loopback0" : {
+            "name" : "Loopback0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "3.1.1.1/32"
+            ],
+            "autostate" : true,
+            "bandwidth" : 8.0E9,
+            "declaredNames" : [
+              "Loopback0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "3.1.1.1/32",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "LOOPBACK",
+            "vrf" : "default"
+          }
+        },
+        "ipAccessLists" : {
+          "101" : {
+            "name" : "101",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.255.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "1.0.1.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 1.0.1.0 host 255.255.255.0"
+              },
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.255.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "1.0.2.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 1.0.2.0 host 255.255.255.0"
+              }
+            ],
+            "sourceName" : "101",
+            "sourceType" : "extended ipv4 access-list"
+          },
+          "102" : {
+            "name" : "102",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.0.0.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "2.0.0.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 2.0.0.0 host 255.0.0.0"
+              },
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.0.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "2.128.0.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 2.128.0.0 host 255.255.0.0"
+              }
+            ],
+            "sourceName" : "102",
+            "sourceType" : "extended ipv4 access-list"
+          },
+          "103" : {
+            "name" : "103",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.255.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "3.0.1.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 3.0.1.0 host 255.255.255.0"
+              },
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.255.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "3.0.2.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 3.0.2.0 host 255.255.255.0"
+              }
+            ],
+            "sourceName" : "103",
+            "sourceType" : "extended ipv4 access-list"
+          }
+        },
+        "ntpServers" : [
+          "18.18.18.18",
+          "23.23.23.23"
+        ],
+        "routeFilterLists" : {
+          "101" : {
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "1.0.1.0/24",
+                "lengthRange" : "24-24"
+              },
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "1.0.2.0/24",
+                "lengthRange" : "24-24"
+              }
+            ],
+            "name" : "101"
+          },
+          "102" : {
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "2.0.0.0/8",
+                "lengthRange" : "8-8"
+              },
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "2.128.0.0/16",
+                "lengthRange" : "16-16"
+              }
+            ],
+            "name" : "102"
+          },
+          "103" : {
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "3.0.1.0/24",
+                "lengthRange" : "24-24"
+              },
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "3.0.2.0/24",
+                "lengthRange" : "24-24"
+              }
+            ],
+            "name" : "103"
+          },
+          "default_list" : {
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "0.0.0.0/0",
+                "lengthRange" : "0-0"
+              }
+            ],
+            "name" : "default_list"
+          },
+          "inbound_route_filter" : {
+            "lines" : [
+              {
+                "action" : "DENY",
+                "ipWildcard" : "3.0.0.0/8",
+                "lengthRange" : "8-32"
+              },
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "0.0.0.0/0",
+                "lengthRange" : "0-32"
+              }
+            ],
+            "name" : "inbound_route_filter"
+          }
+        },
+        "routingPolicies" : {
+          "as1_to_as3" : {
+            "name" : "as1_to_as3",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as1_to_as3~100~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnLocalDefaultAction"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchCommunitySet",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedCommunitySet",
+                    "name" : "as1_community"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetLocalPreference",
+                    "localPreference" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralInt",
+                      "value" : 350
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
+          "as2_to_as3" : {
+            "name" : "as2_to_as3",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as2_to_as3~100~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnLocalDefaultAction"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchCommunitySet",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedCommunitySet",
+                    "name" : "as2_community"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetLocalPreference",
+                    "localPreference" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralInt",
+                      "value" : 350
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
+          "as3_to_as1" : {
+            "name" : "as3_to_as1",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as3_to_as1~2~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                    "comment" : "~RMCLAUSE~as3_to_as1~3~",
+                    "falseStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                        "type" : "ReturnLocalDefaultAction"
+                      }
+                    ],
+                    "guard" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                      "prefix" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                      },
+                      "prefixSet" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                        "name" : "103"
+                      }
+                    },
+                    "trueStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                        "metric" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                          "value" : 50
+                        }
+                      },
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                        "expr" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySet",
+                          "communities" : [
+                            196609
+                          ]
+                        }
+                      },
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                        "type" : "ReturnTrue"
+                      }
+                    ]
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                    "name" : "102"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                    "metric" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                      "value" : 50
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                    "expr" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySet",
+                      "communities" : [
+                        196609
+                      ]
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
+          "as3_to_as2" : {
+            "name" : "as3_to_as2",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as3_to_as2~1~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                    "comment" : "~RMCLAUSE~as3_to_as2~3~",
+                    "falseStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                        "comment" : "~RMCLAUSE~as3_to_as2~5~",
+                        "falseStatements" : [
+                          {
+                            "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                            "type" : "ReturnLocalDefaultAction"
+                          }
+                        ],
+                        "guard" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                          "prefix" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                          },
+                          "prefixSet" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                            "name" : "default_list"
+                          }
+                        },
+                        "trueStatements" : [
+                          {
+                            "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                            "metric" : {
+                              "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                              "value" : 50
+                            }
+                          },
+                          {
+                            "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                            "expr" : {
+                              "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySet",
+                              "communities" : [
+                                196610
+                              ]
+                            }
+                          },
+                          {
+                            "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                            "type" : "ReturnTrue"
+                          }
+                        ]
+                      }
+                    ],
+                    "guard" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                      "prefix" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                      },
+                      "prefixSet" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                        "name" : "103"
+                      }
+                    },
+                    "trueStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                        "metric" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                          "value" : 50
+                        }
+                      },
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                        "expr" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySet",
+                          "communities" : [
+                            196610
+                          ]
+                        }
+                      },
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                        "type" : "ReturnTrue"
+                      }
+                    ]
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                    "name" : "101"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                    "metric" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                      "value" : 50
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                    "expr" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySet",
+                      "communities" : [
+                        196610
+                      ]
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
+          "~BGP_COMMON_EXPORT_POLICY:default~" : {
+            "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
+                  "disjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                      "conjuncts" : [
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                          "prefix" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                          },
+                          "prefixSet" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                            "prefixSpace" : [
+                              "3.0.1.0/24"
+                            ]
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                            "protocol" : "bgp"
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                            "protocol" : "ibgp"
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                            "protocol" : "aggregate"
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.WithEnvironmentExpr",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.BooleanExprs$StaticBooleanExpr",
+                            "type" : "True"
+                          },
+                          "postStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "UnsetWriteIntermediateBgpAttributes"
+                            }
+                          ],
+                          "postTrueStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "SetReadIntermediateBgpAttributes"
+                            },
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.SetOrigin",
+                              "originType" : {
+                                "class" : "org.batfish.datamodel.routing_policy.expr.LiteralOrigin",
+                                "originType" : "igp"
+                              }
+                            }
+                          ],
+                          "preStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "SetWriteIntermediateBgpAttributes"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                      "conjuncts" : [
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                          "prefix" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                          },
+                          "prefixSet" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                            "prefixSpace" : [
+                              "3.0.2.0/24"
+                            ]
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                            "protocol" : "bgp"
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                            "protocol" : "ibgp"
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                            "protocol" : "aggregate"
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.WithEnvironmentExpr",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.BooleanExprs$StaticBooleanExpr",
+                            "type" : "True"
+                          },
+                          "postStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "UnsetWriteIntermediateBgpAttributes"
+                            }
+                          ],
+                          "postTrueStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "SetReadIntermediateBgpAttributes"
+                            },
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.SetOrigin",
+                              "originType" : {
+                                "class" : "org.batfish.datamodel.routing_policy.expr.LiteralOrigin",
+                                "originType" : "igp"
+                              }
+                            }
+                          ],
+                          "preStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "SetWriteIntermediateBgpAttributes"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "bgp"
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "ibgp"
+                    }
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              },
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                "type" : "ReturnFalse"
+              }
+            ]
+          },
+          "~BGP_PEER_EXPORT_POLICY:default:10.23.21.2~" : {
+            "name" : "~BGP_PEER_EXPORT_POLICY:default:10.23.21.2~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                  "conjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                      "calledPolicyName" : "as3_to_as2"
+                    }
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          },
+          "~BGP_PEER_EXPORT_POLICY:default:3.10.1.1~" : {
+            "name" : "~BGP_PEER_EXPORT_POLICY:default:3.10.1.1~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          },
+          "~OSPF_EXPORT_POLICY:default~" : {
+            "name" : "~OSPF_EXPORT_POLICY:default~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "OSPF export routes for connected",
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                  "conjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "connected"
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                      "expr" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                        "comment" : "match default route",
+                        "prefix" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                        },
+                        "prefixSet" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                          "prefixSpace" : [
+                            "0.0.0.0/0"
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetOspfMetricType",
+                    "metricType" : "E2"
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                    "metric" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                      "value" : 20
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "vendorFamily" : {
+          "cisco" : {
+            "aaa" : {
+              "newModel" : false
+            },
+            "hostname" : "as3border1",
+            "lines" : {
+              "aux0" : {
+                "name" : "aux0",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "AUX"
+              },
+              "con0" : {
+                "name" : "con0",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "CON"
+              },
+              "vty0" : {
+                "name" : "vty0",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty1" : {
+                "name" : "vty1",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty2" : {
+                "name" : "vty2",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty3" : {
+                "name" : "vty3",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty4" : {
+                "name" : "vty4",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              }
+            },
+            "logging" : {
+              "on" : true
+            },
+            "ntp" : {
+              "servers" : {
+                "18.18.18.18" : {
+                  "name" : "18.18.18.18"
+                },
+                "23.23.23.23" : {
+                  "name" : "23.23.23.23"
+                }
+              }
+            },
+            "services" : {
+              "timestamps" : {
+                "enabled" : true,
+                "subservices" : {
+                  "debug" : {
+                    "enabled" : true,
+                    "subservices" : {
+                      "datetime" : {
+                        "enabled" : true,
+                        "subservices" : {
+                          "msec" : {
+                            "enabled" : true
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "log" : {
+                    "enabled" : true,
+                    "subservices" : {
+                      "datetime" : {
+                        "enabled" : true,
+                        "subservices" : {
+                          "msec" : {
+                            "enabled" : true
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "vrfs" : {
+          "default" : {
+            "name" : "default",
+            "bgpProcess" : {
+              "multipathEbgp" : true,
+              "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
+              "multipathIbgp" : true,
+              "neighbors" : {
+                "3.10.1.1/32" : {
+                  "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "additionalPathsReceive" : true,
+                  "additionalPathsSelectAll" : true,
+                  "additionalPathsSend" : true,
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : false,
+                  "allowRemoteAsOut" : true,
+                  "clusterId" : 50397441,
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:3.10.1.1~",
+                  "group" : "as3",
+                  "localAs" : 3,
+                  "localIp" : "3.1.1.1",
+                  "peerAddress" : "3.10.1.1",
+                  "remoteAs" : 3,
+                  "routeReflectorClient" : false,
+                  "sendCommunity" : true
+                },
+                "10.23.21.2/32" : {
+                  "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "additionalPathsReceive" : true,
+                  "additionalPathsSelectAll" : true,
+                  "additionalPathsSend" : true,
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : false,
+                  "allowRemoteAsOut" : true,
+                  "clusterId" : 50397441,
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.23.21.2~",
+                  "exportPolicySources" : [
+                    "as3_to_as2"
+                  ],
+                  "group" : "as2",
+                  "importPolicy" : "as2_to_as3",
+                  "importPolicySources" : [
+                    "as2_to_as3"
+                  ],
+                  "localAs" : 3,
+                  "localIp" : "10.23.21.3",
+                  "peerAddress" : "10.23.21.2",
+                  "remoteAs" : 2,
+                  "routeReflectorClient" : false,
+                  "sendCommunity" : true
+                }
+              },
+              "routerId" : "3.1.1.1",
+              "tieBreaker" : "ARRIVAL_ORDER"
+            },
+            "interfaces" : [
+              "Ethernet0/0",
+              "GigabitEthernet0/0",
+              "GigabitEthernet1/0",
+              "Loopback0"
+            ],
+            "ospfProcess" : {
+              "areas" : {
+                "1" : {
+                  "name" : 1,
+                  "injectDefaultRoute" : true,
+                  "interfaces" : [
+                    "GigabitEthernet0/0",
+                    "Loopback0"
+                  ],
+                  "metricOfDefaultRoute" : 0,
+                  "stubType" : "NONE"
+                }
+              },
+              "exportPolicy" : "~OSPF_EXPORT_POLICY:default~",
+              "processId" : "1",
+              "referenceBandwidth" : 1.0E8,
+              "routerId" : "3.1.1.1"
+            }
+          }
+        }
+      },
+      "as3border2" : {
+        "configurationFormat" : "CISCO_IOS",
+        "name" : "as3border2",
+        "communityLists" : {
+          "as1_community" : {
+            "class" : "org.batfish.datamodel.CommunityList",
+            "invertMatch" : false,
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.RegexCommunitySet",
+                  "regex" : "(,|\\{|\\}|^|$| )1:"
+                }
+              }
+            ],
+            "name" : "as1_community"
+          },
+          "as2_community" : {
+            "class" : "org.batfish.datamodel.CommunityList",
+            "invertMatch" : false,
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.RegexCommunitySet",
+                  "regex" : "(,|\\{|\\}|^|$| )2:"
+                }
+              }
+            ],
+            "name" : "as2_community"
+          },
+          "as3_community" : {
+            "class" : "org.batfish.datamodel.CommunityList",
+            "invertMatch" : false,
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.RegexCommunitySet",
+                  "regex" : "(,|\\{|\\}|^|$| )3:"
+                }
+              }
+            ],
+            "name" : "as3_community"
+          }
+        },
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
+        "deviceType" : "ROUTER",
+        "domainName" : "lab.local",
+        "interfaces" : {
+          "Ethernet0/0" : {
+            "name" : "Ethernet0/0",
+            "accessVlan" : 0,
+            "active" : false,
+            "autostate" : true,
+            "bandwidth" : 1.0E7,
+            "declaredNames" : [
+              "Ethernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "GigabitEthernet0/0" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "10.13.22.3/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "10.13.22.3/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "GigabitEthernet1/0" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "3.0.2.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "3.0.2.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "Loopback0" : {
+            "name" : "Loopback0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "3.2.2.2/32"
+            ],
+            "autostate" : true,
+            "bandwidth" : 8.0E9,
+            "declaredNames" : [
+              "Loopback0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "3.2.2.2/32",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "LOOPBACK",
+            "vrf" : "default"
+          }
+        },
+        "ipAccessLists" : {
+          "101" : {
+            "name" : "101",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.255.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "1.0.1.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 1.0.1.0 host 255.255.255.0"
+              },
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.255.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "1.0.2.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 1.0.2.0 host 255.255.255.0"
+              }
+            ],
+            "sourceName" : "101",
+            "sourceType" : "extended ipv4 access-list"
+          },
+          "102" : {
+            "name" : "102",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.0.0.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "2.0.0.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 2.0.0.0 host 255.0.0.0"
+              },
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.0.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "2.128.0.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 2.128.0.0 host 255.255.0.0"
+              }
+            ],
+            "sourceName" : "102",
+            "sourceType" : "extended ipv4 access-list"
+          },
+          "103" : {
+            "name" : "103",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.255.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "3.0.1.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 3.0.1.0 host 255.255.255.0"
+              },
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "255.255.255.0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "3.0.2.0"
+                    }
+                  }
+                },
+                "name" : "permit ip host 3.0.2.0 host 255.255.255.0"
+              }
+            ],
+            "sourceName" : "103",
+            "sourceType" : "extended ipv4 access-list"
+          }
+        },
+        "ntpServers" : [
+          "18.18.18.18",
+          "23.23.23.23"
+        ],
+        "routeFilterLists" : {
+          "101" : {
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "1.0.1.0/24",
+                "lengthRange" : "24-24"
+              },
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "1.0.2.0/24",
+                "lengthRange" : "24-24"
+              }
+            ],
+            "name" : "101"
+          },
+          "102" : {
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "2.0.0.0/8",
+                "lengthRange" : "8-8"
+              },
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "2.128.0.0/16",
+                "lengthRange" : "16-16"
+              }
+            ],
+            "name" : "102"
+          },
+          "103" : {
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "3.0.1.0/24",
+                "lengthRange" : "24-24"
+              },
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "3.0.2.0/24",
+                "lengthRange" : "24-24"
+              }
+            ],
+            "name" : "103"
+          },
+          "inbound_route_filter" : {
+            "lines" : [
+              {
+                "action" : "DENY",
+                "ipWildcard" : "3.0.0.0/8",
+                "lengthRange" : "8-32"
+              },
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "0.0.0.0/0",
+                "lengthRange" : "0-32"
+              }
+            ],
+            "name" : "inbound_route_filter"
+          }
+        },
+        "routingPolicies" : {
+          "as1_to_as3" : {
+            "name" : "as1_to_as3",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as1_to_as3~100~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnLocalDefaultAction"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchCommunitySet",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedCommunitySet",
+                    "name" : "as1_community"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetLocalPreference",
+                    "localPreference" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralInt",
+                      "value" : 350
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
+          "as2_to_as3" : {
+            "name" : "as2_to_as3",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as2_to_as3~100~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnLocalDefaultAction"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchCommunitySet",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedCommunitySet",
+                    "name" : "as2_community"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetLocalPreference",
+                    "localPreference" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralInt",
+                      "value" : 350
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
+          "as3_to_as1" : {
+            "name" : "as3_to_as1",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as3_to_as1~2~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                    "comment" : "~RMCLAUSE~as3_to_as1~3~",
+                    "falseStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                        "type" : "ReturnLocalDefaultAction"
+                      }
+                    ],
+                    "guard" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                      "prefix" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                      },
+                      "prefixSet" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                        "name" : "103"
+                      }
+                    },
+                    "trueStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                        "metric" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                          "value" : 50
+                        }
+                      },
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                        "expr" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySet",
+                          "communities" : [
+                            196609
+                          ]
+                        }
+                      },
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                        "type" : "ReturnTrue"
+                      }
+                    ]
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                    "name" : "102"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                    "metric" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                      "value" : 50
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                    "expr" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySet",
+                      "communities" : [
+                        196609
+                      ]
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
+          "as3_to_as2" : {
+            "name" : "as3_to_as2",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "~RMCLAUSE~as3_to_as2~1~",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                    "comment" : "~RMCLAUSE~as3_to_as2~3~",
+                    "falseStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                        "type" : "ReturnLocalDefaultAction"
+                      }
+                    ],
+                    "guard" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                      "prefix" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                      },
+                      "prefixSet" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                        "name" : "103"
+                      }
+                    },
+                    "trueStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                        "metric" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                          "value" : 50
+                        }
+                      },
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                        "expr" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySet",
+                          "communities" : [
+                            196610
+                          ]
+                        }
+                      },
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                        "type" : "ReturnTrue"
+                      }
+                    ]
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                    "name" : "101"
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                    "metric" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                      "value" : 50
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.AddCommunity",
+                    "expr" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySet",
+                      "communities" : [
+                        196610
+                      ]
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          },
+          "~BGP_COMMON_EXPORT_POLICY:default~" : {
+            "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
+                  "disjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                      "conjuncts" : [
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                          "prefix" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                          },
+                          "prefixSet" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                            "prefixSpace" : [
+                              "3.0.1.0/24"
+                            ]
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                            "protocol" : "bgp"
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                            "protocol" : "ibgp"
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                            "protocol" : "aggregate"
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.WithEnvironmentExpr",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.BooleanExprs$StaticBooleanExpr",
+                            "type" : "True"
+                          },
+                          "postStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "UnsetWriteIntermediateBgpAttributes"
+                            }
+                          ],
+                          "postTrueStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "SetReadIntermediateBgpAttributes"
+                            },
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.SetOrigin",
+                              "originType" : {
+                                "class" : "org.batfish.datamodel.routing_policy.expr.LiteralOrigin",
+                                "originType" : "igp"
+                              }
+                            }
+                          ],
+                          "preStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "SetWriteIntermediateBgpAttributes"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                      "conjuncts" : [
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                          "prefix" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                          },
+                          "prefixSet" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                            "prefixSpace" : [
+                              "3.0.2.0/24"
+                            ]
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                            "protocol" : "bgp"
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                            "protocol" : "ibgp"
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                            "protocol" : "aggregate"
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.WithEnvironmentExpr",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.BooleanExprs$StaticBooleanExpr",
+                            "type" : "True"
+                          },
+                          "postStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "UnsetWriteIntermediateBgpAttributes"
+                            }
+                          ],
+                          "postTrueStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "SetReadIntermediateBgpAttributes"
+                            },
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.SetOrigin",
+                              "originType" : {
+                                "class" : "org.batfish.datamodel.routing_policy.expr.LiteralOrigin",
+                                "originType" : "igp"
+                              }
+                            }
+                          ],
+                          "preStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "SetWriteIntermediateBgpAttributes"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "bgp"
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "ibgp"
+                    }
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              },
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                "type" : "ReturnFalse"
+              }
+            ]
+          },
+          "~BGP_PEER_EXPORT_POLICY:default:10.13.22.1~" : {
+            "name" : "~BGP_PEER_EXPORT_POLICY:default:10.13.22.1~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                  "conjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                      "calledPolicyName" : "as3_to_as1"
+                    }
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          },
+          "~BGP_PEER_EXPORT_POLICY:default:3.10.1.1~" : {
+            "name" : "~BGP_PEER_EXPORT_POLICY:default:3.10.1.1~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          },
+          "~OSPF_EXPORT_POLICY:default~" : {
+            "name" : "~OSPF_EXPORT_POLICY:default~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "OSPF export routes for connected",
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                  "conjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "connected"
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                      "expr" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                        "comment" : "match default route",
+                        "prefix" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                        },
+                        "prefixSet" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                          "prefixSpace" : [
+                            "0.0.0.0/0"
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetOspfMetricType",
+                    "metricType" : "E2"
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                    "metric" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                      "value" : 20
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "vendorFamily" : {
+          "cisco" : {
+            "aaa" : {
+              "newModel" : false
+            },
+            "hostname" : "as3border2",
+            "lines" : {
+              "aux0" : {
+                "name" : "aux0",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "AUX"
+              },
+              "con0" : {
+                "name" : "con0",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "CON"
+              },
+              "vty0" : {
+                "name" : "vty0",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty1" : {
+                "name" : "vty1",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty2" : {
+                "name" : "vty2",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty3" : {
+                "name" : "vty3",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty4" : {
+                "name" : "vty4",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              }
+            },
+            "logging" : {
+              "on" : true
+            },
+            "ntp" : {
+              "servers" : {
+                "18.18.18.18" : {
+                  "name" : "18.18.18.18"
+                },
+                "23.23.23.23" : {
+                  "name" : "23.23.23.23"
+                }
+              }
+            },
+            "services" : {
+              "timestamps" : {
+                "enabled" : true,
+                "subservices" : {
+                  "debug" : {
+                    "enabled" : true,
+                    "subservices" : {
+                      "datetime" : {
+                        "enabled" : true,
+                        "subservices" : {
+                          "msec" : {
+                            "enabled" : true
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "log" : {
+                    "enabled" : true,
+                    "subservices" : {
+                      "datetime" : {
+                        "enabled" : true,
+                        "subservices" : {
+                          "msec" : {
+                            "enabled" : true
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "vrfs" : {
+          "default" : {
+            "name" : "default",
+            "bgpProcess" : {
+              "multipathEbgp" : true,
+              "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
+              "multipathIbgp" : true,
+              "neighbors" : {
+                "3.10.1.1/32" : {
+                  "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "additionalPathsReceive" : true,
+                  "additionalPathsSelectAll" : true,
+                  "additionalPathsSend" : true,
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : false,
+                  "allowRemoteAsOut" : true,
+                  "clusterId" : 50463234,
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:3.10.1.1~",
+                  "group" : "as3",
+                  "localAs" : 3,
+                  "localIp" : "3.2.2.2",
+                  "peerAddress" : "3.10.1.1",
+                  "remoteAs" : 3,
+                  "routeReflectorClient" : false,
+                  "sendCommunity" : true
+                },
+                "10.13.22.1/32" : {
+                  "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "additionalPathsReceive" : true,
+                  "additionalPathsSelectAll" : true,
+                  "additionalPathsSend" : true,
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : false,
+                  "allowRemoteAsOut" : true,
+                  "clusterId" : 50463234,
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:10.13.22.1~",
+                  "exportPolicySources" : [
+                    "as3_to_as1"
+                  ],
+                  "group" : "as1",
+                  "importPolicy" : "as1_to_as3",
+                  "importPolicySources" : [
+                    "as1_to_as3"
+                  ],
+                  "localAs" : 3,
+                  "localIp" : "10.13.22.3",
+                  "peerAddress" : "10.13.22.1",
+                  "remoteAs" : 1,
+                  "routeReflectorClient" : false,
+                  "sendCommunity" : true
+                }
+              },
+              "routerId" : "3.2.2.2",
+              "tieBreaker" : "ARRIVAL_ORDER"
+            },
+            "interfaces" : [
+              "Ethernet0/0",
+              "GigabitEthernet0/0",
+              "GigabitEthernet1/0",
+              "Loopback0"
+            ],
+            "ospfProcess" : {
+              "areas" : {
+                "1" : {
+                  "name" : 1,
+                  "injectDefaultRoute" : true,
+                  "interfaces" : [
+                    "GigabitEthernet1/0",
+                    "Loopback0"
+                  ],
+                  "metricOfDefaultRoute" : 0,
+                  "stubType" : "NONE"
+                }
+              },
+              "exportPolicy" : "~OSPF_EXPORT_POLICY:default~",
+              "processId" : "1",
+              "referenceBandwidth" : 1.0E8,
+              "routerId" : "3.2.2.2"
+            }
+          }
+        }
+      },
+      "as3core1" : {
+        "configurationFormat" : "CISCO_IOS",
+        "name" : "as3core1",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
+        "deviceType" : "ROUTER",
+        "domainName" : "lab.local",
+        "interfaces" : {
+          "Ethernet0/0" : {
+            "name" : "Ethernet0/0",
+            "accessVlan" : 0,
+            "active" : false,
+            "autostate" : true,
+            "bandwidth" : 1.0E7,
+            "declaredNames" : [
+              "Ethernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "GigabitEthernet0/0" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "3.0.2.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "3.0.2.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "GigabitEthernet1/0" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "3.0.1.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "3.0.1.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "GigabitEthernet2/0" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "90.90.90.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "90.90.90.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "GigabitEthernet3/0" : {
+            "name" : "GigabitEthernet3/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "90.90.90.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet3/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "90.90.90.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "Loopback0" : {
+            "name" : "Loopback0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "3.10.1.1/32"
+            ],
+            "autostate" : true,
+            "bandwidth" : 8.0E9,
+            "declaredNames" : [
+              "Loopback0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "3.10.1.1/32",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "LOOPBACK",
+            "vrf" : "default"
+          }
+        },
+        "loggingServers" : [
+          "1.1.1.1",
+          "2.2.2.2"
+        ],
+        "routingPolicies" : {
+          "~BGP_COMMON_EXPORT_POLICY:default~" : {
+            "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
+                  "disjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                      "conjuncts" : [
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                          "prefix" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                          },
+                          "prefixSet" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                            "prefixSpace" : [
+                              "3.0.1.0/24"
+                            ]
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                            "protocol" : "bgp"
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                            "protocol" : "ibgp"
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                            "protocol" : "aggregate"
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.WithEnvironmentExpr",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.BooleanExprs$StaticBooleanExpr",
+                            "type" : "True"
+                          },
+                          "postStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "UnsetWriteIntermediateBgpAttributes"
+                            }
+                          ],
+                          "postTrueStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "SetReadIntermediateBgpAttributes"
+                            },
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.SetOrigin",
+                              "originType" : {
+                                "class" : "org.batfish.datamodel.routing_policy.expr.LiteralOrigin",
+                                "originType" : "igp"
+                              }
+                            }
+                          ],
+                          "preStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "SetWriteIntermediateBgpAttributes"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                      "conjuncts" : [
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                          "prefix" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                          },
+                          "prefixSet" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                            "prefixSpace" : [
+                              "3.0.2.0/24"
+                            ]
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                            "protocol" : "bgp"
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                            "protocol" : "ibgp"
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.Not",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                            "protocol" : "aggregate"
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.WithEnvironmentExpr",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.BooleanExprs$StaticBooleanExpr",
+                            "type" : "True"
+                          },
+                          "postStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "UnsetWriteIntermediateBgpAttributes"
+                            }
+                          ],
+                          "postTrueStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "SetReadIntermediateBgpAttributes"
+                            },
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.SetOrigin",
+                              "originType" : {
+                                "class" : "org.batfish.datamodel.routing_policy.expr.LiteralOrigin",
+                                "originType" : "igp"
+                              }
+                            }
+                          ],
+                          "preStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "SetWriteIntermediateBgpAttributes"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "bgp"
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "ibgp"
+                    }
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              },
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                "type" : "ReturnFalse"
+              }
+            ]
+          },
+          "~BGP_PEER_EXPORT_POLICY:default:3.1.1.1~" : {
+            "name" : "~BGP_PEER_EXPORT_POLICY:default:3.1.1.1~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          },
+          "~BGP_PEER_EXPORT_POLICY:default:3.2.2.2~" : {
+            "name" : "~BGP_PEER_EXPORT_POLICY:default:3.2.2.2~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          },
+          "~OSPF_EXPORT_POLICY:default~" : {
+            "name" : "~OSPF_EXPORT_POLICY:default~"
+          }
+        },
+        "vendorFamily" : {
+          "cisco" : {
+            "aaa" : {
+              "newModel" : false
+            },
+            "hostname" : "as3core1",
+            "lines" : {
+              "aux0" : {
+                "name" : "aux0",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "AUX"
+              },
+              "con0" : {
+                "name" : "con0",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "CON"
+              },
+              "vty0" : {
+                "name" : "vty0",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty1" : {
+                "name" : "vty1",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty2" : {
+                "name" : "vty2",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty3" : {
+                "name" : "vty3",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              },
+              "vty4" : {
+                "name" : "vty4",
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "VTY"
+              }
+            },
+            "logging" : {
+              "hosts" : {
+                "1.1.1.1" : {
+                  "name" : "1.1.1.1"
+                },
+                "2.2.2.2" : {
+                  "name" : "2.2.2.2"
+                }
+              },
+              "on" : true
+            },
+            "services" : {
+              "timestamps" : {
+                "enabled" : true,
+                "subservices" : {
+                  "debug" : {
+                    "enabled" : true,
+                    "subservices" : {
+                      "datetime" : {
+                        "enabled" : true,
+                        "subservices" : {
+                          "msec" : {
+                            "enabled" : true
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "log" : {
+                    "enabled" : true,
+                    "subservices" : {
+                      "datetime" : {
+                        "enabled" : true,
+                        "subservices" : {
+                          "msec" : {
+                            "enabled" : true
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "vrfs" : {
+          "default" : {
+            "name" : "default",
+            "bgpProcess" : {
+              "multipathEbgp" : true,
+              "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
+              "multipathIbgp" : true,
+              "neighbors" : {
+                "3.1.1.1/32" : {
+                  "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "additionalPathsReceive" : true,
+                  "additionalPathsSelectAll" : true,
+                  "additionalPathsSend" : true,
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : false,
+                  "allowRemoteAsOut" : true,
+                  "clusterId" : 50987265,
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:3.1.1.1~",
+                  "group" : "as3",
+                  "localAs" : 3,
+                  "localIp" : "3.10.1.1",
+                  "peerAddress" : "3.1.1.1",
+                  "remoteAs" : 3,
+                  "routeReflectorClient" : true,
+                  "sendCommunity" : true
+                },
+                "3.2.2.2/32" : {
+                  "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "additionalPathsReceive" : true,
+                  "additionalPathsSelectAll" : true,
+                  "additionalPathsSend" : true,
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : false,
+                  "allowRemoteAsOut" : true,
+                  "clusterId" : 50987265,
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:3.2.2.2~",
+                  "group" : "as3",
+                  "localAs" : 3,
+                  "localIp" : "3.10.1.1",
+                  "peerAddress" : "3.2.2.2",
+                  "remoteAs" : 3,
+                  "routeReflectorClient" : true,
+                  "sendCommunity" : true
+                }
+              },
+              "routerId" : "3.10.1.1",
+              "tieBreaker" : "ARRIVAL_ORDER"
+            },
+            "interfaces" : [
+              "Ethernet0/0",
+              "GigabitEthernet0/0",
+              "GigabitEthernet1/0",
+              "GigabitEthernet2/0",
+              "GigabitEthernet3/0",
+              "Loopback0"
+            ],
+            "ospfProcess" : {
+              "areas" : {
+                "1" : {
+                  "name" : 1,
+                  "injectDefaultRoute" : true,
+                  "interfaces" : [
+                    "GigabitEthernet0/0",
+                    "GigabitEthernet1/0",
+                    "Loopback0"
+                  ],
+                  "metricOfDefaultRoute" : 0,
+                  "stubType" : "NONE"
+                }
+              },
+              "exportPolicy" : "~OSPF_EXPORT_POLICY:default~",
+              "processId" : "1",
+              "referenceBandwidth" : 1.0E8,
+              "routerId" : "3.10.1.1"
+            }
+          }
+        }
+      },
+      "host1" : {
+        "configurationFormat" : "HOST",
+        "name" : "host1",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
+        "deviceType" : "HOST",
+        "interfaces" : {
+          "eth0" : {
+            "name" : "eth0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.128.0.101/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "eth0"
+            ],
+            "incomingFilter" : "filter::INPUT",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "outgoingFilter" : "filter::OUTPUT",
+            "prefix" : "2.128.0.101/24",
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        "ipAccessLists" : {
+          "filter::FORWARD" : {
+            "name" : "filter::FORWARD",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.TrueExpr"
+                },
+                "name" : "default"
+              }
+            ]
+          },
+          "filter::INPUT" : {
+            "name" : "filter::INPUT",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstPorts" : [
+                      "53-53"
+                    ],
+                    "ipProtocols" : [
+                      "UDP"
+                    ],
+                    "negate" : false
+                  }
+                },
+                "name" : "-p udp --dport 53 -j ACCEPT"
+              },
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstPorts" : [
+                      "22-22"
+                    ],
+                    "ipProtocols" : [
+                      "TCP"
+                    ],
+                    "negate" : false
+                  }
+                },
+                "name" : "-p tcp --dport 22 -j ACCEPT"
+              },
+              {
+                "action" : "DENY",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.TrueExpr"
+                },
+                "name" : "default"
+              }
+            ]
+          },
+          "filter::OUTPUT" : {
+            "name" : "filter::OUTPUT",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.TrueExpr"
+                },
+                "name" : "default"
+              }
+            ]
+          },
+          "mangle::FORWARD" : {
+            "name" : "mangle::FORWARD",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.TrueExpr"
+                },
+                "name" : "default"
+              }
+            ]
+          },
+          "mangle::INPUT" : {
+            "name" : "mangle::INPUT",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.TrueExpr"
+                },
+                "name" : "default"
+              }
+            ]
+          },
+          "mangle::OUTPUT" : {
+            "name" : "mangle::OUTPUT",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.TrueExpr"
+                },
+                "name" : "default"
+              }
+            ]
+          },
+          "mangle::POSTROUTING" : {
+            "name" : "mangle::POSTROUTING",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.TrueExpr"
+                },
+                "name" : "default"
+              }
+            ]
+          },
+          "mangle::PREROUTING" : {
+            "name" : "mangle::PREROUTING",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.TrueExpr"
+                },
+                "name" : "default"
+              }
+            ]
+          },
+          "nat::OUTPUT" : {
+            "name" : "nat::OUTPUT",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.TrueExpr"
+                },
+                "name" : "default"
+              }
+            ]
+          },
+          "nat::POSTROUTING" : {
+            "name" : "nat::POSTROUTING",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.TrueExpr"
+                },
+                "name" : "default"
+              }
+            ]
+          },
+          "nat::PREROUTING" : {
+            "name" : "nat::PREROUTING",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.TrueExpr"
+                },
+                "name" : "default"
+              }
+            ]
+          }
+        },
+        "vendorFamily" : { },
+        "vrfs" : {
+          "default" : {
+            "name" : "default",
+            "interfaces" : [
+              "eth0"
+            ],
+            "staticRoutes" : [
+              {
+                "class" : "org.batfish.datamodel.StaticRoute",
+                "administrativeCost" : 1,
+                "metric" : 0,
+                "network" : "0.0.0.0/0",
+                "nextHopInterface" : "eth0",
+                "nextHopIp" : "2.128.0.1",
+                "tag" : -1
+              }
+            ]
+          }
+        }
+      },
+      "host2" : {
+        "configurationFormat" : "HOST",
+        "name" : "host2",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
+        "deviceType" : "HOST",
+        "interfaces" : {
+          "eth0" : {
+            "name" : "eth0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.128.1.101/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "eth0"
+            ],
+            "incomingFilter" : "filter::INPUT",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "outgoingFilter" : "filter::OUTPUT",
+            "prefix" : "2.128.1.101/24",
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        "ipAccessLists" : {
+          "filter::FORWARD" : {
+            "name" : "filter::FORWARD",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.TrueExpr"
+                },
+                "name" : "default"
+              }
+            ]
+          },
+          "filter::INPUT" : {
+            "name" : "filter::INPUT",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstPorts" : [
+                      "22-22"
+                    ],
+                    "ipProtocols" : [
+                      "TCP"
+                    ],
+                    "negate" : false
+                  }
+                },
+                "name" : "-p tcp --dport 22 -j ACCEPT"
+              },
+              {
+                "action" : "DENY",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.TrueExpr"
+                },
+                "name" : "default"
+              }
+            ]
+          },
+          "filter::OUTPUT" : {
+            "name" : "filter::OUTPUT",
+            "lines" : [
+              {
+                "action" : "DENY",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "2.128.0.101"
+                    },
+                    "negate" : false
+                  }
+                },
+                "name" : "-d 2.128.0.101 -j DROP"
+              },
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.TrueExpr"
+                },
+                "name" : "default"
+              }
+            ]
+          },
+          "mangle::FORWARD" : {
+            "name" : "mangle::FORWARD",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.TrueExpr"
+                },
+                "name" : "default"
+              }
+            ]
+          },
+          "mangle::INPUT" : {
+            "name" : "mangle::INPUT",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.TrueExpr"
+                },
+                "name" : "default"
+              }
+            ]
+          },
+          "mangle::OUTPUT" : {
+            "name" : "mangle::OUTPUT",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.TrueExpr"
+                },
+                "name" : "default"
+              }
+            ]
+          },
+          "mangle::POSTROUTING" : {
+            "name" : "mangle::POSTROUTING",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.TrueExpr"
+                },
+                "name" : "default"
+              }
+            ]
+          },
+          "mangle::PREROUTING" : {
+            "name" : "mangle::PREROUTING",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.TrueExpr"
+                },
+                "name" : "default"
+              }
+            ]
+          },
+          "nat::OUTPUT" : {
+            "name" : "nat::OUTPUT",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.TrueExpr"
+                },
+                "name" : "default"
+              }
+            ]
+          },
+          "nat::POSTROUTING" : {
+            "name" : "nat::POSTROUTING",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.TrueExpr"
+                },
+                "name" : "default"
+              }
+            ]
+          },
+          "nat::PREROUTING" : {
+            "name" : "nat::PREROUTING",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.TrueExpr"
+                },
+                "name" : "default"
+              }
+            ]
+          }
+        },
+        "vendorFamily" : { },
+        "vrfs" : {
+          "default" : {
+            "name" : "default",
+            "interfaces" : [
+              "eth0"
+            ],
+            "staticRoutes" : [
+              {
+                "class" : "org.batfish.datamodel.StaticRoute",
+                "administrativeCost" : 1,
+                "metric" : 0,
+                "network" : "0.0.0.0/0",
+                "nextHopInterface" : "eth0",
+                "nextHopIp" : "2.128.1.1",
+                "tag" : -1
+              }
+            ]
+          }
+        }
+      }
+    },
+    "ospfEdges" : [
+      {
+        "edgeSummary" : {
+          "ip1" : "1.0.1.1",
+          "ip2" : "1.0.1.2",
+          "node1" : "as1border1",
+          "node2" : "as1core1"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "1.0.1.1",
+            "ip2" : "1.0.1.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "1.0.1.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "1.0.1.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "1.0.1.2",
+            "ip2" : "1.0.1.1"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "1.0.1.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "1.0.1.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "1.0.2.1",
+          "ip2" : "1.0.2.2",
+          "node1" : "as1border2",
+          "node2" : "as1core1"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "1.0.2.1",
+            "ip2" : "1.0.2.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "1.0.2.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "1.0.2.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "1.0.2.2",
+            "ip2" : "1.0.2.1"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "1.0.2.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "1.0.2.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "1.0.1.2",
+          "ip2" : "1.0.1.1",
+          "node1" : "as1core1",
+          "node2" : "as1border1"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "1.0.1.2",
+            "ip2" : "1.0.1.1"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "1.0.1.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "1.0.1.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "1.0.1.1",
+            "ip2" : "1.0.1.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "1.0.1.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "1.0.1.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "1.0.2.2",
+          "ip2" : "1.0.2.1",
+          "node1" : "as1core1",
+          "node2" : "as1border2"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "1.0.2.2",
+            "ip2" : "1.0.2.1"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "1.0.2.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "1.0.2.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "1.0.2.1",
+            "ip2" : "1.0.2.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "1.0.2.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "1.0.2.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "2.12.11.1",
+          "ip2" : "2.12.11.2",
+          "node1" : "as2border1",
+          "node2" : "as2core1"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "2.12.11.1",
+            "ip2" : "2.12.11.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.11.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.11.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "2.12.11.2",
+            "ip2" : "2.12.11.1"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.11.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.11.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "2.12.12.1",
+          "ip2" : "2.12.12.2",
+          "node1" : "as2border1",
+          "node2" : "as2core2"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "2.12.12.1",
+            "ip2" : "2.12.12.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.12.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.12.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "2.12.12.2",
+            "ip2" : "2.12.12.1"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.12.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1600,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.12.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "2.12.21.1",
+          "ip2" : "2.12.21.2",
+          "node1" : "as2border2",
+          "node2" : "as2core1"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "2.12.21.1",
+            "ip2" : "2.12.21.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.21.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.21.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "2.12.21.2",
+            "ip2" : "2.12.21.1"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.21.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.21.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "2.12.22.1",
+          "ip2" : "2.12.22.2",
+          "node1" : "as2border2",
+          "node2" : "as2core2"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "2.12.22.1",
+            "ip2" : "2.12.22.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.22.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.22.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "2.12.22.2",
+            "ip2" : "2.12.22.1"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.22.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1800,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.22.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "2.12.11.2",
+          "ip2" : "2.12.11.1",
+          "node1" : "as2core1",
+          "node2" : "as2border1"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "2.12.11.2",
+            "ip2" : "2.12.11.1"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.11.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.11.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "2.12.11.1",
+            "ip2" : "2.12.11.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.11.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.11.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "2.12.21.2",
+          "ip2" : "2.12.21.1",
+          "node1" : "as2core1",
+          "node2" : "as2border2"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "2.12.21.2",
+            "ip2" : "2.12.21.1"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.21.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.21.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "2.12.21.1",
+            "ip2" : "2.12.21.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.21.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.21.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "2.23.11.2",
+          "ip2" : "2.23.11.3",
+          "node1" : "as2core1",
+          "node2" : "as2dist1"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "2.23.11.2",
+            "ip2" : "2.23.11.3"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.11.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "incomingFilter" : "blocktelnet",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.11.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "2.23.11.3",
+            "ip2" : "2.23.11.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.11.3/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.11.3/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "2.23.12.2",
+          "ip2" : "2.23.12.3",
+          "node1" : "as2core1",
+          "node2" : "as2dist2"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "2.23.12.2",
+            "ip2" : "2.23.12.3"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet3/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.12.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet3/0"
+            ],
+            "incomingFilter" : "blocktelnet",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.12.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "2.23.12.3",
+            "ip2" : "2.23.12.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.12.3/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.12.3/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "2.12.12.2",
+          "ip2" : "2.12.12.1",
+          "node1" : "as2core2",
+          "node2" : "as2border1"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "2.12.12.2",
+            "ip2" : "2.12.12.1"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.12.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1600,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.12.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "2.12.12.1",
+            "ip2" : "2.12.12.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.12.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.12.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "2.12.22.2",
+          "ip2" : "2.12.22.1",
+          "node1" : "as2core2",
+          "node2" : "as2border2"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "2.12.22.2",
+            "ip2" : "2.12.22.1"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.22.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1800,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.22.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "2.12.22.1",
+            "ip2" : "2.12.22.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.12.22.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.12.22.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "2.23.21.2",
+          "ip2" : "2.23.21.3",
+          "node1" : "as2core2",
+          "node2" : "as2dist1"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "2.23.21.2",
+            "ip2" : "2.23.21.3"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet3/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.21.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet3/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.21.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "2.23.21.3",
+            "ip2" : "2.23.21.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.21.3/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.21.3/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "2.23.22.2",
+          "ip2" : "2.23.22.3",
+          "node1" : "as2core2",
+          "node2" : "as2dist2"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "2.23.22.2",
+            "ip2" : "2.23.22.3"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.22.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "mtu" : 1700,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.22.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "2.23.22.3",
+            "ip2" : "2.23.22.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.22.3/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.22.3/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "2.23.11.3",
+          "ip2" : "2.23.11.2",
+          "node1" : "as2dist1",
+          "node2" : "as2core1"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "2.23.11.3",
+            "ip2" : "2.23.11.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.11.3/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.11.3/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "2.23.11.2",
+            "ip2" : "2.23.11.3"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.11.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "incomingFilter" : "blocktelnet",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.11.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "2.23.21.3",
+          "ip2" : "2.23.21.2",
+          "node1" : "as2dist1",
+          "node2" : "as2core2"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "2.23.21.3",
+            "ip2" : "2.23.21.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.21.3/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.21.3/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "2.23.21.2",
+            "ip2" : "2.23.21.3"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet3/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.21.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet3/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.21.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "2.23.12.3",
+          "ip2" : "2.23.12.2",
+          "node1" : "as2dist2",
+          "node2" : "as2core1"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "2.23.12.3",
+            "ip2" : "2.23.12.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.12.3/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.12.3/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "2.23.12.2",
+            "ip2" : "2.23.12.3"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet3/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.12.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet3/0"
+            ],
+            "incomingFilter" : "blocktelnet",
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.12.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "2.23.22.3",
+          "ip2" : "2.23.22.2",
+          "node1" : "as2dist2",
+          "node2" : "as2core2"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "2.23.22.3",
+            "ip2" : "2.23.22.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.22.3/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.22.3/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "2.23.22.2",
+            "ip2" : "2.23.22.3"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet2/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "2.23.22.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet2/0"
+            ],
+            "mtu" : 1700,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "2.23.22.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "3.0.1.1",
+          "ip2" : "3.0.1.2",
+          "node1" : "as3border1",
+          "node2" : "as3core1"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "3.0.1.1",
+            "ip2" : "3.0.1.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "3.0.1.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "3.0.1.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "3.0.1.2",
+            "ip2" : "3.0.1.1"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "3.0.1.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "3.0.1.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "3.0.2.1",
+          "ip2" : "3.0.2.2",
+          "node1" : "as3border2",
+          "node2" : "as3core1"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "3.0.2.1",
+            "ip2" : "3.0.2.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "3.0.2.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "3.0.2.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "3.0.2.2",
+            "ip2" : "3.0.2.1"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "3.0.2.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "3.0.2.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "3.0.1.2",
+          "ip2" : "3.0.1.1",
+          "node1" : "as3core1",
+          "node2" : "as3border1"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "3.0.1.2",
+            "ip2" : "3.0.1.1"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "3.0.1.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "3.0.1.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "3.0.1.1",
+            "ip2" : "3.0.1.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "3.0.1.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "3.0.1.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
+      },
+      {
+        "edgeSummary" : {
+          "ip1" : "3.0.2.2",
+          "ip2" : "3.0.2.1",
+          "node1" : "as3core1",
+          "node2" : "as3border2"
+        },
+        "node1Session" : {
+          "name" : {
+            "ip1" : "3.0.2.2",
+            "ip2" : "3.0.2.1"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "3.0.2.2/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "3.0.2.2/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        },
+        "node2Session" : {
+          "name" : {
+            "ip1" : "3.0.2.1",
+            "ip2" : "3.0.2.2"
+          },
+          "area" : 1,
+          "iface" : {
+            "name" : "GigabitEthernet1/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allPrefixes" : [
+              "3.0.2.1/24"
+            ],
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "GigabitEthernet1/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfArea" : 1,
+            "ospfCost" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : true,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "3.0.2.1/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vrf" : "default"
+        }
+      }
+    ]
+  }
+]

--- a/tests/questions/experimental/commands
+++ b/tests/questions/experimental/commands
@@ -53,3 +53,6 @@ test -raw tests/questions/experimental/specifiersReachability.ref validate-templ
 
 # test traceroute
 test  -raw tests/questions/experimental/traceroute.ref validate-template traceroute dscp=12, dst="1.2.3.4", dstPort=23, dstProtocol="dns", ecn=1, fragmentOffset=12, icmpCode=12, icmpType=23, ignoreAcls=false, ipProtocol="tcp", packetLength=12, srcIpSpace="1.1.1.1", srcPort=123, srcProtocol="http", state="new", tcpAck=true, tcpCwr=false, tcpEce=true, tcpFin=false, tcpPsh=true, tcpRst=false, tcpSyn=true, tcpUrg=false, traceStart="location"
+
+# test viModel
+test -raw tests/questions/experimental/viModel.ref validate-template viModel 

--- a/tests/questions/experimental/viModel.ref
+++ b/tests/questions/experimental/viModel.ref
@@ -1,0 +1,13 @@
+{
+  "class" : "org.batfish.question.VIModelQuestionPlugin$VIModelQuestion",
+  "differential" : false,
+  "includeOneTableKeys" : true,
+  "instance" : {
+    "description" : "Lists configuration attributes of nodes and edges in the network",
+    "instanceName" : "qname",
+    "longDescription" : "Returns a JSON dictionary with all of the configuration parameters and neighbor relations stored in the vendor independent data-model.",
+    "tags" : [
+      "dataModel"
+    ]
+  }
+}


### PR DESCRIPTION
The new question produces all the information produced by the existing Nodes and Neighbors questions, new & improved, in one big JSON.

The keys are: nodes, bgpEdges, eigrpEdges, layer1Edges, layer2Edges, layer3Edges, ospfEdges, and ripEdges. Let me know if it would be better to group all the edges output under one `edges` key.

The only (intentional) difference between the new question's answer and the Nodes/Neighbors answers is that Neighbors separates ebgpEdges and ibgpEdges, whereas the new question combines them into bgpEdges (based on advice from @progwriter ).