### PR TITLE
Pack allowed vlans as String, not List<String>

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/InterfacePropertySpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/InterfacePropertySpecifier.java
@@ -75,9 +75,7 @@ public class InterfacePropertySpecifier extends PropertySpecifier {
           .put(
               ADDITIONAL_ARP_IPS,
               new PropertyDescriptor<>(Interface::getAdditionalArpIps, Schema.list(Schema.IP)))
-          .put(
-              ALLOWED_VLANS,
-              new PropertyDescriptor<>(Interface::getAllowedVlans, Schema.list(Schema.STRING)))
+          .put(ALLOWED_VLANS, new PropertyDescriptor<>(Interface::getAllowedVlans, Schema.STRING))
           .put(
               ALL_PREFIXES,
               new PropertyDescriptor<>(Interface::getAllAddresses, Schema.list(Schema.STRING)))


### PR DESCRIPTION
Catching up after 6b3a90845876934928ba6bd18851dc5cd1fcdab9. 

(There are downstream tests that started failing after the commit. That nothing failed in this repo reveals a testing gap.)