### PR TITLE
use default throwing implementation inside IBatfishTestAdapter

### DIFF
--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/plugin/IBatfishTestAdapter.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/plugin/IBatfishTestAdapter.java
@@ -50,7 +50,6 @@ import org.batfish.referencelibrary.ReferenceLibrary;
 import org.batfish.role.NodeRoleDimension;
 import org.batfish.role.NodeRolesData;
 import org.batfish.specifier.SpecifierContext;
-import org.batfish.specifier.SpecifierContextImpl;
 
 /**
  * A helper for tests that need an {@link IBatfish} implementation. Extend this and implement the
@@ -418,7 +417,7 @@ public class IBatfishTestAdapter implements IBatfish {
 
   @Override
   public SpecifierContext specifierContext() {
-    return new SpecifierContextImpl(this, this.loadConfigurations());
+    throw new UnsupportedOperationException();
   }
 
   @Override

--- a/projects/question/src/test/java/org/batfish/question/filterlinereachability/FilterLineReachabilityTest.java
+++ b/projects/question/src/test/java/org/batfish/question/filterlinereachability/FilterLineReachabilityTest.java
@@ -48,6 +48,8 @@ import org.batfish.datamodel.acl.MatchSrcInterface;
 import org.batfish.datamodel.acl.PermittedByAcl;
 import org.batfish.datamodel.table.Row;
 import org.batfish.datamodel.table.TableAnswerElement;
+import org.batfish.specifier.SpecifierContext;
+import org.batfish.specifier.SpecifierContextImpl;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -485,6 +487,11 @@ public class FilterLineReachabilityTest {
           @Override
           public SortedMap<String, Configuration> loadConfigurations() {
             return ImmutableSortedMap.of(_c1.getHostname(), _c1, _c2.getHostname(), _c2);
+          }
+
+          @Override
+          public SpecifierContext specifierContext() {
+            return new SpecifierContextImpl(this, this.loadConfigurations());
           }
         };
     FilterLineReachabilityAnswerer answerer = new FilterLineReachabilityAnswerer(q, batfish);


### PR DESCRIPTION
- non-throwing implementation is unexpected
- it is the job of extenders to provide functionality