### PR TITLE
Traceroute: fix enter(interface)

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteEngineImplContext.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteEngineImplContext.java
@@ -109,10 +109,6 @@ public class TracerouteEngineImplContext {
     }
   }
 
-  static final String TRACEROUTE_DUMMY_OUT_INTERFACE = "traceroute_dummy_out_interface";
-
-  static final String TRACEROUTE_DUMMY_NODE = "traceroute_dummy_node";
-
   private final Map<String, Configuration> _configurations;
   private final DataPlane _dataPlane;
   private final Map<String, Map<String, Fib>> _fibs;

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteEngineImplContext.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteEngineImplContext.java
@@ -1,6 +1,5 @@
 package org.batfish.dataplane.traceroute;
 
-import static org.batfish.dataplane.traceroute.TracerouteUtils.createDummyHop;
 import static org.batfish.dataplane.traceroute.TracerouteUtils.createEnterSrcIfaceStep;
 import static org.batfish.dataplane.traceroute.TracerouteUtils.isArpSuccessful;
 import static org.batfish.dataplane.traceroute.TracerouteUtils.validateInputs;
@@ -340,30 +339,18 @@ public class TracerouteEngineImplContext {
               List<Hop> hops = new ArrayList<>();
               String ingressInterfaceName = flow.getIngressInterface();
               if (ingressInterfaceName != null) {
-                Hop dummyHop = createDummyHop();
-                hops.add(dummyHop);
                 TransmissionContext transmissionContext =
                     new TransmissionContext(
                         Maps.newHashMap(),
-                        dummyHop.getNode(),
+                        new Node(ingressNodeName),
                         currentFlowTraces,
                         hops,
                         Maps.newTreeMap(),
                         flow,
                         new ArrayList<>(),
                         flow);
-                if (isArpSuccessful(
-                    flow.getDstIp(),
-                    _forwardingAnalysis,
-                    _configurations.get(ingressNodeName),
-                    ingressInterfaceName)) {
-                  processHop(
-                      ingressNodeName,
-                      ingressInterfaceName,
-                      transmissionContext,
-                      flow,
-                      visitedHops);
-                }
+                processHop(
+                    ingressNodeName, ingressInterfaceName, transmissionContext, flow, visitedHops);
               } else {
                 TransmissionContext transmissionContext =
                     new TransmissionContext(

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteUtils.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteUtils.java
@@ -3,11 +3,7 @@ package org.batfish.dataplane.traceroute;
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.batfish.datamodel.flow.StepAction.BLOCKED;
 import static org.batfish.datamodel.flow.StepAction.SENT_IN;
-import static org.batfish.datamodel.flow.StepAction.SENT_OUT;
-import static org.batfish.dataplane.traceroute.TracerouteEngineImplContext.TRACEROUTE_DUMMY_NODE;
-import static org.batfish.dataplane.traceroute.TracerouteEngineImplContext.TRACEROUTE_DUMMY_OUT_INTERFACE;
 
-import com.google.common.collect.ImmutableList;
 import java.util.Map;
 import java.util.NavigableMap;
 import javax.annotation.Nullable;
@@ -25,11 +21,8 @@ import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.flow.EnterInputIfaceStep;
 import org.batfish.datamodel.flow.EnterInputIfaceStep.EnterInputIfaceStepDetail;
-import org.batfish.datamodel.flow.ExitOutputIfaceStep;
-import org.batfish.datamodel.flow.ExitOutputIfaceStep.ExitOutputIfaceStepDetail;
 import org.batfish.datamodel.flow.Hop;
 import org.batfish.datamodel.flow.Step;
-import org.batfish.datamodel.pojo.Node;
 
 @ParametersAreNonnullByDefault
 final class TracerouteUtils {
@@ -62,24 +55,6 @@ final class TracerouteUtils {
 
     checkArgument(
         flow.getDstIp() != null, "Cannot construct flow trace since dstIp is not specified");
-  }
-
-  /**
-   * Creates a dummy {@link Hop} for starting a trace when ingressInterface is provided
-   *
-   * @return a dummy {@link Hop}
-   */
-  static Hop createDummyHop() {
-    ImmutableList.Builder<Step<?>> steps = ImmutableList.builder();
-
-    // creating the exit from out interface step
-    ExitOutputIfaceStep.Builder exitOutStepBuilder = ExitOutputIfaceStep.builder();
-    ExitOutputIfaceStepDetail.Builder stepDetailBuilder = ExitOutputIfaceStepDetail.builder();
-    stepDetailBuilder.setOutputInterface(
-        new NodeInterfacePair(TRACEROUTE_DUMMY_NODE, TRACEROUTE_DUMMY_OUT_INTERFACE));
-    exitOutStepBuilder.setDetail(stepDetailBuilder.build()).setAction(SENT_OUT);
-
-    return new Hop(new Node(TRACEROUTE_DUMMY_NODE), steps.add(exitOutStepBuilder.build()).build());
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteUtils.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteUtils.java
@@ -6,7 +6,6 @@ import static org.batfish.datamodel.flow.StepAction.SENT_IN;
 
 import java.util.Map;
 import java.util.NavigableMap;
-import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DataPlane;
@@ -67,13 +66,12 @@ final class TracerouteUtils {
    * @return true if ARP request will get a response
    */
   static boolean isArpSuccessful(
-      @Nullable Ip arpIp, ForwardingAnalysis forwardingAnalysis, Configuration node, String iface) {
-    return arpIp != null
-        && forwardingAnalysis
-            .getArpReplies()
-            .get(node.getHostname())
-            .get(iface)
-            .containsIp(arpIp, node.getIpSpaces());
+      Ip arpIp, ForwardingAnalysis forwardingAnalysis, Configuration node, String iface) {
+    return forwardingAnalysis
+        .getArpReplies()
+        .get(node.getHostname())
+        .get(iface)
+        .containsIp(arpIp, node.getIpSpaces());
   }
 
   /**

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TracerouteEngineImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TracerouteEngineImplTest.java
@@ -179,8 +179,6 @@ public class TracerouteEngineImplTest {
     Flow flow1 = fb.setIngressInterface(i1.getName()).setIngressVrf(vrf1.getName()).build();
     Flow flow2 = fb.setIngressInterface(i2.getName()).setIngressVrf(vrf2.getName()).build();
 
-    System.out.print("aha");
-
     // Compute flow traces
     SortedMap<Flow, List<Trace>> traces =
         TracerouteEngineImpl.getInstance()


### PR DESCRIPTION
1. Remove the dummy hop :tada:
2. Remove the ARP analysis. The intended semantics of this question
   is that the flow is delivered to this interface and processed from
   there.