### PR TITLE
convert an entire ACL to a single self-contained AclLineMatchExpr

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpAccessListLine.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpAccessListLine.java
@@ -73,6 +73,10 @@ public final class IpAccessListLine implements Serializable {
     return new Builder().setAction(LineAction.PERMIT);
   }
 
+  public static IpAccessListLine accepting(AclLineMatchExpr expr) {
+    return new Builder().setAction(LineAction.PERMIT).setMatchCondition(expr).build();
+  }
+
   public static IpAccessListLine acceptingHeaderSpace(HeaderSpace headerSpace) {
     return accepting().setMatchCondition(new MatchHeaderSpace(headerSpace)).build();
   }
@@ -83,6 +87,10 @@ public final class IpAccessListLine implements Serializable {
 
   public static Builder rejecting() {
     return new Builder().setAction(LineAction.DENY);
+  }
+
+  public static IpAccessListLine rejecting(AclLineMatchExpr expr) {
+    return new Builder().setAction(LineAction.DENY).setMatchCondition(expr).build();
   }
 
   public static IpAccessListLine rejectingHeaderSpace(HeaderSpace headerSpace) {

--- a/projects/batfish/src/main/java/org/batfish/datamodel/acl/normalize/AclToAclLineMatchExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/datamodel/acl/normalize/AclToAclLineMatchExpr.java
@@ -1,0 +1,186 @@
+package org.batfish.datamodel.acl.normalize;
+
+import static org.batfish.datamodel.acl.AclLineMatchExprs.FALSE;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.not;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.or;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedSet;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import javax.annotation.Nonnull;
+import net.sf.javabdd.BDD;
+import org.batfish.common.util.NonRecursiveSupplier;
+import org.batfish.datamodel.IpAccessList;
+import org.batfish.datamodel.IpAccessListLine;
+import org.batfish.datamodel.LineAction;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.acl.AndMatchExpr;
+import org.batfish.datamodel.acl.FalseExpr;
+import org.batfish.datamodel.acl.GenericAclLineMatchExprVisitor;
+import org.batfish.datamodel.acl.MatchHeaderSpace;
+import org.batfish.datamodel.acl.MatchSrcInterface;
+import org.batfish.datamodel.acl.NotMatchExpr;
+import org.batfish.datamodel.acl.OrMatchExpr;
+import org.batfish.datamodel.acl.OriginatingFromDevice;
+import org.batfish.datamodel.acl.PermittedByAcl;
+import org.batfish.datamodel.acl.TrueExpr;
+import org.batfish.datamodel.acl.explanation.ConjunctsBuilder;
+import org.batfish.datamodel.acl.explanation.DisjunctsBuilder;
+import org.batfish.symbolic.bdd.AclLineMatchExprToBDD;
+
+/**
+ * Reduce an {@link org.batfish.datamodel.IpAccessList} to a single {@link AclLineMatchExpr}.
+ *
+ * <p>All references to other {@link org.batfish.datamodel.IpAccessList ACLs} are inlined. For each
+ * {@link LineAction#PERMIT} line, we generate an expression of the form "matches that line AND does
+ * not match any earlier {@link LineAction#DENY} line". We then combine all those expressions into a
+ * single {@link OrMatchExpr}. Note that the line expressions may overlap. This is OK because we are
+ * only trying to express the space of the entire ACL as an {@link AclLineMatchExpr}. If you're
+ * interested in an {@link AclLineMatchExpr} that describes exactly what is matched by a particular
+ * line, you want something of the form "matches that line AND does not match ANY early line ({@link
+ * LineAction#PERMIT} or {@link LineAction#DENY})". This class does not do that.
+ *
+ * <p>We use {@link BDD BDDs} to keep the expressions small. This refines the generated line
+ * expressions to the form "matches that line AND does not match any early OVERLAPPING {@link
+ * LineAction#DENY} line".
+ */
+public final class AclToAclLineMatchExpr
+    implements GenericAclLineMatchExprVisitor<AclLineMatchExpr> {
+
+  /** Reduce an entire {@link IpAccessList} to a single {@link AclLineMatchExpr}. */
+  public static AclLineMatchExpr toAclLineMatchExpr(
+      @Nonnull AclLineMatchExprToBDD aclMatchExprToBDD,
+      IpAccessList acl,
+      Map<String, IpAccessList> namedAcls) {
+    return new AclToAclLineMatchExpr(aclMatchExprToBDD, namedAcls).toAclLineMatchExpr(acl);
+  }
+
+  /**
+   * Inline all {@link PermittedByAcl} expressions in each line of the input {@link IpAccessList},
+   * returning a list of self-contained {@link IpAccessListLine IpAccessListLines} that is
+   * equivalent to the input ACL.
+   */
+  public static List<IpAccessListLine> aclLines(
+      AclLineMatchExprToBDD aclMatchExprToBDD,
+      IpAccessList acl,
+      Map<String, IpAccessList> namedAcls) {
+    AclToAclLineMatchExpr toMatchExpr = new AclToAclLineMatchExpr(aclMatchExprToBDD, namedAcls);
+    return acl.getLines()
+        .stream()
+        .map(
+            ln ->
+                IpAccessListLine.builder()
+                    .setAction(ln.getAction())
+                    .setMatchCondition(ln.getMatchCondition().accept(toMatchExpr))
+                    .build())
+        .collect(ImmutableList.toImmutableList());
+  }
+
+  private final Map<String, Supplier<AclLineMatchExpr>> _namedAclThunks;
+
+  private AclLineMatchExprToBDD _aclMatchExprToBDD;
+
+  @VisibleForTesting
+  AclToAclLineMatchExpr(
+      @Nonnull AclLineMatchExprToBDD aclMatchExprToBDD, Map<String, IpAccessList> namedAcls) {
+    _aclMatchExprToBDD = aclMatchExprToBDD;
+    _namedAclThunks = createThunks(namedAcls);
+  }
+
+  private Map<String, Supplier<AclLineMatchExpr>> createThunks(
+      Map<String, IpAccessList> namedAcls) {
+    ImmutableMap.Builder<String, Supplier<AclLineMatchExpr>> thunks = ImmutableMap.builder();
+    namedAcls.forEach(
+        (name, acl) ->
+            thunks.put(name, new NonRecursiveSupplier<>(() -> this.toAclLineMatchExpr(acl))));
+    return thunks.build();
+  }
+
+  private AclLineMatchExpr toAclLineMatchExpr(IpAccessList acl) {
+    List<AclLineMatchExpr> rejects = new ArrayList<>();
+    DisjunctsBuilder disjunctsBuilder = new DisjunctsBuilder(_aclMatchExprToBDD);
+    for (IpAccessListLine line : acl.getLines()) {
+      if (line.getMatchCondition() == FALSE) {
+        continue;
+      }
+      AclLineMatchExpr expr = line.getMatchCondition().accept(this);
+      if (line.getAction() == LineAction.PERMIT) {
+        if (rejects.isEmpty()) {
+          disjunctsBuilder.add(expr);
+        } else {
+          ConjunctsBuilder conjunctsBuilder = new ConjunctsBuilder(_aclMatchExprToBDD);
+          conjunctsBuilder.add(expr);
+          rejects.forEach(conjunctsBuilder::add);
+          if (!conjunctsBuilder.unsat()) {
+            disjunctsBuilder.add(conjunctsBuilder.build());
+          }
+        }
+      } else {
+        rejects.add(not(expr));
+      }
+    }
+    return disjunctsBuilder.build();
+  }
+
+  @Override
+  public AclLineMatchExpr visitAndMatchExpr(AndMatchExpr andMatchExpr) {
+    return and(
+        andMatchExpr
+            .getConjuncts()
+            .stream()
+            .map(this::visit)
+            .collect(ImmutableSortedSet.toImmutableSortedSet(Comparator.naturalOrder())));
+  }
+
+  @Override
+  public AclLineMatchExpr visitFalseExpr(FalseExpr falseExpr) {
+    return falseExpr;
+  }
+
+  @Override
+  public AclLineMatchExpr visitMatchHeaderSpace(MatchHeaderSpace matchHeaderSpace) {
+    return matchHeaderSpace;
+  }
+
+  @Override
+  public AclLineMatchExpr visitMatchSrcInterface(MatchSrcInterface matchSrcInterface) {
+    return matchSrcInterface;
+  }
+
+  @Override
+  public AclLineMatchExpr visitNotMatchExpr(NotMatchExpr notMatchExpr) {
+    return new NotMatchExpr(notMatchExpr.getOperand().accept(this));
+  }
+
+  @Override
+  public AclLineMatchExpr visitOriginatingFromDevice(OriginatingFromDevice originatingFromDevice) {
+    return originatingFromDevice;
+  }
+
+  @Override
+  public AclLineMatchExpr visitOrMatchExpr(OrMatchExpr orMatchExpr) {
+    return or(
+        orMatchExpr
+            .getDisjuncts()
+            .stream()
+            .map(this::visit)
+            .collect(ImmutableSortedSet.toImmutableSortedSet(Comparator.naturalOrder())));
+  }
+
+  @Override
+  public AclLineMatchExpr visitPermittedByAcl(PermittedByAcl permittedByAcl) {
+    return _namedAclThunks.get(permittedByAcl.getAclName()).get();
+  }
+
+  @Override
+  public AclLineMatchExpr visitTrueExpr(TrueExpr trueExpr) {
+    return trueExpr;
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/datamodel/acl/normalize/AclToAclLineMatchExprTest.java
+++ b/projects/batfish/src/test/java/org/batfish/datamodel/acl/normalize/AclToAclLineMatchExprTest.java
@@ -1,0 +1,177 @@
+package org.batfish.datamodel.acl.normalize;
+
+import static org.batfish.datamodel.IpAccessListLine.accepting;
+import static org.batfish.datamodel.IpAccessListLine.rejecting;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.FALSE;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.ORIGINATING_FROM_DEVICE;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.TRUE;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDstIp;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrcInterface;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrcIp;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.not;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.or;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.permittedByAcl;
+import static org.batfish.datamodel.acl.normalize.AclToAclLineMatchExpr.aclLines;
+import static org.batfish.datamodel.acl.normalize.AclToAclLineMatchExpr.toAclLineMatchExpr;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.List;
+import java.util.Map;
+import org.batfish.common.bdd.BDDPacket;
+import org.batfish.datamodel.HeaderSpace;
+import org.batfish.datamodel.IpAccessList;
+import org.batfish.datamodel.IpAccessListLine;
+import org.batfish.datamodel.IpProtocol;
+import org.batfish.datamodel.SubRange;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.acl.AclLineMatchExprs;
+import org.batfish.symbolic.bdd.AclLineMatchExprToBDD;
+import org.batfish.symbolic.bdd.BDDAcl;
+import org.junit.Test;
+
+public class AclToAclLineMatchExprTest {
+  // 5 orthogonal match expressions
+  private static final AclLineMatchExpr EXPR_A = matchDstIp("1.1.1.1");
+  private static final AclLineMatchExpr EXPR_B = matchSrcIp("2.2.2.2");
+  private static final AclLineMatchExpr EXPR_C =
+      AclLineMatchExprs.match(
+          HeaderSpace.builder().setDstPorts(ImmutableList.of(new SubRange(1, 1))).build());
+  private static final AclLineMatchExpr EXPR_D =
+      AclLineMatchExprs.match(
+          HeaderSpace.builder().setSrcPorts(ImmutableList.of(new SubRange(2, 2))).build());
+  private static final AclLineMatchExpr EXPR_E =
+      AclLineMatchExprs.match(
+          HeaderSpace.builder().setIpProtocols(ImmutableList.of(IpProtocol.TCP)).build());
+
+  private static final IpAccessListLine ACCEPT_A = accepting(EXPR_A);
+  private static final IpAccessListLine ACCEPT_B = accepting(EXPR_B);
+  private static final IpAccessListLine REJECT_B = rejecting(EXPR_B);
+  private static final IpAccessListLine ACCEPT_C = accepting(EXPR_C);
+  private static final IpAccessListLine REJECT_C = rejecting(EXPR_C);
+  private static final IpAccessListLine ACCEPT_D = accepting(EXPR_D);
+  private static final IpAccessListLine REJECT_E = rejecting(EXPR_E);
+
+  private static final List<IpAccessListLine> SIMPLE_ACL_LINES =
+      ImmutableList.of(ACCEPT_A, REJECT_B, ACCEPT_C, REJECT_C, ACCEPT_D, REJECT_E);
+
+  private static final IpAccessList SIMPLE_ACL =
+      IpAccessList.builder().setName("acl").setLines(SIMPLE_ACL_LINES).build();
+
+  private static final AclLineMatchExpr ACL_REFERENT_EXPR = or(EXPR_A, EXPR_B);
+
+  private static final List<IpAccessListLine> ACL_REFERENT_LINES =
+      ImmutableList.of(ACCEPT_A, ACCEPT_B);
+
+  private static final IpAccessList ACL_REFERENT =
+      IpAccessList.builder().setName("referent").setLines(ACL_REFERENT_LINES).build();
+
+  private static final AclLineMatchExpr EXPR_REFERENCE = permittedByAcl(ACL_REFERENT.getName());
+
+  private static final IpAccessList ACL_REFERRER =
+      IpAccessList.builder()
+          .setName("referrer")
+          .setLines(
+              ImmutableList.of(ACCEPT_C, REJECT_C, accepting(EXPR_REFERENCE), ACCEPT_D, REJECT_E))
+          .build();
+
+  private static AclLineMatchExprToBDD aclLineMatchExprToBDD(IpAccessList acl) {
+    return aclLineMatchExprToBDD(acl, ImmutableMap.of());
+  }
+
+  private static AclLineMatchExprToBDD aclLineMatchExprToBDD(
+      IpAccessList acl, Map<String, IpAccessList> namedAcls) {
+    return BDDAcl.create(new BDDPacket(), acl, namedAcls, ImmutableMap.of())
+        .getAclLineMatchExprToBDD();
+  }
+
+  private static AclToAclLineMatchExpr aclToAclLineMatchExpr() {
+    return new AclToAclLineMatchExpr(
+        BDDAcl.create(new BDDPacket(), IpAccessList.builder().setName("").build())
+            .getAclLineMatchExprToBDD(),
+        ImmutableMap.of(ACL_REFERENT.getName(), ACL_REFERENT));
+  }
+
+  @Test
+  public void testSimple() {
+    assertThat(
+        toAclLineMatchExpr(aclLineMatchExprToBDD(SIMPLE_ACL), SIMPLE_ACL, ImmutableMap.of()),
+        equalTo(or(EXPR_A, and(not(EXPR_B), EXPR_C), and(not(EXPR_B), not(EXPR_C), EXPR_D))));
+  }
+
+  @Test
+  public void testSimpleLines() {
+    assertThat(
+        aclLines(aclLineMatchExprToBDD(SIMPLE_ACL), SIMPLE_ACL, ImmutableMap.of()),
+        equalTo(SIMPLE_ACL_LINES));
+  }
+
+  @Test
+  public void testReference() {
+    Map<String, IpAccessList> namedAcls = ImmutableMap.of(ACL_REFERENT.getName(), ACL_REFERENT);
+    AclLineMatchExpr expr =
+        toAclLineMatchExpr(aclLineMatchExprToBDD(ACL_REFERRER, namedAcls), ACL_REFERRER, namedAcls);
+    assertThat(
+        expr,
+        equalTo(
+            or(
+                // line 1: ACCEPT_C
+                EXPR_C,
+                // line 3: permitted by ACL_REFERENT
+                and(not(EXPR_C), ACL_REFERENT_EXPR),
+                // line 4: ACCEPT_D
+                and(not(EXPR_C), EXPR_D))));
+  }
+
+  @Test
+  public void testReferenceLines() {
+    Map<String, IpAccessList> namedAcls = ImmutableMap.of(ACL_REFERENT.getName(), ACL_REFERENT);
+    List<IpAccessListLine> lines =
+        aclLines(aclLineMatchExprToBDD(ACL_REFERRER, namedAcls), ACL_REFERRER, namedAcls);
+    assertThat(
+        lines,
+        equalTo(
+            ImmutableList.of(
+                ACCEPT_C,
+                REJECT_C,
+                // line 3: reference to ACL_REFERENT is inlined
+                accepting(ACL_REFERENT_EXPR),
+                ACCEPT_D,
+                REJECT_E)));
+  }
+
+  @Test
+  public void testAnd() {
+    AclToAclLineMatchExpr toAclLineMatchExpr = aclToAclLineMatchExpr();
+    AclLineMatchExpr and = and(EXPR_REFERENCE, EXPR_C);
+    assertThat(toAclLineMatchExpr.visit(and), equalTo(and(ACL_REFERENT_EXPR, EXPR_C)));
+  }
+
+  @Test
+  public void testOr() {
+    AclToAclLineMatchExpr toAclLineMatchExpr = aclToAclLineMatchExpr();
+    AclLineMatchExpr or = or(EXPR_REFERENCE, EXPR_C);
+    assertThat(toAclLineMatchExpr.visit(or), equalTo(or(ACL_REFERENT_EXPR, EXPR_C)));
+  }
+
+  @Test
+  public void testNot() {
+    AclToAclLineMatchExpr toAclLineMatchExpr = aclToAclLineMatchExpr();
+    AclLineMatchExpr not = not(EXPR_REFERENCE);
+    assertThat(toAclLineMatchExpr.visit(not), equalTo(not(ACL_REFERENT_EXPR)));
+  }
+
+  @Test
+  public void testIdentities() {
+    AclToAclLineMatchExpr toAclLineMatchExpr = aclToAclLineMatchExpr();
+    assertThat(toAclLineMatchExpr.visit(EXPR_A), equalTo(EXPR_A));
+    assertThat(toAclLineMatchExpr.visit(FALSE), equalTo(FALSE));
+    assertThat(
+        toAclLineMatchExpr.visit(matchSrcInterface("foo")), equalTo(matchSrcInterface("foo")));
+    assertThat(toAclLineMatchExpr.visit(ORIGINATING_FROM_DEVICE), equalTo(ORIGINATING_FROM_DEVICE));
+    assertThat(toAclLineMatchExpr.visit(TRUE), equalTo(TRUE));
+  }
+}


### PR DESCRIPTION
Self-contained means we inline all references to other ACLs. 