### PR TITLE
fix ReachFilter*Test*

### DIFF
--- a/projects/allinone/src/test/java/org/batfish/question/reachfilter/ReachFilterDifferentialTest.java
+++ b/projects/allinone/src/test/java/org/batfish/question/reachfilter/ReachFilterDifferentialTest.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 /** End-to-end tests of {@link ReachFilterQuestion} in differential mode. */
-public class ReachFilterQuestionTestDifferentialEndToEnd {
+public class ReachFilterDifferentialTest {
   @Rule public TemporaryFolder _tmp = new TemporaryFolder();
 
   private static final String HOSTNAME = "hostname";

--- a/projects/allinone/src/test/java/org/batfish/question/reachfilter/ReachFilterTest.java
+++ b/projects/allinone/src/test/java/org/batfish/question/reachfilter/ReachFilterTest.java
@@ -67,7 +67,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 /** End-to-end tests of {@link ReachFilterQuestion}. */
-public final class ReachFilterQuestionTestEndToEnd {
+public final class ReachFilterTest {
   private static final String IFACE1 = "iface1";
 
   private static final String IFACE2 = "iface2";

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishDifferentialReachFilterTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishDifferentialReachFilterTest.java
@@ -1,4 +1,4 @@
-package org.batfish.question.reachfilter;
+package org.batfish.main;
 
 import static org.batfish.datamodel.IpAccessListLine.accepting;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
@@ -21,9 +21,8 @@ import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.UniverseIpSpace;
-import org.batfish.main.Batfish;
-import org.batfish.main.BatfishTestUtils;
 import org.batfish.question.ReachFilterParameters;
+import org.batfish.question.reachfilter.DifferentialReachFilterResult;
 import org.batfish.specifier.ConstantIpSpaceSpecifier;
 import org.batfish.specifier.NameRegexInterfaceLinkLocationSpecifier;
 import org.junit.Before;
@@ -31,8 +30,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-/** Test of the internal implementation of {@link ReachFilterQuestion}. */
-public class ReachFilterQuestionTestDifferential {
+/** Tests of {@link Batfish#reachFilter} in differential mode. */
+public class BatfishDifferentialReachFilterTest {
   @Rule public TemporaryFolder _tmp = new TemporaryFolder();
 
   private static final String HOSTNAME = "hostname";


### PR DESCRIPTION
1. JUnit test classes needs to be named *Test or they will not be picked up
   by test libraries.
2. Tests should be in the module containing the code they test. In this case,
   the file that was called ReachFilterQuestionTestDifferential was testing
   code in *Batfish*, and did not in fact use ReachFilterQuestion in any way.
3. Tests should be named for what they're testing. In this case, end-to-end
   tests are not testing ReachFilterQuestion -- they're testing the ReachFilter
   plugin -- Question, Answerer, and Batfish. My standard for this has been
   to name the tests '<Plugin>Test', and the natural extension is
   '<Plugin><Type>Test' for things like '<Type=Differential>'.