### PR TITLE
Add snapshot validation

### DIFF
--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -1577,8 +1577,12 @@ public class WorkMgr extends AbstractCoordinator {
     }
   }
 
-  /** Helper function to assert that the specified snapshot subdir contains configs
-   * @throws BatfishException */
+  /**
+   * Helper function to assert that the specified dir contains configs
+   *
+   * @throws BatfishException when specified dir does not contain network configs dir, AWS configs
+   *     dir, or a hosts dir
+   */
   private static void validateSnapshotDir(Path subDir) {
     // Confirm there is a configs, hosts, or AWS configs dir
     boolean configsFound = false;

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -1585,21 +1585,12 @@ public class WorkMgr extends AbstractCoordinator {
    */
   private static void validateSnapshotDir(Path subDir) {
     // Confirm there is a configs, hosts, or AWS configs dir
-    boolean configsFound = false;
     Path hostConfigsPath = subDir.resolve(BfConsts.RELPATH_HOST_CONFIGS_DIR);
-    if (Files.exists(hostConfigsPath)) {
-      configsFound = true;
-    }
     Path networkConfigsPath = subDir.resolve(BfConsts.RELPATH_CONFIGURATIONS_DIR);
-    if (Files.exists(networkConfigsPath)) {
-      configsFound = true;
-    }
     Path awsConfigsPath = subDir.resolve(BfConsts.RELPATH_AWS_CONFIGS_DIR);
-    if (Files.exists(awsConfigsPath)) {
-      configsFound = true;
-    }
-
-    if (!configsFound) {
+    if (!Files.exists(hostConfigsPath)
+        && !Files.exists(networkConfigsPath)
+        && !Files.exists(awsConfigsPath)) {
       Path srcDir = subDir.getParent();
       throw new BatfishException(
           String.format(

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
@@ -1416,12 +1416,12 @@ public final class WorkMgrTest {
 
     _manager.initNetwork(networkName, null);
 
-    // Create zip with a new file to add to the forked snapshot
+    // Create snapshot dir to pass into init
     Path srcDir = createSnapshot(snapshotName, fileName, fileContents, _folder);
 
     _manager.initSnapshot(networkName, snapshotName, srcDir, false);
 
-    // Confirm the forked snapshot exists
+    // Confirm the new snapshot exists
     assertThat(_manager.getLatestTestrig(networkName), equalTo(Optional.of(snapshotName)));
   }
 
@@ -1434,7 +1434,7 @@ public final class WorkMgrTest {
 
     _manager.initNetwork(networkName, null);
 
-    // Create zip with a new file to add to the forked snapshot
+    // Create snapshot dir to pass into init
     Path srcDir = createSnapshot(snapshotName, fileName, fileContents, _folder);
 
     // Init should fail with improperly formatted source dir

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTestUtils.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTestUtils.java
@@ -97,8 +97,8 @@ public final class WorkMgrTestUtils {
     }
   }
 
-  /** Creates a snapshot zip with the specified config and returns the path to that zip */
-  public static Path createSnapshotZip(
+  /** Creates and returns path to a snapshot dir with the specified config */
+  public static Path createSnapshot(
       String snapshot, String fileName, String content, TemporaryFolder folder) {
     Path tmpSnapshotSrcDir = folder.getRoot().toPath().resolve(snapshot);
     // intentional duplication of snapshot to provide subdir
@@ -107,9 +107,17 @@ public final class WorkMgrTestUtils {
             .resolve(snapshot)
             .resolve(BfConsts.RELPATH_CONFIGURATIONS_DIR)
             .resolve(fileName);
-    Path tmpSnapshotZip = tmpSnapshotSrcDir.resolve(String.format("%s.zip", snapshot));
     tmpSnapshotConfig.getParent().toFile().mkdirs();
     CommonUtil.writeFile(tmpSnapshotConfig, content);
+    return tmpSnapshotSrcDir;
+  }
+
+  /** Creates a snapshot zip with the specified config and returns the path to that zip */
+  public static Path createSnapshotZip(
+      String snapshot, String fileName, String content, TemporaryFolder folder) {
+    Path tmpSnapshotSrcDir = createSnapshot(snapshot, fileName, content, folder);
+
+    Path tmpSnapshotZip = tmpSnapshotSrcDir.resolve(String.format("%s.zip", snapshot));
     ZipUtility.zipFiles(tmpSnapshotSrcDir.resolve(snapshot), tmpSnapshotZip);
     return tmpSnapshotZip;
   }


### PR DESCRIPTION
* Add snapshot validation to snapshot init in `WorkMgr`
  * Checks for existence of configs, aws_configs, or hosts dir
* Surface more details to clients during snapshot init failure
  * Including failures in the newly added ss validation

For example: when uploading an improperly formatted snapshot dir, `Pybatfish` previously displayed:
```
>>> bf_init_snapshot("/networks/example", name="example", overwrite=True)
BatfishException: Initializing snapshot example_snapshot failed with status TERMINATEDABNORMALLY
Exception in container:0be21c77-3056-48dc-98d3-bf3ec929825e, testrig:17e18286-7aea-4553-9292-b02bc13461e2; exception:org.batfish.common.BatfishException: No valid configurations found in snapshot path /path/to/containers/0be21c77-3056-48dc-98d3-bf3ec929825e/snapshots/17e18286-7aea-4553-9292-b02bc13461e2/input
	at org.batfish.main.Batfish.serializeVendorConfigs(Batfish.java:3389)
	at org.batfish.main.Batfish.run(Batfish.java:3026)
	at org.batfish.main.Driver.lambda$runBatfish$3(Driver.java:580)
	at java.lang.Thread.run(Thread.java:748)
{
  "answerElements" : [
    {
      "class" : "org.batfish.common.BatfishException$BatfishStackTrace",
      "answer" : [
        "org.batfish.common.BatfishException: No valid configurations found in snapshot path /Users/spencer/Code/batfish-extension-pack/containers/0be21c77-3056-48dc-98d3-bf3ec929825e/snapshots/17e18286-7aea-4553-9292-b02bc13461e2/input",
        "   at org.batfish.main.Batfish.serializeVendorConfigs(Batfish.java:3389)",
        "   at org.batfish.main.Batfish.run(Batfish.java:3026)",
        "   at org.batfish.main.Driver.lambda$runBatfish$3(Driver.java:580)",
        "   at java.lang.Thread.run(Thread.java:748)",
        ""
      ]
    }
  ],
  "status" : "FAILURE",
  "summary" : {
    "numFailed" : 0,
    "numPassed" : 0,
    "numResults" : 0
  }
}
```
but now displays:
```
>>> bf_init_snapshot("/networks/example", name="example", overwrite=True)
BatfishException: Coordinator returned failure: Error initializing snapshot: Unexpected packaging of snapshot.  No networks configs dir 'example/configs', AWS configs dir 'example/aws_configs', or hosts dir 'example/hosts' found.
```
