### PR TITLE
Fix 2 bugs in BGP topology generation; start tests

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/BgpTopologyUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/BgpTopologyUtils.java
@@ -144,7 +144,7 @@ public final class BgpTopologyUtils {
           || neighbor.getRemoteAs() == null) {
         continue;
       }
-      // Check what nodes exist that could match with neighbor's peer address
+      // Find nodes that own the neighbor's peer address
       Set<String> possibleHostnames = ipOwners.get(neighbor.getPeerAddress());
       if (possibleHostnames == null) {
         continue;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/BgpTopologyUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/BgpTopologyUtils.java
@@ -137,7 +137,16 @@ public final class BgpTopologyUtils {
         continue;
       }
       BgpActivePeerConfig neighbor = networkConfigurations.getBgpPointToPointPeerConfig(neighborId);
-      if (neighbor == null || neighbor.getPeerAddress() == null) {
+      if (neighbor == null
+          || neighbor.getLocalIp() == null
+          || neighbor.getLocalAs() == null
+          || neighbor.getPeerAddress() == null
+          || neighbor.getRemoteAs() == null) {
+        continue;
+      }
+      // Check what nodes exist that could match with neighbor's peer address
+      Set<String> possibleHostnames = ipOwners.get(neighbor.getPeerAddress());
+      if (possibleHostnames == null) {
         continue;
       }
       Set<BgpPeerConfigId> candidates = localAddresses.get(neighbor.getPeerAddress());
@@ -147,24 +156,10 @@ public final class BgpTopologyUtils {
         if (candidates == null) {
           continue;
         }
-        candidates =
-            candidates
-                .stream()
-                .filter(c -> c.getRemotePeerPrefix().containsIp(neighbor.getPeerAddress()))
-                .collect(ImmutableSet.toImmutableSet());
-        if (candidates.isEmpty()) {
-          // No remote connection candidates
-          continue;
-        }
-      }
-      Long localLocalAs = neighbor.getLocalAs();
-      Long localRemoteAs = neighbor.getRemoteAs();
-      if (localLocalAs == null || localRemoteAs == null) {
-        // AS numbers not configured properly, cannot establish edge.
-        continue;
       }
       for (BgpPeerConfigId candidateNeighborId : candidates) {
-        if (!bgpCandidatePassesSanityChecks(neighbor, candidateNeighborId, networkConfigurations)) {
+        if (!bgpCandidatePassesSanityChecks(
+            neighbor, candidateNeighborId, possibleHostnames, networkConfigurations)) {
           // Short-circuit if there is no way the remote end will accept our connection
           continue;
         }
@@ -219,14 +214,15 @@ public final class BgpTopologyUtils {
   static boolean bgpCandidatePassesSanityChecks(
       @Nonnull BgpActivePeerConfig neighbor,
       @Nonnull BgpPeerConfigId candidateId,
+      @Nonnull Set<String> possibleHostnames,
       @Nonnull NetworkConfigurations nc) {
     if (candidateId.isDynamic()) {
       BgpPassivePeerConfig candidate = nc.getBgpDynamicPeerConfig(candidateId);
       return candidate != null
-          && neighbor.getLocalIp() != null
           && candidate.canConnect(neighbor.getLocalAs())
           && Objects.equals(neighbor.getRemoteAs(), candidate.getLocalAs())
-          && candidate.canConnect(neighbor.getLocalIp());
+          && candidate.canConnect(neighbor.getLocalIp())
+          && possibleHostnames.contains(candidateId.getHostname());
     } else {
       BgpActivePeerConfig candidate = nc.getBgpPointToPointPeerConfig(candidateId);
       return candidate != null

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/BgpTopologyUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/BgpTopologyUtilsTest.java
@@ -1,0 +1,161 @@
+package org.batfish.datamodel.bgp;
+
+import static org.batfish.datamodel.bgp.BgpTopologyUtils.initBgpTopology;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.graph.ValueGraph;
+import java.util.Map;
+import java.util.Set;
+import org.batfish.datamodel.BgpActivePeerConfig;
+import org.batfish.datamodel.BgpPassivePeerConfig;
+import org.batfish.datamodel.BgpPeerConfigId;
+import org.batfish.datamodel.BgpProcess;
+import org.batfish.datamodel.BgpSessionProperties;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.Vrf;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class BgpTopologyUtilsTest {
+
+  private static BgpProcess _node1BgpProcess = new BgpProcess();
+  private static BgpProcess _node2BgpProcess = new BgpProcess();
+  private static BgpProcess _node3BgpProcess = new BgpProcess();
+  private static Map<String, Configuration> _configs;
+
+  /** Sets up three nodes with a BGP process on each. Tests can populate BGP processes. */
+  @BeforeClass
+  public static void setup() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration.Builder cb =
+        nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+
+    Vrf vrf1 = new Vrf("vrf1");
+    vrf1.setBgpProcess(_node1BgpProcess);
+    Configuration c1 = cb.setHostname("node1").build();
+    c1.setVrfs(ImmutableMap.of("vrf1", vrf1));
+
+    Vrf vrf2 = new Vrf("vrf2");
+    vrf2.setBgpProcess(_node2BgpProcess);
+    Configuration c2 = cb.setHostname("node2").build();
+    c2.setVrfs(ImmutableMap.of("vrf2", vrf2));
+
+    Vrf vrf3 = new Vrf("vrf3");
+    vrf3.setBgpProcess(_node3BgpProcess);
+    Configuration c3 = cb.setHostname("node3").build();
+    c3.setVrfs(ImmutableMap.of("vrf3", vrf3));
+
+    _configs = ImmutableMap.of("node1", c1, "node2", c2, "node3", c3);
+  }
+
+  @Before
+  public void clearBgpProcesses() {
+    _node1BgpProcess.setNeighbors(ImmutableSortedMap.of());
+    _node2BgpProcess.setNeighbors(ImmutableSortedMap.of());
+    _node3BgpProcess.setNeighbors(ImmutableSortedMap.of());
+    _node1BgpProcess.setPassiveNeighbors(ImmutableSortedMap.of());
+    _node2BgpProcess.setPassiveNeighbors(ImmutableSortedMap.of());
+    _node3BgpProcess.setPassiveNeighbors(ImmutableSortedMap.of());
+  }
+
+  @Test
+  public void testInitTopologyRemotePrefixNotMatchingLocalIp() {
+    // Peer 1 is active, on node1 with IP 1.1.1.1, set up to peer with 1.1.1.2
+    // Peer 2 is passive, on node2 with IP 2.2.2.2, with remote prefix 1.1.1.0/24
+    // Should see one edge in BGP topology: peer 1 to peer 2
+
+    Ip ip1 = new Ip("1.1.1.1");
+    Ip ip2 = new Ip("2.2.2.2");
+
+    Prefix peer1PeerPrefix = new Prefix(ip2, 32);
+    BgpActivePeerConfig peer1 =
+        BgpActivePeerConfig.builder()
+            .setLocalIp(ip1)
+            .setLocalAs(1L)
+            .setPeerAddress(ip2)
+            .setRemoteAs(2L)
+            .build();
+    _node1BgpProcess.setNeighbors(ImmutableSortedMap.of(peer1PeerPrefix, peer1));
+
+    Prefix peer2PeerPrefix = new Prefix(ip1, 24);
+    BgpPassivePeerConfig peer2 =
+        BgpPassivePeerConfig.builder()
+            .setLocalIp(Ip.AUTO)
+            .setLocalAs(2L)
+            .setRemoteAs(ImmutableList.of(1L))
+            .setPeerPrefix(peer2PeerPrefix)
+            .build();
+    _node2BgpProcess.setPassiveNeighbors(ImmutableSortedMap.of(peer2PeerPrefix, peer2));
+
+    Map<Ip, Set<String>> ipOwners =
+        ImmutableMap.of(ip1, ImmutableSet.of("node1"), ip2, ImmutableSet.of("node2"));
+
+    ValueGraph<BgpPeerConfigId, BgpSessionProperties> bgpTopology =
+        initBgpTopology(_configs, ipOwners, true, false, null, null);
+    assertThat(bgpTopology.edges(), hasSize(1));
+  }
+
+  @Test
+  public void testInitTopologyLocalIpNotMatchingRemoteHost() {
+    // Peer 1 is active, set up to peer with 1.1.1.2
+    // Peer 2 is passive, on node2 with IP 1.1.1.2, able to peer with peer 1
+    // Peer 3 has the same configuration as peer 2, but on node3 with IP 1.1.1.3
+    // Should see one edge in BGP topology: peer 1 to peer 2
+
+    Ip ip1 = new Ip("1.1.1.1");
+    Ip ip2 = new Ip("1.1.1.2");
+    Ip ip3 = new Ip("1.1.1.3");
+
+    Prefix peer1PeerPrefix = new Prefix(ip2, 32);
+    BgpActivePeerConfig peer1 =
+        BgpActivePeerConfig.builder()
+            .setLocalIp(ip1)
+            .setLocalAs(1L)
+            .setPeerAddress(ip2)
+            .setRemoteAs(2L)
+            .build();
+    _node1BgpProcess.setNeighbors(ImmutableSortedMap.of(peer1PeerPrefix, peer1));
+
+    Prefix peer2PeerPrefix = new Prefix(ip1, 24);
+    BgpPassivePeerConfig peer2 =
+        BgpPassivePeerConfig.builder()
+            .setLocalIp(Ip.AUTO)
+            .setLocalAs(2L)
+            .setRemoteAs(ImmutableList.of(1L))
+            .setPeerPrefix(peer2PeerPrefix)
+            .build();
+    _node2BgpProcess.setPassiveNeighbors(ImmutableSortedMap.of(peer2PeerPrefix, peer2));
+
+    BgpPassivePeerConfig peer3 =
+        BgpPassivePeerConfig.builder()
+            .setLocalIp(Ip.AUTO)
+            .setLocalAs(2L)
+            .setRemoteAs(ImmutableList.of(1L))
+            .setPeerPrefix(peer2PeerPrefix)
+            .build();
+    _node3BgpProcess.setPassiveNeighbors(ImmutableSortedMap.of(peer2PeerPrefix, peer3));
+
+    Map<Ip, Set<String>> ipOwners =
+        ImmutableMap.of(
+            ip1,
+            ImmutableSet.of("node1"),
+            ip2,
+            ImmutableSet.of("node2"),
+            ip3,
+            ImmutableSet.of("node3"));
+
+    ValueGraph<BgpPeerConfigId, BgpSessionProperties> bgpTopology =
+        initBgpTopology(_configs, ipOwners, true, false, null, null);
+    assertThat(bgpTopology.edges(), hasSize(1));
+  }
+}


### PR DESCRIPTION
Fixed two bugs in the code that adds edges to the BGP topology:
1. When considering passive candidates for the remote peer, the old code filtered out candidates whose remote peer prefix didn't contain the neighbor's peer address (old line 153). AFAICT this should have been filtering for peer prefix containing the neighbor's local IP instead. However, that's already done a few lines later with `bgpCandidatePassesSanityChecks()`, so I just took out the filter.
2. For passive candidates for the remote peer, we were never checking that the passive peer's host owned the neighbor's remote IP. Since passive peers have their local IPs set to `Ip.AUTO`, this wasn't caught by sanity checking the `BgpPeerConfig` fields. I added a line to `bgpCandidatePassesSanityChecks()` to ensure that for passive candidates, the candidate's hostname was among the possible remote hostnames based on the neighbor's remote IP and the `ipOwners` argument.

Other changes:
- Collected all the checks for fields of `neighbor` being null into one place. This will have caused a very minor functional change where active peers with null local IP now can't ever have edges, whereas before they could have had edges to an active remote peer with null peer address.
- Added two tests that would have surfaced the two bugs that were fixed. More tests needed for `BgpTopologyUtils`, but would like to merge this first to fix these bugs.