### PR TITLE
preserve order of NatRule definitions

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -2311,12 +2311,8 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   @Override
   public void enterNat_rule_set(Nat_rule_setContext ctx) {
     String rulesetName = ctx.name.getText();
-    Map<String, NatRuleSet> currentNatRuleSets = _currentNat.getRuleSets();
-    _currentNatRuleSet = currentNatRuleSets.get(rulesetName);
-    if (_currentNatRuleSet == null) {
-      _currentNatRuleSet = new NatRuleSet();
-      currentNatRuleSets.put(rulesetName, _currentNatRuleSet);
-    }
+    _currentNatRuleSet =
+        _currentNat.getRuleSets().computeIfAbsent(rulesetName, k -> new NatRuleSet());
     defineStructure(NAT_RULE_SET, rulesetName, ctx);
   }
 
@@ -2713,8 +2709,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
     _currentNatRule =
         currentNatRules.isEmpty() ? null : currentNatRules.get(currentNatRules.size() - 1);
     if (_currentNatRule == null || !name.equals(_currentNatRule.getName())) {
-      _currentNatRule = new NatRule();
-      _currentNatRule.setName(name);
+      _currentNatRule = new NatRule(name);
       currentNatRules.add(_currentNatRule);
     }
     defineStructure(NAT_RULE, name, ctx);

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -2316,7 +2316,6 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
     if (_currentNatRuleSet == null) {
       _currentNatRuleSet = new NatRuleSet();
       currentNatRuleSets.put(rulesetName, _currentNatRuleSet);
-      _currentNatRule = null;
     }
     defineStructure(NAT_RULE_SET, rulesetName, ctx);
   }

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -1838,8 +1838,6 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
 
   private NatRuleSet _currentNatRuleSet;
 
-  private Map<String, NatRule> _currentNatRuleSetRules;
-
   private PolicyStatement _currentPolicyStatement;
 
   private PrefixList _currentPrefixList;
@@ -2318,7 +2316,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
     if (_currentNatRuleSet == null) {
       _currentNatRuleSet = new NatRuleSet();
       currentNatRuleSets.put(rulesetName, _currentNatRuleSet);
-      _currentNatRuleSetRules = new TreeMap<>();
+      _currentNatRule = null;
     }
     defineStructure(NAT_RULE_SET, rulesetName, ctx);
   }
@@ -2712,12 +2710,13 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   @Override
   public void enterRs_rule(Rs_ruleContext ctx) {
     String name = ctx.name.getText();
-    _currentNatRule = _currentNatRuleSetRules.get(name);
-    if (_currentNatRule == null) {
+    List<NatRule> currentNatRules = _currentNatRuleSet.getRules();
+    _currentNatRule =
+        currentNatRules.isEmpty() ? null : currentNatRules.get(currentNatRules.size() - 1);
+    if (_currentNatRule == null || !name.equals(_currentNatRule.getName())) {
       _currentNatRule = new NatRule();
       _currentNatRule.setName(name);
-      _currentNatRuleSet.getRules().add(_currentNatRule);
-      _currentNatRuleSetRules.put(name, _currentNatRule);
+      currentNatRules.add(_currentNatRule);
     }
     defineStructure(NAT_RULE, name, ctx);
   }

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -1838,6 +1838,8 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
 
   private NatRuleSet _currentNatRuleSet;
 
+  private Map<String, NatRule> _currentNatRuleSetRules;
+
   private PolicyStatement _currentPolicyStatement;
 
   private PrefixList _currentPrefixList;
@@ -2311,8 +2313,13 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   @Override
   public void enterNat_rule_set(Nat_rule_setContext ctx) {
     String rulesetName = ctx.name.getText();
-    _currentNatRuleSet =
-        _currentNat.getRuleSets().computeIfAbsent(rulesetName, p -> new NatRuleSet());
+    Map<String, NatRuleSet> currentNatRuleSets = _currentNat.getRuleSets();
+    _currentNatRuleSet = currentNatRuleSets.get(rulesetName);
+    if (_currentNatRuleSet == null) {
+      _currentNatRuleSet = new NatRuleSet();
+      currentNatRuleSets.put(rulesetName, _currentNatRuleSet);
+      _currentNatRuleSetRules = new TreeMap<>();
+    }
     defineStructure(NAT_RULE_SET, rulesetName, ctx);
   }
 
@@ -2705,7 +2712,13 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   @Override
   public void enterRs_rule(Rs_ruleContext ctx) {
     String name = ctx.name.getText();
-    _currentNatRule = _currentNatRuleSet.getRules().computeIfAbsent(name, r -> new NatRule());
+    _currentNatRule = _currentNatRuleSetRules.get(name);
+    if (_currentNatRule == null) {
+      _currentNatRule = new NatRule();
+      _currentNatRule.setName(name);
+      _currentNatRuleSet.getRules().add(_currentNatRule);
+      _currentNatRuleSetRules.put(name, _currentNatRule);
+    }
     defineStructure(NAT_RULE, name, ctx);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/NatRule.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/NatRule.java
@@ -15,13 +15,13 @@ public final class NatRule implements Serializable {
 
   private List<NatRuleMatch> _matches;
 
-  private String _name;
+  private final String _name;
 
   @Nullable private NatRuleThen _then;
 
-  public NatRule() {
+  public NatRule(String name) {
     _matches = new LinkedList<>();
-    _name = null;
+    _name = name;
     _then = null;
   }
 
@@ -38,10 +38,6 @@ public final class NatRule implements Serializable {
   @Nullable
   public NatRuleThen getThen() {
     return _then;
-  }
-
-  public void setName(@Nullable String name) {
-    _name = name;
   }
 
   public void setThen(@Nullable NatRuleThen then) {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/NatRule.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/NatRule.java
@@ -15,10 +15,13 @@ public final class NatRule implements Serializable {
 
   private List<NatRuleMatch> _matches;
 
+  private String _name;
+
   @Nullable private NatRuleThen _then;
 
   public NatRule() {
     _matches = new LinkedList<>();
+    _name = null;
     _then = null;
   }
 
@@ -28,8 +31,17 @@ public final class NatRule implements Serializable {
   }
 
   @Nullable
+  public String getName() {
+    return _name;
+  }
+
+  @Nullable
   public NatRuleThen getThen() {
     return _then;
+  }
+
+  public void setName(@Nullable String name) {
+    _name = name;
   }
 
   public void setThen(@Nullable NatRuleThen then) {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/NatRuleSet.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/NatRuleSet.java
@@ -1,8 +1,8 @@
 package org.batfish.representation.juniper;
 
 import java.io.Serializable;
-import java.util.Map;
-import java.util.TreeMap;
+import java.util.ArrayList;
+import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -14,13 +14,13 @@ public final class NatRuleSet implements Serializable {
 
   private final NatPacketLocation _fromLocation;
 
-  private final Map<String, NatRule> _rules;
+  private final List<NatRule> _rules;
 
   private final NatPacketLocation _toLocation;
 
   public NatRuleSet() {
     _fromLocation = new NatPacketLocation();
-    _rules = new TreeMap<>();
+    _rules = new ArrayList<>();
     _toLocation = new NatPacketLocation();
   }
 
@@ -30,7 +30,7 @@ public final class NatRuleSet implements Serializable {
   }
 
   @Nonnull
-  public Map<String, NatRule> getRules() {
+  public List<NatRule> getRules() {
     return _rules;
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -2512,11 +2512,12 @@ public class FlatJuniperGrammarTest {
     assertThat(ruleSet.getFromLocation().getZone(), equalTo("FROM-ZONE"));
 
     // test rules
-    Map<String, NatRule> rules = ruleSet.getRules();
-    assertThat(rules.keySet(), containsInAnyOrder("RULE1", "RULE2"));
+    List<NatRule> rules = ruleSet.getRules();
+    assertThat(rules, hasSize(2));
 
     // test rule1
-    NatRule rule1 = rules.get("RULE1");
+    NatRule rule1 = rules.get(0);
+    assertThat(rule1.getName(), equalTo("RULE1"));
     assertThat(
         rule1.getMatches(),
         equalTo(
@@ -2526,7 +2527,8 @@ public class FlatJuniperGrammarTest {
     assertThat(rule1.getThen(), equalTo(NatRuleThenOff.INSTANCE));
 
     // test rule2
-    NatRule rule2 = rules.get("RULE2");
+    NatRule rule2 = rules.get(1);
+    assertThat(rule2.getName(), equalTo("RULE2"));
     assertThat(
         rule2.getMatches(),
         equalTo(
@@ -2582,11 +2584,12 @@ public class FlatJuniperGrammarTest {
     assertThat(ruleSet.getToLocation().getZone(), equalTo("TO-ZONE"));
 
     // test rules
-    Map<String, NatRule> rules = ruleSet.getRules();
-    assertThat(rules.keySet(), containsInAnyOrder("RULE1", "RULE2"));
+    List<NatRule> rules = ruleSet.getRules();
+    assertThat(rules, hasSize(2));
 
     // test rule1
-    NatRule rule1 = rules.get("RULE1");
+    NatRule rule1 = rules.get(0);
+    assertThat(rule1.getName(), equalTo("RULE1"));
     assertThat(
         rule1.getMatches(),
         equalTo(
@@ -2596,7 +2599,8 @@ public class FlatJuniperGrammarTest {
     assertThat(rule1.getThen(), equalTo(NatRuleThenOff.INSTANCE));
 
     // test rule2
-    NatRule rule2 = rules.get("RULE2");
+    NatRule rule2 = rules.get(1);
+    assertThat(rule2.getName(), equalTo("RULE2"));
     assertThat(
         rule2.getMatches(),
         equalTo(


### PR DESCRIPTION
Currently NatRules in a NatRuleSet are kept in a map, and the order in
which they are defined is lost. The semantics requires they be applied
in definition order, so this change stores them in a list instead (and
makes the NatRule name a field rather than a key in the map).