### PR TITLE
Remove lying nonnull annotation on ospfNeighbors

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfProcess.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfProcess.java
@@ -206,7 +206,7 @@ public final class OspfProcess implements Serializable {
 
   @Nullable private Long _maxMetricTransitLinks;
 
-  @Nonnull private transient Map<IpLink, OspfNeighbor> _ospfNeighbors;
+  private transient Map<IpLink, OspfNeighbor> _ospfNeighbors;
 
   @Nullable private String _processId;
 
@@ -334,7 +334,6 @@ public final class OspfProcess implements Serializable {
     return _maxMetricTransitLinks;
   }
 
-  @Nonnull
   @JsonIgnore
   public Map<IpLink, OspfNeighbor> getOspfNeighbors() {
     return _ospfNeighbors;


### PR DESCRIPTION
For the interim until better OSPF topology generation is ready