### PR TITLE
Juniper: put physical interfaces in VI datamodel, track dependencies

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -622,6 +622,10 @@ public final class Interface extends ComparableStructure<String> {
       return InterfaceType.REDUNDANT;
     } else if (name.startsWith("ae")) {
       return InterfaceType.AGGREGATED;
+    } else if (name.startsWith("lo")) {
+      return InterfaceType.LOOPBACK;
+    } else if (name.contains(".")) {
+      return InterfaceType.LOGICAL;
     } else {
       return InterfaceType.PHYSICAL;
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/pojo/Link.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/pojo/Link.java
@@ -81,6 +81,7 @@ public class Link extends BfObject {
 
     switch (iface1type) {
       case PHYSICAL:
+      case LOGICAL:
         return LinkType.PHYSICAL;
 
       case AGGREGATED:

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/InterfaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/InterfaceTest.java
@@ -1,0 +1,23 @@
+package org.batfish.datamodel;
+
+import com.google.common.testing.EqualsTester;
+import org.batfish.datamodel.Interface.Dependency;
+import org.batfish.datamodel.Interface.DependencyType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests of {@link org.batfish.datamodel.Interface} */
+@RunWith(JUnit4.class)
+public class InterfaceTest {
+
+  @Test
+  public void testDependencyEquals() {
+    new EqualsTester()
+        .addEqualityGroup(
+            new Dependency("i1", DependencyType.BIND), new Dependency("i1", DependencyType.BIND))
+        .addEqualityGroup(new Dependency("i1", DependencyType.AGGREGATE))
+        .addEqualityGroup(new Dependency("i2", DependencyType.BIND))
+        .testEquals();
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -2398,7 +2398,10 @@ public class Batfish extends PluginConsumer implements IBatfish {
         .filter(
             i ->
                 i.getInterfaceType() == InterfaceType.AGGREGATED
-                    && i.getChannelGroupMembers().isEmpty())
+                    && i.getChannelGroupMembers().isEmpty()
+                    // TODO: Temporary hack to avoid disabling juniper AE unit interfaces
+                    && !i.getName().startsWith("ae")
+                    && !i.getName().contains("."))
         .forEach(i -> i.setActive(false));
 
     /* Compute bandwidth for aggregated interfaces. */

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -2466,6 +2466,13 @@ public final class JuniperConfiguration extends VendorConfiguration {
                 .stream()
                 .flatMap(nodeDevice -> nodeDevice.getInterfaces().values().stream()))
         .forEach(
+            /*
+             * For each interface, add it to the VI model. Since Juniper splits attributes
+             * between physical and logical (unit) interfaces, do the conversion in two steps.
+             * - Physical interface first, with physical attributes: speed, aggregation tracking, etc.
+             * - Then all units of the interface. Units have the attributes batfish
+             *   cares most about: IPs, MTUs, ACLs, etc.)
+             */
             iface -> {
               // Process parent interface
               iface.inheritUnsetFields();
@@ -2487,6 +2494,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
             });
   }
 
+  /** Ensure that the interface is placed in VI {@link Configuration} and {@link Vrf} */
   private void resolveInterfacePointers(
       String ifaceName, Interface iface, org.batfish.datamodel.Interface viIface) {
     _c.getAllInterfaces().put(ifaceName, viIface);

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperAggregationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperAggregationTest.java
@@ -1,6 +1,6 @@
 package org.batfish.grammar.flatjuniper;
 
-import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
@@ -33,7 +33,10 @@ public class FlatJuniperAggregationTest {
     Topology t = batfish.getEnvironmentTopology();
     assertThat(
         t.getEdges(),
-        contains(Edge.of("ae1", "ae1.0", "ae2", "ae2.0"), Edge.of("ae2", "ae2.0", "ae1", "ae1.0")));
-    // TODO: this should contain ae1.1<-->ae2.1 links also, but those are not supported yet.
+        containsInAnyOrder(
+            Edge.of("ae1", "ae1.0", "ae2", "ae2.0"),
+            Edge.of("ae2", "ae2.0", "ae1", "ae1.0"),
+            Edge.of("ae1", "ae1.1", "ae2", "ae2.1"),
+            Edge.of("ae2", "ae2.1", "ae1", "ae1.1")));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -128,6 +128,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.hasValue;
@@ -1139,10 +1140,8 @@ public class FlatJuniperGrammarTest {
     // Should have two zones
     assertThat(c.getZones().keySet(), containsInAnyOrder(zoneTrust, zoneUntrust));
 
-    // Should have two interfaces
-    assertThat(
-        c.getAllInterfaces().keySet(),
-        containsInAnyOrder(interfaceNameTrust, interfaceNameUntrust));
+    // Should have two logical interfaces
+    assertThat(c.getAllInterfaces().keySet(), hasItems(interfaceNameTrust, interfaceNameUntrust));
 
     // Confirm the interfaces are associated with their zones
     assertThat(c.getAllInterfaces().get(interfaceNameTrust), hasZoneName(equalTo(zoneTrust)));
@@ -1442,7 +1441,7 @@ public class FlatJuniperGrammarTest {
     Configuration c = parseConfig("interfaceMtu");
 
     /* Properly configured interfaces should be present in respective areas. */
-    assertThat(c.getAllInterfaces().keySet(), equalTo(Collections.singleton("xe-0/0/0:0.0")));
+    assertThat(c.getAllInterfaces().keySet(), hasItem("xe-0/0/0:0.0"));
     assertThat(c, hasInterface("xe-0/0/0:0.0", hasMtu(9000)));
   }
 
@@ -2195,9 +2194,11 @@ public class FlatJuniperGrammarTest {
 
     // ensure interfaces have been divided appropriately
     assertThat(
-        masterConfig.getAllInterfaces().keySet(), containsInAnyOrder("xe-0/0/0.0", "xe-0/0/1.1"));
+        masterConfig.getAllInterfaces().keySet(),
+        containsInAnyOrder("xe-0/0/0", "xe-0/0/0.0", "xe-0/0/1", "xe-0/0/1.1"));
     assertThat(
-        lsConfig.getAllInterfaces().keySet(), containsInAnyOrder("xe-0/0/1.0", "xe-0/0/2.0"));
+        lsConfig.getAllInterfaces().keySet(),
+        containsInAnyOrder("xe-0/0/1", "xe-0/0/1.0", "xe-0/0/2", "xe-0/0/2.0"));
 
     // shared physical interface should have same settings on both configs
     assertThat(masterConfig.getAllInterfaces().get("xe-0/0/1.1"), hasMtu(2345));

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -14453,6 +14453,32 @@
         "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "interfaces" : {
+          "xe-0/0/1" : {
+            "name" : "xe-0/0/1",
+            "accessVlan" : 0,
+            "active" : true,
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E10,
+            "declaredNames" : [
+              "xe-0/0/1"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
           "xe-0/0/1.0" : {
             "name" : "xe-0/0/1.0",
             "accessVlan" : 0,
@@ -14462,6 +14488,32 @@
             "bandwidth" : 1.0E10,
             "declaredNames" : [
               "xe-0/0/1.0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "LOGICAL",
+            "vrf" : "default"
+          },
+          "xe-0/0/20:0" : {
+            "name" : "xe-0/0/20:0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E10,
+            "declaredNames" : [
+              "xe-0/0/20:0"
             ],
             "mtu" : 1500,
             "nativeVlan" : 1,
@@ -14502,6 +14554,32 @@
             "spanningTreePortfast" : false,
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "LOGICAL",
+            "vrf" : "default"
+          },
+          "xe-0/0/21:0" : {
+            "name" : "xe-0/0/21:0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E10,
+            "declaredNames" : [
+              "xe-0/0/21:0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
             "type" : "PHYSICAL",
             "vrf" : "default"
           },
@@ -14528,7 +14606,7 @@
             "spanningTreePortfast" : false,
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
+            "type" : "LOGICAL",
             "vrf" : "default"
           }
         },
@@ -14680,8 +14758,11 @@
               }
             ],
             "interfaces" : [
+              "xe-0/0/1",
               "xe-0/0/1.0",
+              "xe-0/0/20:0",
               "xe-0/0/20:0.0",
+              "xe-0/0/21:0",
               "xe-0/0/21:0.0"
             ],
             "ospfProcess" : {
@@ -16049,6 +16130,32 @@
         "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "interfaces" : {
+          "et-0/0/10" : {
+            "name" : "et-0/0/10",
+            "accessVlan" : 0,
+            "active" : true,
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E12,
+            "declaredNames" : [
+              "et-0/0/10"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
           "et-0/0/10.0" : {
             "name" : "et-0/0/10.0",
             "accessVlan" : 0,
@@ -16058,6 +16165,32 @@
             "bandwidth" : 1.0E12,
             "declaredNames" : [
               "et-0/0/10.0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "LOGICAL",
+            "vrf" : "default"
+          },
+          "ge-0/2/5" : {
+            "name" : "ge-0/2/5",
+            "accessVlan" : 0,
+            "active" : true,
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "ge-0/2/5"
             ],
             "mtu" : 1500,
             "nativeVlan" : 1,
@@ -16101,6 +16234,32 @@
             "spanningTreePortfast" : false,
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "LOGICAL",
+            "vrf" : "default"
+          },
+          "xe-1/0/0" : {
+            "name" : "xe-1/0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E10,
+            "declaredNames" : [
+              "xe-1/0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
             "type" : "PHYSICAL",
             "vrf" : "default"
           },
@@ -16127,7 +16286,7 @@
             "spanningTreePortfast" : false,
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
+            "type" : "LOGICAL",
             "vrf" : "default"
           }
         },
@@ -16168,8 +16327,11 @@
           "default" : {
             "name" : "default",
             "interfaces" : [
+              "et-0/0/10",
               "et-0/0/10.0",
+              "ge-0/2/5",
               "ge-0/2/5.0",
+              "xe-1/0/0",
               "xe-1/0/0.0"
             ]
           }
@@ -16182,10 +16344,39 @@
         "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "interfaces" : {
+          "ae0" : {
+            "name" : "ae0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "channelGroupMembers" : [
+              "ge-1/0/0"
+            ],
+            "declaredNames" : [
+              "ae0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "AGGREGATED",
+            "vrf" : "default"
+          },
           "ae0.0" : {
             "name" : "ae0.0",
             "accessVlan" : 0,
-            "active" : false,
+            "active" : true,
             "allowedVlans" : "",
             "autostate" : true,
             "bandwidth" : 0.0,
@@ -16208,6 +16399,32 @@
             "type" : "AGGREGATED",
             "vrf" : "SOME_INSTANCE"
           },
+          "ge-0/0/0" : {
+            "name" : "ge-0/0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "ge-0/0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
           "ge-1/0/0" : {
             "name" : "ge-1/0/0",
             "accessVlan" : 0,
@@ -16215,9 +16432,35 @@
             "allowedVlans" : "",
             "autostate" : true,
             "bandwidth" : 1.0E9,
-            "channelGroup" : "ae0.0",
+            "channelGroup" : "ae0",
             "declaredNames" : [
               "ge-1/0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "irb" : {
+            "name" : "irb",
+            "accessVlan" : 0,
+            "active" : true,
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "irb"
             ],
             "mtu" : 1500,
             "nativeVlan" : 1,
@@ -16263,7 +16506,7 @@
             "spanningTreePortfast" : false,
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
+            "type" : "LOGICAL",
             "vrf" : "default",
             "vrrpGroups" : {
               "5" : {
@@ -16272,6 +16515,32 @@
                 "priority" : 100
               }
             }
+          },
+          "xe-0/0/0:0" : {
+            "name" : "xe-0/0/0:0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E10,
+            "declaredNames" : [
+              "xe-0/0/0:0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
           },
           "xe-0/0/0:0.0" : {
             "name" : "xe-0/0/0:0.0",
@@ -16282,6 +16551,32 @@
             "bandwidth" : 1.0E10,
             "declaredNames" : [
               "xe-0/0/0:0.0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "LOGICAL",
+            "vrf" : "default"
+          },
+          "xe-0/0/5:0" : {
+            "name" : "xe-0/0/5:0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E10,
+            "declaredNames" : [
+              "xe-0/0/5:0"
             ],
             "mtu" : 1500,
             "nativeVlan" : 1,
@@ -16322,7 +16617,7 @@
             "spanningTreePortfast" : false,
             "switchportMode" : "ACCESS",
             "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
+            "type" : "LOGICAL",
             "vrf" : "default"
           }
         },
@@ -16369,9 +16664,14 @@
           "default" : {
             "name" : "default",
             "interfaces" : [
+              "ae0",
+              "ge-0/0/0",
               "ge-1/0/0",
+              "irb",
               "irb.5",
+              "xe-0/0/0:0",
               "xe-0/0/0:0.0",
+              "xe-0/0/5:0",
               "xe-0/0/5:0.0"
             ]
           }
@@ -16384,6 +16684,32 @@
         "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "interfaces" : {
+          "ge-0/0/0" : {
+            "name" : "ge-0/0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "ge-0/0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
           "ge-0/0/0.0" : {
             "name" : "ge-0/0/0.0",
             "accessVlan" : 0,
@@ -16407,7 +16733,7 @@
             "spanningTreePortfast" : false,
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
+            "type" : "LOGICAL",
             "vrf" : "default"
           }
         },
@@ -16448,6 +16774,7 @@
           "default" : {
             "name" : "default",
             "interfaces" : [
+              "ge-0/0/0",
               "ge-0/0/0.0"
             ]
           }
@@ -17040,6 +17367,32 @@
         "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "interfaces" : {
+          "irb" : {
+            "name" : "irb",
+            "accessVlan" : 0,
+            "active" : true,
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "irb"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
           "irb.10" : {
             "name" : "irb.10",
             "accessVlan" : 0,
@@ -17066,7 +17419,7 @@
             "spanningTreePortfast" : false,
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
+            "type" : "LOGICAL",
             "vrf" : "default"
           },
           "irb.20" : {
@@ -17095,7 +17448,7 @@
             "spanningTreePortfast" : false,
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
+            "type" : "LOGICAL",
             "vrf" : "default"
           }
         },
@@ -17136,6 +17489,7 @@
           "default" : {
             "name" : "default",
             "interfaces" : [
+              "irb",
               "irb.10",
               "irb.20"
             ]
@@ -18062,6 +18416,32 @@
         "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
         "interfaces" : {
+          "xe-0/0/0" : {
+            "name" : "xe-0/0/0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E10,
+            "declaredNames" : [
+              "xe-0/0/0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
           "xe-0/0/0.0" : {
             "name" : "xe-0/0/0.0",
             "accessVlan" : 0,
@@ -18085,7 +18465,7 @@
             "spanningTreePortfast" : false,
             "switchportMode" : "TRUNK",
             "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
+            "type" : "LOGICAL",
             "vrf" : "default"
           }
         },
@@ -18126,6 +18506,7 @@
           "default" : {
             "name" : "default",
             "interfaces" : [
+              "xe-0/0/0",
               "xe-0/0/0.0"
             ]
           }
@@ -25853,6 +26234,32 @@
         "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
         "interfaces" : {
+          "fxp0" : {
+            "name" : "fxp0",
+            "accessVlan" : 0,
+            "active" : false,
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E12,
+            "declaredNames" : [
+              "fxp0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
           "fxp0.0" : {
             "name" : "fxp0.0",
             "accessVlan" : 0,
@@ -25874,6 +26281,32 @@
             "ospfPassive" : false,
             "ospfPointToPoint" : false,
             "prefix" : "10.10.20.4/24",
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "LOGICAL",
+            "vrf" : "default"
+          },
+          "irb" : {
+            "name" : "irb",
+            "accessVlan" : 0,
+            "active" : true,
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "irb"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
             "proxyArp" : false,
             "ripEnabled" : false,
             "ripPassive" : false,
@@ -25910,16 +26343,39 @@
             "spanningTreePortfast" : false,
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
+            "type" : "LOGICAL",
+            "vrf" : "default"
+          },
+          "lo0" : {
+            "name" : "lo0",
+            "accessVlan" : 0,
+            "active" : true,
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E12,
+            "declaredNames" : [
+              "lo0"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "LOOPBACK",
             "vrf" : "default"
           },
           "lo0.0" : {
             "name" : "lo0.0",
             "accessVlan" : 0,
             "active" : true,
-            "allPrefixes" : [
-              "192.168.1.2/32"
-            ],
             "allowedVlans" : "",
             "autostate" : true,
             "bandwidth" : 1.0E12,
@@ -25933,15 +26389,14 @@
             "ospfHelloMultiplier" : 0,
             "ospfPassive" : false,
             "ospfPointToPoint" : false,
-            "prefix" : "192.168.1.2/32",
             "proxyArp" : false,
             "ripEnabled" : false,
             "ripPassive" : false,
             "spanningTreePortfast" : false,
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
+            "type" : "LOOPBACK",
+            "vrf" : "fabric"
           },
           "lo0.1" : {
             "name" : "lo0.1",
@@ -25970,8 +26425,34 @@
             "spanningTreePortfast" : false,
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
+            "type" : "LOOPBACK",
             "vrf" : "vr"
+          },
+          "xe-0/0/2" : {
+            "name" : "xe-0/0/2",
+            "accessVlan" : 0,
+            "active" : true,
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E10,
+            "declaredNames" : [
+              "xe-0/0/2"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
           },
           "xe-0/0/2.0" : {
             "name" : "xe-0/0/2.0",
@@ -25994,6 +26475,32 @@
             "ospfPassive" : false,
             "ospfPointToPoint" : false,
             "prefix" : "172.16.7.1/30",
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "LOGICAL",
+            "vrf" : "default"
+          },
+          "xe-0/0/3" : {
+            "name" : "xe-0/0/3",
+            "accessVlan" : 0,
+            "active" : true,
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E10,
+            "declaredNames" : [
+              "xe-0/0/3"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
             "proxyArp" : false,
             "ripEnabled" : false,
             "ripPassive" : false,
@@ -26030,6 +26537,32 @@
             "spanningTreePortfast" : false,
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "LOGICAL",
+            "vrf" : "default"
+          },
+          "xe-0/0/4" : {
+            "name" : "xe-0/0/4",
+            "accessVlan" : 0,
+            "active" : true,
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E10,
+            "declaredNames" : [
+              "xe-0/0/4"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
             "type" : "PHYSICAL",
             "vrf" : "default"
           },
@@ -26060,7 +26593,7 @@
             "spanningTreePortfast" : false,
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
+            "type" : "LOGICAL",
             "vrf" : "default"
           }
         },
@@ -27282,16 +27815,25 @@
               "tieBreaker" : "ARRIVAL_ORDER"
             },
             "interfaces" : [
+              "fxp0",
               "fxp0.0",
+              "irb",
               "irb.100",
+              "lo0",
               "lo0.0",
+              "xe-0/0/2",
               "xe-0/0/2.0",
+              "xe-0/0/3",
               "xe-0/0/3.0",
+              "xe-0/0/4",
               "xe-0/0/4.0"
             ]
           },
           "fabric" : {
-            "name" : "fabric"
+            "name" : "fabric",
+            "interfaces" : [
+              "lo0.0"
+            ]
           },
           "vr" : {
             "name" : "vr",


### PR DESCRIPTION
Few things happening here:
- Put juniper physical interfaces in the VI datamodel
- Track dependencies between units and physical interfaces
- Fix the todo introduced in #2604 
- Introduce another todo: we should be disabling interfaces based on dependencies now and not portChannelGroupMembers. I have fixes for this locally but I didn't want to glom too much into 1 PR since it's a non-trivial change.
- Correctly identify loopback and unit interfaces on juniper