### PR TITLE
Track packet sources in BDDReachabilityAnalysis

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDSourceManager.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDSourceManager.java
@@ -176,7 +176,15 @@ public final class BDDSourceManager {
                     activeEntry.getValue(), referencedSources.get(activeEntry.getKey())));
 
     // Number of values needed to track sources in any node
-    int valuesNeeded = activeAndReferenced.values().stream().mapToInt(Set::size).max().orElse(0);
+    int valuesNeeded =
+        activeAndReferenced
+            .keySet()
+            .stream()
+            .mapToInt(
+                node ->
+                    valuesRequired(activeAndReferenced.get(node), activeButNotReferenced.get(node)))
+            .max()
+            .orElse(0);
 
     if (valuesNeeded == 0) {
       return toImmutableMap(
@@ -234,7 +242,7 @@ public final class BDDSourceManager {
         LongMath.log2(
             valuesRequired(activeAndReferenced, activeButUnreferenced), RoundingMode.CEILING);
     checkArgument(
-        sourceVar.getBitvec().length <= bitsRequired,
+        bitsRequired <= sourceVar.getBitvec().length,
         "sourceVar not big enough to track active and referenced sources");
 
     ImmutableMap.Builder<String, BDD> matchSrcBDDs = ImmutableMap.builder();

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
@@ -15,6 +15,8 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import net.sf.javabdd.BDD;
 import org.batfish.common.bdd.BDDPacket;
+import org.batfish.common.bdd.BDDSourceManager;
+import org.batfish.common.bdd.IpAccessListToBDD;
 import org.batfish.common.bdd.IpSpaceToBDD;
 import org.batfish.common.util.CommonUtil;
 import org.batfish.datamodel.Configuration;
@@ -27,7 +29,6 @@ import org.batfish.specifier.InterfaceLocation;
 import org.batfish.specifier.IpSpaceAssignment;
 import org.batfish.specifier.Location;
 import org.batfish.specifier.LocationVisitor;
-import org.batfish.symbolic.bdd.BDDAcl;
 import org.batfish.z3.expr.StateExpr;
 import org.batfish.z3.state.Accept;
 import org.batfish.z3.state.Drop;
@@ -54,13 +55,22 @@ import org.batfish.z3.state.PreOutVrf;
  * provides two methods for constructing {@link BDDReachabilityAnalysis}, depending on whether or
  * not you have a destination Ip constraint.
  *
- * <p>The core of the implementation is the {@link BDDReachabilityAnalysisFactory#generateRules()}
+ * <p>The core of the implementation is the {@link BDDReachabilityAnalysisFactory#generateEdges()}
  * method and its many helpers, which generate the {@link StateExpr nodes} and {@link Edge edges} of
  * the reachability graph. Each node represents a step of the routing process within some network
  * device or between devices. The edges represent the flow of traffic between these steps. Each edge
  * is labeled with a {@link BDD} that represents the set of packets that can traverse that edge. If
  * the edge represents a source NAT, the edge will be labeled with the NAT rules (match conditions
  * and set of pool IPs).
+ *
+ * <p>To support {@link org.batfish.datamodel.acl.MatchSrcInterface} and {@link
+ * org.batfish.datamodel.acl.OriginatingFromDevice} {@link
+ * org.batfish.datamodel.acl.AclLineMatchExpr ACL expressions}, we maintain the invariant that
+ * whenever a packet is inside a node, it has a valid source (according to the BDDSourceManager of
+ * that node). For forward edges this is established by constraining to a single source. For
+ * backward edges it's established using {@link BDDSourceManager#isValidValue}. When we exit the
+ * node (e.g. forward into another node or a disposition state, or backward into another node or an
+ * origination state), we erase the contraint on source by existential quantification.
  */
 public final class BDDReachabilityAnalysisFactory {
   // node name --> acl name --> set of packets denied by the acl.
@@ -82,11 +92,10 @@ public final class BDDReachabilityAnalysisFactory {
    */
   private final BDDPacket _bddPacket;
 
+  private final Map<String, BDDSourceManager> _bddSourceManagers;
+
   // node name -> node
   private final Map<String, Configuration> _configs;
-
-  // preState --> postState --> edge.
-  private final Map<StateExpr, Map<StateExpr, Edge>> _edges;
 
   private final ForwardingAnalysis _forwardingAnalysis;
 
@@ -114,11 +123,12 @@ public final class BDDReachabilityAnalysisFactory {
   public BDDReachabilityAnalysisFactory(
       BDDPacket packet, Map<String, Configuration> configs, ForwardingAnalysis forwardingAnalysis) {
     _bddPacket = packet;
+    _bddSourceManagers = BDDSourceManager.forNetwork(_bddPacket, configs);
     _configs = configs;
     _forwardingAnalysis = forwardingAnalysis;
     _dstIpSpaceToBDD = new IpSpaceToBDD(_bddPacket.getFactory(), _bddPacket.getDstIp());
 
-    Map<String, Map<String, BDDAcl>> bddAcls = computeBDDAcls(_bddPacket, configs);
+    Map<String, Map<String, BDD>> bddAcls = computeAclBDDs(_bddPacket, _bddSourceManagers, configs);
     _aclDenyBDDs = computeAclDenyBDDs(bddAcls);
     _aclPermitBDDs = computeAclPermitBDDs(bddAcls);
 
@@ -131,58 +141,54 @@ public final class BDDReachabilityAnalysisFactory {
     _sourceIpVars =
         Arrays.stream(_bddPacket.getSrcIp().getBitvec())
             .reduce(_bddPacket.getFactory().one(), BDD::and);
-
-    _edges = computeEdges();
   }
 
-  private static Map<String, Map<String, BDDAcl>> computeBDDAcls(
-      BDDPacket bddPacket, Map<String, Configuration> configs) {
+  private static Map<String, Map<String, BDD>> computeAclBDDs(
+      BDDPacket bddPacket,
+      Map<String, BDDSourceManager> bddSourceManagers,
+      Map<String, Configuration> configs) {
     return toImmutableMap(
         configs,
         Entry::getKey,
-        nodeEntry ->
-            toImmutableMap(
-                nodeEntry.getValue().getIpAccessLists(),
-                Entry::getKey,
-                aclEntry ->
-                    BDDAcl.create(
-                        bddPacket,
-                        aclEntry.getValue(),
-                        nodeEntry.getValue().getIpAccessLists(),
-                        nodeEntry.getValue().getIpSpaces())));
+        nodeEntry -> {
+          Configuration config = nodeEntry.getValue();
+          IpAccessListToBDD aclToBdd =
+              IpAccessListToBDD.create(
+                  bddPacket,
+                  bddSourceManagers.get(config.getHostname()),
+                  config.getIpAccessLists(),
+                  config.getIpSpaces());
+          return toImmutableMap(
+              config.getIpAccessLists(),
+              Entry::getKey,
+              aclEntry -> aclToBdd.toBdd(aclEntry.getValue()));
+        });
   }
 
   private static Map<String, Map<String, BDD>> computeAclDenyBDDs(
-      Map<String, Map<String, BDDAcl>> aclBDDs) {
+      Map<String, Map<String, BDD>> aclBDDs) {
     return toImmutableMap(
         aclBDDs,
         Entry::getKey,
         nodeEntry ->
             toImmutableMap(
-                nodeEntry.getValue(),
-                Entry::getKey,
-                aclEntry -> aclEntry.getValue().getBdd().not()));
+                nodeEntry.getValue(), Entry::getKey, aclEntry -> aclEntry.getValue().not()));
   }
 
   private static Map<String, Map<String, BDD>> computeAclPermitBDDs(
-      Map<String, Map<String, BDDAcl>> aclBDDs) {
+      Map<String, Map<String, BDD>> aclBDDs) {
     return toImmutableMap(
         aclBDDs,
         Entry::getKey,
-        nodeEntry ->
-            toImmutableMap(
-                nodeEntry.getValue(), Entry::getKey, aclEntry -> aclEntry.getValue().getBdd()));
+        nodeEntry -> toImmutableMap(nodeEntry.getValue(), Entry::getKey, Entry::getValue));
   }
 
-  private Map<StateExpr, Map<StateExpr, Edge>> computeEdges() {
+  private static Map<StateExpr, Map<StateExpr, Edge>> computeEdges(Stream<Edge> edgeStream) {
     Map<StateExpr, Map<StateExpr, Edge>> edges = new HashMap<>();
 
-    generateRules()
-        .forEach(
-            edge ->
-                edges
-                    .computeIfAbsent(edge._preState, k -> new HashMap<>())
-                    .put(edge._postState, edge));
+    edgeStream.forEach(
+        edge ->
+            edges.computeIfAbsent(edge._preState, k -> new HashMap<>()).put(edge._postState, edge));
 
     // freeze
     return toImmutableMap(
@@ -245,7 +251,61 @@ public final class BDDReachabilityAnalysisFactory {
                         ifaceEntry -> ifaceEntry.getValue().accept(ipSpaceToBDD))));
   }
 
-  private Stream<Edge> generateRules() {
+  private Stream<Edge> generateRootEdges(Map<StateExpr, BDD> rootBdds) {
+    return Streams.concat(
+        generateRootEdges_OriginateInterfaceLink_PreInInterface(rootBdds),
+        generateRootEdges_OriginateVrf_PostInVrf(rootBdds));
+  }
+
+  private Stream<Edge> generateRootEdges_OriginateInterfaceLink_PreInInterface(
+      Map<StateExpr, BDD> rootBdds) {
+    return rootBdds
+        .entrySet()
+        .stream()
+        .filter(entry -> entry.getKey() instanceof OriginateInterfaceLink)
+        .map(
+            entry -> {
+              OriginateInterfaceLink originateInterfaceLink =
+                  (OriginateInterfaceLink) entry.getKey();
+              String hostname = originateInterfaceLink.getHostname();
+              String iface = originateInterfaceLink.getIface();
+              PreInInterface preInInterface = new PreInInterface(hostname, iface);
+
+              BDD rootBdd = entry.getValue();
+              BDD sourceConstraint = _bddSourceManagers.get(hostname).getSourceInterfaceBDD(iface);
+              BDD constraint = rootBdd.and(sourceConstraint);
+              return new Edge(
+                  originateInterfaceLink,
+                  preInInterface,
+                  eraseSourceAfter(constraint, hostname),
+                  constraint::and);
+            });
+  }
+
+  private Stream<Edge> generateRootEdges_OriginateVrf_PostInVrf(Map<StateExpr, BDD> rootBdds) {
+    return rootBdds
+        .entrySet()
+        .stream()
+        .filter(entry -> entry.getKey() instanceof OriginateVrf)
+        .map(
+            entry -> {
+              OriginateVrf originateVrf = (OriginateVrf) entry.getKey();
+              String hostname = originateVrf.getHostname();
+              String vrf = originateVrf.getVrf();
+              PostInVrf postInVrf = new PostInVrf(hostname, vrf);
+              BDD rootBdd = entry.getValue();
+              BDD sourceConstraint = _bddSourceManagers.get(hostname).getOriginatingFromDeviceBDD();
+              BDD constraint = rootBdd.and(sourceConstraint);
+              return new Edge(
+                  originateVrf, postInVrf, eraseSourceAfter(constraint, hostname), constraint::and);
+            });
+  }
+
+  /*
+   * These edges do not depend on the query. Compute them separately so that we can later cache them
+   * across queries if we want to.
+   */
+  private Stream<Edge> generateEdges() {
     return Streams.concat(
         generateRules_NodeAccept_Accept(),
         generateRules_NodeDropAclIn_NodeDrop(),
@@ -356,7 +416,10 @@ public final class BDDReachabilityAnalysisFactory {
                           String vrf = vrfEntry.getKey();
                           BDD acceptBDD = vrfEntry.getValue();
                           return new Edge(
-                              new PostInVrf(node, vrf), new NodeAccept(node), acceptBDD);
+                              new PostInVrf(node, vrf),
+                              new NodeAccept(node),
+                              validSource(acceptBDD, node),
+                              eraseSourceAfter(acceptBDD, node));
                         }));
   }
 
@@ -376,10 +439,12 @@ public final class BDDReachabilityAnalysisFactory {
                           String vrf = vrfEntry.getKey();
                           BDD notAcceptBDD = vrfEntry.getValue();
                           BDD notRoutableBDD = _routableBDDs.get(node).get(vrf).not();
+                          BDD edgeBdd = notAcceptBDD.and(notRoutableBDD);
                           return new Edge(
                               new PostInVrf(node, vrf),
                               new NodeDropNoRoute(node),
-                              notAcceptBDD.and(notRoutableBDD));
+                              validSource(edgeBdd, node),
+                              eraseSourceAfter(edgeBdd, node));
                         }));
   }
 
@@ -416,14 +481,17 @@ public final class BDDReachabilityAnalysisFactory {
         .flatMap(vrf -> vrf.getInterfaces().values().stream())
         .filter(iface -> iface.getIncomingFilter() != null)
         .map(
-            iface -> {
-              String aclName = iface.getIncomingFilterName();
-              String nodeName = iface.getOwner().getHostname();
-              String ifaceName = iface.getName();
+            i -> {
+              String acl = i.getIncomingFilterName();
+              String node = i.getOwner().getHostname();
+              String iface = i.getName();
 
-              BDD aclDenyBDD = _aclDenyBDDs.get(nodeName).get(aclName);
+              BDD aclDenyBDD = _aclDenyBDDs.get(node).get(acl);
               return new Edge(
-                  new PreInInterface(nodeName, ifaceName), new NodeDropAclIn(nodeName), aclDenyBDD);
+                  new PreInInterface(node, iface),
+                  new NodeDropAclIn(node),
+                  validSource(aclDenyBDD, node),
+                  eraseSourceAfter(aclDenyBDD, node));
             });
   }
 
@@ -524,7 +592,8 @@ public final class BDDReachabilityAnalysisFactory {
                       new Edge(
                           new PreOutEdgePostNat(node1, iface1, node2, iface2),
                           new NodeDropAclOut(node1),
-                          aclDenyBDD))
+                          validSource(aclDenyBDD, node1),
+                          eraseSourceAfter(aclDenyBDD, node1)))
                   : Stream.of();
             });
   }
@@ -552,7 +621,8 @@ public final class BDDReachabilityAnalysisFactory {
               return new Edge(
                   new PreOutEdgePostNat(node1, iface1, node2, iface2),
                   new PreInInterface(node2, iface2),
-                  aclPermitBDD);
+                  preInInterfaceBackward(aclPermitBDD, node1, node2, iface2),
+                  preInInterfaceForward(aclPermitBDD, node2, iface2));
             });
   }
 
@@ -573,7 +643,10 @@ public final class BDDReachabilityAnalysisFactory {
                           String vrf = vrfEntry.getKey();
                           BDD nullRoutedBDD = vrfEntry.getValue().accept(_dstIpSpaceToBDD);
                           return new Edge(
-                              new PreOutVrf(node, vrf), new NodeDropNullRoute(node), nullRoutedBDD);
+                              new PreOutVrf(node, vrf),
+                              new NodeDropNullRoute(node),
+                              nullRoutedBDD::and,
+                              eraseSourceAfter(nullRoutedBDD, node));
                         }));
   }
 
@@ -609,10 +682,12 @@ public final class BDDReachabilityAnalysisFactory {
                                       outAcl == null
                                           ? _bddPacket.getFactory().one()
                                           : _aclPermitBDDs.get(node).get(outAcl);
+                                  BDD edgeBdd = ipSpaceBDD.and(outAclBDD);
                                   return new Edge(
                                       new PreOutVrf(node, vrf),
                                       new NodeInterfaceNeighborUnreachable(node, iface),
-                                      ipSpaceBDD.and(outAclBDD));
+                                      edgeBdd::and,
+                                      eraseSourceAfter(edgeBdd, node));
                                 });
                       });
             });
@@ -684,7 +759,10 @@ public final class BDDReachabilityAnalysisFactory {
       }
     }
 
-    return new BDDReachabilityAnalysis(_bddPacket, roots, _edges);
+    Map<StateExpr, Map<StateExpr, Edge>> edges =
+        computeEdges(Stream.concat(generateEdges(), generateRootEdges(roots)));
+
+    return new BDDReachabilityAnalysis(_bddPacket, roots, edges);
   }
 
   private String ifaceVrf(String node, String iface) {
@@ -705,6 +783,52 @@ public final class BDDReachabilityAnalysisFactory {
                 nodeEntry.getValue(),
                 Entry::getKey,
                 vrfEntry -> vrfEntry.getValue().accept(ipSpaceToBDD)));
+  }
+
+  /*
+   * Used for backward edges from disposition states into the router.
+   */
+  private Function<BDD, BDD> validSource(BDD constraint, String node) {
+    return _bddSourceManagers.get(node).isValidValue().and(constraint)::and;
+  }
+
+  /*
+   * Whenever the packet is inside the router, we track its source in the source variable. We erase
+   * the variable when the packet is sent to another router (in which case it is immediately reset
+   * to a new value for the other router), or when the flow stops (enters some state related to a
+   * disposition), in which case the value is left undefined. This method is used in the latter
+   * (flow stops) case.
+   */
+  private Function<BDD, BDD> eraseSourceAfter(BDD constraint, String node) {
+    BDDSourceManager mgr = _bddSourceManagers.get(node);
+    // check the constraint (which may reference the source), then erase the source by existential
+    // quantification
+    return orig -> mgr.existsSource(orig.and(constraint));
+  }
+
+  private Function<BDD, BDD> preInInterfaceForward(BDD constraint, String node, String iface) {
+    BDDSourceManager mgr = _bddSourceManagers.get(node);
+    BDD ifaceBdd = mgr.getSourceInterfaceBDD(iface);
+    // 1. apply the constraint
+    // 2. existentially quantify away the previous node's source,
+    // 3. add the next node's source constraint.
+    return orig -> mgr.existsSource(orig.and(constraint)).and(ifaceBdd);
+  }
+
+  private Function<BDD, BDD> preInInterfaceBackward(
+      BDD constraint, String exitNode, String enterNode, String enterIface) {
+    BDD exitNodeValidSource = _bddSourceManagers.get(exitNode).isValidValue();
+    BDDSourceManager enterSrcMgr = _bddSourceManagers.get(enterNode);
+    BDD ifaceBdd = enterSrcMgr.getSourceInterfaceBDD(enterIface);
+    BDD exitNodeBdd = constraint.and(exitNodeValidSource);
+
+    // 3. add the next node's source constraint.
+    // 2. existentially quantify away the previous node's source,
+    // 1. constrain the source variable to be a valid value for the exit node and apply the
+    //    constraint
+    return exitNodeBdd.isZero()
+        ? orig -> _bddPacket.getFactory().zero()
+        : orig -> enterSrcMgr.existsSource(orig.and(ifaceBdd)).and(exitNodeBdd);
   }
 
   private Function<BDD, BDD> sourceNatForwardEdge(List<BDDSourceNat> sourceNats) {
@@ -743,7 +867,11 @@ public final class BDDReachabilityAnalysisFactory {
     };
   }
 
-  public Map<StateExpr, Map<StateExpr, Edge>> getEdges() {
-    return _edges;
+  public Map<String, BDDSourceManager> getBDDSourceManagers() {
+    return _bddSourceManagers;
+  }
+
+  public Map<String, Map<String, Map<String, BDD>>> getNeighborUnreachableBDDs() {
+    return _neighborUnreachableBDDs;
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactorySourcesTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactorySourcesTest.java
@@ -1,0 +1,199 @@
+package org.batfish.bddreachability;
+
+import static org.batfish.bddreachability.TestNetworkSources.CONFIG_NAME;
+import static org.batfish.bddreachability.TestNetworkSources.INGRESS_IFACE_NAME;
+import static org.batfish.bddreachability.TestNetworkSources.MATCH_SRC_INTERFACE_ACL_IFACE_NAME;
+import static org.batfish.bddreachability.TestNetworkSources.ORIGINATING_FROM_DEVICE_ACL_IFACE_NAME;
+import static org.batfish.bddreachability.TestNetworkSources.PEER_IFACE_NAME;
+import static org.batfish.bddreachability.TestNetworkSources.PEER_NAME;
+import static org.batfish.bddreachability.TestNetworkSources.VRF_NAME;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.SortedMap;
+import net.sf.javabdd.BDD;
+import org.batfish.common.bdd.BDDPacket;
+import org.batfish.common.bdd.BDDSourceManager;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.DataPlane;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.UniverseIpSpace;
+import org.batfish.main.Batfish;
+import org.batfish.main.BatfishTestUtils;
+import org.batfish.specifier.InterfaceLinkLocation;
+import org.batfish.specifier.InterfaceLocation;
+import org.batfish.specifier.IpSpaceAssignment;
+import org.batfish.z3.expr.StateExpr;
+import org.batfish.z3.state.NodeAccept;
+import org.batfish.z3.state.NodeInterfaceNeighborUnreachable;
+import org.batfish.z3.state.OriginateInterfaceLink;
+import org.batfish.z3.state.OriginateVrf;
+import org.batfish.z3.state.PostInVrf;
+import org.batfish.z3.state.PreInInterface;
+import org.batfish.z3.state.PreOutEdgePostNat;
+import org.batfish.z3.state.PreOutVrf;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Tests source tracking (for ACLs that use {@link org.batfish.datamodel.acl.MatchSrcInterface} and
+ * {@link org.batfish.datamodel.acl.OriginatingFromDevice} expressions).
+ */
+public class BDDReachabilityAnalysisFactorySourcesTest {
+  @ClassRule public static TemporaryFolder temp = new TemporaryFolder();
+
+  private static final BDDPacket pkt = new BDDPacket();
+  private static Map<StateExpr, Map<StateExpr, Edge>> edges;
+  private static BDDReachabilityAnalysisFactory factory;
+  private static BDD ingressIfaceSrcIpBdd;
+  private static BDD matchSrcInterfaceBdd;
+  private static BDD originatingFromDeviceSrcIpBdd;
+  private static BDD one;
+  private static BDD originatingFromDeviceBdd;
+  private static BDD zero;
+  private static BDDSourceManager srcMgr;
+  private static BDDSourceManager peerSrcMgr;
+
+  @BeforeClass
+  public static void setup() throws IOException {
+    SortedMap<String, Configuration> configs = TestNetworkSources.twoNodeNetwork();
+    Batfish batfish = BatfishTestUtils.getBatfish(configs, temp);
+    batfish.computeDataPlane(false);
+    DataPlane dataPlane = batfish.loadDataPlane();
+    factory = new BDDReachabilityAnalysisFactory(pkt, configs, dataPlane.getForwardingAnalysis());
+    peerSrcMgr = factory.getBDDSourceManagers().get(PEER_NAME);
+    srcMgr = factory.getBDDSourceManagers().get(CONFIG_NAME);
+
+    Ip ingressIfaceSrcIp = new Ip("6.6.6.6");
+    ingressIfaceSrcIpBdd = pkt.getSrcIp().value(ingressIfaceSrcIp.asLong());
+
+    Ip originatingFromDeviceSrcIp = new Ip("7.7.7.7");
+    originatingFromDeviceSrcIpBdd = pkt.getSrcIp().value(originatingFromDeviceSrcIp.asLong());
+
+    one = pkt.getFactory().one();
+    zero = pkt.getFactory().zero();
+    originatingFromDeviceBdd = srcMgr.getOriginatingFromDeviceBDD();
+    matchSrcInterfaceBdd = srcMgr.getSourceInterfaceBDD(INGRESS_IFACE_NAME);
+
+    edges =
+        factory
+            .bddReachabilityAnalysis(
+                IpSpaceAssignment.builder()
+                    .assign(
+                        new InterfaceLinkLocation(CONFIG_NAME, INGRESS_IFACE_NAME),
+                        ingressIfaceSrcIp.toIpSpace())
+                    .assign(
+                        new InterfaceLocation(CONFIG_NAME, INGRESS_IFACE_NAME),
+                        originatingFromDeviceSrcIp.toIpSpace())
+                    .assign(
+                        new InterfaceLocation(PEER_NAME, PEER_IFACE_NAME), UniverseIpSpace.INSTANCE)
+                    .build())
+            .getEdges();
+  }
+
+  /*
+   * Test the PreOutVrf -> NodeInterfaceNeighborUnreachable edge for the interface with the
+   * OriginatingFromDevice ACL.
+   */
+  @Test
+  public void preOutVrf_NodeInterfaceNeighborUnreachable_OriginatingFromDevice() {
+    Edge edge =
+        edges
+            .get(new PreOutVrf(CONFIG_NAME, VRF_NAME))
+            .get(
+                new NodeInterfaceNeighborUnreachable(
+                    CONFIG_NAME, ORIGINATING_FROM_DEVICE_ACL_IFACE_NAME));
+    BDD headerSpaceBdd =
+        factory
+            .getNeighborUnreachableBDDs()
+            .get(CONFIG_NAME)
+            .get(VRF_NAME)
+            .get(ORIGINATING_FROM_DEVICE_ACL_IFACE_NAME);
+    assertThat(edge.traverseForward(one), equalTo(headerSpaceBdd));
+    assertThat(edge.traverseForward(originatingFromDeviceBdd), equalTo(headerSpaceBdd));
+    assertThat(edge.traverseForward(matchSrcInterfaceBdd), equalTo(zero));
+    assertThat(edge.traverseBackward(one), equalTo(headerSpaceBdd.and(originatingFromDeviceBdd)));
+  }
+
+  /*
+   * Test the PreOutVrf -> NodeInterfaceNeighborUnreachable edge for the interface with the
+   * MatchSrcInterface ACL.
+   */
+  @Test
+  public void preOutVrf_NodeInterfaceNeighborUnreachable_MatchSrcInterface() {
+    Edge edge =
+        edges
+            .get(new PreOutVrf(CONFIG_NAME, VRF_NAME))
+            .get(
+                new NodeInterfaceNeighborUnreachable(
+                    CONFIG_NAME, MATCH_SRC_INTERFACE_ACL_IFACE_NAME));
+    BDD headerSpaceBdd =
+        factory
+            .getNeighborUnreachableBDDs()
+            .get(CONFIG_NAME)
+            .get(VRF_NAME)
+            .get(MATCH_SRC_INTERFACE_ACL_IFACE_NAME);
+    assertThat(edge.traverseForward(one), equalTo(headerSpaceBdd));
+    assertThat(edge.traverseForward(originatingFromDeviceBdd), equalTo(zero));
+    assertThat(edge.traverseForward(matchSrcInterfaceBdd), equalTo(headerSpaceBdd));
+    assertThat(edge.traverseBackward(one), equalTo(headerSpaceBdd.and(matchSrcInterfaceBdd)));
+  }
+
+  /*
+   * Test one of several edges that don't constrain the source variable, but just erase it in the
+   * forward direction.
+   */
+  @Test
+  public void postInVrf_NodeAccept() {
+    // PostInVrf -> NodeAccept edge.
+    Edge edge = edges.get(new PostInVrf(CONFIG_NAME, VRF_NAME)).get(new NodeAccept(CONFIG_NAME));
+    BDD headerSpaceBdd = factory.getVrfAcceptBDDs().get(CONFIG_NAME).get(VRF_NAME);
+    BDD validSrcBdd = srcMgr.isValidValue();
+    assertThat(edge.traverseForward(one), equalTo(headerSpaceBdd));
+    assertThat(edge.traverseForward(originatingFromDeviceBdd), equalTo(headerSpaceBdd));
+    assertThat(edge.traverseForward(matchSrcInterfaceBdd), equalTo(headerSpaceBdd));
+    assertThat(edge.traverseBackward(one), equalTo(headerSpaceBdd.and(validSrcBdd)));
+  }
+
+  @Test
+  public void originateInterfaceLink_PreInInterface() {
+    Edge edge =
+        edges
+            .get(new OriginateInterfaceLink(CONFIG_NAME, INGRESS_IFACE_NAME))
+            .get(new PreInInterface(CONFIG_NAME, INGRESS_IFACE_NAME));
+    assertThat(edge.traverseForward(one), equalTo(ingressIfaceSrcIpBdd.and(matchSrcInterfaceBdd)));
+    assertThat(edge.traverseBackward(one), equalTo(ingressIfaceSrcIpBdd));
+    assertThat(edge.traverseBackward(originatingFromDeviceBdd), equalTo(zero));
+    assertThat(edge.traverseBackward(matchSrcInterfaceBdd), equalTo(ingressIfaceSrcIpBdd));
+  }
+
+  @Test
+  public void originateVrf_PostInVrf() {
+    Edge edge =
+        edges
+            .get(new OriginateVrf(CONFIG_NAME, VRF_NAME))
+            .get(new PostInVrf(CONFIG_NAME, VRF_NAME));
+    assertThat(
+        edge.traverseForward(one),
+        equalTo(originatingFromDeviceSrcIpBdd.and(originatingFromDeviceBdd)));
+    assertThat(edge.traverseBackward(one), equalTo(originatingFromDeviceSrcIpBdd));
+    assertThat(
+        edge.traverseBackward(originatingFromDeviceBdd), equalTo(originatingFromDeviceSrcIpBdd));
+    assertThat(edge.traverseBackward(matchSrcInterfaceBdd), equalTo(zero));
+  }
+
+  @Test
+  public void preOutEdgePostNat_PreInInterface() {
+    Edge edge =
+        edges
+            .get(new PreOutEdgePostNat(PEER_NAME, PEER_IFACE_NAME, CONFIG_NAME, INGRESS_IFACE_NAME))
+            .get(new PreInInterface(CONFIG_NAME, INGRESS_IFACE_NAME));
+    assertThat(edge.traverseForward(one), equalTo(matchSrcInterfaceBdd));
+    assertThat(edge.traverseBackward(matchSrcInterfaceBdd), equalTo(peerSrcMgr.isValidValue()));
+    assertThat(edge.traverseBackward(originatingFromDeviceBdd), equalTo(zero));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisTest.java
@@ -187,15 +187,11 @@ public final class BDDReachabilityAnalysisTest {
   }
 
   private BDD bddTransition(StateExpr preState, StateExpr postState) {
-    return _graphFactory
-        .getEdges()
-        .get(preState)
-        .get(postState)
-        .traverseForward(PKT.getFactory().one());
+    return _graph.getEdges().get(preState).get(postState).traverseForward(PKT.getFactory().one());
   }
 
   private Edge edge(StateExpr preState, StateExpr postState) {
-    return _graphFactory.getEdges().get(preState).get(postState);
+    return _graph.getEdges().get(preState).get(postState);
   }
 
   private static BDD dstIpBDD(Ip ip) {
@@ -430,7 +426,8 @@ public final class BDDReachabilityAnalysisTest {
   @Test
   public void testDefaultAcceptBDD() {
     BDDPacket pkt = new BDDPacket();
-    OriginateVrf originateVrf = new OriginateVrf("host", "vrf");
+    String hostname = "host";
+    OriginateVrf originateVrf = new OriginateVrf(hostname, "vrf");
     BDD one = pkt.getFactory().one();
     BDDReachabilityAnalysis graph =
         new BDDReachabilityAnalysis(

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/TestNetworkSources.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/TestNetworkSources.java
@@ -1,0 +1,119 @@
+package org.batfish.bddreachability;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSortedMap;
+import java.util.SortedMap;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.InterfaceAddress;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpAccessList;
+import org.batfish.datamodel.IpAccessListLine;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.acl.AclLineMatchExprs;
+import org.batfish.datamodel.acl.OriginatingFromDevice;
+
+/**
+ * A test network with a single node that exercises {@link
+ * org.batfish.datamodel.acl.MatchSrcInterface} and {@link
+ * org.batfish.datamodel.acl.OriginatingFromDevice}.
+ */
+public class TestNetworkSources {
+  /* Properties of the primary config, which has the ACLs that use MatchSrcInterface and
+   * OriginatingFromDevice.
+   */
+  private static final InterfaceAddress CONFIG_ADDR = new InterfaceAddress("0.0.0.1/24");
+  static final String CONFIG_NAME = "config";
+  static final String INGRESS_IFACE_NAME = "ingress interface";
+  static final String MATCH_SRC_INTERFACE_ACL_IFACE_NAME = "interface with match src interface ACL";
+  static final String ORIGINATING_FROM_DEVICE_ACL_IFACE_NAME =
+      "interface with originating from device ACL";
+
+  /*
+   * Properties of the peer config that just forwards traffic to the primary config.
+   */
+  static final String PEER_IFACE_NAME = "peer interface";
+  static final String PEER_NAME = "peer";
+  static final InterfaceAddress PEER_ADDR = new InterfaceAddress("0.0.0.2/24");
+
+  /*
+   * Properties shared by both nodes
+   */
+  static final String VRF_NAME = "vrf";
+
+  /**
+   * Builds the config with ACLs that use {@link org.batfish.datamodel.acl.MatchSrcInterface} and
+   * {@link OriginatingFromDevice} in the test networks.
+   */
+  private static Configuration makeConfigWithAcls(NetworkFactory nf) {
+    Configuration config =
+        nf.configurationBuilder()
+            .setHostname(CONFIG_NAME)
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .build();
+    Vrf vrf = nf.vrfBuilder().setName(VRF_NAME).setOwner(config).build();
+    Interface.Builder ib = nf.interfaceBuilder().setActive(true).setOwner(config).setVrf(vrf);
+
+    Interface inInterface = ib.setName(INGRESS_IFACE_NAME).setAddress(CONFIG_ADDR).build();
+
+    // only traffic originating from device can go out this interface
+    IpAccessList acl1 =
+        nf.aclBuilder()
+            .setOwner(config)
+            .setLines(ImmutableList.of(IpAccessListLine.accepting(OriginatingFromDevice.INSTANCE)))
+            .build();
+    ib.setName(ORIGINATING_FROM_DEVICE_ACL_IFACE_NAME)
+        .setOutgoingFilter(acl1)
+        .setAddress(new InterfaceAddress(new Ip("1.0.0.1"), 24))
+        .build();
+
+    // only traffic from inInterface from device can go out this interface
+    IpAccessList acl2 =
+        nf.aclBuilder()
+            .setOwner(config)
+            .setLines(
+                ImmutableList.of(
+                    IpAccessListLine.accepting(
+                        AclLineMatchExprs.matchSrcInterface(inInterface.getName()))))
+            .build();
+    ib.setName(MATCH_SRC_INTERFACE_ACL_IFACE_NAME)
+        .setOutgoingFilter(acl2)
+        .setAddress(new InterfaceAddress(new Ip("2.0.0.1"), 24))
+        .build();
+
+    return config;
+  }
+
+  private static Configuration makePeerConfig(NetworkFactory nf) {
+    Configuration config =
+        nf.configurationBuilder()
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .setHostname(PEER_NAME)
+            .build();
+    Vrf vrf = nf.vrfBuilder().setName(VRF_NAME).setOwner(config).build();
+    nf.interfaceBuilder()
+        .setActive(true)
+        .setOwner(config)
+        .setName(PEER_IFACE_NAME)
+        .setVrf(vrf)
+        .setAddress(PEER_ADDR)
+        .build();
+    return config;
+  }
+
+  /** @return A one-node network. For testing traffic originating from the device or its links. */
+  public static SortedMap<String, Configuration> oneNodeNetwork() {
+    Configuration config = makeConfigWithAcls(new NetworkFactory());
+    return ImmutableSortedMap.of(config.getHostname(), config);
+  }
+
+  public static SortedMap<String, Configuration> twoNodeNetwork() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration configWithAcls = makeConfigWithAcls(nf);
+    Configuration peerConfig = makePeerConfig(nf);
+    return ImmutableSortedMap.of(
+        configWithAcls.getHostname(), configWithAcls, peerConfig.getHostname(), peerConfig);
+  }
+}


### PR DESCRIPTION
For MatchSrcInterface and OriginatingFromDevice ACL expressions.
Maintains the invariant that whenever a packet is inside a node, it has
a valid source (according to the BDDSourceManager of that node). For
forward edges this is established by constraining to a single source.
For backward edges it's established using BDDSourceManager#isValidValue.

Also moved all edge creation into the factory. Previously,
BDDReachabilityAnalysis created edges that are specific per query. This
is too complicated now that we have to maintain this invariant -- better
to make that the responsiblity of the factory. The reason for the prior
separation was so that the edges that don't vary across queries could be
cached (someday). We can still do that, but will do it another way.