### PR TITLE
Make VI OSPF area class as immutable as possible

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -118,8 +118,8 @@ public final class Interface extends ComparableStructure<String> {
       iface.setIsis(_isis);
       iface.setOspfArea(_ospfArea);
       if (_ospfArea != null) {
-        _ospfArea.getInterfaces().add(name);
-        iface.setOspfAreaName(_ospfArea.getName());
+        _ospfArea.addInterface(name);
+        iface.setOspfAreaName(_ospfArea.getAreaNumber());
       }
       iface.setOspfCost(_ospfCost);
       iface.setOspfEnabled(_ospfEnabled);
@@ -1002,7 +1002,7 @@ public final class Interface extends ComparableStructure<String> {
   @JsonPropertyDescription("The OSPF area to which this interface belongs.")
   public Long getOspfAreaName() {
     if (_ospfArea != null) {
-      return _ospfArea.getName();
+      return _ospfArea.getAreaNumber();
     } else {
       return _ospfAreaName;
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfArea.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfArea.java
@@ -93,7 +93,7 @@ public class OspfArea implements Serializable {
       return this;
     }
 
-    /** Set this are no be not a stub area of any type, and remove any stub settings */
+    /** Remove any stub settings, make this area not a Stub of any type */
     public Builder setNonStub() {
       _stubType = StubType.NONE;
       _nssa = null;
@@ -102,8 +102,7 @@ public class OspfArea implements Serializable {
     }
 
     /**
-     * Set this are no be not a not-so-stubby area with given settings, erase any other stub
-     * settings
+     * Set this area to be a not-so-stubby area with given settings, erase any other stub settings
      */
     public Builder setNssa(@Nonnull NssaSettings nssa) {
       _stubType = StubType.NSSA;
@@ -112,7 +111,7 @@ public class OspfArea implements Serializable {
       return this;
     }
 
-    /** Set NSSA settings only */
+    /** Set the not-so-stubby settings only */
     public Builder setNssaSettings(@Nonnull NssaSettings nssa) {
       _nssa = nssa;
       return this;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfArea.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfArea.java
@@ -1,56 +1,99 @@
 package org.batfish.datamodel.ospf;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Ordering;
 import java.io.Serializable;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
 import java.util.SortedMap;
 import java.util.SortedSet;
-import java.util.TreeMap;
-import java.util.TreeSet;
-import org.batfish.common.util.ComparableStructure;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.NetworkFactory.NetworkFactoryBuilder;
 import org.batfish.datamodel.Prefix;
 
-public class OspfArea extends ComparableStructure<Long> implements Serializable {
+/** Represents an OSPF area configuration */
+public class OspfArea implements Serializable {
 
+  /** A builder for {@link OspfArea} */
   public static class Builder extends NetworkFactoryBuilder<OspfArea> {
 
-    private NssaSettings _nssa;
-
-    private Long _number;
-
-    private OspfProcess _ospfProcess;
-
-    private StubSettings _stub;
-
-    private StubType _stubType;
-
     private boolean _injectDefaultRoute = DEFAULT_INJECT_DEFAULT_ROUTE;
-
+    @Nonnull private final ImmutableSortedSet.Builder<String> _interfaces;
+    @Nullable private NssaSettings _nssa;
+    @Nullable private Long _number;
     private int _metricOfDefaultRoute = DEFAULT_METRIC_OF_DEFAULT_ROUTE;
+    @Nullable private OspfProcess _ospfProcess;
+    @Nullable private StubSettings _stub;
+    @Nonnull private StubType _stubType;
+    @Nonnull private final ImmutableSortedMap.Builder<Prefix, OspfAreaSummary> _summaries;
+    @Nullable private String _summaryFilter;
 
     Builder(NetworkFactory networkFactory) {
       super(networkFactory, OspfArea.class);
+      _interfaces = new ImmutableSortedSet.Builder<>(Ordering.natural());
       _stubType = StubType.NONE;
+      _summaries = new ImmutableSortedMap.Builder<>(Ordering.natural());
     }
 
     @Override
     public OspfArea build() {
       long number = _number != null ? _number : generateLong();
-      OspfArea ospfArea = new OspfArea(number);
+      OspfArea ospfArea =
+          new OspfArea(
+              number,
+              _injectDefaultRoute,
+              _interfaces.build(),
+              _metricOfDefaultRoute,
+              _nssa,
+              _stub,
+              _stubType,
+              _summaries.build(),
+              _summaryFilter);
       if (_ospfProcess != null) {
         _ospfProcess.getAreas().put(number, ospfArea);
       }
-      ospfArea._nssa = _nssa;
-      ospfArea._stub = _stub;
-      ospfArea._stubType = _stubType;
-      ospfArea._injectDefaultRoute = _injectDefaultRoute;
-      ospfArea._metricOfDefaultRoute = _metricOfDefaultRoute;
       return ospfArea;
     }
 
+    public Builder setInjectDefaultRoute(boolean injectDefaultRoute) {
+      _injectDefaultRoute = injectDefaultRoute;
+      return this;
+    }
+
+    public Builder addInterface(@Nonnull String interfaceName) {
+      _interfaces.add(interfaceName);
+      return this;
+    }
+
+    public Builder addInterfaces(@Nonnull Collection<String> interfaces) {
+      _interfaces.addAll(interfaces);
+      return this;
+    }
+
+    public Builder addSummary(@Nonnull Prefix prefix, @Nonnull OspfAreaSummary summary) {
+      _summaries.put(prefix, summary);
+      return this;
+    }
+
+    public Builder addSummaries(@Nonnull Map<Prefix, OspfAreaSummary> summaries) {
+      _summaries.putAll(summaries);
+      return this;
+    }
+
+    public Builder setMetricOfDefaultRoute(int metricOfDefaultRoute) {
+      _metricOfDefaultRoute = metricOfDefaultRoute;
+      return this;
+    }
+
+    /** Set this are no be not a stub area of any type, and remove any stub settings */
     public Builder setNonStub() {
       _stubType = StubType.NONE;
       _nssa = null;
@@ -58,32 +101,55 @@ public class OspfArea extends ComparableStructure<Long> implements Serializable 
       return this;
     }
 
-    public Builder setNssa(NssaSettings nssa) {
-      _nssa = nssa;
+    /**
+     * Set this are no be not a not-so-stubby area with given settings, erase any other stub
+     * settings
+     */
+    public Builder setNssa(@Nonnull NssaSettings nssa) {
       _stubType = StubType.NSSA;
+      _nssa = nssa;
       _stub = null;
       return this;
     }
 
-    public Builder setNumber(Long number) {
+    /** Set NSSA settings only */
+    public Builder setNssaSettings(@Nonnull NssaSettings nssa) {
+      _nssa = nssa;
+      return this;
+    }
+
+    /** Set the area number */
+    public Builder setNumber(long number) {
       _number = number;
       return this;
     }
 
-    public Builder setOspfProcess(OspfProcess ospfProcess) {
+    public Builder setOspfProcess(@Nonnull OspfProcess ospfProcess) {
       _ospfProcess = ospfProcess;
       return this;
     }
 
-    public Builder setStub(StubSettings stub) {
-      _stub = stub;
+    /** Set this area to be a stub area with given settings, erase any NSSA settings */
+    public Builder setStub(@Nonnull StubSettings stub) {
       _stubType = StubType.STUB;
+      _stub = stub;
       _nssa = null;
       return this;
     }
 
-    public Builder setStubType(StubType stubType) {
+    /** Set Stub settings only */
+    public Builder setStubSettings(@Nonnull StubSettings stubSettings) {
+      _stub = stubSettings;
+      return this;
+    }
+
+    public Builder setStubType(@Nonnull StubType stubType) {
       _stubType = stubType;
+      return this;
+    }
+
+    public Builder setSummaryFilter(@Nullable String summaryFilter) {
+      _summaryFilter = summaryFilter;
       return this;
     }
   }
@@ -102,19 +168,13 @@ public class OspfArea extends ComparableStructure<Long> implements Serializable 
   private static final int DEFAULT_METRIC_OF_DEFAULT_ROUTE = 0;
 
   private static final String PROP_INJECT_DEFAULT_ROUTE = "injectDefaultRoute";
-
   private static final String PROP_INTERFACES = "interfaces";
-
   private static final String PROP_METRIC_OF_DEFAULT_ROUTE = "metricOfDefaultRoute";
-
+  private static final String PROP_NAME = "name";
   private static final String PROP_NSSA = "nssa";
-
   private static final String PROP_STUB = "stub";
-
   private static final String PROP_STUB_TYPE = "stubType";
-
   private static final String PROP_SUMMARIES = "summaries";
-
   private static final String PROP_SUMMARY_FILTER = "summaryFilter";
 
   private static final long serialVersionUID = 1L;
@@ -123,110 +183,165 @@ public class OspfArea extends ComparableStructure<Long> implements Serializable 
     return new Builder(networkFactory);
   }
 
-  private boolean _injectDefaultRoute = DEFAULT_INJECT_DEFAULT_ROUTE;
-
-  private SortedSet<String> _interfaces;
-
-  private int _metricOfDefaultRoute = DEFAULT_METRIC_OF_DEFAULT_ROUTE;
-
-  private NssaSettings _nssa;
-
-  private StubSettings _stub;
-
-  private StubType _stubType;
-
-  private SortedMap<Prefix, OspfAreaSummary> _summaries;
-
-  private String _summaryFilter;
-
-  @JsonCreator
-  public OspfArea(@JsonProperty(PROP_NAME) Long number) {
-    super(number);
-    _interfaces = new TreeSet<>();
-    _stubType = StubType.NONE;
-    _summaries = new TreeMap<>();
+  public static Builder builder() {
+    return new Builder(null);
   }
 
+  private final long _areaNumber;
+  private final boolean _injectDefaultRoute;
+  // Not final because of the need to support addInterface
+  @Nonnull private SortedSet<String> _interfaces;
+  private final int _metricOfDefaultRoute;
+  @Nullable private final NssaSettings _nssa;
+  @Nullable private final StubSettings _stub;
+  @Nonnull private final StubType _stubType;
+  @Nonnull private final SortedMap<Prefix, OspfAreaSummary> _summaries;
+  @Nullable private final String _summaryFilter;
+
+  public OspfArea(
+      long areaNumber,
+      boolean injectDefaultRoute,
+      @Nonnull SortedSet<String> interfaces,
+      int metricOfDefaultRoute,
+      @Nullable NssaSettings nssa,
+      @Nullable StubSettings stub,
+      @Nonnull StubType stubType,
+      @Nonnull SortedMap<Prefix, OspfAreaSummary> summaries,
+      @Nullable String summaryFilter) {
+    _areaNumber = areaNumber;
+    _injectDefaultRoute = injectDefaultRoute;
+    _interfaces = ImmutableSortedSet.copyOf(interfaces);
+    _metricOfDefaultRoute = metricOfDefaultRoute;
+    _nssa = nssa;
+    _stub = stub;
+    _stubType = stubType;
+    _summaries = ImmutableSortedMap.copyOf(summaries);
+    _summaryFilter = summaryFilter;
+  }
+
+  @JsonCreator
+  private static OspfArea create(
+      @JsonProperty(PROP_NAME) long number,
+      @JsonProperty(PROP_INJECT_DEFAULT_ROUTE) boolean injectDefaultRoute,
+      @JsonProperty(PROP_INTERFACES) @Nullable SortedSet<String> interfaces,
+      @JsonProperty(PROP_METRIC_OF_DEFAULT_ROUTE) int metricOfDefaultRoute,
+      @JsonProperty(PROP_NSSA) @Nullable NssaSettings nssa,
+      @JsonProperty(PROP_STUB) @Nullable StubSettings stub,
+      @JsonProperty(PROP_STUB_TYPE) @Nullable StubType stubType,
+      @JsonProperty(PROP_SUMMARIES) @Nullable SortedMap<Prefix, OspfAreaSummary> summaries,
+      @JsonProperty(PROP_SUMMARY_FILTER) @Nullable String summaryFilter) {
+    return new OspfArea(
+        number,
+        injectDefaultRoute,
+        firstNonNull(interfaces, ImmutableSortedSet.of()),
+        metricOfDefaultRoute,
+        nssa,
+        stub,
+        firstNonNull(stubType, StubType.NONE),
+        firstNonNull(summaries, ImmutableSortedMap.of()),
+        summaryFilter);
+  }
+
+  /** Add a new interface into this area. */
+  public void addInterface(String interfaceName) {
+    _interfaces =
+        new ImmutableSortedSet.Builder<String>(Ordering.natural())
+            .addAll(_interfaces)
+            .add(interfaceName)
+            .build();
+  }
+
+  @JsonProperty(PROP_NAME)
+  public long getAreaNumber() {
+    return _areaNumber;
+  }
+
+  /** Whether the default route should be injected */
   @JsonProperty(PROP_INJECT_DEFAULT_ROUTE)
-  @JsonPropertyDescription("Whether the default route should be injected")
   public boolean getInjectDefaultRoute() {
     return _injectDefaultRoute;
   }
 
+  /** The interfaces assigned to this OSPF area */
+  @Nonnull
   @JsonProperty(PROP_INTERFACES)
-  @JsonPropertyDescription("The interfaces assigned to this OSPF area")
   public SortedSet<String> getInterfaces() {
     return _interfaces;
   }
 
+  /** The metric to use for the injected default route */
   @JsonProperty(PROP_METRIC_OF_DEFAULT_ROUTE)
-  @JsonPropertyDescription("The metric to use for the injected default route")
   public int getMetricOfDefaultRoute() {
     return _metricOfDefaultRoute;
   }
 
+  /** @deprecated Use {@link #getAreaNumber} */
+  @Deprecated
+  public long getName() {
+    return getAreaNumber();
+  }
+
+  @Nullable
   @JsonProperty(PROP_NSSA)
   public NssaSettings getNssa() {
     return _nssa;
   }
 
+  @Nullable
   @JsonProperty(PROP_STUB)
   public StubSettings getStub() {
     return _stub;
   }
 
+  @Nonnull
   @JsonProperty(PROP_STUB_TYPE)
   public StubType getStubType() {
     return _stubType;
   }
 
+  @Nonnull
   @JsonProperty(PROP_SUMMARIES)
   public SortedMap<Prefix, OspfAreaSummary> getSummaries() {
     return _summaries;
   }
 
+  @Nullable
   @JsonProperty(PROP_SUMMARY_FILTER)
   public String getSummaryFilter() {
     return _summaryFilter;
   }
 
-  @JsonProperty(PROP_INJECT_DEFAULT_ROUTE)
-  public void setInjectDefaultRoute(boolean injectDefaultRoute) {
-    _injectDefaultRoute = injectDefaultRoute;
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof OspfArea)) {
+      return false;
+    }
+    OspfArea ospfArea = (OspfArea) o;
+    return _areaNumber == ospfArea._areaNumber
+        && _injectDefaultRoute == ospfArea._injectDefaultRoute
+        && _metricOfDefaultRoute == ospfArea._metricOfDefaultRoute
+        && Objects.equals(_interfaces, ospfArea._interfaces)
+        && Objects.equals(_nssa, ospfArea._nssa)
+        && Objects.equals(_stub, ospfArea._stub)
+        && _stubType == ospfArea._stubType
+        && Objects.equals(_summaries, ospfArea._summaries)
+        && Objects.equals(_summaryFilter, ospfArea._summaryFilter);
   }
 
-  @JsonProperty(PROP_INTERFACES)
-  public void setInterfaces(SortedSet<String> interfaces) {
-    _interfaces = interfaces;
-  }
-
-  @JsonProperty(PROP_METRIC_OF_DEFAULT_ROUTE)
-  public void setMetricOfDefaultRoute(int metricOfDefaultRoute) {
-    _metricOfDefaultRoute = metricOfDefaultRoute;
-  }
-
-  @JsonProperty(PROP_NSSA)
-  public void setNssa(NssaSettings nssa) {
-    _nssa = nssa;
-  }
-
-  @JsonProperty(PROP_STUB)
-  public void setStub(StubSettings stub) {
-    _stub = stub;
-  }
-
-  @JsonProperty(PROP_STUB_TYPE)
-  public void setStubType(StubType stubType) {
-    _stubType = stubType;
-  }
-
-  @JsonProperty(PROP_SUMMARIES)
-  public void setSummaries(SortedMap<Prefix, OspfAreaSummary> summaries) {
-    _summaries = summaries;
-  }
-
-  @JsonProperty(PROP_SUMMARY_FILTER)
-  public void setSummaryFilter(String summaryFilterName) {
-    this._summaryFilter = summaryFilterName;
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        _areaNumber,
+        _injectDefaultRoute,
+        _interfaces,
+        _metricOfDefaultRoute,
+        _nssa,
+        _stub,
+        _stubType,
+        _summaries,
+        _summaryFilter);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfArea.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfArea.java
@@ -9,6 +9,7 @@ import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Ordering;
 import java.io.Serializable;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.SortedMap;
@@ -26,14 +27,14 @@ public class OspfArea implements Serializable {
   public static class Builder extends NetworkFactoryBuilder<OspfArea> {
 
     private boolean _injectDefaultRoute = DEFAULT_INJECT_DEFAULT_ROUTE;
-    @Nonnull private final ImmutableSortedSet.Builder<String> _interfaces;
+    @Nonnull private ImmutableSortedSet.Builder<String> _interfaces;
     @Nullable private NssaSettings _nssa;
     @Nullable private Long _number;
     private int _metricOfDefaultRoute = DEFAULT_METRIC_OF_DEFAULT_ROUTE;
     @Nullable private OspfProcess _ospfProcess;
     @Nullable private StubSettings _stub;
     @Nonnull private StubType _stubType;
-    @Nonnull private final ImmutableSortedMap.Builder<Prefix, OspfAreaSummary> _summaries;
+    @Nonnull private ImmutableSortedMap.Builder<Prefix, OspfAreaSummary> _summaries;
     @Nullable private String _summaryFilter;
 
     Builder(NetworkFactory networkFactory) {
@@ -85,6 +86,13 @@ public class OspfArea implements Serializable {
 
     public Builder addSummaries(@Nonnull Map<Prefix, OspfAreaSummary> summaries) {
       _summaries.putAll(summaries);
+      return this;
+    }
+
+    /** Replace all interfaces in the area */
+    public Builder setInterfaces(@Nonnull Collection<String> interfaces) {
+      _interfaces = new ImmutableSortedSet.Builder<>(Comparator.naturalOrder());
+      _interfaces.addAll(interfaces);
       return this;
     }
 
@@ -144,6 +152,13 @@ public class OspfArea implements Serializable {
 
     public Builder setStubType(@Nonnull StubType stubType) {
       _stubType = stubType;
+      return this;
+    }
+
+    /** Replace the area summaries */
+    public Builder setSummaries(@Nonnull Map<Prefix, OspfAreaSummary> summaries) {
+      _summaries = new ImmutableSortedMap.Builder<>(Comparator.naturalOrder());
+      _summaries.putAll(summaries);
       return this;
     }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/NetworkFactoryTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/NetworkFactoryTest.java
@@ -102,10 +102,10 @@ public class NetworkFactoryTest {
     Interface iface =
         nf.interfaceBuilder().setOwner(c).setActive(false).setVrf(vrf).setOspfArea(oa2).build();
 
-    assertThat(oa1.getName(), not(equalTo(oa2.getName())));
+    assertThat(oa1.getAreaNumber(), not(equalTo(oa2.getAreaNumber())));
     assertThat(oa1, not(sameInstance(oa2)));
-    assertThat(ospfProcess.getAreas().get(oa2.getName()), sameInstance(oa2));
+    assertThat(ospfProcess.getAreas().get(oa2.getAreaNumber()), sameInstance(oa2));
     assertThat(oa2, OspfAreaMatchers.hasInterfaces(hasItem(iface.getName())));
-    assertThat(iface.getOspfAreaName(), equalTo(oa2.getName()));
+    assertThat(iface.getOspfAreaName(), equalTo(oa2.getAreaNumber()));
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -1550,7 +1550,7 @@ public class VirtualRouter implements Serializable {
           && !neighborInterface.getOspfPassive()
           && area != null
           && neighborArea != null
-          && area.getName().equals(neighborArea.getName())) {
+          && area.getAreaNumber() == (neighborArea.getAreaNumber())) {
         /*
          * We have an ospf neighbor relationship on this edge. So we
          * should add all ospf external type 1(2) routes from this
@@ -1573,7 +1573,7 @@ public class VirtualRouter implements Serializable {
           boolean withdraw = routeAdvert.isWithdrawn();
           if (neighborRoute instanceof OspfExternalType1Route) {
             long oldArea = neighborRoute.getArea();
-            long connectionArea = area.getName();
+            long connectionArea = area.getAreaNumber();
             long newArea;
             long baseMetric = neighborRoute.getMetric();
             long baseCostToAdvertiser = neighborRoute.getCostToAdvertiser();
@@ -1613,7 +1613,7 @@ public class VirtualRouter implements Serializable {
 
           } else if (neighborRoute instanceof OspfExternalType2Route) {
             long oldArea = neighborRoute.getArea();
-            long connectionArea = area.getName();
+            long connectionArea = area.getAreaNumber();
             long newArea;
             long baseCostToAdvertiser = neighborRoute.getCostToAdvertiser();
             if (oldArea == OspfRoute.NO_AREA) {
@@ -1727,7 +1727,7 @@ public class VirtualRouter implements Serializable {
         || neighborInterface.getOspfPassive()
         || area == null
         || neighborArea == null
-        || !area.getName().equals(neighborArea.getName())) {
+        || area.getAreaNumber() != neighborArea.getAreaNumber()) {
       return false;
     }
     /*
@@ -1741,7 +1741,7 @@ public class VirtualRouter implements Serializable {
         proc.getMaxMetricTransitLinks() != null
             ? proc.getMaxMetricTransitLinks()
             : connectingInterfaceCost;
-    Long linkAreaNum = area.getName();
+    long linkAreaNum = area.getAreaNumber();
     Configuration neighborConfiguration = neighbor.getConfiguration();
     String neighborVrfName = neighborInterface.getVrfName();
     OspfProcess neighborProc =
@@ -1807,7 +1807,7 @@ public class VirtualRouter implements Serializable {
             neighborInterface.getAddress().getIp(),
             adminCost,
             metric,
-            area.getName()));
+            area.getAreaNumber()));
   }
 
   boolean propagateOspfInterAreaRouteFromInterAreaRoute(
@@ -2597,7 +2597,7 @@ public class VirtualRouter implements Serializable {
           && !neighborInterface.getOspfPassive()
           && area != null
           && neighborArea != null
-          && area.getName().equals(neighborArea.getName())) {
+          && area.getAreaNumber() == neighborArea.getAreaNumber()) {
         neighbors.put(
             connectingInterface.getAddress().getPrefix(),
             new OspfLink(area, neighborArea, neighborVirtualRouter));

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -3,6 +3,7 @@ package org.batfish.representation.cisco;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
 import static org.batfish.common.util.CommonUtil.toImmutableMap;
+import static org.batfish.common.util.CommonUtil.toImmutableSortedMap;
 import static org.batfish.datamodel.Interface.UNSET_LOCAL_INTERFACE;
 import static org.batfish.datamodel.Interface.computeInterfaceType;
 import static org.batfish.datamodel.MultipathEquivalentAsPathMatchMode.EXACT_PATH;
@@ -2322,7 +2323,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
     newProcess.setProcessId(proc.getName());
 
     // establish areas and associated interfaces
-    Map<Long, OspfArea> areas = newProcess.getAreas();
+    Map<Long, OspfArea.Builder> areas = new HashMap<>();
     Map<Long, ImmutableSortedSet.Builder<String>> areaInterfacesBuilders = new HashMap<>();
     // Sort networks with longer prefixes first, then lower start IPs and areas.
     SortedSet<OspfNetwork> networks =
@@ -2351,12 +2352,11 @@ public final class CiscoConfiguration extends VendorConfiguration {
         if (maskedInterfaceAddress.equals(networkAddress)) {
           // we have a longest prefix match
           long areaNum = network.getArea();
-          OspfArea newArea = areas.computeIfAbsent(areaNum, OspfArea::new);
+          areas.computeIfAbsent(areaNum, areaNumber -> OspfArea.builder().setNumber(areaNumber));
           ImmutableSortedSet.Builder<String> newAreaInterfacesBuilder =
               areaInterfacesBuilders.computeIfAbsent(
                   areaNum, n -> ImmutableSortedSet.naturalOrder());
           newAreaInterfacesBuilder.add(ifaceName);
-          iface.setOspfArea(newArea);
           iface.setOspfEnabled(true);
           boolean passive =
               proc.getPassiveInterfaceList().contains(iface.getName())
@@ -2368,7 +2368,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
       }
       areaInterfacesBuilders.forEach(
           (areaNum, interfacesBuilder) ->
-              areas.get(areaNum).setInterfaces(interfacesBuilder.build()));
+              areas.get(areaNum).addInterfaces(interfacesBuilder.build()));
     }
     proc.getNssas()
         .forEach(
@@ -2377,7 +2377,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
                 return;
               }
               areas.get(areaId).setStubType(StubType.NSSA);
-              areas.get(areaId).setNssa(toNssaSettings(nssaSettings));
+              areas.get(areaId).setNssaSettings(toNssaSettings(nssaSettings));
             });
 
     proc.getStubs()
@@ -2387,19 +2387,19 @@ public final class CiscoConfiguration extends VendorConfiguration {
                 return;
               }
               areas.get(areaId).setStubType(StubType.STUB);
-              areas.get(areaId).setStub(toStubSettings(stubSettings));
+              areas.get(areaId).setStubSettings(toStubSettings(stubSettings));
             });
 
     // create summarization filters for inter-area routes
     for (Entry<Long, Map<Prefix, OspfAreaSummary>> e1 : proc.getSummaries().entrySet()) {
       long areaLong = e1.getKey();
       Map<Prefix, OspfAreaSummary> summaries = e1.getValue();
-      OspfArea area = areas.get(areaLong);
+      OspfArea.Builder area = areas.get(areaLong);
       String summaryFilterName = "~OSPF_SUMMARY_FILTER:" + vrfName + ":" + areaLong + "~";
       RouteFilterList summaryFilter = new RouteFilterList(summaryFilterName);
       c.getRouteFilterLists().put(summaryFilterName, summaryFilter);
       if (area == null) {
-        area = new OspfArea(areaLong);
+        area = OspfArea.builder().setNumber(areaLong);
         areas.put(areaLong, area);
       }
       area.setSummaryFilter(summaryFilterName);
@@ -2417,13 +2417,28 @@ public final class CiscoConfiguration extends VendorConfiguration {
                 new IpWildcard(prefix),
                 new SubRange(filterMinPrefixLength, Prefix.MAX_PREFIX_LENGTH)));
       }
-      area.setSummaries(ImmutableSortedMap.copyOf(summaries));
+      area.addSummaries(ImmutableSortedMap.copyOf(summaries));
       summaryFilter.addLine(
           new RouteFilterLine(
               LineAction.PERMIT,
               new IpWildcard(Prefix.ZERO),
               new SubRange(0, Prefix.MAX_PREFIX_LENGTH)));
     }
+    newProcess.setAreas(toImmutableSortedMap(areas, Entry::getKey, e -> e.getValue().build()));
+    // set pointers from interfaces to their parent areas
+    newProcess
+        .getAreas()
+        .values()
+        .forEach(
+            area ->
+                area.getInterfaces()
+                    .forEach(
+                        ifaceName ->
+                            c.getVrfs()
+                                .get(vrfName)
+                                .getInterfaces()
+                                .get(ifaceName)
+                                .setOspfArea(area)));
 
     String ospfExportPolicyName = "~OSPF_EXPORT_POLICY:" + vrfName + "~";
     RoutingPolicy ospfExportPolicy = new RoutingPolicy(ospfExportPolicyName, c);

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -737,31 +737,56 @@ public final class JuniperConfiguration extends VendorConfiguration {
               }
             });
     // areas
-    Map<Long, org.batfish.datamodel.ospf.OspfArea> newAreas = newProc.getAreas();
-    newAreas.putAll(
+    Map<Long, org.batfish.datamodel.ospf.OspfArea.Builder> newAreaBuilders =
         CommonUtil.toImmutableMap(
-            routingInstance.getOspfAreas(), Entry::getKey, e -> toOspfArea(e.getValue())));
+            routingInstance.getOspfAreas(), Entry::getKey, e -> toOspfAreaBuilder(e.getValue()));
     // place interfaces into areas
     for (Entry<String, Interface> e : routingInstance.getInterfaces().entrySet()) {
       String name = e.getKey();
       Interface iface = e.getValue();
-      placeInterfaceIntoArea(newAreas, name, iface, vrfName);
+      placeInterfaceIntoArea(newAreaBuilders, name, iface, vrfName);
     }
+
+    // Build areas
+    newProc.setAreas(
+        newAreaBuilders
+            .entrySet()
+            .stream()
+            .collect(
+                ImmutableSortedMap.toImmutableSortedMap(
+                    Comparator.naturalOrder(), Entry::getKey, entry -> entry.getValue().build())));
+
+    // set pointers from interfaces to their parent areas
+    newProc
+        .getAreas()
+        .values()
+        .forEach(
+            area ->
+                area.getInterfaces()
+                    .forEach(
+                        ifaceName ->
+                            _c.getVrfs()
+                                .get(vrfName)
+                                .getInterfaces()
+                                .get(ifaceName)
+                                .setOspfArea(area)));
+
     newProc.setRouterId(getOspfRouterId(routingInstance));
     newProc.setReferenceBandwidth(routingInstance.getOspfReferenceBandwidth());
     return newProc;
   }
 
-  private org.batfish.datamodel.ospf.OspfArea toOspfArea(OspfArea area) {
-    org.batfish.datamodel.ospf.OspfArea newArea =
-        new org.batfish.datamodel.ospf.OspfArea(area.getName());
-    newArea.setNssa(toNssaSettings(area.getNssaSettings()));
-    newArea.setStub(toStubSettings(area.getStubSettings()));
-    newArea.setStubType(area.getStubType());
-    newArea.setSummaries(area.getSummaries());
-    newArea.setInjectDefaultRoute(area.getInjectDefaultRoute());
-    newArea.setMetricOfDefaultRoute(area.getMetricOfDefaultRoute());
-    return newArea;
+  private org.batfish.datamodel.ospf.OspfArea.Builder toOspfAreaBuilder(OspfArea area) {
+    org.batfish.datamodel.ospf.OspfArea.Builder newAreaBuilder =
+        org.batfish.datamodel.ospf.OspfArea.builder();
+    newAreaBuilder.setNumber(area.getName());
+    newAreaBuilder.setNssaSettings(toNssaSettings(area.getNssaSettings()));
+    newAreaBuilder.setStubSettings(toStubSettings(area.getStubSettings()));
+    newAreaBuilder.setStubType(area.getStubType());
+    newAreaBuilder.addSummaries(area.getSummaries());
+    newAreaBuilder.setInjectDefaultRoute(area.getInjectDefaultRoute());
+    newAreaBuilder.setMetricOfDefaultRoute(area.getMetricOfDefaultRoute());
+    return newAreaBuilder;
   }
 
   private org.batfish.datamodel.ospf.NssaSettings toNssaSettings(NssaSettings nssaSettings) {
@@ -977,12 +1002,12 @@ public final class JuniperConfiguration extends VendorConfiguration {
   }
 
   private void placeInterfaceIntoArea(
-      Map<Long, org.batfish.datamodel.ospf.OspfArea> newAreas,
-      String name,
+      Map<Long, org.batfish.datamodel.ospf.OspfArea.Builder> newAreas,
+      String interfaceName,
       Interface iface,
       String vrfName) {
     Vrf vrf = _c.getVrfs().get(vrfName);
-    org.batfish.datamodel.Interface newIface = vrf.getInterfaces().get(name);
+    org.batfish.datamodel.Interface newIface = vrf.getInterfaces().get(interfaceName);
     Ip ospfArea = iface.getOspfArea();
     if (ospfArea == null) {
       return;
@@ -991,13 +1016,12 @@ public final class JuniperConfiguration extends VendorConfiguration {
       _w.redFlag(
           String.format(
               "Cannot assign interface %s to area %s because it has no IP address.",
-              name, ospfArea));
+              interfaceName, ospfArea));
       return;
     }
     long ospfAreaLong = ospfArea.asLong();
-    org.batfish.datamodel.ospf.OspfArea newArea = newAreas.get(ospfAreaLong);
-    newArea.getInterfaces().add(name);
-    newIface.setOspfArea(newArea);
+    org.batfish.datamodel.ospf.OspfArea.Builder newArea = newAreas.get(ospfAreaLong);
+    newArea.addInterface(interfaceName);
     newIface.setOspfEnabled(true);
     newIface.setOspfPassive(iface.getOspfPassive());
     Integer ospfCost = iface.getOspfCost();

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/OspfProtocolHelperTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/OspfProtocolHelperTest.java
@@ -85,25 +85,27 @@ public class OspfProtocolHelperTest {
     Builder b = nf.ospfProcessBuilder();
     OspfProcess proc = b.build();
     OspfProcess neighborProc = b.build();
-    OspfArea area0 = new OspfArea(0L);
-    OspfArea area1 = new OspfArea(1L);
-    area1.setStubType(StubType.STUB);
-    neighborProc.setAreas(ImmutableSortedMap.of(0L, area0, 1L, area1));
+    OspfArea area0 = nf.ospfAreaBuilder().setNumber(0L).build();
+    OspfArea.Builder area1 = nf.ospfAreaBuilder().setNumber(1L).setStubType(StubType.STUB);
+    neighborProc.setAreas(ImmutableSortedMap.of(0L, area0, 1L, area1.build()));
 
     // Receiving process is NOT an ABR
-    proc.setAreas(ImmutableSortedMap.of(1L, area1));
+    proc.setAreas(ImmutableSortedMap.of(1L, area1.build()));
     assertThat(
-        isOspfInterAreaDefaultOriginationAllowed(proc, neighborProc, area0, area1), equalTo(true));
+        isOspfInterAreaDefaultOriginationAllowed(proc, neighborProc, area0, area1.build()),
+        equalTo(true));
 
     // Area1 is stub without default route injection
     area1.setInjectDefaultRoute(false);
     assertThat(
-        isOspfInterAreaDefaultOriginationAllowed(proc, neighborProc, area0, area1), equalTo(false));
+        isOspfInterAreaDefaultOriginationAllowed(proc, neighborProc, area0, area1.build()),
+        equalTo(false));
 
     // Area injects the default route, but the receiving process IS an ABR
-    area0.setInjectDefaultRoute(true);
-    proc.setAreas(ImmutableSortedMap.of(0L, area0, 1L, area1));
+    area0 = OspfArea.builder(nf).setNumber(0L).setInjectDefaultRoute(true).build();
+    proc.setAreas(ImmutableSortedMap.of(0L, area0, 1L, area1.build()));
     assertThat(
-        isOspfInterAreaDefaultOriginationAllowed(proc, neighborProc, area0, area1), equalTo(false));
+        isOspfInterAreaDefaultOriginationAllowed(proc, neighborProc, area0, area1.build()),
+        equalTo(false));
   }
 }

--- a/projects/question/src/test/java/org/batfish/question/edges/EdgesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/edges/EdgesAnswererTest.java
@@ -205,10 +205,10 @@ public class EdgesAnswererTest {
     OspfProcess ospf2 = new OspfProcess();
 
     NetworkFactory nf = new NetworkFactory();
-    OspfArea one = OspfArea.builder(nf).setNumber(1L).setOspfProcess(ospf1).build();
-    OspfArea two = OspfArea.builder(nf).setNumber(2L).setOspfProcess(ospf2).build();
-    one.getInterfaces().add("int1");
-    two.getInterfaces().add("int2");
+    OspfArea one =
+        OspfArea.builder(nf).setNumber(1L).setOspfProcess(ospf1).addInterface("int1").build();
+    OspfArea two =
+        OspfArea.builder(nf).setNumber(2L).setOspfProcess(ospf2).addInterface("int2").build();
     ospf1.getAreas().put(1L, one);
     ospf2.getAreas().put(1L, two);
 

--- a/tests/aws/nodes-example-aws.ref
+++ b/tests/aws/nodes-example-aws.ref
@@ -1996,7 +1996,6 @@
             "ospfProcess" : {
               "areas" : {
                 "0" : {
-                  "name" : 0,
                   "injectDefaultRoute" : true,
                   "interfaces" : [
                     "Ethernet1/0",
@@ -2004,6 +2003,7 @@
                     "Loopback0"
                   ],
                   "metricOfDefaultRoute" : 0,
+                  "name" : 0,
                   "stubType" : "NONE"
                 }
               },

--- a/tests/basic/nodes.ref
+++ b/tests/basic/nodes.ref
@@ -1187,13 +1187,13 @@
             "ospfProcess" : {
               "areas" : {
                 "1" : {
-                  "name" : 1,
                   "injectDefaultRoute" : true,
                   "interfaces" : [
                     "GigabitEthernet0/0",
                     "Loopback0"
                   ],
                   "metricOfDefaultRoute" : 0,
+                  "name" : 1,
                   "stubType" : "NONE"
                 }
               },
@@ -2433,13 +2433,13 @@
             "ospfProcess" : {
               "areas" : {
                 "1" : {
-                  "name" : 1,
                   "injectDefaultRoute" : true,
                   "interfaces" : [
                     "GigabitEthernet1/0",
                     "Loopback0"
                   ],
                   "metricOfDefaultRoute" : 0,
+                  "name" : 1,
                   "stubType" : "NONE"
                 }
               },
@@ -2829,7 +2829,6 @@
             "ospfProcess" : {
               "areas" : {
                 "1" : {
-                  "name" : 1,
                   "injectDefaultRoute" : true,
                   "interfaces" : [
                     "GigabitEthernet0/0",
@@ -2837,6 +2836,7 @@
                     "Loopback0"
                   ],
                   "metricOfDefaultRoute" : 0,
+                  "name" : 1,
                   "stubType" : "NONE"
                 }
               },
@@ -4096,7 +4096,6 @@
             "ospfProcess" : {
               "areas" : {
                 "1" : {
-                  "name" : 1,
                   "injectDefaultRoute" : true,
                   "interfaces" : [
                     "GigabitEthernet1/0",
@@ -4104,6 +4103,7 @@
                     "Loopback0"
                   ],
                   "metricOfDefaultRoute" : 0,
+                  "name" : 1,
                   "stubType" : "NONE"
                 }
               },
@@ -5306,7 +5306,6 @@
             "ospfProcess" : {
               "areas" : {
                 "1" : {
-                  "name" : 1,
                   "injectDefaultRoute" : true,
                   "interfaces" : [
                     "GigabitEthernet1/0",
@@ -5314,6 +5313,7 @@
                     "Loopback0"
                   ],
                   "metricOfDefaultRoute" : 0,
+                  "name" : 1,
                   "stubType" : "NONE"
                 }
               },
@@ -5914,7 +5914,6 @@
             "ospfProcess" : {
               "areas" : {
                 "1" : {
-                  "name" : 1,
                   "injectDefaultRoute" : true,
                   "interfaces" : [
                     "GigabitEthernet0/0",
@@ -5924,6 +5923,7 @@
                     "Loopback0"
                   ],
                   "metricOfDefaultRoute" : 0,
+                  "name" : 1,
                   "stubType" : "NONE"
                 }
               },
@@ -6471,7 +6471,6 @@
             "ospfProcess" : {
               "areas" : {
                 "1" : {
-                  "name" : 1,
                   "injectDefaultRoute" : true,
                   "interfaces" : [
                     "GigabitEthernet0/0",
@@ -6481,6 +6480,7 @@
                     "Loopback0"
                   ],
                   "metricOfDefaultRoute" : 0,
+                  "name" : 1,
                   "stubType" : "NONE"
                 }
               },
@@ -8185,7 +8185,6 @@
             "ospfProcess" : {
               "areas" : {
                 "1" : {
-                  "name" : 1,
                   "injectDefaultRoute" : true,
                   "interfaces" : [
                     "GigabitEthernet0/0",
@@ -8193,6 +8192,7 @@
                     "Loopback0"
                   ],
                   "metricOfDefaultRoute" : 0,
+                  "name" : 1,
                   "stubType" : "NONE"
                 }
               },
@@ -8942,7 +8942,6 @@
             "ospfProcess" : {
               "areas" : {
                 "1" : {
-                  "name" : 1,
                   "injectDefaultRoute" : true,
                   "interfaces" : [
                     "GigabitEthernet0/0",
@@ -8950,6 +8949,7 @@
                     "Loopback0"
                   ],
                   "metricOfDefaultRoute" : 0,
+                  "name" : 1,
                   "stubType" : "NONE"
                 }
               },
@@ -10068,13 +10068,13 @@
             "ospfProcess" : {
               "areas" : {
                 "1" : {
-                  "name" : 1,
                   "injectDefaultRoute" : true,
                   "interfaces" : [
                     "GigabitEthernet0/0",
                     "Loopback0"
                   ],
                   "metricOfDefaultRoute" : 0,
+                  "name" : 1,
                   "stubType" : "NONE"
                 }
               },
@@ -11145,13 +11145,13 @@
             "ospfProcess" : {
               "areas" : {
                 "1" : {
-                  "name" : 1,
                   "injectDefaultRoute" : true,
                   "interfaces" : [
                     "GigabitEthernet1/0",
                     "Loopback0"
                   ],
                   "metricOfDefaultRoute" : 0,
+                  "name" : 1,
                   "stubType" : "NONE"
                 }
               },
@@ -11741,7 +11741,6 @@
             "ospfProcess" : {
               "areas" : {
                 "1" : {
-                  "name" : 1,
                   "injectDefaultRoute" : true,
                   "interfaces" : [
                     "GigabitEthernet0/0",
@@ -11749,6 +11748,7 @@
                     "Loopback0"
                   ],
                   "metricOfDefaultRoute" : 0,
+                  "name" : 1,
                   "stubType" : "NONE"
                 }
               },

--- a/tests/basic/outliers-verbose.ref
+++ b/tests/basic/outliers-verbose.ref
@@ -2434,13 +2434,13 @@
           "ospfProcess" : {
             "areas" : {
               "1" : {
-                "name" : 1,
                 "injectDefaultRoute" : true,
                 "interfaces" : [
                   "GigabitEthernet0/0",
                   "Loopback0"
                 ],
                 "metricOfDefaultRoute" : 0,
+                "name" : 1,
                 "stubType" : "NONE"
               }
             },

--- a/tests/basic/viModel.ref
+++ b/tests/basic/viModel.ref
@@ -8339,13 +8339,13 @@
             "ospfProcess" : {
               "areas" : {
                 "1" : {
-                  "name" : 1,
                   "injectDefaultRoute" : true,
                   "interfaces" : [
                     "GigabitEthernet0/0",
                     "Loopback0"
                   ],
                   "metricOfDefaultRoute" : 0,
+                  "name" : 1,
                   "stubType" : "NONE"
                 }
               },
@@ -9585,13 +9585,13 @@
             "ospfProcess" : {
               "areas" : {
                 "1" : {
-                  "name" : 1,
                   "injectDefaultRoute" : true,
                   "interfaces" : [
                     "GigabitEthernet1/0",
                     "Loopback0"
                   ],
                   "metricOfDefaultRoute" : 0,
+                  "name" : 1,
                   "stubType" : "NONE"
                 }
               },
@@ -9981,7 +9981,6 @@
             "ospfProcess" : {
               "areas" : {
                 "1" : {
-                  "name" : 1,
                   "injectDefaultRoute" : true,
                   "interfaces" : [
                     "GigabitEthernet0/0",
@@ -9989,6 +9988,7 @@
                     "Loopback0"
                   ],
                   "metricOfDefaultRoute" : 0,
+                  "name" : 1,
                   "stubType" : "NONE"
                 }
               },
@@ -11248,7 +11248,6 @@
             "ospfProcess" : {
               "areas" : {
                 "1" : {
-                  "name" : 1,
                   "injectDefaultRoute" : true,
                   "interfaces" : [
                     "GigabitEthernet1/0",
@@ -11256,6 +11255,7 @@
                     "Loopback0"
                   ],
                   "metricOfDefaultRoute" : 0,
+                  "name" : 1,
                   "stubType" : "NONE"
                 }
               },
@@ -12458,7 +12458,6 @@
             "ospfProcess" : {
               "areas" : {
                 "1" : {
-                  "name" : 1,
                   "injectDefaultRoute" : true,
                   "interfaces" : [
                     "GigabitEthernet1/0",
@@ -12466,6 +12465,7 @@
                     "Loopback0"
                   ],
                   "metricOfDefaultRoute" : 0,
+                  "name" : 1,
                   "stubType" : "NONE"
                 }
               },
@@ -13066,7 +13066,6 @@
             "ospfProcess" : {
               "areas" : {
                 "1" : {
-                  "name" : 1,
                   "injectDefaultRoute" : true,
                   "interfaces" : [
                     "GigabitEthernet0/0",
@@ -13076,6 +13075,7 @@
                     "Loopback0"
                   ],
                   "metricOfDefaultRoute" : 0,
+                  "name" : 1,
                   "stubType" : "NONE"
                 }
               },
@@ -13623,7 +13623,6 @@
             "ospfProcess" : {
               "areas" : {
                 "1" : {
-                  "name" : 1,
                   "injectDefaultRoute" : true,
                   "interfaces" : [
                     "GigabitEthernet0/0",
@@ -13633,6 +13632,7 @@
                     "Loopback0"
                   ],
                   "metricOfDefaultRoute" : 0,
+                  "name" : 1,
                   "stubType" : "NONE"
                 }
               },
@@ -15337,7 +15337,6 @@
             "ospfProcess" : {
               "areas" : {
                 "1" : {
-                  "name" : 1,
                   "injectDefaultRoute" : true,
                   "interfaces" : [
                     "GigabitEthernet0/0",
@@ -15345,6 +15344,7 @@
                     "Loopback0"
                   ],
                   "metricOfDefaultRoute" : 0,
+                  "name" : 1,
                   "stubType" : "NONE"
                 }
               },
@@ -16094,7 +16094,6 @@
             "ospfProcess" : {
               "areas" : {
                 "1" : {
-                  "name" : 1,
                   "injectDefaultRoute" : true,
                   "interfaces" : [
                     "GigabitEthernet0/0",
@@ -16102,6 +16101,7 @@
                     "Loopback0"
                   ],
                   "metricOfDefaultRoute" : 0,
+                  "name" : 1,
                   "stubType" : "NONE"
                 }
               },
@@ -17220,13 +17220,13 @@
             "ospfProcess" : {
               "areas" : {
                 "1" : {
-                  "name" : 1,
                   "injectDefaultRoute" : true,
                   "interfaces" : [
                     "GigabitEthernet0/0",
                     "Loopback0"
                   ],
                   "metricOfDefaultRoute" : 0,
+                  "name" : 1,
                   "stubType" : "NONE"
                 }
               },
@@ -18297,13 +18297,13 @@
             "ospfProcess" : {
               "areas" : {
                 "1" : {
-                  "name" : 1,
                   "injectDefaultRoute" : true,
                   "interfaces" : [
                     "GigabitEthernet1/0",
                     "Loopback0"
                   ],
                   "metricOfDefaultRoute" : 0,
+                  "name" : 1,
                   "stubType" : "NONE"
                 }
               },
@@ -18893,7 +18893,6 @@
             "ospfProcess" : {
               "areas" : {
                 "1" : {
-                  "name" : 1,
                   "injectDefaultRoute" : true,
                   "interfaces" : [
                     "GigabitEthernet0/0",
@@ -18901,6 +18900,7 @@
                     "Loopback0"
                   ],
                   "metricOfDefaultRoute" : 0,
+                  "name" : 1,
                   "stubType" : "NONE"
                 }
               },

--- a/tests/jsonpath-addons/jsonpath-display-hints-prefixofsuffix.ref
+++ b/tests/jsonpath-addons/jsonpath-display-hints-prefixofsuffix.ref
@@ -1269,7 +1269,6 @@
                   "ospfProcess" : {
                     "areas" : {
                       "1" : {
-                        "name" : 1,
                         "injectDefaultRoute" : true,
                         "interfaces" : [
                           "GigabitEthernet1/0",
@@ -1277,6 +1276,7 @@
                           "Loopback0"
                         ],
                         "metricOfDefaultRoute" : 0,
+                        "name" : 1,
                         "stubType" : "NONE"
                       }
                     },

--- a/tests/jsonpath-addons/jsonpath-display-hints-suffixofsuffix.ref
+++ b/tests/jsonpath-addons/jsonpath-display-hints-suffixofsuffix.ref
@@ -1269,7 +1269,6 @@
                   "ospfProcess" : {
                     "areas" : {
                       "1" : {
-                        "name" : 1,
                         "injectDefaultRoute" : true,
                         "interfaces" : [
                           "GigabitEthernet1/0",
@@ -1277,6 +1276,7 @@
                           "Loopback0"
                         ],
                         "metricOfDefaultRoute" : 0,
+                        "name" : 1,
                         "stubType" : "NONE"
                       }
                     },

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -1770,12 +1770,12 @@
             "ospfProcess" : {
               "areas" : {
                 "0" : {
-                  "name" : 0,
                   "injectDefaultRoute" : true,
                   "interfaces" : [
                     "blah"
                   ],
                   "metricOfDefaultRoute" : 0,
+                  "name" : 0,
                   "stubType" : "NONE"
                 }
               },
@@ -9699,9 +9699,9 @@
             "ospfProcess" : {
               "areas" : {
                 "0" : {
-                  "name" : 0,
                   "injectDefaultRoute" : true,
                   "metricOfDefaultRoute" : 0,
+                  "name" : 0,
                   "stubType" : "NONE",
                   "summaries" : {
                     "1.2.3.0/24" : {
@@ -9712,9 +9712,9 @@
                   "summaryFilter" : "~OSPF_SUMMARY_FILTER:default:0~"
                 },
                 "16909056" : {
-                  "name" : 16909056,
                   "injectDefaultRoute" : true,
                   "metricOfDefaultRoute" : 0,
+                  "name" : 16909056,
                   "stubType" : "NONE",
                   "summaries" : {
                     "1.2.3.0/24" : {
@@ -12247,13 +12247,13 @@
             "ospfProcess" : {
               "areas" : {
                 "0" : {
-                  "name" : 0,
                   "injectDefaultRoute" : true,
                   "interfaces" : [
                     "Ethernet0",
                     "Ethernet1"
                   ],
                   "metricOfDefaultRoute" : 0,
+                  "name" : 0,
                   "stubType" : "NONE"
                 }
               },
@@ -13951,9 +13951,9 @@
             "ospfProcess" : {
               "areas" : {
                 "0" : {
-                  "name" : 0,
                   "injectDefaultRoute" : true,
                   "metricOfDefaultRoute" : 0,
+                  "name" : 0,
                   "stubType" : "NONE",
                   "summaries" : {
                     "10.0.0.0/15" : {
@@ -14435,9 +14435,9 @@
             "ospfProcess" : {
               "areas" : {
                 "66051" : {
-                  "name" : 66051,
                   "injectDefaultRoute" : false,
                   "metricOfDefaultRoute" : 0,
+                  "name" : 66051,
                   "nssa" : {
                     "defaultOriginateType" : "INTER_AREA",
                     "suppressType3" : true
@@ -16346,18 +16346,18 @@
             "ospfProcess" : {
               "areas" : {
                 "7" : {
-                  "name" : 7,
                   "injectDefaultRoute" : true,
                   "metricOfDefaultRoute" : 10,
+                  "name" : 7,
                   "stub" : {
                     "suppressType3" : false
                   },
                   "stubType" : "STUB"
                 },
                 "46" : {
-                  "name" : 46,
                   "injectDefaultRoute" : false,
                   "metricOfDefaultRoute" : 0,
+                  "name" : 46,
                   "stub" : {
                     "suppressType3" : true
                   },


### PR DESCRIPTION
I did this as an exercise to see how easy/challenging it would be to move towards immutable Configurations or even smaller datamodel pieces (spoiler alert, it's hard 🙂 )

Key points:
* Move OspfArea off of comparable structure
* Make most fields final and immutable sets/maps
* Replace `name` with `areaNumber` (although kept as `name` in JSON representation for backwards compatibility
* Annotations/Javadoc, etc. usual cleanup.