### PR TITLE
Searchfilters: class naming consistency, fix bazel build

### DIFF
--- a/projects/allinone/BUILD
+++ b/projects/allinone/BUILD
@@ -115,10 +115,10 @@ junit_tests(
 )
 
 junit_tests(
-    name = "ReachFilterDifferentialTest",
+    name = "SearchFiltersDifferentialTest",
     size = "small",
     srcs = [
-        "src/test/java/org/batfish/question/reachfilter/ReachFilterDifferentialTest.java",
+        "src/test/java/org/batfish/question/searchfilters/SearchFiltersDifferentialTest.java",
     ],
     deps = [
         "//projects/batfish",
@@ -132,10 +132,10 @@ junit_tests(
 )
 
 junit_tests(
-    name = "ReachFilterTest",
+    name = "SearchFiltersTest",
     size = "small",
     srcs = [
-        "src/test/java/org/batfish/question/reachfilter/ReachFilterTest.java",
+        "src/test/java/org/batfish/question/searchfilters/SearchFiltersTest.java",
     ],
     deps = [
         "//projects/batfish",

--- a/projects/allinone/src/test/java/org/batfish/question/searchfilters/SearchFiltersDifferentialTest.java
+++ b/projects/allinone/src/test/java/org/batfish/question/searchfilters/SearchFiltersDifferentialTest.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 /** End-to-end tests of {@link SearchFiltersQuestion} in differential mode. */
-public class SearchFilterDifferentialTest {
+public class SearchFiltersDifferentialTest {
   @Rule public TemporaryFolder _tmp = new TemporaryFolder();
 
   private static final String HOSTNAME = "hostname";

--- a/projects/allinone/src/test/java/org/batfish/question/searchfilters/SearchFiltersTest.java
+++ b/projects/allinone/src/test/java/org/batfish/question/searchfilters/SearchFiltersTest.java
@@ -58,7 +58,7 @@ import org.batfish.datamodel.answers.Schema;
 import org.batfish.datamodel.table.TableAnswerElement;
 import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
-import org.batfish.question.SearchFilterParameters;
+import org.batfish.question.SearchFiltersParameters;
 import org.batfish.question.testfilters.TestFiltersAnswerer;
 import org.batfish.specifier.ConstantIpSpaceSpecifier;
 import org.batfish.specifier.NameRegexInterfaceLinkLocationSpecifier;
@@ -68,7 +68,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 /** End-to-end tests of {@link org.batfish.question.searchfilters}. */
-public final class SearchFilterTest {
+public final class SearchFiltersTest {
   private static final String IFACE1 = "iface1";
 
   private static final String IFACE2 = "iface2";
@@ -161,7 +161,7 @@ public final class SearchFilterTest {
 
   private static Configuration _config;
 
-  private static SearchFilterParameters _allLocationsParams;
+  private static SearchFiltersParameters _allLocationsParams;
 
   @BeforeClass
   public static void setup() throws IOException {
@@ -246,50 +246,50 @@ public final class SearchFilterTest {
 
   @Test
   public void testReachFilter_deny_ACCEPT_ALL() {
-    Optional<SearchFilterResult> result =
+    Optional<SearchFiltersResult> result =
         _batfish.reachFilter(_config, toDenyAcl(ACCEPT_ALL_ACL), _allLocationsParams);
     assertThat("Should not find permitted flow", !result.isPresent());
   }
 
   @Test
   public void testReachFilter_deny_REJECT_ALL() {
-    Optional<SearchFilterResult> result =
+    Optional<SearchFiltersResult> result =
         _batfish.reachFilter(_config, toDenyAcl(REJECT_ALL_ACL), _allLocationsParams);
     assertThat("Should find permitted flow", result.isPresent());
   }
 
   @Test
   public void testReachFilter_permit_ACCEPT_ALL() {
-    Optional<SearchFilterResult> result =
+    Optional<SearchFiltersResult> result =
         _batfish.reachFilter(_config, ACCEPT_ALL_ACL, _allLocationsParams);
     assertThat("Should find permitted flow", result.isPresent());
   }
 
   @Test
   public void testReachFilter_permit_REJECT_ALL() {
-    Optional<SearchFilterResult> result =
+    Optional<SearchFiltersResult> result =
         _batfish.reachFilter(_config, REJECT_ALL_ACL, _allLocationsParams);
     assertThat(result, equalTo(Optional.empty()));
   }
 
   @Test
   public void testReachFilter_permit() {
-    Optional<SearchFilterResult> result = _batfish.reachFilter(_config, ACL, _allLocationsParams);
+    Optional<SearchFiltersResult> result = _batfish.reachFilter(_config, ACL, _allLocationsParams);
     assertThat("Should find permitted flow", result.isPresent());
     assertThat(result.get().getExampleFlow(), hasDstIp(oneOf(IP0, IP3)));
   }
 
   @Test
   public void testReachFilter_permit_headerSpace() {
-    SearchFilterParameters.Builder paramsBuilder =
+    SearchFiltersParameters.Builder paramsBuilder =
         _allLocationsParams
             .toBuilder()
             .setDestinationIpSpaceSpecifier(new ConstantIpSpaceSpecifier(IP0.toIpSpace()))
             .setSourceIpSpaceSpecifier(new ConstantIpSpaceSpecifier(UniverseIpSpace.INSTANCE))
             .setHeaderSpace(HeaderSpace.builder().build());
 
-    SearchFilterParameters params = paramsBuilder.build();
-    Optional<SearchFilterResult> result = _batfish.reachFilter(_config, ACL, params);
+    SearchFiltersParameters params = paramsBuilder.build();
+    Optional<SearchFiltersResult> result = _batfish.reachFilter(_config, ACL, params);
     assertThat("Should find result", result.isPresent());
     assertThat(result.get().getExampleFlow(), hasDstIp(IP0));
 
@@ -301,7 +301,7 @@ public final class SearchFilterTest {
 
   @Test
   public void testReachFilter_deny() {
-    Optional<SearchFilterResult> permitResult =
+    Optional<SearchFiltersResult> permitResult =
         _batfish.reachFilter(_config, toDenyAcl(ACL), _allLocationsParams);
     assertThat("Should find permitted flow", permitResult.isPresent());
     assertThat(permitResult.get().getExampleFlow(), hasDstIp(not(oneOf(IP0, IP3))));
@@ -309,7 +309,7 @@ public final class SearchFilterTest {
 
   @Test
   public void testReachFilter_matchLine() {
-    Optional<SearchFilterResult> permitResult =
+    Optional<SearchFiltersResult> permitResult =
         _batfish.reachFilter(_config, toMatchLineAcl(0, ACL), _allLocationsParams);
     assertThat("Should find permitted flow", permitResult.isPresent());
     assertThat(permitResult.get().getExampleFlow(), hasDstIp(IP0));
@@ -329,7 +329,7 @@ public final class SearchFilterTest {
 
   @Test
   public void testReachFilter_matchLine_blocked() {
-    Optional<SearchFilterResult> permitResult =
+    Optional<SearchFiltersResult> permitResult =
         _batfish.reachFilter(_config, toMatchLineAcl(2, BLOCKED_LINE_ACL), _allLocationsParams);
     assertThat("Should not find permitted flow", !permitResult.isPresent());
   }
@@ -369,7 +369,7 @@ public final class SearchFilterTest {
 
   @Test
   public void testMatchSrcInterface() {
-    Optional<SearchFilterResult> result =
+    Optional<SearchFiltersResult> result =
         _batfish.reachFilter(_config, toMatchLineAcl(0, SRC_ACL), _allLocationsParams);
     assertThat(
         result.get().getExampleFlow(), allOf(hasIngressInterface(nullValue()), hasDstIp(IP0)));
@@ -402,7 +402,7 @@ public final class SearchFilterTest {
                     rejecting().setMatchCondition(matchSrcInterface(IFACE2)).build(),
                     ACCEPT_ALL))
             .build();
-    Optional<SearchFilterResult> flow =
+    Optional<SearchFiltersResult> flow =
         _batfish.reachFilter(_config, denyAllSourcesAcl, _allLocationsParams);
     assertThat(flow, equalTo(Optional.empty()));
   }
@@ -419,7 +419,7 @@ public final class SearchFilterTest {
                     rejecting().setMatchCondition(matchSrcInterface(IFACE1)).build(),
                     ACCEPT_ALL))
             .build();
-    Optional<SearchFilterResult> flow =
+    Optional<SearchFiltersResult> flow =
         _batfish.reachFilter(_config, denyAllSourcesAcl, _allLocationsParams);
     assertThat("Should find a result", flow.isPresent());
     assertThat(flow.get().getExampleFlow(), hasIngressInterface(IFACE2));
@@ -427,14 +427,14 @@ public final class SearchFilterTest {
 
   @Test
   public void testSourceInterfaceParameter() {
-    SearchFilterParameters params =
+    SearchFiltersParameters params =
         _allLocationsParams
             .toBuilder()
             .setStartLocationSpecifier(new NameRegexInterfaceLinkLocationSpecifier(IFACE1))
             .build();
 
     // can match line 1 because IFACE1 is specified
-    Optional<SearchFilterResult> result =
+    Optional<SearchFiltersResult> result =
         _batfish.reachFilter(_config, toMatchLineAcl(1, SRC_ACL), params);
     assertThat(result.get().getExampleFlow(), allOf(hasIngressInterface(IFACE1), hasDstIp(IP1)));
 
@@ -446,28 +446,28 @@ public final class SearchFilterTest {
   @Test
   public void testReachFilter_ACCEPT_ALL_dstIpConstraint() {
     Ip constraintIp = new Ip("21.21.21.21");
-    SearchFilterParameters params =
+    SearchFiltersParameters params =
         _allLocationsParams
             .toBuilder()
             .setDestinationIpSpaceSpecifier(new ConstantIpSpaceSpecifier(constraintIp.toIpSpace()))
             .setSourceIpSpaceSpecifier(new ConstantIpSpaceSpecifier(UniverseIpSpace.INSTANCE))
             .setHeaderSpace(new HeaderSpace())
             .build();
-    Optional<SearchFilterResult> result = _batfish.reachFilter(_config, ACCEPT_ALL_ACL, params);
+    Optional<SearchFiltersResult> result = _batfish.reachFilter(_config, ACCEPT_ALL_ACL, params);
     assertThat(result.get().getExampleFlow(), hasDstIp(constraintIp));
   }
 
   @Test
   public void testReachFilter_ACCEPT_ALL_srcIpConstraint() {
     Ip constraintIp = new Ip("21.21.21.21");
-    SearchFilterParameters params =
+    SearchFiltersParameters params =
         _allLocationsParams
             .toBuilder()
             .setDestinationIpSpaceSpecifier(new ConstantIpSpaceSpecifier(UniverseIpSpace.INSTANCE))
             .setSourceIpSpaceSpecifier(new ConstantIpSpaceSpecifier(constraintIp.toIpSpace()))
             .setHeaderSpace(new HeaderSpace())
             .build();
-    Optional<SearchFilterResult> result = _batfish.reachFilter(_config, ACCEPT_ALL_ACL, params);
+    Optional<SearchFiltersResult> result = _batfish.reachFilter(_config, ACCEPT_ALL_ACL, params);
     assertThat(result.get().getExampleFlow(), hasSrcIp(constraintIp));
   }
 
@@ -476,14 +476,14 @@ public final class SearchFilterTest {
     HeaderSpace hs = new HeaderSpace();
     hs.setSrcPorts(Collections.singletonList(new SubRange(1111, 1111)));
     hs.setDstPorts(Collections.singletonList(new SubRange(2222, 2222)));
-    SearchFilterParameters params =
+    SearchFiltersParameters params =
         _allLocationsParams
             .toBuilder()
             .setDestinationIpSpaceSpecifier(new ConstantIpSpaceSpecifier(UniverseIpSpace.INSTANCE))
             .setSourceIpSpaceSpecifier(new ConstantIpSpaceSpecifier(UniverseIpSpace.INSTANCE))
             .setHeaderSpace(hs)
             .build();
-    Optional<SearchFilterResult> result = _batfish.reachFilter(_config, ACCEPT_ALL_ACL, params);
+    Optional<SearchFiltersResult> result = _batfish.reachFilter(_config, ACCEPT_ALL_ACL, params);
     assertThat(result.get().getExampleFlow(), allOf(hasSrcPort(1111), hasDstPort(2222)));
   }
 
@@ -505,9 +505,9 @@ public final class SearchFilterTest {
 
   @Test
   public void testGetExplanation() {
-    SearchFilterParameters params =
+    SearchFiltersParameters params =
         _allLocationsParams.toBuilder().setGenerateExplanations(false).build();
-    Optional<SearchFilterResult> result = _batfish.reachFilter(_config, ACCEPT_ALL_ACL, params);
+    Optional<SearchFiltersResult> result = _batfish.reachFilter(_config, ACCEPT_ALL_ACL, params);
     assertThat("Should get a result", result.isPresent());
     assertThat(
         "Should not get an explanation", !result.get().getHeaderSpaceDescription().isPresent());

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
@@ -42,9 +42,9 @@ import org.batfish.datamodel.questions.smt.RoleQuestion;
 import org.batfish.grammar.BgpTableFormat;
 import org.batfish.grammar.GrammarSettings;
 import org.batfish.question.ReachabilityParameters;
-import org.batfish.question.SearchFilterParameters;
-import org.batfish.question.searchfilters.DifferentialSearchFilterResult;
-import org.batfish.question.searchfilters.SearchFilterResult;
+import org.batfish.question.SearchFiltersParameters;
+import org.batfish.question.searchfilters.DifferentialSearchFiltersResult;
+import org.batfish.question.searchfilters.SearchFiltersResult;
 import org.batfish.referencelibrary.ReferenceLibrary;
 import org.batfish.role.NodeRoleDimension;
 import org.batfish.role.NodeRolesData;
@@ -62,12 +62,12 @@ public interface IBatfish extends IPluginConsumer {
 
   boolean debugFlagEnabled(String flag);
 
-  DifferentialSearchFilterResult differentialReachFilter(
+  DifferentialSearchFiltersResult differentialReachFilter(
       Configuration baseConfig,
       IpAccessList baseAcl,
       Configuration deltaConfig,
       IpAccessList deltaAcl,
-      SearchFilterParameters searchFilterParameters);
+      SearchFiltersParameters searchFiltersParameters);
 
   ReferenceLibrary getReferenceLibraryData();
 
@@ -192,8 +192,8 @@ public interface IBatfish extends IPluginConsumer {
   void registerExternalBgpAdvertisementPlugin(
       ExternalBgpAdvertisementPlugin externalBgpAdvertisementPlugin);
 
-  Optional<SearchFilterResult> reachFilter(
-      Configuration node, IpAccessList acl, SearchFilterParameters parameters);
+  Optional<SearchFiltersResult> reachFilter(
+      Configuration node, IpAccessList acl, SearchFiltersParameters parameters);
 
   AnswerElement smtBlackhole(HeaderQuestion q);
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/question/SearchFiltersParameters.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/question/SearchFiltersParameters.java
@@ -16,14 +16,14 @@ import org.batfish.specifier.LocationSpecifier;
 import org.batfish.specifier.SpecifierContext;
 
 /** A set of parameters for ACL filter analysis that uses high-level specifiers. */
-public final class SearchFilterParameters {
+public final class SearchFiltersParameters {
   private final @Nonnull IpSpaceSpecifier _destinationIpSpaceSpecifier;
   private final boolean _generateExplanations;
   private final @Nonnull HeaderSpace _headerSpace;
   private final @Nonnull LocationSpecifier _startLocationSpecifier;
   private final @Nonnull IpSpaceSpecifier _sourceIpSpaceSpecifier;
 
-  private SearchFilterParameters(
+  private SearchFiltersParameters(
       @Nonnull IpSpaceSpecifier destinationIpSpaceSpecifier,
       @Nonnull LocationSpecifier startLocationSpecifier,
       @Nonnull IpSpaceSpecifier sourceIpSpaceSpecifier,
@@ -115,8 +115,8 @@ public final class SearchFilterParameters {
       return this;
     }
 
-    public SearchFilterParameters build() {
-      return new SearchFilterParameters(
+    public SearchFiltersParameters build() {
+      return new SearchFiltersParameters(
           requireNonNull(_destinationIpSpaceSpecifier),
           requireNonNull(_startLocationSpecifier),
           requireNonNull(_sourceIpSpaceSpecifier),

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/question/searchfilters/DifferentialSearchFiltersResult.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/question/searchfilters/DifferentialSearchFiltersResult.java
@@ -4,23 +4,24 @@ import java.util.Optional;
 import javax.annotation.Nullable;
 
 /** The result of a differential reachFilter question. */
-public final class DifferentialSearchFilterResult {
-  private final @Nullable SearchFilterResult _decreasedResult;
-  private final @Nullable SearchFilterResult _increasedResult;
+public final class DifferentialSearchFiltersResult {
+  private final @Nullable SearchFiltersResult _decreasedResult;
+  private final @Nullable SearchFiltersResult _increasedResult;
 
-  public DifferentialSearchFilterResult(
-      @Nullable SearchFilterResult increasedResult, @Nullable SearchFilterResult decreasedResult) {
+  public DifferentialSearchFiltersResult(
+      @Nullable SearchFiltersResult increasedResult,
+      @Nullable SearchFiltersResult decreasedResult) {
     _decreasedResult = decreasedResult;
     _increasedResult = increasedResult;
   }
 
   /** @return The result for the decreased space. */
-  public Optional<SearchFilterResult> getDecreasedResult() {
+  public Optional<SearchFiltersResult> getDecreasedResult() {
     return Optional.ofNullable(_decreasedResult);
   }
 
   /** @return The result for the decreased space. */
-  public Optional<SearchFilterResult> getIncreasedResult() {
+  public Optional<SearchFiltersResult> getIncreasedResult() {
     return Optional.ofNullable(_increasedResult);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/question/searchfilters/SearchFiltersResult.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/question/searchfilters/SearchFiltersResult.java
@@ -12,11 +12,11 @@ import org.batfish.datamodel.acl.AclLineMatchExpr;
  * AclLineMatchExpr} and an example flow in the headerspace.
  */
 @ParametersAreNonnullByDefault
-public class SearchFilterResult {
+public class SearchFiltersResult {
   private final @Nullable AclLineMatchExpr _headerSpaceDescription;
   private final Flow _exampleFlow;
 
-  public SearchFilterResult(Flow exampleFlow, @Nullable AclLineMatchExpr headerSpaceDescription) {
+  public SearchFiltersResult(Flow exampleFlow, @Nullable AclLineMatchExpr headerSpaceDescription) {
     _headerSpaceDescription = headerSpaceDescription;
     _exampleFlow = exampleFlow;
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/plugin/IBatfishTestAdapter.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/plugin/IBatfishTestAdapter.java
@@ -43,9 +43,9 @@ import org.batfish.datamodel.questions.smt.RoleQuestion;
 import org.batfish.grammar.BgpTableFormat;
 import org.batfish.grammar.GrammarSettings;
 import org.batfish.question.ReachabilityParameters;
-import org.batfish.question.SearchFilterParameters;
-import org.batfish.question.searchfilters.DifferentialSearchFilterResult;
-import org.batfish.question.searchfilters.SearchFilterResult;
+import org.batfish.question.SearchFiltersParameters;
+import org.batfish.question.searchfilters.DifferentialSearchFiltersResult;
+import org.batfish.question.searchfilters.SearchFiltersResult;
 import org.batfish.referencelibrary.ReferenceLibrary;
 import org.batfish.role.NodeRoleDimension;
 import org.batfish.role.NodeRolesData;
@@ -84,12 +84,12 @@ public class IBatfishTestAdapter implements IBatfish {
   }
 
   @Override
-  public DifferentialSearchFilterResult differentialReachFilter(
+  public DifferentialSearchFiltersResult differentialReachFilter(
       Configuration baseConfig,
       IpAccessList baseAcl,
       Configuration deltaConfig,
       IpAccessList deltaAcl,
-      SearchFilterParameters searchFilterParameters) {
+      SearchFiltersParameters searchFiltersParameters) {
     throw new UnsupportedOperationException();
   }
 
@@ -321,8 +321,8 @@ public class IBatfishTestAdapter implements IBatfish {
   }
 
   @Override
-  public Optional<SearchFilterResult> reachFilter(
-      Configuration node, IpAccessList acl, SearchFilterParameters params) {
+  public Optional<SearchFiltersResult> reachFilter(
+      Configuration node, IpAccessList acl, SearchFiltersParameters params) {
     throw new UnsupportedOperationException();
   }
 

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishSearchFiltersDifferentialTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishSearchFiltersDifferentialTest.java
@@ -22,8 +22,8 @@ import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.UniverseIpSpace;
-import org.batfish.question.SearchFilterParameters;
-import org.batfish.question.searchfilters.DifferentialSearchFilterResult;
+import org.batfish.question.SearchFiltersParameters;
+import org.batfish.question.searchfilters.DifferentialSearchFiltersResult;
 import org.batfish.specifier.ConstantIpSpaceSpecifier;
 import org.batfish.specifier.NameRegexInterfaceLinkLocationSpecifier;
 import org.junit.Before;
@@ -32,7 +32,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 /** Tests of {@link Batfish#differentialReachFilter}. */
-public class BatfishSearchFilterDifferentialTest {
+public class BatfishSearchFiltersDifferentialTest {
   @Rule public TemporaryFolder _tmp = new TemporaryFolder();
 
   private static final String HOSTNAME = "hostname";
@@ -44,7 +44,7 @@ public class BatfishSearchFilterDifferentialTest {
   private Configuration.Builder _cb;
   private Interface.Builder _ib;
   private IpAccessList.Builder _ab;
-  private SearchFilterParameters _params;
+  private SearchFiltersParameters _params;
 
   @Before
   public void setup() {
@@ -56,7 +56,7 @@ public class BatfishSearchFilterDifferentialTest {
     _ib = _nf.interfaceBuilder();
     _ab = _nf.aclBuilder();
     _params =
-        SearchFilterParameters.builder()
+        SearchFiltersParameters.builder()
             .setDestinationIpSpaceSpecifier(new ConstantIpSpaceSpecifier(UniverseIpSpace.INSTANCE))
             .setSourceIpSpaceSpecifier(new ConstantIpSpaceSpecifier(UniverseIpSpace.INSTANCE))
             .setStartLocationSpecifier(ALL_LOCATIONS)
@@ -87,7 +87,7 @@ public class BatfishSearchFilterDifferentialTest {
                         .build()))
             .build();
     Batfish batfish = getBatfish(baseConfig, deltaConfig);
-    DifferentialSearchFilterResult result =
+    DifferentialSearchFiltersResult result =
         batfish.differentialReachFilter(baseConfig, baseAcl, deltaConfig, deltaAcl, _params);
     assertThat("Expected no decreased result", !result.getDecreasedResult().isPresent());
     assertThat("Expected increased result", result.getIncreasedResult().isPresent());
@@ -112,7 +112,7 @@ public class BatfishSearchFilterDifferentialTest {
         _ab.setLines(ImmutableList.of(accepting().setMatchCondition(matchDst(IP)).build())).build();
     Batfish batfish = getBatfish(config, config);
 
-    DifferentialSearchFilterResult result =
+    DifferentialSearchFiltersResult result =
         batfish.differentialReachFilter(config, baseAcl, config, deltaAcl, _params);
     assertThat("Expected no decreased result", !result.getDecreasedResult().isPresent());
     assertThat("Expected increased result", result.getIncreasedResult().isPresent());
@@ -154,14 +154,14 @@ public class BatfishSearchFilterDifferentialTest {
             .build();
 
     Batfish batfish = getBatfish(baseConfig, deltaConfig);
-    SearchFilterParameters params =
+    SearchFiltersParameters params =
         _params
             .toBuilder()
             .setStartLocationSpecifier(new NameRegexInterfaceLinkLocationSpecifier(IFACE1))
             .build();
 
     // can match line 1 because IFACE1 is specified
-    DifferentialSearchFilterResult result =
+    DifferentialSearchFiltersResult result =
         batfish.differentialReachFilter(baseConfig, baseAcl, deltaConfig, deltaAcl, params);
     assertThat("Expected no decreased result", !result.getDecreasedResult().isPresent());
     assertThat("Expected increased result", result.getIncreasedResult().isPresent());

--- a/projects/question/src/main/java/org/batfish/question/searchfilters/SearchFiltersAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/searchfilters/SearchFiltersAnswerer.java
@@ -44,7 +44,7 @@ import org.batfish.datamodel.table.Row.RowBuilder;
 import org.batfish.datamodel.table.TableAnswerElement;
 import org.batfish.datamodel.table.TableDiff;
 import org.batfish.datamodel.table.TableMetadata;
-import org.batfish.question.SearchFilterParameters;
+import org.batfish.question.SearchFiltersParameters;
 import org.batfish.question.testfilters.TestFiltersAnswerer;
 import org.batfish.question.testfilters.TestFiltersQuestion;
 import org.batfish.specifier.FilterSpecifier;
@@ -83,7 +83,7 @@ public final class SearchFiltersAnswerer extends Answerer {
     Multimap<String, String> deltaAcls = getSpecifiedAcls(question);
     _batfish.popEnvironment();
 
-    SearchFilterParameters parameters = question.toReachFilterParameters();
+    SearchFiltersParameters parameters = question.toReachFilterParameters();
 
     TableAnswerElement baseTable =
         toReachFilterTable(
@@ -127,7 +127,7 @@ public final class SearchFiltersAnswerer extends Answerer {
         }
 
         // present in both snapshot
-        DifferentialSearchFilterResult results =
+        DifferentialSearchFiltersResult results =
             _batfish.differentialReachFilter(
                 baseConfig, baseAcl.get(), deltaConfig, deltaAcl.get(), parameters);
 
@@ -224,7 +224,7 @@ public final class SearchFiltersAnswerer extends Answerer {
       String hostname = pair.getFirst();
       Configuration node = configurations.get(hostname);
       IpAccessList acl = pair.getSecond();
-      Optional<SearchFilterResult> optionalResult;
+      Optional<SearchFiltersResult> optionalResult;
       try {
         optionalResult = _batfish.reachFilter(node, acl, question.toReachFilterParameters());
       } catch (Throwable t) {

--- a/projects/question/src/main/java/org/batfish/question/searchfilters/SearchFiltersQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/searchfilters/SearchFiltersQuestion.java
@@ -16,7 +16,7 @@ import org.batfish.common.BatfishException;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.PacketHeaderConstraints;
 import org.batfish.datamodel.questions.Question;
-import org.batfish.question.SearchFilterParameters;
+import org.batfish.question.SearchFiltersParameters;
 import org.batfish.specifier.FilterSpecifier;
 import org.batfish.specifier.FilterSpecifierFactory;
 import org.batfish.specifier.FlexibleFilterSpecifierFactory;
@@ -191,8 +191,8 @@ public final class SearchFiltersQuestion extends Question {
 
   @Nonnull
   @VisibleForTesting
-  SearchFilterParameters toReachFilterParameters() {
-    return SearchFilterParameters.builder()
+  SearchFiltersParameters toReachFilterParameters() {
+    return SearchFiltersParameters.builder()
         .setDestinationIpSpaceSpecifier(getDestinationSpecifier())
         .setGenerateExplanations(_generateExplanations)
         .setHeaderSpace(getHeaderSpace())

--- a/projects/question/src/test/java/org/batfish/question/searchfilters/SearchFiltersQuestionTest.java
+++ b/projects/question/src/test/java/org/batfish/question/searchfilters/SearchFiltersQuestionTest.java
@@ -17,7 +17,7 @@ import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.PacketHeaderConstraints;
 import org.batfish.datamodel.UniverseIpSpace;
-import org.batfish.question.SearchFilterParameters;
+import org.batfish.question.SearchFiltersParameters;
 import org.batfish.question.searchfilters.SearchFiltersQuestion.Type;
 import org.batfish.specifier.IpSpaceAssignment.Entry;
 import org.batfish.specifier.IpSpaceSpecifier;
@@ -45,7 +45,7 @@ public class SearchFiltersQuestionTest {
     assertThat(q.getHeaderSpace().getDstIps(), nullValue());
     assertThat(q.getHeaderSpace().getSrcIps(), nullValue());
     // src/dst IPs are in specifiers at this stage
-    SearchFilterParameters parameters = q.toReachFilterParameters();
+    SearchFiltersParameters parameters = q.toReachFilterParameters();
 
     for (IpSpaceSpecifier s :
         Arrays.asList(


### PR DESCRIPTION
- Fix bazel build
- Be consistent about using the plural form in class names