### PR TITLE
Traceroute: populate filterIn unconditionally

### DIFF
--- a/tests/basic/traceroute-1-2.ref
+++ b/tests/basic/traceroute-1-2.ref
@@ -103,6 +103,7 @@
                     "node2" : "host1",
                     "node2interface" : "eth0"
                   },
+                  "filterIn" : "{filter::INPUT}{default}",
                   "routes" : [
                     "ConnectedRoute<2.128.0.0/24,nhip:AUTO/NONE(-1l),nhint:GigabitEthernet2/0>_fnhip:null"
                   ]
@@ -177,6 +178,7 @@
                     "node2" : "host1",
                     "node2interface" : "eth0"
                   },
+                  "filterIn" : "{filter::INPUT}{default}",
                   "routes" : [
                     "ConnectedRoute<2.128.0.0/24,nhip:AUTO/NONE(-1l),nhint:GigabitEthernet2/0>_fnhip:null"
                   ]
@@ -251,6 +253,7 @@
                     "node2" : "host1",
                     "node2interface" : "eth0"
                   },
+                  "filterIn" : "{filter::INPUT}{default}",
                   "routes" : [
                     "ConnectedRoute<2.128.0.0/24,nhip:AUTO/NONE(-1l),nhint:GigabitEthernet2/0>_fnhip:null"
                   ]
@@ -325,6 +328,7 @@
                     "node2" : "host1",
                     "node2interface" : "eth0"
                   },
+                  "filterIn" : "{filter::INPUT}{default}",
                   "routes" : [
                     "ConnectedRoute<2.128.0.0/24,nhip:AUTO/NONE(-1l),nhint:GigabitEthernet2/0>_fnhip:null"
                   ]

--- a/tests/basic/traceroute2-1-2.ref
+++ b/tests/basic/traceroute2-1-2.ref
@@ -123,6 +123,7 @@
                   "node2" : "host1",
                   "node2interface" : "eth0"
                 },
+                "filterIn" : "{filter::INPUT}{default}",
                 "routes" : [
                   "ConnectedRoute<2.128.0.0/24,nhip:AUTO/NONE(-1l),nhint:GigabitEthernet2/0>_fnhip:null"
                 ]
@@ -205,6 +206,7 @@
                   "node2" : "host1",
                   "node2interface" : "eth0"
                 },
+                "filterIn" : "{filter::INPUT}{default}",
                 "routes" : [
                   "ConnectedRoute<2.128.0.0/24,nhip:AUTO/NONE(-1l),nhint:GigabitEthernet2/0>_fnhip:null"
                 ]
@@ -287,6 +289,7 @@
                   "node2" : "host1",
                   "node2interface" : "eth0"
                 },
+                "filterIn" : "{filter::INPUT}{default}",
                 "routes" : [
                   "ConnectedRoute<2.128.0.0/24,nhip:AUTO/NONE(-1l),nhint:GigabitEthernet2/0>_fnhip:null"
                 ]
@@ -369,6 +372,7 @@
                   "node2" : "host1",
                   "node2interface" : "eth0"
                 },
+                "filterIn" : "{filter::INPUT}{default}",
                 "routes" : [
                   "ConnectedRoute<2.128.0.0/24,nhip:AUTO/NONE(-1l),nhint:GigabitEthernet2/0>_fnhip:null"
                 ]
@@ -480,6 +484,7 @@
                   "node2" : "host1",
                   "node2interface" : "eth0"
                 },
+                "filterIn" : "{filter::INPUT}{default}",
                 "routes" : [
                   "ConnectedRoute<2.128.0.0/24,nhip:AUTO/NONE(-1l),nhint:GigabitEthernet2/0>_fnhip:null"
                 ]
@@ -562,6 +567,7 @@
                   "node2" : "host1",
                   "node2interface" : "eth0"
                 },
+                "filterIn" : "{filter::INPUT}{default}",
                 "routes" : [
                   "ConnectedRoute<2.128.0.0/24,nhip:AUTO/NONE(-1l),nhint:GigabitEthernet2/0>_fnhip:null"
                 ]
@@ -644,6 +650,7 @@
                   "node2" : "host1",
                   "node2interface" : "eth0"
                 },
+                "filterIn" : "{filter::INPUT}{default}",
                 "routes" : [
                   "ConnectedRoute<2.128.0.0/24,nhip:AUTO/NONE(-1l),nhint:GigabitEthernet2/0>_fnhip:null"
                 ]
@@ -726,6 +733,7 @@
                   "node2" : "host1",
                   "node2interface" : "eth0"
                 },
+                "filterIn" : "{filter::INPUT}{default}",
                 "routes" : [
                   "ConnectedRoute<2.128.0.0/24,nhip:AUTO/NONE(-1l),nhint:GigabitEthernet2/0>_fnhip:null"
                 ]


### PR DESCRIPTION
If the flow passes through an input filter, populate the field. Even if flow is denied.

