### PR TITLE
new scoped multipath consistency question templates

### DIFF
--- a/questions/experimental/loopbackMultipathConsistency.json
+++ b/questions/experimental/loopbackMultipathConsistency.json
@@ -1,0 +1,29 @@
+{
+    "class": "org.batfish.question.multipath.MultipathConsistencyQuestion",
+    "differential": false,
+    "headers": {
+      "dstIps": "ofLocation([type(loopback)])"
+    },
+    "maxTraces": "${maxTraces}",
+    "pathConstraints": {
+      "startLocation": "[type(loopback)]"
+    },
+    "instance": {
+        "description": "Validate multipath consistency between all pairs of loopbacks.",
+        "instanceName": "loopbackMultipathConsistency",
+        "longDescription": "Finds flows between loopbacks that are treated differently by different paths in the presence of multipath routing",
+        "tags": [
+            "dataPlane",
+            "reachability",
+            "multipath consistency"
+        ],
+        "variables": {
+            "maxTraces": {
+                "description": "Limit the number of traces returned",
+                "optional": true,
+                "type": "integer",
+                "displayName": "Max Traces"
+            }
+        }
+    }
+}

--- a/questions/experimental/subnetMultipathConsistency.json
+++ b/questions/experimental/subnetMultipathConsistency.json
@@ -1,0 +1,29 @@
+{
+    "class": "org.batfish.question.multipath.MultipathConsistencyQuestion",
+    "differential": false,
+    "headers": {
+      "dstIps": "ofLocation(enter(.*))"
+    },
+    "maxTraces": "${maxTraces}",
+    "pathConstraints": {
+      "startLocation": "enter(.*)"
+    },
+    "instance": {
+        "description": "Validate multipath consistency between all pairs of subnets.",
+        "instanceName": "subnetMultipathConsistency",
+        "longDescription": "Finds flows between subnets that are treated differently by different paths in the presence of multipath routing",
+        "tags": [
+            "dataPlane",
+            "reachability",
+            "multipath consistency"
+        ],
+        "variables": {
+            "maxTraces": {
+                "description": "Limit the number of traces returned",
+                "optional": true,
+                "type": "integer",
+                "displayName": "Max Traces"
+            }
+        }
+    }
+}

--- a/tests/questions/experimental/commands
+++ b/tests/questions/experimental/commands
@@ -21,6 +21,9 @@ test -raw tests/questions/experimental/detectLoops.ref validate-template detectL
 # validate filterTable
 test -raw tests/questions/experimental/filterTable.ref validate-template filterTable filter = "mtu == 1500", innerQuestion={"class": "org.batfish.question.interfaceproperties.InterfacePropertiesQuestion"}, columns=["interface", "mtu"]
 
+# validate loopbackMultipathConsistency
+test -raw tests/questions/experimental/loopbackMultipathConsistency.ref validate-template loopbackMultipathConsistency maxTraces=1
+
 # validate interfaceMtu
 test -raw tests/questions/experimental/interfaceMtu.ref validate-template interfaceMtu comparator='>', interfaces='Gig.*', mtuBytes=0, nodes='as1core2'
 
@@ -74,6 +77,9 @@ test -raw tests/questions/experimental/resolveNodeSpecifier.ref validate-templat
 
 # validate searchfilters
 test -raw tests/questions/experimental/searchfilters.ref validate-template searchfilters invertSearch=false, filters=".*", action="matchLine 0", headers={dstIps="2.2.2.2", ipProtocols="tcp", srcIps="1.1.1.1", srcPorts="0", dstPorts="0-1000,!22"}, nodes=".*", startLocation="somenode", explain=false
+
+# validate subnetMultipathConsistency
+test -raw tests/questions/experimental/subnetMultipathConsistency.ref validate-template subnetMultipathConsistency maxTraces=1
 
 # test traceroute
 test -raw tests/questions/experimental/traceroute.ref validate-template traceroute startLocation="location", ignoreFilters=false, maxTraces=0, headers={"dstIps" : "1.1.1.1/32"}

--- a/tests/questions/experimental/loopbackMultipathConsistency.ref
+++ b/tests/questions/experimental/loopbackMultipathConsistency.ref
@@ -1,0 +1,31 @@
+{
+  "class" : "org.batfish.question.multipath.MultipathConsistencyQuestion",
+  "headers" : {
+    "dstIps" : "ofLocation([type(loopback)])"
+  },
+  "maxTraces" : 1,
+  "pathConstraints" : {
+    "startLocation" : "[type(loopback)]"
+  },
+  "differential" : false,
+  "includeOneTableKeys" : true,
+  "instance" : {
+    "description" : "Validate multipath consistency between all pairs of loopbacks.",
+    "instanceName" : "qname",
+    "longDescription" : "Finds flows between loopbacks that are treated differently by different paths in the presence of multipath routing",
+    "tags" : [
+      "dataPlane",
+      "multipath consistency",
+      "reachability"
+    ],
+    "variables" : {
+      "maxTraces" : {
+        "description" : "Limit the number of traces returned",
+        "displayName" : "Max Traces",
+        "optional" : true,
+        "type" : "integer",
+        "value" : 1
+      }
+    }
+  }
+}

--- a/tests/questions/experimental/subnetMultipathConsistency.ref
+++ b/tests/questions/experimental/subnetMultipathConsistency.ref
@@ -1,0 +1,31 @@
+{
+  "class" : "org.batfish.question.multipath.MultipathConsistencyQuestion",
+  "headers" : {
+    "dstIps" : "ofLocation(enter(.*))"
+  },
+  "maxTraces" : 1,
+  "pathConstraints" : {
+    "startLocation" : "enter(.*)"
+  },
+  "differential" : false,
+  "includeOneTableKeys" : true,
+  "instance" : {
+    "description" : "Validate multipath consistency between all pairs of subnets.",
+    "instanceName" : "qname",
+    "longDescription" : "Finds flows between subnets that are treated differently by different paths in the presence of multipath routing",
+    "tags" : [
+      "dataPlane",
+      "multipath consistency",
+      "reachability"
+    ],
+    "variables" : {
+      "maxTraces" : {
+        "description" : "Limit the number of traces returned",
+        "displayName" : "Max Traces",
+        "optional" : true,
+        "type" : "integer",
+        "value" : 1
+      }
+    }
+  }
+}


### PR DESCRIPTION
Two new scoped multipath checks that should be more usable on an arbitrary network than the unscoped version. One checks all subnet pairs, and the other all loopback pairs.

cc @saparikh 