### PR TITLE
Prune traces from traceroute, while trying to exhibit wide variety

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/TracePruner.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/TracePruner.java
@@ -1,0 +1,97 @@
+package org.batfish.common.util;
+
+import static org.glassfish.jersey.internal.guava.Predicates.not;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import org.batfish.common.BatfishException;
+import org.batfish.datamodel.FlowDisposition;
+import org.batfish.datamodel.flow.Hop;
+import org.batfish.datamodel.flow.Trace;
+
+/**
+ * Prune sets of traces to some reasonable limit, while maximizing coverage of possible behaviors.
+ *
+ * <p>Prioritize traces with different dispositions first, then traces that transit different nodes.
+ * Once all dispositions and nodes are covered, pick traces until the maxSize is reached. To ensure
+ * determinism, we choose dispositions, nodes, and traces in a consistent order.
+ */
+public class TracePruner {
+  private final Multimap<FlowDisposition, Trace> _dispositionTraces;
+  private final Multimap<String, Trace> _nodeTraces;
+  private final List<Trace> _traces;
+  private final SortedSet<FlowDisposition> _unusedDispositions;
+  private final SortedSet<String> _unusedNodes;
+
+  private TracePruner(List<Trace> traces) {
+    _traces = traces;
+    _dispositionTraces = HashMultimap.create();
+    _nodeTraces = HashMultimap.create();
+
+    for (Trace trace : traces) {
+      _dispositionTraces.put(trace.getDisposition(), trace);
+      for (Hop hop : trace.getHops()) {
+        _nodeTraces.put(hop.getNode().getName(), trace);
+      }
+    }
+
+    _unusedDispositions = new TreeSet<>(_dispositionTraces.keySet());
+    _unusedNodes = new TreeSet<>(_nodeTraces.keySet());
+  }
+
+  public static List<Trace> prune(List<Trace> traces, int maxSize) {
+    if (traces.size() <= maxSize) {
+      return traces;
+    }
+    return new TracePruner(traces).prune(maxSize);
+  }
+
+  private List<Trace> prune(int maxSize) {
+    List<Trace> usedTraces = new ArrayList<>();
+
+    while (usedTraces.size() < maxSize) {
+      if (!_unusedDispositions.isEmpty()) {
+        usedTraces.add(chooseTraceByDisposition(usedTraces));
+      } else if (!_unusedNodes.isEmpty()) {
+        usedTraces.add(chooseTraceByNode(usedTraces));
+      } else {
+        _traces
+            .stream()
+            .filter(not(usedTraces::contains))
+            .limit(maxSize - usedTraces.size())
+            .forEach(usedTraces::add);
+        break;
+      }
+    }
+
+    return usedTraces;
+  }
+
+  private Trace chooseTraceByDisposition(List<Trace> usedTraces) {
+    Trace t =
+        _unusedDispositions
+            .stream()
+            .flatMap(disposition -> _dispositionTraces.get(disposition).stream())
+            .filter(not(usedTraces::contains))
+            .findFirst()
+            .orElseThrow(() -> new BatfishException("No trace with unused disposition"));
+    _unusedDispositions.remove(t.getDisposition());
+    return t;
+  }
+
+  private Trace chooseTraceByNode(List<Trace> usedTraces) {
+    Trace t =
+        _unusedDispositions
+            .stream()
+            .flatMap(disposition -> _dispositionTraces.get(disposition).stream())
+            .filter(not(usedTraces::contains))
+            .findFirst()
+            .orElseThrow(() -> new BatfishException("No trace with unused node"));
+    t.getHops().stream().map(hop -> hop.getNode().getName()).forEach(_unusedNodes::remove);
+    return t;
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/TracePrunerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/TracePrunerTest.java
@@ -1,0 +1,65 @@
+package org.batfish.common.util;
+
+import static org.batfish.common.util.TracePruner.prune;
+import static org.batfish.datamodel.FlowDisposition.ACCEPTED;
+import static org.batfish.datamodel.FlowDisposition.DENIED_IN;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import org.batfish.datamodel.flow.Hop;
+import org.batfish.datamodel.flow.Trace;
+import org.batfish.datamodel.pojo.Node;
+import org.junit.Test;
+
+public class TracePrunerTest {
+  private static final Hop HOP_A = new Hop(new Node("A"), ImmutableList.of());
+  private static final Hop HOP_B = new Hop(new Node("B"), ImmutableList.of());
+  private static final Hop HOP_C = new Hop(new Node("C"), ImmutableList.of());
+
+  private static final Trace TRACE_A_ACCEPTED = new Trace(ACCEPTED, ImmutableList.of(HOP_A));
+  private static final Trace TRACE_A_B_ACCEPTED =
+      new Trace(ACCEPTED, ImmutableList.of(HOP_A, HOP_B));
+  private static final Trace TRACE_A_DENIED_IN = new Trace(DENIED_IN, ImmutableList.of(HOP_A));
+  private static final Trace TRACE_B_ACCEPTED = new Trace(ACCEPTED, ImmutableList.of(HOP_B));
+  private static final Trace TRACE_C_ACCEPTED = new Trace(ACCEPTED, ImmutableList.of(HOP_C));
+
+  @Test
+  public void testEmpty() {
+    assertThat(prune(ImmutableList.of(), 5), empty());
+  }
+
+  @Test
+  public void testPickNone() {
+    assertThat(prune(ImmutableList.of(TRACE_A_ACCEPTED), 0), empty());
+  }
+
+  @Test
+  public void testPreferDispositionOverNode() {
+    assertThat(
+        prune(ImmutableList.of(TRACE_A_ACCEPTED, TRACE_B_ACCEPTED, TRACE_A_DENIED_IN), 2),
+        equalTo(ImmutableList.of(TRACE_A_ACCEPTED, TRACE_A_DENIED_IN)));
+  }
+
+  @Test
+  public void testPickByNode() {
+    assertThat(
+        prune(
+            ImmutableList.of(
+                TRACE_A_B_ACCEPTED, TRACE_A_ACCEPTED, TRACE_B_ACCEPTED, TRACE_C_ACCEPTED),
+            2),
+        equalTo(ImmutableList.of(TRACE_A_B_ACCEPTED, TRACE_C_ACCEPTED)));
+  }
+
+  @Test
+  public void testPickFill() {
+    // once we've covered all dispositions and flows, fill with unused traces in input order
+    assertThat(
+        prune(
+            ImmutableList.of(
+                TRACE_A_B_ACCEPTED, TRACE_A_ACCEPTED, TRACE_B_ACCEPTED, TRACE_C_ACCEPTED),
+            3),
+        equalTo(ImmutableList.of(TRACE_A_B_ACCEPTED, TRACE_C_ACCEPTED, TRACE_A_ACCEPTED)));
+  }
+}

--- a/projects/question/src/main/java/org/batfish/question/traceroute/TracerouteAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/traceroute/TracerouteAnswerer.java
@@ -15,6 +15,7 @@ import java.util.SortedMap;
 import javax.annotation.Nonnull;
 import org.batfish.common.Answerer;
 import org.batfish.common.plugin.IBatfish;
+import org.batfish.common.util.TracePruner;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.Flow;
@@ -63,6 +64,9 @@ public final class TracerouteAnswerer extends Answerer {
   public static final String COL_FLOW = "Flow";
   public static final String COL_TRACES = "Traces";
   private static final int TRACEROUTE_PORT = 33434;
+
+  // maximum number of traces per-flow to include in the output
+  private static final int MAX_FLOW_TRACES = 32;
 
   private final Map<String, Configuration> _configurations;
   private final IpSpaceRepresentative _ipSpaceRepresentative;
@@ -230,7 +234,8 @@ public final class TracerouteAnswerer extends Answerer {
   public static Multiset<Row> flowTracesToRows(SortedMap<Flow, List<Trace>> flowTraces) {
     Multiset<Row> rows = LinkedHashMultiset.create();
     for (Map.Entry<Flow, List<Trace>> flowTrace : flowTraces.entrySet()) {
-      rows.add(Row.of(COL_FLOW, flowTrace.getKey(), COL_TRACES, flowTrace.getValue()));
+      List<Trace> traces = TracePruner.prune(flowTrace.getValue(), MAX_FLOW_TRACES);
+      rows.add(Row.of(COL_FLOW, flowTrace.getKey(), COL_TRACES, traces));
     }
     return rows;
   }


### PR DESCRIPTION
On networks with many equal cost routes, a single flow can have thousands of traces. This is both overwhelming to users and very expensive, particularly serializing the answer to json. 

`TracePruner` picks an input number of traces, greedily picking traces that have new dispositions, and then traces that go through new nodes. 

It's implemented for the new `Trace` class and in traceroute when the new engine is enabled. As we move more questions to that engine, we'll use it there too.