### PR TITLE
Header constraints: support spaces consisting of *only* exclusions

### DIFF
--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/IntegerSpaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/IntegerSpaceTest.java
@@ -5,6 +5,7 @@ import static org.batfish.datamodel.IntegerSpace.PORTS;
 import static org.batfish.datamodel.IntegerSpace.builder;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
 import com.google.common.collect.ImmutableSet;
@@ -246,7 +247,8 @@ public class IntegerSpaceTest {
 
   @Test
   public void testCreationFromStringNull() {
-    assertThat(IntegerSpace.create(null), nullValue());
+    assertThat(IntegerSpace.create(null), equalTo(EMPTY));
+    assertThat(IntegerSpace.Builder.create(null), nullValue());
   }
 
   @Test
@@ -365,5 +367,12 @@ public class IntegerSpaceTest {
     assertThat(
         IntegerSpace.unionOf(r1, r2),
         equalTo(IntegerSpace.builder().including(r1).including(r2).build()));
+  }
+
+  @Test
+  public void testStaticBuilderCreators() {
+    Builder b = Builder.create("10-20");
+    assertThat(b, not(nullValue()));
+    assertThat(b.build(), equalTo(IntegerSpace.of(Range.closed(10, 20))));
   }
 }


### PR DESCRIPTION
*Issue*:
If one specifies exclusions only in string form, e.g., "!22" an empty integer space is produced.

Sort of makes sense... Excluding something from an empty space is still empty; The problem is that there is some implicit finite universe space from which we are excluding, however it varies and isn't known ahead of time.

*Fix*:
Switch PHC to de-serialize to IntegerSpace builder instead and do some post-processing, defining the universe space as needed (per field).