### PR TITLE
fix computeMajorIssueConfigs exception

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AnswerMetadataUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AnswerMetadataUtil.java
@@ -123,7 +123,7 @@ public final class AnswerMetadataUtil {
 
   @VisibleForTesting
   static @Nonnull Map<String, MajorIssueConfig> computeMajorIssueConfigs(TableAnswerElement table) {
-    Map<String, ImmutableList.Builder<MinorIssueConfig>> majorIssueConfigs = new HashMap<>();
+    Map<String, ImmutableSet.Builder<MinorIssueConfig>> majorIssueConfigs = new HashMap<>();
     // For every issue column of every row, extract the issue and use it to update the map
     table
         .getMetadata()
@@ -141,14 +141,14 @@ public final class AnswerMetadataUtil {
         .forEach(
             issue ->
                 majorIssueConfigs
-                    .computeIfAbsent(issue.getType().getMajor(), m -> ImmutableList.builder())
+                    .computeIfAbsent(issue.getType().getMajor(), m -> ImmutableSet.builder())
                     .add(
                         new MinorIssueConfig(
                             issue.getType().getMinor(), issue.getSeverity(), issue.getUrl())));
     return CommonUtil.toImmutableMap(
         majorIssueConfigs,
         Entry::getKey, // major issue type
-        e -> new MajorIssueConfig(e.getKey(), e.getValue().build()));
+        e -> new MajorIssueConfig(e.getKey(), e.getValue().build().asList()));
   }
 
   @VisibleForTesting

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/answers/AnswerMetadataUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/answers/AnswerMetadataUtilTest.java
@@ -312,6 +312,7 @@ public class AnswerMetadataUtilTest {
                 new TableMetadata(
                     ImmutableList.of(new ColumnMetadata(columnName, Schema.ISSUE, "foobar")),
                     new DisplayHints().getTextDesc()))
+            .addRow(Row.of(columnName, value))
             .addRow(Row.of(columnName, value));
 
     assertThat(


### PR DESCRIPTION
tables that have multiple rows with the same issue (most tables in findbugs) would cause an
exception to be thrown in computeMajorIssueConfigs causing the metadata
for that answer to be just a failure status