### PR TITLE
add headerspace constraint to reduced reachability question

### DIFF
--- a/projects/allinone/src/test/java/org/batfish/question/multipath/MultipathConsistencyTest.java
+++ b/projects/allinone/src/test/java/org/batfish/question/multipath/MultipathConsistencyTest.java
@@ -1,20 +1,28 @@
 package org.batfish.question.multipath;
 
+import static org.batfish.datamodel.matchers.FlowMatchers.hasDstIp;
+import static org.batfish.datamodel.matchers.FlowMatchers.hasDstPort;
+import static org.batfish.datamodel.matchers.FlowMatchers.hasIcmpCode;
+import static org.batfish.datamodel.matchers.FlowMatchers.hasIcmpType;
+import static org.batfish.datamodel.matchers.FlowMatchers.hasIngressNode;
+import static org.batfish.datamodel.matchers.FlowMatchers.hasIngressVrf;
+import static org.batfish.datamodel.matchers.FlowMatchers.hasIpProtocol;
+import static org.batfish.datamodel.matchers.FlowMatchers.hasSrcIp;
+import static org.batfish.datamodel.matchers.FlowMatchers.hasTag;
 import static org.batfish.datamodel.matchers.FlowTraceMatchers.hasDisposition;
 import static org.batfish.datamodel.matchers.RowMatchers.hasColumn;
 import static org.batfish.datamodel.matchers.RowsMatchers.hasSize;
 import static org.batfish.question.traceroute.TracerouteAnswerer.COL_FLOW;
 import static org.batfish.question.traceroute.TracerouteAnswerer.COL_TRACES;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.oneOf;
 
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import org.batfish.bddreachability.TestNetwork;
-import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowDisposition;
-import org.batfish.datamodel.FlowState;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.answers.Schema;
@@ -50,25 +58,24 @@ public class MultipathConsistencyTest {
     MultipathConsistencyAnswerer answerer = new MultipathConsistencyAnswerer(question, _batfish);
     TableAnswerElement ae = (TableAnswerElement) answerer.answer();
 
-    Flow testFlow =
-        Flow.builder()
-            .setIngressNode("~Configuration_0~")
-            .setIngressVrf("default")
-            .setSrcIp(new Ip("2.0.0.0"))
-            .setDstIp(new Ip("2.1.0.0"))
-            .setIpProtocol(IpProtocol.HOPOPT)
-            .setState(FlowState.NEW)
-            .setTag("BASE")
-            .setDstPort(1234)
-            .setIcmpCode(0)
-            .setIcmpType(0)
-            .build();
-
     assertThat(ae.getRows(), hasSize(1));
 
     assertThat(
         ae.getRows().getData().iterator().next(),
-        hasColumn(COL_FLOW, equalTo(testFlow), Schema.FLOW));
+        hasColumn(
+            COL_FLOW,
+            allOf(
+                ImmutableList.of(
+                    hasDstIp(new Ip("2.1.0.0")),
+                    hasDstPort(1234),
+                    hasIcmpCode(0),
+                    hasIcmpType(0),
+                    hasIngressNode("~Configuration_0~"),
+                    hasIngressVrf("default"),
+                    hasIpProtocol(IpProtocol.HOPOPT),
+                    hasSrcIp(oneOf(new Ip("2.0.0.0"), new Ip("1.0.0.0"))),
+                    hasTag("BASE"))),
+            Schema.FLOW));
 
     assertThat(
         ae.getRows().getData().iterator().next(),

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
@@ -25,6 +25,7 @@ import org.batfish.datamodel.FlowHistory;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.Topology;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.datamodel.answers.AnswerElement;
 import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
 import org.batfish.datamodel.answers.DataPlaneAnswerElement;
@@ -52,11 +53,15 @@ import org.batfish.question.searchfilters.SearchFiltersResult;
 import org.batfish.referencelibrary.ReferenceLibrary;
 import org.batfish.role.NodeRoleDimension;
 import org.batfish.role.NodeRolesData;
+import org.batfish.specifier.IpSpaceAssignment;
 import org.batfish.specifier.SpecifierContext;
 
 public interface IBatfish extends IPluginConsumer {
 
-  DifferentialReachabilityResult bddReducedReachability(Set<FlowDisposition> actions);
+  DifferentialReachabilityResult bddReducedReachability(
+      Set<FlowDisposition> actions,
+      IpSpaceAssignment ipSpaceAssignment,
+      AclLineMatchExpr headerSpace);
 
   void checkDataPlane();
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/plugin/IBatfishTestAdapter.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/plugin/IBatfishTestAdapter.java
@@ -26,6 +26,7 @@ import org.batfish.datamodel.FlowHistory;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.Topology;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.datamodel.answers.AnswerElement;
 import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
 import org.batfish.datamodel.answers.DataPlaneAnswerElement;
@@ -53,6 +54,7 @@ import org.batfish.question.searchfilters.SearchFiltersResult;
 import org.batfish.referencelibrary.ReferenceLibrary;
 import org.batfish.role.NodeRoleDimension;
 import org.batfish.role.NodeRolesData;
+import org.batfish.specifier.IpSpaceAssignment;
 import org.batfish.specifier.SpecifierContext;
 import org.batfish.specifier.SpecifierContextImpl;
 
@@ -63,7 +65,10 @@ import org.batfish.specifier.SpecifierContextImpl;
 public class IBatfishTestAdapter implements IBatfish {
 
   @Override
-  public DifferentialReachabilityResult bddReducedReachability(Set<FlowDisposition> actions) {
+  public DifferentialReachabilityResult bddReducedReachability(
+      Set<FlowDisposition> actions,
+      IpSpaceAssignment ipSpaceAssignment,
+      AclLineMatchExpr headerSpace) {
     throw new UnsupportedOperationException();
   }
 

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysis.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysis.java
@@ -55,14 +55,18 @@ public class BDDReachabilityAnalysis {
   // stateExprs that correspond to the IngressLocations of interest
   private final ImmutableSet<StateExpr> _ingressLocationStates;
 
+  private final BDD _queryHeaderSpaceBdd;
+
   BDDReachabilityAnalysis(
       BDDPacket packet,
       Set<StateExpr> ingressLocationStates,
-      Map<StateExpr, Map<StateExpr, Edge>> edges) {
+      Map<StateExpr, Map<StateExpr, Edge>> edges,
+      BDD queryHeaderSpaceBdd) {
     _bddPacket = packet;
     _edges = edges;
     _reverseEdges = computeReverseEdges(_edges);
     _ingressLocationStates = ImmutableSet.copyOf(ingressLocationStates);
+    _queryHeaderSpaceBdd = queryHeaderSpaceBdd;
   }
 
   private static Map<StateExpr, Map<StateExpr, Edge>> computeReverseEdges(
@@ -84,7 +88,7 @@ public class BDDReachabilityAnalysis {
     Map<StateExpr, BDD> reverseReachableStates = new HashMap<>();
     Set<StateExpr> dirty = new HashSet<>();
 
-    reverseReachableStates.put(Query.INSTANCE, _bddPacket.getFactory().one());
+    reverseReachableStates.put(Query.INSTANCE, _queryHeaderSpaceBdd);
     dirty.add(Query.INSTANCE);
 
     while (!dirty.isEmpty()) {

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -4469,9 +4469,14 @@ public class Batfish extends PluginConsumer implements IBatfish {
    *
    * @param dispositions Search for differences in the set of packets with the specified {@link
    *     FlowDisposition FlowDispositions}.
+   * @param ipSpaceAssignment
+   * @param headerSpace
    */
   @Override
-  public DifferentialReachabilityResult bddReducedReachability(Set<FlowDisposition> dispositions) {
+  public DifferentialReachabilityResult bddReducedReachability(
+      Set<FlowDisposition> dispositions,
+      IpSpaceAssignment ipSpaceAssignment,
+      AclLineMatchExpr headerSpace) {
     checkArgument(!dispositions.isEmpty(), "Must specify at least one FlowDisposition");
     BDDPacket pkt = new BDDPacket();
 
@@ -4481,8 +4486,8 @@ public class Batfish extends PluginConsumer implements IBatfish {
     Map<IngressLocation, BDD> baseAcceptBDDs =
         getBddReachabilityAnalysisFactory(pkt)
             .bddReachabilityAnalysis(
-                getAllSourcesInferFromLocationIpSpaceAssignment(),
-                UniverseIpSpace.INSTANCE,
+                ipSpaceAssignment,
+                headerSpace,
                 forbiddenTransitNodes,
                 requiredTransitNodes,
                 loadConfigurations().keySet(),
@@ -4494,8 +4499,8 @@ public class Batfish extends PluginConsumer implements IBatfish {
     Map<IngressLocation, BDD> deltaAcceptBDDs =
         getBddReachabilityAnalysisFactory(pkt)
             .bddReachabilityAnalysis(
-                getAllSourcesInferFromLocationIpSpaceAssignment(),
-                UniverseIpSpace.INSTANCE,
+                ipSpaceAssignment,
+                headerSpace,
                 forbiddenTransitNodes,
                 requiredTransitNodes,
                 loadConfigurations().keySet(),

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
@@ -27,7 +27,12 @@ import org.batfish.datamodel.FlowDisposition;
 import org.batfish.datamodel.UniverseIpSpace;
 import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
+import org.batfish.specifier.ConstantIpSpaceSpecifier;
 import org.batfish.specifier.IpSpaceAssignment;
+import org.batfish.specifier.IpSpaceSpecifier;
+import org.batfish.specifier.Location;
+import org.batfish.specifier.LocationSpecifiers;
+import org.batfish.specifier.SpecifierContext;
 import org.batfish.z3.expr.StateExpr;
 import org.batfish.z3.state.Accept;
 import org.batfish.z3.state.DropAclIn;
@@ -53,6 +58,8 @@ public final class BDDReachabilityAnalysisFactoryTest {
   @Rule public TemporaryFolder temp = new TemporaryFolder();
 
   private static final BDDPacket PKT = new BDDPacket();
+  private static final IpSpaceSpecifier CONSTANT_UNIVERSE_IPSPACE_SPECIFIER =
+      new ConstantIpSpaceSpecifier(UniverseIpSpace.INSTANCE);
   private static final BDD ONE = PKT.getFactory().one();
 
   private static final Set<FlowDisposition> ALL_DISPOSITIONS =
@@ -63,6 +70,12 @@ public final class BDDReachabilityAnalysisFactoryTest {
           NO_ROUTE,
           NULL_ROUTED,
           NEIGHBOR_UNREACHABLE_OR_EXITS_NETWORK);
+
+  private static IpSpaceAssignment ipSpaceAssignment(Batfish batfish) {
+    SpecifierContext ctxt = batfish.specifierContext();
+    Set<Location> locations = LocationSpecifiers.ALL_LOCATIONS.resolve(ctxt);
+    return CONSTANT_UNIVERSE_IPSPACE_SPECIFIER.resolve(locations, ctxt);
+  }
 
   @Test
   public void testBDDFactory() throws IOException {
@@ -88,7 +101,7 @@ public final class BDDReachabilityAnalysisFactoryTest {
       Map<StateExpr, Map<StateExpr, Edge>> edges =
           new BDDReachabilityAnalysisFactory(PKT, configs, dataPlane.getForwardingAnalysis())
               .bddReachabilityAnalysis(
-                  IpSpaceAssignment.builder().build(),
+                  ipSpaceAssignment(batfish),
                   UniverseIpSpace.INSTANCE,
                   ImmutableSet.of(),
                   ImmutableSet.of(),
@@ -144,7 +157,7 @@ public final class BDDReachabilityAnalysisFactoryTest {
       Map<StateExpr, Map<StateExpr, Edge>> edgeMap =
           bddReachabilityAnalysisFactory
               .bddReachabilityAnalysis(
-                  IpSpaceAssignment.builder().build(),
+                  ipSpaceAssignment(batfish),
                   UniverseIpSpace.INSTANCE,
                   ImmutableSet.of(node),
                   ImmutableSet.of(),
@@ -195,7 +208,7 @@ public final class BDDReachabilityAnalysisFactoryTest {
       Map<StateExpr, Map<StateExpr, Edge>> edgeMap =
           bddReachabilityAnalysisFactory
               .bddReachabilityAnalysis(
-                  IpSpaceAssignment.builder().build(),
+                  ipSpaceAssignment(batfish),
                   UniverseIpSpace.INSTANCE,
                   ImmutableSet.of(),
                   ImmutableSet.of(node),

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisTest.java
@@ -356,7 +356,8 @@ public final class BDDReachabilityAnalysisTest {
             ImmutableSet.of(originateVrf),
             ImmutableMap.of(
                 originateVrf,
-                ImmutableMap.of(Drop.INSTANCE, new Edge(originateVrf, Drop.INSTANCE, one))));
+                ImmutableMap.of(Drop.INSTANCE, new Edge(originateVrf, Drop.INSTANCE, one))),
+            one);
     assertThat(
         graph.getIngressLocationReachableBDDs(),
         equalTo(ImmutableMap.of(toIngressLocation(originateVrf), pkt.getFactory().zero())));

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishBDDReducedReachabilityTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishBDDReducedReachabilityTest.java
@@ -9,6 +9,7 @@ import static org.batfish.datamodel.FlowDisposition.NEIGHBOR_UNREACHABLE_OR_EXIT
 import static org.batfish.datamodel.FlowDisposition.NO_ROUTE;
 import static org.batfish.datamodel.FlowDisposition.NULL_ROUTED;
 import static org.batfish.datamodel.Interface.NULL_INTERFACE_NAME;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.TRUE;
 import static org.batfish.datamodel.matchers.FlowMatchers.hasDstIp;
 import static org.batfish.datamodel.matchers.FlowMatchers.hasIngressInterface;
 import static org.batfish.datamodel.matchers.FlowMatchers.hasIngressNode;
@@ -29,6 +30,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 import java.util.SortedMap;
+import org.batfish.common.plugin.IBatfish;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowDisposition;
@@ -48,7 +50,10 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-/** Test of {@link Batfish#bddReducedReachability(Set)}. */
+/**
+ * Test of {@link IBatfish#bddReducedReachability(Set, org.batfish.specifier.IpSpaceAssignment,
+ * org.batfish.datamodel.acl.AclLineMatchExpr)}.
+ */
 public class BatfishBDDReducedReachabilityTest {
   private static final Ip DST_IP = new Ip("3.3.3.3");
   private static final String NODE1 = "node1";
@@ -145,7 +150,10 @@ public class BatfishBDDReducedReachabilityTest {
   public void testNeighborUnreachable() throws IOException {
     Batfish batfish = initBatfish(new NeighborUnreachableNetworkGenerator());
     DifferentialReachabilityResult differentialReachabilityResult =
-        batfish.bddReducedReachability(ImmutableSet.of(NEIGHBOR_UNREACHABLE_OR_EXITS_NETWORK));
+        batfish.bddReducedReachability(
+            ImmutableSet.of(NEIGHBOR_UNREACHABLE_OR_EXITS_NETWORK),
+            batfish.getAllSourcesInferFromLocationIpSpaceAssignment(),
+            TRUE);
     assertThat(differentialReachabilityResult.getIncreasedReachabilityFlows(), empty());
     Set<Flow> flows = differentialReachabilityResult.getDecreasedReachabilityFlows();
     assertThat(flows, hasSize(2));
@@ -190,7 +198,10 @@ public class BatfishBDDReducedReachabilityTest {
   public void testAccepted() throws IOException {
     Batfish batfish = initBatfish(new AcceptedNetworkGenerator());
     DifferentialReachabilityResult differentialReachabilityResult =
-        batfish.bddReducedReachability(ImmutableSet.of(FlowDisposition.ACCEPTED));
+        batfish.bddReducedReachability(
+            ImmutableSet.of(FlowDisposition.ACCEPTED),
+            batfish.getAllSourcesInferFromLocationIpSpaceAssignment(),
+            TRUE);
     assertThat(differentialReachabilityResult.getIncreasedReachabilityFlows(), empty());
     Set<Flow> flows = differentialReachabilityResult.getDecreasedReachabilityFlows();
     assertThat(flows, hasSize(2));
@@ -246,7 +257,10 @@ public class BatfishBDDReducedReachabilityTest {
   public void testDeniedIn() throws IOException {
     Batfish batfish = initBatfish(new DeniedInNetworkGenerator());
     DifferentialReachabilityResult differentialReachabilityResult =
-        batfish.bddReducedReachability(ImmutableSet.of(DENIED_IN));
+        batfish.bddReducedReachability(
+            ImmutableSet.of(DENIED_IN),
+            batfish.getAllSourcesInferFromLocationIpSpaceAssignment(),
+            TRUE);
     assertThat(differentialReachabilityResult.getIncreasedReachabilityFlows(), empty());
     Set<Flow> flows = differentialReachabilityResult.getDecreasedReachabilityFlows();
     assertThat(flows, hasSize(3));
@@ -311,7 +325,10 @@ public class BatfishBDDReducedReachabilityTest {
   public void testDeniedOutNeighborUnreachable() throws IOException {
     Batfish batfish = initBatfish(new DeniedOutNeighborUnreachableNetworkGenerator());
     DifferentialReachabilityResult differentialReachabilityResult =
-        batfish.bddReducedReachability(ImmutableSet.of(DENIED_OUT));
+        batfish.bddReducedReachability(
+            ImmutableSet.of(DENIED_OUT),
+            batfish.getAllSourcesInferFromLocationIpSpaceAssignment(),
+            TRUE);
     assertThat(differentialReachabilityResult.getIncreasedReachabilityFlows(), empty());
     Set<Flow> flows = differentialReachabilityResult.getDecreasedReachabilityFlows();
     assertThat(flows, hasSize(2));
@@ -380,7 +397,10 @@ public class BatfishBDDReducedReachabilityTest {
   public void testDeniedOutForward() throws IOException {
     Batfish batfish = initBatfish(new DeniedOutForwardNetworkGenerator());
     DifferentialReachabilityResult differentialReachabilityResult =
-        batfish.bddReducedReachability(ImmutableSet.of(DENIED_OUT));
+        batfish.bddReducedReachability(
+            ImmutableSet.of(DENIED_OUT),
+            batfish.getAllSourcesInferFromLocationIpSpaceAssignment(),
+            TRUE);
     assertThat(differentialReachabilityResult.getIncreasedReachabilityFlows(), empty());
     Set<Flow> flows = differentialReachabilityResult.getDecreasedReachabilityFlows();
     assertThat(flows, hasSize(2));
@@ -435,7 +455,10 @@ public class BatfishBDDReducedReachabilityTest {
   public void testNoRoute() throws IOException {
     Batfish batfish = initBatfish(new NoRouteNetworkGenerator());
     DifferentialReachabilityResult differentialReachabilityResult =
-        batfish.bddReducedReachability(ImmutableSet.of(NO_ROUTE));
+        batfish.bddReducedReachability(
+            ImmutableSet.of(NO_ROUTE),
+            batfish.getAllSourcesInferFromLocationIpSpaceAssignment(),
+            TRUE);
     assertThat(differentialReachabilityResult.getIncreasedReachabilityFlows(), empty());
     Set<Flow> flows = differentialReachabilityResult.getDecreasedReachabilityFlows();
     assertThat(flows, hasSize(2));
@@ -490,7 +513,10 @@ public class BatfishBDDReducedReachabilityTest {
   public void testNullRouted() throws IOException {
     Batfish batfish = initBatfish(new NullRoutedNetworkGenerator());
     DifferentialReachabilityResult differentialReachabilityResult =
-        batfish.bddReducedReachability(ImmutableSet.of(NULL_ROUTED));
+        batfish.bddReducedReachability(
+            ImmutableSet.of(NULL_ROUTED),
+            batfish.getAllSourcesInferFromLocationIpSpaceAssignment(),
+            TRUE);
     assertThat(differentialReachabilityResult.getIncreasedReachabilityFlows(), empty());
     Set<Flow> flows = differentialReachabilityResult.getDecreasedReachabilityFlows();
     assertThat(flows, hasSize(2));

--- a/projects/batfish/src/test/java/org/batfish/z3/ReducedReachabilityTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/ReducedReachabilityTest.java
@@ -1,6 +1,7 @@
 package org.batfish.z3;
 
 import static org.batfish.datamodel.ConfigurationFormat.CISCO_IOS;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.TRUE;
 import static org.batfish.datamodel.matchers.FlowHistoryInfoMatchers.hasFlow;
 import static org.batfish.datamodel.matchers.FlowMatchers.hasDstIp;
 import static org.batfish.datamodel.matchers.FlowMatchers.hasSrcIp;
@@ -148,7 +149,10 @@ public class ReducedReachabilityTest {
   public void testBDDReducedReachability() throws IOException {
     Batfish batfish = initBatfish();
     DifferentialReachabilityResult differentialReachabilityResult =
-        batfish.bddReducedReachability(ImmutableSet.of(FlowDisposition.ACCEPTED));
+        batfish.bddReducedReachability(
+            ImmutableSet.of(FlowDisposition.ACCEPTED),
+            batfish.getAllSourcesInferFromLocationIpSpaceAssignment(),
+            TRUE);
     assertThat(differentialReachabilityResult.getIncreasedReachabilityFlows(), empty());
     Set<Flow> flows = differentialReachabilityResult.getDecreasedReachabilityFlows();
     assertThat(flows, hasSize(1));

--- a/projects/question/src/main/java/org/batfish/question/reducedreachability/ReducedReachabilityAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/reducedreachability/ReducedReachabilityAnswerer.java
@@ -1,5 +1,9 @@
 package org.batfish.question.reducedreachability;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.match;
+import static org.batfish.specifier.LocationSpecifiers.ALL_LOCATIONS;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.LinkedHashMultiset;
 import com.google.common.collect.Multiset;
@@ -7,9 +11,15 @@ import com.google.common.collect.Sets;
 import java.util.Set;
 import org.batfish.common.Answerer;
 import org.batfish.common.plugin.IBatfish;
+import org.batfish.datamodel.AclIpSpace;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowHistory;
 import org.batfish.datamodel.FlowHistory.FlowHistoryInfo;
+import org.batfish.datamodel.IpSpace;
+import org.batfish.datamodel.PacketHeaderConstraints;
+import org.batfish.datamodel.PacketHeaderConstraintsUtil;
+import org.batfish.datamodel.UniverseIpSpace;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.datamodel.answers.Schema;
 import org.batfish.datamodel.questions.Question;
 import org.batfish.datamodel.table.ColumnMetadata;
@@ -17,6 +27,12 @@ import org.batfish.datamodel.table.Row;
 import org.batfish.datamodel.table.TableAnswerElement;
 import org.batfish.datamodel.table.TableDiff;
 import org.batfish.datamodel.table.TableMetadata;
+import org.batfish.specifier.FlexibleInferFromLocationIpSpaceSpecifierFactory;
+import org.batfish.specifier.IpSpaceAssignment;
+import org.batfish.specifier.IpSpaceAssignment.Entry;
+import org.batfish.specifier.IpSpaceSpecifierFactory;
+import org.batfish.specifier.Location;
+import org.batfish.specifier.SpecifierContext;
 
 /** An {@link Answerer} for {@link ReducedReachabilityQuestion}. */
 public class ReducedReachabilityAnswerer extends Answerer {
@@ -42,7 +58,33 @@ public class ReducedReachabilityAnswerer extends Answerer {
   @Override
   public TableAnswerElement answerDiff() {
     ReducedReachabilityQuestion question = (ReducedReachabilityQuestion) _question;
-    DifferentialReachabilityResult result = _batfish.bddReducedReachability(question.getActions());
+    PacketHeaderConstraints headerConstraints = question.getHeaderConstraints();
+    IpSpaceSpecifierFactory flexibleIpSpaceSpecifierFactory =
+        new FlexibleInferFromLocationIpSpaceSpecifierFactory();
+    SpecifierContext ctxt = _batfish.specifierContext();
+    Set<Location> locations = ALL_LOCATIONS.resolve(ctxt);
+    IpSpaceAssignment ipSpaceAssignment =
+        flexibleIpSpaceSpecifierFactory
+            .buildIpSpaceSpecifier(headerConstraints.getSrcIps())
+            .resolve(locations, ctxt);
+    IpSpace dstIps =
+        firstNonNull(
+            AclIpSpace.union(
+                flexibleIpSpaceSpecifierFactory
+                    .buildIpSpaceSpecifier(headerConstraints.getDstIps())
+                    .resolve(locations, ctxt)
+                    .getEntries()
+                    .stream()
+                    .map(Entry::getIpSpace)
+                    .collect(ImmutableList.toImmutableList())),
+            UniverseIpSpace.INSTANCE);
+    AclLineMatchExpr headerSpace =
+        match(
+            PacketHeaderConstraintsUtil.toHeaderSpaceBuilder(headerConstraints)
+                .setDstIps(dstIps)
+                .build());
+    DifferentialReachabilityResult result =
+        _batfish.bddReducedReachability(question.getActions(), ipSpaceAssignment, headerSpace);
 
     Set<Flow> flows =
         Sets.union(result.getDecreasedReachabilityFlows(), result.getIncreasedReachabilityFlows());

--- a/projects/question/src/main/java/org/batfish/question/reducedreachability/ReducedReachabilityQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/reducedreachability/ReducedReachabilityQuestion.java
@@ -1,5 +1,7 @@
 package org.batfish.question.reducedreachability;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableSortedSet;
@@ -7,31 +9,42 @@ import java.util.SortedSet;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.FlowDisposition;
+import org.batfish.datamodel.PacketHeaderConstraints;
 import org.batfish.datamodel.questions.Question;
 
 /** A zero-input question to check for reduced reachability between base and delta snapshots. */
 public final class ReducedReachabilityQuestion extends Question {
   private static final String PROP_ACTIONS = "actions";
+  private static final String PROP_HEADERS = "headers";
 
   @Nonnull private final SortedSet<FlowDisposition> _actions;
+  @Nonnull private final PacketHeaderConstraints _headerConstraints;
 
   @JsonCreator
   public ReducedReachabilityQuestion(
-      @Nullable @JsonProperty(PROP_ACTIONS) SortedSet<FlowDisposition> actions) {
+      @Nullable @JsonProperty(PROP_ACTIONS) SortedSet<FlowDisposition> actions,
+      @JsonProperty(PROP_HEADERS) @Nullable PacketHeaderConstraints headerConstraints) {
     setDifferential(true);
     _actions =
         actions == null
             ? ImmutableSortedSet.of(FlowDisposition.NEIGHBOR_UNREACHABLE_OR_EXITS_NETWORK)
             : ImmutableSortedSet.copyOf(actions);
+    _headerConstraints = firstNonNull(headerConstraints, PacketHeaderConstraints.unconstrained());
   }
 
   public ReducedReachabilityQuestion() {
-    this(null);
+    this(null, null);
   }
 
   @Nonnull
   SortedSet<FlowDisposition> getActions() {
     return _actions;
+  }
+
+  @JsonProperty(PROP_HEADERS)
+  @Nonnull
+  PacketHeaderConstraints getHeaderConstraints() {
+    return _headerConstraints;
   }
 
   @Override


### PR DESCRIPTION
The headerspace constraint becomes an IpSpaceAssignment (per-source
source IpSpace constraints) and an AclLineMatchExpr (for other header
fields).

Also:
- Pass a constraint on the final headerspace into
  BDDReachabilityAnalysis. This will help direct the search.
- Fix bug where InterfaceLink assignments were clobbering each other
  after they were converted to OriginateVrf StateExprs. Now we merge
  them using OR.
- When a headerspace constraint is provided, check that at least one
  source is consistent with that constraint (since we could have source
  IP constraints in the headerspace constraint and in the source
  IpSpaceAssignment).