### PR TITLE
Cisco: fix handling of extended acl log clause

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -5091,6 +5091,8 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
         } else if (feature.HOST_UNREACHABLE() != null) {
           icmpType = IcmpType.DESTINATION_UNREACHABLE;
           icmpCode = IcmpCode.HOST_UNREACHABLE;
+        } else if (feature.LOG() != null) {
+          // Do nothing.
         } else if (feature.NETWORK_UNKNOWN() != null) {
           icmpType = IcmpType.DESTINATION_UNREACHABLE;
           icmpCode = IcmpCode.DESTINATION_NETWORK_UNKNOWN;
@@ -5295,6 +5297,8 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
       } else if (feature.HOST_UNREACHABLE() != null) {
         icmpType = IcmpType.DESTINATION_UNREACHABLE;
         icmpCode = IcmpCode.HOST_UNREACHABLE;
+      } else if (feature.LOG() != null) {
+        // Do nothing.
       } else if (feature.NETWORK_UNKNOWN() != null) {
         icmpType = IcmpType.DESTINATION_UNREACHABLE;
         icmpCode = IcmpCode.DESTINATION_NETWORK_UNKNOWN;

--- a/tests/parsing-tests/networks/unit-tests/configs/cisco_acl
+++ b/tests/parsing-tests/networks/unit-tests/configs/cisco_acl
@@ -25,6 +25,7 @@ ip access-list BLAH-BLAH
    280 permit icmp any any 5 2
    290 permit icmp any any time-exceeded ! believe this is type 11, any code
    300 permit icmp any any ttl-exceeded  ! type 11, code 0
+   410 deny ip any any log
 !
 ! 'extended' is the name
 ip access-list extended

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -4911,6 +4911,24 @@
                   }
                 },
                 "name" : "300 permit icmp any any ttl-exceeded  ! type 11, code 0"
+              },
+              {
+                "action" : "DENY",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "0.0.0.0/0"
+                    },
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "0.0.0.0/0"
+                    }
+                  }
+                },
+                "name" : "410 deny ip any any log"
               }
             ],
             "sourceName" : "BLAH-BLAH",

--- a/tests/parsing-tests/unit-tests-unused.ref
+++ b/tests/parsing-tests/unit-tests-unused.ref
@@ -287,7 +287,8 @@
             24,
             25,
             26,
-            27
+            27,
+            28
           ]
         }
       },
@@ -297,8 +298,8 @@
         "Source_Lines" : {
           "filename" : "configs/cisco_acl",
           "lines" : [
-            34,
-            35
+            35,
+            36
           ]
         }
       },
@@ -308,7 +309,7 @@
         "Source_Lines" : {
           "filename" : "configs/cisco_acl",
           "lines" : [
-            30
+            31
           ]
         }
       },
@@ -318,7 +319,7 @@
         "Source_Lines" : {
           "filename" : "configs/cisco_acl",
           "lines" : [
-            32
+            33
           ]
         }
       },
@@ -328,9 +329,9 @@
         "Source_Lines" : {
           "filename" : "configs/cisco_acl",
           "lines" : [
-            61,
             62,
-            63
+            63,
+            64
           ]
         }
       },
@@ -340,8 +341,8 @@
         "Source_Lines" : {
           "filename" : "configs/cisco_acl",
           "lines" : [
-            37,
-            38
+            38,
+            39
           ]
         }
       },
@@ -351,8 +352,8 @@
         "Source_Lines" : {
           "filename" : "configs/cisco_acl",
           "lines" : [
-            40,
-            41
+            41,
+            42
           ]
         }
       },

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -13848,6 +13848,19 @@
             "          ANY:'any')",
             "        (extended_access_list_additional_feature",
             "          TTL_EXCEEDED:'ttl-exceeded')",
+            "        NEWLINE:'\\n')",
+            "      (extended_access_list_tail",
+            "        num = DEC:'410'",
+            "        ala = (access_list_action",
+            "          DENY:'deny')",
+            "        prot = (protocol",
+            "          IP:'ip')",
+            "        srcipr = (access_list_ip_range",
+            "          ANY:'any')",
+            "        dstipr = (access_list_ip_range",
+            "          ANY:'any')",
+            "        (extended_access_list_additional_feature",
+            "          LOG:'log')",
             "        NEWLINE:'\\n')))",
             "  (stanza",
             "    (extended_access_list_stanza",
@@ -58394,34 +58407,35 @@
                 24,
                 25,
                 26,
-                27
+                27,
+                28
               ],
               "numReferrers" : 0
             },
             "blah" : {
               "definitionLines" : [
-                34,
-                35
+                35,
+                36
               ],
               "numReferrers" : 0
             },
             "extended" : {
               "definitionLines" : [
-                30
+                31
               ],
               "numReferrers" : 0
             },
             "standard" : {
               "definitionLines" : [
-                32
+                33
               ],
               "numReferrers" : 0
             },
             "test-codes" : {
               "definitionLines" : [
-                61,
                 62,
-                63
+                63,
+                64
               ],
               "numReferrers" : 0
             }
@@ -58429,15 +58443,15 @@
           "ipv4 prefix-list" : {
             "allowprefix" : {
               "definitionLines" : [
-                37,
-                38
+                38,
+                39
               ],
               "numReferrers" : 0
             },
             "allowprefix-asa" : {
               "definitionLines" : [
-                40,
-                41
+                41,
+                42
               ],
               "numReferrers" : 0
             }


### PR DESCRIPTION
Otherwise they could be turned into unmatchable lines.