### PR TITLE
Probable fix for nondeterministic test failures

### DIFF
--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -712,7 +712,7 @@ public class WorkMgr extends AbstractCoordinator {
       // If either question or question settings are newer than answer, answer is STALE.
       if (answerLastModifiedTime.compareTo(
               ObjectUtils.max(questionLastModifiedTime, questionSettingsLastModifiedTime))
-          <= 0) {
+          < 0) {
         Answer ans = Answer.failureAnswer("Not fresh", null);
         ans.setStatus(AnswerStatus.STALE);
         answer = BatfishObjectMapper.writePrettyString(ans);


### PR DESCRIPTION
Failing test is tests/ui-focused/analysis-answers-after.ref

I *think* the trouble is that the analysis creation is followed so soon by running and fetching the answer that the difference in timestamps is actually 0 (down to hundredths of seconds). Making the answer stale if `creation timestamp < answer timestamp` rather than `creation timestamp <= answer timestamp` seems to fix the issue.