### PR TITLE
Fix NodeRoleDimension type being null when converting from bean

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/role/NodeRoleDimension.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/role/NodeRoleDimension.java
@@ -48,7 +48,7 @@ public final class NodeRoleDimension implements Comparable<NodeRoleDimension> {
           _type != Type.AUTO || _name.startsWith(AUTO_DIMENSION_PREFIX),
           "Name for a AUTO role dimension must begin with: %s",
           AUTO_DIMENSION_PREFIX);
-      return new NodeRoleDimension(_name, _roles, _type, _roleRegexes);
+      return new NodeRoleDimension(_name, _roles, firstNonNull(_type, Type.CUSTOM), _roleRegexes);
     }
 
     public @Nonnull Builder setName(String name) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/role/NodeRolesData.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/role/NodeRolesData.java
@@ -115,7 +115,7 @@ public class NodeRolesData {
    *
    * @throws IOException If the contents of the file could not be cast to {@link NodeRolesData}
    */
-  @Nullable
+  @Nonnull
   private Optional<NodeRoleDimension> getNodeRoleDimension() throws IOException {
     // check default
     if (getDefaultDimension() != null) {


### PR DESCRIPTION
When running with `@Nonnull` annotation enforcement, `testAddNodeRoleDimension` was failing. Root cause: `getType()` was returning null so the NodeRoleDimension could not be serialized to disk.

Fixed that and also made one minor annotation change to `getNodeRoleDimension` spotted by intellij.