### PR TITLE
BDDSourceManager: share variables among all nodes in the network  

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDSourceManager.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDSourceManager.java
@@ -43,17 +43,17 @@ public final class BDDSourceManager {
 
   private final BDD _falseBDD;
 
-  private final BDD _validValues;
+  private final BDD _isValidValue;
 
   private final Map<String, BDD> _sourceBDDs;
 
   private final BDD _sourceVarBits;
 
-  private BDDSourceManager(BDD validValues, Map<String, BDD> sourceBDDs, BDD sourceVarBits) {
-    _validValues = validValues;
+  private BDDSourceManager(BDD isValidValue, Map<String, BDD> sourceBDDs, BDD sourceVarBits) {
+    _isValidValue = isValidValue;
     _sourceBDDs = ImmutableMap.copyOf(sourceBDDs);
     _sourceVarBits = sourceVarBits;
-    _falseBDD = validValues.getFactory().zero();
+    _falseBDD = isValidValue.getFactory().zero();
   }
 
   private static BDDSourceManager forNoReferencedSources(
@@ -269,7 +269,7 @@ public final class BDDSourceManager {
    */
   public Optional<String> getSourceFromAssignment(BDD bdd) {
     checkArgument(isAssignment(bdd));
-    checkArgument(bdd.imp(_validValues).isOne());
+    checkArgument(bdd.imp(_isValidValue).isOne());
 
     // not tracking any sources, so we can the arbitrarily choose the device
     if (_sourceBDDs.isEmpty()) {
@@ -291,8 +291,8 @@ public final class BDDSourceManager {
    * @return A constraint that the source variable is assigned one of the valid values for this
    *     device.
    */
-  public BDD validValues() {
-    return _validValues;
+  public BDD isValidValue() {
+    return _isValidValue;
   }
 
   /** Existentially quantify the source variable. */

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDSourceManagerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDSourceManagerTest.java
@@ -54,7 +54,7 @@ public class BDDSourceManagerTest {
                 mgr.getSourceInterfaceBDD(IFACE1),
                 mgr.getSourceInterfaceBDD(IFACE2))
             .not();
-    MatcherAssert.assertThat(mgr.isSane().and(noSource), BDDMatchers.isZero());
+    MatcherAssert.assertThat(mgr.validValues().and(noSource), BDDMatchers.isZero());
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDSourceManagerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDSourceManagerTest.java
@@ -8,9 +8,9 @@ import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrcInterface;
 import static org.batfish.datamodel.acl.SourcesReferencedByIpAccessLists.SOURCE_ORIGINATING_FROM_DEVICE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.util.Map;
 import java.util.Optional;
@@ -22,73 +22,112 @@ import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.NetworkFactory;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.Test;
 
 public class BDDSourceManagerTest {
   private static final String IFACE1 = "iface1";
-
   private static final String IFACE2 = "iface2";
+  private static final String IFACE3 = "iface3";
+  private static final String IFACE4 = "iface4";
 
-  private static final Set<String> IFACES = ImmutableSet.of(IFACE1, IFACE2);
+  private static final Set<String> IFACES_1_2 = ImmutableSet.of(IFACE1, IFACE2);
 
-  BDDPacket _pkt = new BDDPacket();
-
-  BDDSourceManager _mgr = BDDSourceManager.forInterfaces(_pkt, IFACES);
+  private BDDPacket _pkt = new BDDPacket();
 
   @Test
   public void test() {
-    BDD deviceBDD = _mgr.getOriginatingFromDeviceBDD();
-    BDD bdd1 = _mgr.getSourceInterfaceBDD(IFACE1);
-    BDD bdd2 = _mgr.getSourceInterfaceBDD(IFACE2);
-    assertThat(_mgr.getSourceFromAssignment(bdd1), equalTo(Optional.of(IFACE1)));
-    assertThat(_mgr.getSourceFromAssignment(bdd2), equalTo(Optional.of(IFACE2)));
-    assertThat(_mgr.getSourceFromAssignment(deviceBDD), equalTo(Optional.empty()));
+    BDDSourceManager mgr = BDDSourceManager.forInterfaces(_pkt, IFACES_1_2);
+    BDD deviceBDD = mgr.getOriginatingFromDeviceBDD();
+    BDD bdd1 = mgr.getSourceInterfaceBDD(IFACE1);
+    BDD bdd2 = mgr.getSourceInterfaceBDD(IFACE2);
+    assertThat(mgr.getSourceFromAssignment(bdd1), equalTo(Optional.of(IFACE1)));
+    assertThat(mgr.getSourceFromAssignment(bdd2), equalTo(Optional.of(IFACE2)));
+    assertThat(mgr.getSourceFromAssignment(deviceBDD), equalTo(Optional.empty()));
   }
 
   @Test
   public void testSane() {
+    BDDSourceManager mgr = BDDSourceManager.forInterfaces(_pkt, IFACES_1_2);
     BDD noSource =
         orNull(
-                _mgr.getOriginatingFromDeviceBDD(),
-                _mgr.getSourceInterfaceBDD(IFACE1),
-                _mgr.getSourceInterfaceBDD(IFACE2))
+                mgr.getOriginatingFromDeviceBDD(),
+                mgr.getSourceInterfaceBDD(IFACE1),
+                mgr.getSourceInterfaceBDD(IFACE2))
             .not();
-    MatcherAssert.assertThat(_mgr.isSane().and(noSource), BDDMatchers.isZero());
+    MatcherAssert.assertThat(mgr.isSane().and(noSource), BDDMatchers.isZero());
   }
 
   @Test
-  public void testForIpAccessList() {
-    NetworkFactory nf = new NetworkFactory();
+  public void testNoReferencedSources() {
+    BDDSourceManager mgr = BDDSourceManager.forSources(_pkt, IFACES_1_2, ImmutableSet.of());
+    BDD one = _pkt.getFactory().one();
+    assertThat(mgr.getSourceBDDs(), equalTo(ImmutableMap.of(IFACE1, one, IFACE2, one)));
+  }
+
+  private static Configuration configWithOneAcl(NetworkFactory nf) {
     Configuration config =
         nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS).build();
     Interface.Builder ib = nf.interfaceBuilder().setOwner(config);
     ib.setName(IFACE1).build();
     ib.setName(IFACE2).build();
-    String iface3 = "iface3";
-    ib.setName(iface3).build();
-    String iface4 = "iface4";
-    ib.setName(iface4).setActive(false).build();
+    ib.setName(IFACE3).build();
+    ib.setName(IFACE4).setActive(false).build();
 
     // an ACL that can only match with an IFACE2 or iface3
     IpAccessList acl =
         IpAccessList.builder()
             .setName("acl")
+            .setOwner(config)
             .setLines(
                 ImmutableList.of(
                     accepting().setMatchCondition(matchSrcInterface(IFACE1)).build(),
-                    rejecting().setMatchCondition(matchSrcInterface(iface4)).build(),
+                    rejecting().setMatchCondition(matchSrcInterface(IFACE4)).build(),
                     ACCEPT_ALL))
             .build();
+    return config;
+  }
+
+  @Test
+  public void testForIpAccessList() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration config = configWithOneAcl(nf);
+    IpAccessList acl = config.getIpAccessLists().values().iterator().next();
 
     BDDSourceManager mgr = BDDSourceManager.forIpAccessList(_pkt, config, acl);
     Map<String, BDD> srcBDDs = mgr.getSourceBDDs();
-    assertThat(srcBDDs.entrySet(), hasSize(2));
-    MatcherAssert.assertThat(
-        srcBDDs, Matchers.hasEntry(equalTo(IFACE1), Matchers.not(BDDMatchers.isZero())));
-    MatcherAssert.assertThat(
-        srcBDDs,
-        Matchers.hasEntry(
-            equalTo(SOURCE_ORIGINATING_FROM_DEVICE), Matchers.not(BDDMatchers.isZero())));
+    assertThat(
+        srcBDDs.keySet(),
+        equalTo(ImmutableSet.of(IFACE1, IFACE2, IFACE3, SOURCE_ORIGINATING_FROM_DEVICE)));
+
+    BDD iface1BDD = srcBDDs.get(IFACE1);
+    BDD iface2BDD = srcBDDs.get(IFACE2);
+    BDD iface3BDD = srcBDDs.get(IFACE3);
+    BDD origBDD = srcBDDs.get(SOURCE_ORIGINATING_FROM_DEVICE);
+
+    assertThat("BDDs for IFACE1 and IFACE2 should be different", !iface1BDD.equals(iface2BDD));
+    assertThat(
+        "BDDs for all sources other than IFACE1 should be the same",
+        iface2BDD.equals(iface3BDD) && iface3BDD.equals(origBDD));
+  }
+
+  @Test
+  public void testForNetwork() {
+    /*
+     * Create a network with two configs. Both have two interfaces and
+     */
+    NetworkFactory nf = new NetworkFactory();
+    Configuration config1 = configWithOneAcl(nf);
+    Configuration config2 = configWithOneAcl(nf);
+    Map<String, Configuration> network =
+        ImmutableMap.of(config1.getHostname(), config1, config2.getHostname(), config2);
+
+    Map<String, BDDSourceManager> bddSourceManagers = BDDSourceManager.forNetwork(_pkt, network);
+    BDDSourceManager mgr1 = bddSourceManagers.get(config1.getHostname());
+    BDDSourceManager mgr2 = bddSourceManagers.get(config2.getHostname());
+
+    /*
+     * The two managers use the same BDD values to track sources.
+     */
+    assertThat(mgr1.getSourceBDDs().values(), equalTo(mgr2.getSourceBDDs().values()));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDSourceManagerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDSourceManagerTest.java
@@ -74,16 +74,15 @@ public class BDDSourceManagerTest {
     ib.setName(IFACE4).setActive(false).build();
 
     // an ACL that can only match with an IFACE2 or iface3
-    IpAccessList acl =
-        IpAccessList.builder()
-            .setName("acl")
-            .setOwner(config)
-            .setLines(
-                ImmutableList.of(
-                    accepting().setMatchCondition(matchSrcInterface(IFACE1)).build(),
-                    rejecting().setMatchCondition(matchSrcInterface(IFACE4)).build(),
-                    ACCEPT_ALL))
-            .build();
+    IpAccessList.builder()
+        .setName("acl")
+        .setOwner(config)
+        .setLines(
+            ImmutableList.of(
+                accepting().setMatchCondition(matchSrcInterface(IFACE1)).build(),
+                rejecting().setMatchCondition(matchSrcInterface(IFACE4)).build(),
+                ACCEPT_ALL))
+        .build();
     return config;
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDSourceManagerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDSourceManagerTest.java
@@ -54,7 +54,7 @@ public class BDDSourceManagerTest {
                 mgr.getSourceInterfaceBDD(IFACE1),
                 mgr.getSourceInterfaceBDD(IFACE2))
             .not();
-    MatcherAssert.assertThat(mgr.validValues().and(noSource), BDDMatchers.isZero());
+    MatcherAssert.assertThat(mgr.isValidValue().and(noSource), BDDMatchers.isZero());
   }
 
   @Test

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -4076,13 +4076,13 @@ public class Batfish extends PluginConsumer implements IBatfish {
                 bddPacket, baseAcl, baseConfig.getIpAccessLists(), baseConfig.getIpSpaces(), mgr)
             .getBdd()
             .and(headerSpaceBDD)
-            .and(mgr.validValues());
+            .and(mgr.isValidValue());
     BDD deltaAclBDD =
         BDDAcl.create(
                 bddPacket, deltaAcl, deltaConfig.getIpAccessLists(), deltaConfig.getIpSpaces(), mgr)
             .getBdd()
             .and(headerSpaceBDD)
-            .and(mgr.validValues());
+            .and(mgr.isValidValue());
 
     String hostname = baseConfig.getHostname();
 
@@ -4209,7 +4209,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
         BDDAcl.create(bddPacket, acl, node.getIpAccessLists(), node.getIpSpaces(), mgr)
             .getBdd()
             .and(headerSpaceBDD)
-            .and(mgr.validValues());
+            .and(mgr.isValidValue());
 
     return getFlow(bddPacket, mgr, node.getHostname(), bdd)
         .map(

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -4076,13 +4076,13 @@ public class Batfish extends PluginConsumer implements IBatfish {
                 bddPacket, baseAcl, baseConfig.getIpAccessLists(), baseConfig.getIpSpaces(), mgr)
             .getBdd()
             .and(headerSpaceBDD)
-            .and(mgr.isSane());
+            .and(mgr.validValues());
     BDD deltaAclBDD =
         BDDAcl.create(
                 bddPacket, deltaAcl, deltaConfig.getIpAccessLists(), deltaConfig.getIpSpaces(), mgr)
             .getBdd()
             .and(headerSpaceBDD)
-            .and(mgr.isSane());
+            .and(mgr.validValues());
 
     String hostname = baseConfig.getHostname();
 
@@ -4209,7 +4209,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
         BDDAcl.create(bddPacket, acl, node.getIpAccessLists(), node.getIpSpaces(), mgr)
             .getBdd()
             .and(headerSpaceBDD)
-            .and(mgr.isSane());
+            .and(mgr.validValues());
 
     return getFlow(bddPacket, mgr, node.getHostname(), bdd)
         .map(


### PR DESCRIPTION
Add a factory method that builds multiple BDDSourceManagers, one per  node in the network, but all backed by the same BDD variables. This is going to be used by BDDReachabilityAnalysis