### PR TITLE
traceroute: include all RIB routes, not just the ones that share a next-hop interface

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteEngineImplContext.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteEngineImplContext.java
@@ -513,18 +513,15 @@ public class TracerouteEngineImplContext {
       Map<AbstractRoute, Map<String, Map<Ip, Set<AbstractRoute>>>> nextHopInterfacesByRoute =
           currentFib.getNextHopInterfacesByRoute(dstIp);
 
-      Set<AbstractRoute> matchedRibRoutes = _dataPlane.getRibs()
-          .get(currentNodeName)
-          .get(vrfName)
-          .longestPrefixMatch(dstIp);
-
-      List<RouteInfo> routesForThisNextHopInterface =
-          matchedRibRoutes
+      List<RouteInfo> matchedRibRouteInfo =
+          _dataPlane
+              .getRibs()
+              .get(currentNodeName)
+              .get(vrfName)
+              .longestPrefixMatch(dstIp)
               .stream()
-              .map(
-                  rc ->
-                      new RouteInfo(
-                          rc.getProtocol(), rc.getNetwork(), rc.getNextHopIp()))
+              .sorted()
+              .map(rc -> new RouteInfo(rc.getProtocol(), rc.getNetwork(), rc.getNextHopIp()))
               .distinct()
               .collect(ImmutableList.toImmutableList());
 
@@ -570,9 +567,7 @@ public class TracerouteEngineImplContext {
                   clonedStepsBuilder.add(
                       RoutingStep.builder()
                           .setDetail(
-                              RoutingStepDetail.builder()
-                                  .setRoutes(routesForThisNextHopInterface)
-                                  .build())
+                              RoutingStepDetail.builder().setRoutes(matchedRibRouteInfo).build())
                           .setAction(StepAction.FORWARDED)
                           .build());
 

--- a/tests/basic/traceroute-1-2.ref
+++ b/tests/basic/traceroute-1-2.ref
@@ -216,6 +216,11 @@
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "2.34.101.4",
                           "protocol" : "ibgp"
+                        },
+                        {
+                          "network" : "2.128.0.0/24",
+                          "nextHopIp" : "2.34.201.4",
+                          "protocol" : "ibgp"
                         }
                       ]
                     }
@@ -495,6 +500,11 @@
                     "action" : "FORWARDED",
                     "detail" : {
                       "routes" : [
+                        {
+                          "network" : "2.128.0.0/24",
+                          "nextHopIp" : "2.34.101.4",
+                          "protocol" : "ibgp"
+                        },
                         {
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "2.34.201.4",
@@ -780,6 +790,11 @@
                       "routes" : [
                         {
                           "network" : "2.128.0.0/24",
+                          "nextHopIp" : "2.34.101.4",
+                          "protocol" : "ibgp"
+                        },
+                        {
+                          "network" : "2.128.0.0/24",
                           "nextHopIp" : "2.34.201.4",
                           "protocol" : "ibgp"
                         }
@@ -1064,6 +1079,11 @@
                         {
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "2.34.101.4",
+                          "protocol" : "ibgp"
+                        },
+                        {
+                          "network" : "2.128.0.0/24",
+                          "nextHopIp" : "2.34.201.4",
                           "protocol" : "ibgp"
                         }
                       ]
@@ -1378,6 +1398,11 @@
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "2.34.101.4",
                           "protocol" : "ibgp"
+                        },
+                        {
+                          "network" : "2.128.0.0/24",
+                          "nextHopIp" : "2.34.201.4",
+                          "protocol" : "ibgp"
                         }
                       ]
                     }
@@ -1657,6 +1682,11 @@
                     "action" : "FORWARDED",
                     "detail" : {
                       "routes" : [
+                        {
+                          "network" : "2.128.0.0/24",
+                          "nextHopIp" : "2.34.101.4",
+                          "protocol" : "ibgp"
+                        },
                         {
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "2.34.201.4",
@@ -1942,6 +1972,11 @@
                       "routes" : [
                         {
                           "network" : "2.128.0.0/24",
+                          "nextHopIp" : "2.34.101.4",
+                          "protocol" : "ibgp"
+                        },
+                        {
+                          "network" : "2.128.0.0/24",
                           "nextHopIp" : "2.34.201.4",
                           "protocol" : "ibgp"
                         }
@@ -2226,6 +2261,11 @@
                         {
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "2.34.101.4",
+                          "protocol" : "ibgp"
+                        },
+                        {
+                          "network" : "2.128.0.0/24",
+                          "nextHopIp" : "2.34.201.4",
                           "protocol" : "ibgp"
                         }
                       ]

--- a/tests/basic/traceroute-2-1.ref
+++ b/tests/basic/traceroute-2-1.ref
@@ -124,6 +124,11 @@
                           "network" : "1.0.1.0/24",
                           "nextHopIp" : "2.34.101.3",
                           "protocol" : "bgp"
+                        },
+                        {
+                          "network" : "1.0.1.0/24",
+                          "nextHopIp" : "2.34.201.3",
+                          "protocol" : "bgp"
                         }
                       ]
                     }
@@ -362,6 +367,11 @@
                           "network" : "1.0.1.0/24",
                           "nextHopIp" : "2.34.101.3",
                           "protocol" : "bgp"
+                        },
+                        {
+                          "network" : "1.0.1.0/24",
+                          "nextHopIp" : "2.34.201.3",
+                          "protocol" : "bgp"
                         }
                       ]
                     }
@@ -595,6 +605,11 @@
                     "action" : "FORWARDED",
                     "detail" : {
                       "routes" : [
+                        {
+                          "network" : "1.0.1.0/24",
+                          "nextHopIp" : "2.34.101.3",
+                          "protocol" : "bgp"
+                        },
                         {
                           "network" : "1.0.1.0/24",
                           "nextHopIp" : "2.34.201.3",
@@ -832,6 +847,11 @@
                     "action" : "FORWARDED",
                     "detail" : {
                       "routes" : [
+                        {
+                          "network" : "1.0.1.0/24",
+                          "nextHopIp" : "2.34.101.3",
+                          "protocol" : "bgp"
+                        },
                         {
                           "network" : "1.0.1.0/24",
                           "nextHopIp" : "2.34.201.3",


### PR DESCRIPTION
And update refs.


Co-authored-by: Victor Heorhiadi <progwriter@noreply.github.com>