### PR TITLE
Update OSPF summary metric computation

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/OspfProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/OspfProtocolHelper.java
@@ -35,8 +35,8 @@ public class OspfProtocolHelper {
       long areaNum,
       boolean useMin) {
     Prefix contributingRoutePrefix = route.getNetwork();
-    // Only update metric for different areas and if the area prefix contains the route prefix
-    if (areaNum == route.getArea() || !areaPrefix.containsPrefix(contributingRoutePrefix)) {
+    // Only update metric for different areas that can contribute to the summary
+    if (areaNum != route.getArea() || !areaPrefix.containsPrefix(contributingRoutePrefix)) {
       return currentMetric;
     }
     long contributingRouteMetric = route.getMetric();

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/OspfProtocolHelperTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/OspfProtocolHelperTest.java
@@ -1,6 +1,7 @@
 package org.batfish.dataplane.protocols;
 
 import static org.batfish.dataplane.protocols.OspfProtocolHelper.isOspfInterAreaDefaultOriginationAllowed;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
 
@@ -32,7 +33,7 @@ public class OspfProtocolHelperTest {
             Ip.MAX,
             RoutingProtocol.OSPF_IA.getDefaultAdministrativeCost(ConfigurationFormat.CISCO_IOS),
             definedMetric,
-            0);
+            definedArea);
 
     // The route is in the prefix and existing metric is null, so return the route's metric
     assertThat(
@@ -71,12 +72,12 @@ public class OspfProtocolHelperTest {
             Ip.MAX,
             RoutingProtocol.OSPF_IA.getDefaultAdministrativeCost(ConfigurationFormat.CISCO_IOS),
             definedMetric,
-            1); // the area is the same as definedArea
-    // Thus the metric should remain null
+            99);
+    // The area is different from definedArea thus the metric should remain null
     assertThat(
         OspfProtocolHelper.computeUpdatedOspfSummaryMetric(
             sameAreaRoute, Prefix.ZERO, null, definedArea, true),
-        equalTo(null));
+        nullValue());
   }
 
   @Test


### PR DESCRIPTION
This code has been carried from old bdp and it looks like incorrect tests were written for it long ago.
A route from a different area should not be considered as a contributing route to a particular area summary.