### PR TITLE
generalize graph edges in BDDReachabilityAnalysis

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/bddreachability/Edge.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/Edge.java
@@ -1,40 +1,42 @@
 package org.batfish.bddreachability;
 
-import java.util.List;
+import java.util.function.Function;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import net.sf.javabdd.BDD;
 import org.batfish.z3.expr.StateExpr;
 
+/** An edge in the graph modeling network behavior. */
+@ParametersAreNonnullByDefault
 final class Edge {
-  final @Nonnull BDD _constraint;
   final @Nonnull StateExpr _postState;
   final @Nonnull StateExpr _preState;
-  final @Nullable List<BDDSourceNat> _sourceNats;
+  final @Nonnull Function<BDD, BDD> _traverseBackward;
+  final @Nonnull Function<BDD, BDD> _traverseForward;
 
-  Edge(@Nonnull StateExpr preState, @Nonnull StateExpr postState, @Nonnull BDD constraint) {
-    _constraint = constraint;
-    _postState = postState;
+  Edge(StateExpr preState, StateExpr postState, BDD constraint) {
     _preState = preState;
-    _sourceNats = null;
+    _postState = postState;
+    _traverseBackward = constraint::and;
+    _traverseForward = constraint::and;
   }
 
   Edge(
-      @Nonnull StateExpr preState,
-      @Nonnull StateExpr postState,
-      @Nonnull BDD constraint,
-      @Nullable List<BDDSourceNat> sourceNats) {
-    _constraint = constraint;
+      StateExpr preState,
+      StateExpr postState,
+      Function<BDD, BDD> traverseBackward,
+      Function<BDD, BDD> traverseForward) {
     _postState = postState;
     _preState = preState;
-    _sourceNats = sourceNats;
+    _traverseBackward = traverseBackward;
+    _traverseForward = traverseForward;
   }
 
-  public @Nonnull BDD getConstraint() {
-    return _constraint;
+  public @Nonnull BDD traverseForward(BDD bdd) {
+    return _traverseForward.apply(bdd);
   }
 
-  public @Nullable List<BDDSourceNat> getSourceNats() {
-    return _sourceNats;
+  public @Nonnull BDD traverseBackward(BDD bdd) {
+    return _traverseBackward.apply(bdd);
   }
 }


### PR DESCRIPTION
Rather than hard-coding two-types of edge (normal constraint edges and
source NAT edges), an edge is now represented as two functions -- one
for traversing forwards and one for backwards.

This will make it easier to add more kinds of transformations (other than source NAT).