### PR TITLE
Add an API call to retrieve a workitem log

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/CoordConstsV2.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/CoordConstsV2.java
@@ -29,4 +29,5 @@ public class CoordConstsV2 {
   public static final String RSC_SETTINGS = "settings";
   public static final String RSC_SNAPSHOTS = "snapshots";
   public static final String RSC_TOPOLOGY = "topology";
+  public static final String RSC_WORK_LOG = "worklog";
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
@@ -752,8 +752,9 @@ public class CommonUtil {
     return ranges.stream().anyMatch(sr -> sr.includes(num));
   }
 
-  public static String readFile(Path file) {
-    String text = null;
+  @Nonnull
+  public static String readFile(Path file) throws BatfishException {
+    String text;
     try {
       text = new String(Files.readAllBytes(file), StandardCharsets.UTF_8);
     } catch (IOException e) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
@@ -300,9 +300,7 @@ public final class FileBasedStorage implements StorageProvider {
   @Nonnull
   public String loadWorkLog(NetworkId network, SnapshotId snapshot, String workId)
       throws IOException {
-    Path logPath =
-        _d.getSnapshotOutputDir(network, snapshot).resolve(workId + BfConsts.SUFFIX_LOG_FILE);
-    return FileUtils.readFileToString(logPath.toFile(), UTF_8);
+    return FileUtils.readFileToString(getWorkLoadPath(network, snapshot, workId).toFile(), UTF_8);
   }
 
   @Override
@@ -894,8 +892,7 @@ public final class FileBasedStorage implements StorageProvider {
   @Override
   public void storeWorkLog(String logOutput, NetworkId network, SnapshotId snapshot, String workId)
       throws IOException {
-    Path path =
-        _d.getSnapshotOutputDir(network, snapshot).resolve(workId + BfConsts.SUFFIX_LOG_FILE);
-    FileUtils.writeStringToFile(path.toFile(), logOutput, UTF_8);
+    FileUtils.writeStringToFile(
+        getWorkLoadPath(network, snapshot, workId).toFile(), logOutput, UTF_8);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
@@ -297,6 +297,15 @@ public final class FileBasedStorage implements StorageProvider {
   }
 
   @Override
+  @Nonnull
+  public String loadWorkLog(NetworkId network, SnapshotId snapshot, String workId)
+      throws IOException {
+    Path logPath =
+        _d.getSnapshotOutputDir(network, snapshot).resolve(workId + BfConsts.SUFFIX_LOG_FILE);
+    return FileUtils.readFileToString(logPath.toFile(), UTF_8);
+  }
+
+  @Override
   public @Nullable MajorIssueConfig loadMajorIssueConfig(
       NetworkId network, IssueSettingsId majorIssueType) {
     Path path = _d.getMajorIssueConfigDir(network, majorIssueType);
@@ -845,6 +854,11 @@ public final class FileBasedStorage implements StorageProvider {
         .resolve(BfConsts.RELPATH_TESTRIG_POJO_TOPOLOGY_PATH);
   }
 
+  @Nonnull
+  private Path getWorkLoadPath(NetworkId network, SnapshotId snapshot, String workId) {
+    return _d.getSnapshotOutputDir(network, snapshot).resolve(workId + BfConsts.SUFFIX_LOG_FILE);
+  }
+
   @Override
   public @Nonnull String loadTopology(NetworkId networkId, SnapshotId snapshotId)
       throws IOException {
@@ -875,5 +889,13 @@ public final class FileBasedStorage implements StorageProvider {
     path.getParent().toFile().mkdirs();
     FileUtils.writeStringToFile(
         path.toFile(), BatfishObjectMapper.writePrettyString(topology), UTF_8);
+  }
+
+  @Override
+  public void storeWorkLog(String logOutput, NetworkId network, SnapshotId snapshot, String workId)
+      throws IOException {
+    Path path =
+        _d.getSnapshotOutputDir(network, snapshot).resolve(workId + BfConsts.SUFFIX_LOG_FILE);
+    FileUtils.writeStringToFile(path.toFile(), logOutput, UTF_8);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
@@ -300,7 +300,12 @@ public final class FileBasedStorage implements StorageProvider {
   @Nonnull
   public String loadWorkLog(NetworkId network, SnapshotId snapshot, String workId)
       throws IOException {
-    return FileUtils.readFileToString(getWorkLoadPath(network, snapshot, workId).toFile(), UTF_8);
+    Path filePath = getWorkLoadPath(network, snapshot, workId);
+    if (!Files.exists(filePath)) {
+      throw new FileNotFoundException(
+          String.format("Could not find log file for work ID: %s", workId));
+    }
+    return FileUtils.readFileToString(filePath.toFile(), UTF_8);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorageDirectoryProvider.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorageDirectoryProvider.java
@@ -112,4 +112,8 @@ public class FileBasedStorageDirectoryProvider {
   public Path getSnapshotInputObjectsDir(NetworkId networkId, SnapshotId snapshotId) {
     return getSnapshotDir(networkId, snapshotId).resolve(BfConsts.RELPATH_INPUT);
   }
+
+  public Path getSnapshotOutputDir(NetworkId networkId, SnapshotId snapshotId) {
+    return getSnapshotDir(networkId, snapshotId).resolve(BfConsts.RELPATH_OUTPUT);
+  }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
@@ -114,7 +114,8 @@ public interface StorageProvider {
   /**
    * Load the log file for a given work item ID.
    *
-   * @throws IOException if the log file is not found
+   * @throws FileNotFoundException if the log file is not found.
+   * @throws IOException if there is an error reading the log file.
    */
   @Nonnull
   String loadWorkLog(NetworkId network, SnapshotId snapshot, String workId) throws IOException;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
@@ -111,6 +111,9 @@ public interface StorageProvider {
   @Nullable
   MajorIssueConfig loadMajorIssueConfig(NetworkId network, IssueSettingsId majorIssueType);
 
+  @Nonnull
+  String loadWorkLog(NetworkId network, SnapshotId snapshot, String workId) throws IOException;
+
   /**
    * Stores the {@link MajorIssueConfig} into the given network. Will replace any previously-stored
    * {@link MajorIssueConfig}s
@@ -432,5 +435,9 @@ public interface StorageProvider {
    */
   void storePojoTopology(
       org.batfish.datamodel.pojo.Topology topology, NetworkId networkId, SnapshotId snapshotId)
+      throws IOException;
+
+  /** Store a given string as a log file for a given work item ID. */
+  void storeWorkLog(String logOutput, NetworkId network, SnapshotId snapshot, String workId)
       throws IOException;
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
@@ -111,6 +111,11 @@ public interface StorageProvider {
   @Nullable
   MajorIssueConfig loadMajorIssueConfig(NetworkId network, IssueSettingsId majorIssueType);
 
+  /**
+   * Load the log file for a given work item ID.
+   *
+   * @throws IOException if the log file is not found
+   */
   @Nonnull
   String loadWorkLog(NetworkId network, SnapshotId snapshot, String workId) throws IOException;
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/storage/FileBasedStorageTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/storage/FileBasedStorageTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -184,7 +185,7 @@ public final class FileBasedStorageTest {
     NetworkId network = new NetworkId("network");
     SnapshotId snapshot = new SnapshotId("snapshot");
 
-    _thrown.expect(IOException.class);
+    _thrown.expect(FileNotFoundException.class);
     assertThat(_storage.loadWorkLog(network, snapshot, "workid"), equalTo("testoutput"));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/storage/FileBasedStorageTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/storage/FileBasedStorageTest.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.Version;
+import org.batfish.common.util.CommonUtil;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
@@ -161,5 +162,29 @@ public final class FileBasedStorageTest {
   public void testObjectKeyToRelativePathValid() throws IOException {
     // no exception should be thrown
     objectKeyToRelativePath("foo/bar");
+  }
+
+  @Test
+  public void testLoadWorkLog() throws IOException {
+    // setup: pretend a worker logger has written a file
+    NetworkId network = new NetworkId("network");
+    SnapshotId snapshot = new SnapshotId("snapshot");
+    Path dir = _storage.getDirectoryProvider().getSnapshotOutputDir(network, snapshot);
+    final boolean mkdirs = dir.toFile().mkdirs();
+    assertThat(mkdirs, equalTo(true));
+    CommonUtil.writeFile(dir.resolve("workid.log"), "testoutput");
+
+    // Test: read log using storage API
+    assertThat(_storage.loadWorkLog(network, snapshot, "workid"), equalTo("testoutput"));
+  }
+
+  @Test
+  public void testLoadWorkLogMissing() throws IOException {
+    // setup: pretend a worker logger has written a file
+    NetworkId network = new NetworkId("network");
+    SnapshotId snapshot = new SnapshotId("snapshot");
+
+    _thrown.expect(IOException.class);
+    assertThat(_storage.loadWorkLog(network, snapshot, "workid"), equalTo("testoutput"));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/storage/TestStorageProvider.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/storage/TestStorageProvider.java
@@ -6,6 +6,7 @@ import java.io.InputStream;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.SortedSet;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.common.topology.Layer1Topology;
 import org.batfish.datamodel.AnalysisMetadata;
@@ -77,6 +78,12 @@ public class TestStorageProvider implements StorageProvider {
 
   @Override
   public MajorIssueConfig loadMajorIssueConfig(NetworkId network, IssueSettingsId majorIssueType) {
+    throw new UnsupportedOperationException("no implementation for generated method");
+  }
+
+  @Nonnull
+  @Override
+  public String loadWorkLog(NetworkId network, SnapshotId snapshot, String workId) {
     throw new UnsupportedOperationException("no implementation for generated method");
   }
 
@@ -281,6 +288,12 @@ public class TestStorageProvider implements StorageProvider {
   public void storePojoTopology(
       org.batfish.datamodel.pojo.Topology topology, NetworkId networkId, SnapshotId snapshotId)
       throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void storeWorkLog(
+      String logOutput, NetworkId network, SnapshotId snapshot, String workId) {
     throw new UnsupportedOperationException();
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/config/Settings.java
+++ b/projects/batfish/src/main/java/org/batfish/config/Settings.java
@@ -20,6 +20,7 @@ import org.batfish.identifiers.NetworkId;
 import org.batfish.identifiers.QuestionId;
 import org.batfish.identifiers.SnapshotId;
 import org.batfish.main.Driver.RunMode;
+import org.batfish.storage.FileBasedStorageDirectoryProvider;
 
 public final class Settings extends BaseSettings implements GrammarSettings {
 
@@ -309,15 +310,12 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     if (getTaskId() == null) {
       return null;
     }
-    String tr = getTestrig().getId();
+    SnapshotId tr = getTestrig();
     if (getDeltaTestrig() != null && !getDifferential()) {
-      tr = getDeltaTestrig().getId();
+      tr = getDeltaTestrig();
     }
-    return getStorageBase()
-        .resolve(getContainer().getId())
-        .resolve(BfConsts.RELPATH_SNAPSHOTS_DIR)
-        .resolve(tr)
-        .resolve(BfConsts.RELPATH_OUTPUT)
+    return new FileBasedStorageDirectoryProvider(getStorageBase())
+        .getSnapshotOutputDir(getContainer(), tr)
         .resolve(getTaskId() + BfConsts.SUFFIX_LOG_FILE)
         .toString();
   }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -1453,7 +1453,9 @@ public class WorkMgr extends AbstractCoordinator {
   /**
    * Load and return the log file for a given work item ID in a given snapshot.
    *
-   * @throws BatfishException if log file cannot be found.
+   * @throws FileNotFoundException if the log file does not exist.
+   * @return Content of the log file as a string; {@code null} if the network or snapshot is not
+   *     available
    */
   @Nullable
   public String getWorkLog(String networkName, String snapshotName, String workId)

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -1450,6 +1450,18 @@ public class WorkMgr extends AbstractCoordinator {
     return _workQueueMgr.getWork(workItemId);
   }
 
+  /**
+   * Load and return the log file for a given work item ID in a given snapshot.
+   *
+   * @throws BatfishException if log file cannot be found.
+   */
+  public String getWorkLog(String networkName, String snapshotName, String workId)
+      throws IOException {
+    NetworkId networkId = _idManager.getNetworkId(networkName);
+    SnapshotId snapshotId = _idManager.getSnapshotId(snapshotName, networkId);
+    return _storage.loadWorkLog(networkId, snapshotId, workId);
+  }
+
   public String initNetwork(@Nullable String network, @Nullable String networkPrefix) {
     String newNetworkName =
         isNullOrEmpty(network) ? networkPrefix + "_" + UUID.randomUUID() : network;

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -1453,9 +1453,9 @@ public class WorkMgr extends AbstractCoordinator {
   /**
    * Load and return the log file for a given work item ID in a given snapshot.
    *
-   * @throws FileNotFoundException if the log file does not exist.
-   * @return Content of the log file as a string; {@code null} if the network or snapshot is not
-   *     available
+   * @throws IOException if the log could not be read successfully.
+   * @return Content of the log file as a string; {@code null} if the network, snapshot or log file
+   *     is not available
    */
   @Nullable
   public String getWorkLog(String networkName, String snapshotName, String workId)
@@ -1468,7 +1468,11 @@ public class WorkMgr extends AbstractCoordinator {
       return null;
     }
     SnapshotId snapshotId = _idManager.getSnapshotId(snapshotName, networkId);
-    return _storage.loadWorkLog(networkId, snapshotId, workId);
+    try {
+      return _storage.loadWorkLog(networkId, snapshotId, workId);
+    } catch (FileNotFoundException e) {
+      return null;
+    }
   }
 
   public String initNetwork(@Nullable String network, @Nullable String networkPrefix) {

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -1455,9 +1455,16 @@ public class WorkMgr extends AbstractCoordinator {
    *
    * @throws BatfishException if log file cannot be found.
    */
+  @Nullable
   public String getWorkLog(String networkName, String snapshotName, String workId)
       throws IOException {
+    if (!_idManager.hasNetworkId(networkName)) {
+      return null;
+    }
     NetworkId networkId = _idManager.getNetworkId(networkName);
+    if (!_idManager.hasSnapshotId(snapshotName, networkId)) {
+      return null;
+    }
     SnapshotId snapshotId = _idManager.getSnapshotId(snapshotName, networkId);
     return _storage.loadWorkLog(networkId, snapshotId, workId);
   }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/resources/SnapshotResource.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/resources/SnapshotResource.java
@@ -8,6 +8,7 @@ import static org.batfish.common.CoordConstsV2.RSC_POJO_TOPOLOGY;
 import static org.batfish.common.CoordConstsV2.RSC_TOPOLOGY;
 import static org.batfish.common.CoordConstsV2.RSC_WORK_LOG;
 
+import com.google.common.base.Throwables;
 import java.io.IOException;
 import javax.annotation.ParametersAreNonnullByDefault;
 import javax.ws.rs.DELETE;
@@ -101,11 +102,13 @@ public final class SnapshotResource {
   @GET
   public Response getWorkLog(@PathParam("workid") String workId) {
     try {
-      return Response.status(Status.OK)
-          .entity(Main.getWorkMgr().getWorkLog(_network, _snapshot, workId))
-          .build();
+      String log = Main.getWorkMgr().getWorkLog(_network, _snapshot, workId);
+      if (log == null) {
+        return Response.status(Status.NOT_FOUND).build();
+      }
+      return Response.status(Status.OK).entity(log).build();
     } catch (IOException e) {
-      return Response.status(Status.NOT_FOUND).build();
+      return Response.status(Status.NOT_FOUND).entity(Throwables.getStackTraceAsString(e)).build();
     }
   }
 }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/resources/SnapshotResource.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/resources/SnapshotResource.java
@@ -8,7 +8,6 @@ import static org.batfish.common.CoordConstsV2.RSC_POJO_TOPOLOGY;
 import static org.batfish.common.CoordConstsV2.RSC_TOPOLOGY;
 import static org.batfish.common.CoordConstsV2.RSC_WORK_LOG;
 
-import com.google.common.base.Throwables;
 import java.io.IOException;
 import javax.annotation.ParametersAreNonnullByDefault;
 import javax.ws.rs.DELETE;
@@ -100,15 +99,11 @@ public final class SnapshotResource {
   @Path(RSC_WORK_LOG + "/{workid}")
   @Produces(MediaType.TEXT_PLAIN)
   @GET
-  public Response getWorkLog(@PathParam("workid") String workId) {
-    try {
-      String log = Main.getWorkMgr().getWorkLog(_network, _snapshot, workId);
-      if (log == null) {
-        return Response.status(Status.NOT_FOUND).build();
-      }
-      return Response.status(Status.OK).entity(log).build();
-    } catch (IOException e) {
-      return Response.status(Status.NOT_FOUND).entity(Throwables.getStackTraceAsString(e)).build();
+  public Response getWorkLog(@PathParam("workid") String workId) throws IOException {
+    String log = Main.getWorkMgr().getWorkLog(_network, _snapshot, workId);
+    if (log == null) {
+      return Response.status(Status.NOT_FOUND).build();
     }
+    return Response.status(Status.OK).entity(log).build();
   }
 }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/resources/SnapshotResource.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/resources/SnapshotResource.java
@@ -6,12 +6,14 @@ import static org.batfish.common.CoordConstsV2.RSC_NODE_ROLES;
 import static org.batfish.common.CoordConstsV2.RSC_OBJECTS;
 import static org.batfish.common.CoordConstsV2.RSC_POJO_TOPOLOGY;
 import static org.batfish.common.CoordConstsV2.RSC_TOPOLOGY;
+import static org.batfish.common.CoordConstsV2.RSC_WORK_LOG;
 
 import java.io.IOException;
 import javax.annotation.ParametersAreNonnullByDefault;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -92,5 +94,18 @@ public final class SnapshotResource {
       return Response.status(Status.NOT_FOUND).build();
     }
     return Response.ok().entity(topology).build();
+  }
+
+  @Path(RSC_WORK_LOG + "/{workid}")
+  @Produces(MediaType.TEXT_PLAIN)
+  @GET
+  public Response getWorkLog(@PathParam("workid") String workId) {
+    try {
+      return Response.status(Status.OK)
+          .entity(Main.getWorkMgr().getWorkLog(_network, _snapshot, workId))
+          .build();
+    } catch (IOException e) {
+      return Response.status(Status.NOT_FOUND).build();
+    }
   }
 }

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/SnapshotResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/SnapshotResourceTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertThat;
 import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import javax.ws.rs.client.Invocation.Builder;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.batfish.common.CoordConsts;
 import org.batfish.common.CoordConstsV2;
@@ -17,8 +18,11 @@ import org.batfish.common.Version;
 import org.batfish.coordinator.Main;
 import org.batfish.coordinator.WorkMgrServiceV2TestBase;
 import org.batfish.coordinator.WorkMgrTestUtils;
+import org.batfish.coordinator.id.IdManager;
 import org.batfish.datamodel.SnapshotMetadata;
 import org.batfish.datamodel.Topology;
+import org.batfish.identifiers.NetworkId;
+import org.batfish.identifiers.SnapshotId;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -58,6 +62,19 @@ public final class SnapshotResourceTest extends WorkMgrServiceV2TestBase {
         .path(CoordConstsV2.RSC_SNAPSHOTS)
         .path(snapshot)
         .path(CoordConstsV2.RSC_TOPOLOGY)
+        .request()
+        .header(CoordConstsV2.HTTP_HEADER_BATFISH_APIKEY, CoordConsts.DEFAULT_API_KEY)
+        .header(CoordConstsV2.HTTP_HEADER_BATFISH_VERSION, Version.getVersion());
+  }
+
+  private Builder getWorkLogTarget(String network, String snapshot, String workId) {
+    return target(CoordConsts.SVC_CFG_WORK_MGR2)
+        .path(CoordConstsV2.RSC_CONTAINERS)
+        .path(network)
+        .path(CoordConstsV2.RSC_SNAPSHOTS)
+        .path(snapshot)
+        .path(CoordConstsV2.RSC_WORK_LOG)
+        .path(workId)
         .request()
         .header(CoordConstsV2.HTTP_HEADER_BATFISH_APIKEY, CoordConsts.DEFAULT_API_KEY)
         .header(CoordConstsV2.HTTP_HEADER_BATFISH_VERSION, Version.getVersion());
@@ -195,5 +212,57 @@ public final class SnapshotResourceTest extends WorkMgrServiceV2TestBase {
 
     assertThat(response.getStatus(), equalTo(OK.getStatusCode()));
     assertThat(response.readEntity(Topology.class), notNullValue());
+  }
+
+  @Test
+  public void testGetWorkLogMissingNetwork() {
+    String network = "network1";
+    String snapshot = "snapshot1";
+
+    Response response = getWorkLogTarget(network, snapshot, "workId").get();
+
+    assertThat(response.getStatus(), equalTo(NOT_FOUND.getStatusCode()));
+  }
+
+  @Test
+  public void testGetWorkLogMissingSnapshot() {
+    String network = "network1";
+    String snapshot = "snapshot1";
+    Main.getWorkMgr().initNetwork(network, null);
+
+    Response response = getWorkLogTarget(network, snapshot, "workid").get();
+
+    assertThat(response.getStatus(), equalTo(NOT_FOUND.getStatusCode()));
+  }
+
+  @Test
+  public void testGetWorkLogMissingFile() throws IOException {
+    String network = "network1";
+    String snapshot = "snapshot1";
+    Main.getWorkMgr().initNetwork(network, null);
+    WorkMgrTestUtils.uploadTestSnapshot(network, "snapshot", _folder);
+
+    Response response = getWorkLogTarget(network, snapshot, "missingworkid").get();
+
+    assertThat(response.getStatus(), equalTo(NOT_FOUND.getStatusCode()));
+  }
+
+  @Test
+  public void testGetWorkLogPresent() throws IOException {
+    String network = "network1";
+    String snapshot = "snapshot1";
+    Main.getWorkMgr().initNetwork(network, null);
+    WorkMgrTestUtils.uploadTestSnapshot(network, snapshot, _folder);
+    IdManager idm = Main.getWorkMgr().getIdManager();
+    NetworkId networkId = idm.getNetworkId(network);
+    SnapshotId snapshotId = idm.getSnapshotId(snapshot, networkId);
+    Main.getWorkMgr().getStorage().storeWorkLog("logoutput", networkId, snapshotId, "workid");
+
+    Builder target = getWorkLogTarget(network, snapshot, "workid");
+    Response response = target.get();
+
+    assertThat(response.getStatus(), equalTo(OK.getStatusCode()));
+    assertThat(response.getMediaType(), equalTo(MediaType.TEXT_PLAIN_TYPE));
+    assertThat(response.readEntity(String.class), equalTo("logoutput"));
   }
 }

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/SnapshotResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/SnapshotResourceTest.java
@@ -240,7 +240,7 @@ public final class SnapshotResourceTest extends WorkMgrServiceV2TestBase {
     String network = "network1";
     String snapshot = "snapshot1";
     Main.getWorkMgr().initNetwork(network, null);
-    WorkMgrTestUtils.uploadTestSnapshot(network, "snapshot", _folder);
+    WorkMgrTestUtils.uploadTestSnapshot(network, snapshot, _folder);
 
     Response response = getWorkLogTarget(network, snapshot, "missingworkid").get();
 


### PR DESCRIPTION
Currently there is no way for clients to get logs/errors for generic "queue work" workitems (it used to be available in a hacky way via `get_object` API call). 
This makes investigating parsing/DP failures and reporting them quite difficult. 

Add a new API call that clients can use to fetch a workitem log if the work terminates abnormally.

Was planning to add tests from clients, but if you have suggestions on how to test in the backend, please lmk.