### PR TITLE
cleanup named structures answerer

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/NamedStructureSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/NamedStructureSpecifier.java
@@ -86,7 +86,7 @@ public class NamedStructureSpecifier extends PropertySpecifier {
   @JsonCreator
   public NamedStructureSpecifier(String expression) {
     _expression = expression;
-    _pattern = Pattern.compile(_expression.trim().toLowerCase()); // canonicalize
+    _pattern = Pattern.compile(_expression.trim(), Pattern.CASE_INSENSITIVE); // canonicalize
   }
 
   /**

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/NamedStructureSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/NamedStructureSpecifier.java
@@ -15,52 +15,66 @@ import org.batfish.datamodel.answers.Schema;
 /** Enables specification a set of named structures. */
 public class NamedStructureSpecifier extends PropertySpecifier {
 
+  public static final String AS_PATH_ACCESS_LIST = "AS_Path_Access_List";
+  public static final String AUTHENTICATION_KEY_CHAIN = "Authentication_Key_Chain";
+  public static final String COMMUNITY_LIST = "Community_List";
+  public static final String IKE_POLICIES = "IKE_Policies";
+  public static final String IP_ACCESS_LIST = "IP_Access_List";
+  public static final String IP_6_ACCESS_LIST = "IP6_Access_List";
+  public static final String IPSEC_POLICY = "IPSec_Policy";
+  public static final String IPSEC_PROPOSAL = "IPSec_Proposal";
+  public static final String IPSEC_VPN = "IPSec_Vpn";
+  public static final String ROUTE_FILTER_LIST = "Route_Filter_List";
+  public static final String ROUTE_6_FILTER_LIST = "Route6_Filter_List";
+  public static final String ROUTING_POLICY = "Routing_Policy";
+  public static final String VRF = "VRF";
+  public static final String ZONE = "Zone";
+
   public static Map<String, PropertyDescriptor<Configuration>> JAVA_MAP =
       new ImmutableMap.Builder<String, PropertyDescriptor<Configuration>>()
           .put(
-              "as-path-access-lists",
+              AS_PATH_ACCESS_LIST,
               new PropertyDescriptor<>(
                   Configuration::getAsPathAccessLists, Schema.set(Schema.STRING)))
           .put(
-              "authentication-key-chains",
+              AUTHENTICATION_KEY_CHAIN,
               new PropertyDescriptor<>(
                   Configuration::getAuthenticationKeyChains, Schema.set(Schema.STRING)))
           .put(
-              "community-lists",
+              COMMUNITY_LIST,
               new PropertyDescriptor<>(Configuration::getCommunityLists, Schema.set(Schema.STRING)))
           .put(
-              "ike-policies",
+              IKE_POLICIES,
               new PropertyDescriptor<>(Configuration::getIkePolicies, Schema.set(Schema.STRING)))
           .put(
-              "ip-access-lists",
+              IP_ACCESS_LIST,
               new PropertyDescriptor<>(Configuration::getIpAccessLists, Schema.set(Schema.STRING)))
           .put(
-              "ip6-access-lists",
+              IP_6_ACCESS_LIST,
               new PropertyDescriptor<>(Configuration::getIp6AccessLists, Schema.set(Schema.STRING)))
           .put(
-              "ipsec-policies",
+              IPSEC_POLICY,
               new PropertyDescriptor<>(Configuration::getIpsecPolicies, Schema.set(Schema.STRING)))
           .put(
-              "ipsec-proposals",
+              IPSEC_PROPOSAL,
               new PropertyDescriptor<>(Configuration::getIpsecProposals, Schema.set(Schema.STRING)))
           .put(
-              "ipsec-vpns",
+              IPSEC_VPN,
               new PropertyDescriptor<>(Configuration::getIpsecVpns, Schema.set(Schema.STRING)))
           .put(
-              "route-filter-lists",
+              ROUTE_FILTER_LIST,
               new PropertyDescriptor<>(
                   Configuration::getRouteFilterLists, Schema.set(Schema.STRING)))
           .put(
-              "route6-filter-lists",
+              ROUTE_6_FILTER_LIST,
               new PropertyDescriptor<>(
                   Configuration::getRoute6FilterLists, Schema.set(Schema.STRING)))
           .put(
-              "routing-policies",
+              ROUTING_POLICY,
               new PropertyDescriptor<>(
                   Configuration::getRoutingPolicies, Schema.set(Schema.STRING)))
-          .put("vrfs", new PropertyDescriptor<>(Configuration::getVrfs, Schema.set(Schema.STRING)))
-          .put(
-              "zones", new PropertyDescriptor<>(Configuration::getZones, Schema.set(Schema.STRING)))
+          .put(VRF, new PropertyDescriptor<>(Configuration::getVrfs, Schema.set(Schema.STRING)))
+          .put(ZONE, new PropertyDescriptor<>(Configuration::getZones, Schema.set(Schema.STRING)))
           .build();
 
   public static final NamedStructureSpecifier ALL = new NamedStructureSpecifier(".*");

--- a/projects/question/src/main/java/org/batfish/question/namedstructures/NamedStructuresAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/namedstructures/NamedStructuresAnswerer.java
@@ -81,9 +81,7 @@ public class NamedStructuresAnswerer extends Answerer {
 
         if (namedStructuresMap != null && namedStructuresMap instanceof Map<?, ?>) {
           for (Map.Entry<?, ?> entry : ((Map<?, ?>) namedStructuresMap).entrySet()) {
-            String structureName = (String) entry.getKey();
-            Object strucutre = entry.getValue();
-            row.put(COL_STRUCTURE_NAME, (String) entry.getKey())
+            row.put(COL_STRUCTURE_NAME, entry.getKey())
                 .put(COL_STRUCTURE_DEFINITION, entry.getValue());
             rows.add(row.build());
           }

--- a/projects/question/src/main/java/org/batfish/question/namedstructures/NamedStructuresAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/namedstructures/NamedStructuresAnswerer.java
@@ -25,6 +25,9 @@ import org.batfish.datamodel.table.TableMetadata;
 public class NamedStructuresAnswerer extends Answerer {
 
   public static final String COL_NODE = "Node";
+  public static final String COL_STRUCTURE_TYPE = "Structure_Type";
+  public static final String COL_STRUCTURE_NAME = "Structure_Name";
+  public static final String COL_STRUCTURE_DEFINITION = "Structure_Definition";
 
   public NamedStructuresAnswerer(Question question, IBatfish batfish) {
     super(question, batfish);
@@ -38,101 +41,54 @@ public class NamedStructuresAnswerer extends Answerer {
    *
    * @return The {@link List} of {@link ColumnMetadata}s
    */
-  public static TableMetadata createNamedStructuresMetadata(
-      NamedStructuresQuestion question,
-      Map<String, Configuration> configurations,
-      Set<String> nodes) {
-    ImmutableList.Builder<ColumnMetadata> columnMetadataList = ImmutableList.builder();
-    columnMetadataList.add(new ColumnMetadata(COL_NODE, Schema.NODE, "Node", true, false));
+  public static TableMetadata createMetadata(NamedStructuresQuestion question) {
+    List<ColumnMetadata> columns =
+        ImmutableList.of(
+            new ColumnMetadata(COL_NODE, Schema.NODE, "Node", true, false),
+            new ColumnMetadata(COL_STRUCTURE_TYPE, Schema.STRING, "Structure type", true, false),
+            new ColumnMetadata(COL_STRUCTURE_NAME, Schema.STRING, "Structure name", true, false),
+            new ColumnMetadata(
+                COL_STRUCTURE_DEFINITION, Schema.OBJECT, "Structure definition", true, false));
 
-    for (String nodeName : nodes) {
-      for (String namedStructure : question.getProperties().getMatchingProperties()) {
-        Object namedStructureValues =
-            NamedStructureSpecifier.JAVA_MAP
-                .get(namedStructure)
-                .getGetter()
-                .apply(configurations.get(nodeName));
-        if (namedStructureValues != null
-            && ((namedStructureValues instanceof Map<?, ?>)
-                && !((Map<?, ?>) namedStructureValues).isEmpty())) {
-
-          for (Map.Entry<?, ?> namedStructureEntry :
-              ((Map<?, ?>) namedStructureValues).entrySet()) {
-            String namedStructureEntryKey = namedStructureEntry.getKey().toString();
-
-            Schema columnSchema = Schema.OBJECT;
-            String finalNameStructureEntry = namedStructure + ":" + namedStructureEntryKey;
-
-            if (!columnMetadataList
-                .build()
-                .stream()
-                .anyMatch(
-                    columnMetadata -> columnMetadata.getName().equals(finalNameStructureEntry))) {
-
-              columnMetadataList.add(
-                  new ColumnMetadata(
-                      finalNameStructureEntry,
-                      columnSchema,
-                      namedStructureEntryKey,
-                      Boolean.FALSE,
-                      Boolean.TRUE));
-            }
-          }
-        }
-      }
-    }
-
-    String textDesc = String.format("Properties of node ${%s}.", COL_NODE);
+    String textDesc = String.format("Structure ${%s} on node ${%s}.", COL_STRUCTURE_NAME, COL_NODE);
     DisplayHints dhints = question.getDisplayHints();
     if (dhints != null && dhints.getTextDesc() != null) {
       textDesc = dhints.getTextDesc();
     }
-    return new TableMetadata(columnMetadataList.build(), textDesc);
+    return new TableMetadata(columns, textDesc);
   }
 
   @VisibleForTesting
-  static Multiset<Row> rawNamedStructuresAnswer(
-      NamedStructuresQuestion question,
-      Map<String, Configuration> configurations,
+  static Multiset<Row> rawAnswer(
+      Set<String> structureTypes,
       Set<String> nodes,
-      TableMetadata tableMetadata) {
+      Map<String, Configuration> configurations,
+      Map<String, ColumnMetadata> columns) {
 
     Multiset<Row> rows = HashMultiset.create();
-    Map<String, ColumnMetadata> columns = tableMetadata.toColumnMap();
+
     for (String nodeName : nodes) {
-      RowBuilder row = Row.builder(columns);
-      row.put(COL_NODE, new Node(nodeName));
+      RowBuilder row = Row.builder(columns).put(COL_NODE, new Node(nodeName));
 
-      for (Map.Entry<String, ColumnMetadata> columnEntry : columns.entrySet()) {
-        String columnName = columnEntry.getKey();
-        if (columnName.equalsIgnoreCase(COL_NODE)) {
-          continue;
-        }
+      for (String structureType : structureTypes) {
+        row.put(COL_STRUCTURE_TYPE, structureType);
 
-        String[] columnSplits = columnName.split(":", 2);
-        String actualNameStructureType = columnSplits[0];
-
-        Object namedStructureValues =
+        Object namedStructuresMap =
             NamedStructureSpecifier.JAVA_MAP
-                .get(actualNameStructureType)
+                .get(structureType)
                 .getGetter()
                 .apply(configurations.get(nodeName));
-        if (namedStructureValues != null) {
 
-          if ((namedStructureValues instanceof Map<?, ?>)
-              && !((Map<?, ?>) namedStructureValues).isEmpty()) {
-            for (Map.Entry<?, ?> namedStructureEntry :
-                ((Map<?, ?>) namedStructureValues).entrySet()) {
-              Object namedStructutureEntryValue = namedStructureEntry.getValue();
-              row.put(columnName, namedStructutureEntryValue);
-            }
-          } else {
-            /* To fill the missing cells in the answer Table. */
-            row.put(columnName, null);
+        if (namedStructuresMap != null && namedStructuresMap instanceof Map<?, ?>) {
+          for (Map.Entry<?, ?> entry : ((Map<?, ?>) namedStructuresMap).entrySet()) {
+            String structureName = (String) entry.getKey();
+            Object strucutre = entry.getValue();
+            row.put(COL_STRUCTURE_NAME, (String) entry.getKey())
+                .put(COL_STRUCTURE_DEFINITION, entry.getValue());
+            rows.add(row.build());
           }
         }
       }
-      rows.add(row.build());
     }
     return rows;
   }
@@ -142,11 +98,12 @@ public class NamedStructuresAnswerer extends Answerer {
     NamedStructuresQuestion question = (NamedStructuresQuestion) _question;
     Map<String, Configuration> configurations = _batfish.loadConfigurations();
     Set<String> nodes = question.getNodes().getMatchingNodes(_batfish);
+    Set<String> properties = question.getStructureTypes().getMatchingProperties();
 
-    TableMetadata tableMetadata = createNamedStructuresMetadata(question, configurations, nodes);
+    TableMetadata tableMetadata = createMetadata(question);
 
     Multiset<Row> propertyRows =
-        rawNamedStructuresAnswer(question, configurations, nodes, tableMetadata);
+        rawAnswer(properties, nodes, configurations, tableMetadata.toColumnMap());
 
     TableAnswerElement answer = new TableAnswerElement(tableMetadata);
     answer.postProcessAnswer(question, propertyRows);

--- a/projects/question/src/main/java/org/batfish/question/namedstructures/NamedStructuresAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/namedstructures/NamedStructuresAnswerer.java
@@ -131,7 +131,6 @@ public class NamedStructuresAnswerer extends Answerer {
     NamedStructuresQuestion question = (NamedStructuresQuestion) _question;
     Map<String, Configuration> configurations = _batfish.loadConfigurations();
     Set<String> nodes = question.getNodes().getMatchingNodes(_batfish);
-    Set<String> properties = question.getStructureTypes().getMatchingProperties();
 
     TableMetadata tableMetadata = createMetadata(question);
 

--- a/projects/question/src/main/java/org/batfish/question/namedstructures/NamedStructuresAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/namedstructures/NamedStructuresAnswerer.java
@@ -4,9 +4,11 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.HashMultiset;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multiset;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import org.batfish.common.Answerer;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.datamodel.Configuration;
@@ -25,6 +27,7 @@ import org.batfish.datamodel.table.TableMetadata;
 public class NamedStructuresAnswerer extends Answerer {
 
   public static final String COL_NODE = "Node";
+  public static final String COL_PRESENT_ON_NODE = "Present_On_Node";
   public static final String COL_STRUCTURE_TYPE = "Structure_Type";
   public static final String COL_STRUCTURE_NAME = "Structure_Name";
   public static final String COL_STRUCTURE_DEFINITION = "Structure_Definition";
@@ -47,8 +50,15 @@ public class NamedStructuresAnswerer extends Answerer {
             new ColumnMetadata(COL_NODE, Schema.NODE, "Node", true, false),
             new ColumnMetadata(COL_STRUCTURE_TYPE, Schema.STRING, "Structure type", true, false),
             new ColumnMetadata(COL_STRUCTURE_NAME, Schema.STRING, "Structure name", true, false),
-            new ColumnMetadata(
-                COL_STRUCTURE_DEFINITION, Schema.OBJECT, "Structure definition", true, false));
+            question.getIndicatePresence()
+                ? new ColumnMetadata(
+                    COL_PRESENT_ON_NODE,
+                    Schema.BOOLEAN,
+                    "Whether the structure is present on the node",
+                    false,
+                    true)
+                : new ColumnMetadata(
+                    COL_STRUCTURE_DEFINITION, Schema.OBJECT, "Structure definition", false, true));
 
     String textDesc = String.format("Structure ${%s} on node ${%s}.", COL_STRUCTURE_NAME, COL_NODE);
     DisplayHints dhints = question.getDisplayHints();
@@ -60,30 +70,55 @@ public class NamedStructuresAnswerer extends Answerer {
 
   @VisibleForTesting
   static Multiset<Row> rawAnswer(
-      Set<String> structureTypes,
+      NamedStructuresQuestion question,
       Set<String> nodes,
       Map<String, Configuration> configurations,
       Map<String, ColumnMetadata> columns) {
 
     Multiset<Row> rows = HashMultiset.create();
 
-    for (String nodeName : nodes) {
-      RowBuilder row = Row.builder(columns).put(COL_NODE, new Node(nodeName));
+    for (String structureType : question.getStructureTypes().getMatchingProperties()) {
+      RowBuilder row = Row.builder(columns).put(COL_STRUCTURE_TYPE, structureType);
 
-      for (String structureType : structureTypes) {
-        row.put(COL_STRUCTURE_TYPE, structureType);
+      Function<Configuration, Object> structMapGetter =
+          NamedStructureSpecifier.JAVA_MAP.get(structureType).getGetter();
 
-        Object namedStructuresMap =
-            NamedStructureSpecifier.JAVA_MAP
-                .get(structureType)
-                .getGetter()
-                .apply(configurations.get(nodeName));
+      // collect all names if we are only indicating presence
+      Set<String> structNames = new HashSet<>();
 
-        if (namedStructuresMap != null && namedStructuresMap instanceof Map<?, ?>) {
+      for (String nodeName : nodes) {
+        row.put(COL_NODE, new Node(nodeName));
+
+        Configuration c = configurations.get(nodeName);
+        Object namedStructuresMap = structMapGetter.apply(c);
+
+        if (namedStructuresMap instanceof Map<?, ?>) {
           for (Map.Entry<?, ?> entry : ((Map<?, ?>) namedStructuresMap).entrySet()) {
-            row.put(COL_STRUCTURE_NAME, entry.getKey())
-                .put(COL_STRUCTURE_DEFINITION, entry.getValue());
-            rows.add(row.build());
+            if (question.getIndicatePresence()) {
+              structNames.add((String) entry.getKey());
+            } else {
+              row.put(COL_STRUCTURE_NAME, entry.getKey());
+              row.put(COL_STRUCTURE_DEFINITION, entry.getValue());
+              rows.add(row.build());
+            }
+          }
+        }
+      }
+
+      // insert values if we are only indicating presence
+      if (question.getIndicatePresence()) {
+        for (String nodeName : nodes) {
+          row.put(COL_NODE, new Node(nodeName));
+
+          Configuration c = configurations.get(nodeName);
+          Object namedStructuresMap = structMapGetter.apply(c);
+
+          if (namedStructuresMap instanceof Map<?, ?>) {
+            for (String structName : structNames) {
+              row.put(COL_STRUCTURE_NAME, structName);
+              row.put(COL_PRESENT_ON_NODE, ((Map) namedStructuresMap).containsKey(structName));
+              rows.add(row.build());
+            }
           }
         }
       }
@@ -101,7 +136,7 @@ public class NamedStructuresAnswerer extends Answerer {
     TableMetadata tableMetadata = createMetadata(question);
 
     Multiset<Row> propertyRows =
-        rawAnswer(properties, nodes, configurations, tableMetadata.toColumnMap());
+        rawAnswer(question, nodes, configurations, tableMetadata.toColumnMap());
 
     TableAnswerElement answer = new TableAnswerElement(tableMetadata);
     answer.postProcessAnswer(question, propertyRows);

--- a/projects/question/src/main/java/org/batfish/question/namedstructures/NamedStructuresPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/namedstructures/NamedStructuresPlugin.java
@@ -17,6 +17,6 @@ public class NamedStructuresPlugin extends QuestionPlugin {
 
   @Override
   protected Question createQuestion() {
-    return new NamedStructuresQuestion(null, null);
+    return new NamedStructuresQuestion(null, null, null);
   }
 }

--- a/projects/question/src/main/java/org/batfish/question/namedstructures/NamedStructuresQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/namedstructures/NamedStructuresQuestion.java
@@ -11,22 +11,22 @@ import org.batfish.datamodel.questions.Question;
 /**
  * A question that returns named structures of nodes in a tabular format. {@link
  * NamedStructuresQuestion#_nodes} determines which nodes are included, and {@link
- * NamedStructuresQuestion#_properties} determines which named structures are included.
+ * NamedStructuresQuestion#_structureTypes} determines which named structures are included.
  */
 public class NamedStructuresQuestion extends Question {
 
   private static final String PROP_NODES = "nodes";
-  private static final String PROP_PROPERTIES = "properties";
+  private static final String PROP_STRUCTURE_TYPES = "structureTypes";
 
   private final NodesSpecifier _nodes;
 
-  @Nonnull private NamedStructureSpecifier _properties;
+  @Nonnull private NamedStructureSpecifier _structureTypes;
 
   public NamedStructuresQuestion(
       @JsonProperty(PROP_NODES) NodesSpecifier nodes,
-      @JsonProperty(PROP_PROPERTIES) NamedStructureSpecifier properties) {
+      @JsonProperty(PROP_STRUCTURE_TYPES) NamedStructureSpecifier structureTypes) {
     _nodes = firstNonNull(nodes, NodesSpecifier.ALL);
-    _properties = firstNonNull(properties, NamedStructureSpecifier.ALL);
+    _structureTypes = firstNonNull(structureTypes, NamedStructureSpecifier.ALL);
   }
 
   @Override
@@ -44,8 +44,8 @@ public class NamedStructuresQuestion extends Question {
     return _nodes;
   }
 
-  @JsonProperty(PROP_PROPERTIES)
-  public NamedStructureSpecifier getProperties() {
-    return _properties;
+  @JsonProperty(PROP_STRUCTURE_TYPES)
+  public NamedStructureSpecifier getStructureTypes() {
+    return _structureTypes;
   }
 }

--- a/projects/question/src/main/java/org/batfish/question/namedstructures/NamedStructuresQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/namedstructures/NamedStructuresQuestion.java
@@ -15,23 +15,35 @@ import org.batfish.datamodel.questions.Question;
  */
 public class NamedStructuresQuestion extends Question {
 
+  private static boolean DEFAULT_INDICATE_PRESENCE = false;
+
+  private static final String PROP_INDICATE_PRESENCE = "indicatePresence";
   private static final String PROP_NODES = "nodes";
   private static final String PROP_STRUCTURE_TYPES = "structureTypes";
 
+  private final boolean _indicatePresence;
+
   private final NodesSpecifier _nodes;
 
-  @Nonnull private NamedStructureSpecifier _structureTypes;
+  @Nonnull private final NamedStructureSpecifier _structureTypes;
 
   public NamedStructuresQuestion(
       @JsonProperty(PROP_NODES) NodesSpecifier nodes,
-      @JsonProperty(PROP_STRUCTURE_TYPES) NamedStructureSpecifier structureTypes) {
+      @JsonProperty(PROP_STRUCTURE_TYPES) NamedStructureSpecifier structureTypes,
+      @JsonProperty(PROP_INDICATE_PRESENCE) Boolean indicatePresence) {
     _nodes = firstNonNull(nodes, NodesSpecifier.ALL);
     _structureTypes = firstNonNull(structureTypes, NamedStructureSpecifier.ALL);
+    _indicatePresence = firstNonNull(indicatePresence, DEFAULT_INDICATE_PRESENCE);
   }
 
   @Override
   public boolean getDataPlane() {
     return false;
+  }
+
+  @JsonProperty(PROP_INDICATE_PRESENCE)
+  public boolean getIndicatePresence() {
+    return _indicatePresence;
   }
 
   @Override

--- a/projects/question/src/test/java/org/batfish/question/namedstructures/NamedStructuresAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/namedstructures/NamedStructuresAnswererTest.java
@@ -6,7 +6,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import com.google.common.collect.HashMultiset;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multiset;
 import java.util.Map;
 import org.batfish.datamodel.Configuration;
@@ -21,7 +20,7 @@ import org.junit.Test;
 public class NamedStructuresAnswererTest {
 
   @Test
-  public void testRawAnswer() {
+  public void testRawAnswerDefinition() {
 
     NetworkFactory nf = new NetworkFactory();
     Configuration c =
@@ -32,13 +31,17 @@ public class NamedStructuresAnswererTest {
 
     Map<String, Configuration> configurations = ImmutableMap.of("node1", c);
 
+    // only get routing policies
+    NamedStructuresQuestion question =
+        new NamedStructuresQuestion(
+            null, new NamedStructureSpecifier(NamedStructureSpecifier.ROUTING_POLICY), false);
+
     Multiset<Row> rows =
         NamedStructuresAnswerer.rawAnswer(
-            ImmutableSet.of(NamedStructureSpecifier.ROUTING_POLICY), // only get routing policies
-            ImmutableSet.of("node1"),
+            question,
+            configurations.keySet(),
             configurations,
-            NamedStructuresAnswerer.createMetadata(new NamedStructuresQuestion(null, null))
-                .toColumnMap());
+            NamedStructuresAnswerer.createMetadata(question).toColumnMap());
 
     Multiset<Row> expected =
         HashMultiset.create(
@@ -58,6 +61,51 @@ public class NamedStructuresAnswererTest {
                         NamedStructureSpecifier.ROUTING_POLICY)
                     .put(NamedStructuresAnswerer.COL_STRUCTURE_NAME, "rp2")
                     .put(NamedStructuresAnswerer.COL_STRUCTURE_DEFINITION, rp2)
+                    .build()));
+
+    assertThat(rows, equalTo(expected));
+  }
+
+  @Test
+  public void testRawAnswerPresence() {
+
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c1 =
+        nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS).build();
+    nf.routingPolicyBuilder().setOwner(c1).setName("rp1").build();
+
+    Configuration c2 =
+        nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS).build();
+
+    Map<String, Configuration> configurations = ImmutableMap.of("node1", c1, "node2", c2);
+
+    NamedStructuresQuestion question = new NamedStructuresQuestion(null, null, true);
+
+    Multiset<Row> rows =
+        NamedStructuresAnswerer.rawAnswer(
+            question,
+            configurations.keySet(),
+            configurations,
+            NamedStructuresAnswerer.createMetadata(question).toColumnMap());
+
+    Multiset<Row> expected =
+        HashMultiset.create(
+            ImmutableList.of(
+                Row.builder()
+                    .put(NamedStructuresAnswerer.COL_NODE, new Node("node1"))
+                    .put(
+                        NamedStructuresAnswerer.COL_STRUCTURE_TYPE,
+                        NamedStructureSpecifier.ROUTING_POLICY)
+                    .put(NamedStructuresAnswerer.COL_STRUCTURE_NAME, "rp1")
+                    .put(NamedStructuresAnswerer.COL_PRESENT_ON_NODE, true)
+                    .build(),
+                Row.builder()
+                    .put(NamedStructuresAnswerer.COL_NODE, new Node("node2"))
+                    .put(
+                        NamedStructuresAnswerer.COL_STRUCTURE_TYPE,
+                        NamedStructureSpecifier.ROUTING_POLICY)
+                    .put(NamedStructuresAnswerer.COL_STRUCTURE_NAME, "rp1")
+                    .put(NamedStructuresAnswerer.COL_PRESENT_ON_NODE, false)
                     .build()));
 
     assertThat(rows, equalTo(expected));

--- a/projects/question/src/test/java/org/batfish/question/namedstructures/NamedStructuresAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/namedstructures/NamedStructuresAnswererTest.java
@@ -1,0 +1,65 @@
+package org.batfish.question.namedstructures;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multiset;
+import java.util.Map;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.pojo.Node;
+import org.batfish.datamodel.questions.NamedStructureSpecifier;
+import org.batfish.datamodel.routing_policy.RoutingPolicy;
+import org.batfish.datamodel.table.Row;
+import org.junit.Test;
+
+public class NamedStructuresAnswererTest {
+
+  @Test
+  public void testRawAnswer() {
+
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c =
+        nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS).build();
+    RoutingPolicy rp1 = nf.routingPolicyBuilder().setOwner(c).setName("rp1").build();
+    RoutingPolicy rp2 = nf.routingPolicyBuilder().setOwner(c).setName("rp2").build();
+    nf.vrfBuilder().setOwner(c).build();
+
+    Map<String, Configuration> configurations = ImmutableMap.of("node1", c);
+
+    Multiset<Row> rows =
+        NamedStructuresAnswerer.rawAnswer(
+            ImmutableSet.of(NamedStructureSpecifier.ROUTING_POLICY), // only get routing policies
+            ImmutableSet.of("node1"),
+            configurations,
+            NamedStructuresAnswerer.createMetadata(new NamedStructuresQuestion(null, null))
+                .toColumnMap());
+
+    Multiset<Row> expected =
+        HashMultiset.create(
+            ImmutableList.of(
+                Row.builder()
+                    .put(NamedStructuresAnswerer.COL_NODE, new Node("node1"))
+                    .put(
+                        NamedStructuresAnswerer.COL_STRUCTURE_TYPE,
+                        NamedStructureSpecifier.ROUTING_POLICY)
+                    .put(NamedStructuresAnswerer.COL_STRUCTURE_NAME, "rp1")
+                    .put(NamedStructuresAnswerer.COL_STRUCTURE_DEFINITION, rp1)
+                    .build(),
+                Row.builder()
+                    .put(NamedStructuresAnswerer.COL_NODE, new Node("node1"))
+                    .put(
+                        NamedStructuresAnswerer.COL_STRUCTURE_TYPE,
+                        NamedStructureSpecifier.ROUTING_POLICY)
+                    .put(NamedStructuresAnswerer.COL_STRUCTURE_NAME, "rp2")
+                    .put(NamedStructuresAnswerer.COL_STRUCTURE_DEFINITION, rp2)
+                    .build()));
+
+    assertThat(rows, equalTo(expected));
+  }
+}

--- a/projects/question/src/test/java/org/batfish/question/namedstructures/NamedStructuresAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/namedstructures/NamedStructuresAnswererTest.java
@@ -1,11 +1,13 @@
 package org.batfish.question.namedstructures;
 
+import static org.batfish.question.namedstructures.NamedStructuresAnswerer.getAllStructureNamesOfType;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.google.common.collect.HashMultiset;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multiset;
 import java.util.Map;
 import org.batfish.datamodel.Configuration;
@@ -18,6 +20,30 @@ import org.batfish.datamodel.table.Row;
 import org.junit.Test;
 
 public class NamedStructuresAnswererTest {
+
+  @Test
+  public void testGetAllStructureNamesOfType() {
+    NetworkFactory nf = new NetworkFactory();
+
+    // c1 has both routing policies
+    Configuration c1 =
+        nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS).build();
+    nf.routingPolicyBuilder().setOwner(c1).setName("rp1").build();
+    nf.routingPolicyBuilder().setOwner(c1).setName("rp2").build();
+
+    // c2 has only one routing policy
+    Configuration c2 =
+        nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS).build();
+    nf.routingPolicyBuilder().setOwner(c1).setName("rp1").build();
+
+    Map<String, Configuration> configurations = ImmutableMap.of("node1", c1, "node2", c2);
+
+    // both policies should be returned
+    assertThat(
+        getAllStructureNamesOfType(
+            NamedStructureSpecifier.ROUTING_POLICY, configurations.keySet(), configurations),
+        equalTo(ImmutableSet.of("rp1", "rp2")));
+  }
 
   @Test
   public void testRawAnswerDefinition() {

--- a/questions/experimental/namedStructures.json
+++ b/questions/experimental/namedStructures.json
@@ -2,7 +2,7 @@
     "class": "org.batfish.question.namedstructures.NamedStructuresQuestion",
     "differential": false,
     "nodes": "${nodes}",
-    "properties": "${properties}",
+    "structureTypes": "${structureTypes}",
     "instance": {
         "description": "Return named structure definitions",
         "instanceName": "namedStructures",
@@ -14,11 +14,11 @@
                 "optional": true,
                 "displayName": "Nodes"
             },
-            "properties": {
-                "description": "Include properties matching this regex",
+            "structureTypes": {
+                "description": "Include structures of this type",
                 "type": "namedStructureSpec",
                 "optional": true,
-                "displayName": "Properties"
+                "displayName": "Structure types"
             }
         }
     }

--- a/tests/questions/experimental/commands
+++ b/tests/questions/experimental/commands
@@ -34,7 +34,7 @@ test -raw tests/questions/experimental/interfaceProperties.ref validate-template
 test -raw tests/questions/experimental/multipathConsistency.ref validate-template multipathConsistency pathConstraints={startLocation: "aaa", "endLocation":"bbb", "transitLocations": "ccc", forbiddenLocations:"ddd"}, headers={srcIps: "sss", dstIps="ddd"}, maxTraces=1
 
 # validate namedStructures
-test -raw tests/questions/experimental/namedStructures.ref validate-template namedStructures nodes=".*", properties=".*"
+test -raw tests/questions/experimental/namedStructures.ref validate-template namedStructures nodes=".*", structureTypes=".*"
 
 # validate neighbors
 test -raw tests/questions/experimental/neighbors.ref validate-template neighbors neighborTypes=["ebgp"], nodes=".*", remoteNodes=".*", style="summary", roleDimension="default"

--- a/tests/questions/experimental/namedStructures.ref
+++ b/tests/questions/experimental/namedStructures.ref
@@ -1,5 +1,6 @@
 {
   "class" : "org.batfish.question.namedstructures.NamedStructuresQuestion",
+  "indicatePresence" : false,
   "nodes" : ".*",
   "structureTypes" : ".*",
   "differential" : false,

--- a/tests/questions/experimental/namedStructures.ref
+++ b/tests/questions/experimental/namedStructures.ref
@@ -1,7 +1,7 @@
 {
   "class" : "org.batfish.question.namedstructures.NamedStructuresQuestion",
   "nodes" : ".*",
-  "properties" : ".*",
+  "structureTypes" : ".*",
   "differential" : false,
   "includeOneTableKeys" : true,
   "instance" : {
@@ -15,9 +15,9 @@
         "type" : "nodeSpec",
         "value" : ".*"
       },
-      "properties" : {
-        "description" : "Include properties matching this regex",
-        "displayName" : "Properties",
+      "structureTypes" : {
+        "description" : "Include structures of this type",
+        "displayName" : "Structure types",
         "optional" : true,
         "type" : "namedStructureSpec",
         "value" : ".*"


### PR DESCRIPTION
Clean up in preparation for better downstream usage
  1. Structures go along rows, not columns, in the answer table
  2. Use constants in NamedStructureSpecifier
  3. Rename the question field 
  4. Test