### PR TITLE
Cleanup IpLink and OspfNeighbor

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpLink.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpLink.java
@@ -1,41 +1,51 @@
 package org.batfish.datamodel;
 
+import static java.util.Objects.requireNonNull;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Comparator;
 import java.util.Objects;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 
-/** Represents a link by a pair of IP addresses. */
+/** Represents a Layer 3 link by a pair of IP addresses. */
+@ParametersAreNonnullByDefault
 public final class IpLink implements Comparable<IpLink> {
   private static final String PROP_IP1 = "ip1";
   private static final String PROP_IP2 = "ip2";
 
-  private final Ip _ip1;
-  private final Ip _ip2;
+  @Nonnull private final Ip _ip1;
+  @Nonnull private final Ip _ip2;
 
   @JsonCreator
-  public IpLink(@JsonProperty(PROP_IP1) Ip ip1, @JsonProperty(PROP_IP2) Ip ip2) {
-    this._ip1 = ip1;
-    this._ip2 = ip2;
+  private static IpLink create(
+      @Nullable @JsonProperty(PROP_IP1) Ip ip1, @Nullable @JsonProperty(PROP_IP2) Ip ip2) {
+    return new IpLink(requireNonNull(ip1), requireNonNull(ip2));
+  }
+
+  /** Create a new IpLink based on two IP addresses. */
+  public IpLink(@Nonnull Ip ip1, @Nonnull Ip ip2) {
+    _ip1 = ip1;
+    _ip2 = ip2;
   }
 
   @JsonProperty(PROP_IP1)
+  @Nonnull
   public Ip getIp1() {
     return _ip1;
   }
 
   @JsonProperty(PROP_IP2)
+  @Nonnull
   public Ip getIp2() {
     return _ip2;
   }
 
   @Override
-  public int compareTo(@Nonnull IpLink o) {
-    int cmp = _ip1.compareTo(o._ip1);
-    if (cmp != 0) {
-      return cmp;
-    }
-    return _ip2.compareTo(o._ip2);
+  public int compareTo(@Nonnull IpLink other) {
+    return Comparator.comparing(IpLink::getIp1).thenComparing(IpLink::getIp2).compare(this, other);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpLink.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpLink.java
@@ -1,6 +1,6 @@
 package org.batfish.datamodel;
 
-import static java.util.Objects.requireNonNull;
+import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -22,7 +22,9 @@ public final class IpLink implements Comparable<IpLink> {
   @JsonCreator
   private static IpLink create(
       @Nullable @JsonProperty(PROP_IP1) Ip ip1, @Nullable @JsonProperty(PROP_IP2) Ip ip2) {
-    return new IpLink(requireNonNull(ip1), requireNonNull(ip2));
+    checkArgument(ip1 != null);
+    checkArgument(ip2 != null);
+    return new IpLink(ip1, ip2);
   }
 
   /** Create a new IpLink based on two IP addresses. */

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfNeighbor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfNeighbor.java
@@ -1,6 +1,6 @@
 package org.batfish.datamodel.ospf;
 
-import static java.util.Objects.requireNonNull;
+import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -36,7 +36,8 @@ public final class OspfNeighbor implements Serializable, Comparable<OspfNeighbor
 
   @JsonCreator
   private static OspfNeighbor create(@Nullable @JsonProperty(PROP_NAME) IpLink ipEdge) {
-    return new OspfNeighbor(requireNonNull(ipEdge));
+    checkArgument(ipEdge != null);
+    return new OspfNeighbor(ipEdge);
   }
 
   public OspfNeighbor(IpLink ipLink) {

--- a/projects/question/src/main/java/org/batfish/question/OspfSessionCheckQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/OspfSessionCheckQuestionPlugin.java
@@ -1,10 +1,14 @@
 package org.batfish.question;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static java.util.Objects.requireNonNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.service.AutoService;
+import java.io.Serializable;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -14,6 +18,9 @@ import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.common.Answerer;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.common.plugin.Plugin;
@@ -29,7 +36,6 @@ import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.answers.AnswerElement;
 import org.batfish.datamodel.collections.IpPair;
 import org.batfish.datamodel.ospf.OspfNeighbor;
-import org.batfish.datamodel.ospf.OspfNeighbor.OspfNeighborSummary;
 import org.batfish.datamodel.ospf.OspfProcess;
 import org.batfish.datamodel.questions.NodesSpecifier;
 import org.batfish.datamodel.questions.Question;
@@ -355,5 +361,77 @@ public class OspfSessionCheckQuestionPlugin extends QuestionPlugin {
   @Override
   protected OspfSessionCheckQuestion createQuestion() {
     return new OspfSessionCheckQuestion();
+  }
+
+  @ParametersAreNonnullByDefault
+  private static final class OspfNeighborSummary
+      implements Serializable, Comparable<OspfNeighborSummary> {
+
+    private static final String PROP_NAME = "name";
+    private static final String PROP_LOCAL_IP = "localIp";
+    private static final String PROP_REMOTE_IP = "remoteIp";
+    private static final String PROP_VRF = "vrf";
+    private static final long serialVersionUID = 1L;
+
+    private final String _name;
+    private final Ip _localIp;
+    private final Ip _remoteIp;
+    private final String _vrf;
+
+    OspfNeighborSummary(OspfNeighbor ospfNeighbor) {
+      _name = ospfNeighbor.getOwner().getHostname() + ":" + ospfNeighbor.getIpLink();
+      _localIp = ospfNeighbor.getLocalIp();
+      _remoteIp = ospfNeighbor.getRemoteIp();
+      _vrf = ospfNeighbor.getVrf();
+    }
+
+    OspfNeighborSummary(String name, Ip localIp, Ip remoteIp, String vrf) {
+      _name = name;
+      _localIp = localIp;
+      _remoteIp = remoteIp;
+      _vrf = vrf;
+    }
+
+    @JsonCreator
+    private static OspfNeighborSummary create(
+        @Nullable @JsonProperty(PROP_NAME) String name,
+        @Nullable @JsonProperty(PROP_LOCAL_IP) Ip localIp,
+        @Nullable @JsonProperty(PROP_REMOTE_IP) Ip remoteIp,
+        @Nullable @JsonProperty(PROP_VRF) String vrf) {
+      return new OspfNeighborSummary(
+          requireNonNull(name),
+          requireNonNull(localIp),
+          requireNonNull(remoteIp),
+          requireNonNull(vrf));
+    }
+
+    @JsonProperty(PROP_LOCAL_IP)
+    public Ip getLocalIp() {
+      return _localIp;
+    }
+
+    @JsonProperty(PROP_NAME)
+    public String getName() {
+      return _name;
+    }
+
+    @JsonProperty(PROP_REMOTE_IP)
+    public Ip getRemoteIp() {
+      return _remoteIp;
+    }
+
+    @JsonProperty(PROP_VRF)
+    public String getVrf() {
+      return _vrf;
+    }
+
+    @Override
+    public int compareTo(@Nonnull OspfNeighborSummary other) {
+      return Comparator.comparing(OspfNeighborSummary::getName)
+          .thenComparing(OspfNeighborSummary::getLocalIp)
+          .thenComparing(OspfNeighborSummary::getRemoteIp)
+          .thenComparing(OspfNeighborSummary::getVrf)
+          .compare(this, other);
+    }
   }
 }


### PR DESCRIPTION
* Move off of comparable structure
* Cleanup json creators
* Move out `OspfNeighborSummary` to the session check question (only place it's used).

Some JSON prop names are weird (`name` where it should be `link`) but kept it that way in the interest of backwards compatibility, can change later.