### PR TITLE
AclExplanation

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclExplanation.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclExplanation.java
@@ -1,0 +1,171 @@
+package org.batfish.datamodel.acl;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Sets;
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.datamodel.HeaderSpace;
+import org.batfish.datamodel.IntersectHeaderSpaces;
+
+/**
+ * Generates reduced explanations of satisfiable {@link AclLineMatchExpr AclLineMatchExprs} in
+ * normal form. Currently only reduces positive spaces, by intersecting {@link HeaderSpace} objects
+ * in {@link MatchHeaderSpace} expressions and intersecting sets of interfaces in {@link
+ * MatchSrcInterface} expressions.
+ */
+public final class AclExplanation {
+
+  /**
+   * Visitor for building {@link AclExplanation} from normalized {@link AclLineMatchExpr
+   * AclLineMatchExprs}.
+   */
+  private final class AclLineMatchExprVisitor implements GenericAclLineMatchExprVisitor<Void> {
+    @Override
+    public Void visitAndMatchExpr(AndMatchExpr andMatchExpr) {
+      throw new IllegalArgumentException("Can only explain normalized AclLineMatchExprs.");
+    }
+
+    @Override
+    public Void visitFalseExpr(FalseExpr falseExpr) {
+      throw new IllegalArgumentException("Can only explain satisfiable AclLineMatchExprs.");
+    }
+
+    @Override
+    public Void visitMatchHeaderSpace(MatchHeaderSpace matchHeaderSpace) {
+      requireHeaderSpace(matchHeaderSpace.getHeaderspace());
+      return null;
+    }
+
+    @Override
+    public Void visitMatchSrcInterface(MatchSrcInterface matchSrcInterface) {
+      requireSourceInterfaces(matchSrcInterface.getSrcInterfaces());
+      return null;
+    }
+
+    @Override
+    public Void visitNotMatchExpr(NotMatchExpr notMatchExpr) {
+      if (notMatchExpr.getOperand() instanceof MatchHeaderSpace) {
+        HeaderSpace headerSpace = ((MatchHeaderSpace) notMatchExpr.getOperand()).getHeaderspace();
+        forbidHeaderSpace(headerSpace);
+        return null;
+      }
+      throw new IllegalArgumentException("Can only explain normalized AclLineMatchExprs.");
+    }
+
+    @Override
+    public Void visitOriginatingFromDevice(OriginatingFromDevice originatingFromDevice) {
+      requireOriginatingFromDevice();
+      return null;
+    }
+
+    @Override
+    public Void visitOrMatchExpr(OrMatchExpr orMatchExpr) {
+      throw new IllegalArgumentException("Can only explain normalized AclLineMatchExprs.");
+    }
+
+    @Override
+    public Void visitPermittedByAcl(PermittedByAcl permittedByAcl) {
+      throw new IllegalArgumentException("Can only explain normalized AclLineMatchExprs.");
+    }
+
+    @Override
+    public Void visitTrueExpr(TrueExpr trueExpr) {
+      // noop
+      return null;
+    }
+  }
+
+  private enum Sources {
+    INTERFACES,
+    DEVICE,
+    ANY
+  }
+
+  private @Nullable HeaderSpace _headerSpace = null;
+
+  private @Nullable SortedSet<HeaderSpace> _notHeaderSpaces = new TreeSet<>();
+
+  private @Nonnull Sources _sources = Sources.ANY;
+
+  private @Nullable Set<String> _sourceInterfaces = null;
+
+  private final @Nonnull AclLineMatchExprVisitor _visitor = new AclLineMatchExprVisitor();
+
+  @VisibleForTesting
+  void requireSourceInterfaces(Set<String> sourceInterfaces) {
+    checkState(_sources != Sources.DEVICE, "AclExplanation is unsatisfiable");
+    _sources = Sources.INTERFACES;
+    _sourceInterfaces =
+        _sourceInterfaces == null
+            ? sourceInterfaces
+            : Sets.intersection(_sourceInterfaces, sourceInterfaces);
+    checkState(!_sourceInterfaces.isEmpty(), "AclExplanation is unsatisfiable");
+  }
+
+  @VisibleForTesting
+  void requireOriginatingFromDevice() {
+    checkState(_sources != Sources.INTERFACES, "AclExplanation is unsatisfiable");
+    _sources = Sources.DEVICE;
+  }
+
+  @VisibleForTesting
+  void requireHeaderSpace(HeaderSpace headerSpace) {
+    if (_headerSpace == null) {
+      _headerSpace = headerSpace;
+    } else {
+      Optional<HeaderSpace> intersection =
+          IntersectHeaderSpaces.intersect(_headerSpace, headerSpace);
+      checkState(intersection.isPresent(), "AclExplanation is unsatisfiable");
+      _headerSpace = intersection.get();
+    }
+  }
+
+  @VisibleForTesting
+  void forbidHeaderSpace(HeaderSpace headerSpace) {
+    _notHeaderSpaces.add(headerSpace);
+  }
+
+  @VisibleForTesting
+  AclLineMatchExpr build() {
+    ImmutableSortedSet.Builder<AclLineMatchExpr> conjunctsBuilder =
+        new ImmutableSortedSet.Builder<>(Comparator.naturalOrder());
+    if (_headerSpace != null) {
+      conjunctsBuilder.add(new MatchHeaderSpace(_headerSpace));
+    }
+    _notHeaderSpaces.forEach(
+        notHeaderSpace ->
+            conjunctsBuilder.add(new NotMatchExpr(new MatchHeaderSpace(notHeaderSpace))));
+    switch (_sources) {
+      case DEVICE:
+        conjunctsBuilder.add(OriginatingFromDevice.INSTANCE);
+        break;
+      case INTERFACES:
+        conjunctsBuilder.add(new MatchSrcInterface(_sourceInterfaces));
+        break;
+      case ANY:
+        break;
+    }
+    SortedSet<AclLineMatchExpr> conjuncts = conjunctsBuilder.build();
+    if (conjuncts.isEmpty()) {
+      return TrueExpr.INSTANCE;
+    }
+    if (conjuncts.size() == 1) {
+      return conjuncts.first();
+    }
+    return new AndMatchExpr(conjuncts);
+  }
+
+  public static AclLineMatchExpr explain(Iterable<AclLineMatchExpr> conjuncts) {
+    AclExplanation explanation = new AclExplanation();
+    conjuncts.forEach(explanation._visitor::visit);
+    return explanation.build();
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/datamodel/acl/AclExplanationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/datamodel/acl/AclExplanationTest.java
@@ -1,7 +1,10 @@
 package org.batfish.datamodel.acl;
 
+import static org.batfish.datamodel.acl.AclLineMatchExprs.ORIGINATING_FROM_DEVICE;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDst;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDstIp;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrcInterface;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -12,6 +15,7 @@ import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.SubRange;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -19,15 +23,35 @@ import org.junit.rules.ExpectedException;
 public class AclExplanationTest {
   @Rule public ExpectedException _exception = ExpectedException.none();
 
+  AclExplanation _explanation;
+
+  @Before
+  public void setup() {
+    _explanation = new AclExplanation();
+  }
+
   @Test
   public void testSimple() {
     MatchHeaderSpace require = matchDst(Prefix.parse("1.2.3.0/24"));
     MatchHeaderSpace forbid = matchDst(new Ip("1.2.3.4"));
 
-    AclExplanation explanation = new AclExplanation();
-    explanation.requireHeaderSpace(require.getHeaderspace());
-    explanation.forbidHeaderSpace(forbid.getHeaderspace());
-    assertThat(explanation.build(), equalTo(and(require, not(forbid))));
+    _explanation.requireHeaderSpace(require.getHeaderspace());
+    _explanation.forbidHeaderSpace(forbid.getHeaderspace());
+    assertThat(_explanation.build(), equalTo(and(require, not(forbid))));
+  }
+
+  @Test
+  public void testIntersectOriginateFromDevice() {
+    _explanation.requireOriginatingFromDevice();
+    _explanation.requireOriginatingFromDevice();
+    assertThat(_explanation.build(), equalTo(ORIGINATING_FROM_DEVICE));
+  }
+
+  @Test
+  public void testIntersectSources() {
+    _explanation.requireSourceInterfaces(ImmutableSet.of("foo", "bar", "baz"));
+    _explanation.requireSourceInterfaces(ImmutableSet.of("foo"));
+    assertThat(_explanation.build(), equalTo(matchSrcInterface("foo")));
   }
 
   @Test
@@ -35,10 +59,9 @@ public class AclExplanationTest {
     MatchHeaderSpace forbid1 = matchDst(new Ip("1.2.3.4"));
     MatchHeaderSpace forbid2 = matchDst(new Ip("1.2.3.5"));
 
-    AclExplanation explanation = new AclExplanation();
-    explanation.forbidHeaderSpace(forbid1.getHeaderspace());
-    explanation.forbidHeaderSpace(forbid2.getHeaderspace());
-    assertThat(explanation.build(), equalTo(and(not(forbid1), not(forbid2))));
+    _explanation.forbidHeaderSpace(forbid1.getHeaderspace());
+    _explanation.forbidHeaderSpace(forbid2.getHeaderspace());
+    assertThat(_explanation.build(), equalTo(and(not(forbid1), not(forbid2))));
   }
 
   @Test
@@ -56,38 +79,45 @@ public class AclExplanationTest {
                 .setDstPorts(ImmutableList.of(new SubRange(80, 80)))
                 .build());
 
-    AclExplanation explanation = new AclExplanation();
-    explanation.requireHeaderSpace(matchDstPrefix.getHeaderspace());
-    explanation.requireHeaderSpace(matchDstPort.getHeaderspace());
-    explanation.forbidHeaderSpace(matchDstIp.getHeaderspace());
+    _explanation.requireHeaderSpace(matchDstPrefix.getHeaderspace());
+    _explanation.requireHeaderSpace(matchDstPort.getHeaderspace());
+    _explanation.forbidHeaderSpace(matchDstIp.getHeaderspace());
     AclLineMatchExpr expr = and(matchDstPrefixAndPort, not(matchDstIp));
-    assertThat(explanation.build(), equalTo(expr));
+    assertThat(_explanation.build(), equalTo(expr));
+  }
+
+  @Test
+  public void testExplainLiterals() {
+    MatchHeaderSpace matchHeaderSpace = matchDstIp("1.2.3.4");
+    AclLineMatchExpr notMatchHeaderSpace = not(matchHeaderSpace);
+    MatchSrcInterface matchSrcInterface = matchSrcInterface("foo");
+    AclLineMatchExpr expr =
+        AclExplanation.explainLiterals(
+            ImmutableList.of(matchHeaderSpace, notMatchHeaderSpace, matchSrcInterface));
+    assertThat(expr, equalTo(and(matchHeaderSpace, matchSrcInterface, notMatchHeaderSpace)));
   }
 
   @Test
   public void testUnsatSource1() {
-    AclExplanation explanation = new AclExplanation();
-    explanation.requireOriginatingFromDevice();
+    _explanation.requireOriginatingFromDevice();
     _exception.expect(IllegalStateException.class);
     _exception.expectMessage("AclExplanation is unsatisfiable");
-    explanation.requireSourceInterfaces(ImmutableSet.of("foo"));
+    _explanation.requireSourceInterfaces(ImmutableSet.of("foo"));
   }
 
   @Test
   public void testUnsatSource2() {
-    AclExplanation explanation = new AclExplanation();
-    explanation.requireSourceInterfaces(ImmutableSet.of("foo"));
+    _explanation.requireSourceInterfaces(ImmutableSet.of("foo"));
     _exception.expect(IllegalStateException.class);
     _exception.expectMessage("AclExplanation is unsatisfiable");
-    explanation.requireOriginatingFromDevice();
+    _explanation.requireOriginatingFromDevice();
   }
 
   @Test
   public void testUnsatSource3() {
-    AclExplanation explanation = new AclExplanation();
-    explanation.requireSourceInterfaces(ImmutableSet.of("foo"));
+    _explanation.requireSourceInterfaces(ImmutableSet.of("foo"));
     _exception.expect(IllegalStateException.class);
     _exception.expectMessage("AclExplanation is unsatisfiable");
-    explanation.requireSourceInterfaces(ImmutableSet.of("bar"));
+    _explanation.requireSourceInterfaces(ImmutableSet.of("bar"));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/datamodel/acl/AclExplanationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/datamodel/acl/AclExplanationTest.java
@@ -1,0 +1,93 @@
+package org.batfish.datamodel.acl;
+
+import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDst;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.batfish.datamodel.HeaderSpace;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.SubRange;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class AclExplanationTest {
+  @Rule public ExpectedException _exception = ExpectedException.none();
+
+  @Test
+  public void testSimple() {
+    MatchHeaderSpace require = matchDst(Prefix.parse("1.2.3.0/24"));
+    MatchHeaderSpace forbid = matchDst(new Ip("1.2.3.4"));
+
+    AclExplanation explanation = new AclExplanation();
+    explanation.requireHeaderSpace(require.getHeaderspace());
+    explanation.forbidHeaderSpace(forbid.getHeaderspace());
+    assertThat(explanation.build(), equalTo(and(require, not(forbid))));
+  }
+
+  @Test
+  public void testMultipleForbids() {
+    MatchHeaderSpace forbid1 = matchDst(new Ip("1.2.3.4"));
+    MatchHeaderSpace forbid2 = matchDst(new Ip("1.2.3.5"));
+
+    AclExplanation explanation = new AclExplanation();
+    explanation.forbidHeaderSpace(forbid1.getHeaderspace());
+    explanation.forbidHeaderSpace(forbid2.getHeaderspace());
+    assertThat(explanation.build(), equalTo(and(not(forbid1), not(forbid2))));
+  }
+
+  @Test
+  public void testIntersectRequire() {
+    MatchHeaderSpace matchDstIp = matchDst(new Ip("1.2.3.4"));
+    MatchHeaderSpace matchDstPrefix = matchDst(Prefix.parse("1.2.3.0/24"));
+    MatchHeaderSpace matchDstPort =
+        new MatchHeaderSpace(
+            HeaderSpace.builder().setDstPorts(ImmutableList.of(new SubRange(80, 80))).build());
+    MatchHeaderSpace matchDstPrefixAndPort =
+        new MatchHeaderSpace(
+            matchDstPrefix
+                .getHeaderspace()
+                .toBuilder()
+                .setDstPorts(ImmutableList.of(new SubRange(80, 80)))
+                .build());
+
+    AclExplanation explanation = new AclExplanation();
+    explanation.requireHeaderSpace(matchDstPrefix.getHeaderspace());
+    explanation.requireHeaderSpace(matchDstPort.getHeaderspace());
+    explanation.forbidHeaderSpace(matchDstIp.getHeaderspace());
+    AclLineMatchExpr expr = and(matchDstPrefixAndPort, not(matchDstIp));
+    assertThat(explanation.build(), equalTo(expr));
+  }
+
+  @Test
+  public void testUnsatSource1() {
+    AclExplanation explanation = new AclExplanation();
+    explanation.requireOriginatingFromDevice();
+    _exception.expect(IllegalStateException.class);
+    _exception.expectMessage("AclExplanation is unsatisfiable");
+    explanation.requireSourceInterfaces(ImmutableSet.of("foo"));
+  }
+
+  @Test
+  public void testUnsatSource2() {
+    AclExplanation explanation = new AclExplanation();
+    explanation.requireSourceInterfaces(ImmutableSet.of("foo"));
+    _exception.expect(IllegalStateException.class);
+    _exception.expectMessage("AclExplanation is unsatisfiable");
+    explanation.requireOriginatingFromDevice();
+  }
+
+  @Test
+  public void testUnsatSource3() {
+    AclExplanation explanation = new AclExplanation();
+    explanation.requireSourceInterfaces(ImmutableSet.of("foo"));
+    _exception.expect(IllegalStateException.class);
+    _exception.expectMessage("AclExplanation is unsatisfiable");
+    explanation.requireSourceInterfaces(ImmutableSet.of("bar"));
+  }
+}


### PR DESCRIPTION
Constructs simplified AclLineMatchExprs of a particular form, used for headerspace explanations.

The form is a conjunction of:
- at most 1 positive `MatchHeaderSpace` expression
- at most 1 `MatchSrcInterface` or `OriginatingFromDevice` expression
- 0 or more negative `MatchHeaderSpace` expressions (subtracted from the positive one).

`AclExplanation` expects a set of literals whose conjunction is satisfiable. The normalizer is used to get arbitrary expressions into that form.