### PR TITLE
Add more detail to requeue failure

### DIFF
--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkQueueMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkQueueMgr.java
@@ -464,7 +464,9 @@ public class WorkQueueMgr {
                 // people may be checking its status and this work may be blocking others
                 _queueIncompleteWork.enque(requeueWork);
                 Task fakeTask =
-                    new Task(TaskStatus.RequeueFailure, "Couldn't requeue after unblocking");
+                    new Task(
+                        TaskStatus.RequeueFailure,
+                        String.format("Couldn't requeue after unblocking.\n%s", e.getMessage()));
                 processTaskCheckResult(requeueWork, fakeTask);
               }
             }


### PR DESCRIPTION
When task requeueing fails, add exception message to the fake task to surface a little more detail to clients 

I opted out of adding stack trace as that ends up being a wall of unformatted text from the client's standpoint - but I can add that back in if the consensus is to err on the side of more data over readability.
