### PR TITLE
better specialization of range fields in headerspaces

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/z3/IpSpaceIpAccessListSpecializer.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/IpSpaceIpAccessListSpecializer.java
@@ -4,6 +4,7 @@ import static org.batfish.datamodel.AclIpSpace.difference;
 import static org.batfish.datamodel.AclIpSpace.union;
 
 import java.util.Map;
+import java.util.Optional;
 import org.batfish.common.ipspace.IpSpaceSpecializer;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.IpSpace;
@@ -65,15 +66,17 @@ public final class IpSpaceIpAccessListSpecializer extends IpAccessListSpecialize
   }
 
   @Override
-  protected HeaderSpace specialize(HeaderSpace headerSpace) {
-    return headerSpace
-        .toBuilder()
-        .setDstIps(specializeWith(headerSpace.getDstIps(), _dstIpSpaceSpecializer))
-        .setNotDstIps(specializeWith(headerSpace.getNotDstIps(), _dstIpSpaceSpecializer))
-        .setNotSrcIps(specializeWith(headerSpace.getNotSrcIps(), _srcIpSpaceSpecializer))
-        .setSrcIps(specializeWith(headerSpace.getSrcIps(), _srcIpSpaceSpecializer))
-        .setSrcOrDstIps(specializeWith(headerSpace.getSrcOrDstIps(), _srcOrDstIpSpaceSpecializer))
-        .build();
+  protected Optional<HeaderSpace> specialize(HeaderSpace headerSpace) {
+    return Optional.of(
+        headerSpace
+            .toBuilder()
+            .setDstIps(specializeWith(headerSpace.getDstIps(), _dstIpSpaceSpecializer))
+            .setNotDstIps(specializeWith(headerSpace.getNotDstIps(), _dstIpSpaceSpecializer))
+            .setNotSrcIps(specializeWith(headerSpace.getNotSrcIps(), _srcIpSpaceSpecializer))
+            .setSrcIps(specializeWith(headerSpace.getSrcIps(), _srcIpSpaceSpecializer))
+            .setSrcOrDstIps(
+                specializeWith(headerSpace.getSrcOrDstIps(), _srcOrDstIpSpaceSpecializer))
+            .build());
   }
 
   @Override


### PR DESCRIPTION
In `BDDIpAccessListSpecializer`, do more to specialize range fields in headerspaces.

In particular remove those ranges that are disjoint from the intersection of the specialization space and the headerspace the range is a part of. 