### PR TITLE
add LocationSpecifier parameter "start" to reachfilter

### DIFF
--- a/projects/allinone/src/test/java/org/batfish/question/reachfilter/ReachFilterDifferentialTest.java
+++ b/projects/allinone/src/test/java/org/batfish/question/reachfilter/ReachFilterDifferentialTest.java
@@ -82,7 +82,9 @@ public class ReachFilterDifferentialTest {
     Batfish batfish = getBatfish(baseConfig, deltaConfig);
     TableAnswerElement answer =
         (TableAnswerElement)
-            new ReachFilterAnswerer(new ReachFilterQuestion(), batfish).answerDiff();
+            new ReachFilterAnswerer(
+                    ReachFilterQuestion.builder().setStart("enter(.*)").build(), batfish)
+                .answerDiff();
     assertThat(
         answer,
         hasRows(

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/question/ReachFilterParameters.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/question/ReachFilterParameters.java
@@ -10,26 +10,26 @@ import org.batfish.datamodel.AclIpSpace;
 import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.IpSpace;
-import org.batfish.specifier.InterfaceSpecifier;
 import org.batfish.specifier.IpSpaceAssignment.Entry;
 import org.batfish.specifier.IpSpaceSpecifier;
+import org.batfish.specifier.LocationSpecifier;
 import org.batfish.specifier.SpecifierContext;
 
 /** A set of parameters for ACL filter analysis that uses high-level specifiers. */
 public final class ReachFilterParameters {
   private final @Nonnull IpSpaceSpecifier _destinationIpSpaceSpecifier;
   private final @Nonnull HeaderSpace _headerSpace;
-  private final @Nonnull InterfaceSpecifier _sourceInterfaceSpecifier;
+  private final @Nonnull LocationSpecifier _startLocationSpecifier;
   private final @Nonnull IpSpaceSpecifier _sourceIpSpaceSpecifier;
 
   private ReachFilterParameters(
       @Nonnull IpSpaceSpecifier destinationIpSpaceSpecifier,
-      @Nonnull InterfaceSpecifier sourceInterfaceSpecifier,
+      @Nonnull LocationSpecifier startLocationSpecifier,
       @Nonnull IpSpaceSpecifier sourceIpSpaceSpecifier,
       @Nonnull HeaderSpace headerSpace) {
     _destinationIpSpaceSpecifier = destinationIpSpaceSpecifier;
     _headerSpace = headerSpace;
-    _sourceInterfaceSpecifier = sourceInterfaceSpecifier;
+    _startLocationSpecifier = startLocationSpecifier;
     _sourceIpSpaceSpecifier = sourceIpSpaceSpecifier;
   }
 
@@ -39,8 +39,8 @@ public final class ReachFilterParameters {
   }
 
   @Nonnull
-  public InterfaceSpecifier getSourceInterfaceSpecifier() {
-    return _sourceInterfaceSpecifier;
+  public LocationSpecifier getStartLocationSpecifier() {
+    return _startLocationSpecifier;
   }
 
   @Nonnull
@@ -74,14 +74,14 @@ public final class ReachFilterParameters {
     return new Builder()
         .setDestinationIpSpaceSpecifier(_destinationIpSpaceSpecifier)
         .setHeaderSpace(_headerSpace)
-        .setSourceInterfaceSpecifier(_sourceInterfaceSpecifier)
+        .setStartLocationSpecifier(_startLocationSpecifier)
         .setSourceIpSpaceSpecifier(_sourceIpSpaceSpecifier);
   }
 
   public static final class Builder {
     private IpSpaceSpecifier _destinationIpSpaceSpecifier;
     private HeaderSpace _headerSpace;
-    private InterfaceSpecifier _sourceInterfaceSpecifier;
+    private LocationSpecifier _startLocationSpecifier;
     private IpSpaceSpecifier _sourceIpSpaceSpecifier;
 
     private Builder() {}
@@ -105,14 +105,13 @@ public final class ReachFilterParameters {
     public ReachFilterParameters build() {
       return new ReachFilterParameters(
           requireNonNull(_destinationIpSpaceSpecifier),
-          requireNonNull(_sourceInterfaceSpecifier),
+          requireNonNull(_startLocationSpecifier),
           requireNonNull(_sourceIpSpaceSpecifier),
           requireNonNull(_headerSpace));
     }
 
-    public Builder setSourceInterfaceSpecifier(
-        @Nonnull InterfaceSpecifier sourceInterfaceSpecifier) {
-      _sourceInterfaceSpecifier = sourceInterfaceSpecifier;
+    public Builder setStartLocationSpecifier(@Nonnull LocationSpecifier startLocationSpecifier) {
+      _startLocationSpecifier = startLocationSpecifier;
       return this;
     }
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/LocationSpecifiers.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/LocationSpecifiers.java
@@ -8,6 +8,10 @@ import org.batfish.datamodel.questions.NodesSpecifier;
 public final class LocationSpecifiers {
   private LocationSpecifiers() {}
 
+  public static final LocationSpecifier ALL_LOCATIONS =
+      new UnionLocationSpecifier(
+          AllInterfacesLocationSpecifier.INSTANCE, AllInterfaceLinksLocationSpecifier.INSTANCE);
+
   public static LocationSpecifier difference(
       @Nonnull LocationSpecifier locsIn, @Nonnull LocationSpecifier locsOut) {
     if (locsIn == NullLocationSpecifier.INSTANCE) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/NameRegexInterfaceLinkLocationSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/NameRegexInterfaceLinkLocationSpecifier.java
@@ -12,6 +12,10 @@ public final class NameRegexInterfaceLinkLocationSpecifier
     super(pattern);
   }
 
+  public NameRegexInterfaceLinkLocationSpecifier(String pattern) {
+    super(Pattern.compile(pattern));
+  }
+
   @Override
   protected Location getLocation(Interface iface) {
     return new InterfaceLinkLocation(iface.getOwner().getHostname(), iface.getName());

--- a/projects/batfish/src/main/java/org/batfish/symbolic/bdd/BDDSourceManager.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/bdd/BDDSourceManager.java
@@ -75,20 +75,18 @@ public final class BDDSourceManager {
 
   public static BDDSourceManager forIpAccessList(
       BDDPacket pkt, Configuration config, IpAccessList acl) {
-    return forIpAccessList(pkt, config.activeInterfaces(), config.getIpAccessLists(), acl);
+    return forIpAccessList(
+        pkt,
+        Sets.union(ImmutableSet.of(SOURCE_ORIGINATING_FROM_DEVICE), config.activeInterfaces()),
+        config.getIpAccessLists(),
+        acl);
   }
 
   public static BDDSourceManager forSources(
-      BDDPacket pkt, Set<String> activeInterfaces, Set<String> referencedSources) {
+      BDDPacket pkt, Set<String> activeSources, Set<String> referencedSources) {
     if (referencedSources.isEmpty()) {
       return new BDDSourceManager(pkt, ImmutableSet.of());
     }
-
-    Set<String> activeSources =
-        ImmutableSet.<String>builder()
-            .add(SOURCE_ORIGINATING_FROM_DEVICE)
-            .addAll(activeInterfaces)
-            .build();
 
     // discard any referenced interfaces that are inactive
     Set<String> referencedActiveSources = Sets.intersection(referencedSources, activeSources);

--- a/projects/batfish/src/test/java/org/batfish/main/DifferentialReachFilterTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/DifferentialReachFilterTest.java
@@ -6,6 +6,7 @@ import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDst;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrcInterface;
 import static org.batfish.datamodel.matchers.FlowMatchers.hasDstIp;
 import static org.batfish.datamodel.matchers.FlowMatchers.hasIngressInterface;
+import static org.batfish.specifier.LocationSpecifiers.ALL_LOCATIONS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 
@@ -20,12 +21,10 @@ import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.UniverseIpSpace;
-import org.batfish.datamodel.questions.InterfacesSpecifier;
 import org.batfish.question.ReachFilterParameters;
 import org.batfish.question.reachfilter.DifferentialReachFilterResult;
 import org.batfish.specifier.ConstantIpSpaceSpecifier;
-import org.batfish.specifier.FlexibleInterfaceSpecifierFactory;
-import org.batfish.specifier.ShorthandInterfaceSpecifier;
+import org.batfish.specifier.NameRegexInterfaceLinkLocationSpecifier;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -58,8 +57,7 @@ public class DifferentialReachFilterTest {
         ReachFilterParameters.builder()
             .setDestinationIpSpaceSpecifier(new ConstantIpSpaceSpecifier(UniverseIpSpace.INSTANCE))
             .setSourceIpSpaceSpecifier(new ConstantIpSpaceSpecifier(UniverseIpSpace.INSTANCE))
-            .setSourceInterfaceSpecifier(
-                new FlexibleInterfaceSpecifierFactory().buildInterfaceSpecifier(null))
+            .setStartLocationSpecifier(ALL_LOCATIONS)
             .setHeaderSpace(HeaderSpace.builder().build())
             .build();
   }
@@ -142,8 +140,7 @@ public class DifferentialReachFilterTest {
     ReachFilterParameters params =
         _params
             .toBuilder()
-            .setSourceInterfaceSpecifier(
-                new ShorthandInterfaceSpecifier(new InterfacesSpecifier(IFACE1)))
+            .setStartLocationSpecifier(new NameRegexInterfaceLinkLocationSpecifier(IFACE1))
             .build();
 
     params = _params;
@@ -158,8 +155,7 @@ public class DifferentialReachFilterTest {
     params =
         _params
             .toBuilder()
-            .setSourceInterfaceSpecifier(
-                new ShorthandInterfaceSpecifier(new InterfacesSpecifier(IFACE2)))
+            .setStartLocationSpecifier(new NameRegexInterfaceLinkLocationSpecifier(IFACE2))
             .build();
 
     // not can't match line 1 because IFACE2 is specified

--- a/projects/question/src/main/java/org/batfish/question/reachfilter/ReachFilterQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/reachfilter/ReachFilterQuestion.java
@@ -23,12 +23,12 @@ import org.batfish.question.ReachFilterParameters;
 import org.batfish.specifier.FilterSpecifier;
 import org.batfish.specifier.FilterSpecifierFactory;
 import org.batfish.specifier.FlexibleFilterSpecifierFactory;
-import org.batfish.specifier.FlexibleInterfaceSpecifierFactory;
+import org.batfish.specifier.FlexibleLocationSpecifierFactory;
 import org.batfish.specifier.FlexibleNodeSpecifierFactory;
 import org.batfish.specifier.FlexibleUniverseIpSpaceSpecifierFactory;
-import org.batfish.specifier.InterfaceSpecifier;
 import org.batfish.specifier.IpSpaceSpecifier;
 import org.batfish.specifier.IpSpaceSpecifierFactory;
+import org.batfish.specifier.LocationSpecifier;
 import org.batfish.specifier.NodeSpecifier;
 import org.batfish.specifier.NodeSpecifierFactory;
 
@@ -64,7 +64,7 @@ public final class ReachFilterQuestion extends Question {
 
   private static final String PROP_SRC_PORTS = "srcPorts";
 
-  private static final String PROP_SOURCE_INTERFACE_FILTER_SPECIFIER = "sourceInterfaces";
+  private static final String PROP_START_LOCATION = "start";
 
   private static final String PROP_SOURCE_IP_SPACE_SPECIFIER_FACTORY =
       "sourceIpSpaceSpecifierFactory";
@@ -101,7 +101,7 @@ public final class ReachFilterQuestion extends Question {
 
   @Nonnull private final SortedSet<IpProtocol> _ipProtocols;
 
-  @Nullable private final String _sourceInterfaces;
+  @Nullable private final String _start;
 
   @Nonnull private final String _sourceIpSpaceSpecifierFactory;
 
@@ -124,7 +124,7 @@ public final class ReachFilterQuestion extends Question {
       @JsonProperty(PROP_IP_PROTOCOLS) @Nullable SortedSet<IpProtocol> ipProtocols,
       @JsonProperty(PROP_NODE_SPECIFIER_FACTORY) @Nullable String nodeSpecifierFactory,
       @JsonProperty(PROP_NODES) @Nullable String nodes,
-      @JsonProperty(PROP_SOURCE_INTERFACE_FILTER_SPECIFIER) @Nullable String sourceInterfaces,
+      @JsonProperty(PROP_START_LOCATION) @Nullable String start,
       @JsonProperty(PROP_SOURCE_IP_SPACE_SPECIFIER_FACTORY) @Nullable
           String sourceIpSpaceSpecifierFactory,
       @JsonProperty(PROP_SOURCE_IP_SPACE_SPECIFIER_INPUT) @Nullable
@@ -141,7 +141,7 @@ public final class ReachFilterQuestion extends Question {
     _dstPorts = firstNonNull(dstPorts, ImmutableSortedSet.of());
     _dstProtocols = firstNonNull(dstProtocols, ImmutableSortedSet.of());
     _ipProtocols = firstNonNull(ipProtocols, ImmutableSortedSet.of());
-    _sourceInterfaces = sourceInterfaces;
+    _start = start;
     _sourceIpSpaceSpecifierFactory =
         firstNonNull(sourceIpSpaceSpecifierFactory, DEFAULT_SRC_IP_SPECIFIER_FACTORY);
     _sourceIpSpaceSpecifierInput = sourceIpSpaceSpecifierInput;
@@ -257,8 +257,8 @@ public final class ReachFilterQuestion extends Question {
   }
 
   @Nonnull
-  private InterfaceSpecifier getSourceInterfaceSpecifier() {
-    return new FlexibleInterfaceSpecifierFactory().buildInterfaceSpecifier(_sourceInterfaces);
+  private LocationSpecifier getStartLocationSpecifier() {
+    return new FlexibleLocationSpecifierFactory().buildLocationSpecifier(_start);
   }
 
   @Nonnull
@@ -305,7 +305,7 @@ public final class ReachFilterQuestion extends Question {
   ReachFilterParameters toReachFilterParameters() {
     return ReachFilterParameters.builder()
         .setHeaderSpace(getHeaderSpace())
-        .setSourceInterfaceSpecifier(getSourceInterfaceSpecifier())
+        .setStartLocationSpecifier(getStartLocationSpecifier())
         .setSourceIpSpaceSpecifier(getSourceSpecifier())
         .setDestinationIpSpaceSpecifier(getDestinationSpecifier())
         .build();
@@ -326,7 +326,7 @@ public final class ReachFilterQuestion extends Question {
     private SortedSet<SubRange> _dstPorts;
     private SortedSet<Protocol> _dstProtocols;
     private SortedSet<IpProtocol> _ipProtocols;
-    private String _sourceInterfaces;
+    private String _start;
     private String _sourceIpSpaceSpecifierFactory;
     private String _sourceIpSpaceSpecifierInput;
     private SortedSet<SubRange> _srcPorts;
@@ -385,8 +385,8 @@ public final class ReachFilterQuestion extends Question {
       return this;
     }
 
-    public Builder setSourceInterfaces(String sourceInterfaces) {
-      _sourceInterfaces = sourceInterfaces;
+    public Builder setStart(String start) {
+      _start = start;
       return this;
     }
 
@@ -416,7 +416,7 @@ public final class ReachFilterQuestion extends Question {
           _ipProtocols,
           _nodeSpecifierFactory,
           _nodeSpecifierInput,
-          _sourceInterfaces,
+          _start,
           _sourceIpSpaceSpecifierFactory,
           _sourceIpSpaceSpecifierInput,
           _srcPorts,


### PR DESCRIPTION
InterfaceLinkLocations are interpreted as source interfaces for MatchSourceInterface ACL expressions. InterfaceLocations are interpreted as OriginatingFromDevice.