### PR TITLE
 handle non-existent source locations and final nodes in bdd reachability engine

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/question/reducedreachability/DifferentialReachabilityParameters.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/question/reducedreachability/DifferentialReachabilityParameters.java
@@ -30,26 +30,55 @@ public class DifferentialReachabilityParameters {
     _requiredTransitNodes = ImmutableSet.copyOf(requiredTransitNodes);
   }
 
+  /**
+   * @return The set of {@link FlowDisposition dispositions} of interest. Search for differences
+   *     between the sets of {@link org.batfish.datamodel.Flow flows} that have a disposition in
+   *     this set.
+   */
   public Set<FlowDisposition> getFlowDispositions() {
     return _flowDispositions;
   }
 
+  /**
+   * @return The set of router hostnames that may not be transited. Search for differences between
+   *     the the sets of {@link org.batfish.datamodel.Flow flows} with at least one path that does
+   *     not transit any node in this set.
+   */
   public Set<String> getForbiddenTransitNodes() {
     return _forbiddenTransitNodes;
   }
 
+  /**
+   * @return The set of router hostnames that must be transited. Search for differences between the
+   *     the sets of {@link org.batfish.datamodel.Flow flows} with at least one path that transits
+   *     any node in this set.
+   */
   public Set<String> getFinalNodes() {
     return _finalNodes;
   }
 
+  /**
+   * @return The headerspace of interest. Search for differences between sets of {@link
+   *     org.batfish.datamodel.Flow flows} whose headers are contained in this space.
+   */
   public AclLineMatchExpr getHeaderSpace() {
     return _headerSpace;
   }
 
+  /**
+   * @return The source {@link IpSpaceAssignment}. Search for differences between sets of {@link
+   *     org.batfish.datamodel.Flow flows} that start at a location and with an initial source IP
+   *     consistent with an entry in the assignment.
+   */
   public IpSpaceAssignment getIpSpaceAssignment() {
     return _ipSpaceAssignment;
   }
 
+  /**
+   * @return The set of router hostnames where flows stop. Search for differences between the sets
+   *     of {@link org.batfish.datamodel.Flow flows} with at least one path that stops at a router
+   *     in this set.
+   */
   public Set<String> getRequiredTransitNodes() {
     return _requiredTransitNodes;
   }

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
@@ -16,6 +16,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -31,6 +33,7 @@ import org.batfish.common.util.CommonUtil;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.FlowDisposition;
 import org.batfish.datamodel.ForwardingAnalysis;
+import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.SourceNat;
 import org.batfish.datamodel.UniverseIpSpace;
@@ -38,7 +41,6 @@ import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.specifier.InterfaceLinkLocation;
 import org.batfish.specifier.InterfaceLocation;
 import org.batfish.specifier.IpSpaceAssignment;
-import org.batfish.specifier.Location;
 import org.batfish.specifier.LocationVisitor;
 import org.batfish.z3.expr.StateExpr;
 import org.batfish.z3.state.Accept;
@@ -403,6 +405,7 @@ public final class BDDReachabilityAnalysisFactory {
     return finalNodes
         .stream()
         .map(_configs::get)
+        .filter(Objects::nonNull) // remove finalNodes that don't exist on this network
         .flatMap(c -> c.getAllInterfaces().values().stream())
         .map(
             iface -> {
@@ -772,25 +775,33 @@ public final class BDDReachabilityAnalysisFactory {
   }
 
   @Nonnull
-  private LocationVisitor<StateExpr> getLocationToStateExpr() {
-    return new LocationVisitor<StateExpr>() {
+  /*
+   * Optional.none is used when the location is not in the snapshot. This can happen in differential reachability,
+   * for example.
+   */
+  private LocationVisitor<Optional<StateExpr>> getLocationToStateExpr() {
+    return new LocationVisitor<Optional<StateExpr>>() {
       @Override
-      public StateExpr visitInterfaceLinkLocation(
+      public Optional<StateExpr> visitInterfaceLinkLocation(
           @Nonnull InterfaceLinkLocation interfaceLinkLocation) {
-        return new OriginateInterfaceLink(
-            interfaceLinkLocation.getNodeName(), interfaceLinkLocation.getInterfaceName());
+        return Optional.of(
+            new OriginateInterfaceLink(
+                interfaceLinkLocation.getNodeName(), interfaceLinkLocation.getInterfaceName()));
       }
 
       @Override
-      public StateExpr visitInterfaceLocation(@Nonnull InterfaceLocation interfaceLocation) {
-        String vrf =
-            _configs
-                .get(interfaceLocation.getNodeName())
-                .getAllInterfaces()
-                .get(interfaceLocation.getInterfaceName())
-                .getVrf()
-                .getName();
-        return new OriginateVrf(interfaceLocation.getNodeName(), vrf);
+      public Optional<StateExpr> visitInterfaceLocation(
+          @Nonnull InterfaceLocation interfaceLocation) {
+        Configuration config = _configs.get(interfaceLocation.getNodeName());
+        if (config == null) {
+          return Optional.empty();
+        }
+        Interface iface = config.getAllInterfaces().get(interfaceLocation.getInterfaceName());
+        if (iface == null) {
+          return Optional.empty();
+        }
+        String vrf = iface.getVrfName();
+        return Optional.of(new OriginateVrf(interfaceLocation.getNodeName(), vrf));
       }
     };
   }
@@ -853,21 +864,24 @@ public final class BDDReachabilityAnalysisFactory {
 
   private Map<StateExpr, BDD> rootConstraints(
       IpSpaceAssignment srcIpSpaceAssignment, BDD initialHeaderSpaceBdd) {
-    LocationVisitor<StateExpr> locationToStateExpr = getLocationToStateExpr();
+    LocationVisitor<Optional<StateExpr>> locationToStateExpr = getLocationToStateExpr();
     IpSpaceToBDD srcIpSpaceToBDD = new IpSpaceToBDD(_bddPacket.getFactory(), _bddPacket.getSrcIp());
 
     // convert Locations to StateExprs, and merge srcIp constraints
     Map<StateExpr, BDD> rootConstraints = new HashMap<>();
     for (IpSpaceAssignment.Entry entry : srcIpSpaceAssignment.getEntries()) {
       BDD srcIpSpaceBDD = entry.getIpSpace().accept(srcIpSpaceToBDD);
-      for (Location loc : entry.getLocations()) {
-        StateExpr root = loc.accept(locationToStateExpr);
-        rootConstraints.merge(root, srcIpSpaceBDD, BDD::or);
-      }
+      entry
+          .getLocations()
+          .stream()
+          .map(locationToStateExpr::visit)
+          .filter(Optional::isPresent)
+          .map(Optional::get)
+          .forEach(root -> rootConstraints.merge(root, srcIpSpaceBDD, BDD::or));
     }
 
     // add the global initial HeaderSpace and remove unsat entries
-    rootConstraints =
+    Map<StateExpr, BDD> finalRootConstraints =
         rootConstraints
             .entrySet()
             .stream()
@@ -880,9 +894,10 @@ public final class BDDReachabilityAnalysisFactory {
 
     // make sure there is at least one possible source
     checkArgument(
-        !rootConstraints.isEmpty(), "No sources are compatible with the headerspace constraint");
+        !finalRootConstraints.isEmpty(),
+        "No sources are compatible with the headerspace constraint");
 
-    return rootConstraints;
+    return finalRootConstraints;
   }
 
   private String ifaceVrf(String node, String iface) {


### PR DESCRIPTION
Make the engine robust to non-exist final nodes and source locations.  These can arise in the context of differential reachability (if nodes/locations are added or removed). It's not immediately clear what the desired semantics is in this case, but it should be up to the question. So the engine should be able to tolerate handle non-existent nodes/locations.