### PR TITLE
OSPF Process cleanup

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/NetworkFactory.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/NetworkFactory.java
@@ -12,6 +12,9 @@ import org.batfish.datamodel.routing_policy.RoutingPolicy;
 /**
  * Network Factory -- helpful in creating test networks, as it allows child builders to
  * automatically generate names/ID for objects they create.
+ *
+ * <p>Some builders pre-populate required fields with a default (usually based on Cisco IOS, if
+ * vendor-dependent).
  */
 public class NetworkFactory {
 
@@ -90,8 +93,9 @@ public class NetworkFactory {
     return OspfArea.builder(this);
   }
 
+  /** Return an OSPF builder. Pre-defines required fields (e.g., reference bandwidth) */
   public OspfProcess.Builder ospfProcessBuilder() {
-    return OspfProcess.builder(this);
+    return OspfProcess.builder(this).setReferenceBandwidth(1e8);
   }
 
   public RipProcess.Builder ripProcessBuilder() {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfArea.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfArea.java
@@ -59,7 +59,7 @@ public class OspfArea implements Serializable {
               _summaries.build(),
               _summaryFilter);
       if (_ospfProcess != null) {
-        _ospfProcess.getAreas().put(number, ospfArea);
+        _ospfProcess.addArea(ospfArea);
       }
       return ospfArea;
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfProcess.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfProcess.java
@@ -1,18 +1,25 @@
 package org.batfish.datamodel.ospf;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyDescription;
-import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDescription;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Ordering;
 import java.io.Serializable;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
-import java.util.TreeSet;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.batfish.common.BatfishException;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.GeneratedRoute;
 import org.batfish.datamodel.Interface;
@@ -23,41 +30,50 @@ import org.batfish.datamodel.NetworkFactory.NetworkFactoryBuilder;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
 
-@JsonSchemaDescription("An OSPF routing process")
-public class OspfProcess implements Serializable {
+/** An OSPF routing process */
+@ParametersAreNonnullByDefault
+public final class OspfProcess implements Serializable {
 
+  /** Builder for {@link OspfProcess} */
   public static class Builder extends NetworkFactoryBuilder<OspfProcess> {
 
     @Nullable private String _exportPolicy;
+    @Nullable private Long _maxMetricExternalNetworks;
+    @Nullable private Long _maxMetricStubNetworks;
+    @Nullable private Long _maxMetricSummaryNetworks;
+    @Nullable private Long _maxMetricTransitLinks;
+    @Nullable private String _processId;
+    @Nullable private Double _referenceBandwidth;
+    @Nullable private Vrf _vrf;
+    @Nullable private SortedMap<Long, OspfArea> _areas;
+    @Nullable private SortedSet<String> _exportPolicySources;
+    @Nullable private SortedSet<GeneratedRoute> _generatedRoutes;
+    @Nullable private Boolean _rfc1583Compatible;
+    @Nullable private Ip _routerId;
 
-    private Long _maxMetricExternalNetworks;
-
-    private Long _maxMetricStubNetworks;
-
-    private Long _maxMetricSummaryNetworks;
-
-    private Long _maxMetricTransitLinks;
-
-    private String _processId;
-
-    private Vrf _vrf;
-
-    Builder(NetworkFactory networkFactory) {
+    private Builder(@Nullable NetworkFactory networkFactory) {
       super(networkFactory, OspfProcess.class);
     }
 
     @Override
     public OspfProcess build() {
-      OspfProcess ospfProcess = new OspfProcess();
+      OspfProcess ospfProcess =
+          new OspfProcess(
+              _areas,
+              _exportPolicy,
+              _exportPolicySources,
+              _generatedRoutes,
+              _maxMetricExternalNetworks,
+              _maxMetricStubNetworks,
+              _maxMetricSummaryNetworks,
+              _maxMetricTransitLinks,
+              _processId,
+              _referenceBandwidth,
+              _rfc1583Compatible,
+              _routerId);
       if (_vrf != null) {
         _vrf.setOspfProcess(ospfProcess);
       }
-      ospfProcess.setExportPolicy(_exportPolicy);
-      ospfProcess.setMaxMetricExternalNetworks(_maxMetricExternalNetworks);
-      ospfProcess.setMaxMetricStubNetworks(_maxMetricStubNetworks);
-      ospfProcess.setMaxMetricSummaryNetworks(_maxMetricSummaryNetworks);
-      ospfProcess.setMaxMetricTransitLinks(_maxMetricTransitLinks);
-      ospfProcess.setProcessId(_processId);
       return ospfProcess;
     }
 
@@ -91,146 +107,230 @@ public class OspfProcess implements Serializable {
       return this;
     }
 
+    public Builder setReferenceBandwidth(Double referenceBandwidth) {
+      _referenceBandwidth = referenceBandwidth;
+      return this;
+    }
+
     public Builder setVrf(Vrf vrf) {
       _vrf = vrf;
       return this;
+    }
+
+    public Builder setAreas(SortedMap<Long, OspfArea> areas) {
+      _areas = areas;
+      return this;
+    }
+
+    public Builder setExportPolicyName(@Nullable String exportPolicy) {
+      _exportPolicy = exportPolicy;
+      return this;
+    }
+
+    public Builder setExportPolicySources(SortedSet<String> exportPolicySources) {
+      _exportPolicySources = exportPolicySources;
+      return this;
+    }
+
+    public Builder setGeneratedRoutes(SortedSet<GeneratedRoute> generatedRoutes) {
+      _generatedRoutes = generatedRoutes;
+      return this;
+    }
+
+    public Builder setRfc1583Compatible(Boolean rfc1583Compatible) {
+      _rfc1583Compatible = rfc1583Compatible;
+      return this;
+    }
+
+    public Builder setRouterId(Ip routerId) {
+      _routerId = routerId;
+      return this;
+    }
+
+    public OspfProcess createOspfProcess() {
+      return new OspfProcess(
+          _areas,
+          _exportPolicy,
+          _exportPolicySources,
+          _generatedRoutes,
+          _maxMetricExternalNetworks,
+          _maxMetricStubNetworks,
+          _maxMetricSummaryNetworks,
+          _maxMetricTransitLinks,
+          _processId,
+          _referenceBandwidth,
+          _rfc1583Compatible,
+          _routerId);
     }
   }
 
   private static final int DEFAULT_CISCO_VLAN_OSPF_COST = 1;
 
   private static final String PROP_AREAS = "areas";
-
   private static final String PROP_EXPORT_POLICY = "exportPolicy";
-
   private static final String PROP_EXPORT_POLICY_SOURCES = "exportPolicySources";
-
   private static final String PROP_GENERATED_ROUTES = "generatedRoutes";
-
   private static final String PROP_MAX_METRIC_EXTERNAL_NETWORKS = "maxMetricExternalNetworks";
-
   private static final String PROP_MAX_METRIC_STUB_NETWORKS = "maxMetricStubNetworks";
-
   private static final String PROP_MAX_METRIC_SUMMARY_NETWORKS = "maxMetricSummaryNetworks";
-
   private static final String PROP_MAX_METRIC_TRANSIT_LINKS = "maxMetricTransitLinks";
-
   private static final String PROP_PROCESS_ID = "processId";
-
   private static final String PROP_REFERENCE_BANDWIDTH = "referenceBandwidth";
-
   private static final String PROP_ROUTER_ID = "routerId";
+  private static final String PROP_RFC1583 = "rfc1583Compatible";
 
   private static final long serialVersionUID = 1L;
 
-  public static Builder builder(NetworkFactory networkFactory) {
+  /** Builder to be used for tests (maintains pointer to {@link NetworkFactory} */
+  public static Builder builder(@Nullable NetworkFactory networkFactory) {
     return new Builder(networkFactory);
   }
 
-  private SortedMap<Long, OspfArea> _areas;
+  public static Builder builder() {
+    return new Builder(null);
+  }
+
+  @Nonnull private SortedMap<Long, OspfArea> _areas;
 
   @Nullable private String _exportPolicy;
 
-  private SortedSet<String> _exportPolicySources;
+  @Nonnull private SortedSet<String> _exportPolicySources;
 
-  private SortedSet<GeneratedRoute> _generatedRoutes;
+  @Nonnull private SortedSet<GeneratedRoute> _generatedRoutes;
 
-  private Long _maxMetricExternalNetworks;
+  @Nullable private Long _maxMetricExternalNetworks;
 
-  private Long _maxMetricStubNetworks;
+  @Nullable private Long _maxMetricStubNetworks;
 
-  private Long _maxMetricSummaryNetworks;
+  @Nullable private Long _maxMetricSummaryNetworks;
 
-  private Long _maxMetricTransitLinks;
+  @Nullable private Long _maxMetricTransitLinks;
 
-  private transient Map<IpLink, OspfNeighbor> _ospfNeighbors;
+  @Nonnull private transient Map<IpLink, OspfNeighbor> _ospfNeighbors;
 
-  private String _processId;
+  @Nullable private String _processId;
 
-  private Double _referenceBandwidth;
+  @Nonnull private Double _referenceBandwidth;
 
-  private @Nullable Boolean _rfc1583Compatible;
+  @Nullable private Boolean _rfc1583Compatible;
 
-  private Ip _routerId;
+  @Nullable private Ip _routerId;
 
-  public OspfProcess() {
-    _exportPolicySources = new TreeSet<>();
-    _generatedRoutes = new TreeSet<>();
-    _areas = new TreeMap<>();
+  @JsonCreator
+  private OspfProcess(
+      @Nullable @JsonProperty(PROP_AREAS) SortedMap<Long, OspfArea> areas,
+      @Nullable @JsonProperty(PROP_EXPORT_POLICY) String exportPolicy,
+      @Nullable @JsonProperty(PROP_EXPORT_POLICY_SOURCES) SortedSet<String> exportPolicySources,
+      @Nullable @JsonProperty(PROP_GENERATED_ROUTES) SortedSet<GeneratedRoute> generatedRoutes,
+      @Nullable @JsonProperty(PROP_MAX_METRIC_EXTERNAL_NETWORKS) Long maxMetricExternalNetworks,
+      @Nullable @JsonProperty(PROP_MAX_METRIC_STUB_NETWORKS) Long maxMetricStubNetworks,
+      @Nullable @JsonProperty(PROP_MAX_METRIC_SUMMARY_NETWORKS) Long maxMetricSummaryNetworks,
+      @Nullable @JsonProperty(PROP_MAX_METRIC_TRANSIT_LINKS) Long maxMetricTransitLinks,
+      @Nullable @JsonProperty(PROP_PROCESS_ID) String processId,
+      @Nullable @JsonProperty(PROP_REFERENCE_BANDWIDTH) Double referenceBandwidth,
+      @Nullable @JsonProperty(PROP_RFC1583) Boolean rfc1583Compatible,
+      @Nullable @JsonProperty(PROP_ROUTER_ID) Ip routerId) {
+    checkArgument(referenceBandwidth != null, "Missing %s", PROP_REFERENCE_BANDWIDTH);
+    _areas = firstNonNull(areas, ImmutableSortedMap.of());
+    _exportPolicy = exportPolicy;
+    _exportPolicySources = firstNonNull(exportPolicySources, ImmutableSortedSet.of());
+    _generatedRoutes = firstNonNull(generatedRoutes, ImmutableSortedSet.of());
+    _maxMetricExternalNetworks = maxMetricExternalNetworks;
+    _maxMetricStubNetworks = maxMetricStubNetworks;
+    _maxMetricSummaryNetworks = maxMetricSummaryNetworks;
+    _maxMetricTransitLinks = maxMetricTransitLinks;
+    _ospfNeighbors = new TreeMap<>();
+    _processId = processId;
+    _referenceBandwidth = referenceBandwidth;
+    _rfc1583Compatible = rfc1583Compatible;
+    _routerId = routerId;
   }
 
   public int computeInterfaceCost(Interface i) {
-    Integer ospfCost = i.getOspfCost();
-    if (ospfCost == null) {
-      String interfaceName = i.getName();
-      if (interfaceName.startsWith("Vlan")) {
-        // TODO: fix for non-cisco
-        ospfCost = DEFAULT_CISCO_VLAN_OSPF_COST;
-      } else {
-        if (i.getBandwidth() != null) {
-          ospfCost = Math.max((int) (_referenceBandwidth / i.getBandwidth()), 1);
-        } else {
-          String hostname = i.getOwner().getHostname();
-          throw new BatfishException(
-              "Expected non-null interface bandwidth for \""
-                  + hostname
-                  + "\":\""
-                  + interfaceName
-                  + "\"");
-        }
-      }
-    }
-    return ospfCost;
+    return computeInterfaceCost(_referenceBandwidth, i);
   }
 
-  @JsonPropertyDescription("The OSPF areas contained in this process")
+  @VisibleForTesting
+  static int computeInterfaceCost(Double referenceBandwidth, Interface i) {
+    Integer ospfCost = i.getOspfCost();
+    if (ospfCost != null) {
+      return ospfCost;
+    }
+
+    String interfaceName = i.getName();
+    if (interfaceName.startsWith("Vlan")) {
+      // Special handling fro VLAN interfaces
+      // TODO: fix for non-cisco
+      return DEFAULT_CISCO_VLAN_OSPF_COST;
+    } else {
+      // Regular physical interface cost computation
+      checkState(
+          i.getBandwidth() != null,
+          "Interface %s on %s is missing bandwidth, cannot compute OSPF cost",
+          interfaceName,
+          i.getOwner().getHostname());
+      return Math.max((int) (referenceBandwidth / i.getBandwidth()), 1);
+    }
+  }
+
+  /** The OSPF areas contained in this process */
+  @Nonnull
   @JsonProperty(PROP_AREAS)
   public SortedMap<Long, OspfArea> getAreas() {
     return _areas;
   }
 
+  /**
+   * The routing policy applied to routes in the main RIB to determine which ones are to be exported
+   * into OSPF and how
+   */
   @JsonProperty(PROP_EXPORT_POLICY)
-  @JsonPropertyDescription(
-      "The routing policy applied to routes in the main RIB to determine which ones are to be "
-          + "exported into OSPF and how")
   @Nullable
   public String getExportPolicy() {
     return _exportPolicy;
   }
 
+  @Nonnull
   @JsonProperty(PROP_EXPORT_POLICY_SOURCES)
   public SortedSet<String> getExportPolicySources() {
     return _exportPolicySources;
   }
 
-  @JsonPropertyDescription(
-      "Generated IPV4 routes for the purpose of export into OSPF. These routes are not imported "
-          + "into the main RIB.")
+  /**
+   * Generated IPV4 routes for the purpose of export into OSPF. These routes are not imported into
+   * the main RIB.
+   */
+  @Nonnull
   @JsonProperty(PROP_GENERATED_ROUTES)
   public SortedSet<GeneratedRoute> getGeneratedRoutes() {
     return _generatedRoutes;
   }
 
+  @Nullable
   @JsonProperty(PROP_MAX_METRIC_EXTERNAL_NETWORKS)
   public Long getMaxMetricExternalNetworks() {
     return _maxMetricExternalNetworks;
   }
 
+  @Nullable
   @JsonProperty(PROP_MAX_METRIC_STUB_NETWORKS)
   public Long getMaxMetricStubNetworks() {
     return _maxMetricStubNetworks;
   }
 
+  @Nullable
   @JsonProperty(PROP_MAX_METRIC_SUMMARY_NETWORKS)
   public Long getMaxMetricSummaryNetworks() {
     return _maxMetricSummaryNetworks;
   }
 
+  @Nullable
   @JsonProperty(PROP_MAX_METRIC_TRANSIT_LINKS)
   public Long getMaxMetricTransitLinks() {
     return _maxMetricTransitLinks;
   }
 
+  @Nonnull
   @JsonIgnore
   public Map<IpLink, OspfNeighbor> getOspfNeighbors() {
     return _ospfNeighbors;
@@ -242,38 +342,42 @@ public class OspfProcess implements Serializable {
     return _processId;
   }
 
-  @JsonPropertyDescription(
-      "The reference bandwidth by which an interface's bandwidth is divided to determine its OSPF "
-          + "cost")
+  /**
+   * The reference bandwidth by which an interface's bandwidth is divided to determine its OSPF cost
+   */
+  @Nonnull
   @JsonProperty(PROP_REFERENCE_BANDWIDTH)
   public Double getReferenceBandwidth() {
     return _referenceBandwidth;
   }
 
-  public @Nullable Boolean getRfc1583Compatible() {
+  @Nullable
+  @JsonProperty(PROP_RFC1583)
+  public Boolean getRfc1583Compatible() {
     return _rfc1583Compatible;
   }
 
-  @JsonPropertyDescription("The router-id of this OSPF process")
+  /** The router-id of this OSPF process */
+  @Nullable
   @JsonProperty(PROP_ROUTER_ID)
   public Ip getRouterId() {
     return _routerId;
   }
 
+  /** Initialize interface costs for all interfaces that belong to this process */
   public void initInterfaceCosts(Configuration c) {
-    for (OspfArea area : _areas.values()) {
-      for (String ifaceName : area.getInterfaces()) {
-        Interface i = c.getAllInterfaces().get(ifaceName);
-        if (i.getActive()) {
-          i.setOspfCost(computeInterfaceCost(i));
-        }
-      }
-    }
+    _areas
+        .values()
+        .stream()
+        .flatMap(a -> a.getInterfaces().stream())
+        .map(interfaceName -> c.getAllInterfaces().get(interfaceName))
+        .filter(Interface::getActive)
+        .forEach(i -> i.setOspfCost(computeInterfaceCost(i)));
   }
 
   /**
-   * An ABR (Area Border Router) has at least one interface in area 0, and at least one interface in
-   * another area.
+   * Check if this process serves as and ABR (Area Border Router). An ABR has at least one interface
+   * in area 0, and at least one interface in another area.
    */
   @JsonIgnore
   public boolean isAreaBorderRouter() {
@@ -285,38 +389,52 @@ public class OspfProcess implements Serializable {
     _areas = areas;
   }
 
-  @JsonProperty(PROP_EXPORT_POLICY)
+  public void addArea(OspfArea area) {
+    _areas =
+        new ImmutableSortedMap.Builder<Long, OspfArea>(Ordering.natural())
+            .putAll(_areas)
+            .put(area.getAreaNumber(), area)
+            .build();
+  }
+
   public void setExportPolicy(@Nullable String exportPolicy) {
     _exportPolicy = exportPolicy;
   }
 
-  @JsonProperty(PROP_EXPORT_POLICY_SOURCES)
   public void setExportPolicySources(SortedSet<String> exportPolicySources) {
-    _exportPolicySources = exportPolicySources;
+    _exportPolicySources = ImmutableSortedSet.copyOf(exportPolicySources);
   }
 
-  @JsonProperty(PROP_GENERATED_ROUTES)
+  /**
+   * Overwrite all generated route. See {@link #getGeneratedRoutes} for explanation of generated
+   * routes.
+   */
   public void setGeneratedRoutes(SortedSet<GeneratedRoute> generatedRoutes) {
     _generatedRoutes = generatedRoutes;
   }
 
-  @JsonProperty(PROP_MAX_METRIC_EXTERNAL_NETWORKS)
-  public void setMaxMetricExternalNetworks(Long maxMetricExternalNetworks) {
+  /** Add a generated route. See {@link #getGeneratedRoutes} for explanation of generated routes. */
+  public void addGeneratedRoute(GeneratedRoute route) {
+    _generatedRoutes =
+        new ImmutableSortedSet.Builder<GeneratedRoute>(Ordering.natural())
+            .addAll(_generatedRoutes)
+            .add(route)
+            .build();
+  }
+
+  public void setMaxMetricExternalNetworks(@Nullable Long maxMetricExternalNetworks) {
     _maxMetricExternalNetworks = maxMetricExternalNetworks;
   }
 
-  @JsonProperty(PROP_MAX_METRIC_STUB_NETWORKS)
-  public void setMaxMetricStubNetworks(Long maxMetricStubNetworks) {
+  public void setMaxMetricStubNetworks(@Nullable Long maxMetricStubNetworks) {
     _maxMetricStubNetworks = maxMetricStubNetworks;
   }
 
-  @JsonProperty(PROP_MAX_METRIC_SUMMARY_NETWORKS)
-  public void setMaxMetricSummaryNetworks(Long maxMetricSummaryNetworks) {
+  public void setMaxMetricSummaryNetworks(@Nullable Long maxMetricSummaryNetworks) {
     _maxMetricSummaryNetworks = maxMetricSummaryNetworks;
   }
 
-  @JsonProperty(PROP_MAX_METRIC_TRANSIT_LINKS)
-  public void setMaxMetricTransitLinks(Long maxMetricTransitLinks) {
+  public void setMaxMetricTransitLinks(@Nullable Long maxMetricTransitLinks) {
     _maxMetricTransitLinks = maxMetricTransitLinks;
   }
 
@@ -325,7 +443,6 @@ public class OspfProcess implements Serializable {
     _ospfNeighbors = ospfNeighbors;
   }
 
-  @JsonProperty(PROP_PROCESS_ID)
   public void setProcessId(@Nullable String id) {
     _processId = id;
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ConfigurationTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ConfigurationTest.java
@@ -102,7 +102,7 @@ public class ConfigurationTest {
     vrf.getGeneratedRoutes().add(gr);
 
     // OSPF
-    OspfProcess ospfProcess = new OspfProcess();
+    OspfProcess ospfProcess = OspfProcess.builder().setReferenceBandwidth(1e8).build();
     vrf.setOspfProcess(ospfProcess);
     RoutingPolicy ospfExportPolicy =
         c.getRoutingPolicies().computeIfAbsent(ospfExportPolicyName, n -> new RoutingPolicy(n, c));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfProcessTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfProcessTest.java
@@ -1,0 +1,85 @@
+package org.batfish.datamodel.ospf;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+import com.google.common.collect.ImmutableSortedMap;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.NetworkFactory;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests of {@link org.batfish.datamodel.ospf.OspfProcess} */
+@RunWith(JUnit4.class)
+public class OspfProcessTest {
+  @Rule public ExpectedException _thrown = ExpectedException.none();
+
+  @Test
+  public void testComputeInterfaceCost() {
+    Interface.Builder ib =
+        Interface.builder()
+            .setName("eth0")
+            .setBandwidth(1e3)
+            .setOwner(new Configuration("r1", ConfigurationFormat.CISCO_IOS));
+    Interface i = ib.build();
+
+    // Round up to 1
+    int cost = OspfProcess.computeInterfaceCost(1.0, i);
+    assertThat(cost, equalTo(1));
+
+    cost = OspfProcess.computeInterfaceCost(1e6, i);
+    assertThat(cost, equalTo(1000));
+
+    _thrown.expectMessage("Interface eth0 on r1 is missing bandwidth");
+    _thrown.expect(IllegalStateException.class);
+    OspfProcess.computeInterfaceCost(1e6, ib.setBandwidth(null).build());
+  }
+
+  @Test
+  public void testInitInterfaceCosts() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c1 =
+        nf.configurationBuilder()
+            .setHostname("r1")
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .build();
+
+    OspfProcess.Builder opb = nf.ospfProcessBuilder();
+    OspfArea.Builder oab = nf.ospfAreaBuilder().setNonStub().setNumber(0L);
+    OspfArea area0 = oab.build();
+    OspfArea area1 = oab.setNumber(1L).build();
+
+    Interface.Builder ib = nf.interfaceBuilder().setOwner(c1);
+    Interface i0 = ib.setName("eth0").setBandwidth(1e3).setOspfArea(area0).build();
+    Interface i1 = ib.setName("eth1").setBandwidth(1e4).setOspfArea(area1).build();
+    Interface i2 = ib.setName("eth2").setBandwidth(1e5).setOspfArea(area1).setActive(false).build();
+    Interface i3 =
+        ib.setName("eth3")
+            .setBandwidth(1e6)
+            .setOspfArea(area1)
+            .setActive(true)
+            .setOspfPassive(true)
+            .build();
+
+    OspfProcess proc =
+        opb.setReferenceBandwidth(1e8)
+            .setAreas(ImmutableSortedMap.of(0L, area0, 1L, area1))
+            .build();
+
+    // Test
+    proc.initInterfaceCosts(c1);
+
+    assertThat(i0.getOspfCost(), equalTo(100000));
+    assertThat(i1.getOspfCost(), equalTo(10000));
+    // No value for shutdown interfaces
+    assertThat(i2.getOspfCost(), nullValue());
+    // Compute values for passive interfaces
+    assertThat(i3.getOspfCost(), equalTo(100));
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -2298,7 +2298,9 @@ public final class CiscoConfiguration extends VendorConfiguration {
   private org.batfish.datamodel.ospf.OspfProcess toOspfProcess(
       OspfProcess proc, String vrfName, Configuration c, CiscoConfiguration oldConfig) {
     org.batfish.datamodel.ospf.OspfProcess newProcess =
-        new org.batfish.datamodel.ospf.OspfProcess();
+        org.batfish.datamodel.ospf.OspfProcess.builder()
+            .setReferenceBandwidth(firstNonNull(proc.getReferenceBandwidth(), 1e8))
+            .build();
     org.batfish.datamodel.Vrf vrf = c.getVrfs().get(vrfName);
 
     if (proc.getMaxMetricRouterLsa()) {
@@ -2419,6 +2421,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
               new SubRange(0, Prefix.MAX_PREFIX_LENGTH)));
     }
     newProcess.setAreas(toImmutableSortedMap(areas, Entry::getKey, e -> e.getValue().build()));
+
     // set pointers from interfaces to their parent areas
     newProcess
         .getAreas()
@@ -2464,7 +2467,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
           route.setNetwork(Prefix.ZERO);
           route.setAdmin(MAX_ADMINISTRATIVE_COST);
           route.setGenerationPolicy(defaultOriginateMapName);
-          newProcess.getGeneratedRoutes().add(route.build());
+          newProcess.addGeneratedRoute(route.build());
         }
       } else if (proc.getDefaultInformationOriginateAlways()) {
         useAggregateDefaultOnly = true;
@@ -2472,7 +2475,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
         GeneratedRoute.Builder route = new GeneratedRoute.Builder();
         route.setNetwork(Prefix.ZERO);
         route.setAdmin(MAX_ADMINISTRATIVE_COST);
-        newProcess.getGeneratedRoutes().add(route.build());
+        newProcess.addGeneratedRoute(route.build());
       } else {
         // do not generate an aggregate default route;
         // just redistribute any existing default route with the new metric
@@ -2487,7 +2490,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
       ospfExportDefault.setGuard(ospfExportDefaultConditions);
     }
 
-    newProcess.setReferenceBandwidth(proc.getReferenceBandwidth());
     Ip routerId = proc.getRouterId();
     if (routerId == null) {
       routerId = CiscoConversions.getHighestIp(oldConfig.getInterfaces());

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -705,7 +705,10 @@ public final class JuniperConfiguration extends VendorConfiguration {
   }
 
   private OspfProcess createOspfProcess(RoutingInstance routingInstance) {
-    OspfProcess newProc = new OspfProcess();
+    OspfProcess newProc =
+        OspfProcess.builder()
+            .setReferenceBandwidth(routingInstance.getOspfReferenceBandwidth())
+            .build();
     String vrfName = routingInstance.getName();
     // export policies
     String ospfExportPolicyName = computeOspfExportPolicyName(vrfName);
@@ -769,7 +772,6 @@ public final class JuniperConfiguration extends VendorConfiguration {
                                 .setOspfArea(area)));
 
     newProc.setRouterId(getOspfRouterId(routingInstance));
-    newProc.setReferenceBandwidth(routingInstance.getOspfReferenceBandwidth());
     return newProc;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/symbolic/abstraction/AbstractionBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/abstraction/AbstractionBuilder.java
@@ -527,10 +527,10 @@ class AbstractionBuilder {
 
       OspfProcess ospf = vrf.getOspfProcess();
       if (ospf != null) {
-        OspfProcess abstractOspf = new OspfProcess();
+        OspfProcess abstractOspf =
+            OspfProcess.builder().setReferenceBandwidth(ospf.getReferenceBandwidth()).build();
         abstractOspf.setAreas(ospf.getAreas());
         abstractOspf.setExportPolicy(ospf.getExportPolicy());
-        abstractOspf.setReferenceBandwidth(ospf.getReferenceBandwidth());
         abstractOspf.setRouterId(ospf.getRouterId());
         // Copy over neighbors
         Map<IpLink, OspfNeighbor> abstractNeighbors = new HashMap<>();

--- a/projects/question/src/test/java/org/batfish/question/edges/EdgesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/edges/EdgesAnswererTest.java
@@ -201,16 +201,12 @@ public class EdgesAnswererTest {
 
   @Test
   public void testGetOspfEdges() {
-    OspfProcess ospf1 = new OspfProcess();
-    OspfProcess ospf2 = new OspfProcess();
+    OspfProcess ospf1 = OspfProcess.builder().setReferenceBandwidth(1e8).build();
+    OspfProcess ospf2 = OspfProcess.builder().setReferenceBandwidth(1e8).build();
 
     NetworkFactory nf = new NetworkFactory();
-    OspfArea one =
-        OspfArea.builder(nf).setNumber(1L).setOspfProcess(ospf1).addInterface("int1").build();
-    OspfArea two =
-        OspfArea.builder(nf).setNumber(2L).setOspfProcess(ospf2).addInterface("int2").build();
-    ospf1.getAreas().put(1L, one);
-    ospf2.getAreas().put(1L, two);
+    OspfArea.builder(nf).setNumber(1L).setOspfProcess(ospf1).addInterface("int1").build();
+    OspfArea.builder(nf).setNumber(1L).setOspfProcess(ospf2).addInterface("int2").build();
 
     Vrf vrf1 = new Vrf("vrf1");
     vrf1.setOspfProcess(ospf1);

--- a/projects/question/src/test/java/org/batfish/question/ospfproperties/OspfPropertiesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/ospfproperties/OspfPropertiesAnswererTest.java
@@ -21,8 +21,7 @@ public class OspfPropertiesAnswererTest {
 
   @Test
   public void getProperties() {
-
-    OspfProcess ospf1 = new OspfProcess();
+    OspfProcess ospf1 = OspfProcess.builder().setReferenceBandwidth(1e8).build();
     ospf1.setExportPolicy("my-policy");
     ospf1.setReferenceBandwidth(42.0);
     ospf1.setProcessId("uber-proc");


### PR DESCRIPTION
 * Sane adders, avoid get().add() pattern
 * Force presence of reference bandwidth, set default in test builders
 * Javadoc, annotations
 * Add cost computation tests