### PR TITLE
factor IpAccessListToBDD out of BDDAcl

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/symbolic/bdd/BDDAcl.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/bdd/BDDAcl.java
@@ -1,68 +1,34 @@
 package org.batfish.symbolic.bdd;
 
-import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import net.sf.javabdd.BDD;
 import net.sf.javabdd.BDDFactory;
 import org.batfish.common.bdd.BDDPacket;
-import org.batfish.common.util.NonRecursiveSupplier;
 import org.batfish.datamodel.IpAccessList;
-import org.batfish.datamodel.IpAccessListLine;
 import org.batfish.datamodel.IpSpace;
-import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.Prefix;
 
 /** Representation of an Access Control List (ACL) as a Binary Decision Diagram (BDD). */
 @ParametersAreNonnullByDefault
 public final class BDDAcl {
-
-  @Nonnull private final Map<String, Supplier<BDD>> _aclEnv;
-
   @Nonnull private BDD _bdd;
-
-  @Nonnull private final BDDSourceManager _bddSrcManager;
-
-  @Nonnull private final BDDFactory _factory;
-
-  @Nonnull private final Map<String, IpSpace> _ipSpaceEnv;
 
   @Nonnull private final BDDPacket _pkt;
 
-  private final AclLineMatchExprToBDD _aclLineMatchExprToBDD;
-
-  private BDDAcl(
-      BDDPacket pkt,
-      IpAccessList acl,
-      Map<String, Supplier<BDD>> aclEnv,
-      Map<String, IpSpace> ipSpaceEnv,
-      BDDSourceManager bddSrcManager) {
-    _aclEnv = ImmutableMap.copyOf(aclEnv);
-    _bddSrcManager = bddSrcManager;
+  private BDDAcl(BDD bdd, BDDPacket pkt) {
+    _bdd = bdd;
     _pkt = pkt;
-    _factory = _pkt.getFactory();
-    _ipSpaceEnv = ImmutableMap.copyOf(ipSpaceEnv);
-    _aclLineMatchExprToBDD =
-        new AclLineMatchExprToBDD(_factory, _pkt, _aclEnv, _ipSpaceEnv, _bddSrcManager);
-    _bdd = computeACL(_factory, _aclLineMatchExprToBDD, acl);
   }
 
   private BDDAcl(BDDAcl other) {
     _bdd = other._bdd;
-    _aclEnv = other._aclEnv;
-    _bddSrcManager = other._bddSrcManager;
-    _factory = other._factory;
-    _ipSpaceEnv = ImmutableMap.copyOf(other._ipSpaceEnv);
     _pkt = other._pkt;
-    _aclLineMatchExprToBDD = other._aclLineMatchExprToBDD;
   }
 
   /**
@@ -104,48 +70,8 @@ public final class BDDAcl {
       Map<String, IpAccessList> aclEnv,
       Map<String, IpSpace> ipSpaceEnv,
       BDDSourceManager bddSrcManager) {
-    // use laziness to tie the recursive knot.
-    Map<String, Supplier<BDD>> bddAclEnv = new HashMap<>();
-    aclEnv.forEach(
-        (name, namedAcl) ->
-            bddAclEnv.put(
-                name,
-                Suppliers.memoize(
-                    new NonRecursiveSupplier<>(
-                        () ->
-                            createWithBDDAclEnv(pkt, namedAcl, bddAclEnv, ipSpaceEnv, bddSrcManager)
-                                ._bdd))));
-
-    return new BDDAcl(pkt, acl, bddAclEnv, ipSpaceEnv, bddSrcManager);
-  }
-
-  private static BDDAcl createWithBDDAclEnv(
-      BDDPacket pkt,
-      IpAccessList acl,
-      Map<String, Supplier<BDD>> aclEnv,
-      Map<String, IpSpace> ipSpaceEnv,
-      BDDSourceManager bddSrcManager) {
-    return new BDDAcl(pkt, acl, aclEnv, ipSpaceEnv, bddSrcManager);
-  }
-
-  /**
-   * Convert an Access Control List (ACL) to a symbolic boolean expression. The default action in an
-   * ACL is to deny all traffic.
-   */
-  @Nonnull
-  private static BDD computeACL(
-      BDDFactory bddFactory, AclLineMatchExprToBDD aclLineMatchExprToBDD, IpAccessList acl) {
-    BDD result = bddFactory.zero();
-    for (IpAccessListLine line : Lists.reverse(acl.getLines())) {
-      BDD lineBDD = aclLineMatchExprToBDD.visit(line.getMatchCondition());
-      BDD actionBDD = line.getAction() == LineAction.PERMIT ? bddFactory.one() : bddFactory.zero();
-      result = lineBDD.ite(actionBDD, result);
-    }
-    return result;
-  }
-
-  public AclLineMatchExprToBDD getAclLineMatchExprToBDD() {
-    return _aclLineMatchExprToBDD;
+    BDD bdd = IpAccessListToBDD.create(pkt, aclEnv, ipSpaceEnv, bddSrcManager).toBdd(acl);
+    return new BDDAcl(bdd, pkt);
   }
 
   @Nonnull
@@ -155,7 +81,7 @@ public final class BDDAcl {
 
   @Nonnull
   public BDDFactory getFactory() {
-    return _factory;
+    return _pkt.getFactory();
   }
 
   @Nonnull

--- a/projects/batfish/src/main/java/org/batfish/symbolic/bdd/IpAccessListToBDD.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/bdd/IpAccessListToBDD.java
@@ -1,0 +1,70 @@
+package org.batfish.symbolic.bdd;
+
+import com.google.common.base.Suppliers;
+import com.google.common.collect.Lists;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+import net.sf.javabdd.BDD;
+import net.sf.javabdd.BDDFactory;
+import org.batfish.common.bdd.BDDPacket;
+import org.batfish.common.util.NonRecursiveSupplier;
+import org.batfish.datamodel.IpAccessList;
+import org.batfish.datamodel.IpAccessListLine;
+import org.batfish.datamodel.IpSpace;
+import org.batfish.datamodel.LineAction;
+
+@ParametersAreNonnullByDefault
+public final class IpAccessListToBDD {
+
+  @Nonnull private final Map<String, Supplier<BDD>> _aclEnv;
+
+  @Nonnull private final AclLineMatchExprToBDD _aclLineMatchExprToBDD;
+
+  @Nonnull private final BDDPacket _pkt;
+
+  private IpAccessListToBDD(
+      @Nonnull Map<String, IpAccessList> aclEnv,
+      @Nonnull BDDSourceManager bddSrcManager,
+      @Nonnull Map<String, IpSpace> ipSpaceEnv,
+      @Nonnull BDDPacket pkt) {
+    // use laziness to tie the recursive knot.
+    _aclEnv = new HashMap<>();
+    aclEnv.forEach(
+        (name, acl) ->
+            _aclEnv.put(name, Suppliers.memoize(new NonRecursiveSupplier<>(() -> toBdd(acl)))));
+    _aclLineMatchExprToBDD =
+        new AclLineMatchExprToBDD(pkt.getFactory(), pkt, _aclEnv, ipSpaceEnv, bddSrcManager);
+    _pkt = pkt;
+  }
+
+  public static IpAccessListToBDD create(
+      BDDPacket pkt,
+      Map<String, IpAccessList> aclEnv,
+      Map<String, IpSpace> ipSpaceEnv,
+      BDDSourceManager bddSrcManager) {
+    return new IpAccessListToBDD(aclEnv, bddSrcManager, ipSpaceEnv, pkt);
+  }
+
+  public AclLineMatchExprToBDD getAclLineMatchExprToBDD() {
+    return _aclLineMatchExprToBDD;
+  }
+
+  /**
+   * Convert an Access Control List (ACL) to a symbolic boolean expression. The default action in an
+   * ACL is to deny all traffic.
+   */
+  @Nonnull
+  public BDD toBdd(IpAccessList acl) {
+    BDDFactory bddFactory = _pkt.getFactory();
+    BDD result = bddFactory.zero();
+    for (IpAccessListLine line : Lists.reverse(acl.getLines())) {
+      BDD lineBDD = _aclLineMatchExprToBDD.visit(line.getMatchCondition());
+      BDD actionBDD = line.getAction() == LineAction.PERMIT ? bddFactory.one() : bddFactory.zero();
+      result = lineBDD.ite(actionBDD, result);
+    }
+    return result;
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/symbolic/bdd/IpAccessListToBDDTest.java
+++ b/projects/batfish/src/test/java/org/batfish/symbolic/bdd/IpAccessListToBDDTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import java.util.Arrays;
 import java.util.Map;
 import net.sf.javabdd.BDD;
@@ -22,7 +23,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-public class BDDAclTest {
+public class IpAccessListToBDDTest {
   @Rule public ExpectedException exception = ExpectedException.none();
 
   private NetworkFactory _nf;
@@ -55,16 +56,28 @@ public class BDDAclTest {
         aclWithLines(accepting(HeaderSpace.builder().setDstIps(fooIp.toIpSpace()).build()));
     Map<String, IpAccessList> namedAcls = ImmutableMap.of("foo", fooAcl);
     IpAccessList acl = aclWithLines(accepting(new PermittedByAcl("foo")));
-    BDD bdd = BDDAcl.create(_pkt, acl, namedAcls, ImmutableMap.of()).getBdd();
+    BDD bdd =
+        IpAccessListToBDD.create(
+                _pkt,
+                namedAcls,
+                ImmutableMap.of(),
+                BDDSourceManager.forInterfaces(_pkt, ImmutableSet.of()))
+            .toBdd(acl);
     assertThat(bdd, equalTo(fooIpBDD));
   }
 
   @Test
   public void testPermittedByAcl_undefined() {
     IpAccessList acl = aclWithLines(accepting(new PermittedByAcl("foo")));
+    IpAccessListToBDD ipAccessListToBDD =
+        IpAccessListToBDD.create(
+            _pkt,
+            ImmutableMap.of(),
+            ImmutableMap.of(),
+            BDDSourceManager.forInterfaces(_pkt, ImmutableSet.of()));
     exception.expect(IllegalArgumentException.class);
     exception.expectMessage("Undefined PermittedByAcl reference: foo");
-    BDDAcl.create(_pkt, acl);
+    ipAccessListToBDD.toBdd(acl);
   }
 
   @Test
@@ -72,8 +85,14 @@ public class BDDAclTest {
     PermittedByAcl permittedByAcl = new PermittedByAcl("foo");
     IpAccessList fooAcl = aclWithLines(accepting(permittedByAcl));
     Map<String, IpAccessList> namedAcls = ImmutableMap.of("foo", fooAcl);
+    IpAccessListToBDD ipAccessListToBDD =
+        IpAccessListToBDD.create(
+            _pkt,
+            namedAcls,
+            ImmutableMap.of(),
+            BDDSourceManager.forInterfaces(_pkt, ImmutableSet.of()));
     exception.expect(BatfishException.class);
     exception.expectMessage("Circular PermittedByAcl reference: foo");
-    BDDAcl.create(_pkt, fooAcl, namedAcls, ImmutableMap.of());
+    ipAccessListToBDD.toBdd(fooAcl);
   }
 }


### PR DESCRIPTION
Previously BDDAcl did two things: provide an abstraction of an ACL
represented by a BDD for minesweeper, and a factory to convert ACLs to
BDD (handling references to IP spaces and other ACLs, sources, etc).
This splits them into two classes, which simplifies things and makes it
easier and more efficient to reuse the factory functionality.