### PR TITLE
Juniper: partial support for 802.3ad aggregate interfaces

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -167,6 +167,7 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.DirectionContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ec_literalContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ec_namedContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Encryption_algorithmContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Eo8023ad_interfaceContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Extended_communityContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.F_familyContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.F_filterContext;
@@ -3151,6 +3152,13 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   public void exitBpa_as(Bpa_asContext ctx) {
     long peerAs = toAsNum(ctx.asn);
     _currentBgpGroup.setPeerAs(peerAs);
+  }
+
+  @Override
+  public void exitEo8023ad_interface(Eo8023ad_interfaceContext ctx) {
+    // TODO: handle node
+    String interfaceName = ctx.name.getText();
+    _currentInterface.set8023adInterface(interfaceName);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
@@ -34,6 +34,8 @@ public class Interface implements Serializable {
     }
   }
 
+  private String _8023adInterface;
+
   private String _accessVlan;
 
   private boolean _active;
@@ -113,6 +115,10 @@ public class Interface implements Serializable {
 
   public void addAllowedRanges(List<SubRange> ranges) {
     _allowedVlans.addAll(ranges);
+  }
+
+  public String get8023adInterface() {
+    return _8023adInterface;
   }
 
   public String getAccessVlan() {
@@ -250,6 +256,10 @@ public class Interface implements Serializable {
     if (_ospfArea == null) {
       _ospfArea = _parent._ospfArea;
     }
+  }
+
+  public void set8023adInterface(String interfaceName) {
+    _8023adInterface = interfaceName;
   }
 
   public void setAccessVlan(String vlan) {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
@@ -34,8 +34,6 @@ public class Interface implements Serializable {
     }
   }
 
-  private String _8023adInterface;
-
   private String _accessVlan;
 
   private boolean _active;
@@ -43,6 +41,9 @@ public class Interface implements Serializable {
   private Set<Ip> _additionalArpIps;
 
   private final Set<InterfaceAddress> _allAddresses;
+
+  // Dumb name to appease checkstyle
+  private String _agg8023adInterface;
 
   private final Set<Ip> _allAddressIps;
 
@@ -118,7 +119,7 @@ public class Interface implements Serializable {
   }
 
   public String get8023adInterface() {
-    return _8023adInterface;
+    return _agg8023adInterface;
   }
 
   public String getAccessVlan() {
@@ -259,7 +260,7 @@ public class Interface implements Serializable {
   }
 
   public void set8023adInterface(String interfaceName) {
-    _8023adInterface = interfaceName;
+    _agg8023adInterface = interfaceName;
   }
 
   public void setAccessVlan(String vlan) {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -1376,6 +1376,12 @@ public final class JuniperConfiguration extends VendorConfiguration {
     // }
     // newIface.getAllAddresses().addAll(allPrefixes);
 
+    // 802.3ad link aggregation
+    if (iface.get8023adInterface() != null) {
+      // TODO: support interface-interface bindings at the physical, rather than logical, level
+      newIface.setChannelGroup(iface.get8023adInterface() + ".0");
+    }
+
     if (iface.getPrimaryAddress() != null) {
       newIface.setAddress(iface.getPrimaryAddress());
     }
@@ -2113,17 +2119,21 @@ public final class JuniperConfiguration extends VendorConfiguration {
     }
 
     // convert interfaces
-    Map<String, Interface> allInterfaces = new LinkedHashMap<>();
+    Map<String, Interface> interfacesToConvert = new LinkedHashMap<>();
 
     for (Interface iface : _interfaces.values()) {
-      allInterfaces.putAll(iface.getUnits());
+      if (iface.get8023adInterface() != null) {
+        interfacesToConvert.put(iface.getName(), iface);
+      } else {
+        interfacesToConvert.putAll(iface.getUnits());
+      }
     }
     for (NodeDevice nd : _nodeDevices.values()) {
       for (Interface iface : nd.getInterfaces().values()) {
-        allInterfaces.putAll(iface.getUnits());
+        interfacesToConvert.putAll(iface.getUnits());
       }
     }
-    for (Entry<String, Interface> eUnit : allInterfaces.entrySet()) {
+    for (Entry<String, Interface> eUnit : interfacesToConvert.entrySet()) {
       String unitName = eUnit.getKey();
       Interface unitIface = eUnit.getValue();
       unitIface.inheritUnsetFields();

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperAggregationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperAggregationTest.java
@@ -1,0 +1,39 @@
+package org.batfish.grammar.flatjuniper;
+
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.util.Arrays;
+import org.batfish.datamodel.Edge;
+import org.batfish.datamodel.Topology;
+import org.batfish.main.Batfish;
+import org.batfish.main.BatfishTestUtils;
+import org.batfish.main.TestrigText;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/** Tests of Juniper aggregate-ethernet devices. */
+public class FlatJuniperAggregationTest {
+
+  private static final String SNAPSHOT_PATH = "org/batfish/grammar/juniper/aggregation";
+
+  @Rule public TemporaryFolder _folder = new TemporaryFolder();
+
+  @Test
+  public void testAe0LinkComesUp() throws IOException {
+    Batfish batfish =
+        BatfishTestUtils.getBatfishFromTestrigText(
+            TestrigText.builder()
+                .setConfigurationText(SNAPSHOT_PATH, Arrays.asList("ae1", "ae2"))
+                .build(),
+            _folder);
+    batfish.loadConfigurations();
+    Topology t = batfish.getEnvironmentTopology();
+    assertThat(
+        t.getEdges(),
+        contains(Edge.of("ae1", "ae1.0", "ae2", "ae2.0"), Edge.of("ae2", "ae2.0", "ae1", "ae1.0")));
+    // TODO: this should contain ae1.1<-->ae2.1 links also, but those are not supported yet.
+  }
+}

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/aggregation/configs/ae1
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/aggregation/configs/ae1
@@ -1,0 +1,8 @@
+#
+set system host-name ae1
+#
+set interfaces ge-0/0/0 ether-options 802.3ad ae1
+#
+set interfaces ae1 unit 0 family inet address 1.2.3.4/31
+set interfaces ae1 unit 1 family inet address 2.3.4.4/31
+

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/aggregation/configs/ae2
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/aggregation/configs/ae2
@@ -1,0 +1,7 @@
+#
+set system host-name ae2
+#
+set interfaces ge-0/0/0 ether-options 802.3ad ae2
+#
+set interfaces ae2 unit 0 family inet address 1.2.3.5/31
+set interfaces ae2 unit 1 family inet address 2.3.4.5/31

--- a/tests/parsing-tests/networks/unit-tests/configs/juniper_interfaces
+++ b/tests/parsing-tests/networks/unit-tests/configs/juniper_interfaces
@@ -4,6 +4,7 @@ set system host-name juniper_interfaces
 #
 set interfaces ae0 unit 0 family ethernet-switching vlan members 1-1000
 set interfaces ge-0/0/0 forwarding-class-accounting
+set interfaces ge-1/0/0 ether-options 802.3ad ae0
 set interfaces xe-0/0/0:0 gigether-options loopback
 set interfaces xe-0/0/0:0 unit 0 family ethernet-switching vlan members all
 set interfaces irb unit 5 family inet address 1.2.3.1/24 vrrp-group 5 authentication-type md5

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -15992,6 +15992,32 @@
             "type" : "AGGREGATED",
             "vrf" : "SOME_INSTANCE"
           },
+          "ge-1/0/0" : {
+            "name" : "ge-1/0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "channelGroup" : "ae0.0",
+            "declaredNames" : [
+              "ge-1/0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
           "irb.5" : {
             "name" : "irb.5",
             "accessVlan" : 0,
@@ -16123,6 +16149,7 @@
           "default" : {
             "name" : "default",
             "interfaces" : [
+              "ge-1/0/0",
               "irb.5",
               "xe-0/0/0:0.0",
               "xe-0/0/5:0.0"

--- a/tests/parsing-tests/unit-tests-undefined.ref
+++ b/tests/parsing-tests/unit-tests-undefined.ref
@@ -2546,7 +2546,7 @@
         "Lines" : {
           "filename" : "configs/juniper_interfaces",
           "lines" : [
-            12
+            13
           ]
         }
       },

--- a/tests/parsing-tests/unit-tests-unused.ref
+++ b/tests/parsing-tests/unit-tests-unused.ref
@@ -2031,8 +2031,8 @@
         "Source_Lines" : {
           "filename" : "configs/juniper_interfaces",
           "lines" : [
-            16,
-            17
+            17,
+            18
           ]
         }
       },

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -46761,6 +46761,26 @@
             "            INTERFACES:'interfaces'",
             "            (int_named",
             "              (interface_id",
+            "                name = VARIABLE:'ge-1/0/0'  <== mode:M_Interface)",
+            "              (i_common",
+            "                (i_ether_options",
+            "                  ETHER_OPTIONS:'ether-options'",
+            "                  (ether_options",
+            "                    (eo_802_3ad",
+            "                      EIGHT02_3AD:'802.3ad'",
+            "                      (eo8023ad_interface",
+            "                        name = (variable",
+            "                          text = VARIABLE:'ae0')))))))))))",
+            "    NEWLINE:'\\n')",
+            "  (set_line",
+            "    SET:'set'",
+            "    (set_line_tail",
+            "      (statement",
+            "        (s_common",
+            "          (s_interfaces",
+            "            INTERFACES:'interfaces'",
+            "            (int_named",
+            "              (interface_id",
             "                name = VARIABLE:'xe-0/0/0'  <== mode:M_Interface",
             "                COLON:':'",
             "                suffix = DEC:'0')",
@@ -61143,44 +61163,50 @@
               ],
               "numReferrers" : 1
             },
+            "ge-1/0/0" : {
+              "definitionLines" : [
+                7
+              ],
+              "numReferrers" : 1
+            },
             "irb" : {
               "definitionLines" : [
-                9,
                 10,
-                11
+                11,
+                12
               ],
               "numReferrers" : 3
             },
             "irb.5" : {
               "definitionLines" : [
-                9,
                 10,
-                11
+                11,
+                12
               ],
               "numReferrers" : 3
             },
             "xe-0/0/0:0" : {
               "definitionLines" : [
-                7,
-                8
+                8,
+                9
               ],
               "numReferrers" : 2
             },
             "xe-0/0/0:0.0" : {
               "definitionLines" : [
-                8
+                9
               ],
               "numReferrers" : 1
             },
             "xe-0/0/5:0" : {
               "definitionLines" : [
-                12
+                13
               ],
               "numReferrers" : 1
             },
             "xe-0/0/5:0.0" : {
               "definitionLines" : [
-                12
+                13
               ],
               "numReferrers" : 1
             }
@@ -61188,8 +61214,8 @@
           "vlan" : {
             "unused-vlan" : {
               "definitionLines" : [
-                16,
-                17
+                17,
+                18
               ],
               "numReferrers" : 0
             }
@@ -64110,7 +64136,7 @@
                 5
               ],
               "routing-instance interface" : [
-                14
+                15
               ]
             },
             "ge-0/0/0" : {
@@ -64118,46 +64144,51 @@
                 6
               ]
             },
+            "ge-1/0/0" : {
+              "interface" : [
+                7
+              ]
+            },
             "irb" : {
               "interface" : [
-                9,
                 10,
-                11
+                11,
+                12
               ]
             },
             "irb.5" : {
               "interface" : [
-                9,
                 10,
-                11
+                11,
+                12
               ]
             },
             "xe-0/0/0:0" : {
               "interface" : [
-                7,
-                8
+                8,
+                9
               ]
             },
             "xe-0/0/0:0.0" : {
               "interface" : [
-                8
+                9
               ]
             },
             "xe-0/0/5:0" : {
               "interface" : [
-                12
+                13
               ]
             },
             "xe-0/0/5:0.0" : {
               "interface" : [
-                12
+                13
               ]
             }
           },
           "vlan" : {
             "bippetyboppety" : {
               "interface vlan" : [
-                12
+                13
               ]
             }
           }
@@ -65943,7 +65974,7 @@
           "vlan" : {
             "bippetyboppety" : {
               "interface vlan" : [
-                12
+                13
               ]
             }
           }


### PR DESCRIPTION
NB: Batfish currently only supports if->if direct aggregation for Cisco channel groups, but
for Juniper and even more advanced Cisco use cases, need to support interface->interface
bindings at a higher level in the hierarchy, with subinterfaces of the aggregation.
   E.g., ge-0/0/0 -> ae0, and then ae0 has ae0.0, ae0.1, ae0.2, ...
For now, model Juniper 802.3ad aggregation as always linking ge-0/0/0 (e.g.) to ae0.0.

Includes a unit test we will need to fix when we improve the model.