### PR TITLE
Cisco parsing fixes

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_line.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_line.g4
@@ -119,6 +119,7 @@ l_null
       | SESSION_DISCONNECT_WARNING
       | SESSION_LIMIT
       | SESSION_TIMEOUT
+      | SPEED
       | STOPBITS
       | TERMINAL_TYPE
       | TIMEOUT

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_ospf.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_ospf.g4
@@ -174,7 +174,11 @@ ro_distribute_list
   (
     IN
     | OUT
-  ) NEWLINE
+  )
+  (
+    iname = interface_name
+  )?
+  NEWLINE
 ;
 
 ro_max_metric
@@ -682,4 +686,3 @@ s_router_ospfv3
       | rov3_common
    )*
 ;
-

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_ospf.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_ospf.g4
@@ -323,6 +323,8 @@ ro_passive_interface
    NO? PASSIVE_INTERFACE i = interface_name NEWLINE
 ;
 
+
+
 ro_redistribute_bgp
 :
    REDISTRIBUTE BGP bgp_asn
@@ -675,6 +677,7 @@ s_router_ospf
       | ro_router_id
       | ro_summary_address
       | ro_vrf
+      | roi_priority
    )*
 ;
 

--- a/tests/parsing-tests/networks/unit-tests/configs/cisco_line
+++ b/tests/parsing-tests/networks/unit-tests/configs/cisco_line
@@ -13,6 +13,7 @@ line vty 0 15
     Unauthorized access prohibited
 ^C
  no vacant-message
+ speed 38400
 !
 line console
  exec-timeout 15
@@ -21,7 +22,7 @@ line vty
  access-class vty-acl in
 !
 line 0/0/0 0/0/15
- session-timeout 60 
+ session-timeout 60
  access-class 40 in
  login authentication SecurID
  no exec
@@ -29,7 +30,7 @@ line 0/0/0 0/0/15
  transport input telnet
  transport output none
 line 35 48
- session-timeout 540 
+ session-timeout 540
  location Covel Opt81 Network
  absolute-timeout 540
  session-disconnect-warning 30 message You will be disconnected in 30 seconds
@@ -55,7 +56,7 @@ line vty 0 4
  access-class 99 in
  accounting commands default
  exec-timeout 60 0
- password xxx  
+ password xxx
  logging synchronous
  ipv6 access-class ipv6-vty-acl in
  rxspeed 300
@@ -64,4 +65,3 @@ line vty 0 4
  notify
 !
 !
-

--- a/tests/parsing-tests/networks/unit-tests/configs/cisco_ospf
+++ b/tests/parsing-tests/networks/unit-tests/configs/cisco_ospf
@@ -46,6 +46,7 @@ router ospf 1
   discard-route internal
   distance 110
   distribute-list aclin in
+  distribute-list aclin in ethernet0/0
   distribute-list aclout out
   distribute-list prefix plin in
   distribute-list prefix plout out

--- a/tests/parsing-tests/networks/unit-tests/configs/cisco_ospf
+++ b/tests/parsing-tests/networks/unit-tests/configs/cisco_ospf
@@ -59,6 +59,7 @@ router ospf 1
   log-adjacency-changes detail
   log-adj-changes
   maximum-paths 32
+  priority 10
   redistribute direct route-map DIRECT_OSPF
   redistribute eigrp 5 metric 6 route-map eigrp-ospf-route-map
   redistribute ospf 2 match internal


### PR DESCRIPTION
We added fixes for three different cisco parsing errors:

1. For `router ospf`, `distribute-list` may be applied to a specific interface.
2. For `line`, ignore `speed`.
3. For `router ospf`, allow `priority` to be applied to all interfaces.

