### PR TITLE
BfConsts: rename testrigs to snapshots in path

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
@@ -177,13 +177,18 @@ public class BfConsts {
   public static final String RELPATH_QUESTIONS_DIR = "questions";
   public static final String RELPATH_SERIALIZED_ENVIRONMENT_BGP_TABLES = "bgp_processed";
   public static final String RELPATH_SERIALIZED_ENVIRONMENT_ROUTING_TABLES = "rt_processed";
+  public static final String RELPATH_SNAPSHOTS_DIR = "snapshots";
   public static final String RELPATH_STANDARD_DIR = "standard";
   public static final String RELPATH_SYNC_TESTRIGS_DIR = "testrig_sync";
   public static final String RELPATH_TEST_RIG_DIR = "testrig";
   public static final String RELPATH_TESTRIG_L1_TOPOLOGY_PATH = "testrig_layer1_topology";
   public static final String RELPATH_TESTRIG_LEGACY_TOPOLOGY_PATH = "topology.net";
   public static final String RELPATH_TESTRIG_TOPOLOGY_PATH = "testrig_topology";
-  public static final String RELPATH_TESTRIGS_DIR = "testrigs";
+
+  @SuppressWarnings("unused")
+  @Deprecated
+  public static final String RELPATH_TESTRIGS_DIR = "snapshots";
+
   public static final String RELPATH_VALIDATE_ENVIRONMENT_ANSWER = "venv_answer";
   public static final String RELPATH_COMPRESSED_CONFIG_DIR = "compressed_configs";
   public static final String RELPATH_VENDOR_INDEPENDENT_CONFIG_DIR = "indep";

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorageDirectoryProvider.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorageDirectoryProvider.java
@@ -100,7 +100,7 @@ public class FileBasedStorageDirectoryProvider {
   }
 
   public @Nonnull Path getSnapshotDir(NetworkId network, SnapshotId snapshot) {
-    return getNetworkDir(network).resolve(BfConsts.RELPATH_TESTRIGS_DIR).resolve(snapshot.getId());
+    return getNetworkDir(network).resolve(BfConsts.RELPATH_SNAPSHOTS_DIR).resolve(snapshot.getId());
   }
 
   public @Nonnull Path getStandardAnswerDir(

--- a/projects/batfish/src/main/java/org/batfish/config/Settings.java
+++ b/projects/batfish/src/main/java/org/batfish/config/Settings.java
@@ -750,7 +750,7 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     }
     return getStorageBase()
         .resolve(getContainer().getId())
-        .resolve(BfConsts.RELPATH_TESTRIGS_DIR)
+        .resolve(BfConsts.RELPATH_SNAPSHOTS_DIR)
         .resolve(tr)
         .resolve(getTaskId() + BfConsts.SUFFIX_LOG_FILE)
         .toString();

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -237,7 +237,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
   public static void applyBaseDir(
       TestrigSettings settings, Path containerDir, SnapshotId testrig, String envName) {
     Path testrigDir =
-        containerDir.resolve(Paths.get(BfConsts.RELPATH_TESTRIGS_DIR, testrig.getId()));
+        containerDir.resolve(Paths.get(BfConsts.RELPATH_SNAPSHOTS_DIR, testrig.getId()));
     settings.setName(testrig);
     settings.setBasePath(testrigDir);
     EnvironmentSettings envSettings = settings.getEnvironmentSettings();
@@ -4614,7 +4614,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
           _settings
               .getStorageBase()
               .resolve(_settings.getContainer().getId())
-              .resolve(BfConsts.RELPATH_TESTRIGS_DIR)
+              .resolve(BfConsts.RELPATH_SNAPSHOTS_DIR)
               .resolve(_settings.getTestrig().getId())
               .resolve(_settings.getTaskId() + BfConsts.SUFFIX_ANSWER_JSON_FILE);
       CommonUtil.writeFile(jsonPath, logString);

--- a/projects/batfish/src/test/java/org/batfish/config/SettingsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/config/SettingsTest.java
@@ -69,7 +69,7 @@ public class SettingsTest {
         new Settings(new String[] {"-storagebase=/path", "-container=foo", "-testrig=main"});
     settings.setTaskId("tid");
 
-    assertThat(settings.getLogFile(), equalTo("/path/foo/testrigs/main/tid.log"));
+    assertThat(settings.getLogFile(), equalTo("/path/foo/snapshots/main/tid.log"));
 
     // Delta testrig present
     settings =
@@ -79,7 +79,7 @@ public class SettingsTest {
             });
     settings.setTaskId("tid");
 
-    assertThat(settings.getLogFile(), equalTo("/path/foo/testrigs/delta/tid.log"));
+    assertThat(settings.getLogFile(), equalTo("/path/foo/snapshots/delta/tid.log"));
 
     // Delta testrig present, but the question is differential
     settings =
@@ -93,6 +93,6 @@ public class SettingsTest {
             });
     settings.setTaskId("tid");
 
-    assertThat(settings.getLogFile(), equalTo("/path/foo/testrigs/main/tid.log"));
+    assertThat(settings.getLogFile(), equalTo("/path/foo/snapshots/main/tid.log"));
   }
 }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -1154,7 +1154,7 @@ public class WorkMgr extends AbstractCoordinator {
 
   @Override
   public Path getdirSnapshots(String networkName) {
-    return getdirNetwork(networkName).resolve(Paths.get(BfConsts.RELPATH_TESTRIGS_DIR));
+    return getdirNetwork(networkName).resolve(Paths.get(BfConsts.RELPATH_SNAPSHOTS_DIR));
   }
 
   private IssueSettingsId getOrCreateIssueSettingsId(NetworkId networkId, String majorIssueType)
@@ -1359,7 +1359,7 @@ public class WorkMgr extends AbstractCoordinator {
 
     Path containerDir = getdirNetwork(networkName);
     Path testrigDir =
-        containerDir.resolve(Paths.get(BfConsts.RELPATH_TESTRIGS_DIR, snapshotId.getId()));
+        containerDir.resolve(Paths.get(BfConsts.RELPATH_SNAPSHOTS_DIR, snapshotId.getId()));
 
     if (!testrigDir.toFile().mkdirs()) {
       throw new BatfishException("Failed to create directory: '" + testrigDir + "'");

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
@@ -131,7 +131,7 @@ public class WorkMgrTest {
             .getdirNetwork(container)
             .resolve(
                 Paths.get(
-                    BfConsts.RELPATH_TESTRIGS_DIR, snapshotId.getId(), BfConsts.RELPATH_OUTPUT));
+                    BfConsts.RELPATH_SNAPSHOTS_DIR, snapshotId.getId(), BfConsts.RELPATH_OUTPUT));
     outputDir.toFile().mkdirs();
     TestrigMetadataMgr.writeMetadata(
         new TestrigMetadata(new Date().toInstant(), "env"), networkId, snapshotId);


### PR DESCRIPTION
Deprecate old constant but leave present for now.

Since we redid the entire file structure inside the storage system, start fixing constants in there too.