### PR TITLE
Edge class: cleanup, meaningful getters

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Edge.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Edge.java
@@ -45,10 +45,10 @@ public class Edge implements Serializable, Comparable<Edge> {
       @Nullable @JsonProperty(PROP_INT1) String int1,
       @Nullable @JsonProperty(PROP_NODE2) String node2,
       @Nullable @JsonProperty(PROP_INT2) String int2) {
-    checkArgument(!Strings.isNullOrEmpty(node1), "Cannot create Edge with null node");
-    checkArgument(!Strings.isNullOrEmpty(int1), "Cannot create Edge with null interface");
-    checkArgument(!Strings.isNullOrEmpty(node2), "Cannot create Edge with null node");
-    checkArgument(!Strings.isNullOrEmpty(int2), "Cannot create Edge with null interface");
+    checkArgument(!Strings.isNullOrEmpty(node1), "Missing %s", PROP_NODE1);
+    checkArgument(!Strings.isNullOrEmpty(int1), "Missing %s", PROP_INT1);
+    checkArgument(!Strings.isNullOrEmpty(node2), "Missing %s", PROP_NODE2);
+    checkArgument(!Strings.isNullOrEmpty(int2), "Missing %s", PROP_INT2);
     return new Edge(new NodeInterfacePair(node1, int1), new NodeInterfacePair(node2, int2));
   }
 
@@ -60,7 +60,7 @@ public class Edge implements Serializable, Comparable<Edge> {
   }
 
   /** Create an edge from names of nodes and interfaces */
-  public static Edge fromStrings(
+  public static Edge of(
       String tailNode, String tailInterface, String headNode, String headInterface) {
     return create(tailNode, tailInterface, headNode, headInterface);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Edge.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Edge.java
@@ -1,72 +1,155 @@
 package org.batfish.datamodel;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.batfish.common.Pair;
+import com.google.common.base.Strings;
+import java.io.Serializable;
+import java.util.Comparator;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.collections.NodeInterfacePair;
 
-public class Edge extends Pair<NodeInterfacePair, NodeInterfacePair> {
+/** Represents a directed edge between two {@link NodeInterfacePair}s */
+@ParametersAreNonnullByDefault
+public class Edge implements Serializable, Comparable<Edge> {
 
   private static final String PROP_INT1 = "node1interface";
-
   private static final String PROP_INT2 = "node2interface";
-
   private static final String PROP_NODE1 = "node1";
-
   private static final String PROP_NODE2 = "node2";
-
   private static final long serialVersionUID = 1L;
 
-  public Edge(NodeInterfacePair p1, NodeInterfacePair p2) {
-    super(p1, p2);
+  @Nonnull private final NodeInterfacePair _tail;
+  @Nonnull private final NodeInterfacePair _head;
+
+  /**
+   * Create a new directed edge connecting two node/interface pairs from {@code tail} to {@code
+   * head}.
+   *
+   * @param tail the edge tail
+   * @param head the edge head
+   */
+  public Edge(NodeInterfacePair tail, NodeInterfacePair head) {
+    _tail = tail;
+    _head = head;
   }
 
   @JsonCreator
-  public Edge(
-      @JsonProperty(PROP_NODE1) String node1,
-      @JsonProperty(PROP_INT1) String int1,
-      @JsonProperty(PROP_NODE2) String node2,
-      @JsonProperty(PROP_INT2) String int2) {
-    super(new NodeInterfacePair(node1, int1), new NodeInterfacePair(node2, int2));
+  private static Edge create(
+      @Nullable @JsonProperty(PROP_NODE1) String node1,
+      @Nullable @JsonProperty(PROP_INT1) String int1,
+      @Nullable @JsonProperty(PROP_NODE2) String node2,
+      @Nullable @JsonProperty(PROP_INT2) String int2) {
+    checkArgument(!Strings.isNullOrEmpty(node1), "Cannot create Edge with null node");
+    checkArgument(!Strings.isNullOrEmpty(int1), "Cannot create Edge with null interface");
+    checkArgument(!Strings.isNullOrEmpty(node2), "Cannot create Edge with null node");
+    checkArgument(!Strings.isNullOrEmpty(int2), "Cannot create Edge with null interface");
+    return new Edge(new NodeInterfacePair(node1, int1), new NodeInterfacePair(node2, int2));
   }
 
-  public Edge(Interface i1, Interface i2) {
-    this(i1.getOwner().getHostname(), i1.getName(), i2.getOwner().getHostname(), i2.getName());
+  /** Create an Edge from {@link Interface}s */
+  public Edge(Interface tail, Interface head) {
+    this(
+        new NodeInterfacePair(tail.getOwner().getHostname(), tail.getName()),
+        new NodeInterfacePair(head.getOwner().getHostname(), head.getName()));
+  }
+
+  /** Create an edge from names of nodes and interfaces */
+  public static Edge fromStrings(
+      String tailNode, String tailInterface, String headNode, String headInterface) {
+    return create(tailNode, tailInterface, headNode, headInterface);
   }
 
   @JsonProperty(PROP_INT1)
   public String getInt1() {
-    return _first.getInterface();
+    return _tail.getInterface();
   }
 
   @JsonProperty(PROP_INT2)
   public String getInt2() {
-    return _second.getInterface();
+    return _head.getInterface();
   }
 
+  /** @deprecated Use {@link #getTail()} */
+  @Deprecated
   @JsonIgnore
+  @Nonnull
   public NodeInterfacePair getInterface1() {
-    return _first;
+    return getTail();
   }
 
   @JsonIgnore
+  @Nonnull
+  public NodeInterfacePair getTail() {
+    return _tail;
+  }
+
+  /** @deprecated Use {@link #getHead()} */
+  @JsonIgnore
+  @Deprecated
+  @Nonnull
   public NodeInterfacePair getInterface2() {
-    return _second;
+    return getHead();
+  }
+
+  @JsonIgnore
+  @Nonnull
+  public NodeInterfacePair getHead() {
+    return _head;
+  }
+
+  /** Return a new edge, pointing in the reverse direction */
+  public Edge reverse() {
+    return new Edge(_head, _tail);
   }
 
   @JsonProperty(PROP_NODE1)
   public String getNode1() {
-    return _first.getHostname();
+    return _tail.getHostname();
   }
 
   @JsonProperty(PROP_NODE2)
   public String getNode2() {
-    return _second.getHostname();
+    return _head.getHostname();
+  }
+
+  @Override
+  public int compareTo(Edge other) {
+    return Comparator.comparing(Edge::getTail).thenComparing(Edge::getHead).compare(this, other);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Edge)) {
+      return false;
+    }
+    Edge edge = (Edge) o;
+    return Objects.equals(_tail, edge._tail) && Objects.equals(_head, edge._head);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_tail, _head);
   }
 
   @Override
   public String toString() {
-    return "<" + getNode1() + ":" + getInt1() + ", " + getNode2() + ":" + getInt2() + ">";
+    return "<"
+        + getTail().getHostname()
+        + ":"
+        + getTail().getInterface()
+        + ", "
+        + getHead().getHostname()
+        + ":"
+        + getHead().getInterface()
+        + ">";
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FlowTrace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FlowTrace.java
@@ -89,7 +89,7 @@ public class FlowTrace implements Comparable<FlowTrace> {
       return null;
     }
     FlowTraceHop lastHop = getLastHop();
-    return lastHop == null ? null : lastHop.getEdge().getInterface2();
+    return lastHop == null ? null : lastHop.getEdge().getHead();
   }
 
   @JsonProperty(PROP_NOTES)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Topology.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Topology.java
@@ -57,8 +57,8 @@ public final class Topology implements Serializable {
     return getInterfaceEdges()
         .getOrDefault(iface, ImmutableSortedSet.of())
         .stream()
-        .filter(e -> e.getFirst().equals(iface))
-        .map(Edge::getSecond)
+        .filter(e -> e.getTail().equals(iface))
+        .map(Edge::getHead)
         .collect(ImmutableSet.toImmutableSet());
   }
 
@@ -94,8 +94,8 @@ public final class Topology implements Serializable {
     for (Edge edge : _edges) {
       String node1 = edge.getNode1();
       String node2 = edge.getNode2();
-      NodeInterfacePair iface1 = edge.getInterface1();
-      NodeInterfacePair iface2 = edge.getInterface2();
+      NodeInterfacePair iface1 = edge.getTail();
+      NodeInterfacePair iface2 = edge.getHead();
 
       _nodeEdges.computeIfAbsent(node1, k -> new TreeSet<>()).add(edge);
       _nodeEdges.computeIfAbsent(node2, k -> new TreeSet<>()).add(edge);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/EdgeTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/EdgeTest.java
@@ -1,0 +1,71 @@
+package org.batfish.datamodel;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.testing.EqualsTester;
+import org.batfish.datamodel.collections.NodeInterfacePair;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests of {@link Edge} */
+@RunWith(JUnit4.class)
+public class EdgeTest {
+
+  private static Edge EDGE =
+      new Edge(new NodeInterfacePair("tail", "tailInt"), new NodeInterfacePair("head", "headInt"));
+
+  @Test
+  public void testFactory() {
+    assertThat(Edge.fromStrings("tail", "tailInt", "head", "headInt"), equalTo(EDGE));
+  }
+
+  @Test
+  public void testGetterEquivalence() {
+    assertThat(EDGE.getNode1(), equalTo(EDGE.getTail().getHostname()));
+    assertThat(EDGE.getNode2(), equalTo(EDGE.getHead().getHostname()));
+    assertThat(EDGE.getInt1(), equalTo(EDGE.getTail().getInterface()));
+    assertThat(EDGE.getInt2(), equalTo(EDGE.getHead().getInterface()));
+  }
+
+  @Test
+  public void testToString() {
+    assertThat(EDGE.toString(), equalTo("<tail:tailInt, head:headInt>"));
+  }
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(
+            EDGE,
+            new Edge(
+                new NodeInterfacePair("tail", "tailInt"), new NodeInterfacePair("head", "headInt")))
+        .addEqualityGroup(EDGE.reverse())
+        .addEqualityGroup(
+            new Edge(
+                new NodeInterfacePair("tail1", "tailInt"),
+                new NodeInterfacePair("head", "headInt")))
+        .addEqualityGroup(
+            new Edge(
+                new NodeInterfacePair("tail", "tailint"), new NodeInterfacePair("head", "headInt")))
+        .addEqualityGroup(
+            new Edge(
+                new NodeInterfacePair("tail", "tailInt"), new NodeInterfacePair("hEad", "headInt")))
+        .addEqualityGroup(
+            new Edge(
+                new NodeInterfacePair("tail", "tailInt"),
+                new NodeInterfacePair("head", "headIntOther")))
+        .testEquals();
+  }
+
+  @Test
+  public void testReverse() {
+    assertThat(
+        EDGE.reverse(),
+        equalTo(
+            new Edge(
+                new NodeInterfacePair("head", "headInt"),
+                new NodeInterfacePair("tail", "tailInt"))));
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/EdgeTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/EdgeTest.java
@@ -18,7 +18,7 @@ public class EdgeTest {
 
   @Test
   public void testFactory() {
-    assertThat(Edge.fromStrings("tail", "tailInt", "head", "headInt"), equalTo(EDGE));
+    assertThat(Edge.of("tail", "tailInt", "head", "headInt"), equalTo(EDGE));
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ForwardingAnalysisImplTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ForwardingAnalysisImplTest.java
@@ -306,7 +306,7 @@ public class ForwardingAnalysisImplTest {
   public void testComputeArpTrueEdge() {
     IpSpace nextHopIpSpace = new MockIpSpace(1);
     IpSpace dstIpSpace = new MockIpSpace(2);
-    Edge e1 = new Edge("c1", "i1", "c2", "i2");
+    Edge e1 = Edge.fromStrings("c1", "i1", "c2", "i2");
     _arpTrueEdgeDestIp = ImmutableMap.of(e1, dstIpSpace);
     _arpTrueEdgeNextHopIp = ImmutableMap.of(e1, nextHopIpSpace);
     ForwardingAnalysisImpl forwardingAnalysisImpl = initForwardingAnalysisImpl();
@@ -348,7 +348,7 @@ public class ForwardingAnalysisImplTest {
                                 .thenPermitting(P1.toIpSpace())
                                 .build()))
                     .build()));
-    Edge edge = new Edge(c1.getHostname(), i1.getName(), c2.getHostname(), i2.getName());
+    Edge edge = Edge.fromStrings(c1.getHostname(), i1.getName(), c2.getHostname(), i2.getName());
     _routesWithDestIpEdge =
         ImmutableMap.of(edge, ImmutableSet.of(new ConnectedRoute(P1, i1.getName())));
     _arpReplies =
@@ -388,7 +388,7 @@ public class ForwardingAnalysisImplTest {
             .setVrf(vrf2)
             .setAddress(new InterfaceAddress(i2Ip, P1.getPrefixLength()))
             .build();
-    Edge edge = new Edge(c1.getHostname(), i1.getName(), c2.getHostname(), i2.getName());
+    Edge edge = Edge.fromStrings(c1.getHostname(), i1.getName(), c2.getHostname(), i2.getName());
     Map<String, Configuration> configurations =
         ImmutableMap.of(c1.getHostname(), c1, c2.getHostname(), c2);
     SortedMap<String, SortedMap<String, GenericRib<AbstractRoute>>> ribs =
@@ -877,7 +877,7 @@ public class ForwardingAnalysisImplTest {
     AbstractRoute r1 = new ConnectedRoute(P1, i1);
     _routesWhereDstIpCanBeArpIp =
         ImmutableMap.of(c1, ImmutableMap.of(v1, ImmutableMap.of(i1, ImmutableSet.of(r1))));
-    Edge e1 = new Edge(c1, i1, c2, i2);
+    Edge e1 = Edge.fromStrings(c1, i1, c2, i2);
     _arpReplies = ImmutableMap.of(c2, ImmutableMap.of(i2, P2.getStartIp().toIpSpace()));
     Topology topology = new Topology(ImmutableSortedSet.of(e1));
     Map<String, Map<String, Fib>> fibs =
@@ -1075,7 +1075,7 @@ public class ForwardingAnalysisImplTest {
     String i1 = "i1";
     String c2 = "c2";
     String i2 = "i2";
-    Edge e1 = new Edge(c1, i1, c2, i2);
+    Edge e1 = Edge.fromStrings(c1, i1, c2, i2);
     _arpReplies = ImmutableMap.of(c2, ImmutableMap.of(i2, P2.getStartIp().toIpSpace()));
     Topology topology = new Topology(ImmutableSortedSet.of(e1));
     String v1 = "v1";
@@ -1126,7 +1126,7 @@ public class ForwardingAnalysisImplTest {
     String i1 = "i1";
     String c2 = "c2";
     String i2 = "i2";
-    Edge e1 = new Edge(c1, i1, c2, i2);
+    Edge e1 = Edge.fromStrings(c1, i1, c2, i2);
     _arpReplies = ImmutableMap.of(c2, ImmutableMap.of(i2, P1.toIpSpace()));
     Topology topology = new Topology(ImmutableSortedSet.of(e1));
     ForwardingAnalysisImpl forwardingAnalysisImpl = initForwardingAnalysisImpl();

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ForwardingAnalysisImplTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ForwardingAnalysisImplTest.java
@@ -306,7 +306,7 @@ public class ForwardingAnalysisImplTest {
   public void testComputeArpTrueEdge() {
     IpSpace nextHopIpSpace = new MockIpSpace(1);
     IpSpace dstIpSpace = new MockIpSpace(2);
-    Edge e1 = Edge.fromStrings("c1", "i1", "c2", "i2");
+    Edge e1 = Edge.of("c1", "i1", "c2", "i2");
     _arpTrueEdgeDestIp = ImmutableMap.of(e1, dstIpSpace);
     _arpTrueEdgeNextHopIp = ImmutableMap.of(e1, nextHopIpSpace);
     ForwardingAnalysisImpl forwardingAnalysisImpl = initForwardingAnalysisImpl();
@@ -348,7 +348,7 @@ public class ForwardingAnalysisImplTest {
                                 .thenPermitting(P1.toIpSpace())
                                 .build()))
                     .build()));
-    Edge edge = Edge.fromStrings(c1.getHostname(), i1.getName(), c2.getHostname(), i2.getName());
+    Edge edge = Edge.of(c1.getHostname(), i1.getName(), c2.getHostname(), i2.getName());
     _routesWithDestIpEdge =
         ImmutableMap.of(edge, ImmutableSet.of(new ConnectedRoute(P1, i1.getName())));
     _arpReplies =
@@ -388,7 +388,7 @@ public class ForwardingAnalysisImplTest {
             .setVrf(vrf2)
             .setAddress(new InterfaceAddress(i2Ip, P1.getPrefixLength()))
             .build();
-    Edge edge = Edge.fromStrings(c1.getHostname(), i1.getName(), c2.getHostname(), i2.getName());
+    Edge edge = Edge.of(c1.getHostname(), i1.getName(), c2.getHostname(), i2.getName());
     Map<String, Configuration> configurations =
         ImmutableMap.of(c1.getHostname(), c1, c2.getHostname(), c2);
     SortedMap<String, SortedMap<String, GenericRib<AbstractRoute>>> ribs =
@@ -877,7 +877,7 @@ public class ForwardingAnalysisImplTest {
     AbstractRoute r1 = new ConnectedRoute(P1, i1);
     _routesWhereDstIpCanBeArpIp =
         ImmutableMap.of(c1, ImmutableMap.of(v1, ImmutableMap.of(i1, ImmutableSet.of(r1))));
-    Edge e1 = Edge.fromStrings(c1, i1, c2, i2);
+    Edge e1 = Edge.of(c1, i1, c2, i2);
     _arpReplies = ImmutableMap.of(c2, ImmutableMap.of(i2, P2.getStartIp().toIpSpace()));
     Topology topology = new Topology(ImmutableSortedSet.of(e1));
     Map<String, Map<String, Fib>> fibs =
@@ -1075,7 +1075,7 @@ public class ForwardingAnalysisImplTest {
     String i1 = "i1";
     String c2 = "c2";
     String i2 = "i2";
-    Edge e1 = Edge.fromStrings(c1, i1, c2, i2);
+    Edge e1 = Edge.of(c1, i1, c2, i2);
     _arpReplies = ImmutableMap.of(c2, ImmutableMap.of(i2, P2.getStartIp().toIpSpace()));
     Topology topology = new Topology(ImmutableSortedSet.of(e1));
     String v1 = "v1";
@@ -1126,7 +1126,7 @@ public class ForwardingAnalysisImplTest {
     String i1 = "i1";
     String c2 = "c2";
     String i2 = "i2";
-    Edge e1 = Edge.fromStrings(c1, i1, c2, i2);
+    Edge e1 = Edge.of(c1, i1, c2, i2);
     _arpReplies = ImmutableMap.of(c2, ImmutableMap.of(i2, P1.toIpSpace()));
     Topology topology = new Topology(ImmutableSortedSet.of(e1));
     ForwardingAnalysisImpl forwardingAnalysisImpl = initForwardingAnalysisImpl();

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/VerboseEdgeTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/VerboseEdgeTest.java
@@ -16,10 +16,10 @@ public class VerboseEdgeTest {
   @Test
   public void testEquals() {
     Interface i1 = new Interface("eth0");
-    VerboseEdge edge1 = new VerboseEdge(i1, i1, new Edge("node1", "eth0", "node2", "eth0"));
+    VerboseEdge edge1 = new VerboseEdge(i1, i1, Edge.fromStrings("node1", "eth0", "node2", "eth0"));
     assertEquals(edge1, edge1);
 
-    VerboseEdge edge2 = new VerboseEdge(i1, i1, new Edge("node2", "eth0", "node1", "eth0"));
+    VerboseEdge edge2 = new VerboseEdge(i1, i1, Edge.fromStrings("node2", "eth0", "node1", "eth0"));
     assertNotEquals(edge1, edge2);
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/VerboseEdgeTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/VerboseEdgeTest.java
@@ -16,10 +16,10 @@ public class VerboseEdgeTest {
   @Test
   public void testEquals() {
     Interface i1 = new Interface("eth0");
-    VerboseEdge edge1 = new VerboseEdge(i1, i1, Edge.fromStrings("node1", "eth0", "node2", "eth0"));
+    VerboseEdge edge1 = new VerboseEdge(i1, i1, Edge.of("node1", "eth0", "node2", "eth0"));
     assertEquals(edge1, edge1);
 
-    VerboseEdge edge2 = new VerboseEdge(i1, i1, Edge.fromStrings("node2", "eth0", "node1", "eth0"));
+    VerboseEdge edge2 = new VerboseEdge(i1, i1, Edge.of("node2", "eth0", "node1", "eth0"));
     assertNotEquals(edge1, edge2);
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/role/InferRolesMixedCaseTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/role/InferRolesMixedCaseTest.java
@@ -45,68 +45,46 @@ public class InferRolesMixedCaseTest {
   private static final Topology EXAMPLE_TOPOLOGY =
       new Topology(
           ImmutableSortedSet.of(
-              Edge.fromStrings(
-                  "as1BORDER1", "GigabitEthernet0/0", "as1core1", "GigabitEthernet1/0"),
-              Edge.fromStrings(
-                  "as1BORDER1", "GigabitEthernet1/0", "as2border1", "GigabitEthernet0/0"),
-              Edge.fromStrings(
-                  "as1bORder2", "GigabitEthernet0/0", "as3border2", "GigabitEthernet0/0"),
-              Edge.fromStrings(
-                  "as1bORder2", "GigabitEthernet1/0", "as1core1", "GigabitEthernet0/0"),
-              Edge.fromStrings(
-                  "as1core1", "GigabitEthernet0/0", "as1bORder2", "GigabitEthernet1/0"),
-              Edge.fromStrings(
-                  "as1core1", "GigabitEthernet1/0", "as1BORDER1", "GigabitEthernet0/0"),
-              Edge.fromStrings(
-                  "as2border1", "GigabitEthernet0/0", "as1BORDER1", "GigabitEthernet1/0"),
-              Edge.fromStrings(
-                  "as2border1", "GigabitEthernet1/0", "as2core1", "GigabitEthernet0/0"),
-              Edge.fromStrings(
-                  "as2border1", "GigabitEthernet2/0", "as2core2", "GigabitEthernet1/0"),
-              Edge.fromStrings(
-                  "as2border2", "GigabitEthernet0/0", "as3border1", "GigabitEthernet1/0"),
-              Edge.fromStrings(
-                  "as2border2", "GigabitEthernet1/0", "as2core2", "GigabitEthernet0/0"),
-              Edge.fromStrings(
-                  "as2border2", "GigabitEthernet2/0", "as2core1", "GigabitEthernet1/0"),
-              Edge.fromStrings(
-                  "as2core1", "GigabitEthernet0/0", "as2border1", "GigabitEthernet1/0"),
-              Edge.fromStrings(
-                  "as2core1", "GigabitEthernet1/0", "as2border2", "GigabitEthernet2/0"),
-              Edge.fromStrings("as2core1", "GigabitEthernet2/0", "as2dist1", "GigabitEthernet0/0"),
-              Edge.fromStrings("as2core1", "GigabitEthernet3/0", "as2dist2", "GigabitEthernet1/0"),
-              Edge.fromStrings(
-                  "as2core2", "GigabitEthernet0/0", "as2border2", "GigabitEthernet1/0"),
-              Edge.fromStrings(
-                  "as2core2", "GigabitEthernet1/0", "as2border1", "GigabitEthernet2/0"),
-              Edge.fromStrings("as2core2", "GigabitEthernet2/0", "as2dist2", "GigabitEthernet0/0"),
-              Edge.fromStrings("as2core2", "GigabitEthernet3/0", "as2dist1", "GigabitEthernet1/0"),
-              Edge.fromStrings("as2DEPT1", "GigabitEthernet0/0", "as2dist1", "GigabitEthernet2/0"),
-              Edge.fromStrings("as2DEPT1", "GigabitEthernet1/0", "as2dist2", "GigabitEthernet2/0"),
-              Edge.fromStrings("as2DEPT1", "GigabitEthernet2/0", "host1", "eth0"),
-              Edge.fromStrings("as2DEPT1", "GigabitEthernet3/0", "host2", "eth0"),
-              Edge.fromStrings("as2dist1", "GigabitEthernet0/0", "as2core1", "GigabitEthernet2/0"),
-              Edge.fromStrings("as2dist1", "GigabitEthernet1/0", "as2core2", "GigabitEthernet3/0"),
-              Edge.fromStrings("as2dist1", "GigabitEthernet2/0", "as2DEPT1", "GigabitEthernet0/0"),
-              Edge.fromStrings("as2dist2", "GigabitEthernet0/0", "as2core2", "GigabitEthernet2/0"),
-              Edge.fromStrings("as2dist2", "GigabitEthernet1/0", "as2core1", "GigabitEthernet3/0"),
-              Edge.fromStrings("as2dist2", "GigabitEthernet2/0", "as2DEPT1", "GigabitEthernet1/0"),
-              Edge.fromStrings(
-                  "as3border1", "GigabitEthernet0/0", "as3core1", "GigabitEthernet1/0"),
-              Edge.fromStrings(
-                  "as3border1", "GigabitEthernet1/0", "as2border2", "GigabitEthernet0/0"),
-              Edge.fromStrings(
-                  "as3border2", "GigabitEthernet0/0", "as1bORder2", "GigabitEthernet0/0"),
-              Edge.fromStrings(
-                  "as3border2", "GigabitEthernet1/0", "as3core1", "GigabitEthernet0/0"),
-              Edge.fromStrings(
-                  "as3core1", "GigabitEthernet0/0", "as3border2", "GigabitEthernet1/0"),
-              Edge.fromStrings(
-                  "as3core1", "GigabitEthernet1/0", "as3border1", "GigabitEthernet0/0"),
-              Edge.fromStrings("as3core1", "GigabitEthernet2/0", "as3core1", "GigabitEthernet3/0"),
-              Edge.fromStrings("as3core1", "GigabitEthernet3/0", "as3core1", "GigabitEthernet2/0"),
-              Edge.fromStrings("host1", "eth0", "as2DEPT1", "GigabitEthernet2/0"),
-              Edge.fromStrings("host2", "eth0", "as2DEPT1", "GigabitEthernet3/0")));
+              Edge.of("as1BORDER1", "GigabitEthernet0/0", "as1core1", "GigabitEthernet1/0"),
+              Edge.of("as1BORDER1", "GigabitEthernet1/0", "as2border1", "GigabitEthernet0/0"),
+              Edge.of("as1bORder2", "GigabitEthernet0/0", "as3border2", "GigabitEthernet0/0"),
+              Edge.of("as1bORder2", "GigabitEthernet1/0", "as1core1", "GigabitEthernet0/0"),
+              Edge.of("as1core1", "GigabitEthernet0/0", "as1bORder2", "GigabitEthernet1/0"),
+              Edge.of("as1core1", "GigabitEthernet1/0", "as1BORDER1", "GigabitEthernet0/0"),
+              Edge.of("as2border1", "GigabitEthernet0/0", "as1BORDER1", "GigabitEthernet1/0"),
+              Edge.of("as2border1", "GigabitEthernet1/0", "as2core1", "GigabitEthernet0/0"),
+              Edge.of("as2border1", "GigabitEthernet2/0", "as2core2", "GigabitEthernet1/0"),
+              Edge.of("as2border2", "GigabitEthernet0/0", "as3border1", "GigabitEthernet1/0"),
+              Edge.of("as2border2", "GigabitEthernet1/0", "as2core2", "GigabitEthernet0/0"),
+              Edge.of("as2border2", "GigabitEthernet2/0", "as2core1", "GigabitEthernet1/0"),
+              Edge.of("as2core1", "GigabitEthernet0/0", "as2border1", "GigabitEthernet1/0"),
+              Edge.of("as2core1", "GigabitEthernet1/0", "as2border2", "GigabitEthernet2/0"),
+              Edge.of("as2core1", "GigabitEthernet2/0", "as2dist1", "GigabitEthernet0/0"),
+              Edge.of("as2core1", "GigabitEthernet3/0", "as2dist2", "GigabitEthernet1/0"),
+              Edge.of("as2core2", "GigabitEthernet0/0", "as2border2", "GigabitEthernet1/0"),
+              Edge.of("as2core2", "GigabitEthernet1/0", "as2border1", "GigabitEthernet2/0"),
+              Edge.of("as2core2", "GigabitEthernet2/0", "as2dist2", "GigabitEthernet0/0"),
+              Edge.of("as2core2", "GigabitEthernet3/0", "as2dist1", "GigabitEthernet1/0"),
+              Edge.of("as2DEPT1", "GigabitEthernet0/0", "as2dist1", "GigabitEthernet2/0"),
+              Edge.of("as2DEPT1", "GigabitEthernet1/0", "as2dist2", "GigabitEthernet2/0"),
+              Edge.of("as2DEPT1", "GigabitEthernet2/0", "host1", "eth0"),
+              Edge.of("as2DEPT1", "GigabitEthernet3/0", "host2", "eth0"),
+              Edge.of("as2dist1", "GigabitEthernet0/0", "as2core1", "GigabitEthernet2/0"),
+              Edge.of("as2dist1", "GigabitEthernet1/0", "as2core2", "GigabitEthernet3/0"),
+              Edge.of("as2dist1", "GigabitEthernet2/0", "as2DEPT1", "GigabitEthernet0/0"),
+              Edge.of("as2dist2", "GigabitEthernet0/0", "as2core2", "GigabitEthernet2/0"),
+              Edge.of("as2dist2", "GigabitEthernet1/0", "as2core1", "GigabitEthernet3/0"),
+              Edge.of("as2dist2", "GigabitEthernet2/0", "as2DEPT1", "GigabitEthernet1/0"),
+              Edge.of("as3border1", "GigabitEthernet0/0", "as3core1", "GigabitEthernet1/0"),
+              Edge.of("as3border1", "GigabitEthernet1/0", "as2border2", "GigabitEthernet0/0"),
+              Edge.of("as3border2", "GigabitEthernet0/0", "as1bORder2", "GigabitEthernet0/0"),
+              Edge.of("as3border2", "GigabitEthernet1/0", "as3core1", "GigabitEthernet0/0"),
+              Edge.of("as3core1", "GigabitEthernet0/0", "as3border2", "GigabitEthernet1/0"),
+              Edge.of("as3core1", "GigabitEthernet1/0", "as3border1", "GigabitEthernet0/0"),
+              Edge.of("as3core1", "GigabitEthernet2/0", "as3core1", "GigabitEthernet3/0"),
+              Edge.of("as3core1", "GigabitEthernet3/0", "as3core1", "GigabitEthernet2/0"),
+              Edge.of("host1", "eth0", "as2DEPT1", "GigabitEthernet2/0"),
+              Edge.of("host2", "eth0", "as2DEPT1", "GigabitEthernet3/0")));
 
   private static Set<String> filterSet(Set<String> nodes, Predicate<String> filter) {
     return nodes.stream().filter(filter).collect(ImmutableSet.toImmutableSet());

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/role/InferRolesMixedCaseTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/role/InferRolesMixedCaseTest.java
@@ -45,46 +45,68 @@ public class InferRolesMixedCaseTest {
   private static final Topology EXAMPLE_TOPOLOGY =
       new Topology(
           ImmutableSortedSet.of(
-              new Edge("as1BORDER1", "GigabitEthernet0/0", "as1core1", "GigabitEthernet1/0"),
-              new Edge("as1BORDER1", "GigabitEthernet1/0", "as2border1", "GigabitEthernet0/0"),
-              new Edge("as1bORder2", "GigabitEthernet0/0", "as3border2", "GigabitEthernet0/0"),
-              new Edge("as1bORder2", "GigabitEthernet1/0", "as1core1", "GigabitEthernet0/0"),
-              new Edge("as1core1", "GigabitEthernet0/0", "as1bORder2", "GigabitEthernet1/0"),
-              new Edge("as1core1", "GigabitEthernet1/0", "as1BORDER1", "GigabitEthernet0/0"),
-              new Edge("as2border1", "GigabitEthernet0/0", "as1BORDER1", "GigabitEthernet1/0"),
-              new Edge("as2border1", "GigabitEthernet1/0", "as2core1", "GigabitEthernet0/0"),
-              new Edge("as2border1", "GigabitEthernet2/0", "as2core2", "GigabitEthernet1/0"),
-              new Edge("as2border2", "GigabitEthernet0/0", "as3border1", "GigabitEthernet1/0"),
-              new Edge("as2border2", "GigabitEthernet1/0", "as2core2", "GigabitEthernet0/0"),
-              new Edge("as2border2", "GigabitEthernet2/0", "as2core1", "GigabitEthernet1/0"),
-              new Edge("as2core1", "GigabitEthernet0/0", "as2border1", "GigabitEthernet1/0"),
-              new Edge("as2core1", "GigabitEthernet1/0", "as2border2", "GigabitEthernet2/0"),
-              new Edge("as2core1", "GigabitEthernet2/0", "as2dist1", "GigabitEthernet0/0"),
-              new Edge("as2core1", "GigabitEthernet3/0", "as2dist2", "GigabitEthernet1/0"),
-              new Edge("as2core2", "GigabitEthernet0/0", "as2border2", "GigabitEthernet1/0"),
-              new Edge("as2core2", "GigabitEthernet1/0", "as2border1", "GigabitEthernet2/0"),
-              new Edge("as2core2", "GigabitEthernet2/0", "as2dist2", "GigabitEthernet0/0"),
-              new Edge("as2core2", "GigabitEthernet3/0", "as2dist1", "GigabitEthernet1/0"),
-              new Edge("as2DEPT1", "GigabitEthernet0/0", "as2dist1", "GigabitEthernet2/0"),
-              new Edge("as2DEPT1", "GigabitEthernet1/0", "as2dist2", "GigabitEthernet2/0"),
-              new Edge("as2DEPT1", "GigabitEthernet2/0", "host1", "eth0"),
-              new Edge("as2DEPT1", "GigabitEthernet3/0", "host2", "eth0"),
-              new Edge("as2dist1", "GigabitEthernet0/0", "as2core1", "GigabitEthernet2/0"),
-              new Edge("as2dist1", "GigabitEthernet1/0", "as2core2", "GigabitEthernet3/0"),
-              new Edge("as2dist1", "GigabitEthernet2/0", "as2DEPT1", "GigabitEthernet0/0"),
-              new Edge("as2dist2", "GigabitEthernet0/0", "as2core2", "GigabitEthernet2/0"),
-              new Edge("as2dist2", "GigabitEthernet1/0", "as2core1", "GigabitEthernet3/0"),
-              new Edge("as2dist2", "GigabitEthernet2/0", "as2DEPT1", "GigabitEthernet1/0"),
-              new Edge("as3border1", "GigabitEthernet0/0", "as3core1", "GigabitEthernet1/0"),
-              new Edge("as3border1", "GigabitEthernet1/0", "as2border2", "GigabitEthernet0/0"),
-              new Edge("as3border2", "GigabitEthernet0/0", "as1bORder2", "GigabitEthernet0/0"),
-              new Edge("as3border2", "GigabitEthernet1/0", "as3core1", "GigabitEthernet0/0"),
-              new Edge("as3core1", "GigabitEthernet0/0", "as3border2", "GigabitEthernet1/0"),
-              new Edge("as3core1", "GigabitEthernet1/0", "as3border1", "GigabitEthernet0/0"),
-              new Edge("as3core1", "GigabitEthernet2/0", "as3core1", "GigabitEthernet3/0"),
-              new Edge("as3core1", "GigabitEthernet3/0", "as3core1", "GigabitEthernet2/0"),
-              new Edge("host1", "eth0", "as2DEPT1", "GigabitEthernet2/0"),
-              new Edge("host2", "eth0", "as2DEPT1", "GigabitEthernet3/0")));
+              Edge.fromStrings(
+                  "as1BORDER1", "GigabitEthernet0/0", "as1core1", "GigabitEthernet1/0"),
+              Edge.fromStrings(
+                  "as1BORDER1", "GigabitEthernet1/0", "as2border1", "GigabitEthernet0/0"),
+              Edge.fromStrings(
+                  "as1bORder2", "GigabitEthernet0/0", "as3border2", "GigabitEthernet0/0"),
+              Edge.fromStrings(
+                  "as1bORder2", "GigabitEthernet1/0", "as1core1", "GigabitEthernet0/0"),
+              Edge.fromStrings(
+                  "as1core1", "GigabitEthernet0/0", "as1bORder2", "GigabitEthernet1/0"),
+              Edge.fromStrings(
+                  "as1core1", "GigabitEthernet1/0", "as1BORDER1", "GigabitEthernet0/0"),
+              Edge.fromStrings(
+                  "as2border1", "GigabitEthernet0/0", "as1BORDER1", "GigabitEthernet1/0"),
+              Edge.fromStrings(
+                  "as2border1", "GigabitEthernet1/0", "as2core1", "GigabitEthernet0/0"),
+              Edge.fromStrings(
+                  "as2border1", "GigabitEthernet2/0", "as2core2", "GigabitEthernet1/0"),
+              Edge.fromStrings(
+                  "as2border2", "GigabitEthernet0/0", "as3border1", "GigabitEthernet1/0"),
+              Edge.fromStrings(
+                  "as2border2", "GigabitEthernet1/0", "as2core2", "GigabitEthernet0/0"),
+              Edge.fromStrings(
+                  "as2border2", "GigabitEthernet2/0", "as2core1", "GigabitEthernet1/0"),
+              Edge.fromStrings(
+                  "as2core1", "GigabitEthernet0/0", "as2border1", "GigabitEthernet1/0"),
+              Edge.fromStrings(
+                  "as2core1", "GigabitEthernet1/0", "as2border2", "GigabitEthernet2/0"),
+              Edge.fromStrings("as2core1", "GigabitEthernet2/0", "as2dist1", "GigabitEthernet0/0"),
+              Edge.fromStrings("as2core1", "GigabitEthernet3/0", "as2dist2", "GigabitEthernet1/0"),
+              Edge.fromStrings(
+                  "as2core2", "GigabitEthernet0/0", "as2border2", "GigabitEthernet1/0"),
+              Edge.fromStrings(
+                  "as2core2", "GigabitEthernet1/0", "as2border1", "GigabitEthernet2/0"),
+              Edge.fromStrings("as2core2", "GigabitEthernet2/0", "as2dist2", "GigabitEthernet0/0"),
+              Edge.fromStrings("as2core2", "GigabitEthernet3/0", "as2dist1", "GigabitEthernet1/0"),
+              Edge.fromStrings("as2DEPT1", "GigabitEthernet0/0", "as2dist1", "GigabitEthernet2/0"),
+              Edge.fromStrings("as2DEPT1", "GigabitEthernet1/0", "as2dist2", "GigabitEthernet2/0"),
+              Edge.fromStrings("as2DEPT1", "GigabitEthernet2/0", "host1", "eth0"),
+              Edge.fromStrings("as2DEPT1", "GigabitEthernet3/0", "host2", "eth0"),
+              Edge.fromStrings("as2dist1", "GigabitEthernet0/0", "as2core1", "GigabitEthernet2/0"),
+              Edge.fromStrings("as2dist1", "GigabitEthernet1/0", "as2core2", "GigabitEthernet3/0"),
+              Edge.fromStrings("as2dist1", "GigabitEthernet2/0", "as2DEPT1", "GigabitEthernet0/0"),
+              Edge.fromStrings("as2dist2", "GigabitEthernet0/0", "as2core2", "GigabitEthernet2/0"),
+              Edge.fromStrings("as2dist2", "GigabitEthernet1/0", "as2core1", "GigabitEthernet3/0"),
+              Edge.fromStrings("as2dist2", "GigabitEthernet2/0", "as2DEPT1", "GigabitEthernet1/0"),
+              Edge.fromStrings(
+                  "as3border1", "GigabitEthernet0/0", "as3core1", "GigabitEthernet1/0"),
+              Edge.fromStrings(
+                  "as3border1", "GigabitEthernet1/0", "as2border2", "GigabitEthernet0/0"),
+              Edge.fromStrings(
+                  "as3border2", "GigabitEthernet0/0", "as1bORder2", "GigabitEthernet0/0"),
+              Edge.fromStrings(
+                  "as3border2", "GigabitEthernet1/0", "as3core1", "GigabitEthernet0/0"),
+              Edge.fromStrings(
+                  "as3core1", "GigabitEthernet0/0", "as3border2", "GigabitEthernet1/0"),
+              Edge.fromStrings(
+                  "as3core1", "GigabitEthernet1/0", "as3border1", "GigabitEthernet0/0"),
+              Edge.fromStrings("as3core1", "GigabitEthernet2/0", "as3core1", "GigabitEthernet3/0"),
+              Edge.fromStrings("as3core1", "GigabitEthernet3/0", "as3core1", "GigabitEthernet2/0"),
+              Edge.fromStrings("host1", "eth0", "as2DEPT1", "GigabitEthernet2/0"),
+              Edge.fromStrings("host2", "eth0", "as2DEPT1", "GigabitEthernet3/0")));
 
   private static Set<String> filterSet(Set<String> nodes, Predicate<String> filter) {
     return nodes.stream().filter(filter).collect(ImmutableSet.toImmutableSet());

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/role/InferRolesTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/role/InferRolesTest.java
@@ -42,68 +42,46 @@ public class InferRolesTest {
   private static final Topology EXAMPLE_TOPOLOGY =
       new Topology(
           ImmutableSortedSet.of(
-              Edge.fromStrings(
-                  "as1border1", "GigabitEthernet0/0", "as1core1", "GigabitEthernet1/0"),
-              Edge.fromStrings(
-                  "as1border1", "GigabitEthernet1/0", "as2border1", "GigabitEthernet0/0"),
-              Edge.fromStrings(
-                  "as1border2", "GigabitEthernet0/0", "as3border2", "GigabitEthernet0/0"),
-              Edge.fromStrings(
-                  "as1border2", "GigabitEthernet1/0", "as1core1", "GigabitEthernet0/0"),
-              Edge.fromStrings(
-                  "as1core1", "GigabitEthernet0/0", "as1border2", "GigabitEthernet1/0"),
-              Edge.fromStrings(
-                  "as1core1", "GigabitEthernet1/0", "as1border1", "GigabitEthernet0/0"),
-              Edge.fromStrings(
-                  "as2border1", "GigabitEthernet0/0", "as1border1", "GigabitEthernet1/0"),
-              Edge.fromStrings(
-                  "as2border1", "GigabitEthernet1/0", "as2core1", "GigabitEthernet0/0"),
-              Edge.fromStrings(
-                  "as2border1", "GigabitEthernet2/0", "as2core2", "GigabitEthernet1/0"),
-              Edge.fromStrings(
-                  "as2border2", "GigabitEthernet0/0", "as3border1", "GigabitEthernet1/0"),
-              Edge.fromStrings(
-                  "as2border2", "GigabitEthernet1/0", "as2core2", "GigabitEthernet0/0"),
-              Edge.fromStrings(
-                  "as2border2", "GigabitEthernet2/0", "as2core1", "GigabitEthernet1/0"),
-              Edge.fromStrings(
-                  "as2core1", "GigabitEthernet0/0", "as2border1", "GigabitEthernet1/0"),
-              Edge.fromStrings(
-                  "as2core1", "GigabitEthernet1/0", "as2border2", "GigabitEthernet2/0"),
-              Edge.fromStrings("as2core1", "GigabitEthernet2/0", "as2dist1", "GigabitEthernet0/0"),
-              Edge.fromStrings("as2core1", "GigabitEthernet3/0", "as2dist2", "GigabitEthernet1/0"),
-              Edge.fromStrings(
-                  "as2core2", "GigabitEthernet0/0", "as2border2", "GigabitEthernet1/0"),
-              Edge.fromStrings(
-                  "as2core2", "GigabitEthernet1/0", "as2border1", "GigabitEthernet2/0"),
-              Edge.fromStrings("as2core2", "GigabitEthernet2/0", "as2dist2", "GigabitEthernet0/0"),
-              Edge.fromStrings("as2core2", "GigabitEthernet3/0", "as2dist1", "GigabitEthernet1/0"),
-              Edge.fromStrings("as2dept1", "GigabitEthernet0/0", "as2dist1", "GigabitEthernet2/0"),
-              Edge.fromStrings("as2dept1", "GigabitEthernet1/0", "as2dist2", "GigabitEthernet2/0"),
-              Edge.fromStrings("as2dept1", "GigabitEthernet2/0", "host1", "eth0"),
-              Edge.fromStrings("as2dept1", "GigabitEthernet3/0", "host2", "eth0"),
-              Edge.fromStrings("as2dist1", "GigabitEthernet0/0", "as2core1", "GigabitEthernet2/0"),
-              Edge.fromStrings("as2dist1", "GigabitEthernet1/0", "as2core2", "GigabitEthernet3/0"),
-              Edge.fromStrings("as2dist1", "GigabitEthernet2/0", "as2dept1", "GigabitEthernet0/0"),
-              Edge.fromStrings("as2dist2", "GigabitEthernet0/0", "as2core2", "GigabitEthernet2/0"),
-              Edge.fromStrings("as2dist2", "GigabitEthernet1/0", "as2core1", "GigabitEthernet3/0"),
-              Edge.fromStrings("as2dist2", "GigabitEthernet2/0", "as2dept1", "GigabitEthernet1/0"),
-              Edge.fromStrings(
-                  "as3border1", "GigabitEthernet0/0", "as3core1", "GigabitEthernet1/0"),
-              Edge.fromStrings(
-                  "as3border1", "GigabitEthernet1/0", "as2border2", "GigabitEthernet0/0"),
-              Edge.fromStrings(
-                  "as3border2", "GigabitEthernet0/0", "as1border2", "GigabitEthernet0/0"),
-              Edge.fromStrings(
-                  "as3border2", "GigabitEthernet1/0", "as3core1", "GigabitEthernet0/0"),
-              Edge.fromStrings(
-                  "as3core1", "GigabitEthernet0/0", "as3border2", "GigabitEthernet1/0"),
-              Edge.fromStrings(
-                  "as3core1", "GigabitEthernet1/0", "as3border1", "GigabitEthernet0/0"),
-              Edge.fromStrings("as3core1", "GigabitEthernet2/0", "as3core1", "GigabitEthernet3/0"),
-              Edge.fromStrings("as3core1", "GigabitEthernet3/0", "as3core1", "GigabitEthernet2/0"),
-              Edge.fromStrings("host1", "eth0", "as2dept1", "GigabitEthernet2/0"),
-              Edge.fromStrings("host2", "eth0", "as2dept1", "GigabitEthernet3/0")));
+              Edge.of("as1border1", "GigabitEthernet0/0", "as1core1", "GigabitEthernet1/0"),
+              Edge.of("as1border1", "GigabitEthernet1/0", "as2border1", "GigabitEthernet0/0"),
+              Edge.of("as1border2", "GigabitEthernet0/0", "as3border2", "GigabitEthernet0/0"),
+              Edge.of("as1border2", "GigabitEthernet1/0", "as1core1", "GigabitEthernet0/0"),
+              Edge.of("as1core1", "GigabitEthernet0/0", "as1border2", "GigabitEthernet1/0"),
+              Edge.of("as1core1", "GigabitEthernet1/0", "as1border1", "GigabitEthernet0/0"),
+              Edge.of("as2border1", "GigabitEthernet0/0", "as1border1", "GigabitEthernet1/0"),
+              Edge.of("as2border1", "GigabitEthernet1/0", "as2core1", "GigabitEthernet0/0"),
+              Edge.of("as2border1", "GigabitEthernet2/0", "as2core2", "GigabitEthernet1/0"),
+              Edge.of("as2border2", "GigabitEthernet0/0", "as3border1", "GigabitEthernet1/0"),
+              Edge.of("as2border2", "GigabitEthernet1/0", "as2core2", "GigabitEthernet0/0"),
+              Edge.of("as2border2", "GigabitEthernet2/0", "as2core1", "GigabitEthernet1/0"),
+              Edge.of("as2core1", "GigabitEthernet0/0", "as2border1", "GigabitEthernet1/0"),
+              Edge.of("as2core1", "GigabitEthernet1/0", "as2border2", "GigabitEthernet2/0"),
+              Edge.of("as2core1", "GigabitEthernet2/0", "as2dist1", "GigabitEthernet0/0"),
+              Edge.of("as2core1", "GigabitEthernet3/0", "as2dist2", "GigabitEthernet1/0"),
+              Edge.of("as2core2", "GigabitEthernet0/0", "as2border2", "GigabitEthernet1/0"),
+              Edge.of("as2core2", "GigabitEthernet1/0", "as2border1", "GigabitEthernet2/0"),
+              Edge.of("as2core2", "GigabitEthernet2/0", "as2dist2", "GigabitEthernet0/0"),
+              Edge.of("as2core2", "GigabitEthernet3/0", "as2dist1", "GigabitEthernet1/0"),
+              Edge.of("as2dept1", "GigabitEthernet0/0", "as2dist1", "GigabitEthernet2/0"),
+              Edge.of("as2dept1", "GigabitEthernet1/0", "as2dist2", "GigabitEthernet2/0"),
+              Edge.of("as2dept1", "GigabitEthernet2/0", "host1", "eth0"),
+              Edge.of("as2dept1", "GigabitEthernet3/0", "host2", "eth0"),
+              Edge.of("as2dist1", "GigabitEthernet0/0", "as2core1", "GigabitEthernet2/0"),
+              Edge.of("as2dist1", "GigabitEthernet1/0", "as2core2", "GigabitEthernet3/0"),
+              Edge.of("as2dist1", "GigabitEthernet2/0", "as2dept1", "GigabitEthernet0/0"),
+              Edge.of("as2dist2", "GigabitEthernet0/0", "as2core2", "GigabitEthernet2/0"),
+              Edge.of("as2dist2", "GigabitEthernet1/0", "as2core1", "GigabitEthernet3/0"),
+              Edge.of("as2dist2", "GigabitEthernet2/0", "as2dept1", "GigabitEthernet1/0"),
+              Edge.of("as3border1", "GigabitEthernet0/0", "as3core1", "GigabitEthernet1/0"),
+              Edge.of("as3border1", "GigabitEthernet1/0", "as2border2", "GigabitEthernet0/0"),
+              Edge.of("as3border2", "GigabitEthernet0/0", "as1border2", "GigabitEthernet0/0"),
+              Edge.of("as3border2", "GigabitEthernet1/0", "as3core1", "GigabitEthernet0/0"),
+              Edge.of("as3core1", "GigabitEthernet0/0", "as3border2", "GigabitEthernet1/0"),
+              Edge.of("as3core1", "GigabitEthernet1/0", "as3border1", "GigabitEthernet0/0"),
+              Edge.of("as3core1", "GigabitEthernet2/0", "as3core1", "GigabitEthernet3/0"),
+              Edge.of("as3core1", "GigabitEthernet3/0", "as3core1", "GigabitEthernet2/0"),
+              Edge.of("host1", "eth0", "as2dept1", "GigabitEthernet2/0"),
+              Edge.of("host2", "eth0", "as2dept1", "GigabitEthernet3/0")));
 
   private static Set<String> filterSet(Set<String> nodes, Predicate<String> filter) {
     return nodes.stream().filter(filter).collect(ImmutableSet.toImmutableSet());

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/role/InferRolesTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/role/InferRolesTest.java
@@ -42,46 +42,68 @@ public class InferRolesTest {
   private static final Topology EXAMPLE_TOPOLOGY =
       new Topology(
           ImmutableSortedSet.of(
-              new Edge("as1border1", "GigabitEthernet0/0", "as1core1", "GigabitEthernet1/0"),
-              new Edge("as1border1", "GigabitEthernet1/0", "as2border1", "GigabitEthernet0/0"),
-              new Edge("as1border2", "GigabitEthernet0/0", "as3border2", "GigabitEthernet0/0"),
-              new Edge("as1border2", "GigabitEthernet1/0", "as1core1", "GigabitEthernet0/0"),
-              new Edge("as1core1", "GigabitEthernet0/0", "as1border2", "GigabitEthernet1/0"),
-              new Edge("as1core1", "GigabitEthernet1/0", "as1border1", "GigabitEthernet0/0"),
-              new Edge("as2border1", "GigabitEthernet0/0", "as1border1", "GigabitEthernet1/0"),
-              new Edge("as2border1", "GigabitEthernet1/0", "as2core1", "GigabitEthernet0/0"),
-              new Edge("as2border1", "GigabitEthernet2/0", "as2core2", "GigabitEthernet1/0"),
-              new Edge("as2border2", "GigabitEthernet0/0", "as3border1", "GigabitEthernet1/0"),
-              new Edge("as2border2", "GigabitEthernet1/0", "as2core2", "GigabitEthernet0/0"),
-              new Edge("as2border2", "GigabitEthernet2/0", "as2core1", "GigabitEthernet1/0"),
-              new Edge("as2core1", "GigabitEthernet0/0", "as2border1", "GigabitEthernet1/0"),
-              new Edge("as2core1", "GigabitEthernet1/0", "as2border2", "GigabitEthernet2/0"),
-              new Edge("as2core1", "GigabitEthernet2/0", "as2dist1", "GigabitEthernet0/0"),
-              new Edge("as2core1", "GigabitEthernet3/0", "as2dist2", "GigabitEthernet1/0"),
-              new Edge("as2core2", "GigabitEthernet0/0", "as2border2", "GigabitEthernet1/0"),
-              new Edge("as2core2", "GigabitEthernet1/0", "as2border1", "GigabitEthernet2/0"),
-              new Edge("as2core2", "GigabitEthernet2/0", "as2dist2", "GigabitEthernet0/0"),
-              new Edge("as2core2", "GigabitEthernet3/0", "as2dist1", "GigabitEthernet1/0"),
-              new Edge("as2dept1", "GigabitEthernet0/0", "as2dist1", "GigabitEthernet2/0"),
-              new Edge("as2dept1", "GigabitEthernet1/0", "as2dist2", "GigabitEthernet2/0"),
-              new Edge("as2dept1", "GigabitEthernet2/0", "host1", "eth0"),
-              new Edge("as2dept1", "GigabitEthernet3/0", "host2", "eth0"),
-              new Edge("as2dist1", "GigabitEthernet0/0", "as2core1", "GigabitEthernet2/0"),
-              new Edge("as2dist1", "GigabitEthernet1/0", "as2core2", "GigabitEthernet3/0"),
-              new Edge("as2dist1", "GigabitEthernet2/0", "as2dept1", "GigabitEthernet0/0"),
-              new Edge("as2dist2", "GigabitEthernet0/0", "as2core2", "GigabitEthernet2/0"),
-              new Edge("as2dist2", "GigabitEthernet1/0", "as2core1", "GigabitEthernet3/0"),
-              new Edge("as2dist2", "GigabitEthernet2/0", "as2dept1", "GigabitEthernet1/0"),
-              new Edge("as3border1", "GigabitEthernet0/0", "as3core1", "GigabitEthernet1/0"),
-              new Edge("as3border1", "GigabitEthernet1/0", "as2border2", "GigabitEthernet0/0"),
-              new Edge("as3border2", "GigabitEthernet0/0", "as1border2", "GigabitEthernet0/0"),
-              new Edge("as3border2", "GigabitEthernet1/0", "as3core1", "GigabitEthernet0/0"),
-              new Edge("as3core1", "GigabitEthernet0/0", "as3border2", "GigabitEthernet1/0"),
-              new Edge("as3core1", "GigabitEthernet1/0", "as3border1", "GigabitEthernet0/0"),
-              new Edge("as3core1", "GigabitEthernet2/0", "as3core1", "GigabitEthernet3/0"),
-              new Edge("as3core1", "GigabitEthernet3/0", "as3core1", "GigabitEthernet2/0"),
-              new Edge("host1", "eth0", "as2dept1", "GigabitEthernet2/0"),
-              new Edge("host2", "eth0", "as2dept1", "GigabitEthernet3/0")));
+              Edge.fromStrings(
+                  "as1border1", "GigabitEthernet0/0", "as1core1", "GigabitEthernet1/0"),
+              Edge.fromStrings(
+                  "as1border1", "GigabitEthernet1/0", "as2border1", "GigabitEthernet0/0"),
+              Edge.fromStrings(
+                  "as1border2", "GigabitEthernet0/0", "as3border2", "GigabitEthernet0/0"),
+              Edge.fromStrings(
+                  "as1border2", "GigabitEthernet1/0", "as1core1", "GigabitEthernet0/0"),
+              Edge.fromStrings(
+                  "as1core1", "GigabitEthernet0/0", "as1border2", "GigabitEthernet1/0"),
+              Edge.fromStrings(
+                  "as1core1", "GigabitEthernet1/0", "as1border1", "GigabitEthernet0/0"),
+              Edge.fromStrings(
+                  "as2border1", "GigabitEthernet0/0", "as1border1", "GigabitEthernet1/0"),
+              Edge.fromStrings(
+                  "as2border1", "GigabitEthernet1/0", "as2core1", "GigabitEthernet0/0"),
+              Edge.fromStrings(
+                  "as2border1", "GigabitEthernet2/0", "as2core2", "GigabitEthernet1/0"),
+              Edge.fromStrings(
+                  "as2border2", "GigabitEthernet0/0", "as3border1", "GigabitEthernet1/0"),
+              Edge.fromStrings(
+                  "as2border2", "GigabitEthernet1/0", "as2core2", "GigabitEthernet0/0"),
+              Edge.fromStrings(
+                  "as2border2", "GigabitEthernet2/0", "as2core1", "GigabitEthernet1/0"),
+              Edge.fromStrings(
+                  "as2core1", "GigabitEthernet0/0", "as2border1", "GigabitEthernet1/0"),
+              Edge.fromStrings(
+                  "as2core1", "GigabitEthernet1/0", "as2border2", "GigabitEthernet2/0"),
+              Edge.fromStrings("as2core1", "GigabitEthernet2/0", "as2dist1", "GigabitEthernet0/0"),
+              Edge.fromStrings("as2core1", "GigabitEthernet3/0", "as2dist2", "GigabitEthernet1/0"),
+              Edge.fromStrings(
+                  "as2core2", "GigabitEthernet0/0", "as2border2", "GigabitEthernet1/0"),
+              Edge.fromStrings(
+                  "as2core2", "GigabitEthernet1/0", "as2border1", "GigabitEthernet2/0"),
+              Edge.fromStrings("as2core2", "GigabitEthernet2/0", "as2dist2", "GigabitEthernet0/0"),
+              Edge.fromStrings("as2core2", "GigabitEthernet3/0", "as2dist1", "GigabitEthernet1/0"),
+              Edge.fromStrings("as2dept1", "GigabitEthernet0/0", "as2dist1", "GigabitEthernet2/0"),
+              Edge.fromStrings("as2dept1", "GigabitEthernet1/0", "as2dist2", "GigabitEthernet2/0"),
+              Edge.fromStrings("as2dept1", "GigabitEthernet2/0", "host1", "eth0"),
+              Edge.fromStrings("as2dept1", "GigabitEthernet3/0", "host2", "eth0"),
+              Edge.fromStrings("as2dist1", "GigabitEthernet0/0", "as2core1", "GigabitEthernet2/0"),
+              Edge.fromStrings("as2dist1", "GigabitEthernet1/0", "as2core2", "GigabitEthernet3/0"),
+              Edge.fromStrings("as2dist1", "GigabitEthernet2/0", "as2dept1", "GigabitEthernet0/0"),
+              Edge.fromStrings("as2dist2", "GigabitEthernet0/0", "as2core2", "GigabitEthernet2/0"),
+              Edge.fromStrings("as2dist2", "GigabitEthernet1/0", "as2core1", "GigabitEthernet3/0"),
+              Edge.fromStrings("as2dist2", "GigabitEthernet2/0", "as2dept1", "GigabitEthernet1/0"),
+              Edge.fromStrings(
+                  "as3border1", "GigabitEthernet0/0", "as3core1", "GigabitEthernet1/0"),
+              Edge.fromStrings(
+                  "as3border1", "GigabitEthernet1/0", "as2border2", "GigabitEthernet0/0"),
+              Edge.fromStrings(
+                  "as3border2", "GigabitEthernet0/0", "as1border2", "GigabitEthernet0/0"),
+              Edge.fromStrings(
+                  "as3border2", "GigabitEthernet1/0", "as3core1", "GigabitEthernet0/0"),
+              Edge.fromStrings(
+                  "as3core1", "GigabitEthernet0/0", "as3border2", "GigabitEthernet1/0"),
+              Edge.fromStrings(
+                  "as3core1", "GigabitEthernet1/0", "as3border1", "GigabitEthernet0/0"),
+              Edge.fromStrings("as3core1", "GigabitEthernet2/0", "as3core1", "GigabitEthernet3/0"),
+              Edge.fromStrings("as3core1", "GigabitEthernet3/0", "as3core1", "GigabitEthernet2/0"),
+              Edge.fromStrings("host1", "eth0", "as2dept1", "GigabitEthernet2/0"),
+              Edge.fromStrings("host2", "eth0", "as2dept1", "GigabitEthernet3/0")));
 
   private static Set<String> filterSet(Set<String> nodes, Predicate<String> filter) {
     return nodes.stream().filter(filter).collect(ImmutableSet.toImmutableSet());

--- a/projects/batfish/src/main/java/org/batfish/dataplane/TracerouteEngineImplContext.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/TracerouteEngineImplContext.java
@@ -592,7 +592,7 @@ class TracerouteEngineImplContext {
               String ingressInterfaceName = flow.getIngressInterface();
               if (ingressInterfaceName != null) {
                 Edge edge =
-                    Edge.fromStrings(
+                    Edge.of(
                         TRACEROUTE_INGRESS_NODE_NAME,
                         TRACEROUTE_INGRESS_NODE_INTERFACE_NAME,
                         ingressNodeName,

--- a/projects/batfish/src/main/java/org/batfish/dataplane/TracerouteEngineImplContext.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/TracerouteEngineImplContext.java
@@ -592,7 +592,7 @@ class TracerouteEngineImplContext {
               String ingressInterfaceName = flow.getIngressInterface();
               if (ingressInterfaceName != null) {
                 Edge edge =
-                    new Edge(
+                    Edge.fromStrings(
                         TRACEROUTE_INGRESS_NODE_NAME,
                         TRACEROUTE_INGRESS_NODE_INTERFACE_NAME,
                         ingressNodeName,

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -1434,9 +1434,8 @@ public class Batfish extends PluginConsumer implements IBatfish {
       if (consumedEdges.contains(edge)) {
         continue;
       }
-      Edge reverseEdge = new Edge(edge.getInterface2(), edge.getInterface1());
       consumedEdges.add(edge);
-      consumedEdges.add(reverseEdge);
+      consumedEdges.add(edge.reverse());
     }
     return consumedEdges;
   }

--- a/projects/batfish/src/main/java/org/batfish/symbolic/Graph.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/Graph.java
@@ -399,7 +399,7 @@ public class Graph {
               }
               // Only look at the first pair
               if (!router.equals(e.getNode2())) {
-                Interface i2 = ifaceMap.get(e.getInterface2());
+                Interface i2 = ifaceMap.get(e.getHead());
                 String neighbor = e.getNode2();
                 GraphEdge ge1 = new GraphEdge(i1, i2, router, neighbor, false, false);
                 GraphEdge ge2 = new GraphEdge(i2, i1, neighbor, router, false, false);

--- a/projects/batfish/src/main/java/org/batfish/symbolic/smt/CounterExample.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/smt/CounterExample.java
@@ -121,7 +121,7 @@ class CounterExample {
     String int1 = graphEdge.getStart() == null ? "none" : graphEdge.getStart().getName();
     String node2 = graphEdge.getPeer();
     String int2 = graphEdge.getEnd() == null ? "none" : graphEdge.getEnd().getName();
-    return Edge.fromStrings(node1, int1, node2, int2);
+    return Edge.of(node1, int1, node2, int2);
   }
 
   SortedSet<Edge> buildFailedLinks(Encoder encoder) {
@@ -232,7 +232,7 @@ class CounterExample {
     String int1 = graphEdge.getStart().getName();
     String node2 = graphEdge.getPeer() == null ? "(none)" : graphEdge.getPeer();
     String int2 = graphEdge.getEnd() == null ? "null_interface" : graphEdge.getEnd().getName();
-    Edge edge = Edge.fromStrings(node1, int1, node2, int2);
+    Edge edge = Edge.of(node1, int1, node2, int2);
     SortedSet<String> routes = new TreeSet<>();
     routes.add(route);
     return new FlowTraceHop(edge, routes, null, null, null);

--- a/projects/batfish/src/main/java/org/batfish/symbolic/smt/CounterExample.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/smt/CounterExample.java
@@ -121,7 +121,7 @@ class CounterExample {
     String int1 = graphEdge.getStart() == null ? "none" : graphEdge.getStart().getName();
     String node2 = graphEdge.getPeer();
     String int2 = graphEdge.getEnd() == null ? "none" : graphEdge.getEnd().getName();
-    return new Edge(node1, int1, node2, int2);
+    return Edge.fromStrings(node1, int1, node2, int2);
   }
 
   SortedSet<Edge> buildFailedLinks(Encoder encoder) {
@@ -232,7 +232,7 @@ class CounterExample {
     String int1 = graphEdge.getStart().getName();
     String node2 = graphEdge.getPeer() == null ? "(none)" : graphEdge.getPeer();
     String int2 = graphEdge.getEnd() == null ? "null_interface" : graphEdge.getEnd().getName();
-    Edge edge = new Edge(node1, int1, node2, int2);
+    Edge edge = Edge.fromStrings(node1, int1, node2, int2);
     SortedSet<String> routes = new TreeSet<>();
     routes.add(route);
     return new FlowTraceHop(edge, routes, null, null, null);

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
@@ -166,7 +166,8 @@ public class BatfishTest {
 
     assertThat(
         batfish.computeTestrigTopology(batfish.loadConfigurations()).getEdges(),
-        containsInAnyOrder(new Edge("c1", "i1", "c2", "i2"), new Edge("c2", "i2", "c1", "i1")));
+        containsInAnyOrder(
+            Edge.fromStrings("c1", "i1", "c2", "i2"), Edge.fromStrings("c2", "i2", "c1", "i1")));
   }
 
   @Test
@@ -181,7 +182,8 @@ public class BatfishTest {
 
     assertThat(
         batfish.computeTestrigTopology(batfish.loadConfigurations()).getEdges(),
-        containsInAnyOrder(new Edge("c1", "i1", "c2", "i2"), new Edge("c2", "i2", "c1", "i1")));
+        containsInAnyOrder(
+            Edge.fromStrings("c1", "i1", "c2", "i2"), Edge.fromStrings("c2", "i2", "c1", "i1")));
   }
 
   @Test
@@ -238,7 +240,7 @@ public class BatfishTest {
     configs.put(
         "h2", BatfishTestUtils.createTestConfiguration("h2", ConfigurationFormat.HOST, "e0"));
     SortedSet<Edge> edges =
-        new TreeSet<>(Collections.singletonList(new Edge("h1", "eth0", "h2", "e0")));
+        new TreeSet<>(Collections.singletonList(Edge.fromStrings("h1", "eth0", "h2", "e0")));
     Topology topology = new Topology(edges);
 
     // test that checkTopology does not throw
@@ -251,7 +253,7 @@ public class BatfishTest {
     configs.put(
         "h1", BatfishTestUtils.createTestConfiguration("h1", ConfigurationFormat.HOST, "eth0"));
     SortedSet<Edge> edges =
-        new TreeSet<>(Collections.singletonList(new Edge("h1", "eth0", "h2", "e0")));
+        new TreeSet<>(Collections.singletonList(Edge.fromStrings("h1", "eth0", "h2", "e0")));
     Topology topology = new Topology(edges);
 
     _thrown.expect(BatfishException.class);
@@ -267,7 +269,7 @@ public class BatfishTest {
     configs.put(
         "h2", BatfishTestUtils.createTestConfiguration("h2", ConfigurationFormat.HOST, "e0"));
     SortedSet<Edge> edges =
-        new TreeSet<>(Collections.singletonList(new Edge("h1", "eth1", "h2", "e0")));
+        new TreeSet<>(Collections.singletonList(Edge.fromStrings("h1", "eth1", "h2", "e0")));
     Topology topology = new Topology(edges);
 
     _thrown.expect(BatfishException.class);

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
@@ -166,8 +166,7 @@ public class BatfishTest {
 
     assertThat(
         batfish.computeTestrigTopology(batfish.loadConfigurations()).getEdges(),
-        containsInAnyOrder(
-            Edge.fromStrings("c1", "i1", "c2", "i2"), Edge.fromStrings("c2", "i2", "c1", "i1")));
+        containsInAnyOrder(Edge.of("c1", "i1", "c2", "i2"), Edge.of("c2", "i2", "c1", "i1")));
   }
 
   @Test
@@ -182,8 +181,7 @@ public class BatfishTest {
 
     assertThat(
         batfish.computeTestrigTopology(batfish.loadConfigurations()).getEdges(),
-        containsInAnyOrder(
-            Edge.fromStrings("c1", "i1", "c2", "i2"), Edge.fromStrings("c2", "i2", "c1", "i1")));
+        containsInAnyOrder(Edge.of("c1", "i1", "c2", "i2"), Edge.of("c2", "i2", "c1", "i1")));
   }
 
   @Test
@@ -240,7 +238,7 @@ public class BatfishTest {
     configs.put(
         "h2", BatfishTestUtils.createTestConfiguration("h2", ConfigurationFormat.HOST, "e0"));
     SortedSet<Edge> edges =
-        new TreeSet<>(Collections.singletonList(Edge.fromStrings("h1", "eth0", "h2", "e0")));
+        new TreeSet<>(Collections.singletonList(Edge.of("h1", "eth0", "h2", "e0")));
     Topology topology = new Topology(edges);
 
     // test that checkTopology does not throw
@@ -253,7 +251,7 @@ public class BatfishTest {
     configs.put(
         "h1", BatfishTestUtils.createTestConfiguration("h1", ConfigurationFormat.HOST, "eth0"));
     SortedSet<Edge> edges =
-        new TreeSet<>(Collections.singletonList(Edge.fromStrings("h1", "eth0", "h2", "e0")));
+        new TreeSet<>(Collections.singletonList(Edge.of("h1", "eth0", "h2", "e0")));
     Topology topology = new Topology(edges);
 
     _thrown.expect(BatfishException.class);
@@ -269,7 +267,7 @@ public class BatfishTest {
     configs.put(
         "h2", BatfishTestUtils.createTestConfiguration("h2", ConfigurationFormat.HOST, "e0"));
     SortedSet<Edge> edges =
-        new TreeSet<>(Collections.singletonList(Edge.fromStrings("h1", "eth1", "h2", "e0")));
+        new TreeSet<>(Collections.singletonList(Edge.of("h1", "eth1", "h2", "e0")));
     Topology topology = new Topology(edges);
 
     _thrown.expect(BatfishException.class);

--- a/projects/batfish/src/test/java/org/batfish/z3/SynthesizerInputImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/SynthesizerInputImplTest.java
@@ -275,11 +275,9 @@ public class SynthesizerInputImplTest {
     BooleanExpr m2 =
         ipSpace2.accept(new IpSpaceBooleanExprTransformer(ImmutableMap.of(), Field.DST_IP));
     Edge edge1 =
-        Edge.fromStrings(
-            srcNode.getHostname(), srcInterface.getName(), nextHop1, nextHopInterface1);
+        Edge.of(srcNode.getHostname(), srcInterface.getName(), nextHop1, nextHopInterface1);
     Edge edge2 =
-        Edge.fromStrings(
-            srcNode.getHostname(), srcInterface.getName(), nextHop2, nextHopInterface2);
+        Edge.of(srcNode.getHostname(), srcInterface.getName(), nextHop2, nextHopInterface2);
 
     SynthesizerInput inputWithoutDataPlane =
         _inputBuilder.setConfigurations(ImmutableMap.of(srcNode.getHostname(), srcNode)).build();

--- a/projects/batfish/src/test/java/org/batfish/z3/SynthesizerInputImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/SynthesizerInputImplTest.java
@@ -275,9 +275,11 @@ public class SynthesizerInputImplTest {
     BooleanExpr m2 =
         ipSpace2.accept(new IpSpaceBooleanExprTransformer(ImmutableMap.of(), Field.DST_IP));
     Edge edge1 =
-        new Edge(srcNode.getHostname(), srcInterface.getName(), nextHop1, nextHopInterface1);
+        Edge.fromStrings(
+            srcNode.getHostname(), srcInterface.getName(), nextHop1, nextHopInterface1);
     Edge edge2 =
-        new Edge(srcNode.getHostname(), srcInterface.getName(), nextHop2, nextHopInterface2);
+        Edge.fromStrings(
+            srcNode.getHostname(), srcInterface.getName(), nextHop2, nextHopInterface2);
 
     SynthesizerInput inputWithoutDataPlane =
         _inputBuilder.setConfigurations(ImmutableMap.of(srcNode.getHostname(), srcNode)).build();

--- a/projects/batfish/src/test/java/org/batfish/z3/state/visitors/DefaultTransitionGeneratorTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/state/visitors/DefaultTransitionGeneratorTest.java
@@ -168,14 +168,14 @@ public class DefaultTransitionGeneratorTest {
         MockSynthesizerInput.builder()
             .setEnabledEdges(
                 ImmutableSet.of(
-                    new Edge(NODE1, INTERFACE1, NODE2, INTERFACE1),
-                    new Edge(NODE1, INTERFACE1, NODE2, INTERFACE2),
-                    new Edge(NODE1, INTERFACE2, NODE2, INTERFACE1),
-                    new Edge(NODE1, INTERFACE2, NODE2, INTERFACE2),
-                    new Edge(NODE2, INTERFACE1, NODE1, INTERFACE1),
-                    new Edge(NODE2, INTERFACE1, NODE1, INTERFACE2),
-                    new Edge(NODE2, INTERFACE2, NODE1, INTERFACE1),
-                    new Edge(NODE2, INTERFACE2, NODE1, INTERFACE2)))
+                    Edge.fromStrings(NODE1, INTERFACE1, NODE2, INTERFACE1),
+                    Edge.fromStrings(NODE1, INTERFACE1, NODE2, INTERFACE2),
+                    Edge.fromStrings(NODE1, INTERFACE2, NODE2, INTERFACE1),
+                    Edge.fromStrings(NODE1, INTERFACE2, NODE2, INTERFACE2),
+                    Edge.fromStrings(NODE2, INTERFACE1, NODE1, INTERFACE1),
+                    Edge.fromStrings(NODE2, INTERFACE1, NODE1, INTERFACE2),
+                    Edge.fromStrings(NODE2, INTERFACE2, NODE1, INTERFACE1),
+                    Edge.fromStrings(NODE2, INTERFACE2, NODE1, INTERFACE2)))
             .build();
     Set<RuleStatement> rules =
         ImmutableSet.copyOf(
@@ -843,10 +843,10 @@ public class DefaultTransitionGeneratorTest {
         MockSynthesizerInput.builder()
             .setEnabledEdges(
                 ImmutableSet.of(
-                    new Edge(NODE1, INTERFACE1, NODE2, INTERFACE1),
-                    new Edge(NODE1, INTERFACE2, NODE2, INTERFACE2),
-                    new Edge(NODE2, INTERFACE1, NODE1, INTERFACE1),
-                    new Edge(NODE2, INTERFACE2, NODE1, INTERFACE2)))
+                    Edge.fromStrings(NODE1, INTERFACE1, NODE2, INTERFACE1),
+                    Edge.fromStrings(NODE1, INTERFACE2, NODE2, INTERFACE2),
+                    Edge.fromStrings(NODE2, INTERFACE1, NODE1, INTERFACE1),
+                    Edge.fromStrings(NODE2, INTERFACE2, NODE1, INTERFACE2)))
             .setOutgoingAcls(
                 ImmutableMap.of(
                     NODE1,
@@ -1219,8 +1219,8 @@ public class DefaultTransitionGeneratorTest {
                     NODE1, ImmutableSet.of(VRF1, VRF2), NODE2, ImmutableSet.of(VRF1, VRF2)))
             .setEnabledEdges(
                 ImmutableSet.of(
-                    new Edge(NODE1, INTERFACE1, NODE2, INTERFACE1),
-                    new Edge(NODE2, INTERFACE1, NODE1, INTERFACE1)))
+                    Edge.fromStrings(NODE1, INTERFACE1, NODE2, INTERFACE1),
+                    Edge.fromStrings(NODE2, INTERFACE1, NODE1, INTERFACE1)))
             .setOutgoingAcls(
                 ImmutableMap.of(
                     NODE1, ImmutableMap.of(),
@@ -1326,10 +1326,10 @@ public class DefaultTransitionGeneratorTest {
         MockSynthesizerInput.builder()
             .setEnabledEdges(
                 ImmutableSet.of(
-                    new Edge(NODE1, INTERFACE1, NODE2, INTERFACE1),
-                    new Edge(NODE1, INTERFACE2, NODE2, INTERFACE2),
-                    new Edge(NODE1, INTERFACE3, NODE2, INTERFACE3),
-                    new Edge(NODE2, INTERFACE1, NODE1, INTERFACE1)))
+                    Edge.fromStrings(NODE1, INTERFACE1, NODE2, INTERFACE1),
+                    Edge.fromStrings(NODE1, INTERFACE2, NODE2, INTERFACE2),
+                    Edge.fromStrings(NODE1, INTERFACE3, NODE2, INTERFACE3),
+                    Edge.fromStrings(NODE2, INTERFACE1, NODE1, INTERFACE1)))
             .setOutgoingAcls(
                 ImmutableMap.of(
                     NODE1,
@@ -1427,8 +1427,8 @@ public class DefaultTransitionGeneratorTest {
         MockSynthesizerInput.builder()
             .setEnabledEdges(
                 ImmutableSet.of(
-                    new Edge(NODE1, INTERFACE1, NODE2, INTERFACE1),
-                    new Edge(NODE2, INTERFACE1, NODE1, INTERFACE1)))
+                    Edge.fromStrings(NODE1, INTERFACE1, NODE2, INTERFACE1),
+                    Edge.fromStrings(NODE2, INTERFACE1, NODE1, INTERFACE1)))
             .setOutgoingAcls(
                 ImmutableMap.of(
                     NODE1, ImmutableMap.of(),
@@ -1474,8 +1474,8 @@ public class DefaultTransitionGeneratorTest {
                     ImmutableMap.of(VRF1, ImmutableSet.of(INTERFACE1))))
             .setEnabledEdges(
                 ImmutableSet.of(
-                    new Edge(NODE1, INTERFACE1, NODE2, INTERFACE1),
-                    new Edge(NODE2, INTERFACE1, NODE1, INTERFACE1)))
+                    Edge.fromStrings(NODE1, INTERFACE1, NODE2, INTERFACE1),
+                    Edge.fromStrings(NODE2, INTERFACE1, NODE1, INTERFACE1)))
             .setOutgoingAcls(
                 ImmutableMap.of(
                     NODE1, ImmutableMap.of(),
@@ -1523,24 +1523,24 @@ public class DefaultTransitionGeneratorTest {
                     NODE2, ImmutableSet.of(INTERFACE1, INTERFACE2, INTERFACE3)))
             .setEnabledEdges(
                 ImmutableSet.of(
-                    new Edge(NODE1, INTERFACE1, NODE2, INTERFACE1),
-                    new Edge(NODE1, INTERFACE1, NODE2, INTERFACE2),
-                    new Edge(NODE1, INTERFACE1, NODE2, INTERFACE3),
-                    new Edge(NODE1, INTERFACE2, NODE2, INTERFACE1),
-                    new Edge(NODE1, INTERFACE2, NODE2, INTERFACE2),
-                    new Edge(NODE1, INTERFACE2, NODE2, INTERFACE3),
-                    new Edge(NODE1, INTERFACE3, NODE2, INTERFACE1),
-                    new Edge(NODE1, INTERFACE3, NODE2, INTERFACE2),
-                    new Edge(NODE1, INTERFACE3, NODE2, INTERFACE3),
-                    new Edge(NODE2, INTERFACE1, NODE1, INTERFACE1),
-                    new Edge(NODE2, INTERFACE1, NODE1, INTERFACE2),
-                    new Edge(NODE2, INTERFACE1, NODE1, INTERFACE3),
-                    new Edge(NODE2, INTERFACE2, NODE1, INTERFACE1),
-                    new Edge(NODE2, INTERFACE2, NODE1, INTERFACE2),
-                    new Edge(NODE2, INTERFACE2, NODE1, INTERFACE3),
-                    new Edge(NODE2, INTERFACE3, NODE1, INTERFACE1),
-                    new Edge(NODE2, INTERFACE3, NODE1, INTERFACE2),
-                    new Edge(NODE2, INTERFACE3, NODE1, INTERFACE3)))
+                    Edge.fromStrings(NODE1, INTERFACE1, NODE2, INTERFACE1),
+                    Edge.fromStrings(NODE1, INTERFACE1, NODE2, INTERFACE2),
+                    Edge.fromStrings(NODE1, INTERFACE1, NODE2, INTERFACE3),
+                    Edge.fromStrings(NODE1, INTERFACE2, NODE2, INTERFACE1),
+                    Edge.fromStrings(NODE1, INTERFACE2, NODE2, INTERFACE2),
+                    Edge.fromStrings(NODE1, INTERFACE2, NODE2, INTERFACE3),
+                    Edge.fromStrings(NODE1, INTERFACE3, NODE2, INTERFACE1),
+                    Edge.fromStrings(NODE1, INTERFACE3, NODE2, INTERFACE2),
+                    Edge.fromStrings(NODE1, INTERFACE3, NODE2, INTERFACE3),
+                    Edge.fromStrings(NODE2, INTERFACE1, NODE1, INTERFACE1),
+                    Edge.fromStrings(NODE2, INTERFACE1, NODE1, INTERFACE2),
+                    Edge.fromStrings(NODE2, INTERFACE1, NODE1, INTERFACE3),
+                    Edge.fromStrings(NODE2, INTERFACE2, NODE1, INTERFACE1),
+                    Edge.fromStrings(NODE2, INTERFACE2, NODE1, INTERFACE2),
+                    Edge.fromStrings(NODE2, INTERFACE2, NODE1, INTERFACE3),
+                    Edge.fromStrings(NODE2, INTERFACE3, NODE1, INTERFACE1),
+                    Edge.fromStrings(NODE2, INTERFACE3, NODE1, INTERFACE2),
+                    Edge.fromStrings(NODE2, INTERFACE3, NODE1, INTERFACE3)))
             .setNodeInterfaces(
                 ImmutableMap.of(
                     NODE1, ImmutableList.of(INTERFACE1, INTERFACE2, INTERFACE3),
@@ -1881,7 +1881,8 @@ public class DefaultTransitionGeneratorTest {
   public void testVisitPreOutEdgePostNat_topologyInterfaceWithNAT() {
     SynthesizerInput input =
         MockSynthesizerInput.builder()
-            .setEnabledEdges(ImmutableSet.of(new Edge(NODE1, INTERFACE1, NODE2, INTERFACE2)))
+            .setEnabledEdges(
+                ImmutableSet.of(Edge.fromStrings(NODE1, INTERFACE1, NODE2, INTERFACE2)))
             .setTopologyInterfaces(ImmutableMap.of(NODE1, ImmutableSet.of(INTERFACE1)))
             .setSourceNats(
                 ImmutableMap.of(

--- a/projects/batfish/src/test/java/org/batfish/z3/state/visitors/DefaultTransitionGeneratorTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/state/visitors/DefaultTransitionGeneratorTest.java
@@ -168,14 +168,14 @@ public class DefaultTransitionGeneratorTest {
         MockSynthesizerInput.builder()
             .setEnabledEdges(
                 ImmutableSet.of(
-                    Edge.fromStrings(NODE1, INTERFACE1, NODE2, INTERFACE1),
-                    Edge.fromStrings(NODE1, INTERFACE1, NODE2, INTERFACE2),
-                    Edge.fromStrings(NODE1, INTERFACE2, NODE2, INTERFACE1),
-                    Edge.fromStrings(NODE1, INTERFACE2, NODE2, INTERFACE2),
-                    Edge.fromStrings(NODE2, INTERFACE1, NODE1, INTERFACE1),
-                    Edge.fromStrings(NODE2, INTERFACE1, NODE1, INTERFACE2),
-                    Edge.fromStrings(NODE2, INTERFACE2, NODE1, INTERFACE1),
-                    Edge.fromStrings(NODE2, INTERFACE2, NODE1, INTERFACE2)))
+                    Edge.of(NODE1, INTERFACE1, NODE2, INTERFACE1),
+                    Edge.of(NODE1, INTERFACE1, NODE2, INTERFACE2),
+                    Edge.of(NODE1, INTERFACE2, NODE2, INTERFACE1),
+                    Edge.of(NODE1, INTERFACE2, NODE2, INTERFACE2),
+                    Edge.of(NODE2, INTERFACE1, NODE1, INTERFACE1),
+                    Edge.of(NODE2, INTERFACE1, NODE1, INTERFACE2),
+                    Edge.of(NODE2, INTERFACE2, NODE1, INTERFACE1),
+                    Edge.of(NODE2, INTERFACE2, NODE1, INTERFACE2)))
             .build();
     Set<RuleStatement> rules =
         ImmutableSet.copyOf(
@@ -843,10 +843,10 @@ public class DefaultTransitionGeneratorTest {
         MockSynthesizerInput.builder()
             .setEnabledEdges(
                 ImmutableSet.of(
-                    Edge.fromStrings(NODE1, INTERFACE1, NODE2, INTERFACE1),
-                    Edge.fromStrings(NODE1, INTERFACE2, NODE2, INTERFACE2),
-                    Edge.fromStrings(NODE2, INTERFACE1, NODE1, INTERFACE1),
-                    Edge.fromStrings(NODE2, INTERFACE2, NODE1, INTERFACE2)))
+                    Edge.of(NODE1, INTERFACE1, NODE2, INTERFACE1),
+                    Edge.of(NODE1, INTERFACE2, NODE2, INTERFACE2),
+                    Edge.of(NODE2, INTERFACE1, NODE1, INTERFACE1),
+                    Edge.of(NODE2, INTERFACE2, NODE1, INTERFACE2)))
             .setOutgoingAcls(
                 ImmutableMap.of(
                     NODE1,
@@ -1219,8 +1219,8 @@ public class DefaultTransitionGeneratorTest {
                     NODE1, ImmutableSet.of(VRF1, VRF2), NODE2, ImmutableSet.of(VRF1, VRF2)))
             .setEnabledEdges(
                 ImmutableSet.of(
-                    Edge.fromStrings(NODE1, INTERFACE1, NODE2, INTERFACE1),
-                    Edge.fromStrings(NODE2, INTERFACE1, NODE1, INTERFACE1)))
+                    Edge.of(NODE1, INTERFACE1, NODE2, INTERFACE1),
+                    Edge.of(NODE2, INTERFACE1, NODE1, INTERFACE1)))
             .setOutgoingAcls(
                 ImmutableMap.of(
                     NODE1, ImmutableMap.of(),
@@ -1326,10 +1326,10 @@ public class DefaultTransitionGeneratorTest {
         MockSynthesizerInput.builder()
             .setEnabledEdges(
                 ImmutableSet.of(
-                    Edge.fromStrings(NODE1, INTERFACE1, NODE2, INTERFACE1),
-                    Edge.fromStrings(NODE1, INTERFACE2, NODE2, INTERFACE2),
-                    Edge.fromStrings(NODE1, INTERFACE3, NODE2, INTERFACE3),
-                    Edge.fromStrings(NODE2, INTERFACE1, NODE1, INTERFACE1)))
+                    Edge.of(NODE1, INTERFACE1, NODE2, INTERFACE1),
+                    Edge.of(NODE1, INTERFACE2, NODE2, INTERFACE2),
+                    Edge.of(NODE1, INTERFACE3, NODE2, INTERFACE3),
+                    Edge.of(NODE2, INTERFACE1, NODE1, INTERFACE1)))
             .setOutgoingAcls(
                 ImmutableMap.of(
                     NODE1,
@@ -1427,8 +1427,8 @@ public class DefaultTransitionGeneratorTest {
         MockSynthesizerInput.builder()
             .setEnabledEdges(
                 ImmutableSet.of(
-                    Edge.fromStrings(NODE1, INTERFACE1, NODE2, INTERFACE1),
-                    Edge.fromStrings(NODE2, INTERFACE1, NODE1, INTERFACE1)))
+                    Edge.of(NODE1, INTERFACE1, NODE2, INTERFACE1),
+                    Edge.of(NODE2, INTERFACE1, NODE1, INTERFACE1)))
             .setOutgoingAcls(
                 ImmutableMap.of(
                     NODE1, ImmutableMap.of(),
@@ -1474,8 +1474,8 @@ public class DefaultTransitionGeneratorTest {
                     ImmutableMap.of(VRF1, ImmutableSet.of(INTERFACE1))))
             .setEnabledEdges(
                 ImmutableSet.of(
-                    Edge.fromStrings(NODE1, INTERFACE1, NODE2, INTERFACE1),
-                    Edge.fromStrings(NODE2, INTERFACE1, NODE1, INTERFACE1)))
+                    Edge.of(NODE1, INTERFACE1, NODE2, INTERFACE1),
+                    Edge.of(NODE2, INTERFACE1, NODE1, INTERFACE1)))
             .setOutgoingAcls(
                 ImmutableMap.of(
                     NODE1, ImmutableMap.of(),
@@ -1523,24 +1523,24 @@ public class DefaultTransitionGeneratorTest {
                     NODE2, ImmutableSet.of(INTERFACE1, INTERFACE2, INTERFACE3)))
             .setEnabledEdges(
                 ImmutableSet.of(
-                    Edge.fromStrings(NODE1, INTERFACE1, NODE2, INTERFACE1),
-                    Edge.fromStrings(NODE1, INTERFACE1, NODE2, INTERFACE2),
-                    Edge.fromStrings(NODE1, INTERFACE1, NODE2, INTERFACE3),
-                    Edge.fromStrings(NODE1, INTERFACE2, NODE2, INTERFACE1),
-                    Edge.fromStrings(NODE1, INTERFACE2, NODE2, INTERFACE2),
-                    Edge.fromStrings(NODE1, INTERFACE2, NODE2, INTERFACE3),
-                    Edge.fromStrings(NODE1, INTERFACE3, NODE2, INTERFACE1),
-                    Edge.fromStrings(NODE1, INTERFACE3, NODE2, INTERFACE2),
-                    Edge.fromStrings(NODE1, INTERFACE3, NODE2, INTERFACE3),
-                    Edge.fromStrings(NODE2, INTERFACE1, NODE1, INTERFACE1),
-                    Edge.fromStrings(NODE2, INTERFACE1, NODE1, INTERFACE2),
-                    Edge.fromStrings(NODE2, INTERFACE1, NODE1, INTERFACE3),
-                    Edge.fromStrings(NODE2, INTERFACE2, NODE1, INTERFACE1),
-                    Edge.fromStrings(NODE2, INTERFACE2, NODE1, INTERFACE2),
-                    Edge.fromStrings(NODE2, INTERFACE2, NODE1, INTERFACE3),
-                    Edge.fromStrings(NODE2, INTERFACE3, NODE1, INTERFACE1),
-                    Edge.fromStrings(NODE2, INTERFACE3, NODE1, INTERFACE2),
-                    Edge.fromStrings(NODE2, INTERFACE3, NODE1, INTERFACE3)))
+                    Edge.of(NODE1, INTERFACE1, NODE2, INTERFACE1),
+                    Edge.of(NODE1, INTERFACE1, NODE2, INTERFACE2),
+                    Edge.of(NODE1, INTERFACE1, NODE2, INTERFACE3),
+                    Edge.of(NODE1, INTERFACE2, NODE2, INTERFACE1),
+                    Edge.of(NODE1, INTERFACE2, NODE2, INTERFACE2),
+                    Edge.of(NODE1, INTERFACE2, NODE2, INTERFACE3),
+                    Edge.of(NODE1, INTERFACE3, NODE2, INTERFACE1),
+                    Edge.of(NODE1, INTERFACE3, NODE2, INTERFACE2),
+                    Edge.of(NODE1, INTERFACE3, NODE2, INTERFACE3),
+                    Edge.of(NODE2, INTERFACE1, NODE1, INTERFACE1),
+                    Edge.of(NODE2, INTERFACE1, NODE1, INTERFACE2),
+                    Edge.of(NODE2, INTERFACE1, NODE1, INTERFACE3),
+                    Edge.of(NODE2, INTERFACE2, NODE1, INTERFACE1),
+                    Edge.of(NODE2, INTERFACE2, NODE1, INTERFACE2),
+                    Edge.of(NODE2, INTERFACE2, NODE1, INTERFACE3),
+                    Edge.of(NODE2, INTERFACE3, NODE1, INTERFACE1),
+                    Edge.of(NODE2, INTERFACE3, NODE1, INTERFACE2),
+                    Edge.of(NODE2, INTERFACE3, NODE1, INTERFACE3)))
             .setNodeInterfaces(
                 ImmutableMap.of(
                     NODE1, ImmutableList.of(INTERFACE1, INTERFACE2, INTERFACE3),
@@ -1881,8 +1881,7 @@ public class DefaultTransitionGeneratorTest {
   public void testVisitPreOutEdgePostNat_topologyInterfaceWithNAT() {
     SynthesizerInput input =
         MockSynthesizerInput.builder()
-            .setEnabledEdges(
-                ImmutableSet.of(Edge.fromStrings(NODE1, INTERFACE1, NODE2, INTERFACE2)))
+            .setEnabledEdges(ImmutableSet.of(Edge.of(NODE1, INTERFACE1, NODE2, INTERFACE2)))
             .setTopologyInterfaces(ImmutableMap.of(NODE1, ImmutableSet.of(INTERFACE1)))
             .setSourceNats(
                 ImmutableMap.of(

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
@@ -521,7 +521,7 @@ public final class WorkMgrTest {
     String snapshotNewName = "snapshotNew";
 
     List<NodeInterfacePair> interfaces = ImmutableList.of(new NodeInterfacePair("n1", "iface1"));
-    List<Edge> links = ImmutableList.of(new Edge("n2", "iface2", "n3", "iface3"));
+    List<Edge> links = ImmutableList.of(Edge.fromStrings("n2", "iface2", "n3", "iface3"));
     List<String> nodes = ImmutableList.of("n4", "n5");
 
     _manager.initNetwork(networkName, null);

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
@@ -521,7 +521,7 @@ public final class WorkMgrTest {
     String snapshotNewName = "snapshotNew";
 
     List<NodeInterfacePair> interfaces = ImmutableList.of(new NodeInterfacePair("n1", "iface1"));
-    List<Edge> links = ImmutableList.of(Edge.fromStrings("n2", "iface2", "n3", "iface3"));
+    List<Edge> links = ImmutableList.of(Edge.of("n2", "iface2", "n3", "iface3"));
     List<String> nodes = ImmutableList.of("n4", "n5");
 
     _manager.initNetwork(networkName, null);

--- a/projects/question/src/test/java/org/batfish/question/NeighborsAnswerElementTest.java
+++ b/projects/question/src/test/java/org/batfish/question/NeighborsAnswerElementTest.java
@@ -19,8 +19,8 @@ public class NeighborsAnswerElementTest {
   public void testPrettyPrint() {
     NeighborsAnswerElement neighborsAnswerElement = new NeighborsAnswerElement();
 
-    Edge testEdge1 = new Edge("node11", "interface11", "node12", "interface12");
-    Edge testEdge2 = new Edge("node21", "interface21", "node22", "interface22");
+    Edge testEdge1 = Edge.fromStrings("node11", "interface11", "node12", "interface12");
+    Edge testEdge2 = Edge.fromStrings("node21", "interface21", "node22", "interface22");
 
     RoleEdge testRoleEdge1 = new RoleEdge("role11", "role12");
 

--- a/projects/question/src/test/java/org/batfish/question/NeighborsAnswerElementTest.java
+++ b/projects/question/src/test/java/org/batfish/question/NeighborsAnswerElementTest.java
@@ -19,8 +19,8 @@ public class NeighborsAnswerElementTest {
   public void testPrettyPrint() {
     NeighborsAnswerElement neighborsAnswerElement = new NeighborsAnswerElement();
 
-    Edge testEdge1 = Edge.fromStrings("node11", "interface11", "node12", "interface12");
-    Edge testEdge2 = Edge.fromStrings("node21", "interface21", "node22", "interface22");
+    Edge testEdge1 = Edge.of("node11", "interface11", "node12", "interface12");
+    Edge testEdge2 = Edge.of("node21", "interface21", "node22", "interface22");
 
     RoleEdge testRoleEdge1 = new RoleEdge("role11", "role12");
 

--- a/projects/question/src/test/java/org/batfish/question/edges/EdgesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/edges/EdgesAnswererTest.java
@@ -124,8 +124,7 @@ public class EdgesAnswererTest {
     _includeRemoteNodes = ImmutableSortedSet.of("host1", "host2");
 
     // Sending an  edge from host1 to host2 in layer 3
-    _topology =
-        new Topology(ImmutableSortedSet.of(Edge.fromStrings("host1", "int1", "host2", "int2")));
+    _topology = new Topology(ImmutableSortedSet.of(Edge.of("host1", "int1", "host2", "int2")));
   }
 
   @Test
@@ -371,7 +370,7 @@ public class EdgesAnswererTest {
   @Test
   public void testGetLayer3Edges() {
     Topology layer3Topology =
-        new Topology(ImmutableSortedSet.of(Edge.fromStrings("host1", "int1", "host2", "int2")));
+        new Topology(ImmutableSortedSet.of(Edge.of("host1", "int1", "host2", "int2")));
 
     Multiset<Row> rows =
         getLayer3Edges(_configurations, _includeNodes, _includeRemoteNodes, layer3Topology);
@@ -511,7 +510,7 @@ public class EdgesAnswererTest {
   public void testLayer3ToRow() {
     Map<String, Configuration> configurationMap =
         ImmutableSortedMap.of("host1", _host1, "host2", _host2);
-    Row row = layer3EdgeToRow(configurationMap, Edge.fromStrings("host1", "int1", "host2", "int2"));
+    Row row = layer3EdgeToRow(configurationMap, Edge.of("host1", "int1", "host2", "int2"));
     assertThat(
         row,
         allOf(

--- a/projects/question/src/test/java/org/batfish/question/edges/EdgesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/edges/EdgesAnswererTest.java
@@ -124,7 +124,8 @@ public class EdgesAnswererTest {
     _includeRemoteNodes = ImmutableSortedSet.of("host1", "host2");
 
     // Sending an  edge from host1 to host2 in layer 3
-    _topology = new Topology(ImmutableSortedSet.of(new Edge("host1", "int1", "host2", "int2")));
+    _topology =
+        new Topology(ImmutableSortedSet.of(Edge.fromStrings("host1", "int1", "host2", "int2")));
   }
 
   @Test
@@ -370,7 +371,7 @@ public class EdgesAnswererTest {
   @Test
   public void testGetLayer3Edges() {
     Topology layer3Topology =
-        new Topology(ImmutableSortedSet.of(new Edge("host1", "int1", "host2", "int2")));
+        new Topology(ImmutableSortedSet.of(Edge.fromStrings("host1", "int1", "host2", "int2")));
 
     Multiset<Row> rows =
         getLayer3Edges(_configurations, _includeNodes, _includeRemoteNodes, layer3Topology);
@@ -510,7 +511,7 @@ public class EdgesAnswererTest {
   public void testLayer3ToRow() {
     Map<String, Configuration> configurationMap =
         ImmutableSortedMap.of("host1", _host1, "host2", _host2);
-    Row row = layer3EdgeToRow(configurationMap, new Edge("host1", "int1", "host2", "int2"));
+    Row row = layer3EdgeToRow(configurationMap, Edge.fromStrings("host1", "int1", "host2", "int2"));
     assertThat(
         row,
         allOf(


### PR DESCRIPTION
Goal: wanted to make a push for less confusing, our topology (currently looking at OSPF) code. `node1`/`node2` is hard to read reason about and it's even worse with `getFirst()` and `getSecond()` inherited from pair. Decided to settle on `tail`/`head` terminology from graph theory (alternative would be guava's `source`/`target` terminology).

Thoughts? 

Work along the way:
* Do not extend pair
* Switch to head/tail language
* Add static factory methods, limit number of constructors
* Add javadoc and some tests

