### PR TITLE
Topology: add L3 edges between interfaces with different subnet masks that could still ping

### DIFF
--- a/projects/allinone/src/test/java/org/batfish/question/traceroute/TracerouteTest.java
+++ b/projects/allinone/src/test/java/org/batfish/question/traceroute/TracerouteTest.java
@@ -55,6 +55,7 @@ import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
 import org.batfish.main.TestrigText;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -444,7 +445,7 @@ public class TracerouteTest {
    * Case 1: mask < 24 : R1 -> DELIVERED_TO_SUBNET
    * Case 2: mask = 24 : same above,
    * since connected route has higher priority than static route
-   * Case 3: mask > 24 : DELIEVERED_TO_SUBNET with trace R1 -> R2
+   * Case 3: mask > 24 : DELIVERED_TO_SUBNET with trace R1 -> R2
    *
    * Note: in practice, R2 would complain about overlapping interfaces
    */
@@ -521,6 +522,7 @@ public class TracerouteTest {
     return answer;
   }
 
+  @Ignore("https://github.com/batfish/batfish/issues/2528")
   @Test
   public void testDeliveredToSubnetVSStaticRoute1() throws IOException {
     TableAnswerElement answer = testDeliveredToSubnetVSStaticRoute("22");
@@ -685,6 +687,7 @@ public class TracerouteTest {
     return answer;
   }
 
+  @Ignore("https://github.com/batfish/batfish/issues/2528")
   @Test
   public void testDispositionMultiInterfaces1() throws IOException {
     TableAnswerElement answer = testDispositionMultiInterfaces("22");
@@ -878,6 +881,7 @@ public class TracerouteTest {
     return answer;
   }
 
+  @Ignore("https://github.com/batfish/batfish/issues/2528")
   @Test
   public void testDispositionMultipleRouters1() throws IOException {
     TableAnswerElement answer = testDispositionMultipleRouters("22");

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
@@ -2,6 +2,7 @@ package org.batfish.common.util;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Comparators;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
@@ -57,6 +58,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -91,7 +93,6 @@ import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.UniverseIpSpace;
-import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.glassfish.grizzly.http.server.HttpServer;
 import org.glassfish.grizzly.ssl.SSLContextConfigurator;
 import org.glassfish.grizzly.ssl.SSLEngineConfigurator;
@@ -828,39 +829,67 @@ public class CommonUtil {
         new SSLEngineConfigurator(sslCon, false, verifyClient, false));
   }
 
+  /** Returns {@code true} if any {@link Ip IP address} is owned by both devices. */
+  private static boolean haveIpInCommon(Interface i1, Interface i2) {
+    for (InterfaceAddress ia : i1.getAllAddresses()) {
+      for (InterfaceAddress ia2 : i2.getAllAddresses()) {
+        if (ia.getIp().equals(ia2.getIp())) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
   public static Topology synthesizeTopology(Map<String, Configuration> configurations) {
-    SortedSet<Edge> edges = new TreeSet<>();
     Map<Prefix, List<Interface>> prefixInterfaces = new HashMap<>();
     configurations.forEach(
         (nodeName, node) -> {
           for (Interface iface : node.getAllInterfaces().values()) {
-            if (!iface.isLoopback(node.getConfigurationFormat()) && iface.getActive()) {
-              for (InterfaceAddress address : iface.getAllAddresses()) {
-                if (address.getNetworkBits() < Prefix.MAX_PREFIX_LENGTH) {
-                  Prefix prefix = address.getPrefix();
-                  List<Interface> interfaceBucket =
-                      prefixInterfaces.computeIfAbsent(prefix, k -> new LinkedList<>());
-                  interfaceBucket.add(iface);
-                }
+            if (iface.isLoopback(node.getConfigurationFormat()) || !iface.getActive()) {
+              continue;
+            }
+            for (InterfaceAddress address : iface.getAllAddresses()) {
+              if (address.getNetworkBits() < Prefix.MAX_PREFIX_LENGTH) {
+                Prefix prefix = address.getPrefix();
+                List<Interface> interfaceBucket =
+                    prefixInterfaces.computeIfAbsent(prefix, k -> new LinkedList<>());
+                interfaceBucket.add(iface);
               }
             }
           }
         });
-    for (List<Interface> bucket : prefixInterfaces.values()) {
-      for (Interface iface1 : bucket) {
-        for (Interface iface2 : bucket) {
-          if (iface1 != iface2
-              // don't connect interfaces that have even a single address in common
-              && Sets.intersection(iface1.getAllAddresses(), iface2.getAllAddresses()).isEmpty()) {
-            edges.add(
-                new Edge(
-                    new NodeInterfacePair(iface1.getOwner().getHostname(), iface1.getName()),
-                    new NodeInterfacePair(iface2.getOwner().getHostname(), iface2.getName())));
+
+    ImmutableSortedSet.Builder<Edge> edges = ImmutableSortedSet.naturalOrder();
+    for (Entry<Prefix, List<Interface>> bucketEntry : prefixInterfaces.entrySet()) {
+      Prefix p = bucketEntry.getKey();
+
+      // Collect all interfaces that have subnets overlapping P iff they have an IP address in P.
+      // Use an IdentityHashSet to prevent duplicates.
+      Set<Interface> candidateInterfaces = Sets.newIdentityHashSet();
+      IntStream.range(0, Prefix.MAX_PREFIX_LENGTH)
+          .mapToObj(
+              i -> prefixInterfaces.getOrDefault(new Prefix(p.getStartIp(), i), ImmutableList.of()))
+          .flatMap(Collection::stream)
+          .filter(
+              iface -> iface.getAllAddresses().stream().anyMatch(ia -> p.containsIp(ia.getIp())))
+          .forEach(candidateInterfaces::add);
+
+      for (Interface iface1 : bucketEntry.getValue()) {
+        for (Interface iface2 : candidateInterfaces) {
+          // no self-edges
+          if (iface1 == iface2) {
+            continue;
           }
+          // don't connect interfaces that have any IP address in common
+          if (haveIpInCommon(iface1, iface2)) {
+            continue;
+          }
+          edges.add(new Edge(iface1, iface2));
         }
       }
     }
-    return new Topology(edges);
+    return new Topology(edges.build());
   }
 
   public static <K1, K2, V1, V2> Map<K2, V2> toImmutableMap(

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Edge.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Edge.java
@@ -54,9 +54,7 @@ public class Edge implements Serializable, Comparable<Edge> {
 
   /** Create an Edge from {@link Interface}s */
   public Edge(Interface tail, Interface head) {
-    this(
-        new NodeInterfacePair(tail.getOwner().getHostname(), tail.getName()),
-        new NodeInterfacePair(head.getOwner().getHostname(), head.getName()));
+    this(new NodeInterfacePair(tail), new NodeInterfacePair(head));
   }
 
   /** Create an edge from names of nodes and interfaces */

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/NodeInterfacePair.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/NodeInterfacePair.java
@@ -10,6 +10,7 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.Interface;
 
 /** Combination of node name and interface name */
 @ParametersAreNonnullByDefault
@@ -34,6 +35,10 @@ public class NodeInterfacePair implements Serializable, Comparable<NodeInterface
   public NodeInterfacePair(String hostname, String interfaceName) {
     _hostname = hostname;
     _interfaceName = interfaceName;
+  }
+
+  public NodeInterfacePair(Interface iface) {
+    this(iface.getOwner().getHostname(), iface.getName());
   }
 
   /** Return node name */

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/CommonUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/CommonUtilTest.java
@@ -5,16 +5,26 @@ import static org.batfish.common.util.CommonUtil.asPositiveIpWildcards;
 import static org.batfish.common.util.CommonUtil.communityStringToLong;
 import static org.batfish.common.util.CommonUtil.longToCommunity;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.Edge;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.InterfaceAddress;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.Topology;
 import org.junit.Ignore;
 import org.junit.Test;
 
 /** Tests of utility methods from {@link org.batfish.common.util.CommonUtil} */
 public class CommonUtilTest {
 
-  /** Test that asPostiveIpWildcards handles null */
+  /** Test that asPositiveIpWildcards handles null */
   @Test
   public void testAsPositiveIpWildcards() {
     assertThat(asPositiveIpWildcards(null), nullValue());
@@ -58,5 +68,49 @@ public class CommonUtilTest {
   public void testLongToCommunity() {
     assertThat(longToCommunity(0L), equalTo("0:0"));
     assertThat(longToCommunity(4294967295L), equalTo("65535:65535"));
+  }
+
+  @Test
+  public void testSynthesizeTopology_asymmetric() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration.Builder cb =
+        nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+    Configuration c1 = cb.build();
+    Configuration c2 = cb.build();
+    Interface i1 =
+        nf.interfaceBuilder().setOwner(c1).setAddresses(new InterfaceAddress("1.2.3.4/24")).build();
+    Interface i2 =
+        nf.interfaceBuilder().setOwner(c2).setAddresses(new InterfaceAddress("1.2.3.5/28")).build();
+    Topology t =
+        CommonUtil.synthesizeTopology(ImmutableMap.of(c1.getHostname(), c1, c2.getHostname(), c2));
+    assertThat(t.getEdges(), equalTo(ImmutableSet.of(new Edge(i1, i2), new Edge(i2, i1))));
+  }
+
+  @Test
+  public void testSynthesizeTopology_asymmetricPartialOverlap() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration.Builder cb =
+        nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+    Configuration c1 = cb.build();
+    Configuration c2 = cb.build();
+    nf.interfaceBuilder().setOwner(c1).setAddresses(new InterfaceAddress("1.2.3.4/24")).build();
+    nf.interfaceBuilder().setOwner(c2).setAddresses(new InterfaceAddress("1.2.3.17/28")).build();
+    Topology t =
+        CommonUtil.synthesizeTopology(ImmutableMap.of(c1.getHostname(), c1, c2.getHostname(), c2));
+    assertThat(t.getEdges(), empty());
+  }
+
+  @Test
+  public void testSynthesizeTopology_asymmetricSharedIp() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration.Builder cb =
+        nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+    Configuration c1 = cb.build();
+    Configuration c2 = cb.build();
+    nf.interfaceBuilder().setOwner(c1).setAddresses(new InterfaceAddress("1.2.3.4/24")).build();
+    nf.interfaceBuilder().setOwner(c2).setAddresses(new InterfaceAddress("1.2.3.4/28")).build();
+    Topology t =
+        CommonUtil.synthesizeTopology(ImmutableMap.of(c1.getHostname(), c1, c2.getHostname(), c2));
+    assertThat(t.getEdges(), empty());
   }
 }

--- a/projects/question/src/main/java/org/batfish/question/UniqueIpAssignmentsQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/UniqueIpAssignmentsQuestionPlugin.java
@@ -106,10 +106,7 @@ public class UniqueIpAssignmentsQuestionPlugin extends QuestionPlugin {
                       .stream()
                       .map(
                           ifaceAdrr ->
-                              Maps.immutableEntry(
-                                  ifaceAdrr.getIp(),
-                                  new NodeInterfacePair(
-                                      iface.getOwner().getHostname(), iface.getName()))))
+                              Maps.immutableEntry(ifaceAdrr.getIp(), new NodeInterfacePair(iface))))
           // group by Ip
           .collect(Multimaps.toMultimap(Entry::getKey, Entry::getValue, TreeMultimap::create))
           // convert to stream of Entry<Ip, Set<NodeInterfacePair>>

--- a/projects/question/src/main/java/org/batfish/question/specifiers/SpecifiersAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/specifiers/SpecifiersAnswerer.java
@@ -107,11 +107,7 @@ public final class SpecifiersAnswerer extends Answerer {
 
     Set<Interface> interfaces = interfaceSpecifier.resolve(nodes, context);
     for (Interface iface : interfaces) {
-      table.addRow(
-          Row.of(
-              columnMap,
-              COL_INTERFACE,
-              new NodeInterfacePair(iface.getOwner().getHostname(), iface.getName())));
+      table.addRow(Row.of(columnMap, COL_INTERFACE, new NodeInterfacePair(iface)));
     }
 
     return table;


### PR DESCRIPTION
This seems like the behavior that would happen in practice, right? Should we support this?

@anothermattbrown  - everything passes except the traceroute tests with hardcoded networks that rely on the edges not being there.