### PR TITLE
IntegerSpace: prettyify toString by default

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IntegerSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IntegerSpace.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.DiscreteDomain;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableRangeSet;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Range;
@@ -19,6 +18,7 @@ import java.util.HashSet;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -54,21 +54,6 @@ public final class IntegerSpace implements Serializable {
   @Nonnull
   static IntegerSpace create(@Nullable String s) {
     return IntegerSpace.Builder.create(s).build();
-  }
-
-  @JsonValue
-  private String value() {
-    return String.join(
-        ",",
-        getRanges()
-            .stream()
-            .map(
-                r ->
-                    String.join(
-                        "-",
-                        ImmutableList.of(
-                            r.lowerEndpoint().toString(), String.valueOf(r.upperEndpoint() - 1))))
-            .collect(ImmutableList.toImmutableList()));
   }
 
   /** This space as a set of included {@link Range}s */
@@ -364,9 +349,19 @@ public final class IntegerSpace implements Serializable {
     return Objects.hash(_rangeset);
   }
 
+  private static String toRangeString(Range<Integer> r) {
+    int lower = r.lowerEndpoint();
+    int upper = r.upperEndpoint() - 1;
+    if (lower == upper) {
+      return Integer.toString(lower);
+    }
+    return lower + "-" + upper;
+  }
+
+  @JsonValue
   @Override
   public String toString() {
-    return _rangeset.toString();
+    return getRanges().stream().map(IntegerSpace::toRangeString).collect(Collectors.joining(","));
   }
 
   private static final long serialVersionUID = 1L;

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/IntegerSpaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/IntegerSpaceTest.java
@@ -400,4 +400,13 @@ public class IntegerSpaceTest {
     List<Integer> streamed = space.stream().boxed().collect(ImmutableList.toImmutableList());
     assertThat(streamed, equalTo(ImmutableList.of(-3, -2, -1, 1, 2, 3, 4, 5)));
   }
+
+  @Test
+  public void testToString() {
+    assertThat(
+        IntegerSpace.builder().including(new SubRange(5, 10)).excluding(9).build().toString(),
+        equalTo("5-8,10"));
+
+    assertThat(IntegerSpace.builder().build().toString(), equalTo(""));
+  }
 }

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -17899,7 +17899,7 @@
             "name" : "xe-0/0/0.0",
             "accessVlan" : 0,
             "active" : true,
-            "allowedVlans" : "30-30,40-40,50-50",
+            "allowedVlans" : "30,40,50",
             "autostate" : true,
             "bandwidth" : 1.0E10,
             "declaredNames" : [
@@ -24876,7 +24876,7 @@
             "name" : "FastEthernet0/1",
             "accessVlan" : 0,
             "active" : true,
-            "allowedVlans" : "12-12,34-34,56-78,99-99",
+            "allowedVlans" : "12,34,56-78,99",
             "autostate" : true,
             "bandwidth" : 1.0E8,
             "declaredNames" : [

--- a/tests/questions/experimental/searchfilters.ref
+++ b/tests/questions/experimental/searchfilters.ref
@@ -7,7 +7,7 @@
     "dstPorts" : "0-21,23-1000",
     "ipProtocols" : "TCP",
     "srcIps" : "1.1.1.1",
-    "srcPorts" : "0-0"
+    "srcPorts" : "0"
   },
   "invertSearch" : false,
   "nodes" : ".*",


### PR DESCRIPTION
Fixes InterfaceProperties for allowed vlans

After #2666, since the refs will conflict.