### PR TITLE
BatfishParserErrorListener: cleanup mode output

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/BatfishParserErrorListener.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/BatfishParserErrorListener.java
@@ -41,8 +41,7 @@ public class BatfishParserErrorListener extends BatfishGrammarErrorListener {
         + tokenName
         + ":"
         + tokenText
-        + "  <== mode:"
-        + mode;
+        + (!"DEFAULT_MODE".equals(mode) ? "  <== mode:" + mode : "");
   }
 
   public void syntaxError(


### PR DESCRIPTION
A missing part of batfish/batfish#2518

This is currently only used on parser errors, so when you're editing parser.