### PR TITLE
Fix static route builder; hide public constructors

### DIFF
--- a/projects/allinone/src/test/java/org/batfish/question/reducedreachability/ReducedReachabilityTest.java
+++ b/projects/allinone/src/test/java/org/batfish/question/reducedreachability/ReducedReachabilityTest.java
@@ -71,6 +71,7 @@ public class ReducedReachabilityTest {
       v1.setStaticRoutes(
           ImmutableSortedSet.of(
               StaticRoute.builder()
+                  .setAdministrativeCost(1)
                   .setNetwork(Prefix.parse("2.2.2.2/32"))
                   .setNextHopInterface(PHYSICAL)
                   .build()));
@@ -87,6 +88,7 @@ public class ReducedReachabilityTest {
             StaticRoute.builder()
                 .setNetwork(Prefix.parse("1.1.1.1/32"))
                 .setNextHopInterface(PHYSICAL)
+                .setAdministrativeCost(1)
                 .build()));
 
     return ImmutableSortedMap.of(NODE1, node1, NODE2, node2);

--- a/projects/allinone/src/test/java/org/batfish/symbolic/smt/TwoNodeNetworkWithTwoLinks.java
+++ b/projects/allinone/src/test/java/org/batfish/symbolic/smt/TwoNodeNetworkWithTwoLinks.java
@@ -79,7 +79,7 @@ public class TwoNodeNetworkWithTwoLinks {
         .setAddress(new InterfaceAddress(DST_PREFIX_2.getStartIp(), DST_PREFIX_2.getPrefixLength()))
         .build();
 
-    StaticRoute.Builder bld = StaticRoute.builder();
+    StaticRoute.Builder bld = StaticRoute.builder().setAdministrativeCost(1);
     srcVrf.setStaticRoutes(
         ImmutableSortedSet.of(
             bld.setNetwork(DST_PREFIX_1).setNextHopIp(LINK_1_NETWORK.getEndIp()).build(),

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/StaticRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/StaticRoute.java
@@ -1,13 +1,17 @@
 package org.batfish.datamodel;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+/** A static route */
 public class StaticRoute extends AbstractRoute {
   static final long DEFAULT_STATIC_ROUTE_METRIC = 0L;
 
@@ -33,17 +37,20 @@ public class StaticRoute extends AbstractRoute {
       @JsonProperty(PROP_ADMINISTRATIVE_COST) int administrativeCost,
       @JsonProperty(PROP_METRIC) long metric,
       @JsonProperty(PROP_TAG) int tag) {
-    return new StaticRoute(network, nextHopIp, nextHopInterface, administrativeCost, metric, tag);
+    return new StaticRoute(
+        requireNonNull(network), nextHopIp, nextHopInterface, administrativeCost, metric, tag);
   }
 
-  public StaticRoute(
-      Prefix network,
+  private StaticRoute(
+      @Nonnull Prefix network,
       @Nullable Ip nextHopIp,
       @Nullable String nextHopInterface,
       int administrativeCost,
       long metric,
       int tag) {
     super(network);
+    checkArgument(
+        administrativeCost >= 0, "Invalid admin distance for static route: %d", administrativeCost);
     _administrativeCost = administrativeCost;
     _metric = metric;
     _nextHopInterface = firstNonNull(nextHopInterface, Route.UNSET_NEXT_HOP_INTERFACE);
@@ -59,11 +66,11 @@ public class StaticRoute extends AbstractRoute {
       return false;
     }
     StaticRoute rhs = (StaticRoute) o;
-    boolean res = _network.equals(rhs._network);
-    res = res && _administrativeCost == rhs._administrativeCost;
-    res = res && _nextHopIp.equals(rhs._nextHopIp);
-    res = res && _nextHopInterface.equals(rhs._nextHopInterface);
-    return res && _tag == rhs._tag;
+    return Objects.equals(_network, rhs._network)
+        && _administrativeCost == rhs._administrativeCost
+        && Objects.equals(_nextHopIp, rhs._nextHopIp)
+        && Objects.equals(_nextHopInterface, rhs._nextHopInterface)
+        && _tag == rhs._tag;
   }
 
   @Override
@@ -114,14 +121,7 @@ public class StaticRoute extends AbstractRoute {
 
   @Override
   public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + _network.hashCode();
-    result = prime * result + _administrativeCost;
-    result = prime * result + _nextHopInterface.hashCode();
-    result = prime * result + _nextHopIp.hashCode();
-    result = prime * result + _tag;
-    return result;
+    return Objects.hash(_administrativeCost, _metric, _nextHopInterface, _nextHopIp, _tag);
   }
 
   @Override
@@ -134,7 +134,8 @@ public class StaticRoute extends AbstractRoute {
     return 0;
   }
 
-  public static class Builder extends AbstractRouteBuilder<Builder, StaticRoute> {
+  /** Builder for {@link StaticRoute} */
+  public static final class Builder extends AbstractRouteBuilder<Builder, StaticRoute> {
 
     private int _administrativeCost = Route.UNSET_ROUTE_ADMIN;
     private String _nextHopInterface = Route.UNSET_NEXT_HOP_INTERFACE;

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ForwardingAnalysisImplTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ForwardingAnalysisImplTest.java
@@ -409,7 +409,11 @@ public class ForwardingAnalysisImplTest {
         ImmutableMap.of(
             edge,
             ImmutableSet.of(
-                StaticRoute.builder().setNetwork(P1).setNextHopIp(P2.getStartIp()).build()));
+                StaticRoute.builder()
+                    .setNetwork(P1)
+                    .setNextHopIp(P2.getStartIp())
+                    .setAdministrativeCost(1)
+                    .build()));
     ForwardingAnalysisImpl forwardingAnalysisImpl = initForwardingAnalysisImpl();
     Map<Edge, IpSpace> result =
         forwardingAnalysisImpl.computeArpTrueEdgeNextHopIp(configurations, ribs);
@@ -494,6 +498,7 @@ public class ForwardingAnalysisImplTest {
         StaticRoute.builder()
             .setNetwork(P2)
             .setNextHopInterface(Interface.NULL_INTERFACE_NAME)
+            .setAdministrativeCost(1)
             .build();
     SortedMap<String, SortedMap<String, GenericRib<AbstractRoute>>> ribs =
         ImmutableSortedMap.of(
@@ -642,7 +647,12 @@ public class ForwardingAnalysisImplTest {
     String c1 = "c1";
     String v1 = "v1";
     String i1 = "i1";
-    AbstractRoute r1 = StaticRoute.builder().setNetwork(P1).setNextHopIp(P2.getStartIp()).build();
+    AbstractRoute r1 =
+        StaticRoute.builder()
+            .setNetwork(P1)
+            .setNextHopIp(P2.getStartIp())
+            .setAdministrativeCost(1)
+            .build();
     _routesWithNextHop =
         ImmutableMap.of(c1, ImmutableMap.of(v1, ImmutableMap.of(i1, ImmutableSet.of(r1))));
     _routesWithNextHopIpArpFalse =
@@ -694,6 +704,7 @@ public class ForwardingAnalysisImplTest {
         StaticRoute.builder()
             .setNextHopInterface(Interface.NULL_INTERFACE_NAME)
             .setNetwork(P1)
+            .setAdministrativeCost(1)
             .build();
     AbstractRoute otherRoute = new ConnectedRoute(P2, i1);
     Map<String, Map<String, Fib>> fibs =
@@ -740,6 +751,7 @@ public class ForwardingAnalysisImplTest {
         StaticRoute.builder()
             .setNetwork(Prefix.parse("1.0.0.0/8"))
             .setNextHopInterface(Interface.NULL_INTERFACE_NAME)
+            .setAdministrativeCost(1)
             .build();
     IpSpace ipSpace = IpWildcardSetIpSpace.builder().including(new IpWildcard("1.0.0.0/8")).build();
     v.setStaticRoutes(ImmutableSortedSet.of(nullRoute));
@@ -815,7 +827,12 @@ public class ForwardingAnalysisImplTest {
     String c1 = "c1";
     String v1 = "v1";
     String i1 = "i1";
-    AbstractRoute r1 = StaticRoute.builder().setNetwork(P1).setNextHopIp(P2.getStartIp()).build();
+    AbstractRoute r1 =
+        StaticRoute.builder()
+            .setNetwork(P1)
+            .setNextHopIp(P2.getStartIp())
+            .setAdministrativeCost(1)
+            .build();
     AbstractRoute ifaceRoute = new ConnectedRoute(P2, i1);
     _routesWithNextHop =
         ImmutableMap.of(
@@ -911,7 +928,12 @@ public class ForwardingAnalysisImplTest {
     String c1 = "c1";
     String v1 = "v1";
     String i1 = "i1";
-    AbstractRoute r1 = StaticRoute.builder().setNetwork(P1).setNextHopIp(P2.getStartIp()).build();
+    AbstractRoute r1 =
+        StaticRoute.builder()
+            .setNetwork(P1)
+            .setNextHopIp(P2.getStartIp())
+            .setAdministrativeCost(1)
+            .build();
     _routesWithNextHop =
         ImmutableMap.of(c1, ImmutableMap.of(v1, ImmutableMap.of(i1, ImmutableSet.of(r1))));
     AbstractRoute ifaceRoute = new ConnectedRoute(P2, i1);
@@ -944,9 +966,17 @@ public class ForwardingAnalysisImplTest {
     String hostname = "c1";
     String outInterface = "i1";
     AbstractRoute nextHopIpRoute1 =
-        StaticRoute.builder().setNetwork(P1).setNextHopIp(P2.getStartIp()).build();
+        StaticRoute.builder()
+            .setNetwork(P1)
+            .setNextHopIp(P2.getStartIp())
+            .setAdministrativeCost(1)
+            .build();
     AbstractRoute nextHopIpRoute2 =
-        StaticRoute.builder().setNetwork(P1).setNextHopIp(P2.getEndIp()).build();
+        StaticRoute.builder()
+            .setNetwork(P1)
+            .setNextHopIp(P2.getEndIp())
+            .setAdministrativeCost(1)
+            .build();
     AbstractRoute ifaceRoute = new ConnectedRoute(P2, outInterface);
     Entry<String, Set<AbstractRoute>> routesWithNextHopByOutInterfaceEntry =
         Maps.immutableEntry(
@@ -990,9 +1020,17 @@ public class ForwardingAnalysisImplTest {
     String hostname = "c1";
     String outInterface = "i1";
     AbstractRoute nextHopIpRoute1 =
-        StaticRoute.builder().setNetwork(P1).setNextHopIp(P2.getStartIp()).build();
+        StaticRoute.builder()
+            .setNetwork(P1)
+            .setNextHopIp(P2.getStartIp())
+            .setAdministrativeCost(1)
+            .build();
     AbstractRoute nextHopIpRoute2 =
-        StaticRoute.builder().setNetwork(P1).setNextHopIp(P2.getEndIp()).build();
+        StaticRoute.builder()
+            .setNetwork(P1)
+            .setNextHopIp(P2.getEndIp())
+            .setAdministrativeCost(1)
+            .build();
     AbstractRoute ifaceRoute = new ConnectedRoute(P2, outInterface);
     Entry<String, Set<AbstractRoute>> routesWithNextHopByOutInterfaceEntry =
         Maps.immutableEntry(
@@ -1041,8 +1079,18 @@ public class ForwardingAnalysisImplTest {
     _arpReplies = ImmutableMap.of(c2, ImmutableMap.of(i2, P2.getStartIp().toIpSpace()));
     Topology topology = new Topology(ImmutableSortedSet.of(e1));
     String v1 = "v1";
-    AbstractRoute r1 = StaticRoute.builder().setNetwork(P1).setNextHopIp(P2.getStartIp()).build();
-    AbstractRoute r2 = StaticRoute.builder().setNetwork(P1).setNextHopIp(P2.getEndIp()).build();
+    AbstractRoute r1 =
+        StaticRoute.builder()
+            .setNetwork(P1)
+            .setNextHopIp(P2.getStartIp())
+            .setAdministrativeCost(1)
+            .build();
+    AbstractRoute r2 =
+        StaticRoute.builder()
+            .setNetwork(P1)
+            .setNextHopIp(P2.getEndIp())
+            .setAdministrativeCost(1)
+            .build();
     _routesWithNextHop =
         ImmutableMap.of(c1, ImmutableMap.of(v1, ImmutableMap.of(i1, ImmutableSet.of(r1, r2))));
     AbstractRoute ifaceRoute = new ConnectedRoute(P2, i1);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/StaticRouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/StaticRouteTest.java
@@ -36,25 +36,40 @@ public class StaticRouteTest {
 
   @Test
   public void checkNullNextHop() {
-    StaticRoute sr = StaticRoute.builder().setNetwork(Prefix.ZERO).setNextHopIp(null).build();
+    StaticRoute sr =
+        StaticRoute.builder()
+            .setNetwork(Prefix.ZERO)
+            .setAdministrativeCost(1)
+            .setNextHopIp(null)
+            .build();
     assertThat(sr.getNextHopIp(), is(Route.UNSET_ROUTE_NEXT_HOP_IP));
   }
 
   @Test
   public void checkNullNextHopInterface() {
     StaticRoute sr =
-        StaticRoute.builder().setNetwork(Prefix.ZERO).setNextHopInterface(null).build();
+        StaticRoute.builder()
+            .setNetwork(Prefix.ZERO)
+            .setAdministrativeCost(1)
+            .setNextHopInterface(null)
+            .build();
     assertThat(sr.getNextHopInterface(), is(Route.UNSET_NEXT_HOP_INTERFACE));
   }
 
   @Test
   public void checkDefaults() {
-    StaticRoute sr = StaticRoute.builder().setNetwork(Prefix.ZERO).build();
+    StaticRoute sr = StaticRoute.builder().setNetwork(Prefix.ZERO).setAdministrativeCost(1).build();
     assertThat(sr.getNextHopInterface(), is(Route.UNSET_NEXT_HOP_INTERFACE));
     assertThat(sr.getNextHopIp(), is(Route.UNSET_ROUTE_NEXT_HOP_IP));
-    assertThat(sr.getAdministrativeCost(), is(Route.UNSET_ROUTE_ADMIN));
+    assertThat(sr.getAdministrativeCost(), is(1));
     assertThat(sr.getTag(), is(Route.UNSET_ROUTE_TAG));
     assertThat(sr.getMetric(), is(StaticRoute.DEFAULT_STATIC_ROUTE_METRIC));
+  }
+
+  @Test
+  public void checkThrowsWithoutAdmin() {
+    _thrown.expect(IllegalArgumentException.class);
+    StaticRoute.builder().setNetwork(Prefix.ZERO).build();
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/TestNetwork.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/TestNetwork.java
@@ -142,7 +142,7 @@ public final class TestNetwork {
                 new InterfaceAddress(DST_PREFIX_2.getStartIp(), DST_PREFIX_2.getPrefixLength()))
             .build();
 
-    StaticRoute.Builder bld = StaticRoute.builder();
+    StaticRoute.Builder bld = StaticRoute.builder().setAdministrativeCost(1);
     srcVrf.setStaticRoutes(
         ImmutableSortedSet.of(
             bld.setNetwork(DST_PREFIX_1).setNextHopIp(LINK_1_NETWORK.getEndIp()).build(),

--- a/projects/batfish/src/test/java/org/batfish/dataplane/PathDiffTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/PathDiffTest.java
@@ -75,7 +75,7 @@ public class PathDiffTest {
 
     if (connected) {
       // add a static route from A to pB
-      StaticRoute.Builder rb = StaticRoute.builder();
+      StaticRoute.Builder rb = StaticRoute.builder().setAdministrativeCost(1);
       vA.getStaticRoutes().add(rb.setNetwork(pB).setNextHopIp(pAB.getEndIp()).build());
       // add a static route from B to pA
       vB.getStaticRoutes().add(rb.setNetwork(pA).setNextHopIp(pAB.getStartIp()).build());

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePluginTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePluginTest.java
@@ -710,12 +710,14 @@ public class IncrementalDataPlanePluginTest {
             .setNetwork(Prefix.parse("10.0.1.0/24"))
             .setNextHopInterface(i.getName())
             .setNextHopIp(new Ip("10.0.0.1"))
+            .setAdministrativeCost(1)
             .build();
     vrf.getStaticRoutes().add(srBoth);
     StaticRoute srJustInterface =
         StaticRoute.builder()
             .setNetwork(Prefix.parse("10.0.2.0/24"))
             .setNextHopInterface(i.getName())
+            .setAdministrativeCost(1)
             .build();
     vrf.getStaticRoutes().add(srJustInterface);
     IncrementalBdpEngine engine =

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/PrefixTracerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/PrefixTracerTest.java
@@ -104,6 +104,7 @@ public class PrefixTracerTest {
             StaticRoute.builder()
                 .setNextHopInterface(i1.getName())
                 .setNetwork(_staticRoutePrefix)
+                .setAdministrativeCost(1)
                 .build()));
     BgpProcess bp = nf.bgpProcessBuilder().setVrf(vrf1).setRouterId(neighbor1Ip).build();
     nf.bgpNeighborBuilder()

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/RouteReflectionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/RouteReflectionTest.java
@@ -127,7 +127,7 @@ public class RouteReflectionTest {
     _ib.setAddress(new InterfaceAddress(edge1EbgpIfaceIp, EDGE_PREFIX_LENGTH)).build();
     _ib.setAddress(new InterfaceAddress(edge1LoopbackIp, Prefix.MAX_PREFIX_LENGTH)).build();
     _ib.setAddress(new InterfaceAddress(edge1IbgpIfaceIp, EDGE_PREFIX_LENGTH)).build();
-    StaticRoute.Builder sb = StaticRoute.builder();
+    StaticRoute.Builder sb = StaticRoute.builder().setAdministrativeCost(1);
     vEdge1.setStaticRoutes(
         ImmutableSortedSet.of(
             sb.setNextHopIp(rrEdge1IfaceIp)
@@ -259,7 +259,7 @@ public class RouteReflectionTest {
     Ip rr2IbgpIfaceIp = new Ip("10.1.23.3");
     Ip rr2LoopbackIp = new Ip("2.0.0.3");
 
-    StaticRoute.Builder sb = StaticRoute.builder();
+    StaticRoute.Builder sb = StaticRoute.builder().setAdministrativeCost(1);
     Configuration edge1 = _cb.setHostname(EDGE1_NAME).build();
     Vrf vEdge1 = _vb.setOwner(edge1).build();
     _ib.setOwner(edge1).setVrf(vEdge1);

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTest.java
@@ -37,7 +37,11 @@ public final class BgpProtocolHelperTest {
     assertNotNull(fromVrf.getBgpProcess());
     Vrf toVrf = nf.vrfBuilder().build();
     AbstractRoute route =
-        StaticRoute.builder().setNetwork(Prefix.parse("1.0.0.0/8")).setTag(12345).build();
+        StaticRoute.builder()
+            .setNetwork(Prefix.parse("1.0.0.0/8"))
+            .setTag(12345)
+            .setAdministrativeCost(1)
+            .build();
     BgpRoute.Builder transformedRoute =
         BgpProtocolHelper.transformBgpRouteOnExport(
             fromNeighbor, toNeighbor, sessionProperties, fromVrf, toVrf, route);

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/GeneratedRouteHelperTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/GeneratedRouteHelperTest.java
@@ -91,7 +91,15 @@ public class GeneratedRouteHelperTest {
         GeneratedRouteHelper.activateGeneratedRoute(
             gr,
             policy,
-            ImmutableSet.of(new StaticRoute(Prefix.parse("2.2.2.2/32"), null, "eth0", 1, 0L, 1)),
+            ImmutableSet.of(
+                StaticRoute.builder()
+                    .setNetwork(Prefix.parse("2.2.2.2/32"))
+                    .setNextHopIp(null)
+                    .setNextHopInterface("eth0")
+                    .setAdministrativeCost(1)
+                    .setMetric(0L)
+                    .setTag(1)
+                    .build()),
             "vrf");
 
     assertThat(newRoute, notNullValue());

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/StaticRouteHelperTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/StaticRouteHelperTest.java
@@ -30,7 +30,8 @@ public class StaticRouteHelperTest {
   @Test
   public void testIsInterfaceRoute() {
 
-    StaticRoute.Builder sb = StaticRoute.builder().setNetwork(Prefix.parse("9.9.9.0/24"));
+    StaticRoute.Builder sb =
+        StaticRoute.builder().setNetwork(Prefix.parse("9.9.9.0/24")).setAdministrativeCost(1);
     Ip someIp = new Ip("1.1.1.1");
 
     // Unset interface
@@ -66,7 +67,11 @@ public class StaticRouteHelperTest {
   public void testShouldActivateEmptyRib() {
     Ip nextHop = new Ip("1.1.1.1");
     StaticRoute sr =
-        StaticRoute.builder().setNetwork(Prefix.parse("9.9.9.0/24")).setNextHopIp(nextHop).build();
+        StaticRoute.builder()
+            .setNetwork(Prefix.parse("9.9.9.0/24"))
+            .setNextHopIp(nextHop)
+            .setAdministrativeCost(1)
+            .build();
     assertThat(shouldActivateNextHopIpRoute(sr, _rib), equalTo(false));
   }
 
@@ -80,6 +85,7 @@ public class StaticRouteHelperTest {
         StaticRoute.builder()
             .setNetwork(Prefix.parse("9.9.9.0/24"))
             .setNextHopIp(new Ip("2.2.2.2"))
+            .setAdministrativeCost(1)
             .build();
 
     // Test & Assert
@@ -93,6 +99,7 @@ public class StaticRouteHelperTest {
         StaticRoute.builder()
             .setNetwork(Prefix.parse("1.0.0.0/8"))
             .setNextHopInterface("Eth0")
+            .setAdministrativeCost(1)
             .build());
 
     // Route in question
@@ -100,6 +107,7 @@ public class StaticRouteHelperTest {
         StaticRoute.builder()
             .setNetwork(Prefix.parse("9.9.9.0/24"))
             .setNextHopIp(new Ip("1.1.1.1"))
+            .setAdministrativeCost(1)
             .build();
 
     // Test & Assert
@@ -113,6 +121,7 @@ public class StaticRouteHelperTest {
         StaticRoute.builder()
             .setNetwork(Prefix.parse("9.9.9.0/24"))
             .setNextHopIp(new Ip("1.1.1.2"))
+            .setAdministrativeCost(1)
             .build());
 
     // Route in question
@@ -120,6 +129,7 @@ public class StaticRouteHelperTest {
         StaticRoute.builder()
             .setNetwork(Prefix.parse("9.9.9.0/24"))
             .setNextHopIp(new Ip("9.9.9.9"))
+            .setAdministrativeCost(1)
             .build();
 
     // Test & Assert
@@ -133,6 +143,7 @@ public class StaticRouteHelperTest {
         StaticRoute.builder()
             .setNetwork(Prefix.parse("1.1.1.0/24"))
             .setNextHopIp(new Ip("1.1.1.1"))
+            .setAdministrativeCost(1)
             .build();
     _rib.mergeRoute(sr);
 
@@ -148,12 +159,14 @@ public class StaticRouteHelperTest {
         StaticRoute.builder()
             .setNetwork(Prefix.parse("1.0.0.0/8"))
             .setNextHopInterface("Eth0")
+            .setAdministrativeCost(1)
             .build());
     // Static route 1, same network as sr, but different next hop ip
     _rib.mergeRoute(
         StaticRoute.builder()
             .setNetwork(Prefix.parse("9.9.9.0/24"))
             .setNextHopIp(new Ip("1.1.1.2"))
+            .setAdministrativeCost(1)
             .build());
 
     // Route in question
@@ -161,6 +174,7 @@ public class StaticRouteHelperTest {
         StaticRoute.builder()
             .setNetwork(Prefix.parse("9.9.9.0/24"))
             .setNextHopIp(new Ip("1.1.1.1"))
+            .setAdministrativeCost(1)
             .build();
 
     // Test & Assert
@@ -178,11 +192,13 @@ public class StaticRouteHelperTest {
         StaticRoute.builder()
             .setNetwork(Prefix.parse("1.1.1.0/24"))
             .setNextHopIp(new Ip("2.2.2.2"))
+            .setAdministrativeCost(1)
             .build());
     _rib.mergeRoute(
         StaticRoute.builder()
             .setNetwork(Prefix.parse("2.2.2.0/24"))
             .setNextHopIp(new Ip("9.9.9.9"))
+            .setAdministrativeCost(1)
             .build());
 
     // Route in question
@@ -190,6 +206,7 @@ public class StaticRouteHelperTest {
         StaticRoute.builder()
             .setNetwork(Prefix.parse("9.9.9.0/24"))
             .setNextHopIp(new Ip("1.1.1.1"))
+            .setAdministrativeCost(1)
             .build();
 
     // Test & Assert
@@ -206,6 +223,7 @@ public class StaticRouteHelperTest {
         StaticRoute.builder()
             .setNetwork(Prefix.parse("9.9.9.0/24"))
             .setNextHopIp(new Ip("9.9.9.9"))
+            .setAdministrativeCost(1)
             .build();
 
     // Test & Assert

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/AbstractRibTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/AbstractRibTest.java
@@ -38,7 +38,14 @@ public class AbstractRibTest {
    */
   private AbstractRib<StaticRoute> _rib;
   private static final StaticRoute _mostGeneralRoute =
-      new StaticRoute(Prefix.ZERO, Ip.ZERO, null, 0, 0L, 0);
+      StaticRoute.builder()
+          .setNetwork(Prefix.ZERO)
+          .setNextHopIp(Ip.ZERO)
+          .setNextHopInterface(null)
+          .setAdministrativeCost(1)
+          .setMetric(0L)
+          .setTag(0)
+          .build();
   @Rule public ExpectedException _expectedException = ExpectedException.none();
 
   @Before
@@ -64,7 +71,15 @@ public class AbstractRibTest {
     // Check that containsRoute works as expected for this simple case
     assertThat(_rib.containsRoute(_mostGeneralRoute), is(true));
     assertThat(
-        _rib.containsRoute(new StaticRoute(Prefix.parse("1.1.1.1/32"), Ip.ZERO, null, 0, 0L, 0)),
+        _rib.containsRoute(
+            StaticRoute.builder()
+                .setNetwork(Prefix.parse("1.1.1.1/32"))
+                .setNextHopIp(Ip.ZERO)
+                .setNextHopInterface(null)
+                .setAdministrativeCost(1)
+                .setMetric(0L)
+                .setTag(0)
+                .build()),
         is(false));
   }
 
@@ -77,7 +92,15 @@ public class AbstractRibTest {
 
     // Test: merge the routes into the RIB
     for (String prefixStr : testPrefixes) {
-      StaticRoute r = new StaticRoute(Prefix.parse(prefixStr), Ip.ZERO, null, 0, 0L, 0);
+      StaticRoute r =
+          StaticRoute.builder()
+              .setNetwork(Prefix.parse(prefixStr))
+              .setNextHopIp(Ip.ZERO)
+              .setNextHopInterface(null)
+              .setAdministrativeCost(1)
+              .setMetric(0L)
+              .setTag(0)
+              .build();
       _rib.mergeRouteGetDelta(r);
       routes.add(r);
     }
@@ -88,7 +111,15 @@ public class AbstractRibTest {
   @Test
   public void testRepeatedAdd() {
     // Setup
-    StaticRoute route = new StaticRoute(Prefix.parse("10.0.0.0/11"), Ip.ZERO, null, 0, 0L, 0);
+    StaticRoute route =
+        StaticRoute.builder()
+            .setNetwork(Prefix.parse("10.0.0.0/11"))
+            .setNextHopIp(Ip.ZERO)
+            .setNextHopInterface(null)
+            .setAdministrativeCost(1)
+            .setMetric(0L)
+            .setTag(0)
+            .build();
 
     // Test
     for (int i = 0; i < 5; i++) {
@@ -109,8 +140,24 @@ public class AbstractRibTest {
   @Test
   public void testNonOverlappingRouteAdd() {
     // Setup
-    StaticRoute r1 = new StaticRoute(Prefix.parse("1.1.1.1/32"), Ip.ZERO, null, 0, 0L, 0);
-    StaticRoute r2 = new StaticRoute(Prefix.parse("128.1.1.1/32"), Ip.ZERO, null, 0, 0L, 0);
+    StaticRoute r1 =
+        StaticRoute.builder()
+            .setNetwork(Prefix.parse("1.1.1.1/32"))
+            .setNextHopIp(Ip.ZERO)
+            .setNextHopInterface(null)
+            .setAdministrativeCost(1)
+            .setMetric(0L)
+            .setTag(0)
+            .build();
+    StaticRoute r2 =
+        StaticRoute.builder()
+            .setNetwork(Prefix.parse("128.1.1.1/32"))
+            .setNextHopIp(Ip.ZERO)
+            .setNextHopInterface(null)
+            .setAdministrativeCost(1)
+            .setMetric(0L)
+            .setTag(0)
+            .build();
 
     // Test:
     _rib.mergeRouteGetDelta(r1);
@@ -244,7 +291,15 @@ public class AbstractRibTest {
   public void testGetRoutesCannotBeModified() {
     _rib.mergeRouteGetDelta(_mostGeneralRoute);
     Set<StaticRoute> routes = _rib.getRoutes();
-    StaticRoute r1 = new StaticRoute(Prefix.parse("1.1.1.1/32"), Ip.ZERO, null, 0, 0L, 0);
+    StaticRoute r1 =
+        StaticRoute.builder()
+            .setNetwork(Prefix.parse("1.1.1.1/32"))
+            .setNextHopIp(Ip.ZERO)
+            .setNextHopInterface(null)
+            .setAdministrativeCost(1)
+            .setMetric(0L)
+            .setTag(0)
+            .build();
 
     // Exception because ImmutableSet
     _expectedException.expect(UnsupportedOperationException.class);
@@ -256,7 +311,15 @@ public class AbstractRibTest {
   public void testGetRoutesIsNotAView() {
     _rib.mergeRouteGetDelta(_mostGeneralRoute);
     Set<StaticRoute> routes = _rib.getRoutes();
-    StaticRoute r1 = new StaticRoute(Prefix.parse("1.1.1.1/32"), Ip.ZERO, null, 0, 0L, 0);
+    StaticRoute r1 =
+        StaticRoute.builder()
+            .setNetwork(Prefix.parse("1.1.1.1/32"))
+            .setNextHopIp(Ip.ZERO)
+            .setNextHopInterface(null)
+            .setAdministrativeCost(1)
+            .setMetric(0L)
+            .setTag(0)
+            .build();
 
     _rib.mergeRouteGetDelta(r1);
 
@@ -309,7 +372,15 @@ public class AbstractRibTest {
    */
   @Test
   public void testRemoveRoute() {
-    StaticRoute r = new StaticRoute(new Prefix(new Ip("1.1.1.1"), 32), Ip.ZERO, null, 1, 0L, 1);
+    StaticRoute r =
+        StaticRoute.builder()
+            .setNetwork(new Prefix(new Ip("1.1.1.1"), 32))
+            .setNextHopIp(Ip.ZERO)
+            .setNextHopInterface(null)
+            .setAdministrativeCost(1)
+            .setMetric(0L)
+            .setTag(1)
+            .build();
     _rib.mergeRoute(_mostGeneralRoute);
     _rib.mergeRoute(r);
 
@@ -340,9 +411,24 @@ public class AbstractRibTest {
   @Test
   public void testRemoveRouteSamePreference() {
     // Two routes for same prefix,
-    StaticRoute r1 = new StaticRoute(new Prefix(new Ip("1.1.1.1"), 32), Ip.ZERO, null, 1, 0L, 1);
+    StaticRoute r1 =
+        StaticRoute.builder()
+            .setNetwork(new Prefix(new Ip("1.1.1.1"), 32))
+            .setNextHopIp(Ip.ZERO)
+            .setNextHopInterface(null)
+            .setAdministrativeCost(1)
+            .setMetric(0L)
+            .setTag(1)
+            .build();
     StaticRoute r2 =
-        new StaticRoute(new Prefix(new Ip("1.1.1.1"), 32), new Ip("2.2.2.2"), null, 1, 0L, 1);
+        StaticRoute.builder()
+            .setNetwork(new Prefix(new Ip("1.1.1.1"), 32))
+            .setNextHopIp(new Ip("2.2.2.2"))
+            .setNextHopInterface(null)
+            .setAdministrativeCost(1)
+            .setMetric(0L)
+            .setTag(1)
+            .build();
 
     _rib.mergeRoute(r1);
     _rib.mergeRoute(r2);
@@ -357,9 +443,24 @@ public class AbstractRibTest {
   @Test
   public void testClear() {
     // Two routes for same prefix,
-    StaticRoute r1 = new StaticRoute(new Prefix(new Ip("1.1.1.1"), 32), Ip.ZERO, null, 1, 0L, 1);
+    StaticRoute r1 =
+        StaticRoute.builder()
+            .setNetwork(new Prefix(new Ip("1.1.1.1"), 32))
+            .setNextHopIp(Ip.ZERO)
+            .setNextHopInterface(null)
+            .setAdministrativeCost(1)
+            .setMetric(0L)
+            .setTag(1)
+            .build();
     StaticRoute r2 =
-        new StaticRoute(new Prefix(new Ip("1.1.1.1"), 32), new Ip("2.2.2.2"), null, 1, 0L, 1);
+        StaticRoute.builder()
+            .setNetwork(new Prefix(new Ip("1.1.1.1"), 32))
+            .setNextHopIp(new Ip("2.2.2.2"))
+            .setNextHopInterface(null)
+            .setAdministrativeCost(1)
+            .setMetric(0L)
+            .setTag(1)
+            .build();
 
     _rib.mergeRoute(r1);
     _rib.mergeRoute(r2);

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibDeltaTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibDeltaTest.java
@@ -41,12 +41,33 @@ public class RibDeltaTest {
   @Test
   public void testBuilderAddRoute() {
     StaticRoute route1 =
-        new StaticRoute(new Prefix(new Ip("1.1.1.0"), 24), Ip.ZERO, null, 1, 0L, 1);
+        StaticRoute.builder()
+            .setNetwork(new Prefix(new Ip("1.1.1.0"), 24))
+            .setNextHopIp(Ip.ZERO)
+            .setNextHopInterface(null)
+            .setAdministrativeCost(1)
+            .setMetric(0L)
+            .setTag(1)
+            .build();
     // Route 2 & 3 should be equal
     StaticRoute route2 =
-        new StaticRoute(new Prefix(new Ip("2.1.1.0"), 24), Ip.ZERO, null, 1, 0L, 1);
+        StaticRoute.builder()
+            .setNetwork(new Prefix(new Ip("2.1.1.0"), 24))
+            .setNextHopIp(Ip.ZERO)
+            .setNextHopInterface(null)
+            .setAdministrativeCost(1)
+            .setMetric(0L)
+            .setTag(1)
+            .build();
     StaticRoute route3 =
-        new StaticRoute(new Prefix(new Ip("2.1.1.0"), 24), Ip.ZERO, null, 1, 0L, 1);
+        StaticRoute.builder()
+            .setNetwork(new Prefix(new Ip("2.1.1.0"), 24))
+            .setNextHopIp(Ip.ZERO)
+            .setNextHopInterface(null)
+            .setAdministrativeCost(1)
+            .setMetric(0L)
+            .setTag(1)
+            .build();
     _builder.add(route1);
     _builder.add(route2);
 
@@ -66,12 +87,33 @@ public class RibDeltaTest {
   @Test
   public void testBuilderRemoveRoute() {
     StaticRoute route1 =
-        new StaticRoute(new Prefix(new Ip("1.1.1.0"), 24), Ip.ZERO, null, 1, 0L, 1);
+        StaticRoute.builder()
+            .setNetwork(new Prefix(new Ip("1.1.1.0"), 24))
+            .setNextHopIp(Ip.ZERO)
+            .setNextHopInterface(null)
+            .setAdministrativeCost(1)
+            .setMetric(0L)
+            .setTag(1)
+            .build();
     // Route 2 & 3 should be equal
     StaticRoute route2 =
-        new StaticRoute(new Prefix(new Ip("2.1.1.0"), 24), Ip.ZERO, null, 1, 0L, 1);
+        StaticRoute.builder()
+            .setNetwork(new Prefix(new Ip("2.1.1.0"), 24))
+            .setNextHopIp(Ip.ZERO)
+            .setNextHopInterface(null)
+            .setAdministrativeCost(1)
+            .setMetric(0L)
+            .setTag(1)
+            .build();
     StaticRoute route3 =
-        new StaticRoute(new Prefix(new Ip("2.1.1.0"), 24), Ip.ZERO, null, 1, 0L, 1);
+        StaticRoute.builder()
+            .setNetwork(new Prefix(new Ip("2.1.1.0"), 24))
+            .setNextHopIp(Ip.ZERO)
+            .setNextHopInterface(null)
+            .setAdministrativeCost(1)
+            .setMetric(0L)
+            .setTag(1)
+            .build();
     _builder.remove(route1, Reason.WITHDRAW);
     _builder.remove(route2, Reason.WITHDRAW);
 

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibTest.java
@@ -24,7 +24,11 @@ public class RibTest {
   public void testNonRoutingIsNotInstalled() {
     Rib rib = new Rib();
     AbstractRoute route =
-        StaticRoute.builder().setNextHopInterface("foo").setNetwork(Prefix.ZERO).build();
+        StaticRoute.builder()
+            .setNextHopInterface("foo")
+            .setNetwork(Prefix.ZERO)
+            .setAdministrativeCost(1)
+            .build();
     route.setNonRouting(true);
 
     assertThat(rib.mergeRouteGetDelta(route), is(nullValue()));

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -1269,6 +1269,7 @@ public class FlatJuniperGrammarTest {
             .setNetwork(Prefix.parse("10.0.1.0/24"))
             .setNextHopInterface("nextint")
             .setNextHopIp(new Ip("10.0.0.1"))
+            .setAdministrativeCost(1)
             .build();
 
     Environment.Builder eb = Environment.builder(c).setDirection(Direction.IN);

--- a/projects/batfish/src/test/java/org/batfish/symbolic/abstraction/BatfishCompressionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/symbolic/abstraction/BatfishCompressionTest.java
@@ -92,7 +92,11 @@ public class BatfishCompressionTest {
         .build();
 
     StaticRoute staticRoute =
-        StaticRoute.builder().setNetwork(p).setNextHopIp(p.getEndIp()).build();
+        StaticRoute.builder()
+            .setNetwork(p)
+            .setNextHopIp(p.getEndIp())
+            .setAdministrativeCost(1)
+            .build();
     v1.getStaticRoutes().add(staticRoute);
     v3.getStaticRoutes().add(staticRoute);
 
@@ -190,7 +194,7 @@ public class BatfishCompressionTest {
         .setAddress(new InterfaceAddress(pD.getEndIp(), pD.getPrefixLength()))
         .build();
 
-    StaticRoute.Builder bld = StaticRoute.builder().setNetwork(pD);
+    StaticRoute.Builder bld = StaticRoute.builder().setNetwork(pD).setAdministrativeCost(1);
     vA.getStaticRoutes().add(bld.setNextHopIp(pAB.getEndIp()).build());
     vA.getStaticRoutes().add(bld.setNextHopIp(pAC.getEndIp()).build());
     vB.getStaticRoutes().add(bld.setNextHopIp(pBD.getEndIp()).build());
@@ -240,9 +244,19 @@ public class BatfishCompressionTest {
         .setVrf(v3)
         .setAddress(new InterfaceAddress(p23.getEndIp(), p23.getPrefixLength()))
         .build();
-    StaticRoute s13 = StaticRoute.builder().setNetwork(p23).setNextHopIp(p12.getEndIp()).build();
+    StaticRoute s13 =
+        StaticRoute.builder()
+            .setNetwork(p23)
+            .setNextHopIp(p12.getEndIp())
+            .setAdministrativeCost(1)
+            .build();
     v1.getStaticRoutes().add(s13);
-    StaticRoute s31 = StaticRoute.builder().setNetwork(p12).setNextHopIp(p23.getStartIp()).build();
+    StaticRoute s31 =
+        StaticRoute.builder()
+            .setNetwork(p12)
+            .setNextHopIp(p23.getStartIp())
+            .setAdministrativeCost(1)
+            .build();
     v3.getStaticRoutes().add(s31);
 
     return new TreeMap<>(

--- a/projects/batfish/src/test/java/org/batfish/z3/NodJobAclTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/NodJobAclTest.java
@@ -122,7 +122,7 @@ public class NodJobAclTest {
         .setOutgoingFilter(matchSrcInterfaceAcl)
         .build();
 
-    StaticRoute.Builder bld = StaticRoute.builder().setNetwork(pDest);
+    StaticRoute.Builder bld = StaticRoute.builder().setNetwork(pDest).setAdministrativeCost(1);
     srcVrf.getStaticRoutes().add(bld.setNextHopIp(new Ip("1.0.0.1")).build());
     srcVrf.getStaticRoutes().add(bld.setNextHopIp(new Ip("2.0.0.1")).build());
 

--- a/projects/batfish/src/test/java/org/batfish/z3/NodJobChunkingTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/NodJobChunkingTest.java
@@ -131,7 +131,7 @@ public class NodJobChunkingTest {
         .setAddress(new InterfaceAddress(pDest.getEndIp(), pDest.getPrefixLength()))
         .build();
 
-    StaticRoute.Builder bld = StaticRoute.builder().setNetwork(pDest);
+    StaticRoute.Builder bld = StaticRoute.builder().setNetwork(pDest).setAdministrativeCost(1);
     _srcVrf1.getStaticRoutes().add(bld.setNextHopIp(p1.getEndIp()).build());
     _srcVrf2.getStaticRoutes().add(bld.setNextHopIp(p2.getEndIp()).build());
 

--- a/projects/batfish/src/test/java/org/batfish/z3/NodJobTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/NodJobTest.java
@@ -157,7 +157,7 @@ public class NodJobTest {
         .setAddress(new InterfaceAddress(pDest.getEndIp(), pDest.getPrefixLength()))
         .build();
 
-    StaticRoute.Builder bld = StaticRoute.builder().setNetwork(pDest);
+    StaticRoute.Builder bld = StaticRoute.builder().setNetwork(pDest).setAdministrativeCost(1);
     _srcVrf.getStaticRoutes().add(bld.setNextHopIp(p1.getEndIp()).build());
 
     _configs =

--- a/projects/batfish/src/test/java/org/batfish/z3/ReducedReachabilityTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/ReducedReachabilityTest.java
@@ -71,6 +71,7 @@ public class ReducedReachabilityTest {
               StaticRoute.builder()
                   .setNetwork(Prefix.parse("2.2.2.2/32"))
                   .setNextHopInterface(PHYSICAL)
+                  .setAdministrativeCost(1)
                   .build()));
     }
 
@@ -85,6 +86,7 @@ public class ReducedReachabilityTest {
             StaticRoute.builder()
                 .setNetwork(Prefix.parse("1.1.1.1/32"))
                 .setNextHopInterface(PHYSICAL)
+                .setAdministrativeCost(1)
                 .build()));
 
     return ImmutableSortedMap.of(NODE1, node1, NODE2, node2);

--- a/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
@@ -95,10 +95,12 @@ public class RoutesAnswererTest {
                         StaticRoute.builder()
                             .setNetwork(Prefix.parse("1.1.1.0/24"))
                             .setNextHopInterface("Null")
+                            .setAdministrativeCost(1)
                             .build(),
                         StaticRoute.builder()
                             .setNetwork(Prefix.parse("2.2.2.0/24"))
                             .setNextHopInterface("Null")
+                            .setAdministrativeCost(1)
                             .build()))));
 
     Multiset<Row> actual =
@@ -120,6 +122,7 @@ public class RoutesAnswererTest {
                 new MockRib<>(
                     ImmutableSet.of(
                         StaticRoute.builder()
+                            .setAdministrativeCost(1)
                             .setNetwork(Prefix.parse("1.1.1.0/24"))
                             .setNextHopInterface("Null")
                             .build()))));
@@ -142,6 +145,7 @@ public class RoutesAnswererTest {
                         StaticRoute.builder()
                             .setNetwork(Prefix.parse("1.1.1.0/24"))
                             .setNextHopInterface("Null")
+                            .setAdministrativeCost(1)
                             .build(),
                         new LocalRoute(new InterfaceAddress("2.2.2.0/24"), "Null")))));
 
@@ -163,6 +167,7 @@ public class RoutesAnswererTest {
                 new MockRib<>(
                     ImmutableSet.of(
                         StaticRoute.builder()
+                            .setAdministrativeCost(1)
                             .setNetwork(Prefix.parse("1.1.1.0/24"))
                             .setNextHopInterface("Null")
                             .build())),
@@ -172,6 +177,7 @@ public class RoutesAnswererTest {
                         StaticRoute.builder()
                             .setNetwork(Prefix.parse("2.2.2.0/24"))
                             .setNextHopInterface("Null")
+                            .setAdministrativeCost(1)
                             .build()))));
 
     Multiset<Row> actual =
@@ -215,6 +221,7 @@ public class RoutesAnswererTest {
                             .setNetwork(Prefix.parse("1.1.1.0/24"))
                             .setNextHopInterface("Null")
                             .setMetric(111)
+                            .setAdministrativeCost(1)
                             .build()))));
 
     Multiset<Row> actual = getMainRibRoutes(ribs, ImmutableSet.of("n1"), null, ".*", ".*", null);
@@ -341,6 +348,7 @@ public class RoutesAnswererTest {
                 new MockRib<>(
                     ImmutableSet.of(
                         StaticRoute.builder()
+                            .setAdministrativeCost(1)
                             .setNetwork(Prefix.parse("1.1.1.1/32"))
                             .setNextHopInterface("Null")
                             .build()))));


### PR DESCRIPTION
*Problem*:
- In StaticRoute builders, we defaulted to making admin cost -1, unless explicitly set. 
- We had no validity checks for this value elsewhere (e.g., RIBs)
- In some corner cases, this made static route better than *any other route* including connected, which is wrong (as discovered by @yifeiyuan).

This affected tests only, admin distance was/is set correctly (AFAIK) upon conversion VS -> VI.

*Fix*:
- Require valid (>= 0) admin cost upon construction of static routes
- Cleanup constructors/builder pattern for static routes: constructor is now private, builders are used everywhere, admin cost is explicitly set. Since many of our tests are Cisco IOS-ish, went with admin cost of 1 for existing tests.

*Future work*:
We should probably pull up admin cost/tags up to abstract route builder, but that's out of scope for the fix here.