### PR TITLE
Juniper: construct route filter lists for OSPF area summaries 

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -2231,8 +2231,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
     _currentAreaRangeRestrict = false;
 
     if (ctx.IP_PREFIX() != null) {
-      Prefix range = Prefix.parse(ctx.IP_PREFIX().getText());
-      _currentAreaRangePrefix = range;
+      _currentAreaRangePrefix = Prefix.parse(ctx.IP_PREFIX().getText());
     } else {
       todo(ctx);
     }
@@ -3832,8 +3831,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
     if (_currentAreaRangePrefix != null) {
       OspfAreaSummary summary =
           new OspfAreaSummary(!_currentAreaRangeRestrict, _currentAreaRangeMetric);
-      Map<Prefix, OspfAreaSummary> summaries = _currentArea.getSummaries();
-      summaries.put(_currentAreaRangePrefix, summary);
+      _currentArea.getSummaries().put(_currentAreaRangePrefix, summary);
     } else {
       todo(ctx);
     }

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -14461,6 +14461,21 @@
           }
         },
         "routeFilterLists" : {
+          "~OSPF_SUMMARY_FILTER:default:66051~" : {
+            "lines" : [
+              {
+                "action" : "DENY",
+                "ipWildcard" : "1.2.0.0/16",
+                "lengthRange" : "17-32"
+              },
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "0.0.0.0/0",
+                "lengthRange" : "0-32"
+              }
+            ],
+            "name" : "~OSPF_SUMMARY_FILTER:default:66051~"
+          },
           "~SUMMARY1_2_0_0_16_RF~" : {
             "lines" : [
               {
@@ -14613,7 +14628,8 @@
                       "advertise" : true,
                       "metric" : 100
                     }
-                  }
+                  },
+                  "summaryFilter" : "~OSPF_SUMMARY_FILTER:default:66051~"
                 }
               },
               "exportPolicy" : "~OSPF_EXPORT_POLICY:default~",
@@ -16469,6 +16485,28 @@
         "defaultCrossZoneAction" : "PERMIT",
         "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
+        "routeFilterLists" : {
+          "~OSPF_SUMMARY_FILTER:default:46~" : {
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "0.0.0.0/0",
+                "lengthRange" : "0-32"
+              }
+            ],
+            "name" : "~OSPF_SUMMARY_FILTER:default:46~"
+          },
+          "~OSPF_SUMMARY_FILTER:default:7~" : {
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "0.0.0.0/0",
+                "lengthRange" : "0-32"
+              }
+            ],
+            "name" : "~OSPF_SUMMARY_FILTER:default:7~"
+          }
+        },
         "routingPolicies" : {
           "~OSPF_EXPORT_POLICY:default~" : {
             "name" : "~OSPF_EXPORT_POLICY:default~",
@@ -16556,7 +16594,8 @@
                   "stub" : {
                     "suppressType3" : false
                   },
-                  "stubType" : "STUB"
+                  "stubType" : "STUB",
+                  "summaryFilter" : "~OSPF_SUMMARY_FILTER:default:7~"
                 },
                 "46" : {
                   "injectDefaultRoute" : false,
@@ -16565,7 +16604,8 @@
                   "stub" : {
                     "suppressType3" : true
                   },
-                  "stubType" : "STUB"
+                  "stubType" : "STUB",
+                  "summaryFilter" : "~OSPF_SUMMARY_FILTER:default:46~"
                 }
               },
               "exportPolicy" : "~OSPF_EXPORT_POLICY:default~",


### PR DESCRIPTION
Previously we were not suppressing the more specific are routes at the juniper ABRs

cc @arifogel 