### PR TITLE
Cleanup snapshot-name passing and handling

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
@@ -58,6 +58,7 @@ public class BfConsts {
   public static final String ARG_PRETTY_PRINT_ANSWER = "ppa";
   public static final String ARG_QUESTION_NAME = "questionname";
   public static final String ARG_RED_FLAG_SUPPRESS = "redflagsuppress";
+  public static final String ARG_SNAPSHOT_NAME = "snapshotname";
   public static final String ARG_SSL_DISABLE = "ssldisable";
   public static final String ARG_SSL_KEYSTORE_FILE = "sslkeystorefile";
   public static final String ARG_SSL_KEYSTORE_PASSWORD = "sslkeystorepassword";

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/identifiers/FileBasedIdResolver.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/identifiers/FileBasedIdResolver.java
@@ -26,8 +26,6 @@ public class FileBasedIdResolver implements IdResolver {
 
   private static final String ID_EXTENSION = ".id";
 
-  private static final String NAME_EXTENSION = ".name";
-
   private static final String RELPATH_ANALYSIS_IDS = "analysis_ids";
 
   private static final String RELPATH_ISSUE_SETTINGS_IDS = "analysis_ids";
@@ -41,8 +39,6 @@ public class FileBasedIdResolver implements IdResolver {
   private static final String RELPATH_QUESTION_SETTINGS_IDS = "question_settings_ids";
 
   private static final String RELPATH_SNAPSHOT_IDS = "snapshot_ids";
-
-  private static final String RELPATH_SNAPSHOT_NAMES = "snapshot_names";
 
   private static @Nonnull String hash(String input) {
     return Hashing.murmur3_128().hashString(input, StandardCharsets.UTF_8).toString();
@@ -231,20 +227,6 @@ public class FileBasedIdResolver implements IdResolver {
 
   protected @Nonnull Path getSnapshotIdsDir(NetworkId networkId) {
     return _d.getNetworkDir(networkId).resolve(RELPATH_SNAPSHOT_IDS);
-  }
-
-  @Override
-  public String getSnapshotName(NetworkId networkId, SnapshotId snapshotId) {
-    return CommonUtil.readFile(getSnapshotNamePath(networkId, snapshotId));
-  }
-
-  protected @Nonnull Path getSnapshotNamePath(NetworkId networkId, SnapshotId snapshotId) {
-    return getSnapshotNamesDir(networkId)
-        .resolve(String.format("%s%s", snapshotId.getId(), NAME_EXTENSION));
-  }
-
-  protected @Nonnull Path getSnapshotNamesDir(NetworkId networkId) {
-    return _d.getNetworkDir(networkId).resolve(RELPATH_SNAPSHOT_NAMES);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/identifiers/IdResolver.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/identifiers/IdResolver.java
@@ -79,10 +79,6 @@ public interface IdResolver {
   @Nonnull
   SnapshotId getSnapshotId(String snapshot, NetworkId networkId);
 
-  /** Retrieve the name of the snapshot with the given ID */
-  @Nonnull
-  String getSnapshotName(NetworkId networkId, SnapshotId snapshotId);
-
   /** Retrieve the {@link NodeRolesId} corresponding to the provided input IDs. */
   @Nonnull
   NodeRolesId getSnapshotNodeRolesId(NetworkId networkId, SnapshotId snapshotId);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/identifiers/TestIdResolver.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/identifiers/TestIdResolver.java
@@ -57,11 +57,6 @@ public class TestIdResolver implements IdResolver {
   }
 
   @Override
-  public String getSnapshotName(NetworkId networkId, SnapshotId snapshotId) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
   public NodeRolesId getSnapshotNodeRolesId(NetworkId networkId, SnapshotId snapshotId) {
     throw new UnsupportedOperationException();
   }

--- a/projects/batfish/src/main/java/org/batfish/config/Settings.java
+++ b/projects/batfish/src/main/java/org/batfish/config/Settings.java
@@ -465,6 +465,10 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     return !_config.getBoolean(ARG_DISABLE_Z3_SIMPLIFICATION);
   }
 
+  public String getSnapshotName() {
+    return _config.getString(BfConsts.ARG_SNAPSHOT_NAME);
+  }
+
   public boolean getSslDisable() {
     return _config.getBoolean(BfConsts.ARG_SSL_DISABLE);
   }
@@ -633,6 +637,7 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     setDefaultProperty(ARG_SERVICE_HOST, "localhost");
     setDefaultProperty(ARG_SERVICE_NAME, "worker-service");
     setDefaultProperty(ARG_SERVICE_PORT, BfConsts.SVC_PORT);
+    setDefaultProperty(BfConsts.ARG_SNAPSHOT_NAME, null);
     setDefaultProperty(BfConsts.ARG_SSL_DISABLE, CoordConsts.SVC_CFG_POOL_SSL_DISABLE);
     setDefaultProperty(BfConsts.ARG_SSL_KEYSTORE_FILE, null);
     setDefaultProperty(BfConsts.ARG_SSL_KEYSTORE_PASSWORD, null);
@@ -702,7 +707,7 @@ public final class Settings extends BaseSettings implements GrammarSettings {
         ARG_CHECK_BGP_REACHABILITY,
         "whether to check BGP session reachability during data plane computation");
 
-    addOption(BfConsts.ARG_CONTAINER, "name of container", ARGNAME_NAME);
+    addOption(BfConsts.ARG_CONTAINER, "ID of network", ARGNAME_NAME);
 
     addOption(
         ARG_COORDINATOR_HOST,
@@ -857,6 +862,8 @@ public final class Settings extends BaseSettings implements GrammarSettings {
 
     addOption(ARG_SERVICE_PORT, "port for batfish service", ARGNAME_PORT);
 
+    addOption(BfConsts.ARG_SNAPSHOT_NAME, "name of snapshot", ARGNAME_NAME);
+
     addBooleanOption(
         BfConsts.ARG_SSL_DISABLE, "whether to disable SSL during communication with coordinator");
 
@@ -876,7 +883,7 @@ public final class Settings extends BaseSettings implements GrammarSettings {
 
     addOption(BfConsts.ARG_TASK_PLUGIN, "fully-qualified name of task plugin class", ARGNAME_NAME);
 
-    addOption(BfConsts.ARG_TESTRIG, "name of testrig", ARGNAME_NAME);
+    addOption(BfConsts.ARG_TESTRIG, "ID of snapshot", ARGNAME_NAME);
 
     addBooleanOption(ARG_THROW_ON_LEXER_ERROR, "throw exception immediately on lexer error");
 
@@ -1007,6 +1014,7 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     getIntOptionValue(ARG_SERVICE_PORT);
     getBooleanOptionValue(ARG_NO_SHUFFLE);
     getBooleanOptionValue(ARG_DISABLE_Z3_SIMPLIFICATION);
+    getStringOptionValue(BfConsts.ARG_SNAPSHOT_NAME);
     getBooleanOptionValue(BfConsts.ARG_SSL_DISABLE);
     getPathOptionValue(BfConsts.ARG_SSL_KEYSTORE_FILE);
     getStringOptionValue(BfConsts.ARG_SSL_KEYSTORE_PASSWORD);
@@ -1182,5 +1190,9 @@ public final class Settings extends BaseSettings implements GrammarSettings {
   public void setQuestionName(QuestionId questionName) {
     _config.setProperty(
         BfConsts.ARG_QUESTION_NAME, questionName != null ? questionName.getId() : null);
+  }
+
+  public void setSnapshotName(String snapshotName) {
+    _config.setProperty(BfConsts.ARG_SNAPSHOT_NAME, snapshotName);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -1367,7 +1367,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
     SortedSet<String> nodeBlackList = getNodeBlacklist();
     // TODO: add bgp tables and external announcements as well
     return new Environment(
-        _idResolver.getSnapshotName(_settings.getContainer(), getTestrigName()),
+        _settings.getSnapshotName(),
         edgeBlackList,
         interfaceBlackList,
         nodeBlackList,
@@ -3637,9 +3637,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
     checkTopology(configurations, testrigTopology);
     org.batfish.datamodel.pojo.Topology pojoTopology =
         org.batfish.datamodel.pojo.Topology.create(
-            _idResolver.getSnapshotName(_settings.getContainer(), _testrigSettings.getName()),
-            configurations,
-            testrigTopology);
+            _settings.getSnapshotName(), configurations, testrigTopology);
     serializeAsJson(_testrigSettings.getPojoTopologyPath(), pojoTopology, "testrig pojo topology");
     _storage.storeConfigurations(
         configurations, answerElement, _settings.getContainer(), _testrigSettings.getName());

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
@@ -39,11 +39,6 @@ public class BatfishTestUtils {
     public TestFileBasedIdResolver(Path storageBase) {
       super(storageBase);
     }
-
-    @Override
-    public String getSnapshotName(NetworkId networkId, SnapshotId snapshotId) {
-      return snapshotId.getId();
-    }
   }
 
   private static Cache<NetworkSnapshot, SortedMap<String, Configuration>> makeTestrigCache() {
@@ -72,14 +67,15 @@ public class BatfishTestUtils {
         makeTestrigCache();
 
     settings.setStorageBase(tempFolder.newFolder().toPath());
-    settings.setContainer("tempContainer");
+    settings.setContainer("tempNetworkId");
     if (!configurations.isEmpty()) {
-      settings.setTestrig("tempTestrig");
+      settings.setTestrig("tempSnapshotId");
+      settings.setSnapshotName("tempSnapshot");
       Batfish.initTestrigSettings(settings);
       settings.getBaseTestrigSettings().getInputPath().toFile().mkdirs();
       settings.getBaseTestrigSettings().getOutputPath().toFile().mkdirs();
       testrigs.put(
-          new NetworkSnapshot(new NetworkId("tempContainer"), new SnapshotId("tempTestrig")),
+          new NetworkSnapshot(new NetworkId("tempNetworkId"), new SnapshotId("tempSnapshotId")),
           configurations);
       settings.setActiveTestrigSettings(settings.getBaseTestrigSettings());
     }
@@ -116,18 +112,20 @@ public class BatfishTestUtils {
         makeTestrigCache();
 
     settings.setStorageBase(tempFolder.newFolder().toPath());
-    settings.setContainer("tempContainer");
+    settings.setContainer("tempNetworkId");
     if (!baseConfigs.isEmpty()) {
-      settings.setTestrig("tempTestrig");
-      settings.setDeltaTestrig(new SnapshotId("tempDeltaTestrig"));
+      settings.setTestrig("tempSnapshotId");
+      settings.setSnapshotName("tempSnapshot");
+      settings.setDeltaTestrig(new SnapshotId("tempReferenceSnapshotId"));
       Batfish.initTestrigSettings(settings);
       settings.getBaseTestrigSettings().getOutputPath().toFile().mkdirs();
       settings.getDeltaTestrigSettings().getOutputPath().toFile().mkdirs();
       testrigs.put(
-          new NetworkSnapshot(new NetworkId("tempContainer"), new SnapshotId("tempTestrig")),
+          new NetworkSnapshot(new NetworkId("tempNetworkId"), new SnapshotId("tempSnapshotId")),
           baseConfigs);
       testrigs.put(
-          new NetworkSnapshot(new NetworkId("tempContainer"), new SnapshotId("tempDeltaTestrig")),
+          new NetworkSnapshot(
+              new NetworkId("tempNetworkId"), new SnapshotId("tempReferenceSnapshotId")),
           deltaConfigs);
       settings.setActiveTestrigSettings(settings.getBaseTestrigSettings());
     }
@@ -194,8 +192,9 @@ public class BatfishTestUtils {
     settings.setThrowOnParserError(true);
     settings.setVerboseParse(true);
     settings.setStorageBase(tempFolder.newFolder().toPath());
-    settings.setContainer("tempContainer");
-    settings.setTestrig("tempTestrig");
+    settings.setContainer("tempNetworkId");
+    settings.setTestrig("tempSnapshotId");
+    settings.setSnapshotName("tempSnapshot");
     Batfish.initTestrigSettings(settings);
     Path testrigPath = settings.getBaseTestrigSettings().getInputPath();
     settings.getBaseTestrigSettings().getOutputPath().toFile().mkdirs();

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -671,9 +671,16 @@ public class WorkMgr extends AbstractCoordinator {
     return true;
   }
 
-  public void delSnapshot(String network, String snapshot) {
+  public boolean delSnapshot(String network, String snapshot) {
+    if (!_idManager.hasNetworkId(network)) {
+      return false;
+    }
     NetworkId networkId = _idManager.getNetworkId(network);
+    if (!_idManager.hasSnapshotId(snapshot, networkId)) {
+      return false;
+    }
     _idManager.deleteSnapshot(snapshot, networkId);
+    return true;
   }
 
   public void delQuestion(String network, String qName) {
@@ -1847,6 +1854,7 @@ public class WorkMgr extends AbstractCoordinator {
     }
     SnapshotId snapshotId = idManager.getSnapshotId(snapshot, networkId);
     params.put(BfConsts.ARG_TESTRIG, snapshotId.getId());
+    params.put(BfConsts.ARG_SNAPSHOT_NAME, snapshot);
 
     // referenceSnapshot
     String referenceSnapshot = params.get(BfConsts.ARG_DELTA_TESTRIG);

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -671,6 +671,10 @@ public class WorkMgr extends AbstractCoordinator {
     return true;
   }
 
+  /**
+   * Delete the specified snapshot under the specified network. Returns {@code true} if deletion is
+   * successful. Returns {@code false} if either network or snapshot does not exist.
+   */
   public boolean delSnapshot(String network, String snapshot) {
     if (!_idManager.hasNetworkId(network)) {
       return false;

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
@@ -505,6 +505,7 @@ public class WorkMgrService {
   @POST
   @Path(CoordConsts.SVC_RSC_DEL_SNAPSHOT)
   @Produces(MediaType.APPLICATION_JSON)
+  @Deprecated
   public JSONArray delSnapshot(
       @FormDataParam(CoordConsts.SVC_KEY_API_KEY) String apiKey,
       @FormDataParam(CoordConsts.SVC_KEY_VERSION) String clientVersion,
@@ -526,7 +527,12 @@ public class WorkMgrService {
       checkClientVersion(clientVersion);
       checkNetworkAccessibility(apiKey, networkNameParam);
 
-      Main.getWorkMgr().delSnapshot(networkNameParam, snapshotNameParam);
+      if (!Main.getWorkMgr().delSnapshot(networkNameParam, snapshotNameParam)) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Could not delete non-existent snapshot:%s in network:%s",
+                snapshotNameParam, networkNameParam));
+      }
 
       return successResponse(new JSONObject().put("result", "true"));
 

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/id/FileBasedIdManager.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/id/FileBasedIdManager.java
@@ -81,9 +81,6 @@ public class FileBasedIdManager extends FileBasedIdResolver implements IdManager
     Path idFile = getSnapshotIdPath(snapshot, networkId);
     idFile.getParent().toFile().mkdirs();
     CommonUtil.writeFile(idFile, snapshotId.getId());
-    Path nameFile = getSnapshotNamePath(networkId, snapshotId);
-    nameFile.getParent().toFile().mkdirs();
-    CommonUtil.writeFile(nameFile, snapshot);
   }
 
   @Override
@@ -104,7 +101,6 @@ public class FileBasedIdManager extends FileBasedIdResolver implements IdManager
 
   @Override
   public void deleteSnapshot(String snapshot, NetworkId networkId) {
-    CommonUtil.delete(getSnapshotNamePath(networkId, getSnapshotId(snapshot, networkId)));
     CommonUtil.delete(getSnapshotIdPath(snapshot, networkId));
   }
 

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/resources/SnapshotResource.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/resources/SnapshotResource.java
@@ -9,6 +9,7 @@ import static org.batfish.common.CoordConstsV2.RSC_TOPOLOGY;
 
 import java.io.IOException;
 import javax.annotation.ParametersAreNonnullByDefault;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -35,7 +36,7 @@ public final class SnapshotResource {
   @Path(RSC_POJO_TOPOLOGY)
   @Produces(MediaType.APPLICATION_JSON)
   @GET
-  public Response get() throws IOException {
+  public Response getPojoTopology() throws IOException {
     org.batfish.datamodel.pojo.Topology topology =
         Main.getWorkMgr().getPojoTopology(_network, _snapshot);
     if (topology == null) {
@@ -52,6 +53,14 @@ public final class SnapshotResource {
   @Path(RSC_INPUT)
   public SnapshotInputObjectsResource getSnapshotInputObjectsResource() {
     return new SnapshotInputObjectsResource(_network, _snapshot);
+  }
+
+  @DELETE
+  public Response deleteSnapshot() {
+    if (!Main.getWorkMgr().delSnapshot(_network, _snapshot)) {
+      return Response.status(Status.NOT_FOUND).build();
+    }
+    return Response.ok().build();
   }
 
   @GET

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
@@ -102,7 +102,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 /** Tests for {@link WorkMgr}. */
-public class WorkMgrTest {
+public final class WorkMgrTest {
 
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
 
@@ -1761,9 +1761,7 @@ public class WorkMgrTest {
     _manager.initNetwork(network, null);
 
     // should not be able to delete non-existent snapshot
-    _thrown.expect(IllegalArgumentException.class);
-    _thrown.expectMessage(containsString(snapshot));
-    _manager.delSnapshot(network, snapshot);
+    assertFalse(_manager.delSnapshot(network, snapshot));
   }
 
   @Test

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/LocalIdManager.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/LocalIdManager.java
@@ -9,7 +9,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -294,21 +293,6 @@ public class LocalIdManager implements IdManager {
     }
     return illegalIfNull(
         _snapshotIds.computeIfAbsent(networkId, n -> new HashMap<>()).get(snapshot));
-  }
-
-  @Override
-  public String getSnapshotName(NetworkId networkId, SnapshotId snapshotId) {
-    if (!_networkIds.values().contains(networkId)) {
-      throw new IllegalArgumentException(String.format("No network with ID: '%s'", networkId));
-    }
-    return _snapshotIds
-        .computeIfAbsent(networkId, n -> new HashMap<>())
-        .entrySet()
-        .stream()
-        .filter(e -> e.getValue().equals(snapshotId))
-        .map(Entry::getKey)
-        .findFirst()
-        .get();
   }
 
   @Override

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/SnapshotResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/SnapshotResourceTest.java
@@ -2,6 +2,7 @@ package org.batfish.coordinator.resources;
 
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.OK;
+import static org.batfish.coordinator.WorkMgrTestUtils.uploadTestSnapshot;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
@@ -65,6 +66,42 @@ public class SnapshotResourceTest extends WorkMgrServiceV2TestBase {
   @Before
   public void initContainerEnvironment() throws Exception {
     WorkMgrTestUtils.initWorkManager(_folder);
+  }
+
+  @Test
+  public void testDeleteSnapshotMissingNetwork() {
+    String network = "network1";
+    String snapshot = "snapshot1";
+    Response response = getTarget(network, snapshot).delete();
+
+    assertThat(response.getStatus(), equalTo(NOT_FOUND.getStatusCode()));
+  }
+
+  @Test
+  public void testDeleteSnapshotMissingSnapshot() {
+    String network = "network1";
+    String snapshot = "snapshot1";
+    Main.getWorkMgr().initNetwork(network, null);
+    Response response = getTarget(network, snapshot).delete();
+
+    assertThat(response.getStatus(), equalTo(NOT_FOUND.getStatusCode()));
+  }
+
+  @Test
+  public void testDeleteSnapshotSuccess() throws IOException {
+    String network = "network1";
+    String snapshot = "snapshot1";
+    Main.getWorkMgr().initNetwork(network, null);
+    uploadTestSnapshot(network, snapshot, _folder);
+    Response response = getTarget(network, snapshot).delete();
+
+    // should succeed first time
+    assertThat(response.getStatus(), equalTo(OK.getStatusCode()));
+
+    response = getTarget(network, snapshot).delete();
+
+    // should fail second time
+    assertThat(response.getStatus(), equalTo(NOT_FOUND.getStatusCode()));
   }
 
   @Test


### PR DESCRIPTION
- add snapshotname arg that gets passed by coordinator to worker
- remove extraneous mapping APIs for getting names from IDs
- clean up snapshot deletion test that broke as result
  - implement v2 call for maximum cleanliness