### PR TITLE
Fixing duplicate routes in traceroute

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/RouteInfo.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/RouteInfo.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.Ip;
@@ -44,6 +45,24 @@ public final class RouteInfo {
     checkArgument(protocol != null, "Missing %s", PROP_PROTOCOL);
     checkArgument(network != null, "Missing %s", PROP_NETWORK);
     return new RouteInfo(protocol, network, nextHopIp);
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof RouteInfo)) {
+      return false;
+    }
+    RouteInfo other = (RouteInfo) o;
+    return Objects.equals(_protocol, other._protocol)
+        && Objects.equals(_network, other._network)
+        && Objects.equals(_nextHopIp, other._nextHopIp);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_protocol, _network, _nextHopIp);
   }
 
   @JsonProperty(PROP_PROTOCOL)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/RoutingStep.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/RoutingStep.java
@@ -7,8 +7,8 @@ import static com.google.common.base.Preconditions.checkState;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.google.common.collect.ImmutableList;
-import java.util.List;
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.Flow;
@@ -35,16 +35,16 @@ public final class RoutingStep extends Step<RoutingStepDetail> {
      * Information about {@link Route}s which led to the selection of the out {@link Interface}, can
      * be multiple in case of ECMP
      */
-    @Nonnull private List<RouteInfo> _routes;
+    @Nonnull private Set<RouteInfo> _routes;
 
     @JsonCreator
-    private RoutingStepDetail(@JsonProperty(PROP_ROUTES) @Nullable List<RouteInfo> routes) {
-      _routes = firstNonNull(routes, ImmutableList.of());
+    private RoutingStepDetail(@JsonProperty(PROP_ROUTES) @Nullable Set<RouteInfo> routes) {
+      _routes = firstNonNull(routes, ImmutableSet.of());
     }
 
     @JsonProperty(PROP_ROUTES)
     @Nonnull
-    public List<RouteInfo> getRoutes() {
+    public Set<RouteInfo> getRoutes() {
       return _routes;
     }
 
@@ -54,13 +54,13 @@ public final class RoutingStep extends Step<RoutingStepDetail> {
 
     /** Chained builder to create a {@link RoutingStepDetail} object */
     public static class Builder {
-      private @Nullable List<RouteInfo> _routes;
+      private @Nullable Set<RouteInfo> _routes;
 
       public RoutingStepDetail build() {
         return new RoutingStepDetail(_routes);
       }
 
-      public Builder setRoutes(List<RouteInfo> routes) {
+      public Builder setRoutes(Set<RouteInfo> routes) {
         _routes = routes;
         return this;
       }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteEngineImplContext.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteEngineImplContext.java
@@ -71,7 +71,6 @@ public class TracerouteEngineImplContext {
     private final List<Hop> _hopsSoFar;
     private final NavigableMap<String, IpSpace> _namedIpSpaces;
     private final Flow _originalFlow;
-    private final List<RouteInfo> _routesForThisNextHopInterface;
     private final Flow _transformedFlow;
 
     private TransmissionContext(
@@ -81,7 +80,6 @@ public class TracerouteEngineImplContext {
         List<Hop> hopsSoFar,
         NavigableMap<String, IpSpace> namedIpSpaces,
         Flow originalFlow,
-        List<RouteInfo> routesForThisNextHopInterface,
         Flow transformedFlow) {
       _aclDefinitions = aclDefinitions;
       _currentNode = currentNode;
@@ -89,7 +87,6 @@ public class TracerouteEngineImplContext {
       _hopsSoFar = new ArrayList<>(hopsSoFar);
       _namedIpSpaces = namedIpSpaces;
       _originalFlow = originalFlow;
-      _routesForThisNextHopInterface = routesForThisNextHopInterface;
       _transformedFlow = transformedFlow;
     }
 
@@ -102,7 +99,6 @@ public class TracerouteEngineImplContext {
               _hopsSoFar,
               _namedIpSpaces,
               _originalFlow,
-              _routesForThisNextHopInterface,
               _transformedFlow);
       transmissionContext._filterOutNotes = _filterOutNotes;
       return transmissionContext;
@@ -343,7 +339,6 @@ public class TracerouteEngineImplContext {
                         hops,
                         Maps.newTreeMap(),
                         flow,
-                        new ArrayList<>(),
                         flow);
                 processHop(
                     ingressNodeName, ingressInterfaceName, transmissionContext, flow, visitedHops);
@@ -356,7 +351,6 @@ public class TracerouteEngineImplContext {
                         hops,
                         Maps.newTreeMap(),
                         flow,
-                        new ArrayList<>(),
                         flow);
                 processHop(ingressNodeName, null, transmissionContext, flow, visitedHops);
               }
@@ -491,13 +485,13 @@ public class TracerouteEngineImplContext {
                     Route.UNSET_ROUTE_NEXT_HOP_IP.equals(resolvedNextHopIp)
                         ? null
                         : resolvedNextHopIp;
-                List<RouteInfo> routesForThisNextHopInterface =
+                Set<RouteInfo> routesForThisNextHopInterface =
                     routeCandidates
                         .stream()
                         .map(
                             rc ->
                                 new RouteInfo(rc.getProtocol(), rc.getNetwork(), rc.getNextHopIp()))
-                        .collect(ImmutableList.toImmutableList());
+                        .collect(ImmutableSet.toImmutableSet());
 
                 ImmutableList.Builder<Step<?>> clonedStepsBuilder = ImmutableList.builder();
                 clonedStepsBuilder.addAll(steps);
@@ -556,7 +550,6 @@ public class TracerouteEngineImplContext {
                         transmissionContext._hopsSoFar,
                         namedIpSpaces,
                         currentFlow,
-                        routesForThisNextHopInterface,
                         newTransformedFlow);
                 if (edges == null || edges.isEmpty()) {
                   updateDeniedOrUnreachableTrace(

--- a/tests/questions/experimental/tracerouteListHops.ref
+++ b/tests/questions/experimental/tracerouteListHops.ref
@@ -159,11 +159,6 @@
                           "network" : "1.0.2.0/24",
                           "nextHopIp" : "10.12.11.1",
                           "protocol" : "ibgp"
-                        },
-                        {
-                          "network" : "1.0.2.0/24",
-                          "nextHopIp" : "10.12.11.1",
-                          "protocol" : "ibgp"
                         }
                       ]
                     }
@@ -433,11 +428,6 @@
                     "action" : "FORWARDED",
                     "detail" : {
                       "routes" : [
-                        {
-                          "network" : "1.0.2.0/24",
-                          "nextHopIp" : "10.12.11.1",
-                          "protocol" : "ibgp"
-                        },
                         {
                           "network" : "1.0.2.0/24",
                           "nextHopIp" : "10.12.11.1",
@@ -714,11 +704,6 @@
                           "network" : "1.0.2.0/24",
                           "nextHopIp" : "10.12.11.1",
                           "protocol" : "ibgp"
-                        },
-                        {
-                          "network" : "1.0.2.0/24",
-                          "nextHopIp" : "10.12.11.1",
-                          "protocol" : "ibgp"
                         }
                       ]
                     }
@@ -987,11 +972,6 @@
                     "action" : "FORWARDED",
                     "detail" : {
                       "routes" : [
-                        {
-                          "network" : "1.0.2.0/24",
-                          "nextHopIp" : "10.12.11.1",
-                          "protocol" : "ibgp"
-                        },
                         {
                           "network" : "1.0.2.0/24",
                           "nextHopIp" : "10.12.11.1",


### PR DESCRIPTION
Not showing routes in the `Routing` step which differ in properties which are not a part of the `RouteInfo` class.
Also removing the unused `routesForThisNextHopInterface ` attribute of `TransmissioinContext`