### PR TITLE
Switch to using IntegerSpace in PacketHeaderConstraints

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IntegerSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IntegerSpace.java
@@ -17,7 +17,6 @@ import java.util.HashSet;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collector;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -37,9 +36,6 @@ public final class IntegerSpace {
   public static final IntegerSpace PORTS = builder().including(Range.closed(0, 65535)).build();
 
   private static final String ERROR_MESSAGE_TEMPLATE = "Invalid range specification %s";
-  private static final Collector<IntegerSpace, ?, IntegerSpace> SPACE_COLLECTOR =
-      Collector.of(
-          IntegerSpace::builder, Builder::including, Builder::combine, IntegerSpace.Builder::build);
 
   /*
    * Invariant: always ensure ranges are stored in canonical form (enforced in builder methods)
@@ -218,7 +214,7 @@ public final class IntegerSpace {
   }
 
   /** Create a new integer space from a {@link SubRange} */
-  public static IntegerSpace of(SubRange... ranges) {
+  public static IntegerSpace unionOf(SubRange... ranges) {
     Builder b = builder();
     for (SubRange range : ranges) {
       b.including(range);
@@ -311,16 +307,6 @@ public final class IntegerSpace {
       rangeSet.removeAll(_excluding);
       return new IntegerSpace(rangeSet);
     }
-
-    Builder combine(Builder b) {
-      _including.addAll(b._including);
-      _excluding.addAll(b._excluding);
-      return this;
-    }
-  }
-
-  public static Collector<IntegerSpace, ?, IntegerSpace> toIntegerSpace() {
-    return SPACE_COLLECTOR;
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PacketHeaderConstraints.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PacketHeaderConstraints.java
@@ -6,11 +6,10 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import java.util.Collections;
-import java.util.Optional;
 import java.util.Set;
-import java.util.function.Predicate;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -53,55 +52,53 @@ public class PacketHeaderConstraints {
    * All fields are nullable to allow being "not set", and therefore, unconstrained
    */
   // Ip fields, unlikely to be specified
-  @Nullable private final Set<SubRange> _dscps;
-
-  @Nullable private final Set<SubRange> _ecns;
-
-  @Nullable private final Set<SubRange> _packetLengths;
-
+  @Nullable private final IntegerSpace _dscps;
+  @Nullable private final IntegerSpace _ecns;
+  @Nullable private final IntegerSpace _packetLengths;
   @Nullable private final Set<FlowState> _flowStates;
-
-  @Nullable private final Set<SubRange> _fragmentOffsets;
+  @Nullable private final IntegerSpace _fragmentOffsets;
 
   // Ip fields, likely to be specified
   @Nullable private final Set<IpProtocol> _ipProtocols;
-
   @Nullable private final String _srcIp;
-
   @Nullable private final String _dstIp;
 
   // ICMP fields
-  @Nullable private final Set<SubRange> _icmpCode;
-
-  @Nullable private final Set<SubRange> _icmpType;
+  @Nullable private final IntegerSpace _icmpCode;
+  @Nullable private final IntegerSpace _icmpType;
 
   // UDP/TCP fields
-  @Nullable private final Set<SubRange> _srcPorts;
-
-  @Nullable private final Set<SubRange> _dstPorts;
+  @Nullable private final IntegerSpace _srcPorts;
+  @Nullable private final IntegerSpace _dstPorts;
 
   // Shorthands for UDP/TCP fields
   // TODO: allow specification of more complex applications, the existing Protocol Enum is limiting.
   @Nullable private final Set<Protocol> _applications;
-
   @Nullable private final Set<TcpFlagsMatchConditions> _tcpFlags;
 
-  private static final SubRange ALLOWED_PORTS = new SubRange(0, 65535);
+  @VisibleForTesting
+  static final IntegerSpace VALID_DSCP =
+      IntegerSpace.builder().including(Range.closed(0, 63)).build();
+
+  private static final IntegerSpace VALID_ECN =
+      IntegerSpace.builder().including(Range.closed(0, 3)).build();
+  private static final IntegerSpace VALID_ICMP_CODE_TYPE =
+      IntegerSpace.builder().including(Range.closed(0, 255)).build();
 
   @JsonCreator
   private PacketHeaderConstraints(
-      @Nullable @JsonProperty(PROP_DSCPS) Set<SubRange> dscps,
-      @Nullable @JsonProperty(PROP_ECNS) Set<SubRange> ecns,
-      @Nullable @JsonProperty(PROP_PACKET_LENGTHS) Set<SubRange> packetLengths,
+      @Nullable @JsonProperty(PROP_DSCPS) IntegerSpace dscps,
+      @Nullable @JsonProperty(PROP_ECNS) IntegerSpace ecns,
+      @Nullable @JsonProperty(PROP_PACKET_LENGTHS) IntegerSpace packetLengths,
       @Nullable @JsonProperty(PROP_FLOW_STATES) Set<FlowState> flowStates,
-      @Nullable @JsonProperty(PROP_FRAGMENT_OFFSETS) Set<SubRange> fragmentOffsets,
+      @Nullable @JsonProperty(PROP_FRAGMENT_OFFSETS) IntegerSpace fragmentOffsets,
       @Nullable @JsonProperty(PROP_IP_PROTOCOLS) Set<IpProtocol> ipProtocols,
       @Nullable @JsonProperty(PROP_SRC_IPS) String srcIps,
       @Nullable @JsonProperty(PROP_DST_IPS) String dstIps,
-      @Nullable @JsonProperty(PROP_ICMP_CODES) Set<SubRange> icmpCodes,
-      @Nullable @JsonProperty(PROP_ICMP_TYPES) Set<SubRange> icmpTypes,
-      @Nullable @JsonProperty(PROP_SRC_PORTS) Set<SubRange> srcPorts,
-      @Nullable @JsonProperty(PROP_DST_PORTS) Set<SubRange> dstPorts,
+      @Nullable @JsonProperty(PROP_ICMP_CODES) IntegerSpace icmpCodes,
+      @Nullable @JsonProperty(PROP_ICMP_TYPES) IntegerSpace icmpTypes,
+      @Nullable @JsonProperty(PROP_SRC_PORTS) IntegerSpace srcPorts,
+      @Nullable @JsonProperty(PROP_DST_PORTS) IntegerSpace dstPorts,
       @Nullable @JsonProperty(PROP_APPLICATIONS) Set<Protocol> applications,
       @Nullable @JsonProperty(PROP_TCP_FLAGS) Set<TcpFlagsMatchConditions> tcpFlags)
       throws IllegalArgumentException {
@@ -130,19 +127,19 @@ public class PacketHeaderConstraints {
 
   @Nullable
   @JsonProperty(PROP_DSCPS)
-  public Set<SubRange> getDscps() {
+  public IntegerSpace getDscps() {
     return _dscps;
   }
 
   @Nullable
   @JsonProperty(PROP_ECNS)
-  public Set<SubRange> getEcns() {
+  public IntegerSpace getEcns() {
     return _ecns;
   }
 
   @Nullable
   @JsonProperty(PROP_PACKET_LENGTHS)
-  public Set<SubRange> getPacketLengths() {
+  public IntegerSpace getPacketLengths() {
     return _packetLengths;
   }
 
@@ -154,7 +151,7 @@ public class PacketHeaderConstraints {
 
   @Nullable
   @JsonProperty(PROP_FRAGMENT_OFFSETS)
-  public Set<SubRange> getFragmentOffsets() {
+  public IntegerSpace getFragmentOffsets() {
     return _fragmentOffsets;
   }
 
@@ -178,25 +175,25 @@ public class PacketHeaderConstraints {
 
   @Nullable
   @JsonProperty(PROP_ICMP_CODES)
-  public Set<SubRange> getIcmpCodes() {
+  public IntegerSpace getIcmpCodes() {
     return _icmpCode;
   }
 
   @Nullable
   @JsonProperty(PROP_ICMP_TYPES)
-  public Set<SubRange> getIcmpTypes() {
+  public IntegerSpace getIcmpTypes() {
     return _icmpType;
   }
 
   @Nullable
   @JsonProperty(PROP_SRC_PORTS)
-  public Set<SubRange> getSrcPorts() {
+  public IntegerSpace getSrcPorts() {
     return _srcPorts;
   }
 
   @Nullable
   @JsonProperty(PROP_DST_PORTS)
-  public Set<SubRange> getDstPorts() {
+  public IntegerSpace getDstPorts() {
     return _dstPorts;
   }
 
@@ -221,7 +218,7 @@ public class PacketHeaderConstraints {
 
   /** Return the set of allowed destination port values */
   @Nullable
-  public Set<SubRange> resolveDstPorts() {
+  public IntegerSpace resolveDstPorts() {
     return resolvePorts(getDstPorts(), getApplications());
   }
 
@@ -252,92 +249,77 @@ public class PacketHeaderConstraints {
     // TODO: validate other fields: fragment offsets, packet lengths, etc.
   }
 
-  private static void validatePortValues(@Nullable Set<SubRange> ports)
+  private static void validatePortValues(@Nullable IntegerSpace ports)
       throws IllegalArgumentException {
-    // Reject empty lists and empty port ranges
+    // Unconstrained is OK
     if (ports == null) {
       return;
     }
-    if (ports.isEmpty() || ports.stream().allMatch(SubRange::isEmpty)) {
-      throw new IllegalArgumentException("Empty port ranges are not allowed");
-    }
-    Optional<SubRange> invalidRange =
-        ports.stream().filter(portRange -> !ALLOWED_PORTS.contains(portRange)).findFirst();
+    // Reject empty port ranges
+    checkArgument(!ports.isEmpty(), "Empty port ranges are not allowed");
     checkArgument(
-        !invalidRange.isPresent(),
-        "Port range %s is outside of the allowed range %s",
-        invalidRange,
-        ALLOWED_PORTS);
+        ports.difference(IntegerSpace.PORTS).isEmpty(), "Invalid port range specified: %s", ports);
   }
 
   private static void validateIcmpFields(@Nonnull PacketHeaderConstraints headerConstraints)
       throws IllegalArgumentException {
+    // TODO: more stringent validation, not all values 0-255 are valid ICMP codes/types
     Set<IpProtocol> ipProtocols = headerConstraints.getIpProtocols();
-    Set<SubRange> icmpTypes = headerConstraints.getIcmpTypes();
+    IntegerSpace icmpTypes = headerConstraints.getIcmpTypes();
     if (icmpTypes != null) {
       checkArgument(!icmpTypes.isEmpty(), "Set of ICMP types cannot be empty");
       checkArgument(
           ipProtocols == null || ipProtocols.equals(ImmutableSet.of(IpProtocol.ICMP)),
           "ICMP types specified when ICMP protocol is forbidden in IpProtocols");
-      Optional<SubRange> invalidRange =
-          icmpTypes.stream().filter(types -> !isValidIcmpTypeOrCode(types)).findFirst();
-      checkArgument(!invalidRange.isPresent(), "Invalid ICMP type range: %s", invalidRange);
+      checkArgument(isValidIcmpTypeOrCode(icmpTypes), "Invalid ICMP type range: %s", icmpTypes);
     }
 
-    Set<SubRange> icmpCodes = headerConstraints.getIcmpCodes();
+    IntegerSpace icmpCodes = headerConstraints.getIcmpCodes();
     if (icmpCodes != null) {
       checkArgument(!icmpCodes.isEmpty(), "Set of ICMP codes cannot be empty");
       checkArgument(
           ipProtocols == null || ipProtocols.equals(ImmutableSet.of(IpProtocol.ICMP)),
           "ICMP codes specified when ICMP protocol is forbidden in IpProtocols");
-      Optional<SubRange> invalidRange =
-          icmpCodes.stream().filter(codes -> !isValidIcmpTypeOrCode(codes)).findFirst();
-      checkArgument(!invalidRange.isPresent(), "Invalid ICMP code range: %s", invalidRange);
+      checkArgument(isValidIcmpTypeOrCode(icmpCodes), "Invalid ICMP code range: %s", icmpCodes);
     }
   }
 
   private static void validateIpFields(@Nonnull PacketHeaderConstraints headerConstraints)
       throws IllegalArgumentException {
-    Set<SubRange> dscps = headerConstraints.getDscps();
+    IntegerSpace dscps = headerConstraints.getDscps();
     if (dscps != null) {
       checkArgument(!dscps.isEmpty(), "Empty set of DSCP values is not allowed");
-      Optional<SubRange> invalidRange =
-          dscps.stream().filter(dscp -> !isValidDscp(dscp)).findFirst();
-      checkArgument(!invalidRange.isPresent(), "Invalid value for DSCP: %s", invalidRange);
+      checkArgument(isValidDscp(dscps), "Invalid DSCP values specified: %s", dscps);
     }
 
-    Set<SubRange> ecns = headerConstraints.getEcns();
+    IntegerSpace ecns = headerConstraints.getEcns();
     if (ecns != null) {
       checkArgument(!ecns.isEmpty(), "Empty set of ECN values is not allowed");
-      Optional<SubRange> invalidRange = ecns.stream().filter(ecn -> !isValidEcn(ecn)).findFirst();
-      checkArgument(!invalidRange.isPresent(), "Invalid value for ECN: %s", invalidRange);
+      checkArgument(isValidEcn(ecns), "Invalid value for ECN: %s", ecns);
     }
   }
 
   /** Check if the subrange represents valid IP DSCP values. */
   @VisibleForTesting
-  static boolean isValidDscp(@Nonnull SubRange dscp) {
-    SubRange allowed = new SubRange(0, 63); // 6 bits in header
-    return !dscp.isEmpty() && allowed.contains(dscp);
+  static boolean isValidDscp(@Nonnull IntegerSpace dscp) {
+    return !dscp.isEmpty() && VALID_DSCP.contains(dscp);
   }
 
   /** Check if the subrange represents valid IP ECN values. */
   @VisibleForTesting
-  static boolean isValidEcn(@Nonnull SubRange ecn) {
-    SubRange allowed = new SubRange(0, 3); // 2 bits in header
-    return !ecn.isEmpty() && allowed.contains(ecn);
+  static boolean isValidEcn(@Nonnull IntegerSpace ecn) {
+    return !ecn.isEmpty() && VALID_ECN.contains(ecn);
   }
 
   @VisibleForTesting
-  static boolean isValidIcmpTypeOrCode(@Nonnull SubRange icmpType) {
-    SubRange allowed = new SubRange(0, 255); // 8 bits in header
-    return !icmpType.isEmpty() && allowed.contains(icmpType);
+  static boolean isValidIcmpTypeOrCode(@Nonnull IntegerSpace icmpType) {
+    return !icmpType.isEmpty() && VALID_ICMP_CODE_TYPE.contains(icmpType);
   }
 
   @VisibleForTesting
   static boolean areProtocolsAndPortsCompatible(
       @Nullable Set<IpProtocol> ipProtocols,
-      @Nullable Set<SubRange> ports,
+      @Nullable IntegerSpace ports,
       @Nullable Set<Protocol> protocols)
       throws IllegalArgumentException {
 
@@ -365,15 +347,16 @@ public class PacketHeaderConstraints {
     // Intersection of ports given and ports resolved from higher-level protocols should
     // not be empty
     if (ports != null && protocols != null) {
-      Set<Integer> resolvedPorts =
-          protocols.stream().map(Protocol::getPort).collect(ImmutableSet.toImmutableSet());
+      IntegerSpace resolvedPorts =
+          protocols
+              .stream()
+              .map(Protocol::getPort)
+              .map(IntegerSpace::of)
+              .collect(IntegerSpace.toIntegerSpace());
 
       // for each subrange, run all resolved ports through it, to see if a match occurs
       checkArgument(
-          ports
-              .stream()
-              .flatMap(subrange -> resolvedPorts.stream().map(subrange::includes))
-              .anyMatch(Predicate.isEqual(true)),
+          ports.contains(resolvedPorts),
           "Given ports (%s) and protocols (%s) do not overlap",
           ports,
           protocols);
@@ -397,8 +380,8 @@ public class PacketHeaderConstraints {
   @VisibleForTesting
   static Set<IpProtocol> resolveIpProtocols(
       @Nullable Set<IpProtocol> ipProtocols,
-      @Nullable Set<SubRange> srcPorts,
-      @Nullable Set<SubRange> dstPorts,
+      @Nullable IntegerSpace srcPorts,
+      @Nullable IntegerSpace dstPorts,
       @Nullable Set<Protocol> applications,
       @Nullable Set<TcpFlagsMatchConditions> tcpFlags)
       throws IllegalArgumentException {
@@ -451,8 +434,8 @@ public class PacketHeaderConstraints {
    */
   @Nullable
   @VisibleForTesting
-  static Set<SubRange> resolvePorts(
-      @Nullable Set<SubRange> ports, @Nullable Set<Protocol> protocols) {
+  static IntegerSpace resolvePorts(
+      @Nullable IntegerSpace ports, @Nullable Set<Protocol> protocols) {
     // Don't care
     if (ports == null && protocols == null) {
       return null;
@@ -468,17 +451,17 @@ public class PacketHeaderConstraints {
       return protocols
           .stream()
           .map(Protocol::getPort)
-          .map(port -> new SubRange(port, port))
-          .collect(ImmutableSet.toImmutableSet());
+          .map(IntegerSpace::of)
+          .collect(IntegerSpace.toIntegerSpace());
     }
 
-    // Intersect. Protocols are the limiting factor, but they must belong to at least one subrange
+    // Intersect. Protocols are the limiting factor, but they must belong to at least one space
     return protocols
         .stream()
         .map(Protocol::getPort)
-        .filter(port -> ports.stream().map(r -> r.includes(port)).anyMatch(Predicate.isEqual(true)))
-        .map(port -> new SubRange(port, port))
-        .collect(ImmutableSet.toImmutableSet());
+        .map(IntegerSpace::of)
+        .collect(IntegerSpace.toIntegerSpace())
+        .intersection(ports);
   }
 
   public static Builder builder() {
@@ -490,38 +473,38 @@ public class PacketHeaderConstraints {
      * All fields are nullable to allow being "not set", and therefore, unconstrained
      */
     // Ip fields, unlikely to be specified
-    private @Nullable Set<SubRange> _dscps;
-    private @Nullable Set<SubRange> _ecns;
-    private @Nullable Set<SubRange> _packetLengths;
+    private @Nullable IntegerSpace _dscps;
+    private @Nullable IntegerSpace _ecns;
+    private @Nullable IntegerSpace _packetLengths;
     private @Nullable Set<FlowState> _flowStates;
-    private @Nullable Set<SubRange> _fragmentOffsets;
+    private @Nullable IntegerSpace _fragmentOffsets;
     // Ip fields, likely to be specified
     private @Nullable Set<IpProtocol> _ipProtocols;
     private @Nullable String _srcIps;
     private @Nullable String _dstIps;
     // ICMP fields
-    private @Nullable Set<SubRange> _icmpCodes;
-    private @Nullable Set<SubRange> _icmpTypes;
+    private @Nullable IntegerSpace _icmpCodes;
+    private @Nullable IntegerSpace _icmpTypes;
     // UDP/TCP fields
-    private @Nullable Set<SubRange> _srcPorts;
-    private @Nullable Set<SubRange> _dstPorts;
+    private @Nullable IntegerSpace _srcPorts;
+    private @Nullable IntegerSpace _dstPorts;
     // Shorthands for UDP/TCP fields
     private @Nullable Set<Protocol> _applications;
     private @Nullable Set<TcpFlagsMatchConditions> _tcpFlags;
 
     private Builder() {}
 
-    public Builder setDscps(@Nullable Set<SubRange> dscps) {
+    public Builder setDscps(@Nullable IntegerSpace dscps) {
       this._dscps = dscps;
       return this;
     }
 
-    public Builder setEcns(@Nullable Set<SubRange> ecns) {
+    public Builder setEcns(@Nullable IntegerSpace ecns) {
       this._ecns = ecns;
       return this;
     }
 
-    public Builder setPacketLengths(@Nullable Set<SubRange> packetLengths) {
+    public Builder setPacketLengths(@Nullable IntegerSpace packetLengths) {
       this._packetLengths = packetLengths;
       return this;
     }
@@ -531,7 +514,7 @@ public class PacketHeaderConstraints {
       return this;
     }
 
-    public Builder setFragmentOffsets(@Nullable Set<SubRange> fragmentOffsets) {
+    public Builder setFragmentOffsets(@Nullable IntegerSpace fragmentOffsets) {
       this._fragmentOffsets = fragmentOffsets;
       return this;
     }
@@ -551,22 +534,22 @@ public class PacketHeaderConstraints {
       return this;
     }
 
-    public Builder setIcmpCodes(@Nullable Set<SubRange> icmpCodes) {
+    public Builder setIcmpCodes(@Nullable IntegerSpace icmpCodes) {
       this._icmpCodes = icmpCodes;
       return this;
     }
 
-    public Builder setIcmpTypes(@Nullable Set<SubRange> icmpTypes) {
+    public Builder setIcmpTypes(@Nullable IntegerSpace icmpTypes) {
       this._icmpTypes = icmpTypes;
       return this;
     }
 
-    public Builder setSrcPorts(@Nullable Set<SubRange> srcPorts) {
+    public Builder setSrcPorts(@Nullable IntegerSpace srcPorts) {
       this._srcPorts = srcPorts;
       return this;
     }
 
-    public Builder setDstPorts(@Nullable Set<SubRange> dstPorts) {
+    public Builder setDstPorts(@Nullable IntegerSpace dstPorts) {
       this._dstPorts = dstPorts;
       return this;
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PacketHeaderConstraints.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PacketHeaderConstraints.java
@@ -352,7 +352,8 @@ public class PacketHeaderConstraints {
               .stream()
               .map(Protocol::getPort)
               .map(IntegerSpace::of)
-              .collect(IntegerSpace.toIntegerSpace());
+              .reduce(IntegerSpace::union)
+              .orElse(IntegerSpace.EMPTY);
 
       // for each subrange, run all resolved ports through it, to see if a match occurs
       checkArgument(
@@ -452,7 +453,8 @@ public class PacketHeaderConstraints {
           .stream()
           .map(Protocol::getPort)
           .map(IntegerSpace::of)
-          .collect(IntegerSpace.toIntegerSpace());
+          .reduce(IntegerSpace::union)
+          .orElse(IntegerSpace.EMPTY);
     }
 
     // Intersect. Protocols are the limiting factor, but they must belong to at least one space
@@ -460,7 +462,8 @@ public class PacketHeaderConstraints {
         .stream()
         .map(Protocol::getPort)
         .map(IntegerSpace::of)
-        .collect(IntegerSpace.toIntegerSpace())
+        .reduce(IntegerSpace::union)
+        .orElse(IntegerSpace.EMPTY)
         .intersection(ports);
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PacketHeaderConstraintsUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PacketHeaderConstraintsUtil.java
@@ -9,6 +9,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedSet;
+import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import net.sf.javabdd.BDD;
 import org.batfish.common.bdd.BDDPacket;
@@ -65,6 +67,13 @@ public class PacketHeaderConstraintsUtil {
     return new HeaderSpaceToBDD(new BDDPacket(), namedIpSpaces).toBDD(b.build());
   }
 
+  private static SortedSet<SubRange> extractSubranges(@Nullable IntegerSpace space) {
+    if (space == null || space.isEmpty()) {
+      return ImmutableSortedSet.of();
+    }
+    return ImmutableSortedSet.copyOf(space.getSubRanges());
+  }
+
   /**
    * Convert packet header constraints to a {@link HeaderSpace.Builder}
    *
@@ -75,24 +84,20 @@ public class PacketHeaderConstraintsUtil {
     HeaderSpace.Builder builder =
         HeaderSpace.builder()
             .setIpProtocols(firstNonNull(phc.resolveIpProtocols(), ImmutableSortedSet.of()))
-            .setSrcPorts(firstNonNull(phc.getSrcPorts(), ImmutableSortedSet.of()))
-            .setDstPorts(firstNonNull(phc.resolveDstPorts(), ImmutableSortedSet.of()))
-            .setIcmpCodes(firstNonNull(phc.getIcmpCodes(), ImmutableSortedSet.of()))
-            .setIcmpTypes(firstNonNull(phc.getIcmpTypes(), ImmutableSortedSet.of()))
+            .setSrcPorts(extractSubranges(phc.getSrcPorts()))
+            .setDstPorts(extractSubranges(phc.resolveDstPorts()))
+            .setIcmpCodes(extractSubranges(phc.getIcmpCodes()))
+            .setIcmpTypes(extractSubranges(phc.getIcmpTypes()))
             .setDstProtocols(firstNonNull(phc.getApplications(), ImmutableSortedSet.of()))
-            .setFragmentOffsets(firstNonNull(phc.getFragmentOffsets(), ImmutableSortedSet.of()))
-            .setPacketLengths(firstNonNull(phc.getPacketLengths(), ImmutableSortedSet.of()))
+            .setFragmentOffsets(extractSubranges(phc.getFragmentOffsets()))
+            .setPacketLengths(extractSubranges(phc.getPacketLengths()))
             .setTcpFlags(firstNonNull(phc.getTcpFlags(), ImmutableSet.of()));
 
     if (phc.getDscps() != null) {
-      builder.setDscps(
-          ImmutableSortedSet.copyOf(
-              phc.getDscps().stream().flatMapToInt(SubRange::asStream).iterator()));
+      builder.setDscps(phc.getDscps().enumerate());
     }
     if (phc.getEcns() != null) {
-      builder.setEcns(
-          ImmutableSortedSet.copyOf(
-              phc.getEcns().stream().flatMapToInt(SubRange::asStream).iterator()));
+      builder.setEcns(ImmutableSortedSet.copyOf(phc.getEcns().enumerate()));
     }
     return builder;
   }
@@ -122,13 +127,10 @@ public class PacketHeaderConstraintsUtil {
 
   @VisibleForTesting
   static void setDscpValue(PacketHeaderConstraints constraints, Flow.Builder builder) {
-    Set<SubRange> dscps = constraints.getDscps();
+    IntegerSpace dscps = constraints.getDscps();
     if (dscps != null) {
-      SubRange dscp = dscps.iterator().next();
-      if (dscps.size() > 1 || !dscp.isSingleValue()) {
-        throw new IllegalArgumentException("Cannot construct flow with multiple DSCP values");
-      }
-      builder.setDscp(dscp.getStart());
+      checkArgument(dscps.isSingleton(), "Cannot construct flow with multiple DSCP values");
+      builder.setDscp(dscps.singletonValue());
     } else {
       builder.setDscp(0);
     }
@@ -136,34 +138,26 @@ public class PacketHeaderConstraintsUtil {
 
   @VisibleForTesting
   static void setIcmpValues(PacketHeaderConstraints constraints, Flow.Builder builder) {
-    Set<SubRange> icmpTypes = constraints.getIcmpTypes();
+    IntegerSpace icmpTypes = constraints.getIcmpTypes();
     if (icmpTypes != null) {
-      SubRange icmpType = icmpTypes.iterator().next();
-      if (icmpTypes.size() > 1 || !icmpType.isSingleValue()) {
-        throw new IllegalArgumentException("Cannot construct flow with multiple ICMP types");
-      }
-      builder.setIcmpType(icmpType.getStart());
+      checkArgument(icmpTypes.isSingleton(), "Cannot construct flow with multiple ICMP types");
+      builder.setIcmpType(icmpTypes.singletonValue());
     }
-    Set<SubRange> icmpCodes = constraints.getIcmpCodes();
+    IntegerSpace icmpCodes = constraints.getIcmpCodes();
     if (icmpCodes != null) {
-      SubRange icmpCode = icmpCodes.iterator().next();
-      if (icmpCodes.size() > 1 || !icmpCode.isSingleValue()) {
-        throw new IllegalArgumentException("Cannot construct flow with multiple ICMP codes");
-      }
-      builder.setIcmpType(icmpCode.getStart());
+      checkArgument(icmpCodes.isSingleton(), "Cannot construct flow with multiple ICMP codes");
+      builder.setIcmpType(icmpCodes.singletonValue());
     }
   }
 
   @VisibleForTesting
   static void setSrcPort(PacketHeaderConstraints constraints, Flow.Builder builder) {
-    Set<SubRange> srcPorts = constraints.getSrcPorts();
+    IntegerSpace srcPorts = constraints.getSrcPorts();
     checkArgument(
-        srcPorts == null || srcPorts.size() == 1,
+        srcPorts == null || srcPorts.isSingleton(),
         "Cannot construct flow with multiple source ports");
     if (srcPorts != null) {
-      SubRange srcPort = srcPorts.iterator().next();
-      checkArgument(srcPort.isSingleValue(), "Cannot construct flow with multiple source ports");
-      builder.setSrcPort(srcPort.getStart());
+      builder.setSrcPort(srcPorts.singletonValue());
     }
   }
 
@@ -181,25 +175,21 @@ public class PacketHeaderConstraintsUtil {
 
   @VisibleForTesting
   static void setDstPort(PacketHeaderConstraints constraints, Builder builder) {
-    Set<SubRange> dstPorts = constraints.resolveDstPorts();
+    IntegerSpace dstPorts = constraints.resolveDstPorts();
     final String errorMessage = "Cannot construct flow with multiple destination ports";
-    checkArgument(dstPorts == null || dstPorts.size() == 1, errorMessage);
+    checkArgument(dstPorts == null || dstPorts.isSingleton(), errorMessage);
     if (dstPorts != null) {
-      SubRange dstPort = dstPorts.iterator().next();
-      checkArgument(dstPort.isSingleValue(), errorMessage);
-      builder.setDstPort(dstPort.getStart());
+      builder.setDstPort(dstPorts.singletonValue());
     }
   }
 
   @VisibleForTesting
   static void setPacketLength(PacketHeaderConstraints constraints, Builder builder) {
-    Set<SubRange> packetLengths = constraints.getPacketLengths();
+    IntegerSpace packetLengths = constraints.getPacketLengths();
     final String errorMessage = "Cannot construct flow with multiple packet lengths";
-    checkArgument(packetLengths == null || packetLengths.size() == 1, errorMessage);
+    checkArgument(packetLengths == null || packetLengths.isSingleton(), errorMessage);
     if (packetLengths != null) {
-      SubRange packetLength = packetLengths.iterator().next();
-      checkArgument(packetLength.isSingleValue(), errorMessage);
-      builder.setPacketLength(packetLength.getStart());
+      builder.setPacketLength(packetLengths.singletonValue());
     } else {
       builder.setPacketLength(DEFAULT_PACKET_LENGTH);
     }
@@ -207,25 +197,21 @@ public class PacketHeaderConstraintsUtil {
 
   @VisibleForTesting
   static void setEcnValue(PacketHeaderConstraints phc, Builder builder) {
-    Set<SubRange> ecns = phc.getEcns();
+    IntegerSpace ecns = phc.getEcns();
     final String errorMessage = "Cannot construct flow with multiple ECN values";
-    checkArgument(ecns == null || ecns.size() == 1, errorMessage);
+    checkArgument(ecns == null || ecns.isSingleton(), errorMessage);
     if (ecns != null) {
-      SubRange ecn = ecns.iterator().next();
-      checkArgument(ecn.isSingleValue(), errorMessage);
-      builder.setEcn(ecn.getStart());
+      builder.setEcn(ecns.singletonValue());
     }
   }
 
   @VisibleForTesting
   static void setFragmentOffsets(PacketHeaderConstraints phc, Builder builder) {
-    Set<SubRange> fragmentOffsets = phc.getFragmentOffsets();
+    IntegerSpace fragmentOffsets = phc.getFragmentOffsets();
     final String errorMessage = "Cannot construct flow with multiple packet lengths";
-    checkArgument(fragmentOffsets == null || fragmentOffsets.size() == 1, errorMessage);
+    checkArgument(fragmentOffsets == null || fragmentOffsets.isSingleton(), errorMessage);
     if (fragmentOffsets != null) {
-      SubRange fragmentOffset = fragmentOffsets.iterator().next();
-      checkArgument(fragmentOffset.isSingleValue(), errorMessage);
-      builder.setFragmentOffset(fragmentOffset.getStart());
+      builder.setFragmentOffset(fragmentOffsets.singletonValue());
     }
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/IntegerSpaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/IntegerSpaceTest.java
@@ -7,11 +7,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Range;
 import com.google.common.testing.EqualsTester;
 import java.io.IOException;
 import java.util.NoSuchElementException;
+import java.util.stream.Stream;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.IntegerSpace.Builder;
 import org.junit.Before;
@@ -348,5 +350,29 @@ public class IntegerSpaceTest {
     assertThat(s2.singletonValue(), equalTo(1));
     _expected.expect(NoSuchElementException.class);
     twoValues.singletonValue();
+  }
+
+  @Test
+  public void testCollector() {
+    assertThat(Stream.of(PORTS).collect(IntegerSpace.toIntegerSpace()), equalTo(PORTS));
+    assertThat(
+        Stream.of(PORTS, IntegerSpace.of(11111111)).collect(IntegerSpace.toIntegerSpace()),
+        equalTo(PORTS.union(IntegerSpace.of(11111111))));
+  }
+
+  @Test
+  public void testConversionToSubrange() {
+    assertThat(IntegerSpace.of(1).getSubRanges(), equalTo(ImmutableSet.of(new SubRange(1, 1))));
+    assertThat(PORTS.getSubRanges(), equalTo(ImmutableSet.of(new SubRange(0, 65535))));
+    assertThat(EMPTY.getSubRanges(), equalTo(ImmutableSet.of()));
+  }
+
+  @Test
+  public void testStaticCreators() {
+    SubRange r1 = new SubRange(1, 1);
+    SubRange r2 = new SubRange(4, 5);
+    assertThat(
+        IntegerSpace.of(r1, r2),
+        equalTo(IntegerSpace.builder().including(r1).including(r2).build()));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/IntegerSpaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/IntegerSpaceTest.java
@@ -13,7 +13,6 @@ import com.google.common.collect.Range;
 import com.google.common.testing.EqualsTester;
 import java.io.IOException;
 import java.util.NoSuchElementException;
-import java.util.stream.Stream;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.IntegerSpace.Builder;
 import org.junit.Before;
@@ -353,14 +352,6 @@ public class IntegerSpaceTest {
   }
 
   @Test
-  public void testCollector() {
-    assertThat(Stream.of(PORTS).collect(IntegerSpace.toIntegerSpace()), equalTo(PORTS));
-    assertThat(
-        Stream.of(PORTS, IntegerSpace.of(11111111)).collect(IntegerSpace.toIntegerSpace()),
-        equalTo(PORTS.union(IntegerSpace.of(11111111))));
-  }
-
-  @Test
   public void testConversionToSubrange() {
     assertThat(IntegerSpace.of(1).getSubRanges(), equalTo(ImmutableSet.of(new SubRange(1, 1))));
     assertThat(PORTS.getSubRanges(), equalTo(ImmutableSet.of(new SubRange(0, 65535))));
@@ -372,7 +363,7 @@ public class IntegerSpaceTest {
     SubRange r1 = new SubRange(1, 1);
     SubRange r2 = new SubRange(4, 5);
     assertThat(
-        IntegerSpace.of(r1, r2),
+        IntegerSpace.unionOf(r1, r2),
         equalTo(IntegerSpace.builder().including(r1).including(r2).build()));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PacketHeaderConstraintsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PacketHeaderConstraintsTest.java
@@ -15,8 +15,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 
 import com.google.common.collect.ImmutableSet;
-import java.util.Collections;
-import java.util.Set;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -32,31 +30,31 @@ public class PacketHeaderConstraintsTest {
   /** Test boundary values for ECN */
   @Test
   public void testIsValidEcn() {
-    assertThat(isValidEcn(new SubRange(0, 3)), equalTo(true));
-    assertThat(isValidEcn(new SubRange(1, 1)), equalTo(true));
-    assertThat(isValidEcn(new SubRange(-1, 0)), equalTo(false));
-    assertThat(isValidEcn(new SubRange(2, 4)), equalTo(false));
-    assertThat(isValidEcn(new SubRange(2, 1)), equalTo(false));
+    assertThat(isValidEcn(IntegerSpace.of(new SubRange(0, 3))), equalTo(true));
+    assertThat(isValidEcn(IntegerSpace.of(new SubRange(1, 1))), equalTo(true));
+    assertThat(isValidEcn(IntegerSpace.of(new SubRange(-1, 0))), equalTo(false));
+    assertThat(isValidEcn(IntegerSpace.of(new SubRange(2, 4))), equalTo(false));
+    assertThat(isValidEcn(IntegerSpace.of(new SubRange(2, 1))), equalTo(false));
   }
 
   /** Test boundary values for DSCP */
   @Test
   public void testIsValidDscp() {
-    assertThat(isValidDscp(new SubRange(0, 63)), equalTo(true));
-    assertThat(isValidDscp(new SubRange(1, 1)), equalTo(true));
-    assertThat(isValidDscp(new SubRange(-1, 0)), equalTo(false));
-    assertThat(isValidDscp(new SubRange(2, 64)), equalTo(false));
-    assertThat(isValidDscp(new SubRange(2, 1)), equalTo(false));
+    assertThat(isValidDscp(IntegerSpace.of(new SubRange(0, 63))), equalTo(true));
+    assertThat(isValidDscp(IntegerSpace.of(new SubRange(1, 1))), equalTo(true));
+    assertThat(isValidDscp(IntegerSpace.of(new SubRange(-1, 0))), equalTo(false));
+    assertThat(isValidDscp(IntegerSpace.of(new SubRange(2, 64))), equalTo(false));
+    assertThat(isValidDscp(IntegerSpace.of(new SubRange(2, 1))), equalTo(false));
   }
 
   /** Test boundary values for ICMP fields */
   @Test
   public void testIsValidIcmp() {
-    assertThat(isValidIcmpTypeOrCode(new SubRange(0, 255)), equalTo(true));
-    assertThat(isValidIcmpTypeOrCode(new SubRange(1, 2)), equalTo(true));
-    assertThat(isValidIcmpTypeOrCode(new SubRange(-1, 0)), equalTo(false));
-    assertThat(isValidIcmpTypeOrCode(new SubRange(2, 256)), equalTo(false));
-    assertThat(isValidIcmpTypeOrCode(new SubRange(2, 1)), equalTo(false));
+    assertThat(isValidIcmpTypeOrCode(IntegerSpace.of(new SubRange(0, 255))), equalTo(true));
+    assertThat(isValidIcmpTypeOrCode(IntegerSpace.of(new SubRange(1, 2))), equalTo(true));
+    assertThat(isValidIcmpTypeOrCode(IntegerSpace.of(new SubRange(-1, 0))), equalTo(false));
+    assertThat(isValidIcmpTypeOrCode(IntegerSpace.of(new SubRange(2, 256))), equalTo(false));
+    assertThat(isValidIcmpTypeOrCode(IntegerSpace.of(new SubRange(2, 1))), equalTo(false));
   }
 
   @Test
@@ -66,7 +64,7 @@ public class PacketHeaderConstraintsTest {
     assertThat(
         areProtocolsAndPortsCompatible(ImmutableSet.of(IpProtocol.IP), null, null), equalTo(true));
     assertThat(
-        areProtocolsAndPortsCompatible(null, ImmutableSet.of(new SubRange(1, 1024)), null),
+        areProtocolsAndPortsCompatible(null, IntegerSpace.of(new SubRange(1, 1024)), null),
         equalTo(true));
     assertThat(areProtocolsAndPortsCompatible(null, null, ImmutableSet.of(SSH)), equalTo(true));
 
@@ -74,12 +72,12 @@ public class PacketHeaderConstraintsTest {
     assertThat(
         areProtocolsAndPortsCompatible(
             ImmutableSet.of(IpProtocol.TCP),
-            ImmutableSet.of(new SubRange(22)),
+            IntegerSpace.of(new SubRange(22)),
             ImmutableSet.of(SSH)),
         equalTo(true));
     assertThat(
         areProtocolsAndPortsCompatible(
-            null, ImmutableSet.of(new SubRange(0, 1000)), ImmutableSet.of(SSH, HTTP)),
+            null, IntegerSpace.of(new SubRange(0, 1000)), ImmutableSet.of(SSH, HTTP)),
         equalTo(true));
   }
 
@@ -87,14 +85,14 @@ public class PacketHeaderConstraintsTest {
   public void testAreProtocolsAndPortsIncompatibleNoTCP() {
     thrown.expect(IllegalArgumentException.class); // Not TCP and SSH
     areProtocolsAndPortsCompatible(
-        ImmutableSet.of(IpProtocol.IP), ImmutableSet.of(new SubRange(22)), ImmutableSet.of(SSH));
+        ImmutableSet.of(IpProtocol.IP), IntegerSpace.of(new SubRange(22)), ImmutableSet.of(SSH));
   }
 
   @Test
   public void testAreProtocolsAndPortsIncompatibleEmptyPortRange() {
     thrown.expect(IllegalArgumentException.class); // empty port subrange
     areProtocolsAndPortsCompatible(
-        ImmutableSet.of(IpProtocol.IP), ImmutableSet.of(new SubRange(20, 1)), ImmutableSet.of(SSH));
+        ImmutableSet.of(IpProtocol.IP), IntegerSpace.of(new SubRange(20, 1)), ImmutableSet.of(SSH));
   }
 
   @Test
@@ -102,7 +100,7 @@ public class PacketHeaderConstraintsTest {
     thrown.expect(IllegalArgumentException.class); // wrong port subrange and application protocols
     areProtocolsAndPortsCompatible(
         ImmutableSet.of(IpProtocol.IP),
-        ImmutableSet.of(new SubRange(30, 40)),
+        IntegerSpace.of(new SubRange(30, 40)),
         ImmutableSet.of(SSH, HTTP));
   }
 
@@ -113,17 +111,17 @@ public class PacketHeaderConstraintsTest {
         resolveIpProtocols(ImmutableSet.of(IpProtocol.TCP), null, null, null, null),
         equalTo(ImmutableSet.of(IpProtocol.TCP)));
     assertThat(
-        resolveIpProtocols(null, ImmutableSet.of(new SubRange(22, 80)), null, null, null),
+        resolveIpProtocols(null, IntegerSpace.of(new SubRange(22, 80)), null, null, null),
         equalTo(IP_PROTOCOLS_WITH_PORTS));
     assertThat(
-        resolveIpProtocols(null, null, ImmutableSet.of(new SubRange(22, 80)), null, null),
+        resolveIpProtocols(null, null, IntegerSpace.of(new SubRange(22, 80)), null, null),
         equalTo(IP_PROTOCOLS_WITH_PORTS));
     assertThat(
         resolveIpProtocols(null, null, null, ImmutableSet.of(Protocol.SSH), null),
         equalTo(ImmutableSet.of(IpProtocol.TCP)));
     assertThat(
         resolveIpProtocols(
-            null, null, null, null, Collections.singleton(TcpFlagsMatchConditions.ACK_TCP_FLAG)),
+            null, null, null, null, ImmutableSet.of(TcpFlagsMatchConditions.ACK_TCP_FLAG)),
         equalTo(ImmutableSet.of(IpProtocol.TCP)));
   }
 
@@ -131,55 +129,53 @@ public class PacketHeaderConstraintsTest {
   public void testResolveIpProtocolsTcpAndUdp() {
     thrown.expect(IllegalArgumentException.class);
     // both tcp and udp at the same time in src/dst
-    resolveIpProtocols(
-        Collections.singleton(IpProtocol.TCP), null, null, ImmutableSet.of(DNS), null);
+    resolveIpProtocols(ImmutableSet.of(IpProtocol.TCP), null, null, ImmutableSet.of(DNS), null);
   }
 
   @Test
   public void testResolveIpProtocolsIcmpAndPorts() {
     thrown.expect(IllegalArgumentException.class);
     resolveIpProtocols(
-        Collections.singleton(IpProtocol.ICMP),
-        Collections.singleton(new SubRange(10, 10)),
-        null,
-        null,
-        null);
+        ImmutableSet.of(IpProtocol.ICMP), IntegerSpace.of(new SubRange(10, 10)), null, null, null);
   }
 
   @Test
   public void testResolveIpProtocolsIcmpAndTcp() {
     thrown.expect(IllegalArgumentException.class);
-    resolveIpProtocols(
-        Collections.singleton(IpProtocol.ICMP), null, null, Collections.singleton(SSH), null);
+    resolveIpProtocols(ImmutableSet.of(IpProtocol.ICMP), null, null, ImmutableSet.of(SSH), null);
   }
 
   @Test
   public void testResolveIpProtocolsTcpFlagsAndUdp() {
     thrown.expect(IllegalArgumentException.class);
     resolveIpProtocols(
-        Collections.singleton(IpProtocol.UDP),
+        ImmutableSet.of(IpProtocol.UDP),
         null,
         null,
         null,
-        Collections.singleton(TcpFlagsMatchConditions.ACK_TCP_FLAG));
+        ImmutableSet.of(TcpFlagsMatchConditions.ACK_TCP_FLAG));
   }
 
   @Test
   public void testResolvePorts() {
-    final Set<SubRange> sshSet = Collections.singleton(new SubRange(22, 22));
+    final IntegerSpace sshSet = IntegerSpace.of(new SubRange(22, 22));
 
     assertThat(resolvePorts(null, null), nullValue());
 
-    assertThat(resolvePorts(sshSet, Collections.singleton(SSH)), equalTo(sshSet));
-    assertThat(resolvePorts(null, Collections.singleton(SSH)), equalTo(sshSet));
+    assertThat(resolvePorts(sshSet, ImmutableSet.of(SSH)), equalTo(sshSet));
+    assertThat(resolvePorts(null, ImmutableSet.of(SSH)), equalTo(sshSet));
 
     assertThat(
-        resolvePorts(Collections.singleton(new SubRange(22, 25)), null),
-        equalTo(Collections.singleton(new SubRange(22, 25))));
+        resolvePorts(IntegerSpace.of(new SubRange(22, 25)), null),
+        equalTo(IntegerSpace.of(new SubRange(22, 25))));
 
     assertThat(
         resolvePorts(
-            ImmutableSet.of(new SubRange(1, 10), new SubRange(20, 30), new SubRange(40, 50)),
+            IntegerSpace.builder()
+                .including(new SubRange(1, 10))
+                .including(new SubRange(20, 30))
+                .including(new SubRange(40, 50))
+                .build(),
             ImmutableSet.of(SSH, HTTP)),
         equalTo(sshSet));
   }
@@ -231,21 +227,19 @@ public class PacketHeaderConstraintsTest {
     PacketHeaderConstraints constraints;
     // concrete resolution
     constraints =
-        PacketHeaderConstraints.builder()
-            .setApplications(Collections.singleton(Protocol.SSH))
-            .build();
-    assertThat(constraints.resolveIpProtocols(), equalTo(Collections.singleton(IpProtocol.TCP)));
-    assertThat(constraints.resolveDstPorts(), equalTo(Collections.singleton(new SubRange(22, 22))));
+        PacketHeaderConstraints.builder().setApplications(ImmutableSet.of(Protocol.SSH)).build();
+    assertThat(constraints.resolveIpProtocols(), equalTo(ImmutableSet.of(IpProtocol.TCP)));
+    assertThat(constraints.resolveDstPorts(), equalTo(IntegerSpace.of(new SubRange(22, 22))));
 
     // Headerspace-like resolution
     constraints =
         PacketHeaderConstraints.builder()
             .setApplications(ImmutableSet.of(Protocol.SSH, Protocol.HTTP))
             .build();
-    assertThat(constraints.resolveIpProtocols(), equalTo(Collections.singleton(IpProtocol.TCP)));
+    assertThat(constraints.resolveIpProtocols(), equalTo(ImmutableSet.of(IpProtocol.TCP)));
     assertThat(
         constraints.resolveDstPorts(),
-        equalTo(ImmutableSet.of(new SubRange(22, 22), new SubRange(80, 80))));
+        equalTo(IntegerSpace.of(new SubRange(22, 22), new SubRange(80, 80))));
   }
 
   @Test
@@ -253,8 +247,8 @@ public class PacketHeaderConstraintsTest {
     // Src port incompatibility
     thrown.expect(IllegalArgumentException.class);
     PacketHeaderConstraints.builder()
-        .setSrcPorts(Collections.singleton(new SubRange(22, 22)))
-        .setIpProtocols(Collections.singleton(IpProtocol.ICMP))
+        .setSrcPorts(IntegerSpace.of(new SubRange(22, 22)))
+        .setIpProtocols(ImmutableSet.of(IpProtocol.ICMP))
         .build();
   }
 
@@ -263,8 +257,8 @@ public class PacketHeaderConstraintsTest {
     // Dst port incompatibility
     thrown.expect(IllegalArgumentException.class);
     PacketHeaderConstraints.builder()
-        .setDstPorts(Collections.singleton(new SubRange(22, 22)))
-        .setIpProtocols(Collections.singleton(IpProtocol.ICMP))
+        .setDstPorts(IntegerSpace.of(new SubRange(22, 22)))
+        .setIpProtocols(ImmutableSet.of(IpProtocol.ICMP))
         .build();
   }
 
@@ -273,8 +267,8 @@ public class PacketHeaderConstraintsTest {
     // TCP + ICMP codes incompatibility
     thrown.expect(IllegalArgumentException.class);
     PacketHeaderConstraints.builder()
-        .setIpProtocols(Collections.singleton(IpProtocol.TCP))
-        .setIcmpCodes(Collections.singleton(new SubRange(1, 1)))
+        .setIpProtocols(ImmutableSet.of(IpProtocol.TCP))
+        .setIcmpCodes(IntegerSpace.of(new SubRange(1, 1)))
         .build();
   }
 
@@ -283,9 +277,9 @@ public class PacketHeaderConstraintsTest {
     // dst port resolution
     thrown.expect(IllegalArgumentException.class);
     PacketHeaderConstraints.builder()
-        .setIpProtocols(Collections.singleton(IpProtocol.TCP))
-        .setDstPorts(Collections.singleton(new SubRange(30, 40)))
-        .setApplications(Collections.singleton(SSH))
+        .setIpProtocols(ImmutableSet.of(IpProtocol.TCP))
+        .setDstPorts(IntegerSpace.of(new SubRange(30, 40)))
+        .setApplications(ImmutableSet.of(SSH))
         .build();
   }
 
@@ -294,8 +288,8 @@ public class PacketHeaderConstraintsTest {
     // Port range too large, src or dst
     thrown.expect(IllegalArgumentException.class);
     PacketHeaderConstraints.builder()
-        .setIpProtocols(Collections.singleton(IpProtocol.TCP))
-        .setSrcPorts(Collections.singleton(new SubRange(0, 1 << 16)))
+        .setIpProtocols(ImmutableSet.of(IpProtocol.TCP))
+        .setSrcPorts(IntegerSpace.of(new SubRange(0, 1 << 16)))
         .build();
   }
 
@@ -303,8 +297,8 @@ public class PacketHeaderConstraintsTest {
   public void testValidationInvalidDstPort() {
     thrown.expect(IllegalArgumentException.class);
     PacketHeaderConstraints.builder()
-        .setIpProtocols(Collections.singleton(IpProtocol.TCP))
-        .setDstPorts(Collections.singleton(new SubRange(0, 1 << 16)))
+        .setIpProtocols(ImmutableSet.of(IpProtocol.TCP))
+        .setDstPorts(IntegerSpace.of(new SubRange(0, 1 << 16)))
         .build();
   }
 
@@ -317,25 +311,25 @@ public class PacketHeaderConstraintsTest {
   @Test
   public void testValidationNoSrcPorts() {
     thrown.expect(IllegalArgumentException.class);
-    PacketHeaderConstraints.builder().setSrcPorts(ImmutableSet.of()).build();
+    PacketHeaderConstraints.builder().setSrcPorts(IntegerSpace.EMPTY).build();
   }
 
   @Test
   public void testValidationNoDestPorts() {
     thrown.expect(IllegalArgumentException.class);
-    PacketHeaderConstraints.builder().setDstPorts(ImmutableSet.of()).build();
+    PacketHeaderConstraints.builder().setDstPorts(IntegerSpace.EMPTY).build();
   }
 
   @Test
   public void testValidationNoIcmpCodes() {
     thrown.expect(IllegalArgumentException.class);
-    PacketHeaderConstraints.builder().setIcmpCodes(ImmutableSet.of()).build();
+    PacketHeaderConstraints.builder().setIcmpCodes(IntegerSpace.EMPTY).build();
   }
 
   @Test
   public void testValidationNoIcmpTypes() {
     thrown.expect(IllegalArgumentException.class);
-    PacketHeaderConstraints.builder().setIcmpTypes(ImmutableSet.of()).build();
+    PacketHeaderConstraints.builder().setIcmpTypes(IntegerSpace.EMPTY).build();
   }
 
   @Test
@@ -344,7 +338,7 @@ public class PacketHeaderConstraintsTest {
     thrown.expect(IllegalArgumentException.class);
     PacketHeaderConstraints.builder()
         .setIpProtocols(ImmutableSet.of(IpProtocol.ICMP, IpProtocol.TCP))
-        .setApplications(Collections.singleton(Protocol.DNS))
+        .setApplications(ImmutableSet.of(Protocol.DNS))
         .build();
   }
 
@@ -353,8 +347,8 @@ public class PacketHeaderConstraintsTest {
     // Reject empty port intersections
     thrown.expect(IllegalArgumentException.class);
     PacketHeaderConstraints.builder()
-        .setApplications(Collections.singleton(Protocol.DNS))
-        .setDstPorts(Collections.singleton(new SubRange(1, 2)))
+        .setApplications(ImmutableSet.of(Protocol.DNS))
+        .setDstPorts(IntegerSpace.of(new SubRange(1, 2)))
         .build();
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PacketHeaderConstraintsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PacketHeaderConstraintsTest.java
@@ -239,7 +239,7 @@ public class PacketHeaderConstraintsTest {
     assertThat(constraints.resolveIpProtocols(), equalTo(ImmutableSet.of(IpProtocol.TCP)));
     assertThat(
         constraints.resolveDstPorts(),
-        equalTo(IntegerSpace.of(new SubRange(22, 22), new SubRange(80, 80))));
+        equalTo(IntegerSpace.unionOf(new SubRange(22, 22), new SubRange(80, 80))));
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PacketHeaderConstraintsUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PacketHeaderConstraintsUtilTest.java
@@ -32,9 +32,13 @@ public class PacketHeaderConstraintsUtilTest {
   public void testToHeaderSpaceConversion() {
     PacketHeaderConstraints phc =
         PacketHeaderConstraints.builder()
-            .setSrcPorts(ImmutableSortedSet.of(new SubRange(1, 3), new SubRange(5, 6)))
-            .setDstPorts(Collections.singleton(new SubRange(11, 12)))
-            .setEcns(Collections.singleton(new SubRange(1, 3)))
+            .setSrcPorts(
+                IntegerSpace.builder()
+                    .including(new SubRange(1, 3))
+                    .including(new SubRange(5, 6))
+                    .build())
+            .setDstPorts(IntegerSpace.of(new SubRange(11, 12)))
+            .setEcns(IntegerSpace.of(new SubRange(1, 3)))
             .setIpProtocols(Collections.singleton(IpProtocol.TCP))
             .build();
 
@@ -61,7 +65,7 @@ public class PacketHeaderConstraintsUtilTest {
   public void testSetIcmpValueMultiple() {
     PacketHeaderConstraints phc =
         PacketHeaderConstraints.builder()
-            .setIcmpCodes(ImmutableSet.of(new SubRange(0, 10)))
+            .setIcmpCodes(IntegerSpace.of(new SubRange(0, 10)))
             .build();
     Builder builder = Flow.builder();
     thrown.expect(IllegalArgumentException.class);
@@ -71,7 +75,7 @@ public class PacketHeaderConstraintsUtilTest {
   @Test
   public void testSetDscpValueMultiple() {
     PacketHeaderConstraints phc =
-        PacketHeaderConstraints.builder().setDscps(ImmutableSet.of(new SubRange(0, 10))).build();
+        PacketHeaderConstraints.builder().setDscps(PacketHeaderConstraints.VALID_DSCP).build();
     Builder builder = Flow.builder();
     thrown.expect(IllegalArgumentException.class);
     setDscpValue(phc, builder);
@@ -81,7 +85,7 @@ public class PacketHeaderConstraintsUtilTest {
   public void testSetSrcPortMultiple() {
     Builder builder = Flow.builder().setIngressNode("node").setTag("tag");
     PacketHeaderConstraints phc =
-        PacketHeaderConstraints.builder().setSrcPorts(ImmutableSet.of(new SubRange(1, 10))).build();
+        PacketHeaderConstraints.builder().setSrcPorts(IntegerSpace.of(new SubRange(1, 10))).build();
     thrown.expect(IllegalArgumentException.class);
     setSrcPort(phc, builder);
   }
@@ -89,7 +93,7 @@ public class PacketHeaderConstraintsUtilTest {
   @Test
   public void testSetDstPortMultiple() {
     PacketHeaderConstraints phc =
-        PacketHeaderConstraints.builder().setDstPorts(ImmutableSet.of(new SubRange(1, 10))).build();
+        PacketHeaderConstraints.builder().setDstPorts(IntegerSpace.of(new SubRange(1, 10))).build();
     Builder builder = Flow.builder();
     thrown.expect(IllegalArgumentException.class);
     setDstPort(phc, builder);
@@ -99,7 +103,7 @@ public class PacketHeaderConstraintsUtilTest {
   public void testSetMultiplePacketLengths() {
     PacketHeaderConstraints phc =
         PacketHeaderConstraints.builder()
-            .setPacketLengths(ImmutableSet.of(new SubRange(1, 10)))
+            .setPacketLengths(IntegerSpace.of(new SubRange(1, 10)))
             .build();
     Builder builder = Flow.builder();
     thrown.expect(IllegalArgumentException.class);
@@ -120,9 +124,7 @@ public class PacketHeaderConstraintsUtilTest {
     Builder builder =
         Flow.builder().setIngressNode("node").setIngressInterface("iface").setTag("tag");
     PacketHeaderConstraints phc =
-        PacketHeaderConstraints.builder()
-            .setEcns(Collections.singleton(new SubRange(1, 1)))
-            .build();
+        PacketHeaderConstraints.builder().setEcns(IntegerSpace.of(1)).build();
     setEcnValue(phc, builder);
     assertThat(builder.build().getEcn(), equalTo(1));
   }
@@ -130,7 +132,7 @@ public class PacketHeaderConstraintsUtilTest {
   @Test
   public void testSetEcnValuesMultiple() {
     PacketHeaderConstraints phc =
-        PacketHeaderConstraints.builder().setEcns(ImmutableSet.of(new SubRange(0, 3))).build();
+        PacketHeaderConstraints.builder().setEcns(IntegerSpace.of(new SubRange(0, 3))).build();
     Builder builder = Flow.builder();
     thrown.expect(IllegalArgumentException.class);
     setEcnValue(phc, builder);
@@ -142,7 +144,7 @@ public class PacketHeaderConstraintsUtilTest {
         Flow.builder().setIngressNode("node").setIngressInterface("iface").setTag("tag");
     PacketHeaderConstraints phc =
         PacketHeaderConstraints.builder()
-            .setFragmentOffsets(Collections.singleton(new SubRange(2, 2)))
+            .setFragmentOffsets(IntegerSpace.of(new SubRange(2, 2)))
             .build();
     setFragmentOffsets(phc, builder);
     assertThat(builder.build().getFragmentOffset(), equalTo(2));
@@ -152,7 +154,7 @@ public class PacketHeaderConstraintsUtilTest {
   public void testSetFragmentOffsetsMultiple() {
     PacketHeaderConstraints phc =
         PacketHeaderConstraints.builder()
-            .setFragmentOffsets(ImmutableSet.of(new SubRange(0, 10)))
+            .setFragmentOffsets(IntegerSpace.of(new SubRange(0, 10)))
             .build();
     Builder builder = Flow.builder();
     thrown.expect(IllegalArgumentException.class);

--- a/projects/question/src/main/java/org/batfish/question/searchfilters/SearchFiltersQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/searchfilters/SearchFiltersQuestion.java
@@ -9,12 +9,12 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableSet;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.common.BatfishException;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.PacketHeaderConstraints;
+import org.batfish.datamodel.PacketHeaderConstraintsUtil;
 import org.batfish.datamodel.questions.Question;
 import org.batfish.question.SearchFiltersParameters;
 import org.batfish.specifier.FilterSpecifier;
@@ -181,10 +181,7 @@ public final class SearchFiltersQuestion extends Question {
   @VisibleForTesting
   @Nonnull
   HeaderSpace getHeaderSpace() {
-    return HeaderSpace.builder()
-        .setDstPorts(firstNonNull(_headerConstraints.resolveDstPorts(), ImmutableSet.of()))
-        .setIpProtocols(firstNonNull(_headerConstraints.resolveIpProtocols(), ImmutableSet.of()))
-        .setSrcPorts(firstNonNull(_headerConstraints.getSrcPorts(), ImmutableSet.of()))
+    return PacketHeaderConstraintsUtil.toHeaderSpaceBuilder(_headerConstraints)
         .setNegate(_complementHeaderSpace)
         .build();
   }

--- a/projects/question/src/main/java/org/batfish/question/specifiers/SpecifiersReachabilityQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/specifiers/SpecifiersReachabilityQuestion.java
@@ -10,8 +10,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.PacketHeaderConstraints;
+import org.batfish.datamodel.PacketHeaderConstraintsUtil;
 import org.batfish.datamodel.PathConstraints;
-import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.questions.Question;
 import org.batfish.question.ReachabilityParameters;
 import org.batfish.specifier.FlexibleInferFromLocationIpSpaceSpecifierFactory;
@@ -91,35 +91,9 @@ public final class SpecifiersReachabilityQuestion extends Question {
     return true;
   }
 
-  public static HeaderSpace toHeaderSpace(PacketHeaderConstraints headerConstraints) {
-    // Note: headerspace builder does not accept nulls, so we have to convert nulls to empty sets
-    HeaderSpace.Builder builder =
-        HeaderSpace.builder()
-            .setIpProtocols(
-                firstNonNull(headerConstraints.resolveIpProtocols(), ImmutableSortedSet.of()))
-            .setSrcPorts(firstNonNull(headerConstraints.getSrcPorts(), ImmutableSortedSet.of()))
-            .setDstPorts(firstNonNull(headerConstraints.resolveDstPorts(), ImmutableSortedSet.of()))
-            .setIcmpCodes(firstNonNull(headerConstraints.getIcmpCodes(), ImmutableSortedSet.of()))
-            .setIcmpTypes(firstNonNull(headerConstraints.getIcmpTypes(), ImmutableSortedSet.of()))
-            .setDstProtocols(
-                firstNonNull(headerConstraints.getApplications(), ImmutableSortedSet.of()));
-
-    if (headerConstraints.getDscps() != null) {
-      builder.setDscps(
-          ImmutableSortedSet.copyOf(
-              headerConstraints.getDscps().stream().flatMapToInt(SubRange::asStream).iterator()));
-    }
-    if (headerConstraints.getEcns() != null) {
-      builder.setEcns(
-          ImmutableSortedSet.copyOf(
-              headerConstraints.getEcns().stream().flatMapToInt(SubRange::asStream).iterator()));
-    }
-    return builder.build();
-  }
-
   @VisibleForTesting
   HeaderSpace getHeaderSpace() {
-    return toHeaderSpace(getHeaderConstraints());
+    return PacketHeaderConstraintsUtil.toHeaderSpaceBuilder(getHeaderConstraints()).build();
   }
 
   @VisibleForTesting

--- a/projects/question/src/test/java/org/batfish/question/specifiers/SpecifiersReachabilityQuestionTest.java
+++ b/projects/question/src/test/java/org/batfish/question/specifiers/SpecifiersReachabilityQuestionTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.Matchers.nullValue;
 
 import com.google.common.collect.ImmutableSortedSet;
 import org.batfish.datamodel.HeaderSpace;
+import org.batfish.datamodel.IntegerSpace;
 import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.IpWildcardSetIpSpace;
 import org.batfish.datamodel.PacketHeaderConstraints;
@@ -76,7 +77,7 @@ public class SpecifiersReachabilityQuestionTest {
   @Test
   public void testInvalidApplicationsSpecification() {
     ImmutableSortedSet<Protocol> applications = ImmutableSortedSet.of(Protocol.DNS);
-    ImmutableSortedSet<SubRange> dstPorts = ImmutableSortedSet.of(new SubRange(1, 2));
+    IntegerSpace dstPorts = IntegerSpace.of(new SubRange(1, 2));
 
     exception.expect(IllegalArgumentException.class);
     SpecifiersReachabilityQuestion.builder()

--- a/tests/questions/experimental/commands
+++ b/tests/questions/experimental/commands
@@ -52,7 +52,7 @@ test -raw tests/questions/experimental/reachability.ref validate-template reacha
 test -raw tests/questions/experimental/reducedReachability.ref validate-template reducedReachability actions="success", pathConstraints={startLocation: "aaa", "endLocation":"bbb", "transitLocations": "ccc", forbiddenLocations:"ddd"}, headers={srcIps: "sss", dstIps="ddd"}
 
 # validate searchfilters
-test -raw tests/questions/experimental/searchfilters.ref validate-template searchfilters invertSearch=false, filters=".*", action="matchLine 0", headers={dstIps="2.2.2.2", ipProtocols=["tcp"], srcIps="1.1.1.1", srcPorts=[0], dstPorts=[0]}, nodes=".*", startLocation="somenode", explain=false
+test -raw tests/questions/experimental/searchfilters.ref validate-template searchfilters invertSearch=false, filters=".*", action="matchLine 0", headers={dstIps="2.2.2.2", ipProtocols=["tcp"], srcIps="1.1.1.1", srcPorts="0", dstPorts="0-1000,!22"}, nodes=".*", startLocation="somenode", explain=false
 
 # validate specifiers
 test -raw tests/questions/experimental/specifiers.ref validate-template specifiers queryType="filter", filterSpecifierFactory="FlexibleFilterSpecifierFactory", filterSpecifierInput="filterSpecifierInput", interfaceSpecifierFactory="FlexibleInterfaceSpecifierFactory", interfaceSpecifierInput="filterSpecifierInput", ipSpaceSpecifierFactory="InferFromLocationIpSpaceSpecifierFactory", ipSpaceSpecifierInput="ipSpaceSpecifierInput", locationSpecifierFactory="FlexibleLocationSpecifierFactory", locationSpecifierInput="locationSpecifierInput", nodeSpecifierFactory="FlexibleNodeSpecifierFactory", nodeSpecifierInput="nodeSpecifierInput"

--- a/tests/questions/experimental/searchfilters.ref
+++ b/tests/questions/experimental/searchfilters.ref
@@ -4,16 +4,12 @@
   "filters" : ".*",
   "headers" : {
     "dstIps" : "2.2.2.2",
-    "dstPorts" : [
-      "0-0"
-    ],
+    "dstPorts" : "0-21,23-1000",
     "ipProtocols" : [
       "TCP"
     ],
     "srcIps" : "1.1.1.1",
-    "srcPorts" : [
-      "0-0"
-    ]
+    "srcPorts" : "0-0"
   },
   "invertSearch" : false,
   "nodes" : ".*",
@@ -57,12 +53,8 @@
             "tcp"
           ],
           "srcIps" : "1.1.1.1",
-          "srcPorts" : [
-            0
-          ],
-          "dstPorts" : [
-            0
-          ]
+          "srcPorts" : "0",
+          "dstPorts" : "0-1000,!22"
         }
       },
       "invertSearch" : {


### PR DESCRIPTION
Benefits:
- Can now support port exclusions
- Cleaner support for singleton ranges 
- Simplifies some of the validation logic and conversions

Side effect:
- Cleanup of conversion(s) to headerspace in SearchFilters and new reachability