### PR TITLE
implement loop detection in the new traceroute engine

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteEngineImplContext.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteEngineImplContext.java
@@ -462,6 +462,8 @@ public class TracerouteEngineImplContext {
     // Loop detection
     Breadcrumb breadcrumb = new Breadcrumb(currentNodeName, vrfName, currentFlow);
     if (_breadcrumbs.contains(breadcrumb)) {
+      Hop loopHop = new Hop(new Node(currentNodeName), ImmutableList.copyOf(steps));
+      transmissionContext._hopsSoFar.add(loopHop);
       Trace trace = new Trace(FlowDisposition.LOOP, transmissionContext._hopsSoFar);
       transmissionContext._flowTraces.add(trace);
       return;
@@ -482,7 +484,6 @@ public class TracerouteEngineImplContext {
                 .setDetail(new InboundStepDetail())
                 .build();
         steps.add(inboundStep);
-
         Hop acceptedHop = new Hop(new Node(currentNodeName), ImmutableList.copyOf(steps));
         transmissionContext._hopsSoFar.add(acceptedHop);
         Trace trace = new Trace(FlowDisposition.ACCEPTED, transmissionContext._hopsSoFar);

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TracerouteEngineImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TracerouteEngineImplTest.java
@@ -2,6 +2,8 @@ package org.batfish.dataplane.traceroute;
 
 import static java.util.Collections.singletonList;
 import static org.batfish.datamodel.FlowDisposition.ACCEPTED;
+import static org.batfish.datamodel.FlowDisposition.DENIED_IN;
+import static org.batfish.datamodel.FlowDisposition.LOOP;
 import static org.batfish.datamodel.FlowDisposition.NO_ROUTE;
 import static org.batfish.datamodel.matchers.TraceMatchers.hasDisposition;
 import static org.hamcrest.Matchers.contains;
@@ -14,6 +16,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import java.io.IOException;
@@ -35,8 +38,11 @@ import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.IpAccessListLine;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.SourceNat;
+import org.batfish.datamodel.StaticRoute;
 import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.acl.AclLineMatchExprs;
 import org.batfish.datamodel.acl.TrueExpr;
 import org.batfish.datamodel.flow.Trace;
 import org.batfish.datamodel.matchers.TraceMatchers;
@@ -385,5 +391,84 @@ public class TracerouteEngineImplTest {
 
     _thrown.expect(IllegalArgumentException.class);
     TracerouteEngineImpl.getInstance().buildFlows(dp, flows, fibs, false);
+  }
+
+  /*
+   * Create a network with a forwarding loop. When we run with ACLs enabled, the loop is detected.
+   * When we run with ACLs enabled, it's not an infinite loop: we apply source NAT in the first
+   * iteration, and drop with an ingress ACL in the second iteration.
+   */
+  @Test
+  public void testLoop() throws IOException {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration.Builder cb =
+        nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+    Configuration c1 = cb.build();
+    Vrf v1 = nf.vrfBuilder().setOwner(c1).build();
+    InterfaceAddress c1Addr = new InterfaceAddress("1.0.0.0/31");
+    InterfaceAddress c2Addr = new InterfaceAddress("1.0.0.1/31");
+    Interface i1 =
+        nf.interfaceBuilder().setActive(true).setOwner(c1).setVrf(v1).setAddress(c1Addr).build();
+    Prefix loopPrefix = Prefix.parse("2.0.0.0/32");
+    v1.setStaticRoutes(
+        ImmutableSortedSet.of(
+            StaticRoute.builder()
+                .setNetwork(loopPrefix)
+                .setAdministrativeCost(1)
+                .setNextHopInterface(i1.getName())
+                .setNextHopIp(c2Addr.getIp())
+                .build()));
+    Configuration c2 = cb.build();
+    Vrf v2 = nf.vrfBuilder().setOwner(c2).build();
+    Interface i2 =
+        nf.interfaceBuilder().setActive(true).setOwner(c2).setVrf(v2).setAddress(c2Addr).build();
+    Prefix natPoolIp = Prefix.parse("5.5.5.5/32");
+    i2.setIncomingFilter(
+        nf.aclBuilder()
+            .setOwner(c2)
+            .setLines(
+                ImmutableList.of(IpAccessListLine.rejecting(AclLineMatchExprs.matchSrc(natPoolIp))))
+            .build());
+    i2.setSourceNats(
+        ImmutableList.of(
+            SourceNat.builder()
+                .setAcl(
+                    nf.aclBuilder()
+                        .setOwner(c2)
+                        .setLines(ImmutableList.of(IpAccessListLine.ACCEPT_ALL))
+                        .build())
+                .setPoolIpFirst(natPoolIp.getStartIp())
+                .setPoolIpLast(natPoolIp.getStartIp())
+                .build()));
+    v2.setStaticRoutes(
+        ImmutableSortedSet.of(
+            StaticRoute.builder()
+                .setNetwork(loopPrefix)
+                .setAdministrativeCost(1)
+                .setNextHopInterface(i2.getName())
+                .setNextHopIp(c1Addr.getIp())
+                .build()));
+    Batfish batfish =
+        BatfishTestUtils.getBatfish(
+            ImmutableSortedMap.of(c1.getHostname(), c1, c2.getHostname(), c2), _tempFolder);
+    batfish.computeDataPlane(false);
+    DataPlane dp = batfish.loadDataPlane();
+    Flow flow =
+        Flow.builder()
+            .setTag("tag")
+            .setIngressNode(c1.getHostname())
+            .setIngressVrf(v1.getName())
+            .setDstIp(loopPrefix.getStartIp())
+            // any src Ip other than the NAT pool IP will do
+            .setSrcIp(new Ip("6.6.6.6"))
+            .build();
+    SortedMap<Flow, List<Trace>> flowTraces =
+        TracerouteEngineImpl.getInstance()
+            .buildFlows(dp, ImmutableSet.of(flow), dp.getFibs(), false);
+    assertThat(flowTraces.get(flow), contains(TraceMatchers.hasDisposition(DENIED_IN)));
+    flowTraces =
+        TracerouteEngineImpl.getInstance()
+            .buildFlows(dp, ImmutableSet.of(flow), dp.getFibs(), true);
+    assertThat(flowTraces.get(flow), contains(TraceMatchers.hasDisposition(LOOP)));
   }
 }


### PR DESCRIPTION
Fixes #2543 

This detects infinite loops, as opposed to loops that will exit eventually due to NAT. The check is based on the history of visited VRFs and the current flow at the time of each visit. Since this is not already present in the `Hop`s and `Step`s, I added a new `Breadcrumb` class and keep a stack of them.