### PR TITLE
AclReachability: move out of batfish and integrate test

### DIFF
--- a/projects/allinone/BUILD
+++ b/projects/allinone/BUILD
@@ -47,22 +47,6 @@ junit_tests(
 )
 
 junit_tests(
-    name = "AclReachabilityTest",
-    size = "small",
-    srcs = [
-        "src/test/java/org/batfish/question/aclreachability/AclReachabilityTest.java",
-    ],
-    deps = [
-        "//projects/batfish",
-        "//projects/batfish:batfish_testlib",
-        "//projects/batfish-common-protocol:common",
-        "//projects/question",
-        "@guava//:compile",
-        "@hamcrest//:compile",
-    ],
-)
-
-junit_tests(
     name = "CompareSameNameTest",
     size = "small",
     srcs = [

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
@@ -1,6 +1,5 @@
 package org.batfish.common.plugin;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -25,8 +24,6 @@ import org.batfish.datamodel.FlowHistory;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.Topology;
-import org.batfish.datamodel.answers.AclReachabilityRows;
-import org.batfish.datamodel.answers.AclSpecs;
 import org.batfish.datamodel.answers.AnswerElement;
 import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
 import org.batfish.datamodel.answers.DataPlaneAnswerElement;
@@ -53,8 +50,6 @@ import org.batfish.role.NodeRolesData;
 import org.batfish.specifier.SpecifierContext;
 
 public interface IBatfish extends IPluginConsumer {
-
-  void answerAclReachability(List<AclSpecs> aclSpecs, AclReachabilityRows emptyAnswer);
 
   Set<Flow> bddReducedReachability();
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/plugin/IBatfishTestAdapter.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/plugin/IBatfishTestAdapter.java
@@ -1,6 +1,5 @@
 package org.batfish.common.plugin;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -26,8 +25,6 @@ import org.batfish.datamodel.FlowHistory;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.Topology;
-import org.batfish.datamodel.answers.AclReachabilityRows;
-import org.batfish.datamodel.answers.AclSpecs;
 import org.batfish.datamodel.answers.AnswerElement;
 import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
 import org.batfish.datamodel.answers.DataPlaneAnswerElement;
@@ -52,17 +49,13 @@ import org.batfish.referencelibrary.ReferenceLibrary;
 import org.batfish.role.NodeRoleDimension;
 import org.batfish.role.NodeRolesData;
 import org.batfish.specifier.SpecifierContext;
+import org.batfish.specifier.SpecifierContextImpl;
 
 /**
  * A helper for tests that need an {@link IBatfish} implementation. Extend this and implement the
  * minimal methods needed.
  */
 public class IBatfishTestAdapter implements IBatfish {
-
-  @Override
-  public void answerAclReachability(List<AclSpecs> aclSpecs, AclReachabilityRows emptyAnswer) {
-    throw new UnsupportedOperationException();
-  }
 
   @Override
   public Set<Flow> bddReducedReachability() {
@@ -169,7 +162,7 @@ public class IBatfishTestAdapter implements IBatfish {
 
   @Override
   public BatfishLogger getLogger() {
-    throw new UnsupportedOperationException();
+    return null;
   }
 
   @Override
@@ -424,7 +417,7 @@ public class IBatfishTestAdapter implements IBatfish {
 
   @Override
   public SpecifierContext specifierContext() {
-    throw new UnsupportedOperationException();
+    return new SpecifierContextImpl(this, this.loadConfigurations());
   }
 
   @Override

--- a/projects/question/BUILD
+++ b/projects/question/BUILD
@@ -15,6 +15,7 @@ java_library(
     ],
     deps = [
         "//projects/batfish-common-protocol:common",
+        "//projects/lib/bdd",
         "//projects/lib/jsonpath",
         "@auto_service//:compile",
         "@commons_lang3//:compile",

--- a/projects/question/pom.xml
+++ b/projects/question/pom.xml
@@ -101,6 +101,11 @@
     </dependency>
 
     <dependency>
+      <groupId>net.sf.javabdd</groupId>
+      <artifactId>javabdd</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>

--- a/projects/question/src/test/java/org/batfish/question/UndefinedReferencesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/UndefinedReferencesAnswererTest.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.SortedSet;
-import org.batfish.common.BatfishLogger;
 import org.batfish.common.plugin.IBatfishTestAdapter;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
@@ -109,11 +108,6 @@ public class UndefinedReferencesAnswererTest {
   }
 
   private static class TestBatfish extends IBatfishTestAdapter {
-    @Override
-    public BatfishLogger getLogger() {
-      return null;
-    }
-
     @Override
     public ConvertConfigurationAnswerElement loadConvertConfigurationAnswerElementOrReparse() {
       ConvertConfigurationAnswerElement ccae = new ConvertConfigurationAnswerElement();

--- a/projects/question/src/test/java/org/batfish/question/UnusedStructuresAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/UnusedStructuresAnswererTest.java
@@ -13,7 +13,6 @@ import com.google.common.collect.ImmutableSortedSet;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
-import org.batfish.common.BatfishLogger;
 import org.batfish.common.plugin.IBatfishTestAdapter;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
@@ -102,11 +101,6 @@ public class UnusedStructuresAnswererTest {
   }
 
   private static class TestBatfish extends IBatfishTestAdapter {
-    @Override
-    public BatfishLogger getLogger() {
-      return null;
-    }
-
     @Override
     public ConvertConfigurationAnswerElement loadConvertConfigurationAnswerElementOrReparse() {
       ConvertConfigurationAnswerElement ccae = new ConvertConfigurationAnswerElement();

--- a/projects/question/src/test/java/org/batfish/question/aclreachability/AclReachabilityTest.java
+++ b/projects/question/src/test/java/org/batfish/question/aclreachability/AclReachabilityTest.java
@@ -24,9 +24,11 @@ import com.google.common.collect.ImmutableMultiset;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Multiset;
-import java.io.IOException;
 import java.util.List;
+import java.util.SortedMap;
 import java.util.stream.Collectors;
+import org.batfish.common.plugin.IBatfish;
+import org.batfish.common.plugin.IBatfishTestAdapter;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.HeaderSpace;
@@ -47,8 +49,6 @@ import org.batfish.datamodel.acl.MatchSrcInterface;
 import org.batfish.datamodel.acl.PermittedByAcl;
 import org.batfish.datamodel.table.Row;
 import org.batfish.datamodel.table.TableAnswerElement;
-import org.batfish.main.Batfish;
-import org.batfish.main.BatfishTestUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -83,7 +83,7 @@ public class AclReachabilityTest {
   }
 
   @Test
-  public void testWithIcmpType() throws IOException {
+  public void testWithIcmpType() {
     // First line accepts IP 1.2.3.4
     // Second line accepts same but only ICMP of type 8
     List<IpAccessListLine> lines =
@@ -97,7 +97,7 @@ public class AclReachabilityTest {
                     .setIcmpTypes(ImmutableList.of(new SubRange(8)))
                     .build()));
     _aclb.setLines(lines).setName("acl").build();
-    List<String> lineNames = lines.stream().map(l -> l.toString()).collect(Collectors.toList());
+    List<String> lineNames = lines.stream().map(Object::toString).collect(Collectors.toList());
 
     TableAnswerElement answer = answer(new AclReachabilityQuestion());
 
@@ -123,7 +123,7 @@ public class AclReachabilityTest {
   }
 
   @Test
-  public void testIpWildcards() throws IOException {
+  public void testIpWildcards() {
     // First line accepts src IPs 1.2.3.4/30
     // Second line accepts src IPs 1.2.3.4/32
     List<IpAccessListLine> lines =
@@ -141,7 +141,7 @@ public class AclReachabilityTest {
                     .setSrcIps(new IpWildcard(new Prefix(new Ip("1.2.3.4"), 28)).toIpSpace())
                     .build()));
     _aclb.setLines(lines).setName("acl").build();
-    List<String> lineNames = lines.stream().map(l -> l.toString()).collect(Collectors.toList());
+    List<String> lineNames = lines.stream().map(Object::toString).collect(Collectors.toList());
 
     TableAnswerElement answer = answer(new AclReachabilityQuestion());
 
@@ -167,7 +167,7 @@ public class AclReachabilityTest {
   }
 
   @Test
-  public void testCycleAppearsOnce() throws IOException {
+  public void testCycleAppearsOnce() {
     // acl1 permits anything acl2 permits... twice
     // acl2 permits anything acl1 permits... twice
     _aclb
@@ -204,7 +204,7 @@ public class AclReachabilityTest {
   }
 
   @Test
-  public void testCircularReferences() throws IOException {
+  public void testCircularReferences() {
     // acl0 permits anything acl1 permits
     // acl1 permits anything acl2 permits, plus 1 other line to avoid acl3's line being unmatchable
     // acl2 permits anything acl0 permits
@@ -258,7 +258,7 @@ public class AclReachabilityTest {
   }
 
   @Test
-  public void testUndefinedReference() throws IOException {
+  public void testUndefinedReference() {
 
     IpAccessListLine aclLine =
         IpAccessListLine.accepting().setMatchCondition(new PermittedByAcl("???")).build();
@@ -287,7 +287,7 @@ public class AclReachabilityTest {
   }
 
   @Test
-  public void testIndirection() throws IOException {
+  public void testIndirection() {
     /*
      Referenced ACL contains 1 line: Permit 1.0.0.0/24
      Main ACL contains 2 lines:
@@ -308,7 +308,7 @@ public class AclReachabilityTest {
             acceptingHeaderSpace(
                 HeaderSpace.builder().setSrcIps(Prefix.parse("1.0.0.0/24").toIpSpace()).build()));
     IpAccessList acl = _aclb.setLines(aclLines).setName("acl2").build();
-    List<String> lineNames = aclLines.stream().map(l -> l.toString()).collect(Collectors.toList());
+    List<String> lineNames = aclLines.stream().map(Object::toString).collect(Collectors.toList());
 
     /*
      Runs two questions:
@@ -344,7 +344,7 @@ public class AclReachabilityTest {
   }
 
   @Test
-  public void testMultipleCoveringLines() throws IOException {
+  public void testMultipleCoveringLines() {
     List<IpAccessListLine> aclLines =
         ImmutableList.of(
             acceptingHeaderSpace(
@@ -360,7 +360,7 @@ public class AclReachabilityTest {
                     .setSrcIps(new IpWildcard("1.0.0.0:0.0.0.1").toIpSpace())
                     .build()));
     IpAccessList acl = _aclb.setLines(aclLines).setName("acl").build();
-    List<String> lineNames = aclLines.stream().map(l -> l.toString()).collect(Collectors.toList());
+    List<String> lineNames = aclLines.stream().map(Object::toString).collect(Collectors.toList());
 
     TableAnswerElement answer = answer(new AclReachabilityQuestion());
 
@@ -391,7 +391,7 @@ public class AclReachabilityTest {
   }
 
   @Test
-  public void testIndependentlyUnmatchableLines() throws IOException {
+  public void testIndependentlyUnmatchableLines() {
     /*
     Construct ACL with lines:
     0. Reject 1.0.0.0/24 (unblocked)
@@ -412,7 +412,7 @@ public class AclReachabilityTest {
             acceptingHeaderSpace(
                 HeaderSpace.builder().setSrcIps(Prefix.parse("1.2.3.4/32").toIpSpace()).build()));
     IpAccessList acl = _aclb.setLines(aclLines).setName("acl").build();
-    List<String> lineNames = aclLines.stream().map(l -> l.toString()).collect(Collectors.toList());
+    List<String> lineNames = aclLines.stream().map(Object::toString).collect(Collectors.toList());
 
     TableAnswerElement answer = answer(new AclReachabilityQuestion());
 
@@ -468,7 +468,7 @@ public class AclReachabilityTest {
   }
 
   @Test
-  public void testOriginalAclNotMutated() throws IOException {
+  public void testOriginalAclNotMutated() {
     // ACL that references an undefined ACL and an IpSpace; check line unchanged in original version
     IpAccessList acl =
         _aclb
@@ -508,7 +508,7 @@ public class AclReachabilityTest {
   }
 
   @Test
-  public void testWithSrcInterfaceReference() throws IOException {
+  public void testWithSrcInterfaceReference() {
     List<IpAccessListLine> aclLines =
         ImmutableList.of(
             IpAccessListLine.accepting()
@@ -518,7 +518,7 @@ public class AclReachabilityTest {
                 .setMatchCondition(new MatchSrcInterface(ImmutableList.of("iface")))
                 .build());
     IpAccessList acl = _aclb.setLines(aclLines).setName("acl").build();
-    List<String> lineNames = aclLines.stream().map(l -> l.toString()).collect(Collectors.toList());
+    List<String> lineNames = aclLines.stream().map(Object::toString).collect(Collectors.toList());
 
     TableAnswerElement answer = answer(new AclReachabilityQuestion());
 
@@ -544,10 +544,14 @@ public class AclReachabilityTest {
     assertThat(answer.getRows().getData(), equalTo(expected));
   }
 
-  private TableAnswerElement answer(AclReachabilityQuestion q) throws IOException {
-    Batfish batfish =
-        BatfishTestUtils.getBatfish(
-            ImmutableSortedMap.of(_c1.getHostname(), _c1, _c2.getHostname(), _c2), _folder);
+  private TableAnswerElement answer(AclReachabilityQuestion q) {
+    IBatfish batfish =
+        new IBatfishTestAdapter() {
+          @Override
+          public SortedMap<String, Configuration> loadConfigurations() {
+            return ImmutableSortedMap.of(_c1.getHostname(), _c1, _c2.getHostname(), _c2);
+          }
+        };
     AclReachabilityAnswerer answerer = new AclReachabilityAnswerer(q, batfish);
     return answerer.answer();
   }

--- a/projects/question/src/test/java/org/batfish/question/initialization/FileParseStatusAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/initialization/FileParseStatusAnswererTest.java
@@ -8,7 +8,6 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedMap;
-import org.batfish.common.BatfishLogger;
 import org.batfish.common.plugin.IBatfishTestAdapter;
 import org.batfish.datamodel.answers.ParseStatus;
 import org.batfish.datamodel.answers.ParseVendorConfigurationAnswerElement;
@@ -65,11 +64,6 @@ public class FileParseStatusAnswererTest {
   }
 
   private static class TestBatfish extends IBatfishTestAdapter {
-    @Override
-    public BatfishLogger getLogger() {
-      return null;
-    }
-
     @Override
     public ParseVendorConfigurationAnswerElement loadParseVendorConfigurationAnswerElement() {
       ParseVendorConfigurationAnswerElement pvcae = new ParseVendorConfigurationAnswerElement();

--- a/projects/question/src/test/java/org/batfish/question/initialization/ParseWarningAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/initialization/ParseWarningAnswererTest.java
@@ -9,7 +9,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableSortedMap;
-import org.batfish.common.BatfishLogger;
 import org.batfish.common.Warnings;
 import org.batfish.common.Warnings.ParseWarning;
 import org.batfish.common.plugin.IBatfishTestAdapter;
@@ -86,11 +85,6 @@ public class ParseWarningAnswererTest {
   }
 
   private static class TestBatfish extends IBatfishTestAdapter {
-    @Override
-    public BatfishLogger getLogger() {
-      return null;
-    }
-
     @Override
     public ParseVendorConfigurationAnswerElement loadParseVendorConfigurationAnswerElement() {
       ParseVendorConfigurationAnswerElement pvcae = new ParseVendorConfigurationAnswerElement();

--- a/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
@@ -42,7 +42,6 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.regex.Pattern;
-import org.batfish.common.BatfishLogger;
 import org.batfish.common.plugin.IBatfishTestAdapter;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.BgpRoute.Builder;
@@ -397,11 +396,6 @@ public class RoutesAnswererTest {
     @Override
     public DataPlane loadDataPlane() {
       return _dp;
-    }
-
-    @Override
-    public BatfishLogger getLogger() {
-      return null;
     }
 
     @Override

--- a/projects/question/src/test/java/org/batfish/question/testfilters/TestFiltersAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/testfilters/TestFiltersAnswererTest.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 import java.io.IOException;
 import java.util.SortedMap;
-import org.batfish.common.BatfishLogger;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.common.plugin.IBatfishTestAdapter;
 import org.batfish.datamodel.Configuration;
@@ -67,11 +66,6 @@ public class TestFiltersAnswererTest {
     public MockBatfish(SortedMap<String, Configuration> configurations, SpecifierContext ctxt) {
       _configurations = configurations;
       _specifierContext = ctxt;
-    }
-
-    @Override
-    public BatfishLogger getLogger() {
-      return null;
     }
 
     @Override


### PR DESCRIPTION
Part 1 of batfish/batfish#2318

* Delete IBatfish#answerAclReachability. Inline the logic in AclReachabilityQuestion.
* Move AclReachabilityTest from allinone to question, since it now does not need
  Batfish to run. This required fixing up IBatfishTestAdapter a little.

Lots still to do, but this is a nice first step.