### PR TITLE
apply deMorgan and expand and/or exprs to remove redundant (con/dis)juncts

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/datamodel/acl/explanation/AclLineMatchExprSetBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/datamodel/acl/explanation/AclLineMatchExprSetBuilder.java
@@ -42,7 +42,11 @@ public abstract class AclLineMatchExprSetBuilder {
 
   public abstract AclLineMatchExpr build();
 
-  public void add(AclLineMatchExpr expr) {
+  /** This is the public method to add elements. Abstract so that subclasses can preprocess. */
+  public abstract void add(AclLineMatchExpr expr);
+
+  /** Helper method for subclasses to use to implement {@link AclLineMatchExprSetBuilder#add}. */
+  protected void addHelper(AclLineMatchExpr expr) {
     if (_bdd.equals(shortCircuitBDD()) || _exprs.containsKey(expr)) {
       return;
     }

--- a/projects/batfish/src/main/java/org/batfish/datamodel/acl/explanation/ConjunctsBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/datamodel/acl/explanation/ConjunctsBuilder.java
@@ -61,7 +61,6 @@ public final class ConjunctsBuilder extends AclLineMatchExprSetBuilder {
      * If expr is an AndMatchExpr (or can be simplified by one using deMorgan's law, then add each
      * conjunct separately (so we can detect and remove redundant conjuncts). This could create some
      * extra work though, so only do this if the conjunction won't be unsat after adding.
-     * work
      */
     if (_aclLineMatchExprToBDD.visit(expr).and(getBdd()).isZero()) {
       /*

--- a/projects/batfish/src/main/java/org/batfish/datamodel/acl/explanation/ConjunctsBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/datamodel/acl/explanation/ConjunctsBuilder.java
@@ -8,25 +8,30 @@ import net.sf.javabdd.BDDFactory;
 import org.batfish.common.bdd.AclLineMatchExprToBDD;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.datamodel.acl.AndMatchExpr;
+import org.batfish.datamodel.acl.NotMatchExpr;
 import org.batfish.datamodel.acl.OrMatchExpr;
+import org.batfish.datamodel.acl.normalize.Negate;
 
 /**
  * A builder for the conjuncts of an {@link AndMatchExpr}. Uses {@link BDD BDDs} to remove redundant
  * conjuncts and to short-circuit when the set of disjuncts is unsatisfiable.
  */
 public final class ConjunctsBuilder extends AclLineMatchExprSetBuilder {
+  private final AclLineMatchExprToBDD _aclLineMatchExprToBDD;
   private final BDD _one;
   private final BDD _zero;
 
   public ConjunctsBuilder(AclLineMatchExprToBDD aclLineMatchExprToBDD) {
     super(aclLineMatchExprToBDD, aclLineMatchExprToBDD.getBDDPacket().getFactory().one());
     BDDFactory factory = aclLineMatchExprToBDD.getBDDPacket().getFactory();
+    _aclLineMatchExprToBDD = aclLineMatchExprToBDD;
     _one = factory.one();
     _zero = factory.zero();
   }
 
   public ConjunctsBuilder(ConjunctsBuilder other) {
     super(other);
+    _aclLineMatchExprToBDD = other._aclLineMatchExprToBDD;
     _one = other._one;
     _zero = other._zero;
   }
@@ -49,6 +54,36 @@ public final class ConjunctsBuilder extends AclLineMatchExprSetBuilder {
   @Override
   public AclLineMatchExpr build() {
     return getBdd().isZero() ? FALSE : and(getExprs());
+  }
+
+  @Override
+  public void add(AclLineMatchExpr expr) {
+    /*
+     * If expr is an AndMatchExpr (or can be simplified by one using deMorgan's law, then add each
+     * conjunct separately (so we can detect and remove redundant conjuncts). This could create some
+     * extra work though, so only do this if the conjunction won't be unsat after adding.
+     * work
+     */
+    if (_aclLineMatchExprToBDD.visit(expr).and(getBdd()).isZero()) {
+      /*
+       * expr is inconsistent with the other conjuncts. Just add it now.
+       */
+      addHelper(expr);
+      return;
+    }
+
+    AclLineMatchExpr e = expr;
+    if (e instanceof NotMatchExpr) {
+      /*
+       * Try to apply deMorgan.
+       */
+      e = Negate.negate(((NotMatchExpr) e).getOperand());
+    }
+    if (e instanceof AndMatchExpr) {
+      ((AndMatchExpr) e).getConjuncts().forEach(this::add);
+    } else {
+      addHelper(e);
+    }
   }
 
   public boolean unsat() {

--- a/projects/batfish/src/main/java/org/batfish/datamodel/acl/explanation/DisjunctsBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/datamodel/acl/explanation/DisjunctsBuilder.java
@@ -54,7 +54,6 @@ public final class DisjunctsBuilder extends AclLineMatchExprSetBuilder {
      * If expr is an OrMatchExpr (or can be simplified by one using deMorgan's law, then add each
      * disjunct separately (so we can detect and remove redundant disjuncts). This could create some
      * extra work though, so only do this if the conjunction won't be valid after adding.
-     * work
      */
     if (_aclLineMatchExprToBDD.visit(expr).or(getBdd()).isOne()) {
       /*

--- a/projects/batfish/src/main/java/org/batfish/datamodel/acl/explanation/DisjunctsBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/datamodel/acl/explanation/DisjunctsBuilder.java
@@ -7,19 +7,23 @@ import net.sf.javabdd.BDD;
 import net.sf.javabdd.BDDFactory;
 import org.batfish.common.bdd.AclLineMatchExprToBDD;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.acl.NotMatchExpr;
 import org.batfish.datamodel.acl.OrMatchExpr;
+import org.batfish.datamodel.acl.normalize.Negate;
 
 /**
  * A builder for the disjuncts of an {@link OrMatchExpr}. Uses {@link BDD BDDs} to remove redundant
  * disjuncts and to short-circuit when the set of disjuncts is valid.
  */
 public final class DisjunctsBuilder extends AclLineMatchExprSetBuilder {
+  private AclLineMatchExprToBDD _aclLineMatchExprToBDD;
   BDD _zero;
   BDD _one;
 
   public DisjunctsBuilder(AclLineMatchExprToBDD aclLineMatchExprToBDD) {
     super(aclLineMatchExprToBDD, aclLineMatchExprToBDD.getBDDPacket().getFactory().zero());
     BDDFactory factory = aclLineMatchExprToBDD.getBDDPacket().getFactory();
+    _aclLineMatchExprToBDD = aclLineMatchExprToBDD;
     _one = factory.one();
     _zero = factory.zero();
   }
@@ -42,5 +46,35 @@ public final class DisjunctsBuilder extends AclLineMatchExprSetBuilder {
   @Override
   public AclLineMatchExpr build() {
     return getBdd().isOne() ? TRUE : or(getExprs());
+  }
+
+  @Override
+  public void add(AclLineMatchExpr expr) {
+    /*
+     * If expr is an OrMatchExpr (or can be simplified by one using deMorgan's law, then add each
+     * disjunct separately (so we can detect and remove redundant disjuncts). This could create some
+     * extra work though, so only do this if the conjunction won't be valid after adding.
+     * work
+     */
+    if (_aclLineMatchExprToBDD.visit(expr).or(getBdd()).isOne()) {
+      /*
+       * expr is valid with the other conjuncts. Just add it now.
+       */
+      addHelper(expr);
+      return;
+    }
+
+    AclLineMatchExpr e = expr;
+    if (e instanceof NotMatchExpr) {
+      /*
+       * Try to apply deMorgan.
+       */
+      e = Negate.negate(((NotMatchExpr) e).getOperand());
+    }
+    if (e instanceof OrMatchExpr) {
+      ((OrMatchExpr) e).getDisjuncts().forEach(this::add);
+    } else {
+      addHelper(e);
+    }
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/datamodel/acl/explanation/ConjunctsBuilderTest.java
+++ b/projects/batfish/src/test/java/org/batfish/datamodel/acl/explanation/ConjunctsBuilderTest.java
@@ -5,6 +5,8 @@ import static org.batfish.datamodel.acl.AclLineMatchExprs.TRUE;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDst;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrcIp;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.not;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.or;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -72,5 +74,19 @@ public class ConjunctsBuilderTest {
     _andBuilder.add(SRC_IP);
     _andBuilder.add(matchSrcIp("1.1.1.1"));
     assertThat(_andBuilder.build(), equalTo(FALSE));
+  }
+
+  @Test
+  public void testExpandAnd() {
+    _andBuilder.add(and(DST_IP, SRC_IP));
+    _andBuilder.add(DST_PREFIX);
+    assertThat(_andBuilder.build(), equalTo(and(SRC_IP, DST_IP)));
+  }
+
+  @Test
+  public void testDeMorgan() {
+    _andBuilder.add(not(or(not(DST_IP), SRC_IP)));
+    _andBuilder.add(DST_PREFIX);
+    assertThat(_andBuilder.build(), equalTo(and(not(SRC_IP), DST_IP)));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/datamodel/acl/explanation/DisjunctsBuilderTest.java
+++ b/projects/batfish/src/test/java/org/batfish/datamodel/acl/explanation/DisjunctsBuilderTest.java
@@ -2,8 +2,10 @@ package org.batfish.datamodel.acl.explanation;
 
 import static org.batfish.datamodel.acl.AclLineMatchExprs.FALSE;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.TRUE;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDst;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrcIp;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.not;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.or;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
@@ -73,5 +75,19 @@ public class DisjunctsBuilderTest {
     _orBuilder.add(DST_PREFIX);
     _orBuilder.add(new NotMatchExpr(DST_PREFIX));
     assertThat(_orBuilder.build(), equalTo(TRUE));
+  }
+
+  @Test
+  public void testExpandOr() {
+    _orBuilder.add(or(DST_IP, SRC_IP));
+    _orBuilder.add(DST_PREFIX);
+    assertThat(_orBuilder.build(), equalTo(or(SRC_IP, DST_PREFIX)));
+  }
+
+  @Test
+  public void testDeMorgan() {
+    _orBuilder.add(not(and(not(DST_IP), SRC_IP)));
+    _orBuilder.add(DST_PREFIX);
+    assertThat(_orBuilder.build(), equalTo(or(not(SRC_IP), DST_PREFIX)));
   }
 }


### PR DESCRIPTION
This is a simplification that is especially useful for building ACL expressions that describe the difference between two acls. In general, an ACL is encoded as an expression of the form `or(permitLine1Expr permitLine2Expr ...)`, where each permit line expression is of the form `and(not(denyLine1), not(denyLine2), ... permitLine)` (for each deny line preceding the permit line).   
When expressing the difference between two ACLs, each permit line expression will have the form:
```
and(not(denyAcl), not(denyLine1), not(denyLine2), ... permitLine)
```
Where `denyAcl` is itself a big disjunction `or(denyAclPermitLine1, denyAclPermitLine2, ...)`.

This change will reduce `not(or(denyAclPermitLine1, denyAclPermitLine2, ...))` to `and(not(denyAclPermitLine1), not(denyAclPermitLine2), ...)` and then expand that `and` into the outer `and`.

The result is that we can discard more redundant conjuncts, keeping things smaller and speeding up normalization.