### PR TITLE
(draft) TopologyUtil: robust to native vlan in allowed vlans

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/TopologyUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/TopologyUtil.java
@@ -41,6 +41,13 @@ import org.batfish.datamodel.collections.NodeInterfacePair;
 
 public final class TopologyUtil {
 
+  /** Returns true iff the given trunk interface allows its own native vlan. */
+  private static boolean trunkWithNativeVlanAllowed(Interface i) {
+    return i.getSwitchportMode() == SwitchportMode.TRUNK
+        && i.getAllowedVlans().contains(i.getNativeVlan());
+  }
+
+  // Precondition: at least one of i1 and i2 is a trunk
   private static void addLayer2TrunkEdges(
       Interface i1,
       Interface i2,
@@ -49,18 +56,28 @@ public final class TopologyUtil {
       Layer1Node node2) {
     if (i1.getSwitchportMode() == SwitchportMode.TRUNK
         && i2.getSwitchportMode() == SwitchportMode.TRUNK) {
+      // Both sides are trunks, so add edges from n1,v to n2,v for all shared VLANs.
       i1.getAllowedVlans()
           .stream()
-          .filter(i2.getAllowedVlans()::contains)
           .forEach(
-              allowedVlan ->
-                  edges.add(new Layer2Edge(node1, allowedVlan, node2, allowedVlan, allowedVlan)));
-      edges.add(new Layer2Edge(node1, i1.getNativeVlan(), node2, i2.getNativeVlan(), null));
-    } else if (i1.getSwitchportMode() == SwitchportMode.TRUNK) {
+              vlan -> {
+                if (i1.getNativeVlan() == vlan && trunkWithNativeVlanAllowed(i2)) {
+                  // This frame will not be tagged by i1, and i2 accepts untagged frames.
+                  edges.add(new Layer2Edge(node1, vlan, node2, vlan, null /* untagged */));
+                } else if (i2.getAllowedVlans().contains(vlan)) {
+                  // This frame will be tagged by i1 and we can directly check whether i2 allows.
+                  edges.add(new Layer2Edge(node1, vlan, node2, vlan, vlan));
+                }
+              });
+    } else if (trunkWithNativeVlanAllowed(i1)) {
+      // i1 is a trunk, but the other side is not. The only edge that will come up is i2 receiving
+      // untagged packets.
       Integer node2VlanId =
           i2.getSwitchportMode() == SwitchportMode.ACCESS ? i2.getAccessVlan() : null;
       edges.add(new Layer2Edge(node1, i1.getNativeVlan(), node2, node2VlanId, null));
-    } else if (i2.getSwitchportMode() == SwitchportMode.TRUNK) {
+    } else if (trunkWithNativeVlanAllowed(i2)) {
+      // i1 is not a trunk, but the other side is. The only edge that will come up is the other
+      // side receiving untagged packets and treating them as native VLAN.
       Integer node1VlanId =
           i1.getSwitchportMode() == SwitchportMode.ACCESS ? i1.getAccessVlan() : null;
       edges.add(new Layer2Edge(node1, node1VlanId, node2, i2.getNativeVlan(), null));
@@ -77,15 +94,12 @@ public final class TopologyUtil {
         .forEach(
             i -> {
               if (i.getSwitchportMode() == SwitchportMode.TRUNK) {
-                switchportsByVlan
-                    .computeIfAbsent(i.getNativeVlan(), n -> ImmutableList.builder())
-                    .add(i.getName());
                 i.getAllowedVlans()
                     .stream()
                     .forEach(
-                        allowedVlan ->
+                        vlan ->
                             switchportsByVlan
-                                .computeIfAbsent(allowedVlan, n -> ImmutableList.builder())
+                                .computeIfAbsent(vlan, n -> ImmutableList.builder())
                                 .add(i.getName()));
               }
               if (i.getSwitchportMode() == SwitchportMode.ACCESS) {
@@ -202,15 +216,12 @@ public final class TopologyUtil {
         .forEach(
             i -> {
               if (i.getSwitchportMode() == SwitchportMode.TRUNK) {
-                switchportsByVlan
-                    .computeIfAbsent(i.getNativeVlan(), n -> ImmutableList.builder())
-                    .add(i.getName());
                 i.getAllowedVlans()
                     .stream()
                     .forEach(
-                        allowedVlan ->
+                        vlan ->
                             switchportsByVlan
-                                .computeIfAbsent(allowedVlan, n -> ImmutableList.builder())
+                                .computeIfAbsent(vlan, n -> ImmutableList.builder())
                                 .add(i.getName()));
               }
               if (i.getSwitchportMode() == SwitchportMode.ACCESS) {

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/TopologyUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/TopologyUtilTest.java
@@ -116,7 +116,7 @@ public final class TopologyUtilTest {
     Interface c1i4 = _ib.setName(c1i4Name).build();
     c1i4.setSwitchport(true);
     c1i4.setSwitchportMode(SwitchportMode.TRUNK);
-    c1i4.setAllowedVlans(IntegerSpace.of(new SubRange(1, 3)));
+    c1i4.setAllowedVlans(IntegerSpace.of(new SubRange(0, 3)));
     c1i4.setNativeVlan(0);
     Interface c1i5 = _ib.setName(c1i5Name).build();
     c1i5.setSwitchport(true);
@@ -125,6 +125,7 @@ public final class TopologyUtilTest {
     Interface c1i6 = _ib.setName(c1i6Name).build();
     c1i6.setSwitchport(true);
     c1i6.setSwitchportMode(SwitchportMode.TRUNK);
+    c1i6.setAllowedVlans(IntegerSpace.of(4));
     c1i6.setNativeVlan(4);
 
     Configuration c2 = _cb.setHostname(c2Name).build();
@@ -134,7 +135,7 @@ public final class TopologyUtilTest {
     Interface c2i4 = _ib.setName(c2i4Name).build();
     c2i4.setSwitchport(true);
     c2i4.setSwitchportMode(SwitchportMode.TRUNK);
-    c2i4.setAllowedVlans(IntegerSpace.of(new SubRange(1, 2)));
+    c2i4.setAllowedVlans(IntegerSpace.of(new SubRange(0, 2)));
     c2i4.setNativeVlan(0);
 
     Configuration c3 = _cb.setHostname(c3Name).build();
@@ -256,7 +257,7 @@ public final class TopologyUtilTest {
     Interface c1i4 = _ib.setName(c1i4Name).setAddresses(null).build();
     c1i4.setSwitchport(true);
     c1i4.setSwitchportMode(SwitchportMode.TRUNK);
-    c1i4.setAllowedVlans(IntegerSpace.of(new SubRange(1, 3)));
+    c1i4.setAllowedVlans(IntegerSpace.of(new SubRange(0, 3)));
     c1i4.setNativeVlan(0);
     Interface c1i5 = _ib.setName(c1i5Name).build();
     c1i5.setSwitchport(true);
@@ -265,6 +266,7 @@ public final class TopologyUtilTest {
     Interface c1i6 = _ib.setName(c1i6Name).build();
     c1i6.setSwitchport(true);
     c1i6.setSwitchportMode(SwitchportMode.TRUNK);
+    c1i6.setAllowedVlans(IntegerSpace.of(4));
     c1i6.setNativeVlan(4);
     Interface c1Vlan1 =
         _ib.setName(vlan1Name)


### PR DESCRIPTION
It seems perfectly legal to configure both a native VLAN on a trunk switchport
and to limit the set of allowed VLANs on that trunk. Make the L2 topology
helpers resilient to this configuration.

cc: @agember does this fix your issue?
cc: @arifogel 

still needs tests, but the offending NX-OS config snippet is:

```
interface Ethernet2/1
 no shutdown
 switchport
 switchport mode trunk
 switchport trunk native vlan 23
 switchport trunk allowed vlan 23
```