### PR TITLE
support for specifying interfaces by type

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/FlexibleInterfaceSpecifierFactory.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/FlexibleInterfaceSpecifierFactory.java
@@ -18,6 +18,7 @@ import org.batfish.datamodel.questions.InterfacesSpecifier;
  *       ReferenceInterfaceGroupInterfaceSpecifier};
  *   <li>vrf(regex): returns {@link VrfNameRegexInterfaceSpecifier}
  *   <li>zone(regex): returns {@link ZoneNameRegexInterfaceSpecifier}
+ *   <li>type(regex): returns {@link TypeNameRegexInterfaceSpecifier}
  *   <li>all other inputs go directly to {@link ShorthandInterfaceSpecifier}
  * </ul>
  */
@@ -30,6 +31,9 @@ public class FlexibleInterfaceSpecifierFactory implements InterfaceSpecifierFact
 
   private static final Pattern REF_PATTERN =
       Pattern.compile("ref\\.interfacegroup\\((.*)\\)", Pattern.CASE_INSENSITIVE);
+
+  private static final Pattern TYPE_PATTERN =
+      Pattern.compile("type\\((.*)\\)", Pattern.CASE_INSENSITIVE);
 
   private static final Pattern VRF_PATTERN =
       Pattern.compile("vrf\\((.*)\\)", Pattern.CASE_INSENSITIVE);
@@ -67,6 +71,13 @@ public class FlexibleInterfaceSpecifierFactory implements InterfaceSpecifierFact
           "ref.interfaceGroup() needs interface group and reference book names separated by ','");
 
       return new ReferenceInterfaceGroupInterfaceSpecifier(words[0], words[1]);
+    }
+
+    // interface type pattern
+    matcher = TYPE_PATTERN.matcher(str);
+    if (matcher.find()) {
+      Pattern typeRegex = Pattern.compile(matcher.group(1).trim(), Pattern.CASE_INSENSITIVE);
+      return new TypeNameRegexInterfaceSpecifier(typeRegex);
     }
 
     // VRF pattern

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/TypeNameRegexInterfaceSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/TypeNameRegexInterfaceSpecifier.java
@@ -1,9 +1,9 @@
 package org.batfish.specifier;
 
-import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -49,7 +49,7 @@ public final class TypeNameRegexInterfaceSpecifier implements InterfaceSpecifier
       return false;
     }
     TypeNameRegexInterfaceSpecifier that = (TypeNameRegexInterfaceSpecifier) o;
-    return Objects.equal(_interfaceTypes, that._interfaceTypes);
+    return Objects.equals(_interfaceTypes, that._interfaceTypes);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/TypeNameRegexInterfaceSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/TypeNameRegexInterfaceSpecifier.java
@@ -1,0 +1,59 @@
+package org.batfish.specifier;
+
+import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.InterfaceType;
+
+/**
+ * An {@link InterfaceSpecifier} that specifies interfaces by {@link InterfaceType type}. Uses a
+ * regex to specify which types to include.
+ */
+public final class TypeNameRegexInterfaceSpecifier implements InterfaceSpecifier {
+  private final Set<InterfaceType> _interfaceTypes;
+
+  public TypeNameRegexInterfaceSpecifier(Pattern typeNameRegex) {
+    _interfaceTypes =
+        Stream.of(InterfaceType.values())
+            .filter(type -> typeNameRegex.matcher(type.name()).matches())
+            .collect(ImmutableSet.toImmutableSet());
+    Preconditions.checkArgument(
+        !_interfaceTypes.isEmpty(),
+        String.format("Interface type regex %s matches no types", typeNameRegex.pattern()));
+  }
+
+  @Override
+  public Set<Interface> resolve(Set<String> nodes, SpecifierContext ctxt) {
+    Map<String, Configuration> configs = ctxt.getConfigs();
+
+    return nodes
+        .stream()
+        .map(configs::get)
+        .flatMap(config -> config.getAllInterfaces().values().stream())
+        .filter(iface -> _interfaceTypes.contains(iface.getInterfaceType()))
+        .collect(ImmutableSet.toImmutableSet());
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof TypeNameRegexInterfaceSpecifier)) {
+      return false;
+    }
+    TypeNameRegexInterfaceSpecifier that = (TypeNameRegexInterfaceSpecifier) o;
+    return Objects.equal(_interfaceTypes, that._interfaceTypes);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(_interfaceTypes);
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/FlexibleInterfaceSpecifierFactoryTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/FlexibleInterfaceSpecifierFactoryTest.java
@@ -57,6 +57,14 @@ public class FlexibleInterfaceSpecifierFactoryTest {
   }
 
   @Test
+  public void testType() {
+    assertThat(
+        new FlexibleInterfaceSpecifierFactory().buildInterfaceSpecifier("type(.*)"),
+        equalTo(
+            new TypeNameRegexInterfaceSpecifier(Pattern.compile(".*", Pattern.CASE_INSENSITIVE))));
+  }
+
+  @Test
   public void testVrf() {
     assertThat(
         new FlexibleInterfaceSpecifierFactory().buildInterfaceSpecifier("vrf(.*)"),

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/TypeNameRegexInterfaceSpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/TypeNameRegexInterfaceSpecifierTest.java
@@ -1,0 +1,107 @@
+package org.batfish.specifier;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.InterfaceType;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.Vrf;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class TypeNameRegexInterfaceSpecifierTest {
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  private static final Interface AGGREGATED;
+  private static final Interface LOOPBACK;
+  private static final Interface NULL;
+  private static final Interface PHYSICAL;
+  private static final Interface REDUNDANT;
+  private static final Interface TUNNEL;
+  private static final Interface UNKNOWN;
+  private static final Interface VLAN;
+  private static final Interface VPN;
+
+  private static final String HOSTNAME = "hostname";
+  private static final MockSpecifierContext CTXT;
+
+  static {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration config =
+        nf.configurationBuilder()
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .setHostname(HOSTNAME)
+            .build();
+    Vrf vrf = nf.vrfBuilder().setOwner(config).build();
+    Interface.Builder ib = nf.interfaceBuilder().setOwner(config).setVrf(vrf);
+
+    AGGREGATED = ib.build();
+    AGGREGATED.setInterfaceType(InterfaceType.AGGREGATED);
+
+    LOOPBACK = ib.build();
+    LOOPBACK.setInterfaceType(InterfaceType.LOOPBACK);
+
+    NULL = ib.build();
+    NULL.setInterfaceType(InterfaceType.NULL);
+
+    PHYSICAL = ib.build();
+    PHYSICAL.setInterfaceType(InterfaceType.PHYSICAL);
+
+    REDUNDANT = ib.build();
+    REDUNDANT.setInterfaceType(InterfaceType.REDUNDANT);
+
+    TUNNEL = ib.build();
+    TUNNEL.setInterfaceType(InterfaceType.TUNNEL);
+
+    UNKNOWN = ib.build();
+    UNKNOWN.setInterfaceType(InterfaceType.UNKNOWN);
+
+    VLAN = ib.build();
+    VLAN.setInterfaceType(InterfaceType.VLAN);
+
+    VPN = ib.build();
+    VPN.setInterfaceType(InterfaceType.VPN);
+
+    CTXT =
+        MockSpecifierContext.builder()
+            .setConfigs(ImmutableMap.of(config.getHostname(), config))
+            .build();
+  }
+
+  @Test
+  public void testBadRegex() {
+    thrown.expect(IllegalArgumentException.class);
+    new TypeNameRegexInterfaceSpecifier(Pattern.compile("bad regex"));
+  }
+
+  private Set<Interface> specifiedInterfaces(String regex) {
+    return new TypeNameRegexInterfaceSpecifier(Pattern.compile(regex, Pattern.CASE_INSENSITIVE))
+        .resolve(ImmutableSet.of(HOSTNAME), CTXT);
+  }
+
+  @Test
+  public void test() {
+    assertThat(specifiedInterfaces("a.*"), equalTo(ImmutableSet.of(AGGREGATED)));
+    assertThat(specifiedInterfaces("l.*"), equalTo(ImmutableSet.of(LOOPBACK)));
+    assertThat(specifiedInterfaces("n.*"), equalTo(ImmutableSet.of(NULL)));
+    assertThat(specifiedInterfaces("p.*"), equalTo(ImmutableSet.of(PHYSICAL)));
+    assertThat(specifiedInterfaces("r.*"), equalTo(ImmutableSet.of(REDUNDANT)));
+    assertThat(specifiedInterfaces("t.*"), equalTo(ImmutableSet.of(TUNNEL)));
+    assertThat(specifiedInterfaces("u.*"), equalTo(ImmutableSet.of(UNKNOWN)));
+    assertThat(specifiedInterfaces("vlan"), equalTo(ImmutableSet.of(VLAN)));
+    assertThat(specifiedInterfaces("vpn"), equalTo(ImmutableSet.of(VPN)));
+    assertThat(
+        specifiedInterfaces(".*"),
+        equalTo(
+            ImmutableSet.of(
+                AGGREGATED, LOOPBACK, NULL, PHYSICAL, REDUNDANT, TUNNEL, UNKNOWN, VLAN, VPN)));
+  }
+}


### PR DESCRIPTION
Adds `TypeNameRegexInterfaceSpecifier`, which allows interfaces to be specified by type, and incorporates it into `FlexibleInterfaceSpecifier`. This will allow us to provide generic queries that work on any network, e.g. verify reachability or multipath consistency  between all pairs of loopbacks.

```
# verify all-pairs reachability between loopbacks
bfq.reachability(
    pathConstraints=PathConstraints(startLocation="[type(loopback)]"),
    headers=HeaderConstraints(dstIps="ofLocation([type(loopback)])"),
    actions="FAILURE")

# verify multipath consistency between all pairs of loopbacks
bfq.multipathConsistency(
    pathConstraints=PathConstraints(startLocation="[type(loopback)]"),
    headers=HeaderConstraints(dstIps="ofLocation([type(loopback)])"))
```

cc @saparikh 