### PR TITLE
Check row for correct columns when adding to table

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/table/TableAnswerElement.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/table/TableAnswerElement.java
@@ -1,5 +1,7 @@
 package org.batfish.datamodel.table;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -47,6 +49,11 @@ public final class TableAnswerElement extends AnswerElement {
    * @param row The row to add
    */
   public @Nonnull TableAnswerElement addRow(Row row) {
+    checkArgument(
+        row.getColumnNames().equals(_tableMetadata.toColumnMap().keySet()),
+        "Row columns %s do not match metadata columns metadata %s",
+        row.getColumnNames(),
+        _tableMetadata.toColumnMap().keySet());
     _rows.add(row);
     _rowsList.add(row);
     return this;
@@ -58,6 +65,11 @@ public final class TableAnswerElement extends AnswerElement {
    * @param row The row to add
    */
   public @Nonnull TableAnswerElement addExcludedRow(Row row, String exclusionName) {
+    checkArgument(
+        row.getColumnNames().equals(_tableMetadata.toColumnMap().keySet()),
+        "Row columns %s do not match metadata columns metadata %s",
+        row.getColumnNames(),
+        row);
     for (ExcludedRows exRows : _excludedRows) {
       if (exRows.getExclusionName().equals(exclusionName)) {
         exRows.addRow(row);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/answers/AnswerMetadataUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/answers/AnswerMetadataUtilTest.java
@@ -292,12 +292,13 @@ public class AnswerMetadataUtilTest {
   public void testComputeMajorIssueTypesNone() {
     String columnName = "col";
 
+    TableMetadata tableMetadata =
+        new TableMetadata(
+            ImmutableList.of(new ColumnMetadata(columnName, Schema.ISSUE, "foobar")),
+            new DisplayHints().getTextDesc());
     TableAnswerElement table =
-        new TableAnswerElement(
-                new TableMetadata(
-                    ImmutableList.of(new ColumnMetadata(columnName, Schema.ISSUE, "foobar")),
-                    new DisplayHints().getTextDesc()))
-            .addRow(Row.of());
+        new TableAnswerElement(tableMetadata)
+            .addRow(Row.builder(tableMetadata.toColumnMap()).build());
 
     assertThat(AnswerMetadataUtil.computeMajorIssueConfigs(table), equalTo(ImmutableMap.of()));
   }


### PR DESCRIPTION
`TableAnswerElement` now throws an `IllegalArgumentException` if you call `addRow` or `addExcludedRow` with a row whose columns don't exactly match the table metadata columns.