### PR TITLE
Skip parsing empty files

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/job/ParseVendorConfigurationJob.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ParseVendorConfigurationJob.java
@@ -119,6 +119,11 @@ public class ParseVendorConfigurationJob extends BatfishJob<ParseVendorConfigura
     if (format == ConfigurationFormat.UNKNOWN) {
       format = VendorConfigurationFormatDetector.identifyConfigurationFormat(_fileText);
     }
+
+    if (_fileText.length() == 0) {
+      format = ConfigurationFormat.EMPTY;
+    }
+
     switch (format) {
       case EMPTY:
         _warnings.redFlag("Empty file: '" + _filename + "'\n");

--- a/projects/batfish/src/main/java/org/batfish/job/ParseVendorConfigurationJob.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ParseVendorConfigurationJob.java
@@ -120,7 +120,7 @@ public class ParseVendorConfigurationJob extends BatfishJob<ParseVendorConfigura
       format = VendorConfigurationFormatDetector.identifyConfigurationFormat(_fileText);
     }
 
-    if (_fileText.length() == 0) {
+    if (_fileText.trim().isEmpty()) {
       format = ConfigurationFormat.EMPTY;
     }
 

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -1041,6 +1041,7 @@
         "configs/vxlan" : "PASSED",
         "hosts/host1.json" : "PASSED",
         "hosts/host2.json" : "PASSED",
+        "hosts/hostEmpty.json" : "EMPTY",
         "iptables/host1.iptables" : "PASSED",
         "iptables/host2.iptables" : "PASSED"
       },
@@ -68184,6 +68185,7 @@
         "configs/vxlan" : "PASSED",
         "hosts/host1.json" : "PASSED",
         "hosts/host2.json" : "PASSED",
+        "hosts/hostEmpty.json" : "EMPTY",
         "iptables/host1.iptables" : "PASSED",
         "iptables/host2.iptables" : "PASSED"
       }


### PR DESCRIPTION
Detect and skip parsing empty files - even when config format is not dynamically detected.
