### PR TITLE
Cisco: remove bogus todo

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -1039,7 +1039,6 @@ import org.batfish.grammar.cisco.CiscoParser.Viafv_addressContext;
 import org.batfish.grammar.cisco.CiscoParser.Viafv_preemptContext;
 import org.batfish.grammar.cisco.CiscoParser.Viafv_priorityContext;
 import org.batfish.grammar.cisco.CiscoParser.Vrf_block_rb_stanzaContext;
-import org.batfish.grammar.cisco.CiscoParser.Vrfc_ip_routeContext;
 import org.batfish.grammar.cisco.CiscoParser.Vrfd_descriptionContext;
 import org.batfish.grammar.cisco.CiscoParser.Vrrp_interfaceContext;
 import org.batfish.grammar.cisco.CiscoParser.Wccp_idContext;
@@ -9141,11 +9140,6 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   public void exitVrf_block_rb_stanza(Vrf_block_rb_stanzaContext ctx) {
     _currentVrf = Configuration.DEFAULT_VRF_NAME;
     popPeer();
-  }
-
-  @Override
-  public void exitVrfc_ip_route(Vrfc_ip_routeContext ctx) {
-    todo(ctx);
   }
 
   @Override

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -25730,7 +25730,7 @@
             ],
             "allowedVlans" : "",
             "autostate" : true,
-            "bandwidth" : 1.0E12,
+            "bandwidth" : 1.0E9,
             "declaredNames" : [
               "irb.100"
             ],

--- a/tests/parsing-tests/unit-tests-warnings.ref
+++ b/tests/parsing-tests/unit-tests-warnings.ref
@@ -414,13 +414,6 @@
         "Comment" : "This feature is not currently supported"
       },
       {
-        "Filename" : "cisco_vrf",
-        "Line" : 9,
-        "Text" : "ip route 0.0.0.0/0 1.2.3.4",
-        "Parser_Context" : "[vrfc_ip_route s_vrf_context stanza cisco_configuration]",
-        "Comment" : "This feature is not currently supported"
-      },
-      {
         "Filename" : "foundry_access_list",
         "Line" : 11,
         "Text" : "133",
@@ -559,20 +552,13 @@
         "Text" : "ip default-gateway 128.125.253.254",
         "Parser_Context" : "[s_ip_default_gateway stanza cisco_configuration]",
         "Comment" : "This feature is not currently supported"
-      },
-      {
-        "Filename" : "vrf_context",
-        "Line" : 7,
-        "Text" : "ip route 0.0.0.0/0 1.2.3.4",
-        "Parser_Context" : "[vrfc_ip_route s_vrf_context stanza cisco_configuration]",
-        "Comment" : "This feature is not currently supported"
       }
     ],
     "summary" : {
-      "notes" : "Found 75 results",
+      "notes" : "Found 73 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 75
+      "numResults" : 73
     }
   }
 ]

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -60237,16 +60237,6 @@
             }
           ]
         },
-        "cisco_vrf" : {
-          "Parse warnings" : [
-            {
-              "Comment" : "This feature is not currently supported",
-              "Line" : 9,
-              "Parser_Context" : "[vrfc_ip_route s_vrf_context stanza cisco_configuration]",
-              "Text" : "ip route 0.0.0.0/0 1.2.3.4"
-            }
-          ]
-        },
         "foundry_access_list" : {
           "Parse warnings" : [
             {
@@ -60490,16 +60480,6 @@
               "Line" : 4,
               "Parser_Context" : "[s_ip_default_gateway stanza cisco_configuration]",
               "Text" : "ip default-gateway 128.125.253.254"
-            }
-          ]
-        },
-        "vrf_context" : {
-          "Parse warnings" : [
-            {
-              "Comment" : "This feature is not currently supported",
-              "Line" : 7,
-              "Parser_Context" : "[vrfc_ip_route s_vrf_context stanza cisco_configuration]",
-              "Text" : "ip route 0.0.0.0/0 1.2.3.4"
             }
           ]
         }


### PR DESCRIPTION
vrf context > ip route is actually supported just fine. The actual static
route assignments happens in the inner context ip_route_tail.