### PR TITLE
OSPF inter-area route propagation: better honor suppress type3 LSAs

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/OspfProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/OspfProtocolHelper.java
@@ -95,18 +95,16 @@ public class OspfProtocolHelper {
      * Once an inter-area route has been propagated across a link of a given area, it may continue to propagate throughout that area.
      * To propagate into a different area, the propagator must be an ABR, and type-3 LSAs must be allowed across the link.
      */
-    if (linkAreaNum != neighborRouteAreaNum) {
-      if (!neighborProc.isAreaBorderRouter()) {
-        return false;
-      }
-      // Don't propagate inter-area routes into a [not-so-stubby-]stub area for which type-3 LSAs
-      // are
-      // suppressed.
-      if ((neighborArea.getStubType() == StubType.STUB && neighborArea.getStub().getSuppressType3())
-          || (neighborArea.getStubType() == StubType.NSSA
-              && neighborArea.getNssa().getSuppressType3())) {
-        return false;
-      }
+    if (linkAreaNum != neighborRouteAreaNum && !neighborProc.isAreaBorderRouter()) {
+      return false;
+    }
+    // Don't propagate inter-area routes into a [not-so-stubby-]stub area for which type-3 LSAs
+    // are
+    // suppressed.
+    if ((neighborArea.getStubType() == StubType.STUB && neighborArea.getStub().getSuppressType3())
+        || (neighborArea.getStubType() == StubType.NSSA
+            && neighborArea.getNssa().getSuppressType3())) {
+      return false;
     }
 
     // ABR should not accept OSPF internal default route

--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/OspfProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/OspfProtocolHelper.java
@@ -92,15 +92,19 @@ public class OspfProtocolHelper {
       OspfArea neighborArea) {
     long neighborRouteAreaNum = neighborRoute.getArea();
     /*
-     * Once an inter-area route has been propagated across a link of a given area, it may continue to propagate throughout that area.
-     * To propagate into a different area, the propagator must be an ABR, and type-3 LSAs must be allowed across the link.
+     * Once an inter-area route has been propagated across a link of a given area,
+     * it may continue to propagate throughout that area.
+     * To propagate into a different area, the propagator *must* be an ABR.
      */
+
     if (linkAreaNum != neighborRouteAreaNum && !neighborProc.isAreaBorderRouter()) {
+      // trying to cross an area boundary but neighbor is not an ABR
       return false;
     }
-    // Don't propagate inter-area routes into a [not-so-stubby-]stub area for which type-3 LSAs
-    // are
-    // suppressed.
+    /*
+     * Don't propagate inter-area routes into a [not-so-stubby-]stub area for which type-3 LSAs
+     * are suppressed. Stub types are known/configured at the *neighbor* because the neighbor is an ABR.
+     */
     if ((neighborArea.getStubType() == StubType.STUB && neighborArea.getStub().getSuppressType3())
         || (neighborArea.getStubType() == StubType.NSSA
             && neighborArea.getNssa().getSuppressType3())) {


### PR DESCRIPTION
Suppression of type3 LSAs should happen regardless of link/route area numbers.