### PR TITLE
Cisco: support icmp v4 ACL packet-too-big

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -5085,6 +5085,9 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
         } else if (feature.NET_UNREACHABLE() != null) {
           icmpType = IcmpType.DESTINATION_UNREACHABLE;
           icmpCode = IcmpCode.NETWORK_UNREACHABLE;
+        } else if (feature.PACKET_TOO_BIG() != null) {
+          icmpType = IcmpType.DESTINATION_UNREACHABLE;
+          icmpCode = IcmpCode.FRAGMENTATION_NEEDED;
         } else if (feature.PARAMETER_PROBLEM() != null) {
           icmpType = IcmpType.PARAMETER_PROBLEM;
         } else if (feature.PORT_UNREACHABLE() != null) {

--- a/tests/parsing-tests/networks/unit-tests/configs/cisco_acl
+++ b/tests/parsing-tests/networks/unit-tests/configs/cisco_acl
@@ -2,7 +2,7 @@
 hostname cisco_acl
 !
 ip access-list BLAH-BLAH
-   10 permit icmp any any
+   10 permit icmp any any packet-too-big
    20 permit ip any any tracked
    30 permit ospf any any
    40 permit tcp any any eq bgp

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -4435,6 +4435,12 @@
                       "class" : "org.batfish.datamodel.IpWildcardIpSpace",
                       "ipWildcard" : "0.0.0.0/0"
                     },
+                    "icmpCodes" : [
+                      "4-4"
+                    ],
+                    "icmpTypes" : [
+                      "3-3"
+                    ],
                     "ipProtocols" : [
                       "ICMP"
                     ],
@@ -4445,7 +4451,7 @@
                     }
                   }
                 },
-                "name" : "10 permit icmp any any"
+                "name" : "10 permit icmp any any packet-too-big"
               },
               {
                 "action" : "PERMIT",

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -13048,6 +13048,8 @@
             "          ANY:'any'  <== mode:DEFAULT_MODE)",
             "        dstipr = (access_list_ip_range",
             "          ANY:'any'  <== mode:DEFAULT_MODE)",
+            "        (extended_access_list_additional_feature",
+            "          PACKET_TOO_BIG:'packet-too-big'  <== mode:DEFAULT_MODE)",
             "        NEWLINE:'\\n'  <== mode:DEFAULT_MODE)",
             "      (extended_access_list_tail",
             "        num = DEC:'20'  <== mode:DEFAULT_MODE",


### PR DESCRIPTION
Even though this is now an IPv6 code, this is an old v4 flag that means
fragmentation needed but DF bit set.