### PR TITLE
Make prefix-tracer non transient

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -227,9 +227,8 @@ public class VirtualRouter implements Serializable {
 
   private transient Map<Prefix, OspfLink> _ospfNeighbors;
 
-  // TODO: make non-transient. Currently transient because de-serialization crashes.
   /** Metadata about propagated prefixes to/from neighbors */
-  private transient PrefixTracer _prefixTracer;
+  private PrefixTracer _prefixTracer;
 
   /** List of all EIGRP processes in this VRF */
   @VisibleForTesting transient ImmutableMap<Long, VirtualEigrpProcess> _virtualEigrpProcesses;


### PR DESCRIPTION
Enables running the prefix-tracer question on dataplanes that have been deserialized from disk without crashing.

*Note*: this will introduce some overhead when (de-)serializing dataplane. Working on improving prefix tracer logic.