### PR TITLE
Create BgpPeerConfiguration question

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/Schema.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/Schema.java
@@ -49,6 +49,7 @@ public class Schema {
           .put("Interface", getClassString(NodeInterfacePair.class))
           .put("Ip", getClassString(Ip.class))
           .put("Issue", getClassString(Issue.class))
+          .put("Long", getClassString(Long.class))
           .put("Object", getClassString(Object.class))
           .put("Node", getClassString(Node.class))
           .put("Prefix", getClassString(Prefix.class))
@@ -67,6 +68,7 @@ public class Schema {
   public static final Schema INTERFACE = new Schema("Interface");
   public static final Schema IP = new Schema("Ip");
   public static final Schema ISSUE = new Schema("Issue");
+  public static final Schema LONG = new Schema("Long");
   public static final Schema OBJECT = new Schema("Object");
   public static final Schema NODE = new Schema("Node");
   public static final Schema PREFIX = new Schema("Prefix");

--- a/projects/question/src/main/java/org/batfish/question/bgpproperties/BgpPeerConfigurationAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/bgpproperties/BgpPeerConfigurationAnswerer.java
@@ -1,0 +1,155 @@
+package org.batfish.question.bgpproperties;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Multiset;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.batfish.common.Answerer;
+import org.batfish.common.plugin.IBatfish;
+import org.batfish.datamodel.BgpActivePeerConfig;
+import org.batfish.datamodel.BgpPassivePeerConfig;
+import org.batfish.datamodel.BgpProcess;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.answers.AnswerElement;
+import org.batfish.datamodel.answers.Schema;
+import org.batfish.datamodel.answers.SelfDescribingObject;
+import org.batfish.datamodel.pojo.Node;
+import org.batfish.datamodel.questions.DisplayHints;
+import org.batfish.datamodel.questions.Question;
+import org.batfish.datamodel.table.ColumnMetadata;
+import org.batfish.datamodel.table.Row;
+import org.batfish.datamodel.table.Row.RowBuilder;
+import org.batfish.datamodel.table.TableAnswerElement;
+import org.batfish.datamodel.table.TableMetadata;
+
+public class BgpPeerConfigurationAnswerer extends Answerer {
+
+  public static final String COL_NODE = "Node";
+  public static final String COL_VRF = "VRF";
+  public static final String COL_LOCAL_AS = "Local_AS";
+  public static final String COL_REMOTE_AS = "Remote_AS";
+  public static final String COL_LOCAL_IP = "Local_IP";
+  public static final String COL_REMOTE_IP = "Remote_IP";
+  public static final String COL_ROUTE_REFLECTOR_CLIENT = "Route_Reflector_Client";
+  public static final String COL_PEER_GROUP = "Peer_Group";
+  public static final String COL_IMPORT_POLICY = "Import_Policy";
+  public static final String COL_EXPORT_POLICY = "Export_Policy";
+  public static final String COL_SEND_COMMUNITY = "Send_Community";
+
+  public BgpPeerConfigurationAnswerer(Question question, IBatfish batfish) {
+    super(question, batfish);
+  }
+
+  /**
+   * Creates {@link ColumnMetadata}s that the answer should have.
+   *
+   * @return The {@link List} of {@link ColumnMetadata}s
+   */
+  public static List<ColumnMetadata> createColumnMetadata() {
+    return ImmutableList.<ColumnMetadata>builder()
+        .add(new ColumnMetadata(COL_NODE, Schema.NODE, "Node", true, false))
+        .add(new ColumnMetadata(COL_VRF, Schema.STRING, "VRF", true, false))
+        .add(new ColumnMetadata(COL_LOCAL_AS, Schema.INTEGER, "Local AS", false, false))
+        .add(new ColumnMetadata(COL_REMOTE_AS, Schema.SELF_DESCRIBING, "Remote AS", false, false))
+        .add(new ColumnMetadata(COL_LOCAL_IP, Schema.IP, "Local IP", false, false))
+        .add(new ColumnMetadata(COL_REMOTE_IP, Schema.SELF_DESCRIBING, "Remote IP", true, false))
+        .add(
+            new ColumnMetadata(
+                COL_ROUTE_REFLECTOR_CLIENT, Schema.BOOLEAN, "Route reflector client", false, false))
+        .add(new ColumnMetadata(COL_PEER_GROUP, Schema.STRING, "Peer group", false, false))
+        .add(
+            new ColumnMetadata(
+                COL_IMPORT_POLICY, Schema.set(Schema.STRING), "Import policy", false, false))
+        .add(
+            new ColumnMetadata(
+                COL_EXPORT_POLICY, Schema.set(Schema.STRING), "Export policy", false, false))
+        .add(new ColumnMetadata(COL_SEND_COMMUNITY, Schema.BOOLEAN, "Send community", false, false))
+        .build();
+  }
+
+  /** Creates a {@link TableMetadata} object from the question. */
+  static TableMetadata createTableMetadata(BgpPeerConfigurationQuestion question) {
+    String textDesc =
+        String.format(
+            "Properties of BGP peer ${%s}:${%s}: ${%s} to ${%s}",
+            COL_NODE, COL_VRF, COL_LOCAL_IP, COL_REMOTE_IP);
+    DisplayHints dhints = question.getDisplayHints();
+    if (dhints != null && dhints.getTextDesc() != null) {
+      textDesc = dhints.getTextDesc();
+    }
+    return new TableMetadata(createColumnMetadata(), textDesc);
+  }
+
+  @Override
+  public AnswerElement answer() {
+    BgpPeerConfigurationQuestion question = (BgpPeerConfigurationQuestion) _question;
+    Map<String, Configuration> configurations = _batfish.loadConfigurations();
+    Set<String> nodes = question.getNodes().getMatchingNodes(_batfish);
+
+    TableMetadata tableMetadata = createTableMetadata(question);
+    TableAnswerElement answer = new TableAnswerElement(tableMetadata);
+
+    Multiset<Row> propertyRows = getAnswerRows(configurations, nodes, tableMetadata.toColumnMap());
+
+    answer.postProcessAnswer(question, propertyRows);
+    return answer;
+  }
+
+  @VisibleForTesting
+  public static Multiset<Row> getAnswerRows(
+      Map<String, Configuration> configurations,
+      Set<String> nodes,
+      Map<String, ColumnMetadata> columnMetadata) {
+
+    Multiset<Row> rows = HashMultiset.create();
+
+    for (String nodeName : nodes) {
+      for (Vrf vrf : configurations.get(nodeName).getVrfs().values()) {
+        BgpProcess bgpProcess = vrf.getBgpProcess();
+        if (bgpProcess == null) {
+          continue;
+        }
+        Node node = new Node(nodeName);
+        for (BgpActivePeerConfig peer : bgpProcess.getActiveNeighbors().values()) {
+          RowBuilder rowBuilder =
+              Row.builder(columnMetadata)
+                  .put(COL_NODE, node)
+                  .put(COL_VRF, vrf.getName())
+                  .put(COL_LOCAL_AS, peer.getLocalAs())
+                  .put(COL_REMOTE_AS, new SelfDescribingObject(Schema.LONG, peer.getRemoteAs()))
+                  .put(COL_LOCAL_IP, peer.getLocalIp())
+                  .put(COL_REMOTE_IP, new SelfDescribingObject(Schema.IP, peer.getPeerAddress()))
+                  .put(COL_ROUTE_REFLECTOR_CLIENT, peer.getRouteReflectorClient())
+                  .put(COL_PEER_GROUP, peer.getGroup())
+                  .put(COL_IMPORT_POLICY, peer.getImportPolicySources())
+                  .put(COL_EXPORT_POLICY, peer.getExportPolicySources())
+                  .put(COL_SEND_COMMUNITY, peer.getSendCommunity());
+          rows.add(rowBuilder.build());
+        }
+        for (BgpPassivePeerConfig peer : bgpProcess.getPassiveNeighbors().values()) {
+          RowBuilder rowBuilder =
+              Row.builder(columnMetadata)
+                  .put(COL_NODE, node)
+                  .put(COL_VRF, vrf.getName())
+                  .put(COL_LOCAL_AS, peer.getLocalAs())
+                  .put(
+                      COL_REMOTE_AS,
+                      new SelfDescribingObject(Schema.list(Schema.LONG), peer.getRemoteAs()))
+                  .put(COL_LOCAL_IP, peer.getLocalIp())
+                  .put(COL_REMOTE_IP, new SelfDescribingObject(Schema.PREFIX, peer.getPeerPrefix()))
+                  .put(COL_ROUTE_REFLECTOR_CLIENT, peer.getRouteReflectorClient())
+                  .put(COL_PEER_GROUP, peer.getGroup())
+                  .put(COL_IMPORT_POLICY, peer.getImportPolicySources())
+                  .put(COL_EXPORT_POLICY, peer.getExportPolicySources())
+                  .put(COL_SEND_COMMUNITY, peer.getSendCommunity());
+          rows.add(rowBuilder.build());
+        }
+      }
+    }
+    return rows;
+  }
+}

--- a/projects/question/src/main/java/org/batfish/question/bgpproperties/BgpPeerConfigurationAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/bgpproperties/BgpPeerConfigurationAnswerer.java
@@ -88,7 +88,7 @@ public class BgpPeerConfigurationAnswerer extends Answerer {
   public AnswerElement answer() {
     BgpPeerConfigurationQuestion question = (BgpPeerConfigurationQuestion) _question;
     Map<String, Configuration> configurations = _batfish.loadConfigurations();
-    Set<String> nodes = question.getNodes().getMatchingNodes(_batfish);
+    Set<String> nodes = question.getNodesSpecifier().resolve(_batfish.specifierContext());
 
     TableMetadata tableMetadata = createTableMetadata(question);
     TableAnswerElement answer = new TableAnswerElement(tableMetadata);

--- a/projects/question/src/main/java/org/batfish/question/bgpproperties/BgpPeerConfigurationPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/bgpproperties/BgpPeerConfigurationPlugin.java
@@ -1,0 +1,22 @@
+package org.batfish.question.bgpproperties;
+
+import com.google.auto.service.AutoService;
+import org.batfish.common.Answerer;
+import org.batfish.common.plugin.IBatfish;
+import org.batfish.common.plugin.Plugin;
+import org.batfish.datamodel.questions.Question;
+import org.batfish.question.QuestionPlugin;
+
+@AutoService(Plugin.class)
+public class BgpPeerConfigurationPlugin extends QuestionPlugin {
+
+  @Override
+  protected Answerer createAnswerer(Question question, IBatfish batfish) {
+    return new BgpPeerConfigurationAnswerer(question, batfish);
+  }
+
+  @Override
+  protected Question createQuestion() {
+    return new BgpPeerConfigurationQuestion(null);
+  }
+}

--- a/projects/question/src/main/java/org/batfish/question/bgpproperties/BgpPeerConfigurationQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/bgpproperties/BgpPeerConfigurationQuestion.java
@@ -1,11 +1,13 @@
 package org.batfish.question.bgpproperties;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
-
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import javax.annotation.Nonnull;
-import org.batfish.datamodel.questions.NodesSpecifier;
+import javax.annotation.Nullable;
 import org.batfish.datamodel.questions.Question;
+import org.batfish.specifier.FlexibleNodeSpecifierFactory;
+import org.batfish.specifier.NodeSpecifier;
+import org.batfish.specifier.NodeSpecifierFactory;
 
 /**
  * A question that returns properties of BGP routing processes. {@link #_nodes} determines which
@@ -15,10 +17,11 @@ public class BgpPeerConfigurationQuestion extends Question {
 
   private static final String PROP_NODES = "nodes";
 
-  @Nonnull private NodesSpecifier _nodes;
+  @Nullable private String _nodes;
 
-  public BgpPeerConfigurationQuestion(@JsonProperty(PROP_NODES) NodesSpecifier nodes) {
-    _nodes = firstNonNull(nodes, NodesSpecifier.ALL);
+  @JsonCreator
+  public BgpPeerConfigurationQuestion(@JsonProperty(PROP_NODES) @Nullable String nodes) {
+    _nodes = nodes;
   }
 
   @Override
@@ -32,7 +35,13 @@ public class BgpPeerConfigurationQuestion extends Question {
   }
 
   @JsonProperty(PROP_NODES)
-  public NodesSpecifier getNodes() {
+  @Nullable
+  public String getNodes() {
     return _nodes;
+  }
+
+  @Nonnull
+  NodeSpecifier getNodesSpecifier() {
+    return NodeSpecifierFactory.load(FlexibleNodeSpecifierFactory.NAME).buildNodeSpecifier(_nodes);
   }
 }

--- a/projects/question/src/main/java/org/batfish/question/bgpproperties/BgpPeerConfigurationQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/bgpproperties/BgpPeerConfigurationQuestion.java
@@ -1,0 +1,38 @@
+package org.batfish.question.bgpproperties;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nonnull;
+import org.batfish.datamodel.questions.NodesSpecifier;
+import org.batfish.datamodel.questions.Question;
+
+/**
+ * A question that returns properties of BGP routing processes. {@link #_nodes} determines which
+ * nodes are included. The default is to include everything.
+ */
+public class BgpPeerConfigurationQuestion extends Question {
+
+  private static final String PROP_NODES = "nodes";
+
+  @Nonnull private NodesSpecifier _nodes;
+
+  public BgpPeerConfigurationQuestion(@JsonProperty(PROP_NODES) NodesSpecifier nodes) {
+    _nodes = firstNonNull(nodes, NodesSpecifier.ALL);
+  }
+
+  @Override
+  public boolean getDataPlane() {
+    return false;
+  }
+
+  @Override
+  public String getName() {
+    return "bgpPeerConfiguration";
+  }
+
+  @JsonProperty(PROP_NODES)
+  public NodesSpecifier getNodes() {
+    return _nodes;
+  }
+}

--- a/projects/question/src/test/java/org/batfish/question/bgpproperties/BgpPeerConfigurationAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/bgpproperties/BgpPeerConfigurationAnswererTest.java
@@ -1,0 +1,129 @@
+package org.batfish.question.bgpproperties;
+
+import static org.batfish.question.bgpproperties.BgpPeerConfigurationAnswerer.COL_EXPORT_POLICY;
+import static org.batfish.question.bgpproperties.BgpPeerConfigurationAnswerer.COL_IMPORT_POLICY;
+import static org.batfish.question.bgpproperties.BgpPeerConfigurationAnswerer.COL_LOCAL_AS;
+import static org.batfish.question.bgpproperties.BgpPeerConfigurationAnswerer.COL_LOCAL_IP;
+import static org.batfish.question.bgpproperties.BgpPeerConfigurationAnswerer.COL_NODE;
+import static org.batfish.question.bgpproperties.BgpPeerConfigurationAnswerer.COL_PEER_GROUP;
+import static org.batfish.question.bgpproperties.BgpPeerConfigurationAnswerer.COL_REMOTE_AS;
+import static org.batfish.question.bgpproperties.BgpPeerConfigurationAnswerer.COL_REMOTE_IP;
+import static org.batfish.question.bgpproperties.BgpPeerConfigurationAnswerer.COL_ROUTE_REFLECTOR_CLIENT;
+import static org.batfish.question.bgpproperties.BgpPeerConfigurationAnswerer.COL_SEND_COMMUNITY;
+import static org.batfish.question.bgpproperties.BgpPeerConfigurationAnswerer.COL_VRF;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Multiset;
+import org.batfish.datamodel.BgpActivePeerConfig;
+import org.batfish.datamodel.BgpPassivePeerConfig;
+import org.batfish.datamodel.BgpProcess;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.answers.Schema;
+import org.batfish.datamodel.answers.SelfDescribingObject;
+import org.batfish.datamodel.pojo.Node;
+import org.batfish.datamodel.table.Row;
+import org.junit.Test;
+
+public class BgpPeerConfigurationAnswererTest {
+
+  @Test
+  public void testAnswer() {
+    Multiset<Row> rows =
+        BgpPeerConfigurationAnswerer.getAnswerRows(
+            ImmutableMap.of("c", getConfig()),
+            ImmutableSet.of("c"),
+            BgpPeerConfigurationAnswerer.createTableMetadata(new BgpPeerConfigurationQuestion(null))
+                .toColumnMap());
+
+    Node node = new Node("c");
+    Multiset<Row> expected = HashMultiset.create();
+    expected.add(
+        Row.builder()
+            .put(COL_NODE, node)
+            .put(COL_VRF, "v")
+            .put(COL_LOCAL_AS, 100L)
+            .put(COL_REMOTE_AS, new SelfDescribingObject(Schema.LONG, 200L))
+            .put(COL_LOCAL_IP, new Ip("1.1.1.1"))
+            .put(COL_REMOTE_IP, new SelfDescribingObject(Schema.IP, new Ip("2.2.2.2")))
+            .put(COL_ROUTE_REFLECTOR_CLIENT, false)
+            .put(COL_PEER_GROUP, "g1")
+            .put(COL_IMPORT_POLICY, ImmutableSet.of("p1"))
+            .put(COL_EXPORT_POLICY, ImmutableSet.of("p2"))
+            .put(COL_SEND_COMMUNITY, false)
+            .build());
+    expected.add(
+        Row.builder()
+            .put(COL_NODE, node)
+            .put(COL_VRF, "v")
+            .put(COL_LOCAL_AS, 100L)
+            .put(
+                COL_REMOTE_AS,
+                new SelfDescribingObject(Schema.list(Schema.LONG), ImmutableList.of(300L)))
+            .put(COL_LOCAL_IP, new Ip("1.1.1.2"))
+            .put(
+                COL_REMOTE_IP,
+                new SelfDescribingObject(Schema.PREFIX, new Prefix(new Ip("3.3.3.0"), 24)))
+            .put(COL_ROUTE_REFLECTOR_CLIENT, false)
+            .put(COL_PEER_GROUP, "g2")
+            .put(COL_IMPORT_POLICY, ImmutableSet.of("p3"))
+            .put(COL_EXPORT_POLICY, ImmutableSet.of("p4"))
+            .put(COL_SEND_COMMUNITY, false)
+            .build());
+
+    assertThat(rows, equalTo(expected));
+  }
+
+  private static Configuration getConfig() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c =
+        nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS).build();
+
+    BgpActivePeerConfig activePeer =
+        BgpActivePeerConfig.builder()
+            .setLocalAs(100L)
+            .setRemoteAs(200L)
+            .setLocalIp(new Ip("1.1.1.1"))
+            .setPeerAddress(new Ip("2.2.2.2"))
+            .setRouteReflectorClient(false)
+            .setGroup("g1")
+            .setImportPolicySources(ImmutableSortedSet.of("p1"))
+            .setExportPolicySources(ImmutableSortedSet.of("p2"))
+            .setSendCommunity(false)
+            .build();
+    BgpPassivePeerConfig passivePeer =
+        BgpPassivePeerConfig.builder()
+            .setLocalAs(100L)
+            .setRemoteAs(ImmutableList.of(300L))
+            .setLocalIp(new Ip("1.1.1.2"))
+            .setPeerPrefix(new Prefix(new Ip("3.3.3.0"), 24))
+            .setRouteReflectorClient(false)
+            .setGroup("g2")
+            .setImportPolicySources(ImmutableSortedSet.of("p3"))
+            .setExportPolicySources(ImmutableSortedSet.of("p4"))
+            .setSendCommunity(false)
+            .build();
+
+    BgpProcess process = new BgpProcess();
+    process.setNeighbors(ImmutableSortedMap.of(new Prefix(new Ip("1.1.1.0"), 24), activePeer));
+    process.setPassiveNeighbors(
+        ImmutableSortedMap.of(new Prefix(new Ip("1.1.1.0"), 24), passivePeer));
+
+    Vrf vrf = new Vrf("v");
+    vrf.setBgpProcess(process);
+
+    c.setVrfs(ImmutableMap.of("v", vrf, "emptyVrf", new Vrf("emptyVrf")));
+    return c;
+  }
+}

--- a/questions/experimental/bgpPeerConfiguration.json
+++ b/questions/experimental/bgpPeerConfiguration.json
@@ -1,0 +1,20 @@
+{
+    "class": "org.batfish.question.bgpproperties.BgpPeerConfigurationQuestion",
+    "differential": false,
+    "nodes": "${nodes}",
+    "instance": {
+        "description": "Return BGP peer configuration properties",
+        "instanceName": "bgpPeerConfiguration",
+        "tags": [
+            "bgp",
+            "configuration"
+        ],
+        "variables": {
+            "nodes": {
+                "description": "Include nodes matching this name or regex",
+                "type": "nodeSpec",
+                "optional": true
+            }
+        }
+    }
+}

--- a/tests/questions/experimental/bgpPeerConfiguration.ref
+++ b/tests/questions/experimental/bgpPeerConfiguration.ref
@@ -1,0 +1,22 @@
+{
+  "class" : "org.batfish.question.bgpproperties.BgpPeerConfigurationQuestion",
+  "nodes" : ".*",
+  "differential" : false,
+  "includeOneTableKeys" : true,
+  "instance" : {
+    "description" : "Return BGP peer configuration properties",
+    "instanceName" : "qname",
+    "tags" : [
+      "bgp",
+      "configuration"
+    ],
+    "variables" : {
+      "nodes" : {
+        "description" : "Include nodes matching this name or regex",
+        "optional" : true,
+        "type" : "nodeSpec",
+        "value" : ".*"
+      }
+    }
+  }
+}

--- a/tests/questions/experimental/commands
+++ b/tests/questions/experimental/commands
@@ -3,6 +3,9 @@ load-questions questions/experimental
 # validate filterLineReachability
 test -raw tests/questions/experimental/filterLineReachability.ref validate-template filterLineReachability filters=".*", nodes=".*"
 
+# validate bgpPeerConfiguration
+test -raw tests/questions/experimental/bgpPeerConfiguration.ref validate-template bgpPeerConfiguration nodes=".*"
+
 # validate bgpProcessConfiguration
 test -raw tests/questions/experimental/bgpProcessConfiguration.ref validate-template bgpProcessConfiguration nodes=".*", properties="multipath-.*"
 


### PR DESCRIPTION
Each row of the table answer is a BGP peer with the following properties:
-  Node
- VRF
- Local AS
- Remote AS (which is a list for passive neighbors)
- Local IP
- Remote IP (which is a prefix for passive neighbors)
- Route-reflector client
- Peer group
- Import policy
- Export policy
- Send community

More properties will be added as we find ways to surface them effectively; see [design doc](https://docs.google.com/document/d/1SZeswG8qsXcjeMhETQr6QRLSboEv73R7-UQqQGBqC-I) for details.