### PR TITLE
Routes question: bgp rib should include tag column

### DIFF
--- a/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswerer.java
@@ -27,6 +27,7 @@ import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.GenericRib;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.Route;
 import org.batfish.datamodel.answers.AnswerElement;
 import org.batfish.datamodel.answers.Schema;
 import org.batfish.datamodel.pojo.Node;
@@ -245,6 +246,7 @@ public class RoutesAnswerer extends Answerer {
                             .map(CommonUtil::longToCommunity)
                             .collect(toImmutableList()))
                     .put(COL_ORIGIN_PROTOCOL, route.getSrcProtocol())
+                    .put(COL_TAG, route.getTag() == Route.UNSET_ROUTE_TAG ? null : route.getTag())
                     .build())
         .collect(toImmutableList());
   }

--- a/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
@@ -318,6 +318,28 @@ public class RoutesAnswererTest {
   }
 
   @Test
+  public void testBgpRoutesHaveTagColumn() {
+    Ip ip = new Ip("1.1.1.1");
+    List<Row> rows =
+        getRowsForBgpRoutes(
+            "node",
+            "vrf",
+            null,
+            Pattern.compile(".*"),
+            ImmutableSet.of(
+                new Builder()
+                    .setNetwork(new Prefix(ip, MAX_PREFIX_LENGTH))
+                    .setOriginType(OriginType.IGP)
+                    .setOriginatorIp(ip)
+                    .setReceivedFromIp(ip)
+                    .setCommunities(ImmutableSortedSet.of(65537L))
+                    .setProtocol(RoutingProtocol.BGP)
+                    .build()));
+
+    assertThat(rows.get(0).get(COL_TAG, Schema.STRING), nullValue());
+  }
+
+  @Test
   public void testComputeNextHopNode() {
     assertThat(computeNextHopNode(null, ImmutableMap.of()), nullValue());
     assertThat(computeNextHopNode(new Ip("1.1.1.1"), null), nullValue());


### PR DESCRIPTION
Fixes an IllegalArgumentException after stricter standards added in #2541