### PR TITLE
Fib: let next hop interface take precedence

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/dataplane/FibImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/FibImplTest.java
@@ -1,0 +1,110 @@
+package org.batfish.dataplane;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.ImmutableSortedSet;
+import java.io.IOException;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.Configuration.Builder;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.Fib;
+import org.batfish.datamodel.FibImpl;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.InterfaceAddress;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.StaticRoute;
+import org.batfish.datamodel.Vrf;
+import org.batfish.main.Batfish;
+import org.batfish.main.BatfishTestUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests of {@link FibImpl} */
+@RunWith(JUnit4.class)
+public class FibImplTest {
+  @Rule public TemporaryFolder folder = new TemporaryFolder();
+
+  private static final Ip DST_IP = new Ip("3.3.3.3");
+  private static final String NODE1 = "node1";
+  private static final String FAST_ETHERNET_0 = "FastEthernet0/0";
+  private static final InterfaceAddress NODE1_PHYSICAL_NETWORK = new InterfaceAddress("2.0.0.1/8");
+  private static final Ip EXTERNAL_IP = new Ip("7.7.7.7");
+
+  private NetworkFactory _nf;
+  private Builder _cb;
+  private Interface.Builder _ib;
+  private Vrf.Builder _vb;
+
+  private Configuration _config;
+  private Vrf _vrf;
+
+  @Before
+  public void setup() {
+    _nf = new NetworkFactory();
+    _cb = _nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+    _ib = _nf.interfaceBuilder();
+    _vb = _nf.vrfBuilder();
+    _config = _cb.setHostname(NODE1).build();
+    _vrf = _vb.setOwner(_config).setName(Configuration.DEFAULT_VRF_NAME).build();
+    _ib.setOwner(_config).setVrf(_vrf);
+  }
+
+  @Test
+  public void testNextHopInterfaceTakesPrecedence() throws IOException {
+    _ib.setName(FAST_ETHERNET_0).setAddresses(NODE1_PHYSICAL_NETWORK).build();
+    // Both next hop IP and interface, interface should take precendence
+    _vrf.setStaticRoutes(
+        ImmutableSortedSet.of(
+            StaticRoute.builder()
+                .setNetwork(new Prefix(DST_IP, 32))
+                .setNextHopInterface(FAST_ETHERNET_0)
+                .setNextHopIp(EXTERNAL_IP)
+                .setAdministrativeCost(1)
+                .build()));
+
+    Batfish batfish =
+        BatfishTestUtils.getBatfish(ImmutableSortedMap.of(_config.getHostname(), _config), folder);
+    batfish.computeDataPlane(false);
+    Fib fib =
+        batfish
+            .loadDataPlane()
+            .getFibs()
+            .get(_config.getHostname())
+            .get(Configuration.DEFAULT_VRF_NAME);
+
+    assertThat(fib.getNextHopInterfaces(DST_IP), contains(FAST_ETHERNET_0));
+  }
+
+  @Test
+  public void testNextHopIpIsResolved() throws IOException {
+    _ib.setName(FAST_ETHERNET_0).setAddresses(NODE1_PHYSICAL_NETWORK).build();
+    // only next hop interface
+    _vrf.setStaticRoutes(
+        ImmutableSortedSet.of(
+            StaticRoute.builder()
+                .setNetwork(new Prefix(DST_IP, 32))
+                .setNextHopIp(new Ip("2.1.1.1"))
+                .setAdministrativeCost(1)
+                .build()));
+
+    Batfish batfish =
+        BatfishTestUtils.getBatfish(ImmutableSortedMap.of(_config.getHostname(), _config), folder);
+    batfish.computeDataPlane(false);
+    Fib fib =
+        batfish
+            .loadDataPlane()
+            .getFibs()
+            .get(_config.getHostname())
+            .get(Configuration.DEFAULT_VRF_NAME);
+
+    assertThat(fib.getNextHopInterfaces(DST_IP), contains(FAST_ETHERNET_0));
+  }
+}

--- a/tests/basic/oldtraceroute-2-1.ref
+++ b/tests/basic/oldtraceroute-2-1.ref
@@ -48,136 +48,7 @@
                   "filterIn" : "{RESTRICT_HOST_TRAFFIC_IN}{permit ip 2.128.0.0 0.0.255.255 any}",
                   "filterOut" : "{filter::OUTPUT}{default}",
                   "routes" : [
-                    "StaticRoute<0.0.0.0/0,nhip:2.128.1.1,nhint:eth0>_fnhip:2.128.1.1"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as2dept1",
-                    "node1interface" : "GigabitEthernet1/0",
-                    "node2" : "as2dist2",
-                    "node2interface" : "GigabitEthernet2/0"
-                  },
-                  "routes" : [
-                    "BgpRoute<1.0.1.0/24,nhip:2.34.201.3,nhint:dynamic>_fnhip:2.34.201.3"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as2dist2",
-                    "node1interface" : "GigabitEthernet0/0",
-                    "node2" : "as2core2",
-                    "node2interface" : "GigabitEthernet2/0"
-                  },
-                  "routes" : [
-                    "BgpRoute<1.0.1.0/24,nhip:10.12.11.1,nhint:dynamic>_fnhip:2.23.22.2"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as2core2",
-                    "node1interface" : "GigabitEthernet1/0",
-                    "node2" : "as2border1",
-                    "node2interface" : "GigabitEthernet2/0"
-                  },
-                  "routes" : [
-                    "BgpRoute<1.0.1.0/24,nhip:10.12.11.1,nhint:dynamic>_fnhip:2.12.12.1"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as2border1",
-                    "node1interface" : "GigabitEthernet0/0",
-                    "node2" : "as1border1",
-                    "node2interface" : "GigabitEthernet1/0"
-                  },
-                  "filterOut" : "{INSIDE_TO_AS1}{permit ip 2.0.0.0 0.255.255.255 1.0.0.0 0.255.255.255}",
-                  "routes" : [
-                    "BgpRoute<1.0.1.0/24,nhip:10.12.11.1,nhint:dynamic>_fnhip:10.12.11.1"
-                  ]
-                }
-              ],
-              "notes" : "ACCEPTED"
-            },
-            {
-              "disposition" : "ACCEPTED",
-              "hops" : [
-                {
-                  "edge" : {
-                    "node1" : "host2",
-                    "node1interface" : "eth0",
-                    "node2" : "as2dept1",
-                    "node2interface" : "GigabitEthernet3/0"
-                  },
-                  "filterIn" : "{RESTRICT_HOST_TRAFFIC_IN}{permit ip 2.128.0.0 0.0.255.255 any}",
-                  "filterOut" : "{filter::OUTPUT}{default}",
-                  "routes" : [
-                    "StaticRoute<0.0.0.0/0,nhip:2.128.1.1,nhint:eth0>_fnhip:2.128.1.1"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as2dept1",
-                    "node1interface" : "GigabitEthernet1/0",
-                    "node2" : "as2dist2",
-                    "node2interface" : "GigabitEthernet2/0"
-                  },
-                  "routes" : [
-                    "BgpRoute<1.0.1.0/24,nhip:2.34.201.3,nhint:dynamic>_fnhip:2.34.201.3"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as2dist2",
-                    "node1interface" : "GigabitEthernet1/0",
-                    "node2" : "as2core1",
-                    "node2interface" : "GigabitEthernet3/0"
-                  },
-                  "filterIn" : "{blocktelnet}{permit ip any any}",
-                  "routes" : [
-                    "BgpRoute<1.0.1.0/24,nhip:10.12.11.1,nhint:dynamic>_fnhip:2.23.12.2"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as2core1",
-                    "node1interface" : "GigabitEthernet0/0",
-                    "node2" : "as2border1",
-                    "node2interface" : "GigabitEthernet1/0"
-                  },
-                  "routes" : [
-                    "BgpRoute<1.0.1.0/24,nhip:10.12.11.1,nhint:dynamic>_fnhip:2.12.11.1"
-                  ]
-                },
-                {
-                  "edge" : {
-                    "node1" : "as2border1",
-                    "node1interface" : "GigabitEthernet0/0",
-                    "node2" : "as1border1",
-                    "node2interface" : "GigabitEthernet1/0"
-                  },
-                  "filterOut" : "{INSIDE_TO_AS1}{permit ip 2.0.0.0 0.255.255.255 1.0.0.0 0.255.255.255}",
-                  "routes" : [
-                    "BgpRoute<1.0.1.0/24,nhip:10.12.11.1,nhint:dynamic>_fnhip:10.12.11.1"
-                  ]
-                }
-              ],
-              "notes" : "ACCEPTED"
-            },
-            {
-              "disposition" : "ACCEPTED",
-              "hops" : [
-                {
-                  "edge" : {
-                    "node1" : "host2",
-                    "node1interface" : "eth0",
-                    "node2" : "as2dept1",
-                    "node2interface" : "GigabitEthernet3/0"
-                  },
-                  "filterIn" : "{RESTRICT_HOST_TRAFFIC_IN}{permit ip 2.128.0.0 0.0.255.255 any}",
-                  "filterOut" : "{filter::OUTPUT}{default}",
-                  "routes" : [
-                    "StaticRoute<0.0.0.0/0,nhip:2.128.1.1,nhint:eth0>_fnhip:2.128.1.1"
+                    "StaticRoute<0.0.0.0/0,nhip:2.128.1.1,nhint:eth0>_fnhip:null"
                   ]
                 },
                 {
@@ -242,7 +113,7 @@
                   "filterIn" : "{RESTRICT_HOST_TRAFFIC_IN}{permit ip 2.128.0.0 0.0.255.255 any}",
                   "filterOut" : "{filter::OUTPUT}{default}",
                   "routes" : [
-                    "StaticRoute<0.0.0.0/0,nhip:2.128.1.1,nhint:eth0>_fnhip:2.128.1.1"
+                    "StaticRoute<0.0.0.0/0,nhip:2.128.1.1,nhint:eth0>_fnhip:null"
                   ]
                 },
                 {
@@ -265,6 +136,135 @@
                   },
                   "routes" : [
                     "BgpRoute<1.0.1.0/24,nhip:10.12.11.1,nhint:dynamic>_fnhip:2.23.21.2"
+                  ]
+                },
+                {
+                  "edge" : {
+                    "node1" : "as2core2",
+                    "node1interface" : "GigabitEthernet1/0",
+                    "node2" : "as2border1",
+                    "node2interface" : "GigabitEthernet2/0"
+                  },
+                  "routes" : [
+                    "BgpRoute<1.0.1.0/24,nhip:10.12.11.1,nhint:dynamic>_fnhip:2.12.12.1"
+                  ]
+                },
+                {
+                  "edge" : {
+                    "node1" : "as2border1",
+                    "node1interface" : "GigabitEthernet0/0",
+                    "node2" : "as1border1",
+                    "node2interface" : "GigabitEthernet1/0"
+                  },
+                  "filterOut" : "{INSIDE_TO_AS1}{permit ip 2.0.0.0 0.255.255.255 1.0.0.0 0.255.255.255}",
+                  "routes" : [
+                    "BgpRoute<1.0.1.0/24,nhip:10.12.11.1,nhint:dynamic>_fnhip:10.12.11.1"
+                  ]
+                }
+              ],
+              "notes" : "ACCEPTED"
+            },
+            {
+              "disposition" : "ACCEPTED",
+              "hops" : [
+                {
+                  "edge" : {
+                    "node1" : "host2",
+                    "node1interface" : "eth0",
+                    "node2" : "as2dept1",
+                    "node2interface" : "GigabitEthernet3/0"
+                  },
+                  "filterIn" : "{RESTRICT_HOST_TRAFFIC_IN}{permit ip 2.128.0.0 0.0.255.255 any}",
+                  "filterOut" : "{filter::OUTPUT}{default}",
+                  "routes" : [
+                    "StaticRoute<0.0.0.0/0,nhip:2.128.1.1,nhint:eth0>_fnhip:null"
+                  ]
+                },
+                {
+                  "edge" : {
+                    "node1" : "as2dept1",
+                    "node1interface" : "GigabitEthernet1/0",
+                    "node2" : "as2dist2",
+                    "node2interface" : "GigabitEthernet2/0"
+                  },
+                  "routes" : [
+                    "BgpRoute<1.0.1.0/24,nhip:2.34.201.3,nhint:dynamic>_fnhip:2.34.201.3"
+                  ]
+                },
+                {
+                  "edge" : {
+                    "node1" : "as2dist2",
+                    "node1interface" : "GigabitEthernet1/0",
+                    "node2" : "as2core1",
+                    "node2interface" : "GigabitEthernet3/0"
+                  },
+                  "filterIn" : "{blocktelnet}{permit ip any any}",
+                  "routes" : [
+                    "BgpRoute<1.0.1.0/24,nhip:10.12.11.1,nhint:dynamic>_fnhip:2.23.12.2"
+                  ]
+                },
+                {
+                  "edge" : {
+                    "node1" : "as2core1",
+                    "node1interface" : "GigabitEthernet0/0",
+                    "node2" : "as2border1",
+                    "node2interface" : "GigabitEthernet1/0"
+                  },
+                  "routes" : [
+                    "BgpRoute<1.0.1.0/24,nhip:10.12.11.1,nhint:dynamic>_fnhip:2.12.11.1"
+                  ]
+                },
+                {
+                  "edge" : {
+                    "node1" : "as2border1",
+                    "node1interface" : "GigabitEthernet0/0",
+                    "node2" : "as1border1",
+                    "node2interface" : "GigabitEthernet1/0"
+                  },
+                  "filterOut" : "{INSIDE_TO_AS1}{permit ip 2.0.0.0 0.255.255.255 1.0.0.0 0.255.255.255}",
+                  "routes" : [
+                    "BgpRoute<1.0.1.0/24,nhip:10.12.11.1,nhint:dynamic>_fnhip:10.12.11.1"
+                  ]
+                }
+              ],
+              "notes" : "ACCEPTED"
+            },
+            {
+              "disposition" : "ACCEPTED",
+              "hops" : [
+                {
+                  "edge" : {
+                    "node1" : "host2",
+                    "node1interface" : "eth0",
+                    "node2" : "as2dept1",
+                    "node2interface" : "GigabitEthernet3/0"
+                  },
+                  "filterIn" : "{RESTRICT_HOST_TRAFFIC_IN}{permit ip 2.128.0.0 0.0.255.255 any}",
+                  "filterOut" : "{filter::OUTPUT}{default}",
+                  "routes" : [
+                    "StaticRoute<0.0.0.0/0,nhip:2.128.1.1,nhint:eth0>_fnhip:null"
+                  ]
+                },
+                {
+                  "edge" : {
+                    "node1" : "as2dept1",
+                    "node1interface" : "GigabitEthernet1/0",
+                    "node2" : "as2dist2",
+                    "node2interface" : "GigabitEthernet2/0"
+                  },
+                  "routes" : [
+                    "BgpRoute<1.0.1.0/24,nhip:2.34.201.3,nhint:dynamic>_fnhip:2.34.201.3"
+                  ]
+                },
+                {
+                  "edge" : {
+                    "node1" : "as2dist2",
+                    "node1interface" : "GigabitEthernet0/0",
+                    "node2" : "as2core2",
+                    "node2interface" : "GigabitEthernet2/0"
+                  },
+                  "routes" : [
+                    "BgpRoute<1.0.1.0/24,nhip:10.12.11.1,nhint:dynamic>_fnhip:2.23.22.2"
                   ]
                 },
                 {

--- a/tests/basic/traceroute-2-1.ref
+++ b/tests/basic/traceroute-2-1.ref
@@ -61,7 +61,7 @@
                 "filterIn" : "{RESTRICT_HOST_TRAFFIC_IN}{permit ip 2.128.0.0 0.0.255.255 any}",
                 "filterOut" : "{filter::OUTPUT}{default}",
                 "routes" : [
-                  "StaticRoute<0.0.0.0/0,nhip:2.128.1.1,nhint:eth0>_fnhip:2.128.1.1"
+                  "StaticRoute<0.0.0.0/0,nhip:2.128.1.1,nhint:eth0>_fnhip:null"
                 ]
               },
               {
@@ -126,7 +126,7 @@
                 "filterIn" : "{RESTRICT_HOST_TRAFFIC_IN}{permit ip 2.128.0.0 0.0.255.255 any}",
                 "filterOut" : "{filter::OUTPUT}{default}",
                 "routes" : [
-                  "StaticRoute<0.0.0.0/0,nhip:2.128.1.1,nhint:eth0>_fnhip:2.128.1.1"
+                  "StaticRoute<0.0.0.0/0,nhip:2.128.1.1,nhint:eth0>_fnhip:null"
                 ]
               },
               {
@@ -190,7 +190,7 @@
                 "filterIn" : "{RESTRICT_HOST_TRAFFIC_IN}{permit ip 2.128.0.0 0.0.255.255 any}",
                 "filterOut" : "{filter::OUTPUT}{default}",
                 "routes" : [
-                  "StaticRoute<0.0.0.0/0,nhip:2.128.1.1,nhint:eth0>_fnhip:2.128.1.1"
+                  "StaticRoute<0.0.0.0/0,nhip:2.128.1.1,nhint:eth0>_fnhip:null"
                 ]
               },
               {
@@ -254,7 +254,7 @@
                 "filterIn" : "{RESTRICT_HOST_TRAFFIC_IN}{permit ip 2.128.0.0 0.0.255.255 any}",
                 "filterOut" : "{filter::OUTPUT}{default}",
                 "routes" : [
-                  "StaticRoute<0.0.0.0/0,nhip:2.128.1.1,nhint:eth0>_fnhip:2.128.1.1"
+                  "StaticRoute<0.0.0.0/0,nhip:2.128.1.1,nhint:eth0>_fnhip:null"
                 ]
               },
               {


### PR DESCRIPTION
Next hop interface should take precedence over resolving next hop IP, at least in the FIB. it is up to consumers (traceroute/reachability) to determine if next hop IP has ARP reply and assign disposition accordingly. 

Fix by changing evaluation oder interface first, nhip second.