### PR TITLE
Integrate loop in bdd single reachability

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/question/ReachabilityParameters.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/question/ReachabilityParameters.java
@@ -5,7 +5,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.google.common.collect.ImmutableSortedSet;
 import java.util.Set;
 import java.util.SortedSet;
-import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.FlowDisposition;
@@ -242,12 +241,6 @@ public final class ReachabilityParameters {
   @Nonnull
   public static Set<FlowDisposition> filterDispositions(Set<FlowDisposition> dispositions) {
     checkArgument(!dispositions.isEmpty(), "Invalid empty set of actions specified");
-    Set<FlowDisposition> result =
-        dispositions
-            .stream()
-            .filter(disposition -> FlowDisposition.LOOP != disposition)
-            .collect(Collectors.toSet());
-    checkArgument(!result.isEmpty(), "Unsupported set of actions specified: %s", dispositions);
-    return result;
+    return dispositions;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
@@ -14,6 +14,7 @@ import com.google.common.collect.Streams;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -48,6 +49,7 @@ import org.batfish.specifier.InterfaceLinkLocation;
 import org.batfish.specifier.InterfaceLocation;
 import org.batfish.specifier.IpSpaceAssignment;
 import org.batfish.specifier.LocationVisitor;
+import org.batfish.z3.IngressLocation;
 import org.batfish.z3.expr.StateExpr;
 import org.batfish.z3.state.Accept;
 import org.batfish.z3.state.DeliveredToSubnet;
@@ -1023,6 +1025,54 @@ public final class BDDReachabilityAnalysisFactory {
         requiredTransitNodes,
         finalNodes,
         actions);
+  }
+
+  /**
+   * Given a set of parameters finds a {@link Map} of {@link IngressLocation}s to {@link BDD}s while
+   * including the results for {@link FlowDisposition#LOOP} if required
+   *
+   * @param srcIpSpaceAssignment An assignment of active source locations to the corresponding
+   *     source {@link IpSpace}.
+   * @param initialHeaderSpace The initial headerspace (i.e. before any packet transformations).
+   * @param forbiddenTransitNodes A set of hostnames that must not be transited.
+   * @param requiredTransitNodes A set of hostnames of which one must be transited.
+   * @param finalNodes Find flows that stop at one of these nodes.
+   * @param actions Find flows for which at least one trace has one of these actions.
+   * @return {@link Map} of {@link IngressLocation}s to {@link BDD}s
+   */
+  public Map<IngressLocation, BDD> getAllBDDs(
+      IpSpaceAssignment srcIpSpaceAssignment,
+      AclLineMatchExpr initialHeaderSpace,
+      Set<String> forbiddenTransitNodes,
+      Set<String> requiredTransitNodes,
+      Set<String> finalNodes,
+      Set<FlowDisposition> actions) {
+    Set<FlowDisposition> actionsCopy = new HashSet<>(actions);
+
+    boolean loopIncluded = actionsCopy.remove(FlowDisposition.LOOP);
+
+    BDDReachabilityAnalysis analysis =
+        bddReachabilityAnalysis(
+            srcIpSpaceAssignment,
+            initialHeaderSpace,
+            forbiddenTransitNodes,
+            requiredTransitNodes,
+            finalNodes,
+            actionsCopy.isEmpty() ? ImmutableSet.of(FlowDisposition.ACCEPTED) : actionsCopy);
+
+    Map<IngressLocation, BDD> bddsNoLoop =
+        actionsCopy.isEmpty() ? Maps.newHashMap() : analysis.getIngressLocationReachableBDDs();
+
+    if (!loopIncluded) {
+      return bddsNoLoop;
+    } else {
+      Map<IngressLocation, BDD> bddsLoop = analysis.detectLoops();
+
+      // merging the two BDDs
+      Map<IngressLocation, BDD> mergedBDDs = new HashMap<>(bddsNoLoop);
+      bddsLoop.forEach(((ingressLocation, bdd) -> mergedBDDs.merge(ingressLocation, bdd, BDD::or)));
+      return mergedBDDs;
+    }
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
@@ -1051,6 +1051,7 @@ public final class BDDReachabilityAnalysisFactory {
 
     boolean loopIncluded = actionsCopy.remove(FlowDisposition.LOOP);
 
+    // detecting Loops can work with any disposition, using ACCEPTED arbitrarily here
     BDDReachabilityAnalysis analysis =
         bddReachabilityAnalysis(
             srcIpSpaceAssignment,

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -3806,16 +3806,15 @@ public class Batfish extends PluginConsumer implements IBatfish {
     boolean ignoreFilters = params.getIgnoreFilters();
     BDDReachabilityAnalysisFactory bddReachabilityAnalysisFactory =
         getBddReachabilityAnalysisFactory(pkt, ignoreFilters);
+
     Map<IngressLocation, BDD> reachableBDDs =
-        bddReachabilityAnalysisFactory
-            .bddReachabilityAnalysis(
-                params.getSourceIpAssignment(),
-                params.getHeaderSpace(),
-                params.getForbiddenTransitNodes(),
-                params.getRequiredTransitNodes(),
-                params.getFinalNodes(),
-                params.getActions())
-            .getIngressLocationReachableBDDs();
+        bddReachabilityAnalysisFactory.getAllBDDs(
+            params.getSourceIpAssignment(),
+            params.getHeaderSpace(),
+            params.getForbiddenTransitNodes(),
+            params.getRequiredTransitNodes(),
+            params.getFinalNodes(),
+            params.getActions());
 
     String flowTag = getFlowTag();
     Set<Flow> flows =

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
@@ -12,6 +12,7 @@ import static org.batfish.datamodel.FlowDisposition.NULL_ROUTED;
 import static org.batfish.z3.expr.NodeInterfaceNeighborUnreachableMatchers.hasHostname;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
@@ -26,16 +27,21 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 import net.sf.javabdd.BDD;
 import org.batfish.common.bdd.BDDPacket;
 import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowDisposition;
 import org.batfish.datamodel.HeaderSpace;
+import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.UniverseIpSpace;
+import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.answers.AnswerElement;
 import org.batfish.datamodel.flow.Trace;
 import org.batfish.datamodel.flow.TraceWrapperAsAnswerElement;
@@ -349,17 +355,36 @@ public final class BDDReachabilityAnalysisFactoryTest {
   }
 
   @Test
-  public void testGetAllBDDsLoopWithAccepted() throws IOException {
-    SortedMap<String, Configuration> configs = LoopNetwork.testLoopNetwork(true);
+  public void testGetAllBDDsLoopWithNoroute() throws IOException {
+    SortedMap<String, Configuration> configs = new TreeMap<>(LoopNetwork.testLoopNetwork(true));
+
+    // adding an isolated config which has no route to the looping destination prefix
+    NetworkFactory nf = new NetworkFactory();
+    Configuration loopbackConfig =
+        nf.configurationBuilder()
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .setHostname("loopbackConfig")
+            .build();
+    Vrf vrf = nf.vrfBuilder().setOwner(loopbackConfig).build();
+
+    InterfaceAddress loopbackAddress = new InterfaceAddress("1.2.3.4/32");
+    nf.interfaceBuilder()
+        .setActive(true)
+        .setOwner(loopbackConfig)
+        .setVrf(vrf)
+        .setAddress(loopbackAddress)
+        .build();
+    configs.put(loopbackConfig.getHostname(), loopbackConfig);
+
     Batfish batfish = BatfishTestUtils.getBatfish(configs, temp);
     batfish.computeDataPlane(false);
 
     ReachabilityParameters reachabilityParameters =
         ReachabilityParameters.builder()
             .setSourceLocationSpecifier(AllInterfacesLocationSpecifier.INSTANCE)
-            .setActions(ImmutableSortedSet.of(FlowDisposition.LOOP, FlowDisposition.ACCEPTED))
+            .setActions(ImmutableSortedSet.of(FlowDisposition.LOOP, FlowDisposition.NO_ROUTE))
             .setFinalNodesSpecifier(AllNodesNodeSpecifier.INSTANCE)
-            .setHeaderSpace(new HeaderSpace())
+            .setHeaderSpace(HeaderSpace.builder().setDstIps(new Ip("2.0.0.0").toIpSpace()).build())
             .build();
 
     AnswerElement answer = batfish.bddSingleReachability(reachabilityParameters);
@@ -367,13 +392,13 @@ public final class BDDReachabilityAnalysisFactoryTest {
     assertThat(answer, instanceOf(TraceWrapperAsAnswerElement.class));
     Map<Flow, List<Trace>> flowTraces = ((TraceWrapperAsAnswerElement) answer).getFlowTraces();
     Set<Flow> flows = flowTraces.keySet();
-    assertThat(flows, hasSize(2));
+    assertThat(flows, hasSize(3));
 
     Set<Ip> srcIps = flows.stream().map(Flow::getSrcIp).collect(Collectors.toSet());
     Set<Ip> dstIps = flows.stream().map(Flow::getDstIp).collect(Collectors.toSet());
 
-    assertThat(srcIps, contains(new Ip("1.0.0.0"), new Ip("1.0.0.1")));
-    assertThat(dstIps, contains(new Ip("1.0.0.0")));
+    assertThat(srcIps, contains(new Ip("1.0.0.0"), new Ip("1.0.0.1"), new Ip("1.2.3.4")));
+    assertThat(dstIps, contains(new Ip("2.0.0.0")));
 
     Set<FlowDisposition> flowDispositions =
         flowTraces
@@ -383,6 +408,7 @@ public final class BDDReachabilityAnalysisFactoryTest {
             .map(Trace::getDisposition)
             .collect(ImmutableSet.toImmutableSet());
 
-    assertThat(flowDispositions, contains(FlowDisposition.ACCEPTED));
+    assertThat(
+        flowDispositions, containsInAnyOrder(FlowDisposition.LOOP, FlowDisposition.NO_ROUTE));
   }
 }

--- a/projects/question/src/test/java/org/batfish/question/specifiers/SpecifiersReachabilityQuestionTest.java
+++ b/projects/question/src/test/java/org/batfish/question/specifiers/SpecifiersReachabilityQuestionTest.java
@@ -4,13 +4,10 @@ import static org.batfish.datamodel.FlowDisposition.ACCEPTED;
 import static org.batfish.datamodel.FlowDisposition.DELIVERED_TO_SUBNET;
 import static org.batfish.datamodel.FlowDisposition.EXITS_NETWORK;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
 import com.google.common.collect.ImmutableSortedSet;
-import org.batfish.datamodel.FlowDisposition;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.IntegerSpace;
 import org.batfish.datamodel.IpWildcard;
@@ -134,15 +131,6 @@ public class SpecifiersReachabilityQuestionTest {
         equalTo(
             NodeSpecifierFactory.load(FlexibleNodeSpecifierFactory.NAME)
                 .buildNodeSpecifier("bar")));
-  }
-
-  @Test
-  public void testSkipLoops() {
-    SpecifiersReachabilityQuestion q =
-        SpecifiersReachabilityQuestion.builder()
-            .setActions(DispositionSpecifier.FAILURE_SPECIFIER)
-            .build();
-    assertThat(q.getReachabilityParameters().getActions(), not(contains(FlowDisposition.LOOP)));
   }
 
   @Test


### PR DESCRIPTION
- This will allow specifiers reachability to include `LOOP` disposition in normal reachability queries