### PR TITLE
use AclLineMatchExpr to represent HeaderSpace constraints in reachability

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/IpAccessListToBDD.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/IpAccessListToBDD.java
@@ -98,6 +98,10 @@ public class IpAccessListToBDD implements GenericAclLineMatchExprVisitor<BDD> {
     return _pkt;
   }
 
+  public HeaderSpaceToBDD getHeaderSpaceToBDD() {
+    return _headerSpaceToBDD;
+  }
+
   /**
    * Convert an Access Control List (ACL) to a symbolic boolean expression. The default action in an
    * ACL is to deny all traffic.

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/question/ReachabilityParameters.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/question/ReachabilityParameters.java
@@ -7,6 +7,8 @@ import javax.annotation.Nullable;
 import org.batfish.datamodel.FlowDisposition;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.UniverseIpSpace;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.specifier.AllInterfacesLocationSpecifier;
 import org.batfish.specifier.ConstantIpSpaceSpecifier;
 import org.batfish.specifier.InferFromLocationIpSpaceSpecifier;
@@ -34,7 +36,7 @@ public final class ReachabilityParameters {
 
     private @Nullable NodeSpecifier _forbiddenTransitNodesSpecifier = null;
 
-    private @Nullable HeaderSpace _headerSpace;
+    private @Nullable AclLineMatchExpr _headerSpace;
 
     private int _maxChunkSize;
 
@@ -89,7 +91,7 @@ public final class ReachabilityParameters {
     }
 
     public Builder setHeaderSpace(@Nonnull HeaderSpace headerSpace) {
-      _headerSpace = headerSpace;
+      _headerSpace = new MatchHeaderSpace(headerSpace);
       return this;
     }
 
@@ -127,7 +129,7 @@ public final class ReachabilityParameters {
 
   private final @Nullable NodeSpecifier _forbiddenTransitNodesSpecifier;
 
-  private final HeaderSpace _headerSpace;
+  private final AclLineMatchExpr _headerSpace;
 
   private final int _maxChunkSize;
 
@@ -181,7 +183,7 @@ public final class ReachabilityParameters {
     return _forbiddenTransitNodesSpecifier;
   }
 
-  public HeaderSpace getHeaderSpace() {
+  public AclLineMatchExpr getHeaderSpace() {
     return _headerSpace;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/question/ResolvedReachabilityParameters.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/question/ResolvedReachabilityParameters.java
@@ -9,7 +9,7 @@ import java.util.SortedSet;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.FlowDisposition;
-import org.batfish.datamodel.HeaderSpace;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.datamodel.questions.InvalidReachabilityParametersException;
 import org.batfish.specifier.IpSpaceAssignment;
 
@@ -30,7 +30,7 @@ public final class ResolvedReachabilityParameters {
 
     private Set<String> _forbiddenTransitNodes;
 
-    private HeaderSpace _headerSpace;
+    private AclLineMatchExpr _headerSpace;
 
     private int _maxChunkSize;
 
@@ -73,7 +73,7 @@ public final class ResolvedReachabilityParameters {
       return this;
     }
 
-    public Builder setHeaderSpace(HeaderSpace headerSpace) {
+    public Builder setHeaderSpace(AclLineMatchExpr headerSpace) {
       _headerSpace = headerSpace;
       return this;
     }
@@ -119,7 +119,7 @@ public final class ResolvedReachabilityParameters {
 
   private Set<String> _forbiddenTransitNodes;
 
-  private final HeaderSpace _headerSpace;
+  private final AclLineMatchExpr _headerSpace;
 
   private final int _maxChunkSize;
 
@@ -172,7 +172,7 @@ public final class ResolvedReachabilityParameters {
     return _forbiddenTransitNodes;
   }
 
-  public HeaderSpace getHeaderSpace() {
+  public AclLineMatchExpr getHeaderSpace() {
     return _headerSpace;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -3,6 +3,7 @@ package org.batfish.main;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.stream.Collectors.toMap;
 import static org.batfish.bddreachability.BDDMultipathInconsistency.computeMultipathInconsistencies;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.TRUE;
 import static org.batfish.datamodel.acl.SourcesReferencedByIpAccessLists.SOURCE_ORIGINATING_FROM_DEVICE;
 import static org.batfish.datamodel.acl.SourcesReferencedByIpAccessLists.referencedSources;
 import static org.batfish.main.ReachabilityParametersResolver.resolveReachabilityParameters;
@@ -124,6 +125,8 @@ import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.UniverseIpSpace;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.acl.AclExplainer;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.acl.AclLineMatchExprs;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.datamodel.answers.Answer;
 import org.batfish.datamodel.answers.AnswerElement;
@@ -2813,7 +2816,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
           new ReachEdgeQuerySynthesizer(
               ingressNode, vrf, edge, true, reachabilityParameters.getHeaderSpace());
       ReachEdgeQuerySynthesizer noReachQuery =
-          new ReachEdgeQuerySynthesizer(ingressNode, vrf, edge, true, new HeaderSpace());
+          new ReachEdgeQuerySynthesizer(ingressNode, vrf, edge, true, TRUE);
       noReachQuery.setNegate(true);
       List<QuerySynthesizer> queries = ImmutableList.of(reachQuery, noReachQuery, blacklistQuery);
       CompositeNodJob job =
@@ -4005,7 +4008,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
     Map<String, Configuration> configurations = parameters.getConfigurations();
     DataPlane dataPlane = parameters.getDataPlane();
     Set<String> forbiddenTransitNodes = parameters.getForbiddenTransitNodes();
-    HeaderSpace headerSpace = parameters.getHeaderSpace();
+    AclLineMatchExpr headerSpace = parameters.getHeaderSpace();
     Set<String> requiredTransitNodes = parameters.getRequiredTransitNodes();
     Synthesizer dataPlaneSynthesizer =
         synthesizeDataPlane(
@@ -4352,7 +4355,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
     return synthesizeDataPlane(
         configurations,
         dataPlane,
-        new HeaderSpace(),
+        AclLineMatchExprs.TRUE,
         ImmutableSet.of(),
         ImmutableSet.of(),
         IpSpaceAssignment.empty(),
@@ -4498,7 +4501,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
   public Synthesizer synthesizeDataPlane(
       Map<String, Configuration> configurations,
       DataPlane dataPlane,
-      HeaderSpace headerSpace,
+      AclLineMatchExpr headerSpace,
       Set<String> nonTransitNodes,
       Set<String> transitNodes,
       IpSpaceAssignment ipSpaceAssignment,
@@ -4536,7 +4539,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
   public static SynthesizerInputImpl computeSynthesizerInput(
       Map<String, Configuration> configurations,
       DataPlane dataPlane,
-      HeaderSpace headerSpace,
+      AclLineMatchExpr headerSpace,
       IpSpaceAssignment ipSpaceAssignment,
       Set<String> transitNodes,
       Set<String> nonTransitNodes,

--- a/projects/batfish/src/main/java/org/batfish/main/ReachabilityParametersResolver.java
+++ b/projects/batfish/src/main/java/org/batfish/main/ReachabilityParametersResolver.java
@@ -1,6 +1,11 @@
 package org.batfish.main;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDst;
+
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.util.Map;
@@ -16,6 +21,8 @@ import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.FlowDisposition;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.IpSpace;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.acl.AclLineMatchExprs;
 import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.questions.InvalidReachabilityParametersException;
 import org.batfish.datamodel.visitors.IpSpaceRepresentative;
@@ -106,16 +113,10 @@ final class ReachabilityParametersResolver {
         .build();
   }
 
-  private HeaderSpace resolveHeaderSpace() throws InvalidReachabilityParametersException {
-    IpSpace destinationIpSpace = resolveDestinationIpSpace();
-
-    HeaderSpace headerSpace = _params.getHeaderSpace();
-    if (headerSpace == null) {
-      headerSpace = HeaderSpace.builder().setDstIps(destinationIpSpace).build();
-    } else {
-      headerSpace.setDstIps(destinationIpSpace);
-    }
-    return headerSpace;
+  private AclLineMatchExpr resolveHeaderSpace() throws InvalidReachabilityParametersException {
+    return and(
+        firstNonNull(_params.getHeaderSpace(), AclLineMatchExprs.TRUE),
+        matchDst(resolveDestinationIpSpace()));
   }
 
   @VisibleForTesting
@@ -209,7 +210,15 @@ final class ReachabilityParametersResolver {
   }
 
   private void initConfigsAndDataPlane() {
-    boolean useCompression = _params.getUseCompression();
+    /*
+     * TODO Fix compression to use a more expressive representation of HeaderSpaces
+     * The compression code expects the headerspace to be expressed as a HeaderSpace object,
+     * but ReachabilityParameters use a more expressive representation. Until we update compression,
+     * we can't use it.
+     */
+    Preconditions.checkArgument(!_params.getUseCompression(), "Compression is currently disabled.");
+    boolean useCompression = false;
+    HeaderSpace compressionHeaderSpace = null;
 
     /*
      * TODO specialized compression is currently broken.
@@ -238,7 +247,7 @@ final class ReachabilityParametersResolver {
 
     CompressDataPlaneResult compressionResult =
         useCompression && useSpecializedCompression
-            ? _batfish.computeCompressedDataPlane(_params.getHeaderSpace())
+            ? _batfish.computeCompressedDataPlane(compressionHeaderSpace)
             : null;
 
     _configs =

--- a/projects/batfish/src/main/java/org/batfish/z3/MultipathInconsistencyQuerySynthesizer.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/MultipathInconsistencyQuerySynthesizer.java
@@ -1,18 +1,18 @@
 package org.batfish.z3;
 
+import static org.batfish.z3.AclLineMatchExprToBooleanExpr.NO_ACLS_NO_IP_SPACES_NO_SOURCES_ORIG_HEADERSPACE;
+
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import org.batfish.datamodel.FlowDisposition;
-import org.batfish.datamodel.HeaderSpace;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.question.SrcNattedConstraint;
 import org.batfish.z3.expr.AndExpr;
 import org.batfish.z3.expr.BasicRuleStatement;
 import org.batfish.z3.expr.BooleanExpr;
-import org.batfish.z3.expr.HeaderSpaceMatchExpr;
 import org.batfish.z3.expr.QueryStatement;
 import org.batfish.z3.expr.RuleStatement;
 import org.batfish.z3.state.Accept;
@@ -57,7 +57,7 @@ public class MultipathInconsistencyQuerySynthesizer extends ReachabilityQuerySyn
   }
 
   private MultipathInconsistencyQuerySynthesizer(
-      @Nonnull HeaderSpace headerSpace,
+      @Nonnull AclLineMatchExpr headerSpace,
       @Nonnull Map<IngressLocation, BooleanExpr> ingressLocations,
       @Nonnull SrcNattedConstraint srcNatted,
       @Nonnull Set<String> transitNodes,
@@ -84,7 +84,7 @@ public class MultipathInconsistencyQuerySynthesizer extends ReachabilityQuerySyn
         .setSmtConstraint(
             new AndExpr(
                 ImmutableList.of(
-                    new HeaderSpaceMatchExpr(_headerSpace, ImmutableMap.of(), true),
+                    NO_ACLS_NO_IP_SPACES_NO_SOURCES_ORIG_HEADERSPACE.toBooleanExpr(_headerSpace),
                     getSrcNattedConstraint())))
         .build();
   }

--- a/projects/batfish/src/main/java/org/batfish/z3/ReachEdgeQuerySynthesizer.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/ReachEdgeQuerySynthesizer.java
@@ -1,14 +1,12 @@
 package org.batfish.z3;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.batfish.datamodel.Edge;
-import org.batfish.datamodel.HeaderSpace;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.z3.expr.AndExpr;
 import org.batfish.z3.expr.BasicRuleStatement;
 import org.batfish.z3.expr.EqExpr;
-import org.batfish.z3.expr.HeaderSpaceMatchExpr;
 import org.batfish.z3.expr.QueryStatement;
 import org.batfish.z3.expr.StateExpr;
 import org.batfish.z3.expr.TrueExpr;
@@ -23,7 +21,7 @@ public class ReachEdgeQuerySynthesizer extends BaseQuerySynthesizer {
 
   private Edge _edge;
 
-  private HeaderSpace _headerSpace;
+  private AclLineMatchExpr _headerSpace;
 
   private String _ingressVrf;
 
@@ -36,7 +34,7 @@ public class ReachEdgeQuerySynthesizer extends BaseQuerySynthesizer {
       String ingressVrf,
       Edge edge,
       boolean requireAcceptance,
-      HeaderSpace headerSpace) {
+      AclLineMatchExpr headerSpace) {
     _edge = edge;
     _headerSpace = headerSpace;
     _ingressVrf = ingressVrf;
@@ -65,7 +63,9 @@ public class ReachEdgeQuerySynthesizer extends BaseQuerySynthesizer {
                                 new VarIntExpr(Field.ORIG_SRC_IP), new VarIntExpr(Field.SRC_IP)),
                             _headerSpace == null
                                 ? TrueExpr.INSTANCE
-                                : new HeaderSpaceMatchExpr(_headerSpace, ImmutableMap.of()))),
+                                : AclLineMatchExprToBooleanExpr
+                                    .NO_ACLS_NO_IP_SPACES_NO_SOURCES_ORIG_HEADERSPACE.toBooleanExpr(
+                                    _headerSpace))),
                     new OriginateVrf(_originationNode, _ingressVrf)),
                 new BasicRuleStatement(
                     queryPreconditionPreTransformationStates.build(), Query.INSTANCE)))

--- a/projects/batfish/src/main/java/org/batfish/z3/ReachabilityQuerySynthesizer.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/ReachabilityQuerySynthesizer.java
@@ -10,7 +10,8 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import org.batfish.common.BatfishException;
 import org.batfish.datamodel.FlowDisposition;
-import org.batfish.datamodel.HeaderSpace;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.acl.AclLineMatchExprs;
 import org.batfish.question.SrcNattedConstraint;
 import org.batfish.z3.expr.BasicRuleStatement;
 import org.batfish.z3.expr.BooleanExpr;
@@ -28,7 +29,7 @@ public abstract class ReachabilityQuerySynthesizer extends BaseQuerySynthesizer 
       Q extends ReachabilityQuerySynthesizer, T extends Builder<Q, T>> {
     protected Set<String> _forbiddenTransitNodes;
 
-    protected HeaderSpace _headerSpace;
+    protected AclLineMatchExpr _headerSpace;
 
     protected Map<IngressLocation, BooleanExpr> _srcIpConstraints;
 
@@ -38,7 +39,7 @@ public abstract class ReachabilityQuerySynthesizer extends BaseQuerySynthesizer 
 
     public Builder() {
       _forbiddenTransitNodes = ImmutableSet.of();
-      _headerSpace = new HeaderSpace();
+      _headerSpace = AclLineMatchExprs.TRUE;
       _srcIpConstraints = ImmutableMap.of();
       _requiredTransitNodes = ImmutableSet.of();
       _srcNatted = UNCONSTRAINED;
@@ -57,7 +58,7 @@ public abstract class ReachabilityQuerySynthesizer extends BaseQuerySynthesizer 
       return getThis();
     }
 
-    public T setHeaderSpace(HeaderSpace headerSpace) {
+    public T setHeaderSpace(AclLineMatchExpr headerSpace) {
       _headerSpace = headerSpace;
       return getThis();
     }
@@ -78,7 +79,7 @@ public abstract class ReachabilityQuerySynthesizer extends BaseQuerySynthesizer 
     }
   }
 
-  protected final @Nonnull HeaderSpace _headerSpace;
+  protected final @Nonnull AclLineMatchExpr _headerSpace;
 
   protected final @Nonnull ImmutableMap<IngressLocation, BooleanExpr> _srcIpConstraints;
 
@@ -89,7 +90,7 @@ public abstract class ReachabilityQuerySynthesizer extends BaseQuerySynthesizer 
   protected final @Nonnull Set<String> _transitNodes;
 
   public ReachabilityQuerySynthesizer(
-      @Nonnull HeaderSpace headerSpace,
+      @Nonnull AclLineMatchExpr headerSpace,
       @Nonnull Map<IngressLocation, BooleanExpr> srcIpConstraints,
       @Nonnull SrcNattedConstraint srcNatted,
       @Nonnull Set<String> transitNodes,

--- a/projects/batfish/src/main/java/org/batfish/z3/StandardReachabilityQuerySynthesizer.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/StandardReachabilityQuerySynthesizer.java
@@ -1,7 +1,8 @@
 package org.batfish.z3;
 
+import static org.batfish.z3.AclLineMatchExprToBooleanExpr.NO_ACLS_NO_IP_SPACES_NO_SOURCES_ORIG_HEADERSPACE;
+
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.util.List;
 import java.util.Map;
@@ -9,13 +10,12 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import org.batfish.common.BatfishException;
 import org.batfish.datamodel.FlowDisposition;
-import org.batfish.datamodel.HeaderSpace;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.question.SrcNattedConstraint;
 import org.batfish.z3.expr.AndExpr;
 import org.batfish.z3.expr.BasicRuleStatement;
 import org.batfish.z3.expr.BooleanExpr;
 import org.batfish.z3.expr.EqExpr;
-import org.batfish.z3.expr.HeaderSpaceMatchExpr;
 import org.batfish.z3.expr.QueryStatement;
 import org.batfish.z3.expr.RuleStatement;
 import org.batfish.z3.expr.StateExpr;
@@ -91,7 +91,7 @@ public class StandardReachabilityQuerySynthesizer extends ReachabilityQuerySynth
 
   protected StandardReachabilityQuerySynthesizer(
       @Nonnull Set<FlowDisposition> actions,
-      @Nonnull HeaderSpace headerSpace,
+      @Nonnull AclLineMatchExpr headerSpace,
       @Nonnull Set<String> finalNodes,
       @Nonnull Map<IngressLocation, BooleanExpr> srcIpConstraints,
       @Nonnull SrcNattedConstraint srcNatted,
@@ -206,7 +206,7 @@ public class StandardReachabilityQuerySynthesizer extends ReachabilityQuerySynth
         .setSmtConstraint(
             new AndExpr(
                 ImmutableList.of(
-                    new HeaderSpaceMatchExpr(_headerSpace, ImmutableMap.of(), true),
+                    NO_ACLS_NO_IP_SPACES_NO_SOURCES_ORIG_HEADERSPACE.toBooleanExpr(_headerSpace),
                     getSrcNattedConstraint(),
                     transitNodesConstraint)))
         .build();

--- a/projects/batfish/src/test/java/org/batfish/main/ReachabilityParametersResolverTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/ReachabilityParametersResolverTest.java
@@ -6,7 +6,6 @@ import static org.batfish.main.ReachabilityParametersResolver.isActive;
 import static org.batfish.main.ReachabilityParametersResolver.resolveReachabilityParameters;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -26,6 +25,7 @@ import org.batfish.datamodel.IpIpSpace;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.UniverseIpSpace;
 import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.acl.AclLineMatchExprs;
 import org.batfish.datamodel.questions.InvalidReachabilityParametersException;
 import org.batfish.question.ReachabilityParameters;
 import org.batfish.question.ReachabilityParameters.Builder;
@@ -78,10 +78,11 @@ public class ReachabilityParametersResolverTest {
     ReachabilityParameters reachabilityParameters = reachabilityParametersBuilder.build();
     ResolvedReachabilityParameters resolvedReachabilityParameters =
         resolveReachabilityParameters(_batfish, reachabilityParameters, _snapshot);
-    assertThat(resolvedReachabilityParameters.getHeaderSpace().getNotDstIps(), nullValue());
     assertThat(
-        resolvedReachabilityParameters.getHeaderSpace().getDstIps(),
-        equalTo(UniverseIpSpace.INSTANCE));
+        resolvedReachabilityParameters.getHeaderSpace(),
+        equalTo(
+            AclLineMatchExprs.and(
+                AclLineMatchExprs.matchDst(UniverseIpSpace.INSTANCE), AclLineMatchExprs.TRUE)));
 
     // test setting destination IpSpace
     IpIpSpace dstIpSpace = new Ip("1.1.1.1").toIpSpace();
@@ -91,8 +92,10 @@ public class ReachabilityParametersResolverTest {
             .build();
     resolvedReachabilityParameters =
         resolveReachabilityParameters(_batfish, reachabilityParameters, _snapshot);
-    assertThat(resolvedReachabilityParameters.getHeaderSpace().getNotDstIps(), nullValue());
-    assertThat(resolvedReachabilityParameters.getHeaderSpace().getDstIps(), equalTo(dstIpSpace));
+    assertThat(
+        resolvedReachabilityParameters.getHeaderSpace(),
+        equalTo(
+            AclLineMatchExprs.and(AclLineMatchExprs.matchDst(dstIpSpace), AclLineMatchExprs.TRUE)));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/z3/NodJobAclTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/NodJobAclTest.java
@@ -2,6 +2,7 @@ package org.batfish.z3;
 
 import static org.batfish.datamodel.FlowDisposition.DENIED_OUT;
 import static org.batfish.datamodel.FlowDisposition.NEIGHBOR_UNREACHABLE_OR_EXITS_NETWORK;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.match;
 import static org.batfish.datamodel.matchers.EdgeMatchers.hasInt2;
 import static org.batfish.datamodel.matchers.FlowTraceHopMatchers.hasEdge;
 import static org.batfish.datamodel.matchers.FlowTraceMatchers.hasDisposition;
@@ -47,6 +48,7 @@ import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.StaticRoute;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.datamodel.acl.MatchSrcInterface;
 import org.batfish.datamodel.acl.PermittedByAcl;
@@ -150,11 +152,12 @@ public class NodJobAclTest {
     Synthesizer synthesizer = new Synthesizer(input);
 
     /* Construct NodJob */
-    HeaderSpace headerSpace =
-        HeaderSpace.builder()
-            .setSrcIps(ImmutableList.of(new IpWildcard("1.1.1.1/32")))
-            .setDstIps(ImmutableList.of(new IpWildcard("3.0.0.1/32")))
-            .build();
+    AclLineMatchExpr headerSpace =
+        match(
+            HeaderSpace.builder()
+                .setSrcIps(ImmutableList.of(new IpWildcard("1.1.1.1/32")))
+                .setDstIps(ImmutableList.of(new IpWildcard("3.0.0.1/32")))
+                .build());
     IngressLocation ingressLocation = IngressLocation.vrf(srcNode.getHostname(), srcVrf.getName());
     Map<IngressLocation, BooleanExpr> srcIpConstraints =
         ImmutableMap.of(ingressLocation, TrueExpr.INSTANCE);
@@ -286,11 +289,12 @@ public class NodJobAclTest {
     Synthesizer synthesizer = new Synthesizer(input);
 
     /* Construct NodJob */
-    HeaderSpace headerSpace =
-        HeaderSpace.builder()
-            .setSrcIps(ImmutableList.of(new IpWildcard("1.1.1.1/32")))
-            .setDstIps(ImmutableList.of(new IpWildcard("3.0.0.1/32")))
-            .build();
+    AclLineMatchExpr headerSpace =
+        match(
+            HeaderSpace.builder()
+                .setSrcIps(ImmutableList.of(new IpWildcard("1.1.1.1/32")))
+                .setDstIps(ImmutableList.of(new IpWildcard("3.0.0.1/32")))
+                .build());
 
     Map<IngressLocation, BooleanExpr> srcIpConstraints =
         ImmutableMap.of(
@@ -407,11 +411,12 @@ public class NodJobAclTest {
 
     /* set up synthesizer */
     Topology topology = new Topology(dataPlane.getTopologyEdges());
-    HeaderSpace headerSpace =
-        HeaderSpace.builder()
-            .setSrcIps(ImmutableList.of(srcIp))
-            .setDstIps(ImmutableList.of(new IpWildcard("1.2.3.4/32")))
-            .build();
+    AclLineMatchExpr headerSpace =
+        match(
+            HeaderSpace.builder()
+                .setSrcIps(ImmutableList.of(srcIp))
+                .setDstIps(ImmutableList.of(new IpWildcard("1.2.3.4/32")))
+                .build());
     SynthesizerInput input =
         SynthesizerInputImpl.builder()
             .setConfigurations(configs)

--- a/projects/batfish/src/test/java/org/batfish/z3/NodJobChunkingTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/NodJobChunkingTest.java
@@ -30,6 +30,7 @@ import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.StaticRoute;
 import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.acl.AclLineMatchExprs;
 import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
 import org.batfish.specifier.IpSpaceAssignment;
@@ -156,7 +157,7 @@ public class NodJobChunkingTest {
             Batfish.computeSynthesizerInput(
                 _configs,
                 _dataPlane,
-                new HeaderSpace(),
+                AclLineMatchExprs.TRUE,
                 IpSpaceAssignment.empty(),
                 ImmutableSortedSet.of(),
                 ImmutableSortedSet.of(),
@@ -176,7 +177,7 @@ public class NodJobChunkingTest {
     StandardReachabilityQuerySynthesizer querySynthesizer =
         StandardReachabilityQuerySynthesizer.builder()
             .setActions(ImmutableSet.of(FlowDisposition.ACCEPTED))
-            .setHeaderSpace(new HeaderSpace())
+            .setHeaderSpace(AclLineMatchExprs.TRUE)
             .setSrcIpConstraints(srcIpConstraints)
             .setFinalNodes(ImmutableSet.of(_dstNode.getHostname()))
             .build();

--- a/projects/batfish/src/test/java/org/batfish/z3/NodJobTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/NodJobTest.java
@@ -48,6 +48,7 @@ import org.batfish.datamodel.SourceNat;
 import org.batfish.datamodel.StaticRoute;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.acl.AclLineMatchExprs;
 import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
 import org.batfish.question.SrcNattedConstraint;
@@ -89,7 +90,7 @@ public class NodJobTest {
         StandardReachabilityQuerySynthesizer.builder()
             .setActions(ImmutableSet.of(FlowDisposition.ACCEPTED))
             .setFinalNodes(ImmutableSet.of(_dstNode.getHostname()))
-            .setHeaderSpace(headerSpace)
+            .setHeaderSpace(AclLineMatchExprs.match(headerSpace))
             .setSrcIpConstraints(srcIpConstraints)
             .setSrcNatted(srcNatted)
             .setRequiredTransitNodes(ImmutableSet.of())

--- a/tests/java-smt/commands
+++ b/tests/java-smt/commands
@@ -137,8 +137,8 @@ test tests/java-smt/campus2-reachability1.ref get smt-reachability ingressNodeRe
 test tests/java-smt/campus2-reachability2.ref get smt-reachability ingressNodeRegex="as2border.*", finalNodeRegex="as2dept1", finalIfaceRegex="FastEthernet1/0" , failures=1
 #test tests/java-smt/campus2-reachability3.ref get smt-reachability ingressNodeRegex="as2border.*", finalNodeRegex="as2dept1", finalIfaceRegex="FastEthernet1/0" , failures=2, noEnvironment=True
 
-# Test dataplane reachability on compressed network
-test tests/java-smt/compressed-reachability1.ref get reachability ingressNodeRegex="as2border.*", finalNodeRegex="as2dept1", srcIps=['0.0.0.0'], dstIps=['2.34.101.4'], srcPorts=[0], dstPorts=[0], ipProtocols=['ICMP'],  useCompression=True
+# Test dataplane reachability on compressed network. Disabled until compression works with generalized headerspaces
+# test tests/java-smt/compressed-reachability1.ref get reachability ingressNodeRegex="as2border.*", finalNodeRegex="as2dept1", srcIps=['0.0.0.0'], dstIps=['2.34.101.4'], srcPorts=[0], dstPorts=[0], ipProtocols=['ICMP'],  useCompression=True
 
 # Test differential reachabililty 
 init-snapshot tests/java-smt/networks/OSPF5 tr-smt-ospf5


### PR DESCRIPTION
Switch to AclLineMatchExpr as an intermediate representation in the reachability question pipeline (from ReachabilityParamters on). Mostly straightforward, with the following exceptions:
- Compression is now completely disabled since it expects a headerspace expressed as a single `HeaderSpace` object. Was already mostly disabled for different reasons. I left the code there for when we fix it. For now, an error is thrown if the user sets the `useCompression` flag.
- `AclLineMatchExprToBooleanExpr` needed a new parameter to indicate that `HeaderSpace` constraints should be applied to the original headerspace variables (i.e. before any transformation).