### PR TITLE
Juniper: fix a bug where interface dependency was pointing the wrong way

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -1207,7 +1207,6 @@ public final class JuniperConfiguration extends VendorConfiguration {
     // 802.3ad link aggregation
     if (iface.get8023adInterface() != null) {
       newIface.setChannelGroup(iface.get8023adInterface());
-      newIface.addDependency(new Dependency(iface.get8023adInterface(), DependencyType.AGGREGATE));
     }
 
     newIface.setBandwidth(iface.getBandwidth());
@@ -2555,6 +2554,25 @@ public final class JuniperConfiguration extends VendorConfiguration {
                             new Dependency(newParentIface.getName(), DependencyType.BIND));
                         resolveInterfacePointers(unit.getName(), unit, newUnitInterface);
                       });
+            });
+
+    /*
+     * Do a second pass where we look over all interfaces
+     * and set dependency pointers for aggregated interfaces in the VI configuration
+     */
+    Stream.concat(
+            _masterLogicalSystem.getInterfaces().values().stream(),
+            _nodeDevices
+                .values()
+                .stream()
+                .flatMap(nodeDevice -> nodeDevice.getInterfaces().values().stream()))
+        .forEach(
+            iface -> {
+              if (iface.get8023adInterface() != null) {
+                org.batfish.datamodel.Interface viIface =
+                    _c.getAllInterfaces().get(iface.get8023adInterface());
+                viIface.addDependency(new Dependency(iface.getName(), DependencyType.AGGREGATE));
+              }
             });
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -2571,6 +2571,9 @@ public final class JuniperConfiguration extends VendorConfiguration {
               if (iface.get8023adInterface() != null) {
                 org.batfish.datamodel.Interface viIface =
                     _c.getAllInterfaces().get(iface.get8023adInterface());
+                if (viIface == null) {
+                  return;
+                }
                 viIface.addDependency(new Dependency(iface.getName(), DependencyType.AGGREGATE));
               }
             });

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperAggregationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperAggregationTest.java
@@ -2,6 +2,7 @@ package org.batfish.grammar.flatjuniper;
 
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasInterface;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasBandwidth;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertThat;
 
@@ -10,6 +11,8 @@ import java.util.Arrays;
 import java.util.SortedMap;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Edge;
+import org.batfish.datamodel.Interface.Dependency;
+import org.batfish.datamodel.Interface.DependencyType;
 import org.batfish.datamodel.Topology;
 import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
@@ -39,6 +42,9 @@ public class FlatJuniperAggregationTest {
     // interfaces
     assertThat(configs.get("ae1"), hasInterface("ae1.0", hasBandwidth(1e9)));
     assertThat(configs.get("ae1"), hasInterface("ae1.1", hasBandwidth(1e9)));
+    assertThat(
+        configs.get("ae1").getAllInterfaces().get("ae1").getDependencies(),
+        contains(new Dependency("ge-0/0/0", DependencyType.AGGREGATE)));
     assertThat(
         t.getEdges(),
         containsInAnyOrder(


### PR DESCRIPTION
Dependency pointer should go AE -> physical interface, not the other way around.