### PR TITLE
Juniper: infer bandwidth for "et:" interfaces

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
@@ -32,6 +32,8 @@ public class Interface implements Serializable {
       return 1E8;
     } else if (name.startsWith("irb")) {
       return 1E9;
+    } else if (name.startsWith("et")) {
+      return 1E11;
     } else {
       return 1E12;
     }

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -16190,7 +16190,7 @@
             "active" : true,
             "allowedVlans" : "",
             "autostate" : true,
-            "bandwidth" : 1.0E12,
+            "bandwidth" : 1.0E11,
             "declaredNames" : [
               "et-0/0/10"
             ],
@@ -16216,7 +16216,7 @@
             "active" : true,
             "allowedVlans" : "",
             "autostate" : true,
-            "bandwidth" : 1.0E12,
+            "bandwidth" : 1.0E11,
             "declaredNames" : [
               "et-0/0/10.0"
             ],


### PR DESCRIPTION
Docs say (https://www.juniper.net/documentation/en_US/junos/topics/concept/interfaces-interface-naming-overview.html)
that "et-*" should be 100G interfaces.