### PR TITLE
Saner condition to check for multiple remotes

### DIFF
--- a/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionAnswerer.java
@@ -88,8 +88,7 @@ public abstract class BgpSessionAnswerer extends Answerer {
       return ConfiguredSessionStatus.UNKNOWN_REMOTE;
     } else if (configuredBgpTopology.adjacentNodes(bgpPeerConfigId).isEmpty()) {
       return ConfiguredSessionStatus.HALF_OPEN;
-      // degree > 2 because of directed edges. 1 edge in, 1 edge out == single connection
-    } else if (configuredBgpTopology.degree(bgpPeerConfigId) > 2) {
+    } else if (configuredBgpTopology.outDegree(bgpPeerConfigId) > 1) {
       return ConfiguredSessionStatus.MULTIPLE_REMOTES;
     }
     return ConfiguredSessionStatus.UNIQUE_MATCH;


### PR DESCRIPTION
Used to check for `degree > 2`, on the assumption that:
- an active peer with degree 1 must be correctly configured to peer with a passive peer
- an active peer with degree 2 must be correctly configured to peer with another active peer

Changing because it seems plausible that there are some broken edge cases that could violate those assumptions.