### PR TITLE
Traceroute: add InboundStep

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/InboundStep.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/InboundStep.java
@@ -1,0 +1,65 @@
+package org.batfish.datamodel.flow;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.flow.InboundStep.InboundStepDetail;
+
+/** {@link InboundStep} represents processing when a flow is directed to the local device. */
+@JsonTypeName("Inbound")
+@ParametersAreNonnullByDefault
+public final class InboundStep extends Step<InboundStepDetail> {
+
+  /* Currently empty, what goes here? Inbound filter? */
+  /** Detail about {@link InboundStep}. */
+  public static class InboundStepDetail {}
+
+  private static final String PROP_DETAIL = "detail";
+  private static final String PROP_ACTION = "action";
+
+  private InboundStep(InboundStepDetail detail, StepAction action) {
+    super(detail, action);
+  }
+
+  @JsonCreator
+  private static InboundStep jsonCreator(
+      @Nullable @JsonProperty(PROP_DETAIL) InboundStepDetail detail,
+      @Nullable @JsonProperty(PROP_ACTION) StepAction action) {
+    checkArgument(detail != null, "Missing detail");
+    checkArgument(action != null, "Missing action");
+    return new InboundStep(detail, action);
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /** Chained builder to create a {@link InboundStep} object */
+  public static class Builder {
+    private InboundStepDetail _detail = new InboundStepDetail();
+    private @Nullable StepAction _action;
+
+    public InboundStep build() {
+      checkState(_action != null, "must call setAction before building");
+      return new InboundStep(_detail, _action);
+    }
+
+    public Builder setDetail(InboundStepDetail detail) {
+      _detail = detail;
+      return this;
+    }
+
+    public Builder setAction(StepAction action) {
+      _action = action;
+      return this;
+    }
+
+    /** Only for use by {@link InboundStep#builder()}. */
+    private Builder() {}
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/InboundStep.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/InboundStep.java
@@ -1,5 +1,6 @@
 package org.batfish.datamodel.flow;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 
@@ -22,15 +23,14 @@ public final class InboundStep extends Step<InboundStepDetail> {
   private static final String PROP_DETAIL = "detail";
   private static final String PROP_ACTION = "action";
 
-  private InboundStep(InboundStepDetail detail, StepAction action) {
-    super(detail, action);
+  private InboundStep(@Nullable InboundStepDetail detail, StepAction action) {
+    super(firstNonNull(detail, new InboundStepDetail()), action);
   }
 
   @JsonCreator
   private static InboundStep jsonCreator(
       @Nullable @JsonProperty(PROP_DETAIL) InboundStepDetail detail,
       @Nullable @JsonProperty(PROP_ACTION) StepAction action) {
-    checkArgument(detail != null, "Missing detail");
     checkArgument(action != null, "Missing action");
     return new InboundStep(detail, action);
   }
@@ -41,7 +41,7 @@ public final class InboundStep extends Step<InboundStepDetail> {
 
   /** Chained builder to create a {@link InboundStep} object */
   public static class Builder {
-    private InboundStepDetail _detail = new InboundStepDetail();
+    private @Nullable InboundStepDetail _detail;
     private @Nullable StepAction _action;
 
     public InboundStep build() {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/Step.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/Step.java
@@ -1,12 +1,11 @@
 package org.batfish.datamodel.flow;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDescription;
-import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.Flow;
 
 /**
@@ -14,40 +13,38 @@ import org.batfish.datamodel.Flow;
  * goes through while traversing {@link Hop}s to reach the destination
  */
 @JsonSchemaDescription("Represents an operation within a hop")
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = As.PROPERTY, property = "type")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({
   @JsonSubTypes.Type(value = EnterInputIfaceStep.class, name = "EnterInputInterface"),
   @JsonSubTypes.Type(value = RoutingStep.class, name = "Routing"),
   @JsonSubTypes.Type(value = ExitOutputIfaceStep.class, name = "ExitOutputInterface")
 })
+@ParametersAreNonnullByDefault
 public abstract class Step<D> {
 
   private static final String PROP_DETAIL = "detail";
   private static final String PROP_ACTION = "action";
 
   /** Metadata about the {@link Step} */
-  protected @Nullable final D _detail;
+  @Nonnull private final D _detail;
 
   /** The action which was taken at the end of this step */
-  protected @Nullable final StepAction _action;
+  @Nonnull private final StepAction _action;
 
-  @JsonCreator
-  Step(
-      @JsonProperty(PROP_DETAIL) @Nullable D detail,
-      @JsonProperty(PROP_ACTION) @Nullable StepAction action) {
+  Step(D detail, StepAction action) {
     _detail = detail;
     _action = action;
   }
 
   @JsonProperty(PROP_DETAIL)
-  @Nullable
-  public D getDetail() {
+  @Nonnull
+  public final D getDetail() {
     return _detail;
   }
 
   @JsonProperty(PROP_ACTION)
-  @Nullable
-  public StepAction getAction() {
+  @Nonnull
+  public final StepAction getAction() {
     return _action;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/Step.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/Step.java
@@ -16,8 +16,9 @@ import org.batfish.datamodel.Flow;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({
   @JsonSubTypes.Type(value = EnterInputIfaceStep.class, name = "EnterInputInterface"),
+  @JsonSubTypes.Type(value = ExitOutputIfaceStep.class, name = "ExitOutputInterface"),
+  @JsonSubTypes.Type(value = InboundStep.class, name = "Inbound"),
   @JsonSubTypes.Type(value = RoutingStep.class, name = "Routing"),
-  @JsonSubTypes.Type(value = ExitOutputIfaceStep.class, name = "ExitOutputInterface")
 })
 @ParametersAreNonnullByDefault
 public abstract class Step<D> {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/StepAction.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/StepAction.java
@@ -5,7 +5,8 @@ public enum StepAction {
   BLOCKED,
   DROPPED,
   FORWARDED,
+  RECEIVED,
   SENT_IN,
   SENT_OUT,
-  TERMINATED
+  TERMINATED,
 }

--- a/tests/questions/experimental/tracerouteListHops.ref
+++ b/tests/questions/experimental/tracerouteListHops.ref
@@ -309,7 +309,7 @@
                 "steps" : [
                   {
                     "type" : "EnterInputInterface",
-                    "action" : "TERMINATED",
+                    "action" : "SENT_IN",
                     "detail" : {
                       "inputInterface" : {
                         "hostname" : "as1core1",
@@ -317,6 +317,10 @@
                       },
                       "inputVrf" : "default"
                     }
+                  },
+                  {
+                    "type" : "Inbound",
+                    "action" : "RECEIVED"
                   }
                 ]
               }
@@ -582,7 +586,7 @@
                 "steps" : [
                   {
                     "type" : "EnterInputInterface",
-                    "action" : "TERMINATED",
+                    "action" : "SENT_IN",
                     "detail" : {
                       "inputInterface" : {
                         "hostname" : "as1core1",
@@ -590,6 +594,10 @@
                       },
                       "inputVrf" : "default"
                     }
+                  },
+                  {
+                    "type" : "Inbound",
+                    "action" : "RECEIVED"
                   }
                 ]
               }
@@ -855,7 +863,7 @@
                 "steps" : [
                   {
                     "type" : "EnterInputInterface",
-                    "action" : "TERMINATED",
+                    "action" : "SENT_IN",
                     "detail" : {
                       "inputInterface" : {
                         "hostname" : "as1core1",
@@ -863,6 +871,10 @@
                       },
                       "inputVrf" : "default"
                     }
+                  },
+                  {
+                    "type" : "Inbound",
+                    "action" : "RECEIVED"
                   }
                 ]
               }
@@ -1129,7 +1141,7 @@
                 "steps" : [
                   {
                     "type" : "EnterInputInterface",
-                    "action" : "TERMINATED",
+                    "action" : "SENT_IN",
                     "detail" : {
                       "inputInterface" : {
                         "hostname" : "as1core1",
@@ -1137,6 +1149,10 @@
                       },
                       "inputVrf" : "default"
                     }
+                  },
+                  {
+                    "type" : "Inbound",
+                    "action" : "RECEIVED"
                   }
                 ]
               }


### PR DESCRIPTION
Fix #2463

* Only use EnterSrcIfaceStep if there is actually a src interface. If the
  packet originates in a virtual router, do not add this step.
* Add an InboundStep, which is a terminal step taking the place of RoutingStep,
  for handling traffic destined to the node itself. This catches the old "ingressVrf"
  case as well as coming after any enter src interface processing.
* This automatically makes us check inbound filter before handling traffic
  destined for the node itself, fixing #2463.