### PR TITLE
IsisLevel.intersection method: fix and test

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/isis/IsisEdge.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/isis/IsisEdge.java
@@ -9,6 +9,7 @@ import static org.batfish.datamodel.isis.IsisLevel.LEVEL_2;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.VisibleForTesting;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Map;
@@ -30,9 +31,17 @@ public final class IsisEdge implements Comparable<IsisEdge> {
         settings.getLevel2() != null ? LEVEL_2 : null);
   }
 
+  @VisibleForTesting
   @Nullable
-  private static IsisLevel intersection(IsisLevel... levels) {
-    return levels.length == 0 ? null : Arrays.stream(levels).reduce(IsisEdge::intersection).get();
+  public static IsisLevel intersection(IsisLevel... levels) {
+    if (levels.length == 0) {
+      return null;
+    }
+    IsisLevel overlap = LEVEL_1_2;
+    for (IsisLevel level : levels) {
+      overlap = intersection(overlap, level);
+    }
+    return overlap;
   }
 
   @Nullable

--- a/projects/batfish/src/test/java/org/batfish/dataplane/topology/IsisEdgeTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/topology/IsisEdgeTest.java
@@ -1,12 +1,15 @@
 package org.batfish.dataplane.topology;
 
 import static org.batfish.common.util.CommonUtil.synthesizeTopology;
+import static org.batfish.datamodel.isis.IsisLevel.LEVEL_1;
 import static org.batfish.datamodel.isis.IsisLevel.LEVEL_1_2;
 import static org.batfish.datamodel.isis.IsisLevel.LEVEL_2;
 import static org.batfish.dataplane.topology.matchers.IsisEdgeMatchers.hasCircuitType;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -112,5 +115,15 @@ public final class IsisEdgeTest {
     assertThat(
         isisEdgesDifferentSystemId,
         contains(ImmutableList.of(hasCircuitType(LEVEL_1_2), hasCircuitType(LEVEL_1_2))));
+  }
+
+  @Test
+  public void testLevelIntersection() {
+    assertThat(IsisEdge.intersection(), nullValue());
+    assertThat(IsisEdge.intersection(LEVEL_1), equalTo(LEVEL_1));
+    assertThat(IsisEdge.intersection(LEVEL_1, LEVEL_2), nullValue());
+    assertThat(IsisEdge.intersection(LEVEL_1, LEVEL_1_2), equalTo(LEVEL_1));
+    assertThat(IsisEdge.intersection(LEVEL_1, LEVEL_1_2, LEVEL_2), nullValue());
+    assertThat(IsisEdge.intersection(LEVEL_1, null), nullValue());
   }
 }


### PR DESCRIPTION
Fixes bug where `intersection(LEVEL_1, LEVEL_2)` threw a `NullPointerException` because the `reduce` method [throws NPE if the result of the reduction is null](https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html#reduce-java.util.function.BinaryOperator-).