### PR TITLE
Juniper: parse and extract static route no-install

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractRoute.java
@@ -42,6 +42,7 @@ public abstract class AbstractRoute implements Serializable, Comparable<Abstract
   @Nonnull protected final Prefix _network;
   @Nullable private String _nextHop;
   private boolean _nonRouting;
+  private boolean _nonForwarding;
 
   @JsonCreator
   protected AbstractRoute(@Nullable @JsonProperty(PROP_NETWORK) Prefix network) {
@@ -105,6 +106,15 @@ public abstract class AbstractRoute implements Serializable, Comparable<Abstract
     return _nonRouting;
   }
 
+  /**
+   * Returns {@code true} if this route is non-forwarding, i.e., it can be installed in the main RIB
+   * but not the FIB.
+   */
+  @JsonIgnore
+  public final boolean getNonForwarding() {
+    return _nonForwarding;
+  }
+
   @JsonIgnore
   public abstract RoutingProtocol getProtocol();
 
@@ -136,6 +146,11 @@ public abstract class AbstractRoute implements Serializable, Comparable<Abstract
   @JsonIgnore
   public final void setNonRouting(boolean nonRouting) {
     _nonRouting = nonRouting;
+  }
+
+  @JsonIgnore
+  public final void setNonForwarding(boolean nonForwarding) {
+    _nonForwarding = nonForwarding;
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractRoute.java
@@ -100,12 +100,6 @@ public abstract class AbstractRoute implements Serializable, Comparable<Abstract
   @Nonnull
   public abstract Ip getNextHopIp();
 
-  /** Check if this route is "non-routing", i.e., should not be installed in the main RIB. */
-  @JsonIgnore
-  public final boolean getNonRouting() {
-    return _nonRouting;
-  }
-
   /**
    * Returns {@code true} if this route is non-forwarding, i.e., it can be installed in the main RIB
    * but not the FIB.
@@ -113,6 +107,12 @@ public abstract class AbstractRoute implements Serializable, Comparable<Abstract
   @JsonIgnore
   public final boolean getNonForwarding() {
     return _nonForwarding;
+  }
+
+  /** Check if this route is "non-routing", i.e., should not be installed in the main RIB. */
+  @JsonIgnore
+  public final boolean getNonRouting() {
+    return _nonRouting;
   }
 
   @JsonIgnore
@@ -144,13 +144,13 @@ public abstract class AbstractRoute implements Serializable, Comparable<Abstract
   }
 
   @JsonIgnore
-  public final void setNonRouting(boolean nonRouting) {
-    _nonRouting = nonRouting;
+  public final void setNonForwarding(boolean nonForwarding) {
+    _nonForwarding = nonForwarding;
   }
 
   @JsonIgnore
-  public final void setNonForwarding(boolean nonForwarding) {
-    _nonForwarding = nonForwarding;
+  public final void setNonRouting(boolean nonRouting) {
+    _nonRouting = nonRouting;
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/AbstractRouteMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/AbstractRouteMatchers.java
@@ -12,6 +12,7 @@ import org.batfish.datamodel.matchers.AbstractRouteMatchersImpl.HasNextHopInterf
 import org.batfish.datamodel.matchers.AbstractRouteMatchersImpl.HasNextHopIp;
 import org.batfish.datamodel.matchers.AbstractRouteMatchersImpl.HasPrefix;
 import org.batfish.datamodel.matchers.AbstractRouteMatchersImpl.HasProtocol;
+import org.batfish.datamodel.matchers.AbstractRouteMatchersImpl.IsNonForwarding;
 import org.hamcrest.Matcher;
 
 public final class AbstractRouteMatchers {
@@ -88,6 +89,14 @@ public final class AbstractRouteMatchers {
    */
   public static HasProtocol hasProtocol(RoutingProtocol expectedProtocol) {
     return new HasProtocol(equalTo(expectedProtocol));
+  }
+
+  /**
+   * Provides a matcher that matches when the supplied {@code nonForwarding} is equal to the {@link
+   * AbstractRoute}'s nonForwarding.
+   */
+  public static IsNonForwarding isNonForwarding(boolean nonForwarding) {
+    return new IsNonForwarding(equalTo(nonForwarding));
   }
 
   private AbstractRouteMatchers() {}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/AbstractRouteMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/AbstractRouteMatchersImpl.java
@@ -75,5 +75,16 @@ final class AbstractRouteMatchersImpl {
     }
   }
 
+  static final class IsNonForwarding extends FeatureMatcher<AbstractRoute, Boolean> {
+    IsNonForwarding(@Nonnull Matcher<? super Boolean> subMatcher) {
+      super(subMatcher, "An AbstractRoute with nonRouting:", "nonRouting");
+    }
+
+    @Override
+    protected Boolean featureValueOf(AbstractRoute actual) {
+      return actual.getNonForwarding();
+    }
+  }
+
   private AbstractRouteMatchersImpl() {}
 }

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_routing_instances.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_routing_instances.g4
@@ -481,6 +481,7 @@ rosr_common
    | rosr_community
    | rosr_discard
    | rosr_install
+   | rosr_no_install
    | rosr_metric
    | rosr_next_hop
    | rosr_next_table
@@ -531,6 +532,11 @@ rosr_next_hop
 rosr_next_table
 :
    NEXT_TABLE name = variable
+;
+
+rosr_no_install
+:
+   NO_INSTALL
 ;
 
 rosr_no_readvertise

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -355,6 +355,7 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ros_routeContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Rosr_discardContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Rosr_metricContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Rosr_next_hopContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Rosr_no_installContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Rosr_preferenceContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Rosr_rejectContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Rosr_tagContext;
@@ -4366,6 +4367,11 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
           STATIC_ROUTE_NEXT_HOP_INTERFACE,
           getLine(ctx.interface_id().getStop()));
     }
+  }
+
+  @Override
+  public void exitRosr_no_install(Rosr_no_installContext ctx) {
+    _currentStaticRoute.setNoInstall(ctx.NO_INSTALL() != null);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -1946,6 +1946,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
             .setTag(tag)
             .build();
 
+    newStaticRoute.setNonForwarding(firstNonNull(route.getNoInstall(), Boolean.FALSE));
     return newStaticRoute;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/StaticRoute.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/StaticRoute.java
@@ -3,6 +3,7 @@ package org.batfish.representation.juniper;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
 
@@ -30,6 +31,8 @@ public class StaticRoute implements Serializable {
 
   private Integer _tag;
 
+  private Boolean _noInstall;
+
   public StaticRoute(Prefix prefix) {
     _prefix = prefix;
     _policies = new ArrayList<>();
@@ -55,6 +58,11 @@ public class StaticRoute implements Serializable {
 
   public Ip getNextHopIp() {
     return _nextHopIp;
+  }
+
+  @Nullable
+  public Boolean getNoInstall() {
+    return _noInstall;
   }
 
   public List<String> getPolicies() {
@@ -87,6 +95,10 @@ public class StaticRoute implements Serializable {
 
   public void setNextHopIp(Ip nextHopIp) {
     _nextHopIp = nextHopIp;
+  }
+
+  public void setNoInstall(@Nullable Boolean noInstall) {
+    _noInstall = noInstall;
   }
 
   public void setTag(int tag) {

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -5,6 +5,7 @@ import static org.batfish.datamodel.AuthenticationMethod.GROUP_TACACS;
 import static org.batfish.datamodel.AuthenticationMethod.PASSWORD;
 import static org.batfish.datamodel.matchers.AaaAuthenticationLoginListMatchers.hasMethods;
 import static org.batfish.datamodel.matchers.AbstractRouteMatchers.hasPrefix;
+import static org.batfish.datamodel.matchers.AbstractRouteMatchers.isNonForwarding;
 import static org.batfish.datamodel.matchers.BgpNeighborMatchers.hasAllowLocalAsIn;
 import static org.batfish.datamodel.matchers.BgpNeighborMatchers.hasClusterId;
 import static org.batfish.datamodel.matchers.BgpNeighborMatchers.hasEnforceFirstAs;
@@ -2620,6 +2621,11 @@ public class FlatJuniperGrammarTest {
 
     assertThat(c, hasDefaultVrf(hasStaticRoutes(hasItem(hasPrefix(Prefix.parse("1.0.0.0/8"))))));
     assertThat(c, hasVrf("ri2", hasStaticRoutes(hasItem(hasPrefix(Prefix.parse("2.0.0.0/8"))))));
+    assertThat(
+        c,
+        hasDefaultVrf(
+            hasStaticRoutes(
+                hasItem(allOf(hasPrefix(Prefix.parse("3.0.0.0/8")), isNonForwarding(true))))));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/static-routes
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/static-routes
@@ -3,4 +3,5 @@ set system host-name static-routes
 #
 set routing-options static route 1.0.0.0/8 next-hop 10.0.0.1
 set routing-instances ri2 routing-options static route 2.0.0.0/8 next-hop 10.0.0.2
+set routing-options static route 3.0.0.0/8 no-install
 #


### PR DESCRIPTION
*Note* no changes to FIB computation process, extraction only (to keep self-contained).