### PR TITLE
create Configurations from juniper logical systems

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/vendor/VendorConfiguration.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/vendor/VendorConfiguration.java
@@ -176,7 +176,8 @@ public abstract class VendorConfiguration implements Serializable, GenericConfig
     _w = warnings;
   }
 
-  public abstract Configuration toVendorIndependentConfiguration() throws VendorConversionException;
+  public abstract List<Configuration> toVendorIndependentConfigurations()
+      throws VendorConversionException;
 
   private void addStructureReference(
       SortedMap<String, SortedMap<String, SortedMap<String, SortedMap<String, SortedSet<Integer>>>>>

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -2873,7 +2873,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
   }
 
   @Override
-  public Configuration toVendorIndependentConfiguration() {
+  public List<Configuration> toVendorIndependentConfigurations() {
     final Configuration c = new Configuration(_hostname, _vendor);
     c.getVendorFamily().setCisco(_cf);
     c.setDefaultInboundAction(LineAction.PERMIT);
@@ -3591,7 +3591,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
 
     c.computeRoutingPolicySources(_w);
 
-    return c;
+    return ImmutableList.of(c);
   }
 
   private void createInspectClassMapAcls(Configuration c) {

--- a/projects/batfish/src/main/java/org/batfish/representation/host/HostConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/host/HostConfiguration.java
@@ -4,7 +4,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
@@ -194,7 +196,7 @@ public class HostConfiguration extends VendorConfiguration {
   }
 
   @Override
-  public Configuration toVendorIndependentConfiguration() throws VendorConversionException {
+  public List<Configuration> toVendorIndependentConfigurations() throws VendorConversionException {
     if (_underlayConfiguration != null) {
       _hostInterfaces.forEach(
           (name, iface) ->
@@ -265,11 +267,12 @@ public class HostConfiguration extends VendorConfiguration {
                   .setTag(AbstractRoute.NO_TAG)
                   .build());
     }
-    return _c;
+    return ImmutableList.of(_c);
   }
 
-  public Configuration toVendorIndependentConfiguration(VendorConfiguration underlayConfiguration) {
+  public List<Configuration> toVendorIndependentConfigurations(
+      VendorConfiguration underlayConfiguration) {
     _underlayConfiguration = underlayConfiguration;
-    return toVendorIndependentConfiguration();
+    return toVendorIndependentConfigurations();
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/iptables/IptablesVendorConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/iptables/IptablesVendorConfiguration.java
@@ -242,7 +242,7 @@ public class IptablesVendorConfiguration extends IptablesConfiguration {
   }
 
   @Override
-  public Configuration toVendorIndependentConfiguration() throws VendorConversionException {
+  public List<Configuration> toVendorIndependentConfigurations() throws VendorConversionException {
     throw new BatfishException("Not meant to be converted to vendor-independent format");
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/ApplicationOrApplicationSetReference.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/ApplicationOrApplicationSetReference.java
@@ -13,9 +13,10 @@ public class ApplicationOrApplicationSetReference extends ApplicationSetMemberRe
 
   @Override
   public ApplicationSetMember resolve(JuniperConfiguration jc) {
-    ApplicationSetMember applicationSetMember = jc.getApplications().get(_name);
+    ApplicationSetMember applicationSetMember =
+        jc.getMasterLogicalSystem().getApplications().get(_name);
     return (applicationSetMember != null)
         ? applicationSetMember
-        : jc.getApplicationSets().get(_name);
+        : jc.getMasterLogicalSystem().getApplicationSets().get(_name);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/ApplicationReference.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/ApplicationReference.java
@@ -13,6 +13,6 @@ public class ApplicationReference extends ApplicationSetMemberReference {
 
   @Override
   public ApplicationSetMember resolve(JuniperConfiguration jc) {
-    return jc.getApplications().get(_name);
+    return jc.getMasterLogicalSystem().getApplications().get(_name);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/ApplicationSetReference.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/ApplicationSetReference.java
@@ -13,6 +13,6 @@ public class ApplicationSetReference extends ApplicationSetMemberReference {
 
   @Override
   public ApplicationSetMember resolve(JuniperConfiguration jc) {
-    return jc.getApplicationSets().get(_name);
+    return jc.getMasterLogicalSystem().getApplicationSets().get(_name);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromApplicationOrApplicationSet.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromApplicationOrApplicationSet.java
@@ -23,9 +23,11 @@ public final class FwFromApplicationOrApplicationSet extends FwFromApplicationSe
       LineAction action,
       List<IpAccessListLine> lines,
       Warnings w) {
-    ApplicationSetMember application = jc.getApplications().get(_applicationOrApplicationSetName);
+    ApplicationSetMember application =
+        jc.getMasterLogicalSystem().getApplications().get(_applicationOrApplicationSetName);
     if (application == null) {
-      application = jc.getApplicationSets().get(_applicationOrApplicationSetName);
+      application =
+          jc.getMasterLogicalSystem().getApplicationSets().get(_applicationOrApplicationSetName);
     }
     if (application != null) {
       application.applyTo(jc, srcHeaderSpaceBuilder, action, lines, w);

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromDestinationPrefixList.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromDestinationPrefixList.java
@@ -26,7 +26,7 @@ public final class FwFromDestinationPrefixList extends FwFrom {
       JuniperConfiguration jc,
       Warnings w,
       Configuration c) {
-    PrefixList pl = jc.getPrefixLists().get(_name);
+    PrefixList pl = jc.getMasterLogicalSystem().getPrefixLists().get(_name);
     if (pl != null) {
       if (pl.getIpv6()) {
         return;

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromDestinationPrefixListExcept.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromDestinationPrefixListExcept.java
@@ -26,7 +26,7 @@ public final class FwFromDestinationPrefixListExcept extends FwFrom {
       JuniperConfiguration jc,
       Warnings w,
       Configuration c) {
-    PrefixList pl = jc.getPrefixLists().get(_name);
+    PrefixList pl = jc.getMasterLogicalSystem().getPrefixLists().get(_name);
     if (pl != null) {
       if (pl.getIpv6()) {
         return;

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromPrefixList.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromPrefixList.java
@@ -26,7 +26,7 @@ public final class FwFromPrefixList extends FwFrom {
       JuniperConfiguration jc,
       Warnings w,
       Configuration c) {
-    PrefixList pl = jc.getPrefixLists().get(_name);
+    PrefixList pl = jc.getMasterLogicalSystem().getPrefixLists().get(_name);
     if (pl != null) {
       if (pl.getIpv6()) {
         return;

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromSourcePrefixList.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromSourcePrefixList.java
@@ -26,7 +26,7 @@ public final class FwFromSourcePrefixList extends FwFrom {
       JuniperConfiguration jc,
       Warnings w,
       Configuration c) {
-    PrefixList pl = jc.getPrefixLists().get(_name);
+    PrefixList pl = jc.getMasterLogicalSystem().getPrefixLists().get(_name);
     if (pl != null) {
       if (pl.getIpv6()) {
         return;

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromSourcePrefixListExcept.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromSourcePrefixListExcept.java
@@ -26,7 +26,7 @@ public class FwFromSourcePrefixListExcept extends FwFrom {
       JuniperConfiguration jc,
       Warnings w,
       Configuration c) {
-    PrefixList pl = jc.getPrefixLists().get(_name);
+    PrefixList pl = jc.getMasterLogicalSystem().getPrefixLists().get(_name);
     if (pl != null) {
       if (pl.getIpv6()) {
         return;

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -1877,6 +1877,12 @@ public final class JuniperConfiguration extends VendorConfiguration {
             (ifaceName, lsMasterIface) -> {
               Interface masterPhysicalInterface =
                   _masterLogicalSystem.getInterfaces().get(ifaceName);
+              if (masterPhysicalInterface == null) {
+                // the physical interface is not mentioned globally, so just copy the whole thing
+                // from the logical system
+                _masterLogicalSystem.getInterfaces().put(ifaceName, lsMasterIface);
+                return;
+              }
               // copy units from logical system
               masterPhysicalInterface.getUnits().putAll(lsMasterIface.getUnits());
               // delete unassigned units
@@ -1936,7 +1942,11 @@ public final class JuniperConfiguration extends VendorConfiguration {
       ByteArrayInputStream bais = closer.register(new ByteArrayInputStream(baos.toByteArray()));
       ObjectInputStream ois = closer.register(new ObjectInputStream(bais));
       Object clonedObject = ois.readObject();
-      return (JuniperConfiguration) clonedObject;
+      JuniperConfiguration clonedConfiguration = (JuniperConfiguration) clonedObject;
+      clonedConfiguration.setAnswerElement(getAnswerElement());
+      clonedConfiguration.setUnrecognized(getUnrecognized());
+      clonedConfiguration.setWarnings(_w);
+      return clonedConfiguration;
     } catch (IOException | ClassNotFoundException e) {
       throw new VendorConversionException("Failed to clone master vendor configuration", e);
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -6,6 +6,12 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.io.Closer;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -17,12 +23,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NavigableMap;
-import java.util.NavigableSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.TreeSet;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -112,9 +116,7 @@ import org.batfish.datamodel.routing_policy.statement.SetOrigin;
 import org.batfish.datamodel.routing_policy.statement.SetOspfMetricType;
 import org.batfish.datamodel.routing_policy.statement.Statement;
 import org.batfish.datamodel.routing_policy.statement.Statements;
-import org.batfish.datamodel.vendor_family.juniper.JuniperFamily;
 import org.batfish.representation.juniper.BgpGroup.BgpGroupType;
-import org.batfish.representation.juniper.Nat.Type;
 import org.batfish.vendor.VendorConfiguration;
 
 public final class JuniperConfiguration extends VendorConfiguration {
@@ -166,117 +168,25 @@ public final class JuniperConfiguration extends VendorConfiguration {
 
   private final Set<Long> _allStandardCommunities;
 
-  private final Map<String, BaseApplication> _applications;
-
-  private final Map<String, ApplicationSet> _applicationSets;
-
-  private final NavigableMap<String, JuniperAuthenticationKeyChain> _authenticationKeyChains;
-
   Configuration _c;
-
-  private final Map<String, CommunityList> _communityLists;
-
-  private boolean _defaultAddressSelection;
-
-  private LineAction _defaultCrossZoneAction;
-
-  private LineAction _defaultInboundAction;
-
-  private final RoutingInstance _defaultRoutingInstance;
-
-  private NavigableSet<String> _dnsServers;
-
-  private final Map<String, FirewallFilter> _filters;
-
-  private final Map<String, AddressBook> _globalAddressBooks;
-
-  private final Set<String> _ignoredPrefixLists;
-
-  private final Map<String, IkeGateway> _ikeGateways;
-
-  private final Map<String, IkePolicy> _ikePolicies;
-
-  private final Map<String, IkeProposal> _ikeProposals;
-
-  private final Map<String, Interface> _interfaces;
-
-  private final Map<String, Zone> _interfaceZones;
-
-  private final Map<String, IpsecPolicy> _ipsecPolicies;
-
-  private final Map<String, IpsecProposal> _ipsecProposals;
-
-  private final Map<String, IpsecVpn> _ipsecVpns;
-
-  private final JuniperFamily _jf;
 
   private transient Interface _lo0;
 
   private transient boolean _lo0Initialized;
 
-  @Nullable private Nat _natDestination = null;
-
-  @Nullable private Nat _natSource = null;
-
-  @Nullable private Nat _natStatic = null;
-
   private final Map<String, NodeDevice> _nodeDevices;
-
-  private NavigableSet<String> _ntpServers;
-
-  private final Map<String, PolicyStatement> _policyStatements;
-
-  private final Map<String, PrefixList> _prefixLists;
-
-  private final Map<String, RouteFilter> _routeFilters;
-
-  private final Map<String, RoutingInstance> _routingInstances;
-
-  private NavigableSet<String> _syslogHosts;
-
-  private NavigableSet<String> _tacplusServers;
 
   private ConfigurationFormat _vendor;
 
-  private final Map<String, Vlan> _vlanNameToVlan;
+  private Map<String, LogicalSystem> _logicalSystems;
 
-  private final Map<String, Zone> _zones;
-
-  private final Map<String, AsPathGroup> _asPathGroups;
+  private LogicalSystem _masterLogicalSystem;
 
   public JuniperConfiguration() {
     _allStandardCommunities = new HashSet<>();
-    _applications = new TreeMap<>();
-    _applicationSets = new TreeMap<>();
-    _asPathGroups = new TreeMap<>();
-    _authenticationKeyChains = new TreeMap<>();
-    _communityLists = new TreeMap<>();
-    _defaultCrossZoneAction = LineAction.PERMIT;
-    _defaultRoutingInstance = new RoutingInstance(Configuration.DEFAULT_VRF_NAME);
-    _dnsServers = new TreeSet<>();
-    _filters = new TreeMap<>();
-    _globalAddressBooks = new TreeMap<>();
-    _ignoredPrefixLists = new HashSet<>();
-    _ikeGateways = new TreeMap<>();
-    _ikePolicies = new TreeMap<>();
-    _ikeProposals = new TreeMap<>();
-    _interfaces = new TreeMap<>();
-    _interfaceZones = new TreeMap<>();
-    _ipsecPolicies = new TreeMap<>();
-    _ipsecProposals = new TreeMap<>();
-    _ipsecVpns = new TreeMap<>();
-    _jf = new JuniperFamily();
+    _logicalSystems = new TreeMap<>();
+    _masterLogicalSystem = new LogicalSystem("");
     _nodeDevices = new TreeMap<>();
-    _ntpServers = new TreeSet<>();
-    _prefixLists = new TreeMap<>();
-    _policyStatements = new TreeMap<>();
-    _routeFilters = new TreeMap<>();
-    _routingInstances = new TreeMap<>();
-    _routingInstances.put(Configuration.DEFAULT_VRF_NAME, _defaultRoutingInstance);
-    _syslogHosts = new TreeSet<>();
-    _tacplusServers = new TreeSet<>();
-    _vlanNameToVlan = new TreeMap<>();
-    _zones = new TreeMap<>();
   }
 
   private NavigableMap<String, AuthenticationKeyChain> convertAuthenticationKeyChains(
@@ -314,7 +224,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
     BgpProcess proc = new BgpProcess();
     Ip routerId = routingInstance.getRouterId();
     if (routerId == null) {
-      routerId = _defaultRoutingInstance.getRouterId();
+      routerId = _masterLogicalSystem.getDefaultRoutingInstance().getRouterId();
       if (routerId == null) {
         routerId = Ip.ZERO;
       }
@@ -331,7 +241,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
     if (mg.getLocalAs() == null) {
       Long routingInstanceAs = routingInstance.getAs();
       if (routingInstanceAs == null) {
-        routingInstanceAs = _defaultRoutingInstance.getAs();
+        routingInstanceAs = _masterLogicalSystem.getDefaultRoutingInstance().getAs();
       }
       if (routingInstanceAs == null) {
         _w.redFlag("BGP BROKEN FOR THIS ROUTER: Cannot determine local autonomous system");
@@ -407,7 +317,10 @@ public final class JuniperConfiguration extends VendorConfiguration {
       // Check for loops in the following order:
       Integer loops =
           Stream.of(
-                  ig.getLoops(), routingInstance.getLoops(), _defaultRoutingInstance.getLoops(), 0)
+                  ig.getLoops(),
+                  routingInstance.getLoops(),
+                  _masterLogicalSystem.getDefaultRoutingInstance().getLoops(),
+                  0)
               .filter(Objects::nonNull)
               .findFirst()
               .get();
@@ -443,7 +356,8 @@ public final class JuniperConfiguration extends VendorConfiguration {
       ig.getImportPolicies()
           .forEach(
               importPolicyName -> {
-                PolicyStatement importPolicy = _policyStatements.get(importPolicyName);
+                PolicyStatement importPolicy =
+                    _masterLogicalSystem.getPolicyStatements().get(importPolicyName);
                 if (importPolicy != null) {
                   setPolicyStatementReferent(importPolicyName);
                   CallExpr callPolicy = new CallExpr(importPolicyName);
@@ -487,7 +401,8 @@ public final class JuniperConfiguration extends VendorConfiguration {
       ig.getExportPolicies()
           .forEach(
               exportPolicyName -> {
-                PolicyStatement exportPolicy = _policyStatements.get(exportPolicyName);
+                PolicyStatement exportPolicy =
+                    _masterLogicalSystem.getPolicyStatements().get(exportPolicyName);
                 if (exportPolicy != null) {
                   setPolicyStatementReferent(exportPolicyName);
                   CallExpr callPolicy = new CallExpr(exportPolicyName);
@@ -560,7 +475,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
           }
         }
       }
-      if (localIp == null && _defaultAddressSelection) {
+      if (localIp == null && _masterLogicalSystem.getDefaultAddressSelection()) {
         initFirstLoopbackInterface();
         if (_lo0 != null) {
           InterfaceAddress lo0Unit0Address = _lo0.getPrimaryAddress();
@@ -629,7 +544,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
   private IsisProcess createIsisProcess(RoutingInstance routingInstance, IsoAddress netAddress) {
     IsisProcess.Builder newProc = IsisProcess.builder();
     newProc.setNetAddress(netAddress);
-    IsisSettings settings = _defaultRoutingInstance.getIsisSettings();
+    IsisSettings settings = _masterLogicalSystem.getDefaultRoutingInstance().getIsisSettings();
     for (String policyName : settings.getExportPolicies()) {
       RoutingPolicy policy = _c.getRoutingPolicies().get(policyName);
       if (policy == null) {
@@ -741,7 +656,8 @@ public final class JuniperConfiguration extends VendorConfiguration {
         .getOspfExportPolicies()
         .forEach(
             exportPolicyName -> {
-              PolicyStatement exportPolicy = _policyStatements.get(exportPolicyName);
+              PolicyStatement exportPolicy =
+                  _masterLogicalSystem.getPolicyStatements().get(exportPolicyName);
               if (exportPolicy != null) {
                 setPolicyStatementReferent(exportPolicyName);
                 CallExpr callPolicy = new CallExpr(exportPolicyName);
@@ -858,159 +774,8 @@ public final class JuniperConfiguration extends VendorConfiguration {
     return _allStandardCommunities;
   }
 
-  public Map<String, BaseApplication> getApplications() {
-    return _applications;
-  }
-
-  public Map<String, JuniperAuthenticationKeyChain> getAuthenticationKeyChains() {
-    return _authenticationKeyChains;
-  }
-
-  public Map<String, CommunityList> getCommunityLists() {
-    return _communityLists;
-  }
-
-  public LineAction getDefaultCrossZoneAction() {
-    return _defaultCrossZoneAction;
-  }
-
-  public RoutingInstance getDefaultRoutingInstance() {
-    return _defaultRoutingInstance;
-  }
-
-  public NavigableSet<String> getDnsServers() {
-    return _dnsServers;
-  }
-
-  public Map<String, FirewallFilter> getFirewallFilters() {
-    return _filters;
-  }
-
-  public Map<String, AddressBook> getGlobalAddressBooks() {
-    return _globalAddressBooks;
-  }
-
-  public Interface getGlobalMasterInterface() {
-    return _defaultRoutingInstance.getGlobalMasterInterface();
-  }
-
-  @Override
-  public String getHostname() {
-    return _defaultRoutingInstance.getHostname();
-  }
-
-  public Set<String> getIgnoredPrefixLists() {
-    return _ignoredPrefixLists;
-  }
-
-  public Map<String, IkeGateway> getIkeGateways() {
-    return _ikeGateways;
-  }
-
-  public Map<String, IkePolicy> getIkePolicies() {
-    return _ikePolicies;
-  }
-
-  public Map<String, IkeProposal> getIkeProposals() {
-    return _ikeProposals;
-  }
-
-  public Map<String, Interface> getInterfaces() {
-    return _interfaces;
-  }
-
-  public Map<String, Zone> getInterfaceZones() {
-    return _interfaceZones;
-  }
-
-  public Map<String, IpsecPolicy> getIpsecPolicies() {
-    return _ipsecPolicies;
-  }
-
-  public Map<String, IpsecProposal> getIpsecProposals() {
-    return _ipsecProposals;
-  }
-
-  public Map<String, IpsecVpn> getIpsecVpns() {
-    return _ipsecVpns;
-  }
-
-  public JuniperFamily getJf() {
-    return _jf;
-  }
-
-  public Nat getNatDestination() {
-    return _natDestination;
-  }
-
-  public Nat getNatSource() {
-    return _natSource;
-  }
-
-  public Nat getNatStatic() {
-    return _natStatic;
-  }
-
-  public Nat getOrCreateNat(Nat.Type natType) {
-    switch (natType) {
-      case DESTINATION:
-        if (_natDestination == null) {
-          _natDestination = new Nat(Type.DESTINATION);
-        }
-        return _natDestination;
-      case SOURCE:
-        if (_natSource == null) {
-          _natSource = new Nat(Type.SOURCE);
-        }
-        return _natSource;
-      case STATIC:
-        if (_natStatic == null) {
-          _natStatic = new Nat(Type.STATIC);
-        }
-        return _natStatic;
-      default:
-        throw new IllegalArgumentException("Unknnown nat type " + natType);
-    }
-  }
-
   public Map<String, NodeDevice> getNodeDevices() {
     return _nodeDevices;
-  }
-
-  public NavigableSet<String> getNtpServers() {
-    return _ntpServers;
-  }
-
-  public Map<String, PolicyStatement> getPolicyStatements() {
-    return _policyStatements;
-  }
-
-  public Map<String, PrefixList> getPrefixLists() {
-    return _prefixLists;
-  }
-
-  public Map<String, RouteFilter> getRouteFilters() {
-    return _routeFilters;
-  }
-
-  public Map<String, RoutingInstance> getRoutingInstances() {
-    return _routingInstances;
-  }
-
-  public NavigableSet<String> getSyslogHosts() {
-    return _syslogHosts;
-  }
-
-  public NavigableSet<String> getTacplusServers() {
-    return _tacplusServers;
-  }
-
-  public Map<String, Vlan> getVlanNameToVlan() {
-    return _vlanNameToVlan;
-  }
-
-  public Map<String, Zone> getZones() {
-    return _zones;
   }
 
   private void initDefaultBgpExportPolicy() {
@@ -1051,7 +816,11 @@ public final class JuniperConfiguration extends VendorConfiguration {
       return;
     }
     _lo0Initialized = true;
-    _lo0 = _defaultRoutingInstance.getInterfaces().get(FIRST_LOOPBACK_INTERFACE_NAME);
+    _lo0 =
+        _masterLogicalSystem
+            .getDefaultRoutingInstance()
+            .getInterfaces()
+            .get(FIRST_LOOPBACK_INTERFACE_NAME);
     Pattern p = Pattern.compile("[A-Za-z0-9][A-Za-z0-9]*:lo[0-9][0-9]*\\.[0-9][0-9]*");
     if (_lo0 == null) {
       for (NodeDevice nd : _nodeDevices.values()) {
@@ -1066,7 +835,8 @@ public final class JuniperConfiguration extends VendorConfiguration {
       }
     } else if (_lo0.getPrimaryAddress() == null) {
       Pattern q = Pattern.compile("lo[0-9][0-9]*\\.[0-9][0-9]*");
-      for (Interface iface : _defaultRoutingInstance.getInterfaces().values()) {
+      for (Interface iface :
+          _masterLogicalSystem.getDefaultRoutingInstance().getInterfaces().values()) {
         for (Interface unit : iface.getUnits().values()) {
           if (q.matcher(unit.getName()).matches()) {
             _lo0 = unit;
@@ -1107,25 +877,8 @@ public final class JuniperConfiguration extends VendorConfiguration {
     newIface.setOspfCost(ospfCost);
   }
 
-  public void setDefaultAddressSelection(boolean defaultAddressSelection) {
-    _defaultAddressSelection = defaultAddressSelection;
-  }
-
-  public void setDefaultCrossZoneAction(LineAction defaultCrossZoneAction) {
-    _defaultCrossZoneAction = defaultCrossZoneAction;
-  }
-
-  public void setDefaultInboundAction(LineAction defaultInboundAction) {
-    _defaultInboundAction = defaultInboundAction;
-  }
-
-  @Override
-  public void setHostname(String hostname) {
-    _defaultRoutingInstance.setHostname(hostname);
-  }
-
   private void setPolicyStatementReferent(String policyName) {
-    PolicyStatement policy = _policyStatements.get(policyName);
+    PolicyStatement policy = _masterLogicalSystem.getPolicyStatements().get(policyName);
     if (policy == null) {
       return;
     }
@@ -1147,10 +900,6 @@ public final class JuniperConfiguration extends VendorConfiguration {
         }
       }
     }
-  }
-
-  public void setSyslogHosts(NavigableSet<String> syslogHosts) {
-    _syslogHosts = syslogHosts;
   }
 
   @Override
@@ -1269,7 +1018,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
           .getPolicies()
           .forEach(
               policyName -> {
-                PolicyStatement policy = _policyStatements.get(policyName);
+                PolicyStatement policy = _masterLogicalSystem.getPolicyStatements().get(policyName);
                 if (policy != null) {
                   setPolicyStatementReferent(policyName);
                   CallExpr callPolicy = new CallExpr(policyName);
@@ -1396,7 +1145,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
     newIface.setVrrpGroups(iface.getVrrpGroups());
     newIface.setVrf(_c.getVrfs().get(iface.getRoutingInstance()));
     newIface.setAdditionalArpIps(iface.getAdditionalArpIps());
-    Zone zone = _interfaceZones.get(iface.getName());
+    Zone zone = _masterLogicalSystem.getInterfaceZones().get(iface.getName());
     if (zone != null) {
       // filter for interface in zone
       FirewallFilter zoneInboundInterfaceFilter =
@@ -1418,7 +1167,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
     if (inAclName != null) {
       IpAccessList inAcl = _c.getIpAccessLists().get(inAclName);
       if (inAcl != null) {
-        FirewallFilter inFilter = _filters.get(inAclName);
+        FirewallFilter inFilter = _masterLogicalSystem.getFirewallFilters().get(inAclName);
         newIface.setIncomingFilter(inAcl);
         if (inFilter.getRoutingPolicy()) {
           RoutingPolicy routingPolicy = _c.getRoutingPolicies().get(inAclName);
@@ -1433,7 +1182,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
 
     // Assume the config will need security policies only if it has zones
     IpAccessList securityPolicyAcl = null;
-    if (!_zones.isEmpty()) {
+    if (!_masterLogicalSystem.getZones().isEmpty()) {
       String securityPolicyAclName = ACL_NAME_SECURITY_POLICY + iface.getName();
       securityPolicyAcl = buildSecurityPolicyAcl(securityPolicyAclName, zone);
       if (securityPolicyAcl != null) {
@@ -1467,7 +1216,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
     newIface.setAllAddresses(iface.getAllAddresses());
     newIface.setActive(iface.getActive());
     if (iface.getSwitchportMode() == SwitchportMode.ACCESS && iface.getAccessVlan() != null) {
-      Vlan vlan = getVlanNameToVlan().get(iface.getAccessVlan());
+      Vlan vlan = _masterLogicalSystem.getVlanNameToVlan().get(iface.getAccessVlan());
       if (vlan != null) {
         newIface.setAccessVlan(vlan.getVlanId());
       }
@@ -1477,7 +1226,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
                 iface
                     .getAllowedVlanNames()
                     .stream()
-                    .map(n -> getVlanNameToVlan().get(n))
+                    .map(n -> _masterLogicalSystem.getVlanNameToVlan().get(n))
                     .filter(Objects::nonNull)
                     .map(Vlan::getVlanId)
                     .map(SubRange::new),
@@ -1528,7 +1277,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
     }
 
     /* Global policy if applicable */
-    if (_filters.get(ACL_NAME_GLOBAL_POLICY) != null) {
+    if (_masterLogicalSystem.getFirewallFilters().get(ACL_NAME_GLOBAL_POLICY) != null) {
       /* Handle explicit accept lines for global policy */
       zoneAclLines.add(
           new IpAccessListLine(
@@ -1545,7 +1294,8 @@ public final class JuniperConfiguration extends VendorConfiguration {
 
     /* Add catch-all line with default action */
     zoneAclLines.add(
-        new IpAccessListLine(_defaultCrossZoneAction, TrueExpr.INSTANCE, "DEFAULT_POLICY"));
+        new IpAccessListLine(
+            _masterLogicalSystem.getDefaultCrossZoneAction(), TrueExpr.INSTANCE, "DEFAULT_POLICY"));
 
     IpAccessList zoneAcl = IpAccessList.builder().setName(name).setLines(zoneAclLines).build();
     _c.getIpAccessLists().put(name, zoneAcl);
@@ -1679,7 +1429,8 @@ public final class JuniperConfiguration extends VendorConfiguration {
     if (zoneName != null) {
       matchSrcInterface =
           new MatchSrcInterface(
-              _zones
+              _masterLogicalSystem
+                  .getZones()
                   .get(zoneName)
                   .getInterfaces()
                   .stream()
@@ -1717,7 +1468,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
   private IpsecPeerConfig toIpsecPeerConfig(IpsecVpn ipsecVpn) {
     IpsecStaticPeerConfig.Builder ipsecStaticConfigBuilder = IpsecStaticPeerConfig.builder();
     ipsecStaticConfigBuilder.setTunnelInterface(ipsecVpn.getBindInterface().getName());
-    IkeGateway ikeGateway = _ikeGateways.get(ipsecVpn.getGateway());
+    IkeGateway ikeGateway = _masterLogicalSystem.getIkeGateways().get(ipsecVpn.getGateway());
 
     if (ikeGateway == null) {
       _w.redFlag(
@@ -1973,7 +1724,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
             int actionLineCounter = 0;
             PsFromRouteFilter fromRouteFilter = (PsFromRouteFilter) from;
             String routeFilterName = fromRouteFilter.getRouteFilterName();
-            RouteFilter rf = _routeFilters.get(routeFilterName);
+            RouteFilter rf = _masterLogicalSystem.getRouteFilters().get(routeFilterName);
             for (RouteFilterLine line : rf.getLines()) {
               if (line.getThens().size() > 0) {
                 String lineListName = name + "_ACTION_LINE_" + actionLineCounter;
@@ -2068,22 +1819,68 @@ public final class JuniperConfiguration extends VendorConfiguration {
   }
 
   @Override
-  public Configuration toVendorIndependentConfiguration() throws VendorConversionException {
+  public List<Configuration> toVendorIndependentConfigurations() throws VendorConversionException {
+    ImmutableList.Builder<Configuration> outputConfigurations = ImmutableList.builder();
+    _logicalSystems
+        .keySet()
+        .stream()
+        .map(this::toVendorIndependentConfiguration)
+        .forEach(outputConfigurations::add);
+    outputConfigurations.add(toVendorIndependentConfiguration());
+    return outputConfigurations.build();
+  }
+
+  /** Creates and returns a vendor-independent configuration for the named logical-system. */
+  private Configuration toVendorIndependentConfiguration(@Nullable String logicalSystemName) {
+    /*
+     * 1. Clone this JuniperConfiguration
+     * 2. Inherit/remove relevant pieces from master logical system
+     * 3. Convert it as if it were any other JuniperConfiguration.
+     */
+    JuniperConfiguration lsConfig = cloneConfiguration();
+    lsConfig.processLogicalSystemConfiguration(logicalSystemName, this);
+    return lsConfig.toVendorIndependentConfiguration();
+  }
+
+  private void processLogicalSystemConfiguration(
+      @Nonnull String logicalSystemName, @Nonnull JuniperConfiguration master) {
+    _masterLogicalSystem
+        .getDefaultRoutingInstance()
+        .setHostname(
+            String.format("%s~LOGICAL_SYSTEM~%s", master.getHostname(), logicalSystemName));
+  }
+
+  private @Nonnull JuniperConfiguration cloneConfiguration() {
+    try (Closer closer = Closer.create()) {
+      ByteArrayOutputStream baos = closer.register(new ByteArrayOutputStream());
+      ObjectOutputStream oos = closer.register(new ObjectOutputStream(baos));
+      oos.writeObject(this);
+      ByteArrayInputStream bais = closer.register(new ByteArrayInputStream(baos.toByteArray()));
+      ObjectInputStream ois = closer.register(new ObjectInputStream(bais));
+      Object clonedObject = ois.readObject();
+      return (JuniperConfiguration) clonedObject;
+    } catch (IOException | ClassNotFoundException e) {
+      throw new VendorConversionException("Failed to clone master vendor configuration", e);
+    }
+  }
+
+  private Configuration toVendorIndependentConfiguration() throws VendorConversionException {
     String hostname = getHostname();
     _c = new Configuration(hostname, _vendor);
-    _c.setAuthenticationKeyChains(convertAuthenticationKeyChains(_authenticationKeyChains));
-    _c.setDnsServers(_dnsServers);
-    _c.setDomainName(_defaultRoutingInstance.getDomainName());
-    _c.setLoggingServers(_syslogHosts);
-    _c.setNtpServers(_ntpServers);
-    _c.setTacacsServers(_tacplusServers);
-    _c.getVendorFamily().setJuniper(_jf);
-    for (String riName : _routingInstances.keySet()) {
+    _c.setAuthenticationKeyChains(
+        convertAuthenticationKeyChains(_masterLogicalSystem.getAuthenticationKeyChains()));
+    _c.setDnsServers(_masterLogicalSystem.getDnsServers());
+    _c.setDomainName(_masterLogicalSystem.getDefaultRoutingInstance().getDomainName());
+    _c.setLoggingServers(_masterLogicalSystem.getSyslogHosts());
+    _c.setNtpServers(_masterLogicalSystem.getNtpServers());
+    _c.setTacacsServers(_masterLogicalSystem.getTacplusServers());
+    _c.getVendorFamily().setJuniper(_masterLogicalSystem.getJf());
+    for (String riName : _masterLogicalSystem.getRoutingInstances().keySet()) {
       _c.getVrfs().put(riName, new Vrf(riName));
     }
 
     // convert prefix lists to route filter lists
-    for (Entry<String, PrefixList> e : _prefixLists.entrySet()) {
+    for (Entry<String, PrefixList> e : _masterLogicalSystem.getPrefixLists().entrySet()) {
       String name = e.getKey();
       PrefixList pl = e.getValue();
       RouteFilterList rfl = new RouteFilterList(name);
@@ -2098,26 +1895,28 @@ public final class JuniperConfiguration extends VendorConfiguration {
     }
 
     // Convert AddressBooks to IpSpaces
-    _globalAddressBooks.forEach(
-        (name, addressBook) -> {
-          Map<String, IpSpace> ipspaces = toIpSpaces(name, addressBook);
-          _c.getIpSpaces().putAll(ipspaces);
-          ipspaces
-              .keySet()
-              .forEach(
-                  ipSpaceName ->
-                      _c.getIpSpaceMetadata()
-                          .put(
-                              ipSpaceName,
-                              new IpSpaceMetadata(
+    _masterLogicalSystem
+        .getGlobalAddressBooks()
+        .forEach(
+            (name, addressBook) -> {
+              Map<String, IpSpace> ipspaces = toIpSpaces(name, addressBook);
+              _c.getIpSpaces().putAll(ipspaces);
+              ipspaces
+                  .keySet()
+                  .forEach(
+                      ipSpaceName ->
+                          _c.getIpSpaceMetadata()
+                              .put(
                                   ipSpaceName,
-                                  JuniperStructureType.ADDRESS_BOOK.getDescription())));
-        });
+                                  new IpSpaceMetadata(
+                                      ipSpaceName,
+                                      JuniperStructureType.ADDRESS_BOOK.getDescription())));
+            });
 
     // TODO: instead make both IpAccessList and Ip6AccessList instances from
     // such firewall filters
     // remove ipv6 lines from firewall filters
-    for (FirewallFilter filter : _filters.values()) {
+    for (FirewallFilter filter : _masterLogicalSystem.getFirewallFilters().values()) {
       Set<String> toRemove = new HashSet<>();
       for (Entry<String, FwTerm> e2 : filter.getTerms().entrySet()) {
         String termName = e2.getKey();
@@ -2132,17 +1931,18 @@ public final class JuniperConfiguration extends VendorConfiguration {
     }
 
     // remove empty firewall filters (ipv6-only filters)
-    Map<String, FirewallFilter> allFilters = new LinkedHashMap<>(_filters);
+    Map<String, FirewallFilter> allFilters =
+        new LinkedHashMap<>(_masterLogicalSystem.getFirewallFilters());
     for (Entry<String, FirewallFilter> e : allFilters.entrySet()) {
       String name = e.getKey();
       FirewallFilter filter = e.getValue();
       if (filter.getTerms().size() == 0) {
-        _filters.remove(name);
+        _masterLogicalSystem.getFirewallFilters().remove(name);
       }
     }
 
     // convert firewall filters to ipaccesslists
-    for (Entry<String, FirewallFilter> e : _filters.entrySet()) {
+    for (Entry<String, FirewallFilter> e : _masterLogicalSystem.getFirewallFilters().entrySet()) {
       String name = e.getKey();
       FirewallFilter filter = e.getValue();
       // TODO: support other filter families
@@ -2155,7 +1955,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
 
     // convert firewall filters implementing routing policy to RoutingPolicy
     // objects
-    for (Entry<String, FirewallFilter> e : _filters.entrySet()) {
+    for (Entry<String, FirewallFilter> e : _masterLogicalSystem.getFirewallFilters().entrySet()) {
       String name = e.getKey();
       FirewallFilter filter = e.getValue();
       if (filter.getRoutingPolicy()) {
@@ -2169,7 +1969,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
     }
 
     // convert route filters to route filter lists
-    for (Entry<String, RouteFilter> e : _routeFilters.entrySet()) {
+    for (Entry<String, RouteFilter> e : _masterLogicalSystem.getRouteFilters().entrySet()) {
       String name = e.getKey();
       RouteFilter rf = e.getValue();
       if (rf.getIpv4()) {
@@ -2193,7 +1993,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
     }
 
     // convert community lists
-    for (Entry<String, CommunityList> e : _communityLists.entrySet()) {
+    for (Entry<String, CommunityList> e : _masterLogicalSystem.getCommunityLists().entrySet()) {
       String name = e.getKey();
       CommunityList cl = e.getValue();
       org.batfish.datamodel.CommunityList newCl = toCommunityList(cl);
@@ -2201,7 +2001,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
     }
 
     // convert policy-statements to RoutingPolicy objects
-    for (Entry<String, PolicyStatement> e : _policyStatements.entrySet()) {
+    for (Entry<String, PolicyStatement> e : _masterLogicalSystem.getPolicyStatements().entrySet()) {
       String name = e.getKey();
       PolicyStatement ps = e.getValue();
       RoutingPolicy routingPolicy = toRoutingPolicy(ps);
@@ -2211,7 +2011,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
     // convert interfaces
     Map<String, Interface> interfacesToConvert = new LinkedHashMap<>();
 
-    for (Interface iface : _interfaces.values()) {
+    for (Interface iface : _masterLogicalSystem.getInterfaces().values()) {
       if (iface.get8023adInterface() != null) {
         interfacesToConvert.put(iface.getName(), iface);
       } else {
@@ -2232,13 +2032,20 @@ public final class JuniperConfiguration extends VendorConfiguration {
       Vrf vrf = newUnitIface.getVrf();
       String vrfName = vrf.getName();
       vrf.getInterfaces().put(unitName, newUnitIface);
-      _routingInstances.get(vrfName).getInterfaces().put(unitName, unitIface);
+      _masterLogicalSystem
+          .getRoutingInstances()
+          .get(vrfName)
+          .getInterfaces()
+          .put(unitName, unitIface);
     }
 
     // set router-id
-    if (_defaultRoutingInstance.getRouterId() == null) {
+    if (_masterLogicalSystem.getDefaultRoutingInstance().getRouterId() == null) {
       Interface loopback0 =
-          _defaultRoutingInstance.getInterfaces().get(FIRST_LOOPBACK_INTERFACE_NAME);
+          _masterLogicalSystem
+              .getDefaultRoutingInstance()
+              .getInterfaces()
+              .get(FIRST_LOOPBACK_INTERFACE_NAME);
       if (loopback0 != null) {
         Interface loopback0unit0 = loopback0.getUnits().get(FIRST_LOOPBACK_INTERFACE_NAME + ".0");
         if (loopback0unit0 != null) {
@@ -2246,20 +2053,22 @@ public final class JuniperConfiguration extends VendorConfiguration {
           if (address != null) {
             // now we should set router-id
             Ip routerId = address.getIp();
-            _defaultRoutingInstance.setRouterId(routerId);
+            _masterLogicalSystem.getDefaultRoutingInstance().setRouterId(routerId);
           }
         }
       }
     }
 
     // convert IKE proposals
-    _ikeProposals
+    _masterLogicalSystem
+        .getIkeProposals()
         .values()
         .forEach(
             ikeProposal ->
                 _c.getIkeProposals().put(ikeProposal.getName(), toIkeProposal(ikeProposal)));
 
-    _ikeProposals
+    _masterLogicalSystem
+        .getIkeProposals()
         .values()
         .forEach(
             ikeProposal ->
@@ -2270,7 +2079,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
         ImmutableSortedMap.naturalOrder();
 
     // convert ike policies
-    for (Entry<String, IkePolicy> e : _ikePolicies.entrySet()) {
+    for (Entry<String, IkePolicy> e : _masterLogicalSystem.getIkePolicies().entrySet()) {
       String name = e.getKey();
       IkePolicy oldIkePolicy = e.getValue();
       org.batfish.datamodel.IkePolicy newPolicy = toIkePolicy(oldIkePolicy);
@@ -2282,7 +2091,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
     _c.setIkePhase1Keys(ikePhase1KeysBuilder.build());
 
     // convert ike gateways
-    for (Entry<String, IkeGateway> e : _ikeGateways.entrySet()) {
+    for (Entry<String, IkeGateway> e : _masterLogicalSystem.getIkeGateways().entrySet()) {
       String name = e.getKey();
       IkeGateway oldIkeGateway = e.getValue();
       org.batfish.datamodel.IkeGateway newIkeGateway = toIkeGateway(oldIkeGateway);
@@ -2292,17 +2101,20 @@ public final class JuniperConfiguration extends VendorConfiguration {
     // convert ipsec proposals
     ImmutableSortedMap.Builder<String, IpsecPhase2Proposal> ipsecPhase2ProposalsBuilder =
         ImmutableSortedMap.naturalOrder();
-    _ipsecProposals.forEach(
-        (ipsecProposalName, ipsecProposal) -> {
-          _c.getIpsecProposals().put(ipsecProposalName, toIpsecProposal(ipsecProposal));
-          ipsecPhase2ProposalsBuilder.put(ipsecProposalName, toIpsecPhase2Proposal(ipsecProposal));
-        });
+    _masterLogicalSystem
+        .getIpsecProposals()
+        .forEach(
+            (ipsecProposalName, ipsecProposal) -> {
+              _c.getIpsecProposals().put(ipsecProposalName, toIpsecProposal(ipsecProposal));
+              ipsecPhase2ProposalsBuilder.put(
+                  ipsecProposalName, toIpsecPhase2Proposal(ipsecProposal));
+            });
     _c.setIpsecPhase2Proposals(ipsecPhase2ProposalsBuilder.build());
 
     // convert ipsec policies
     ImmutableSortedMap.Builder<String, IpsecPhase2Policy> ipsecPhase2PoliciesBuilder =
         ImmutableSortedMap.naturalOrder();
-    for (Entry<String, IpsecPolicy> e : _ipsecPolicies.entrySet()) {
+    for (Entry<String, IpsecPolicy> e : _masterLogicalSystem.getIpsecPolicies().entrySet()) {
       String name = e.getKey();
       IpsecPolicy oldIpsecPolicy = e.getValue();
       org.batfish.datamodel.IpsecPolicy newPolicy = toIpsecPolicy(oldIpsecPolicy);
@@ -2314,7 +2126,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
     // convert ipsec vpns
     ImmutableSortedMap.Builder<String, IpsecPeerConfig> ipsecPeerConfigBuilder =
         ImmutableSortedMap.naturalOrder();
-    for (Entry<String, IpsecVpn> e : _ipsecVpns.entrySet()) {
+    for (Entry<String, IpsecVpn> e : _masterLogicalSystem.getIpsecVpns().entrySet()) {
       String name = e.getKey();
       IpsecVpn oldIpsecVpn = e.getValue();
       org.batfish.datamodel.IpsecVpn newIpsecVpn = toIpsecVpn(oldIpsecVpn);
@@ -2328,7 +2140,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
     _c.setIpsecPeerConfigs(ipsecPeerConfigBuilder.build());
 
     // zones
-    for (Zone zone : _zones.values()) {
+    for (Zone zone : _masterLogicalSystem.getZones().values()) {
       org.batfish.datamodel.Zone newZone = toZone(zone);
       _c.getZones().put(zone.getName(), newZone);
       if (!zone.getAddressBook().getEntries().isEmpty()) {
@@ -2346,15 +2158,15 @@ public final class JuniperConfiguration extends VendorConfiguration {
       }
     }
     // If there are zones, then assume we will need to support existing connection ACL
-    if (!_zones.isEmpty()) {
+    if (!_masterLogicalSystem.getZones().isEmpty()) {
       _c.getIpAccessLists().put(ACL_NAME_EXISTING_CONNECTION, ACL_EXISTING_CONNECTION);
     }
 
     // default zone behavior
-    _c.setDefaultCrossZoneAction(_defaultCrossZoneAction);
-    _c.setDefaultInboundAction(_defaultInboundAction);
+    _c.setDefaultCrossZoneAction(_masterLogicalSystem.getDefaultCrossZoneAction());
+    _c.setDefaultInboundAction(_masterLogicalSystem.getDefaultInboundAction());
 
-    for (Entry<String, RoutingInstance> e : _routingInstances.entrySet()) {
+    for (Entry<String, RoutingInstance> e : _masterLogicalSystem.getRoutingInstances().entrySet()) {
       String riName = e.getKey();
       RoutingInstance ri = e.getValue();
       Vrf vrf = _c.getVrfs().get(riName);
@@ -2435,7 +2247,8 @@ public final class JuniperConfiguration extends VendorConfiguration {
       // create is-is process
       // is-is runs only if at least one interface has an ISO address, check loopback first
       Optional<IsoAddress> isoAddress =
-          _defaultRoutingInstance
+          _masterLogicalSystem
+              .getDefaultRoutingInstance()
               .getInterfaces()
               .values()
               .stream()
@@ -2446,7 +2259,8 @@ public final class JuniperConfiguration extends VendorConfiguration {
       // Try all the other interfaces if no ISO address on Loopback
       if (!isoAddress.isPresent()) {
         isoAddress =
-            _defaultRoutingInstance
+            _masterLogicalSystem
+                .getDefaultRoutingInstance()
                 .getInterfaces()
                 .values()
                 .stream()
@@ -2468,26 +2282,26 @@ public final class JuniperConfiguration extends VendorConfiguration {
     }
 
     // destination nats
-    if (_natDestination != null) {
+    if (_masterLogicalSystem.getNatDestination() != null) {
       _w.unimplemented("Destination NAT is not currently implemented");
     }
 
     // source nats
-    if (_natSource != null) {
+    if (_masterLogicalSystem.getNatSource() != null) {
       _w.unimplemented("Source NAT is not currently implemented");
     }
 
     // static nats
-    if (_natStatic != null) {
+    if (_masterLogicalSystem.getNatStatic() != null) {
       _w.unimplemented("Static NAT is not currently implemented");
     }
 
     // mark forwarding table export policy if it exists
     String forwardingTableExportPolicyName =
-        _defaultRoutingInstance.getForwardingTableExportPolicy();
+        _masterLogicalSystem.getDefaultRoutingInstance().getForwardingTableExportPolicy();
     if (forwardingTableExportPolicyName != null) {
       PolicyStatement forwardingTableExportPolicy =
-          _policyStatements.get(forwardingTableExportPolicyName);
+          _masterLogicalSystem.getPolicyStatements().get(forwardingTableExportPolicyName);
       if (forwardingTableExportPolicy != null) {
         setPolicyStatementReferent(forwardingTableExportPolicyName);
       }
@@ -2648,7 +2462,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
   }
 
   private void warnEmptyPrefixLists() {
-    for (Entry<String, PrefixList> e : _prefixLists.entrySet()) {
+    for (Entry<String, PrefixList> e : _masterLogicalSystem.getPrefixLists().entrySet()) {
       String name = e.getKey();
       PrefixList prefixList = e.getValue();
       if (!prefixList.getIpv6() && prefixList.getPrefixes().isEmpty()) {
@@ -2695,11 +2509,21 @@ public final class JuniperConfiguration extends VendorConfiguration {
     return routerId;
   }
 
-  public Map<String, ApplicationSet> getApplicationSets() {
-    return _applicationSets;
+  public @Nonnull Map<String, LogicalSystem> getLogicalSystems() {
+    return _logicalSystems;
   }
 
-  public Map<String, AsPathGroup> getAsPathGroups() {
-    return _asPathGroups;
+  public LogicalSystem getMasterLogicalSystem() {
+    return _masterLogicalSystem;
+  }
+
+  @Override
+  public String getHostname() {
+    return _masterLogicalSystem.getHostname();
+  }
+
+  @Override
+  public void setHostname(String hostname) {
+    _masterLogicalSystem.setHostname(hostname);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -6,12 +6,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
-import com.google.common.io.Closer;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -33,6 +27,7 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.collections4.list.TreeList;
+import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.BatfishException;
 import org.batfish.common.VendorConversionException;
 import org.batfish.common.util.CommonUtil;
@@ -1935,21 +1930,11 @@ public final class JuniperConfiguration extends VendorConfiguration {
   }
 
   private @Nonnull JuniperConfiguration cloneConfiguration() {
-    try (Closer closer = Closer.create()) {
-      ByteArrayOutputStream baos = closer.register(new ByteArrayOutputStream());
-      ObjectOutputStream oos = closer.register(new ObjectOutputStream(baos));
-      oos.writeObject(this);
-      ByteArrayInputStream bais = closer.register(new ByteArrayInputStream(baos.toByteArray()));
-      ObjectInputStream ois = closer.register(new ObjectInputStream(bais));
-      Object clonedObject = ois.readObject();
-      JuniperConfiguration clonedConfiguration = (JuniperConfiguration) clonedObject;
-      clonedConfiguration.setAnswerElement(getAnswerElement());
-      clonedConfiguration.setUnrecognized(getUnrecognized());
-      clonedConfiguration.setWarnings(_w);
-      return clonedConfiguration;
-    } catch (IOException | ClassNotFoundException e) {
-      throw new VendorConversionException("Failed to clone master vendor configuration", e);
-    }
+    JuniperConfiguration clonedConfiguration = SerializationUtils.clone(this);
+    clonedConfiguration.setAnswerElement(getAnswerElement());
+    clonedConfiguration.setUnrecognized(getUnrecognized());
+    clonedConfiguration.setWarnings(_w);
+    return clonedConfiguration;
   }
 
   private Configuration toVendorIndependentConfiguration() throws VendorConversionException {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/LogicalSystem.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/LogicalSystem.java
@@ -35,7 +35,7 @@ public class LogicalSystem implements Serializable {
 
   private LineAction _defaultInboundAction;
 
-  private final RoutingInstance _defaultRoutingInstance;
+  private RoutingInstance _defaultRoutingInstance;
 
   private NavigableSet<String> _dnsServers;
 
@@ -298,8 +298,24 @@ public class LogicalSystem implements Serializable {
     _defaultInboundAction = defaultInboundAction;
   }
 
+  public void setDefaultRoutingInstance(RoutingInstance defaultRoutingInstance) {
+    _defaultRoutingInstance = defaultRoutingInstance;
+  }
+
   public void setHostname(String hostname) {
     _defaultRoutingInstance.setHostname(hostname);
+  }
+
+  public void setNatDestination(Nat natDestination) {
+    _natDestination = natDestination;
+  }
+
+  public void setNatSource(Nat natSource) {
+    _natSource = natSource;
+  }
+
+  public void setNatStatic(Nat natStatic) {
+    _natStatic = natStatic;
   }
 
   public void setSyslogHosts(NavigableSet<String> syslogHosts) {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/LogicalSystem.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/LogicalSystem.java
@@ -1,0 +1,308 @@
+package org.batfish.representation.juniper;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.NavigableSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.LineAction;
+import org.batfish.datamodel.vendor_family.juniper.JuniperFamily;
+import org.batfish.representation.juniper.Nat.Type;
+
+@ParametersAreNonnullByDefault
+public class LogicalSystem implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  private final Map<String, BaseApplication> _applications;
+
+  private final Map<String, ApplicationSet> _applicationSets;
+
+  private final Map<String, AsPathGroup> _asPathGroups;
+
+  private final NavigableMap<String, JuniperAuthenticationKeyChain> _authenticationKeyChains;
+
+  private final Map<String, CommunityList> _communityLists;
+
+  private boolean _defaultAddressSelection;
+
+  private LineAction _defaultCrossZoneAction;
+
+  private LineAction _defaultInboundAction;
+
+  private final RoutingInstance _defaultRoutingInstance;
+
+  private NavigableSet<String> _dnsServers;
+
+  private final Map<String, FirewallFilter> _filters;
+
+  private final Map<String, AddressBook> _globalAddressBooks;
+
+  private final Map<String, IkeGateway> _ikeGateways;
+
+  private final Map<String, IkePolicy> _ikePolicies;
+
+  private final Map<String, IkeProposal> _ikeProposals;
+
+  private final Map<String, Interface> _interfaces;
+
+  private final Map<String, Zone> _interfaceZones;
+
+  private final Map<String, IpsecPolicy> _ipsecPolicies;
+
+  private final Map<String, IpsecProposal> _ipsecProposals;
+
+  private final Map<String, IpsecVpn> _ipsecVpns;
+
+  private final JuniperFamily _jf;
+
+  private final String _name;
+
+  @Nullable private Nat _natDestination;
+
+  @Nullable private Nat _natSource;
+
+  @Nullable private Nat _natStatic;
+
+  private NavigableSet<String> _ntpServers;
+
+  private final Map<String, PolicyStatement> _policyStatements;
+
+  private final Map<String, PrefixList> _prefixLists;
+
+  private final Map<String, RouteFilter> _routeFilters;
+
+  private final Map<String, RoutingInstance> _routingInstances;
+
+  private NavigableSet<String> _syslogHosts;
+
+  private NavigableSet<String> _tacplusServers;
+
+  private final Map<String, Vlan> _vlanNameToVlan;
+
+  private final Map<String, Zone> _zones;
+
+  public LogicalSystem(String name) {
+    _name = name;
+    _applications = new TreeMap<>();
+    _applicationSets = new TreeMap<>();
+    _asPathGroups = new TreeMap<>();
+    _authenticationKeyChains = new TreeMap<>();
+    _communityLists = new TreeMap<>();
+    _defaultCrossZoneAction = LineAction.PERMIT;
+    _defaultRoutingInstance = new RoutingInstance(Configuration.DEFAULT_VRF_NAME);
+    _dnsServers = new TreeSet<>();
+    _filters = new TreeMap<>();
+    _globalAddressBooks = new TreeMap<>();
+    _ikeGateways = new TreeMap<>();
+    _ikePolicies = new TreeMap<>();
+    _ikeProposals = new TreeMap<>();
+    _interfaces = new TreeMap<>();
+    _interfaceZones = new TreeMap<>();
+    _ipsecPolicies = new TreeMap<>();
+    _ipsecProposals = new TreeMap<>();
+    _ipsecVpns = new TreeMap<>();
+    _jf = new JuniperFamily();
+    _ntpServers = new TreeSet<>();
+    _prefixLists = new TreeMap<>();
+    _policyStatements = new TreeMap<>();
+    _routeFilters = new TreeMap<>();
+    _routingInstances = new TreeMap<>();
+    _routingInstances.put(Configuration.DEFAULT_VRF_NAME, _defaultRoutingInstance);
+    _syslogHosts = new TreeSet<>();
+    _tacplusServers = new TreeSet<>();
+    _vlanNameToVlan = new TreeMap<>();
+    _zones = new TreeMap<>();
+  }
+
+  public Map<String, BaseApplication> getApplications() {
+    return _applications;
+  }
+
+  public Map<String, ApplicationSet> getApplicationSets() {
+    return _applicationSets;
+  }
+
+  public Map<String, AsPathGroup> getAsPathGroups() {
+    return _asPathGroups;
+  }
+
+  public Map<String, JuniperAuthenticationKeyChain> getAuthenticationKeyChains() {
+    return _authenticationKeyChains;
+  }
+
+  public Map<String, CommunityList> getCommunityLists() {
+    return _communityLists;
+  }
+
+  public boolean getDefaultAddressSelection() {
+    return _defaultAddressSelection;
+  }
+
+  public LineAction getDefaultCrossZoneAction() {
+    return _defaultCrossZoneAction;
+  }
+
+  public LineAction getDefaultInboundAction() {
+    return _defaultInboundAction;
+  }
+
+  public RoutingInstance getDefaultRoutingInstance() {
+    return _defaultRoutingInstance;
+  }
+
+  public NavigableSet<String> getDnsServers() {
+    return _dnsServers;
+  }
+
+  public Map<String, FirewallFilter> getFirewallFilters() {
+    return _filters;
+  }
+
+  public Map<String, AddressBook> getGlobalAddressBooks() {
+    return _globalAddressBooks;
+  }
+
+  public Interface getGlobalMasterInterface() {
+    return _defaultRoutingInstance.getGlobalMasterInterface();
+  }
+
+  public String getHostname() {
+    return _defaultRoutingInstance.getHostname();
+  }
+
+  public Map<String, IkeGateway> getIkeGateways() {
+    return _ikeGateways;
+  }
+
+  public Map<String, IkePolicy> getIkePolicies() {
+    return _ikePolicies;
+  }
+
+  public Map<String, IkeProposal> getIkeProposals() {
+    return _ikeProposals;
+  }
+
+  public Map<String, Interface> getInterfaces() {
+    return _interfaces;
+  }
+
+  public Map<String, Zone> getInterfaceZones() {
+    return _interfaceZones;
+  }
+
+  public Map<String, IpsecPolicy> getIpsecPolicies() {
+    return _ipsecPolicies;
+  }
+
+  public Map<String, IpsecProposal> getIpsecProposals() {
+    return _ipsecProposals;
+  }
+
+  public Map<String, IpsecVpn> getIpsecVpns() {
+    return _ipsecVpns;
+  }
+
+  public JuniperFamily getJf() {
+    return _jf;
+  }
+
+  public @Nonnull String getName() {
+    return _name;
+  }
+
+  public Nat getNatDestination() {
+    return _natDestination;
+  }
+
+  public Nat getNatSource() {
+    return _natSource;
+  }
+
+  public Nat getNatStatic() {
+    return _natStatic;
+  }
+
+  public NavigableSet<String> getNtpServers() {
+    return _ntpServers;
+  }
+
+  public Nat getOrCreateNat(Nat.Type natType) {
+    switch (natType) {
+      case DESTINATION:
+        if (_natDestination == null) {
+          _natDestination = new Nat(Type.DESTINATION);
+        }
+        return _natDestination;
+      case SOURCE:
+        if (_natSource == null) {
+          _natSource = new Nat(Type.SOURCE);
+        }
+        return _natSource;
+      case STATIC:
+        if (_natStatic == null) {
+          _natStatic = new Nat(Type.STATIC);
+        }
+        return _natStatic;
+      default:
+        throw new IllegalArgumentException("Unknnown nat type " + natType);
+    }
+  }
+
+  public Map<String, PolicyStatement> getPolicyStatements() {
+    return _policyStatements;
+  }
+
+  public Map<String, PrefixList> getPrefixLists() {
+    return _prefixLists;
+  }
+
+  public Map<String, RouteFilter> getRouteFilters() {
+    return _routeFilters;
+  }
+
+  public Map<String, RoutingInstance> getRoutingInstances() {
+    return _routingInstances;
+  }
+
+  public NavigableSet<String> getSyslogHosts() {
+    return _syslogHosts;
+  }
+
+  public NavigableSet<String> getTacplusServers() {
+    return _tacplusServers;
+  }
+
+  public Map<String, Vlan> getVlanNameToVlan() {
+    return _vlanNameToVlan;
+  }
+
+  public Map<String, Zone> getZones() {
+    return _zones;
+  }
+
+  public void setDefaultAddressSelection(boolean defaultAddressSelection) {
+    _defaultAddressSelection = defaultAddressSelection;
+  }
+
+  public void setDefaultCrossZoneAction(LineAction defaultCrossZoneAction) {
+    _defaultCrossZoneAction = defaultCrossZoneAction;
+  }
+
+  public void setDefaultInboundAction(LineAction defaultInboundAction) {
+    _defaultInboundAction = defaultInboundAction;
+  }
+
+  public void setHostname(String hostname) {
+    _defaultRoutingInstance.setHostname(hostname);
+  }
+
+  public void setSyslogHosts(NavigableSet<String> syslogHosts) {
+    _syslogHosts = syslogHosts;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsFromPolicyStatementConjunction.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsFromPolicyStatementConjunction.java
@@ -26,7 +26,7 @@ public final class PsFromPolicyStatementConjunction extends PsFrom {
   public BooleanExpr toBooleanExpr(JuniperConfiguration jc, Configuration c, Warnings warnings) {
     Conjunction conj = new Conjunction();
     for (String conjunct : _conjuncts) {
-      PolicyStatement conjunctPs = jc.getPolicyStatements().get(conjunct);
+      PolicyStatement conjunctPs = jc.getMasterLogicalSystem().getPolicyStatements().get(conjunct);
       if (conjunctPs != null) {
         conj.getConjuncts().add(new CallExpr(conjunct));
       } else {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsFromPrefixListFilterLonger.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsFromPrefixListFilterLonger.java
@@ -26,7 +26,7 @@ public final class PsFromPrefixListFilterLonger extends PsFrom {
 
   @Override
   public BooleanExpr toBooleanExpr(JuniperConfiguration jc, Configuration c, Warnings warnings) {
-    PrefixList pl = jc.getPrefixLists().get(_prefixList);
+    PrefixList pl = jc.getMasterLogicalSystem().getPrefixLists().get(_prefixList);
     if (pl != null) {
       if (pl.getIpv6()) {
         return BooleanExprs.FALSE;

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsFromPrefixListFilterOrLonger.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsFromPrefixListFilterOrLonger.java
@@ -26,7 +26,7 @@ public final class PsFromPrefixListFilterOrLonger extends PsFrom {
 
   @Override
   public BooleanExpr toBooleanExpr(JuniperConfiguration jc, Configuration c, Warnings warnings) {
-    PrefixList pl = jc.getPrefixLists().get(_prefixList);
+    PrefixList pl = jc.getMasterLogicalSystem().getPrefixLists().get(_prefixList);
     if (pl != null) {
       if (pl.getIpv6()) {
         return BooleanExprs.FALSE;

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenCommunityAdd.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenCommunityAdd.java
@@ -30,7 +30,8 @@ public final class PsThenCommunityAdd extends PsThen {
       JuniperConfiguration juniperVendorConfiguration,
       Configuration c,
       Warnings warnings) {
-    CommunityList namedList = _configuration.getCommunityLists().get(_name);
+    CommunityList namedList =
+        _configuration.getMasterLogicalSystem().getCommunityLists().get(_name);
     if (namedList == null) {
       warnings.redFlag("Reference to undefined community: \"" + _name + "\"");
       return;

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenCommunityDelete.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenCommunityDelete.java
@@ -28,7 +28,8 @@ public final class PsThenCommunityDelete extends PsThen {
       JuniperConfiguration juniperVendorConfiguration,
       Configuration c,
       Warnings warnings) {
-    CommunityList namedList = _configuration.getCommunityLists().get(_name);
+    CommunityList namedList =
+        _configuration.getMasterLogicalSystem().getCommunityLists().get(_name);
     if (namedList == null) {
       warnings.redFlag("Reference to undefined community: \"" + _name + "\"");
     } else {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenCommunitySet.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenCommunitySet.java
@@ -27,7 +27,8 @@ public final class PsThenCommunitySet extends PsThen {
       JuniperConfiguration juniperVendorConfiguration,
       Configuration c,
       Warnings warnings) {
-    CommunityList namedList = _configuration.getCommunityLists().get(_name);
+    CommunityList namedList =
+        _configuration.getMasterLogicalSystem().getCommunityLists().get(_name);
     if (namedList == null) {
       warnings.redFlag("Reference to undefined community: \"" + _name + "\"");
     } else {

--- a/projects/batfish/src/main/java/org/batfish/representation/mrv/MrvConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/mrv/MrvConfiguration.java
@@ -2,6 +2,8 @@ package org.batfish.representation.mrv;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.collect.ImmutableList;
+import java.util.List;
 import org.batfish.common.VendorConversionException;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
@@ -40,10 +42,10 @@ public class MrvConfiguration extends VendorConfiguration {
   }
 
   @Override
-  public Configuration toVendorIndependentConfiguration() throws VendorConversionException {
+  public List<Configuration> toVendorIndependentConfigurations() throws VendorConversionException {
     _c = new Configuration(_hostname, _vendor);
     _c.setDefaultCrossZoneAction(LineAction.PERMIT);
     _c.setDefaultInboundAction(LineAction.PERMIT);
-    return _c;
+    return ImmutableList.of(_c);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -404,7 +404,7 @@ public final class PaloAltoConfiguration extends VendorConfiguration {
   }
 
   @Override
-  public Configuration toVendorIndependentConfiguration() throws VendorConversionException {
+  public List<Configuration> toVendorIndependentConfigurations() throws VendorConversionException {
     String hostname = getHostname();
     _c = new Configuration(hostname, _vendor);
     _c.setDefaultCrossZoneAction(LineAction.DENY);
@@ -462,7 +462,7 @@ public final class PaloAltoConfiguration extends VendorConfiguration {
         ImmutableList.of(PaloAltoStructureType.SERVICE, PaloAltoStructureType.SERVICE_GROUP),
         PaloAltoStructureUsage.SERVICE_GROUP_MEMBER,
         PaloAltoStructureUsage.RULEBASE_SERVICE);
-    return _c;
+    return ImmutableList.of(_c);
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/representation/vyos/VyosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/vyos/VyosConfiguration.java
@@ -364,7 +364,7 @@ public class VyosConfiguration extends VendorConfiguration {
   }
 
   @Override
-  public Configuration toVendorIndependentConfiguration() throws VendorConversionException {
+  public List<Configuration> toVendorIndependentConfigurations() throws VendorConversionException {
     _ipToInterfaceMap = new HashMap<>();
     _c = new Configuration(_hostname, _format);
     _c.setDefaultCrossZoneAction(LineAction.PERMIT);
@@ -377,6 +377,6 @@ public class VyosConfiguration extends VendorConfiguration {
 
     // TODO: convert routing processes
 
-    return _c;
+    return ImmutableList.of(_c);
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -2196,7 +2196,8 @@ public class FlatJuniperGrammarTest {
     // ensure interfaces have been divided appropriately
     assertThat(
         masterConfig.getAllInterfaces().keySet(), containsInAnyOrder("xe-0/0/0.0", "xe-0/0/1.1"));
-    assertThat(lsConfig.getAllInterfaces().keySet(), containsInAnyOrder("xe-0/0/1.0"));
+    assertThat(
+        lsConfig.getAllInterfaces().keySet(), containsInAnyOrder("xe-0/0/1.0", "xe-0/0/2.0"));
 
     // shared physical interface should have same settings on both configs
     assertThat(masterConfig.getAllInterfaces().get("xe-0/0/1.1"), hasMtu(2345));

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromDestinationPrefixListExceptTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromDestinationPrefixListExceptTest.java
@@ -34,7 +34,9 @@ public class FwFromDestinationPrefixListExceptTest {
   @Before
   public void setup() {
     _jc = new JuniperConfiguration();
-    _jc.getPrefixLists().put(BASE_PREFIX_LIST_NAME, new PrefixList(BASE_PREFIX_LIST_NAME));
+    _jc.getMasterLogicalSystem()
+        .getPrefixLists()
+        .put(BASE_PREFIX_LIST_NAME, new PrefixList(BASE_PREFIX_LIST_NAME));
     _w = new Warnings();
     _c = new Configuration("test", ConfigurationFormat.FLAT_JUNIPER);
     RouteFilterList rflist = new RouteFilterList(BASE_PREFIX_LIST_NAME);

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromDestinationPrefixListTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromDestinationPrefixListTest.java
@@ -34,7 +34,9 @@ public class FwFromDestinationPrefixListTest {
   @Before
   public void setup() {
     _jc = new JuniperConfiguration();
-    _jc.getPrefixLists().put(BASE_PREFIX_LIST_NAME, new PrefixList(BASE_PREFIX_LIST_NAME));
+    _jc.getMasterLogicalSystem()
+        .getPrefixLists()
+        .put(BASE_PREFIX_LIST_NAME, new PrefixList(BASE_PREFIX_LIST_NAME));
     _w = new Warnings();
     _c = new Configuration("test", ConfigurationFormat.FLAT_JUNIPER);
     RouteFilterList rflist = new RouteFilterList(BASE_PREFIX_LIST_NAME);

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromPrefixListTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromPrefixListTest.java
@@ -34,7 +34,9 @@ public class FwFromPrefixListTest {
   @Before
   public void setup() {
     _jc = new JuniperConfiguration();
-    _jc.getPrefixLists().put(BASE_PREFIX_LIST_NAME, new PrefixList(BASE_PREFIX_LIST_NAME));
+    _jc.getMasterLogicalSystem()
+        .getPrefixLists()
+        .put(BASE_PREFIX_LIST_NAME, new PrefixList(BASE_PREFIX_LIST_NAME));
     _w = new Warnings();
     _c = new Configuration("test", ConfigurationFormat.FLAT_JUNIPER);
     RouteFilterList rflist = new RouteFilterList(BASE_PREFIX_LIST_NAME);

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromSourcePrefixListExceptTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromSourcePrefixListExceptTest.java
@@ -34,7 +34,9 @@ public class FwFromSourcePrefixListExceptTest {
   @Before
   public void setup() {
     _jc = new JuniperConfiguration();
-    _jc.getPrefixLists().put(BASE_PREFIX_LIST_NAME, new PrefixList(BASE_PREFIX_LIST_NAME));
+    _jc.getMasterLogicalSystem()
+        .getPrefixLists()
+        .put(BASE_PREFIX_LIST_NAME, new PrefixList(BASE_PREFIX_LIST_NAME));
     _w = new Warnings();
     _c = new Configuration("test", ConfigurationFormat.FLAT_JUNIPER);
     RouteFilterList rflist = new RouteFilterList(BASE_PREFIX_LIST_NAME);

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromSourcePrefixListTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromSourcePrefixListTest.java
@@ -34,7 +34,9 @@ public class FwFromSourcePrefixListTest {
   @Before
   public void setup() {
     _jc = new JuniperConfiguration();
-    _jc.getPrefixLists().put(BASE_PREFIX_LIST_NAME, new PrefixList(BASE_PREFIX_LIST_NAME));
+    _jc.getMasterLogicalSystem()
+        .getPrefixLists()
+        .put(BASE_PREFIX_LIST_NAME, new PrefixList(BASE_PREFIX_LIST_NAME));
     _w = new Warnings();
     _c = new Configuration("test", ConfigurationFormat.FLAT_JUNIPER);
     RouteFilterList rflist = new RouteFilterList(BASE_PREFIX_LIST_NAME);

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
@@ -52,7 +52,7 @@ public class JuniperConfigurationTest {
     zone.getInterfaces().add(new Interface(interface1Name));
     String interface2Name = "interface2";
     zone.getInterfaces().add(new Interface(interface2Name));
-    config.getZones().put("zone", zone);
+    config.getMasterLogicalSystem().getZones().put("zone", zone);
     filter.setFromZone("zone");
     IpAccessList headerSpaceAndSrcInterfaceAcl = config.toIpAccessList(filter);
 

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testrigs/logical-systems/configs/master1
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testrigs/logical-systems/configs/master1
@@ -14,6 +14,9 @@ set interfaces xe-0/0/1 unit 1 family inet address 10.0.2.1/24
 set logical-systems ls1 interfaces xe-0/0/1 unit 0
 set logical-systems ls1 interfaces xe-0/0/1 unit 0 family inet address 10.0.1.1/24
 #
+### xe-0/0/2 exists only on the logical system
+set logical-systems ls1 interfaces xe-0/0/2 unit 0 family inet address 10.0.3.1/24
+#
 ### some structures defined on master are visible on ls, but can be overridden
 # defined only on master
 set firewall family inet filter ff1 term t1 then accept

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testrigs/logical-systems/configs/master1
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testrigs/logical-systems/configs/master1
@@ -1,0 +1,30 @@
+# RANCID-CONTENT-TYPE: juniper
+#
+set system host-name master1
+#
+### hostname can be manually configured for ls
+set logical-systems ls2 system host-name ls2.example.com
+### xe-0/0/0 exists only on master
+set interfaces xe-0/0/0 unit 0 family inet address 10.0.0.1/24
+#
+### xe-0/0/1 is split between master and ls1
+set interfaces xe-0/0/1 mtu 2345
+set interfaces xe-0/0/1 unit 1 family inet address 10.0.2.1/24
+#
+set logical-systems ls1 interfaces xe-0/0/1 unit 0
+set logical-systems ls1 interfaces xe-0/0/1 unit 0 family inet address 10.0.1.1/24
+#
+### some structures defined on master are visible on ls, but can be overridden
+# defined only on master
+set firewall family inet filter ff1 term t1 then accept
+set policy-options policy-statement ps1 term t1 then accept
+# defined on both
+set firewall family inet filter ff2 term t1 then accept
+set logical-systems ls1 firewall family inet filter ff2 term t1 then reject
+set policy-options policy-statement ps2 term t1 then accept
+set logical-systems ls1 policy-options policy-statement ps2 term t1 then reject
+# defined only on ls
+set logical-systems ls1 firewall family inet filter ff3 term t1 then reject
+set logical-systems ls1 policy-options policy-statement ps3 term t1 then reject
+#
+


### PR DESCRIPTION
- move most JuniperConfiguration structures into new LogicalSystem class
- refactor toVendorConfiguration to toVendorConfigurations which now
  returns list of Configurations
- JuniperConfiguration now produces multiple Configurations
  - one for master logical system
  - one for each logical system
    - clone master logical system
    - remove out of scope settings
    - copy remaining settings from cloned logical system