### PR TITLE
use HashMap instead of IdentityHashMap

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/MemoizedIpSpaceToBDD.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/MemoizedIpSpaceToBDD.java
@@ -1,19 +1,16 @@
 package org.batfish.common.bdd;
 
 import com.google.common.annotations.VisibleForTesting;
-import java.util.IdentityHashMap;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import net.sf.javabdd.BDD;
 import net.sf.javabdd.BDDFactory;
 import org.batfish.datamodel.IpSpace;
 
-/**
- * An {@link IpSpaceToBDD} that memoizes its {@link IpSpaceToBDD#visit} method using an {@link
- * IdentityHashMap}.
- */
+/** An {@link IpSpaceToBDD} that memoizes its {@link IpSpaceToBDD#visit} method. */
 public final class MemoizedIpSpaceToBDD extends IpSpaceToBDD {
-  private final Map<IpSpace, BDD> _cache = new IdentityHashMap<>();
+  private final Map<IpSpace, BDD> _cache = new HashMap<>();
 
   public MemoizedIpSpaceToBDD(
       BDDFactory factory, BDDInteger var, Map<String, IpSpace> namedIpSpaces) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/MemoizedIpSpaceToBDD.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/MemoizedIpSpaceToBDD.java
@@ -19,7 +19,12 @@ public final class MemoizedIpSpaceToBDD extends IpSpaceToBDD {
 
   @Override
   public BDD visit(IpSpace ipSpace) {
-    return _cache.computeIfAbsent(ipSpace, super::visit);
+    BDD bdd = _cache.get(ipSpace);
+    if (bdd == null) {
+      bdd = super.visit(ipSpace);
+      _cache.put(ipSpace, bdd);
+    }
+    return bdd;
   }
 
   @VisibleForTesting


### PR DESCRIPTION
ForwardingAnalysis (especially after recent changes) creates too many
different value-equal objects. With IdentityHashMap, memoization wasn't
helping enough. HashMap works significantly better now.

Long-term, we may want to reduce the number of value-equal IpSpaces we
keep around. For example, there are many ways to express Universe or
Empty -- we could make an effort to canonicalize. Also, each call to
toIpSpace() on an Ip, Prefix or IpWildcard creates a new object.