### PR TITLE
Conform to the standard set by createPathConstraints.

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/question/ReachabilityParameters.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/question/ReachabilityParameters.java
@@ -6,17 +6,19 @@ import com.google.common.collect.ImmutableSortedSet;
 import java.util.Set;
 import java.util.SortedSet;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import org.batfish.datamodel.FlowDisposition;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.UniverseIpSpace;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.acl.AclLineMatchExprs;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.specifier.AllInterfacesLocationSpecifier;
+import org.batfish.specifier.AllNodesNodeSpecifier;
 import org.batfish.specifier.ConstantIpSpaceSpecifier;
 import org.batfish.specifier.InferFromLocationIpSpaceSpecifier;
 import org.batfish.specifier.IpSpaceSpecifier;
 import org.batfish.specifier.LocationSpecifier;
+import org.batfish.specifier.NoNodesNodeSpecifier;
 import org.batfish.specifier.NodeSpecifier;
 
 /**
@@ -35,17 +37,17 @@ public final class ReachabilityParameters {
     private @Nonnull IpSpaceSpecifier _destinationIpSpaceSpecifier =
         new ConstantIpSpaceSpecifier(UniverseIpSpace.INSTANCE);
 
-    private @Nullable NodeSpecifier _finalNodesSpecifier = null;
+    private @Nonnull NodeSpecifier _finalNodesSpecifier = AllNodesNodeSpecifier.INSTANCE;
 
-    private @Nullable NodeSpecifier _forbiddenTransitNodesSpecifier = null;
+    private @Nonnull NodeSpecifier _forbiddenTransitNodesSpecifier = NoNodesNodeSpecifier.INSTANCE;
 
-    private @Nullable AclLineMatchExpr _headerSpace;
+    private @Nonnull AclLineMatchExpr _headerSpace = AclLineMatchExprs.TRUE;
 
     private boolean _ignoreFilters = false;
 
     private int _maxChunkSize;
 
-    private @Nullable NodeSpecifier _requiredTransitNodesSpecifier = null;
+    private @Nonnull NodeSpecifier _requiredTransitNodesSpecifier = NoNodesNodeSpecifier.INSTANCE;
 
     private @Nonnull LocationSpecifier _sourceLocationSpecifier =
         AllInterfacesLocationSpecifier.INSTANCE;
@@ -74,13 +76,13 @@ public final class ReachabilityParameters {
       return this;
     }
 
-    public Builder setFinalNodesSpecifier(@Nullable NodeSpecifier finalNodeSpecifier) {
+    public Builder setFinalNodesSpecifier(@Nonnull NodeSpecifier finalNodeSpecifier) {
       _finalNodesSpecifier = finalNodeSpecifier;
       return this;
     }
 
     public Builder setForbiddenTransitNodesSpecifier(
-        @Nullable NodeSpecifier forbiddenTransitNodesSpecifier) {
+        @Nonnull NodeSpecifier forbiddenTransitNodesSpecifier) {
       _forbiddenTransitNodesSpecifier = forbiddenTransitNodesSpecifier;
       return this;
     }
@@ -135,9 +137,9 @@ public final class ReachabilityParameters {
 
   private final @Nonnull IpSpaceSpecifier _destinationIpSpaceSpecifier;
 
-  private final @Nullable NodeSpecifier _finalNodesSpecifier;
+  private final @Nonnull NodeSpecifier _finalNodesSpecifier;
 
-  private final @Nullable NodeSpecifier _forbiddenTransitNodesSpecifier;
+  private final @Nonnull NodeSpecifier _forbiddenTransitNodesSpecifier;
 
   private final AclLineMatchExpr _headerSpace;
 
@@ -153,7 +155,7 @@ public final class ReachabilityParameters {
 
   private final boolean _specialize;
 
-  private final @Nullable NodeSpecifier _requiredTransitNodesSpecifier;
+  private final @Nonnull NodeSpecifier _requiredTransitNodesSpecifier;
 
   private final boolean _useCompression;
 
@@ -186,12 +188,12 @@ public final class ReachabilityParameters {
     return _destinationIpSpaceSpecifier;
   }
 
-  @Nullable
+  @Nonnull
   public NodeSpecifier getFinalNodesSpecifier() {
     return _finalNodesSpecifier;
   }
 
-  @Nullable
+  @Nonnull
   public NodeSpecifier getForbiddenTransitNodesSpecifier() {
     return _forbiddenTransitNodesSpecifier;
   }
@@ -224,7 +226,7 @@ public final class ReachabilityParameters {
     return _specialize;
   }
 
-  @Nullable
+  @Nonnull
   public NodeSpecifier getRequiredTransitNodesSpecifier() {
     return _requiredTransitNodesSpecifier;
   }

--- a/projects/batfish/src/test/java/org/batfish/main/ReachabilityParametersResolverTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/ReachabilityParametersResolverTest.java
@@ -9,7 +9,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import java.io.IOException;
@@ -33,7 +32,6 @@ import org.batfish.question.ResolvedReachabilityParameters;
 import org.batfish.specifier.AllNodesNodeSpecifier;
 import org.batfish.specifier.ConstantIpSpaceSpecifier;
 import org.batfish.specifier.InterfaceLinkLocation;
-import org.batfish.specifier.NoNodesNodeSpecifier;
 import org.batfish.specifier.NodeNameRegexInterfaceLinkLocationSpecifier;
 import org.junit.Before;
 import org.junit.Rule;
@@ -112,40 +110,6 @@ public class ReachabilityParametersResolverTest {
     exception.expectMessage("Empty destination IpSpace");
     new ReachabilityParametersResolver(_batfish, reachabilityParameters, _snapshot)
         .resolveDestinationIpSpace();
-  }
-
-  @Test
-  public void testResolveNodes_null() throws InvalidReachabilityParametersException {
-    ReachabilityParameters reachabilityParameters =
-        ReachabilityParameters.builder()
-            .setActions(ImmutableSortedSet.of(ACCEPTED))
-            .setFinalNodesSpecifier(null)
-            .setDestinationIpSpaceSpecifier(new ConstantIpSpaceSpecifier(EmptyIpSpace.INSTANCE))
-            .setSourceLocationSpecifier(
-                new NodeNameRegexInterfaceLinkLocationSpecifier(Pattern.compile("")))
-            .build();
-    ReachabilityParametersResolver resolver =
-        new ReachabilityParametersResolver(_batfish, reachabilityParameters, _snapshot);
-    assertThat(
-        resolver.resolveNodes("foo", reachabilityParameters.getFinalNodesSpecifier()),
-        equalTo(ImmutableSet.of()));
-  }
-
-  @Test
-  public void testResolveNodes_noMatch() throws InvalidReachabilityParametersException {
-    ReachabilityParameters reachabilityParameters =
-        ReachabilityParameters.builder()
-            .setActions(ImmutableSortedSet.of(ACCEPTED))
-            .setFinalNodesSpecifier(NoNodesNodeSpecifier.INSTANCE)
-            .setDestinationIpSpaceSpecifier(new ConstantIpSpaceSpecifier(EmptyIpSpace.INSTANCE))
-            .setSourceLocationSpecifier(
-                new NodeNameRegexInterfaceLinkLocationSpecifier(Pattern.compile("")))
-            .build();
-    ReachabilityParametersResolver resolver =
-        new ReachabilityParametersResolver(_batfish, reachabilityParameters, _snapshot);
-    exception.expect(InvalidReachabilityParametersException.class);
-    exception.expectMessage("No nodes match foo specifier");
-    resolver.resolveNodes("foo", reachabilityParameters.getFinalNodesSpecifier());
   }
 
   @Test

--- a/projects/question/src/main/java/org/batfish/question/ReachabilitySettings.java
+++ b/projects/question/src/main/java/org/batfish/question/ReachabilitySettings.java
@@ -13,12 +13,14 @@ import org.batfish.datamodel.UniverseIpSpace;
 import org.batfish.datamodel.questions.InterfacesSpecifier;
 import org.batfish.datamodel.questions.NodesSpecifier;
 import org.batfish.specifier.AllInterfacesLocationSpecifier;
+import org.batfish.specifier.AllNodesNodeSpecifier;
 import org.batfish.specifier.ConstantIpSpaceSpecifier;
 import org.batfish.specifier.DifferenceLocationSpecifier;
 import org.batfish.specifier.IntersectionLocationSpecifier;
 import org.batfish.specifier.IpSpaceSpecifier;
 import org.batfish.specifier.LocationSpecifier;
 import org.batfish.specifier.LocationSpecifiers;
+import org.batfish.specifier.NoNodesNodeSpecifier;
 import org.batfish.specifier.NodeSpecifiers;
 
 public final class ReachabilitySettings {
@@ -362,12 +364,16 @@ public final class ReachabilitySettings {
         .setActions(_actions)
         .setDestinationIpSpaceSpecifier(destinationIpSpaceSpecifier)
         .setFinalNodesSpecifier(
-            NodeSpecifiers.difference(
-                NodeSpecifiers.from(_finalNodes), NodeSpecifiers.from(_notFinalNodes)))
-        .setForbiddenTransitNodesSpecifier(NodeSpecifiers.from(_nonTransitNodes))
+            firstNonNull(
+                NodeSpecifiers.difference(
+                    NodeSpecifiers.from(_finalNodes), NodeSpecifiers.from(_notFinalNodes)),
+                AllNodesNodeSpecifier.INSTANCE))
+        .setForbiddenTransitNodesSpecifier(
+            firstNonNull(NodeSpecifiers.from(_nonTransitNodes), NoNodesNodeSpecifier.INSTANCE))
         .setHeaderSpace(headerSpace)
         .setMaxChunkSize(_maxChunkSize)
-        .setRequiredTransitNodesSpecifier(NodeSpecifiers.from(_transitNodes))
+        .setRequiredTransitNodesSpecifier(
+            firstNonNull(NodeSpecifiers.from(_transitNodes), NoNodesNodeSpecifier.INSTANCE))
         .setSourceIpSpaceSpecifier(sourceIpSpaceSpecifier)
         .setSourceLocationSpecifier(sourceLocations)
         .setSrcNatted(SrcNattedConstraint.fromBoolean(_srcNatted))

--- a/projects/question/src/main/java/org/batfish/question/specifiers/SpecifiersReachabilityQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/specifiers/SpecifiersReachabilityQuestion.java
@@ -17,14 +17,10 @@ import org.batfish.datamodel.PathConstraints;
 import org.batfish.datamodel.questions.Question;
 import org.batfish.question.ReachabilityParameters;
 import org.batfish.specifier.FlexibleInferFromLocationIpSpaceSpecifierFactory;
-import org.batfish.specifier.FlexibleLocationSpecifierFactory;
-import org.batfish.specifier.FlexibleNodeSpecifierFactory;
 import org.batfish.specifier.FlexibleUniverseIpSpaceSpecifierFactory;
 import org.batfish.specifier.IpSpaceSpecifier;
 import org.batfish.specifier.IpSpaceSpecifierFactory;
 import org.batfish.specifier.LocationSpecifier;
-import org.batfish.specifier.LocationSpecifierFactory;
-import org.batfish.specifier.NodeSpecifierFactory;
 
 /**
  * A version of reachability question that supports {@link LocationSpecifier location} and {@link
@@ -36,11 +32,6 @@ public final class SpecifiersReachabilityQuestion extends Question {
   private static final String PROP_IGNORE_FILTERS = "ignoreFilters";
   private static final String PROP_MAX_TRACES = "maxTraces";
   private static final String PROP_PATH_CONSTRAINT = "pathConstraints";
-
-  private static final LocationSpecifierFactory LOCATION_SPECIFIER_FACTORY =
-      LocationSpecifierFactory.load(FlexibleLocationSpecifierFactory.NAME);
-  private static final NodeSpecifierFactory NODE_SPECIFIER_FACTORY =
-      NodeSpecifierFactory.load(FlexibleNodeSpecifierFactory.NAME);
 
   @Nonnull private final DispositionSpecifier _actions;
   @Nonnull private final PacketHeaderConstraints _headerConstraints;

--- a/projects/question/src/main/java/org/batfish/question/specifiers/SpecifiersReachabilityQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/specifiers/SpecifiersReachabilityQuestion.java
@@ -1,6 +1,7 @@
 package org.batfish.question.specifiers;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static org.batfish.question.specifiers.PathConstraintsUtil.createPathConstraints;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -72,12 +73,7 @@ public final class SpecifiersReachabilityQuestion extends Question {
   }
 
   SpecifiersReachabilityQuestion() {
-    this(
-        DispositionSpecifier.SUCCESS_SPECIFIER,
-        PacketHeaderConstraints.unconstrained(),
-        false,
-        TracePruner.DEFAULT_MAX_TRACES,
-        PathConstraintsInput.unconstrained());
+    this(null, null, null, null, null);
   }
 
   @Nonnull
@@ -120,27 +116,7 @@ public final class SpecifiersReachabilityQuestion extends Question {
 
   @VisibleForTesting
   PathConstraints getPathConstraints() {
-    PathConstraints.Builder builder =
-        PathConstraints.builder()
-            .withStartLocation(
-                LOCATION_SPECIFIER_FACTORY.buildLocationSpecifier(
-                    _pathConstraints.getStartLocation()))
-            .withEndLocation(
-                NODE_SPECIFIER_FACTORY.buildNodeSpecifier(_pathConstraints.getEndLocation()));
-    /*
-     * Explicit check for null, because null expands into ALL nodes, which is usually not the
-     * desired behavior for waypointing constraints
-     */
-
-    if (_pathConstraints.getTransitLocations() != null) {
-      builder.through(
-          NODE_SPECIFIER_FACTORY.buildNodeSpecifier(_pathConstraints.getTransitLocations()));
-    }
-    if (_pathConstraints.getForbiddenLocations() != null) {
-      builder.avoid(
-          NODE_SPECIFIER_FACTORY.buildNodeSpecifier(_pathConstraints.getForbiddenLocations()));
-    }
-    return builder.build();
+    return createPathConstraints(_pathConstraints);
   }
 
   @Override

--- a/projects/question/src/test/java/org/batfish/question/specifiers/SpecifiersReachabilityQuestionTest.java
+++ b/projects/question/src/test/java/org/batfish/question/specifiers/SpecifiersReachabilityQuestionTest.java
@@ -5,7 +5,6 @@ import static org.batfish.datamodel.FlowDisposition.DELIVERED_TO_SUBNET;
 import static org.batfish.datamodel.FlowDisposition.EXITS_NETWORK;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.nullValue;
 
 import com.google.common.collect.ImmutableSortedSet;
 import org.batfish.datamodel.HeaderSpace;
@@ -19,6 +18,7 @@ import org.batfish.datamodel.UniverseIpSpace;
 import org.batfish.specifier.ConstantIpSpaceSpecifier;
 import org.batfish.specifier.FlexibleNodeSpecifierFactory;
 import org.batfish.specifier.InferFromLocationIpSpaceSpecifier;
+import org.batfish.specifier.NoNodesNodeSpecifier;
 import org.batfish.specifier.NodeSpecifierFactory;
 import org.junit.Rule;
 import org.junit.Test;
@@ -43,8 +43,12 @@ public class SpecifiersReachabilityQuestionTest {
     assertThat(
         question.getReachabilityParameters().getSourceIpSpaceSpecifier(),
         equalTo(InferFromLocationIpSpaceSpecifier.INSTANCE));
-    assertThat(question.getPathConstraints().getTransitLocations(), nullValue());
-    assertThat(question.getPathConstraints().getForbiddenLocations(), nullValue());
+    assertThat(
+        question.getPathConstraints().getTransitLocations(),
+        equalTo(NoNodesNodeSpecifier.INSTANCE));
+    assertThat(
+        question.getPathConstraints().getForbiddenLocations(),
+        equalTo(NoNodesNodeSpecifier.INSTANCE));
     assertThat(question.getIgnoreFilters(), equalTo(false));
   }
 


### PR DESCRIPTION
This simplifies SpecifiersReachabilityQuestion, but also changes the
invariants of ReachabilityParameters: now all node specifiers are
@Nonnull, but may resolve to the empty set.