### PR TITLE
AclExplainer

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclLineMatchExprs.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclLineMatchExprs.java
@@ -74,6 +74,10 @@ public final class AclLineMatchExprs {
     return matchDst(new Ip(ip).toIpSpace());
   }
 
+  public static AclLineMatchExpr matchDstPrefix(String prefix) {
+    return matchDst(Prefix.parse(prefix));
+  }
+
   public static MatchHeaderSpace matchSrc(IpSpace ipSpace) {
     return new MatchHeaderSpace(HeaderSpace.builder().setSrcIps(ipSpace).build());
   }
@@ -88,6 +92,10 @@ public final class AclLineMatchExprs {
 
   public static MatchHeaderSpace matchSrcIp(String ip) {
     return matchSrc(new Ip(ip).toIpSpace());
+  }
+
+  public static MatchHeaderSpace matchSrcPrefix(String prefix) {
+    return matchSrc(Prefix.parse(prefix).toIpSpace());
   }
 
   public static MatchSrcInterface matchSrcInterface(String... iface) {

--- a/projects/batfish/src/main/java/org/batfish/datamodel/acl/AclExplainer.java
+++ b/projects/batfish/src/main/java/org/batfish/datamodel/acl/AclExplainer.java
@@ -1,0 +1,93 @@
+package org.batfish.datamodel.acl;
+
+import static org.batfish.datamodel.acl.AclLineMatchExprs.not;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Map;
+import org.batfish.common.bdd.BDDPacket;
+import org.batfish.common.bdd.BDDSourceManager;
+import org.batfish.common.bdd.IpAccessListToBDD;
+import org.batfish.common.bdd.MemoizedIpAccessListToBDD;
+import org.batfish.datamodel.IpAccessList;
+import org.batfish.datamodel.IpAccessListLine;
+import org.batfish.datamodel.IpSpace;
+import org.batfish.datamodel.acl.normalize.AclToAclLineMatchExpr;
+
+/**
+ * Generate an explanation of the headerspace permitted by an {@link IpAccessList}. The explanation
+ * is a single {@link AclLineMatchExpr} in a simplified normal form. First we normalize to something
+ * analogous to Disjunctive Normal Form, then simplify further if possible.
+ */
+public final class AclExplainer {
+  private AclExplainer() {}
+
+  public static AclLineMatchExpr explainDifferential(
+      BDDPacket bddPacket,
+      BDDSourceManager mgr,
+      AclLineMatchExpr invariantExpr,
+      IpAccessList denyAcl,
+      Map<String, IpAccessList> denyNamedAcls,
+      Map<String, IpSpace> denyNamedIpSpaces,
+      IpAccessList permitAcl,
+      Map<String, IpAccessList> permitNamedAcls,
+      Map<String, IpSpace> permitNamedIpSpaces) {
+    // Construct an ACL that permits the difference of the two ACLs.
+    DifferentialIpAccessList differentialIpAccessList =
+        DifferentialIpAccessList.create(
+            invariantExpr,
+            denyAcl,
+            denyNamedAcls,
+            denyNamedIpSpaces,
+            permitAcl,
+            permitNamedAcls,
+            permitNamedIpSpaces);
+
+    IpAccessListToBDD ipAccessListToBDD =
+        MemoizedIpAccessListToBDD.create(
+            bddPacket,
+            mgr,
+            differentialIpAccessList.getNamedAcls(),
+            differentialIpAccessList.getNamedIpSpaces());
+
+    return explain(
+        ipAccessListToBDD,
+        differentialIpAccessList.getAcl(),
+        differentialIpAccessList.getNamedAcls());
+  }
+
+  public static AclLineMatchExpr explain(
+      BDDPacket bddPacket,
+      BDDSourceManager mgr,
+      AclLineMatchExpr invariantExpr,
+      IpAccessList acl,
+      Map<String, IpAccessList> namedAcls,
+      Map<String, IpSpace> namedIpSpaces) {
+    IpAccessListToBDD ipAccessListToBDD =
+        MemoizedIpAccessListToBDD.create(bddPacket, mgr, namedAcls, namedIpSpaces);
+
+    IpAccessList aclWithInvariant =
+        IpAccessList.builder()
+            .setName(acl.getName())
+            .setLines(
+                ImmutableList.<IpAccessListLine>builder()
+                    .add(IpAccessListLine.rejecting(not(invariantExpr)))
+                    .addAll(acl.getLines())
+                    .build())
+            .build();
+
+    return explain(ipAccessListToBDD, aclWithInvariant, namedAcls);
+  }
+
+  private static AclLineMatchExpr explain(
+      IpAccessListToBDD ipAccessListToBDD, IpAccessList acl, Map<String, IpAccessList> namedAcls) {
+    // Convert acl to a single expression.
+    AclLineMatchExpr aclExpr =
+        AclToAclLineMatchExpr.toAclLineMatchExpr(ipAccessListToBDD, acl, namedAcls);
+
+    // Reduce that expression to normal form.
+    AclLineMatchExpr aclExprNf = AclLineMatchExprNormalizer.normalize(ipAccessListToBDD, aclExpr);
+
+    // Simplify the normal form
+    return AclExplanation.explainNormalForm(aclExprNf);
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/datamodel/acl/DifferentialIpAccessList.java
+++ b/projects/batfish/src/main/java/org/batfish/datamodel/acl/DifferentialIpAccessList.java
@@ -1,6 +1,7 @@
 package org.batfish.datamodel.acl;
 
 import static org.batfish.datamodel.IpAccessListLine.rejecting;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.not;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -46,6 +47,7 @@ public final class DifferentialIpAccessList {
   }
 
   public static DifferentialIpAccessList create(
+      AclLineMatchExpr invariantExpr,
       IpAccessList denyAcl,
       Map<String, IpAccessList> denyNamedAcls,
       Map<String, IpSpace> denyNamedIpSpaces,
@@ -63,6 +65,8 @@ public final class DifferentialIpAccessList {
             .setName(DIFFERENTIAL_ACL_NAME)
             .setLines(
                 ImmutableList.<IpAccessListLine>builder()
+                    // reject if invariant not satisfied
+                    .add(rejecting(not(invariantExpr)))
                     // reject if permitted by denyAcl
                     .add(rejecting(new PermittedByAcl(denyAclName)))
                     .addAll(permitAcl.getLines())

--- a/projects/batfish/src/main/java/org/batfish/datamodel/acl/DifferentialIpAccessList.java
+++ b/projects/batfish/src/main/java/org/batfish/datamodel/acl/DifferentialIpAccessList.java
@@ -1,7 +1,6 @@
 package org.batfish.datamodel.acl;
 
 import static org.batfish.datamodel.IpAccessListLine.rejecting;
-import static org.batfish.datamodel.acl.AclLineMatchExprs.not;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -46,8 +45,20 @@ public final class DifferentialIpAccessList {
     _namedIpSpaces = ImmutableMap.copyOf(namedIpSpaces);
   }
 
+  /**
+   * Create a new {@link IpAccessList} that permits the difference between two other {@link
+   * IpAccessList IpAccessLists}.
+   *
+   * @param denyAcl The {@link IpAccessList} subtracted in the difference.
+   * @param denyNamedAcls The named {@link IpAccessList IpAccessLists} in scope for {@param
+   *     denyAcl}.
+   * @param denyNamedIpSpaces The named {@link IpSpace IpSpaces} in scope for {@param denyAcl}.
+   * @param permitAcl The {@link IpAccessList} that is subtracted from in the difference.
+   * @param permitNamedAcls The named {@link IpAccessList IpAccessLists} in scope for {@param
+   *     permitAcl}.
+   * @param permitNamedIpSpaces The named {@link IpSpace IpSpaces} in scope for {@param permitAcl}.
+   */
   public static DifferentialIpAccessList create(
-      AclLineMatchExpr invariantExpr,
       IpAccessList denyAcl,
       Map<String, IpAccessList> denyNamedAcls,
       Map<String, IpSpace> denyNamedIpSpaces,
@@ -65,8 +76,6 @@ public final class DifferentialIpAccessList {
             .setName(DIFFERENTIAL_ACL_NAME)
             .setLines(
                 ImmutableList.<IpAccessListLine>builder()
-                    // reject if invariant not satisfied
-                    .add(rejecting(not(invariantExpr)))
                     // reject if permitted by denyAcl
                     .add(rejecting(new PermittedByAcl(denyAclName)))
                     .addAll(permitAcl.getLines())

--- a/projects/batfish/src/test/java/org/batfish/datamodel/acl/AclExplainerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/datamodel/acl/AclExplainerTest.java
@@ -1,0 +1,212 @@
+package org.batfish.datamodel.acl;
+
+import static org.batfish.datamodel.IpAccessListLine.accepting;
+import static org.batfish.datamodel.IpAccessListLine.rejecting;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.TRUE;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDstIp;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDstPrefix;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrcIp;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrcPrefix;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.not;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.or;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.batfish.common.bdd.BDDPacket;
+import org.batfish.common.bdd.BDDSourceManager;
+import org.batfish.datamodel.IpAccessList;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AclExplainerTest {
+
+  private BDDSourceManager _mgr;
+
+  private BDDPacket _pkt;
+
+  @Before
+  public void setup() {
+    _pkt = new BDDPacket();
+    _mgr = BDDSourceManager.forInterfaces(_pkt, ImmutableSet.of());
+  }
+
+  private AclLineMatchExpr explain(IpAccessList acl) {
+    return explain(TRUE, acl);
+  }
+
+  private AclLineMatchExpr explain(AclLineMatchExpr invariantExpr, IpAccessList acl) {
+    return AclExplainer.explain(
+        _pkt, _mgr, invariantExpr, acl, ImmutableMap.of(), ImmutableMap.of());
+  }
+
+  private AclLineMatchExpr explainDifferential(IpAccessList denyAcl, IpAccessList permitAcl) {
+    return explainDifferential(TRUE, denyAcl, permitAcl);
+  }
+
+  private AclLineMatchExpr explainDifferential(
+      AclLineMatchExpr invariantExpr, IpAccessList denyAcl, IpAccessList permitAcl) {
+    return AclExplainer.explainDifferential(
+        _pkt,
+        _mgr,
+        invariantExpr,
+        denyAcl,
+        ImmutableMap.of(),
+        ImmutableMap.of(),
+        permitAcl,
+        ImmutableMap.of(),
+        ImmutableMap.of());
+  }
+
+  @Test
+  public void testExplainSimple() {
+    MatchHeaderSpace matchDstIp1 = matchDstIp("1.1.1.1");
+    AclLineMatchExpr matchDstIp2 = matchDstIp("2.2.2.2");
+    IpAccessList acl =
+        IpAccessList.builder()
+            .setName("acl")
+            .setLines(ImmutableList.of(accepting(matchDstIp1), accepting(matchDstIp2)))
+            .build();
+    AclLineMatchExpr explanation = explain(acl);
+    assertThat(explanation, equalTo(or(matchDstIp1, matchDstIp2)));
+  }
+
+  @Test
+  public void testExplainInvariant() {
+    MatchHeaderSpace matchDstIp1 = matchDstIp("1.1.1.1");
+    AclLineMatchExpr matchDstIp2 = matchDstIp("2.2.2.2");
+    IpAccessList acl =
+        IpAccessList.builder()
+            .setName("acl")
+            .setLines(ImmutableList.of(accepting(matchDstIp1), accepting(matchDstIp2)))
+            .build();
+    AclLineMatchExpr explanation = explain(matchDstPrefix("2.0.0.0/8"), acl);
+    assertThat(explanation, equalTo(matchDstIp2));
+  }
+
+  @Test
+  public void testExplainRedundantPermit() {
+    MatchHeaderSpace matchDstIp = matchDstIp("1.2.3.4");
+    AclLineMatchExpr matchDstPrefix = matchDstPrefix("1.2.3.0/24");
+    IpAccessList acl =
+        IpAccessList.builder()
+            .setName("acl")
+            .setLines(ImmutableList.of(accepting(matchDstIp), accepting(matchDstPrefix)))
+            .build();
+    AclLineMatchExpr explanation = explain(acl);
+    assertThat(explanation, equalTo(matchDstPrefix));
+  }
+
+  @Test
+  public void testExplainRedundantDeny() {
+    MatchHeaderSpace matchSrcIp = matchSrcIp("1.2.3.4");
+    AclLineMatchExpr matchSrcPrefix = matchSrcPrefix("1.2.3.0/24");
+    MatchHeaderSpace matchDstIp = matchDstIp("1.2.3.4");
+    AclLineMatchExpr matchDstPrefix = matchDstPrefix("1.2.3.0/24");
+    IpAccessList acl =
+        IpAccessList.builder()
+            .setName("acl")
+            .setLines(
+                ImmutableList.of(
+                    rejecting(matchSrcIp),
+                    accepting(matchDstIp),
+                    rejecting(matchSrcPrefix),
+                    accepting(matchDstPrefix)))
+            .build();
+    assertThat(
+        explain(acl),
+        equalTo(or(and(matchDstIp, not(matchSrcIp)), and(matchDstPrefix, not(matchSrcPrefix)))));
+
+    /*
+     * Reverse the order of the rejecting lines. Now we get:
+     * or(and(matchDstIp, not(matchSrcPrefix)), and(matchDstPrefix, not(matchSrcPrefix)))))
+     * And then the first disjunct is removed because it's subsumed by the second.
+     */
+    acl =
+        IpAccessList.builder()
+            .setName("acl")
+            .setLines(
+                ImmutableList.of(
+                    rejecting(matchSrcPrefix),
+                    accepting(matchDstIp),
+                    rejecting(matchSrcIp),
+                    accepting(matchDstPrefix)))
+            .build();
+    assertThat(explain(acl), equalTo(or(and(matchDstPrefix, not(matchSrcPrefix)))));
+  }
+
+  @Test
+  public void testExplainRejectLines() {
+    MatchHeaderSpace matchDstIp = matchDstIp("1.2.3.4");
+    AclLineMatchExpr matchDstPrefix = matchDstPrefix("1.2.3.0/24");
+    IpAccessList acl =
+        IpAccessList.builder()
+            .setName("acl")
+            .setLines(ImmutableList.of(accepting(matchDstIp), accepting(matchDstPrefix)))
+            .build();
+    AclLineMatchExpr explanation = explain(acl);
+    assertThat(explanation, equalTo(matchDstPrefix));
+  }
+
+  @Test
+  public void testExplainDifferentialSimple() {
+    MatchHeaderSpace matchDstIp = matchDstIp("1.2.3.4");
+    AclLineMatchExpr matchDstPrefix = matchDstPrefix("1.2.3.0/24");
+    IpAccessList denyAcl =
+        IpAccessList.builder()
+            .setName("deny")
+            .setLines(ImmutableList.of(accepting(matchDstIp)))
+            .build();
+    IpAccessList permitAcl =
+        IpAccessList.builder()
+            .setName("permit")
+            .setLines(ImmutableList.of(accepting(matchDstPrefix)))
+            .build();
+    AclLineMatchExpr explanation = explainDifferential(denyAcl, permitAcl);
+    assertThat(explanation, equalTo(and(matchDstPrefix, not(matchDstIp))));
+  }
+
+  @Test
+  public void testExplainDifferentialReject() {
+    MatchHeaderSpace matchDstIp = matchDstIp("1.2.3.4");
+    AclLineMatchExpr matchDstPrefix24 = matchDstPrefix("1.2.3.0/24");
+    AclLineMatchExpr matchDstPrefix16 = matchDstPrefix("1.2.0.0/16");
+    IpAccessList denyAcl =
+        IpAccessList.builder()
+            .setName("deny")
+            .setLines(ImmutableList.of(rejecting(matchDstIp), accepting(matchDstPrefix24)))
+            .build();
+    IpAccessList permitAcl =
+        IpAccessList.builder()
+            .setName("permit")
+            .setLines(ImmutableList.of(accepting(matchDstPrefix16)))
+            .build();
+    assertThat(
+        explainDifferential(denyAcl, permitAcl),
+        equalTo(or(matchDstIp, and(matchDstPrefix16, not(matchDstPrefix24)))));
+    /*
+     * Add an invariant that contradicts the second disjunct
+     */
+    assertThat(explainDifferential(matchDstPrefix24, denyAcl, permitAcl), equalTo(matchDstIp));
+
+    /*
+     * Switch the prefixes. Now the second explanation becomes
+     *   and(matchDstPrefix24, not(matchDstPrefix16))
+     * Which is False and gets removed.
+     */
+    denyAcl =
+        IpAccessList.builder()
+            .setName("deny")
+            .setLines(ImmutableList.of(rejecting(matchDstIp), accepting(matchDstPrefix16)))
+            .build();
+    permitAcl =
+        IpAccessList.builder()
+            .setName("permit")
+            .setLines(ImmutableList.of(accepting(matchDstPrefix24)))
+            .build();
+    assertThat(explainDifferential(denyAcl, permitAcl), equalTo(matchDstIp));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/datamodel/acl/DifferentialIpAccessListTest.java
+++ b/projects/batfish/src/test/java/org/batfish/datamodel/acl/DifferentialIpAccessListTest.java
@@ -1,7 +1,9 @@
 package org.batfish.datamodel.acl;
 
 import static org.batfish.datamodel.IpAccessListLine.accepting;
-import static org.batfish.datamodel.acl.AclLineMatchExprs.TRUE;
+import static org.batfish.datamodel.IpAccessListLine.rejecting;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDstIp;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.not;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.permittedByAcl;
 import static org.batfish.datamodel.acl.DifferentialIpAccessList.RENAMER;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -71,9 +73,10 @@ public class DifferentialIpAccessListTest {
     Map<String, IpSpace> permitNamedIpSpaces =
         ImmutableMap.of(permitNamedIpSpace, new IpSpaceReference(permitNamedIpSpace));
 
+    AclLineMatchExpr invariantExpr = matchDstIp("1.1.1.1");
     DifferentialIpAccessList differential =
         DifferentialIpAccessList.create(
-            TRUE,
+            invariantExpr,
             denyAcl,
             denyNamedAcls,
             denyNamedIpSpaces,
@@ -86,7 +89,8 @@ public class DifferentialIpAccessListTest {
             .setName(DifferentialIpAccessList.DIFFERENTIAL_ACL_NAME)
             .setLines(
                 ImmutableList.<IpAccessListLine>builder()
-                    .add(IpAccessListLine.rejecting(permittedByAcl(renamedDenyAclName)))
+                    .add(rejecting(not(invariantExpr)))
+                    .add(rejecting(permittedByAcl(renamedDenyAclName)))
                     .addAll(permitAclLines)
                     .build())
             .build();

--- a/projects/batfish/src/test/java/org/batfish/datamodel/acl/DifferentialIpAccessListTest.java
+++ b/projects/batfish/src/test/java/org/batfish/datamodel/acl/DifferentialIpAccessListTest.java
@@ -2,8 +2,6 @@ package org.batfish.datamodel.acl;
 
 import static org.batfish.datamodel.IpAccessListLine.accepting;
 import static org.batfish.datamodel.IpAccessListLine.rejecting;
-import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDstIp;
-import static org.batfish.datamodel.acl.AclLineMatchExprs.not;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.permittedByAcl;
 import static org.batfish.datamodel.acl.DifferentialIpAccessList.RENAMER;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -73,10 +71,8 @@ public class DifferentialIpAccessListTest {
     Map<String, IpSpace> permitNamedIpSpaces =
         ImmutableMap.of(permitNamedIpSpace, new IpSpaceReference(permitNamedIpSpace));
 
-    AclLineMatchExpr invariantExpr = matchDstIp("1.1.1.1");
     DifferentialIpAccessList differential =
         DifferentialIpAccessList.create(
-            invariantExpr,
             denyAcl,
             denyNamedAcls,
             denyNamedIpSpaces,
@@ -89,7 +85,6 @@ public class DifferentialIpAccessListTest {
             .setName(DifferentialIpAccessList.DIFFERENTIAL_ACL_NAME)
             .setLines(
                 ImmutableList.<IpAccessListLine>builder()
-                    .add(rejecting(not(invariantExpr)))
                     .add(rejecting(permittedByAcl(renamedDenyAclName)))
                     .addAll(permitAclLines)
                     .build())

--- a/projects/batfish/src/test/java/org/batfish/datamodel/acl/DifferentialIpAccessListTest.java
+++ b/projects/batfish/src/test/java/org/batfish/datamodel/acl/DifferentialIpAccessListTest.java
@@ -1,6 +1,7 @@
 package org.batfish.datamodel.acl;
 
 import static org.batfish.datamodel.IpAccessListLine.accepting;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.TRUE;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.permittedByAcl;
 import static org.batfish.datamodel.acl.DifferentialIpAccessList.RENAMER;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -72,6 +73,7 @@ public class DifferentialIpAccessListTest {
 
     DifferentialIpAccessList differential =
         DifferentialIpAccessList.create(
+            TRUE,
             denyAcl,
             denyNamedAcls,
             denyNamedIpSpaces,


### PR DESCRIPTION
Generate explanations of the headerspace permitted by an ACL or the
difference between the headerspaces permitted by two ACLs.