### PR TITLE
Record AWS parsing warnings in answer element

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/ParseVendorConfigurationAnswerElement.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/ParseVendorConfigurationAnswerElement.java
@@ -12,7 +12,6 @@ import org.batfish.common.Warnings;
 public class ParseVendorConfigurationAnswerElement extends ParseAnswerElement
     implements Serializable {
 
-  /** */
   private static final long serialVersionUID = 1L;
 
   private static final String PROP_FILE_MAP = "fileMap";
@@ -21,6 +20,7 @@ public class ParseVendorConfigurationAnswerElement extends ParseAnswerElement
 
   private SortedMap<String, BatfishException.BatfishStackTrace> _errors;
 
+  /* Map of hostname to source filename (e.g. "configs/foo.cfg") */
   private SortedMap<String, String> _fileMap;
 
   private SortedMap<String, ParseStatus> _parseStatus;
@@ -29,6 +29,7 @@ public class ParseVendorConfigurationAnswerElement extends ParseAnswerElement
 
   private String _version;
 
+  /* Map of hostname to warnings */
   private SortedMap<String, Warnings> _warnings;
 
   public ParseVendorConfigurationAnswerElement() {
@@ -40,10 +41,11 @@ public class ParseVendorConfigurationAnswerElement extends ParseAnswerElement
   }
 
   public void addRedFlagWarning(String name, Warning warning) {
-    if (!_warnings.containsKey(name)) {
-      _warnings.put(name, new Warnings());
-    }
-    _warnings.get(name).getRedFlagWarnings().add(warning);
+    _warnings.computeIfAbsent(name, n -> new Warnings()).getRedFlagWarnings().add(warning);
+  }
+
+  public void addUnimplementedWarning(String name, Warning warning) {
+    _warnings.computeIfAbsent(name, n -> new Warnings()).getUnimplementedWarnings().add(warning);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -2058,25 +2058,31 @@ public class Batfish extends PluginConsumer implements IBatfish {
     return parse(parser);
   }
 
-  private AwsConfiguration parseAwsConfigurations(Map<Path, String> configurationData) {
+  @VisibleForTesting
+  public static AwsConfiguration parseAwsConfigurations(
+      Map<Path, String> configurationData, ParseVendorConfigurationAnswerElement pvcae) {
     AwsConfiguration config = new AwsConfiguration();
     for (Entry<Path, String> configFile : configurationData.entrySet()) {
-      Path file = configFile.getKey();
+      Path path = configFile.getKey();
+      int pathLength = configFile.getKey().getNameCount();
       String fileText = configFile.getValue();
-      String regionName = file.getName(file.getNameCount() - 2).toString(); // parent dir name
+      String regionName = path.getName(pathLength - 2).toString(); // parent dir name
+      String fileName = path.subpath(pathLength - 3, pathLength).toString();
 
       JSONObject jsonObj = null;
       try {
         jsonObj = new JSONObject(fileText);
       } catch (JSONException e) {
-        _logger.errorf("%s does not have valid json\n", file);
+        pvcae.addRedFlagWarning(
+            BfConsts.RELPATH_AWS_CONFIGS_FILE,
+            new Warning(String.format("AWS file %s is not valid JSON", fileName), "AWS"));
       }
 
       if (jsonObj != null) {
         try {
-          config.addConfigElement(regionName, jsonObj, _logger);
+          config.addConfigElement(regionName, jsonObj, fileName, pvcae);
         } catch (JSONException e) {
-          throw new BatfishException("Problems parsing JSON in " + file, e);
+          throw new BatfishException("Problems parsing JSON in " + fileName, e);
         }
       }
     }
@@ -3092,15 +3098,15 @@ public class Batfish extends PluginConsumer implements IBatfish {
     }
   }
 
-  private Answer serializeAwsConfigs(Path testRigPath, Path outputPath) {
-    Answer answer = new Answer();
+  private void serializeAwsConfigs(
+      Path testRigPath, Path outputPath, ParseVendorConfigurationAnswerElement pvcae) {
     Map<Path, String> configurationData =
         readConfigurationFiles(testRigPath, BfConsts.RELPATH_AWS_CONFIGS_DIR);
     AwsConfiguration config;
     try (ActiveSpan parseAwsConfigsSpan =
         GlobalTracer.get().buildSpan("Parse AWS configs").startActive()) {
       assert parseAwsConfigsSpan != null; // avoid unused warning
-      config = parseAwsConfigurations(configurationData);
+      config = parseAwsConfigurations(configurationData, pvcae);
     }
 
     _logger.info("\n*** SERIALIZING AWS CONFIGURATION STRUCTURES ***\n");
@@ -3111,7 +3117,6 @@ public class Batfish extends PluginConsumer implements IBatfish {
     serializeObject(config, currentOutputPath);
     _logger.debug("OK\n");
     _logger.printElapsedTime();
-    return answer;
   }
 
   private Answer serializeEnvironmentBgpTables(Path inputPath, Path outputPath) {
@@ -3399,12 +3404,12 @@ public class Batfish extends PluginConsumer implements IBatfish {
     // look for AWS VPC configs
     Path awsVpcConfigsPath = testRigPath.resolve(BfConsts.RELPATH_AWS_CONFIGS_DIR);
     if (Files.exists(awsVpcConfigsPath)) {
-      answer.append(serializeAwsConfigs(testRigPath, outputPath));
+      serializeAwsConfigs(testRigPath, outputPath, answerElement);
       configsFound = true;
     }
 
     if (!configsFound) {
-      throw new BatfishException("No valid configurations found in testrig path " + testRigPath);
+      throw new BatfishException("No valid configurations found in snapshot path " + testRigPath);
     }
 
     // serialize warnings

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/AwsConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/AwsConfiguration.java
@@ -3,7 +3,6 @@ package org.batfish.representation.aws;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
-import org.batfish.common.BatfishLogger;
 import org.batfish.common.Pair;
 import org.batfish.common.Warnings;
 import org.batfish.config.Settings;
@@ -12,6 +11,7 @@ import org.batfish.datamodel.GenericConfigObject;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.answers.ParseVendorConfigurationAnswerElement;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
 
@@ -35,14 +35,15 @@ public class AwsConfiguration implements Serializable, GenericConfigObject {
     _currentGeneratedIpAsLong = INITIAL_GENERATED_IP;
   }
 
-  public void addConfigElement(String region, JSONObject jsonObj, BatfishLogger logger)
+  public void addConfigElement(
+      String region,
+      JSONObject jsonObj,
+      String sourceFileName,
+      ParseVendorConfigurationAnswerElement pvcae)
       throws JSONException {
-
-    if (!_regions.containsKey(region)) {
-      _regions.put(region, new Region(region));
-    }
-
-    _regions.get(region).addConfigElement(jsonObj, logger);
+    _regions
+        .computeIfAbsent(region, r -> new Region(region))
+        .addConfigElement(jsonObj, sourceFileName, pvcae);
   }
 
   public Map<String, Configuration> getConfigurationNodes() {

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/VpnConnection.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/VpnConnection.java
@@ -10,7 +10,6 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import org.batfish.common.BatfishException;
-import org.batfish.common.BatfishLogger;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.BgpActivePeerConfig;
 import org.batfish.datamodel.BgpProcess;
@@ -137,15 +136,13 @@ public class VpnConnection implements AwsVpcEntity, Serializable {
 
   private final String _vpnGatewayId;
 
-  public VpnConnection(JSONObject jObj, BatfishLogger logger) throws JSONException {
+  public VpnConnection(JSONObject jObj) throws JSONException {
     _vgwTelemetrys = new LinkedList<>();
     _routes = new LinkedList<>();
     _ipsecTunnels = new LinkedList<>();
     _vpnConnectionId = jObj.getString(JSON_KEY_VPN_CONNECTION_ID);
     _customerGatewayId = jObj.getString(JSON_KEY_CUSTOMER_GATEWAY_ID);
     _vpnGatewayId = jObj.getString(JSON_KEY_VPN_GATEWAY_ID);
-
-    logger.debugf("parsing vpnconnection id: %s\n", _vpnConnectionId);
 
     String cgwConfiguration = jObj.getString(JSON_KEY_CUSTOMER_GATEWAY_CONFIGURATION);
     Document document;

--- a/projects/batfish/src/test/java/org/batfish/main/AwsParseWarningsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/AwsParseWarningsTest.java
@@ -1,0 +1,50 @@
+package org.batfish.main;
+
+import static org.batfish.common.BfConsts.RELPATH_AWS_CONFIGS_FILE;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.batfish.common.BfConsts;
+import org.batfish.common.Warning;
+import org.batfish.datamodel.answers.ParseVendorConfigurationAnswerElement;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AwsParseWarningsTest {
+
+  private ParseVendorConfigurationAnswerElement _pvcae;
+  private Path _path = Paths.get(BfConsts.RELPATH_AWS_CONFIGS_DIR, "region", "file.json");
+
+  @Before
+  public void initializeAnswerElement() {
+    _pvcae = new ParseVendorConfigurationAnswerElement();
+  }
+
+  @Test
+  public void testBadJsonWarning() {
+    Batfish.parseAwsConfigurations(ImmutableMap.of(_path, "{"), _pvcae);
+    assertThat(
+        _pvcae.getWarnings().get(RELPATH_AWS_CONFIGS_FILE).getRedFlagWarnings(),
+        equalTo(
+            ImmutableList.of(
+                new Warning(
+                    String.format("AWS file %s is not valid JSON", _path.toString()), "AWS"))));
+  }
+
+  @Test
+  public void testInvalidKeyWarning() {
+    Batfish.parseAwsConfigurations(ImmutableMap.of(_path, "{ \"invalidKey\": [] }"), _pvcae);
+    assertThat(
+        _pvcae.getWarnings().get(RELPATH_AWS_CONFIGS_FILE).getUnimplementedWarnings(),
+        equalTo(
+            ImmutableList.of(
+                new Warning(
+                    String.format(
+                        "Unrecognized element 'invalidKey' in AWS file %s", _path.toString()),
+                    "AWS"))));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/main/AwsParseWarningsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/AwsParseWarningsTest.java
@@ -2,9 +2,8 @@ package org.batfish.main;
 
 import static org.batfish.common.BfConsts.RELPATH_AWS_CONFIGS_FILE;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -29,10 +28,8 @@ public class AwsParseWarningsTest {
     Batfish.parseAwsConfigurations(ImmutableMap.of(_path, "{"), _pvcae);
     assertThat(
         _pvcae.getWarnings().get(RELPATH_AWS_CONFIGS_FILE).getRedFlagWarnings(),
-        equalTo(
-            ImmutableList.of(
-                new Warning(
-                    String.format("AWS file %s is not valid JSON", _path.toString()), "AWS"))));
+        containsInAnyOrder(
+            new Warning(String.format("AWS file %s is not valid JSON", _path.toString()), "AWS")));
   }
 
   @Test
@@ -40,11 +37,9 @@ public class AwsParseWarningsTest {
     Batfish.parseAwsConfigurations(ImmutableMap.of(_path, "{ \"invalidKey\": [] }"), _pvcae);
     assertThat(
         _pvcae.getWarnings().get(RELPATH_AWS_CONFIGS_FILE).getUnimplementedWarnings(),
-        equalTo(
-            ImmutableList.of(
-                new Warning(
-                    String.format(
-                        "Unrecognized element 'invalidKey' in AWS file %s", _path.toString()),
-                    "AWS"))));
+        containsInAnyOrder(
+            new Warning(
+                String.format("Unrecognized element 'invalidKey' in AWS file %s", _path.toString()),
+                "AWS")));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/main/AwsParseWarningsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/AwsParseWarningsTest.java
@@ -2,7 +2,7 @@ package org.batfish.main;
 
 import static org.batfish.common.BfConsts.RELPATH_AWS_CONFIGS_FILE;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.contains;
 
 import com.google.common.collect.ImmutableMap;
 import java.nio.file.Path;
@@ -28,7 +28,7 @@ public class AwsParseWarningsTest {
     Batfish.parseAwsConfigurations(ImmutableMap.of(_path, "{"), _pvcae);
     assertThat(
         _pvcae.getWarnings().get(RELPATH_AWS_CONFIGS_FILE).getRedFlagWarnings(),
-        containsInAnyOrder(
+        contains(
             new Warning(String.format("AWS file %s is not valid JSON", _path.toString()), "AWS")));
   }
 
@@ -37,7 +37,7 @@ public class AwsParseWarningsTest {
     Batfish.parseAwsConfigurations(ImmutableMap.of(_path, "{ \"invalidKey\": [] }"), _pvcae);
     assertThat(
         _pvcae.getWarnings().get(RELPATH_AWS_CONFIGS_FILE).getUnimplementedWarnings(),
-        containsInAnyOrder(
+        contains(
             new Warning(
                 String.format("Unrecognized element 'invalidKey' in AWS file %s", _path.toString()),
                 "AWS")));

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/VpcPeeringConnectionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/VpcPeeringConnectionTest.java
@@ -18,7 +18,7 @@ public class VpcPeeringConnectionTest {
 
     JSONObject jObj = new JSONObject(text);
     Region region = new Region("r1");
-    region.addConfigElement(jObj, null);
+    region.addConfigElement(jObj, null, null);
 
     /*
      * We should have an entry for the vpc peering connection with status code "active", but not

--- a/tests/aws/init-example-aws.ref
+++ b/tests/aws/init-example-aws.ref
@@ -7,7 +7,29 @@
     "parseStatus" : {
       "configs/lhr-border-02.cfg" : "PASSED"
     },
-    "version" : "0.36.0"
+    "version" : "0.36.0",
+    "warnings" : {
+      "aws_configs" : {
+        "Unimplemented features" : [
+          {
+            "tag" : "AWS",
+            "text" : "Unrecognized element 'Hosts' in AWS file aws_configs/us-west-2/Hosts.json"
+          },
+          {
+            "tag" : "AWS",
+            "text" : "Unrecognized element 'MovingAddressStatuses' in AWS file aws_configs/us-west-2/MovingAddressStatuses.json"
+          },
+          {
+            "tag" : "AWS",
+            "text" : "Unrecognized element 'PrefixLists' in AWS file aws_configs/us-west-2/PrefixLists.json"
+          },
+          {
+            "tag" : "AWS",
+            "text" : "Unrecognized element 'VpcEndpoints' in AWS file aws_configs/us-west-2/VpcEndpoints.json"
+          }
+        ]
+      }
+    }
   },
   {
     "class" : "org.batfish.datamodel.answers.ConvertConfigurationAnswerElement",


### PR DESCRIPTION
Rather than sending warnings to the BatfishLogger when parsing AWS configs, it now adds them to the `ParseVendorConfigurationAnswerElement` under hostname `aws_configs`, which hopefully won't collide with any real hostnames.

I can change `Region.getChildConsumer()` back closer to its original form if reviewers want me to do so -- might be a bit less opaque that way. Each case ends up being annoyingly verbose, though:
```
case (key):
    for (int i = 0; i < jsonArray.length(); i++) {
        JSONObject jsonObj = jsonArray.getJSONObject(i);
        // stuff specific to this case
    }
    break;
```
as opposed to
```
case (key):
    return jsonObj -> {
        // stuff specific to this case
    }
```