### PR TITLE
Fix duplicate hostname logic by removing File.separator from it

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/job/ParseVendorConfigurationResult.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ParseVendorConfigurationResult.java
@@ -2,6 +2,7 @@ package org.batfish.job;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
+import java.io.File;
 import java.util.Map;
 import javax.annotation.Nonnull;
 import org.batfish.common.BatfishException;
@@ -143,13 +144,18 @@ public class ParseVendorConfigurationResult
   }
 
   private static String getModifiedName(String baseName, String filename) {
-    String modifiedName = baseName + "__file__" + filename;
+    String modifiedName = getModifiedNameBase(baseName, filename);
     int index = 0;
     while (_duplicateHostnames.containsEntry(baseName, modifiedName)) {
-      modifiedName = baseName + "__file__" + filename + "." + index;
+      modifiedName = getModifiedNameBase(baseName, filename) + "." + index;
       index++;
     }
     return modifiedName;
+  }
+
+  /** Returns a modified host name to use when duplicate hostnames are encountered */
+  public static String getModifiedNameBase(String baseName, String filename) {
+    return baseName + "__" + filename.replaceAll(File.separator, "__");
   }
 
   public VendorConfiguration getVendorConfiguration() {

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
@@ -53,6 +53,7 @@ import org.batfish.identifiers.NetworkId;
 import org.batfish.identifiers.QuestionId;
 import org.batfish.identifiers.QuestionSettingsId;
 import org.batfish.identifiers.TestIdResolver;
+import org.batfish.job.ParseVendorConfigurationResult;
 import org.batfish.representation.host.HostConfiguration;
 import org.batfish.storage.TestStorageProvider;
 import org.batfish.vendor.VendorConfiguration;
@@ -152,6 +153,27 @@ public class BatfishTest {
     assertThat(
         configurations.get("host1").getAllInterfaces().get("Ethernet0").getIncomingFilterName(),
         is(notNullValue()));
+  }
+
+  @Test
+  public void testInitTestrigWithDuplicateHostnames() throws IOException {
+    String testrigResourcePrefix = "org/batfish/main/snapshots/duplicate_hostnames";
+    List<String> configurationNames = ImmutableList.of("rtr1", "rtr2");
+
+    Batfish batfish =
+        BatfishTestUtils.getBatfishFromTestrigText(
+            TestrigText.builder()
+                .setConfigurationText(testrigResourcePrefix, configurationNames)
+                .build(),
+            _folder);
+    Map<String, Configuration> configurations = batfish.loadConfigurations();
+
+    assertThat(
+        configurations.keySet(),
+        equalTo(
+            ImmutableSet.of(
+                ParseVendorConfigurationResult.getModifiedNameBase("rtr1", "configs/rtr1"),
+                ParseVendorConfigurationResult.getModifiedNameBase("rtr1", "configs/rtr2"))));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/main/snapshots/duplicate_hostnames/configs/rtr1
+++ b/projects/batfish/src/test/resources/org/batfish/main/snapshots/duplicate_hostnames/configs/rtr1
@@ -1,0 +1,11 @@
+!
+hostname rtr1
+feature ospf
+!
+interface Ethernet0
+ ip address 1.0.0.1/24
+ vrrp 123 priority 100
+ vrrp 123 ip 1.0.0.10
+ no shutdown
+!
+!

--- a/projects/batfish/src/test/resources/org/batfish/main/snapshots/duplicate_hostnames/configs/rtr2
+++ b/projects/batfish/src/test/resources/org/batfish/main/snapshots/duplicate_hostnames/configs/rtr2
@@ -1,0 +1,11 @@
+!
+hostname rtr1
+feature ospf
+!
+interface Ethernet0
+ ip address 1.0.0.1/24
+ vrrp 123 priority 100
+ vrrp 123 ip 1.0.0.10
+ no shutdown
+!
+!


### PR DESCRIPTION
Bitrot had set in for the old way of determining duplicate file names. Having '/' in the router name is not legal because of https://github.com/batfish/batfish/blob/97895cfded2b67395294969bfc40577d4c7874ba/projects/batfish/src/main/java/org/batfish/main/Batfish.java#L3280. 

Partially addresses #2684 