### PR TITLE
Automatically add missing columns when building Row

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/table/Row.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/table/Row.java
@@ -49,7 +49,7 @@ public class Row implements Comparable<Row>, Serializable {
 
   public abstract static class RowBuilder {
 
-    @Nonnull private final ObjectNode _data;
+    @Nonnull protected final ObjectNode _data;
 
     private RowBuilder() {
       _data = BatfishObjectMapper.mapper().createObjectNode();
@@ -125,6 +125,13 @@ public class Row implements Comparable<Row>, Serializable {
               "Cannot convert '%s' to Schema '%s' of column '%s'", object, expectedSchema, column));
       super.put(column, object);
       return this;
+    }
+
+    @Override
+    public Row build() {
+      // Fill in missing columns with null entries
+      _columns.keySet().stream().filter(c -> !_data.has(c)).forEach(c -> super.put(c, null));
+      return super.build();
     }
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/table/RowTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/table/RowTest.java
@@ -1,6 +1,7 @@
 package org.batfish.datamodel.table;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.IsEqual.equalTo;
 
@@ -146,6 +147,15 @@ public class RowTest {
       // we should be able to put null
       Row row = builder.put("col", null).build();
       assertThat(row.get("col", Schema.INTEGER), Matchers.is(nullValue()));
+    }
+
+    @Test
+    public void fillInEmptyColumnsOnBuild() {
+      Row row =
+          Row.builder(ImmutableMap.of("col", new ColumnMetadata("col", Schema.INTEGER, "desc")))
+              .build();
+      assertThat(row.getColumnNames(), contains("col"));
+      assertThat(row.hasNonNull("col"), equalTo(false));
     }
   }
 

--- a/tests/basic/filterLineReachability.ref
+++ b/tests/basic/filterLineReachability.ref
@@ -58,6 +58,19 @@
     "rows" : [
       {
         "Sources" : [
+          "as2dept1: RESTRICT_HOST_TRAFFIC_OUT"
+        ],
+        "Unreachable_Line_Action" : "DENY",
+        "Unreachable_Line" : "deny   ip 1.128.0.0 0.0.255.255 2.128.0.0 0.0.255.255",
+        "Blocking_Lines" : [
+          "permit ip any 2.128.0.0 0.0.255.255"
+        ],
+        "Different_Action" : true,
+        "Reason" : "BLOCKING_LINES",
+        "Additional_Info" : null
+      },
+      {
+        "Sources" : [
           "as2dept1: RESTRICT_HOST_TRAFFIC_IN"
         ],
         "Unreachable_Line_Action" : "PERMIT",
@@ -67,19 +80,8 @@
           "deny   ip any any"
         ],
         "Different_Action" : true,
-        "Reason" : "BLOCKING_LINES"
-      },
-      {
-        "Sources" : [
-          "as2dept1: RESTRICT_HOST_TRAFFIC_OUT"
-        ],
-        "Unreachable_Line_Action" : "DENY",
-        "Unreachable_Line" : "deny   ip 1.128.0.0 0.0.255.255 2.128.0.0 0.0.255.255",
-        "Blocking_Lines" : [
-          "permit ip any 2.128.0.0 0.0.255.255"
-        ],
-        "Different_Action" : true,
-        "Reason" : "BLOCKING_LINES"
+        "Reason" : "BLOCKING_LINES",
+        "Additional_Info" : null
       }
     ],
     "summary" : {


### PR DESCRIPTION
Various things including TableDiff rely on rows' columns exactly matching their column metadata. This change ensures that's the case when rows get built.