### PR TITLE
Juniper interface: add support for 'c' modifier

### DIFF
--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchers.java
@@ -23,6 +23,7 @@ import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasAccessVlan;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasAdditionalArpIps;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasAllAddresses;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasAllowedVlans;
+import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasBandwidth;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasDeclaredNames;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasDescription;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasEigrp;
@@ -92,6 +93,14 @@ public final class InterfaceMatchers {
   public static HasAdditionalArpIps hasAdditionalArpIps(
       @Nonnull Matcher<? super SortedSet<Ip>> subMatcher) {
     return new HasAdditionalArpIps(subMatcher);
+  }
+
+  /**
+   * Provides a matcher that matches if the provided {@code subMatcher} matches the interface's
+   * bandwidth.
+   */
+  public static HasBandwidth hasBandwidth(@Nonnull Matcher<? super Double> subMatcher) {
+    return new HasBandwidth(subMatcher);
   }
 
   /**

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -591,6 +591,11 @@ BUNDLE
    'bundle'
 ;
 
+C
+:
+    'c'
+;
+
 CATEGORIES
 :
    'categories'
@@ -6690,6 +6695,11 @@ mode M_Bandwidth;
 M_Bandwidth_DEC
 :
   F_Digit+ -> type ( DEC )
+;
+
+M_Bandwidth_C
+:
+  'c' -> type ( C ) , popMode
 ;
 
 M_Bandwidth_G

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_common.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_common.g4
@@ -531,7 +531,8 @@ bandwidth
 :
   base = DEC
   (
-    K
+    C
+    | K
     | M
     | G
   )?

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -856,7 +856,10 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
 
   private static long toBandwidth(BandwidthContext ctx) {
     long base = toLong(ctx.base);
-    if (ctx.K() != null) {
+    if (ctx.C() != null) {
+      // https://www.juniper.net/documentation/en_US/junos/topics/task/configuration/interfaces-configuring-the-interface-bandwidth.html
+      return base * 384L;
+    } else if (ctx.K() != null) {
       return base * 1000L;
     } else if (ctx.M() != null) {
       return base * 1000000L;

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -177,6 +177,7 @@ import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.IkeAuthenticationMethod;
 import org.batfish.datamodel.IkeHashingAlgorithm;
 import org.batfish.datamodel.IntegerSpace;
+import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpAccessList;

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -32,6 +32,7 @@ import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasIpsecPolic
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasIpsecProposal;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasVrf;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasVrfs;
+import static org.batfish.datamodel.matchers.DataModelMatchers.hasBandwidth;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasDefinedStructureWithDefinitionLines;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasIsisProcess;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasNumReferrers;
@@ -172,7 +173,6 @@ import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.IkeAuthenticationMethod;
 import org.batfish.datamodel.IkeHashingAlgorithm;
 import org.batfish.datamodel.IntegerSpace;
-import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpAccessList;
@@ -1774,17 +1774,22 @@ public class FlatJuniperGrammarTest {
   public void testInterfaceBandwidth() throws IOException {
     Configuration c = parseConfig("interface-bandwidth");
 
-    // Configuration has four interfaces with configured bandwidths 5000000000, 5000000k, 5000m, 5g.
-    // Physical interfaces should have default bandwidth (1E9), unit interfaces should have 5E9.
+    // Configuration has ge-0/0/0 with four units configured bandwidths 5000000000, 5000000k, 5000m,
+    // 5g. Physical interface should have default bandwidth (1E9), unit interfaces should have 5E9.
     double unitBandwidth = 5E9;
     double physicalBandwidth =
         org.batfish.representation.juniper.Interface.getDefaultBandwidthByName("ge-0/0/0");
 
-    Map<String, Interface> interfaces = c.getAllInterfaces();
-    for (int i = 0; i < 4; i++) {
-      assertThat(interfaces.get("ge-" + i + "/0/0").getBandwidth(), equalTo(physicalBandwidth));
-      assertThat(interfaces.get("ge-" + i + "/0/0.0").getBandwidth(), equalTo(unitBandwidth));
-    }
+    assertThat(c, hasInterface("ge-0/0/0", hasBandwidth(physicalBandwidth)));
+    assertThat(c, hasInterface("ge-0/0/0.0", hasBandwidth(unitBandwidth)));
+    assertThat(c, hasInterface("ge-0/0/0.1", hasBandwidth(unitBandwidth)));
+    assertThat(c, hasInterface("ge-0/0/0.2", hasBandwidth(unitBandwidth)));
+    assertThat(c, hasInterface("ge-0/0/0.3", hasBandwidth(unitBandwidth)));
+
+    // Configuration has ge-1/0/0 with one units configured bandwidth 10c (1c = 384 bps).
+    // Physical interface should have default bandwidth (1E9), unit interfaces should have 5E9.
+    assertThat(c, hasInterface("ge-1/0/0", hasBandwidth(physicalBandwidth)));
+    assertThat(c, hasInterface("ge-1/0/0.0", hasBandwidth(3840)));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -1786,8 +1786,8 @@ public class FlatJuniperGrammarTest {
     assertThat(c, hasInterface("ge-0/0/0.2", hasBandwidth(unitBandwidth)));
     assertThat(c, hasInterface("ge-0/0/0.3", hasBandwidth(unitBandwidth)));
 
-    // Configuration has ge-1/0/0 with one units configured bandwidth 10c (1c = 384 bps).
-    // Physical interface should have default bandwidth (1E9), unit interfaces should have 5E9.
+    // Configuration has ge-1/0/0 with one unit with configured bandwidth 10c (1c = 384 bps).
+    // Physical interface should have default bandwidth (1E9), unit 3840.
     assertThat(c, hasInterface("ge-1/0/0", hasBandwidth(physicalBandwidth)));
     assertThat(c, hasInterface("ge-1/0/0.0", hasBandwidth(3840)));
   }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interface-bandwidth
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interface-bandwidth
@@ -2,6 +2,7 @@
 set system host-name interface-bandwidth
 #
 set interfaces ge-0/0/0 unit 0 bandwidth 5000000000
-set interfaces ge-1/0/0 unit 0 bandwidth 5000000k
-set interfaces ge-2/0/0 unit 0 bandwidth 5000m
-set interfaces ge-3/0/0 unit 0 bandwidth 5g
+set interfaces ge-0/0/0 unit 1 bandwidth 5000000k
+set interfaces ge-0/0/0 unit 2 bandwidth 5000m
+set interfaces ge-0/0/0 unit 3 bandwidth 5g
+set interfaces ge-1/0/0 unit 0 bandwidth 10c

--- a/tests/parsing-tests/networks/unit-tests/configs/juniper_interfaces
+++ b/tests/parsing-tests/networks/unit-tests/configs/juniper_interfaces
@@ -6,6 +6,7 @@ set interfaces ae0 unit 0 family ethernet-switching vlan members 1-1000
 set interfaces ge-0/0/0 forwarding-class-accounting
 set interfaces ge-1/0/0 ether-options 802.3ad ae0
 set interfaces ge-2/0/0 unit 0 bandwidth 5
+set interfaces ge-2/0/0 unit 1 bandwidth 5c
 set interfaces ge-3/0/0 unit 0 bandwidth 5k
 set interfaces ge-4/0/0 unit 0 bandwidth 5m
 set interfaces ge-5/0/0 unit 0 bandwidth 5g

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -16584,6 +16584,32 @@
             "type" : "LOGICAL",
             "vrf" : "default"
           },
+          "ge-2/0/0.1" : {
+            "name" : "ge-2/0/0.1",
+            "accessVlan" : 0,
+            "active" : true,
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1920.0,
+            "declaredNames" : [
+              "ge-2/0/0.1"
+            ],
+            "mtu" : 1500,
+            "nativeVlan" : 1,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "LOGICAL",
+            "vrf" : "default"
+          },
           "ge-3/0/0" : {
             "name" : "ge-3/0/0",
             "accessVlan" : 0,
@@ -16958,6 +16984,7 @@
               "ge-1/0/0",
               "ge-2/0/0",
               "ge-2/0/0.0",
+              "ge-2/0/0.1",
               "ge-3/0/0",
               "ge-3/0/0.0",
               "ge-4/0/0",

--- a/tests/parsing-tests/unit-tests-undefined.ref
+++ b/tests/parsing-tests/unit-tests-undefined.ref
@@ -2594,7 +2594,7 @@
         "Lines" : {
           "filename" : "configs/juniper_interfaces",
           "lines" : [
-            20
+            21
           ]
         }
       },
@@ -2606,7 +2606,7 @@
         "Lines" : {
           "filename" : "configs/juniper_interfaces",
           "lines" : [
-            18
+            19
           ]
         }
       },

--- a/tests/parsing-tests/unit-tests-unused.ref
+++ b/tests/parsing-tests/unit-tests-unused.ref
@@ -2094,8 +2094,8 @@
         "Source_Lines" : {
           "filename" : "configs/juniper_interfaces",
           "lines" : [
-            22,
-            23
+            23,
+            24
           ]
         }
       },

--- a/tests/parsing-tests/unit-tests-warnings.ref
+++ b/tests/parsing-tests/unit-tests-warnings.ref
@@ -534,7 +534,7 @@
       },
       {
         "Filename" : "juniper_interfaces",
-        "Line" : 17,
+        "Line" : 18,
         "Text" : "tcp-mss 1400",
         "Parser_Context" : "[ifi_tcp_mss if_inet i_family i_common i_unit int_named s_interfaces s_common statement set_line_tail set_line flat_juniper_configuration]",
         "Comment" : "This feature is not currently supported"

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -47302,6 +47302,25 @@
             "            INTERFACES:'interfaces'",
             "            (int_named",
             "              (interface_id",
+            "                name = VARIABLE:'ge-2/0/0'  <== mode:M_Interface)",
+            "              (i_unit",
+            "                UNIT:'unit'",
+            "                num = DEC:'1'",
+            "                (i_bandwidth",
+            "                  BANDWIDTH:'bandwidth'",
+            "                  (bandwidth",
+            "                    base = DEC:'5'  <== mode:M_Bandwidth",
+            "                    C:'c'  <== mode:M_Bandwidth))))))))",
+            "    NEWLINE:'\\n')",
+            "  (set_line",
+            "    SET:'set'",
+            "    (set_line_tail",
+            "      (statement",
+            "        (s_common",
+            "          (s_interfaces",
+            "            INTERFACES:'interfaces'",
+            "            (int_named",
+            "              (interface_id",
             "                name = VARIABLE:'ge-3/0/0'  <== mode:M_Interface)",
             "              (i_unit",
             "                UNIT:'unit'",
@@ -61066,7 +61085,7 @@
           "Parse warnings" : [
             {
               "Comment" : "This feature is not currently supported",
-              "Line" : 17,
+              "Line" : 18,
               "Parser_Context" : "[ifi_tcp_mss if_inet i_family i_common i_unit int_named s_interfaces s_common statement set_line_tail set_line flat_juniper_configuration]",
               "Text" : "tcp-mss 1400"
             }
@@ -64750,9 +64769,10 @@
             },
             "ge-2/0/0" : {
               "definitionLines" : [
-                8
+                8,
+                9
               ],
-              "numReferrers" : 1
+              "numReferrers" : 2
             },
             "ge-2/0/0.0" : {
               "definitionLines" : [
@@ -64760,82 +64780,88 @@
               ],
               "numReferrers" : 1
             },
-            "ge-3/0/0" : {
+            "ge-2/0/0.1" : {
               "definitionLines" : [
                 9
+              ],
+              "numReferrers" : 1
+            },
+            "ge-3/0/0" : {
+              "definitionLines" : [
+                10
               ],
               "numReferrers" : 1
             },
             "ge-3/0/0.0" : {
               "definitionLines" : [
-                9
+                10
               ],
               "numReferrers" : 1
             },
             "ge-4/0/0" : {
               "definitionLines" : [
-                10
+                11
               ],
               "numReferrers" : 1
             },
             "ge-4/0/0.0" : {
               "definitionLines" : [
-                10
+                11
               ],
               "numReferrers" : 1
             },
             "ge-5/0/0" : {
               "definitionLines" : [
-                11
+                12
               ],
               "numReferrers" : 1
             },
             "ge-5/0/0.0" : {
               "definitionLines" : [
-                11
+                12
               ],
               "numReferrers" : 1
             },
             "irb" : {
               "definitionLines" : [
-                14,
                 15,
                 16,
-                17
+                17,
+                18
               ],
               "numReferrers" : 4
             },
             "irb.5" : {
               "definitionLines" : [
-                14,
                 15,
                 16,
-                17
+                17,
+                18
               ],
               "numReferrers" : 4
             },
             "xe-0/0/0:0" : {
               "definitionLines" : [
-                12,
-                13
+                13,
+                14
               ],
               "numReferrers" : 2
             },
             "xe-0/0/0:0.0" : {
               "definitionLines" : [
-                13
+                14
               ],
               "numReferrers" : 1
             },
             "xe-0/0/5:0" : {
               "definitionLines" : [
-                18
+                19
               ],
               "numReferrers" : 1
             },
             "xe-0/0/5:0.0" : {
               "definitionLines" : [
-                18
+                19
               ],
               "numReferrers" : 1
             }
@@ -64843,8 +64869,8 @@
           "vlan" : {
             "unused-vlan" : {
               "definitionLines" : [
-                22,
-                23
+                23,
+                24
               ],
               "numReferrers" : 0
             }
@@ -68051,7 +68077,7 @@
             },
             "ge-0/0/1" : {
               "routing-instance interface" : [
-                20
+                21
               ]
             },
             "ge-1/0/0" : {
@@ -68061,7 +68087,8 @@
             },
             "ge-2/0/0" : {
               "interface" : [
-                8
+                8,
+                9
               ]
             },
             "ge-2/0/0.0" : {
@@ -68069,78 +68096,83 @@
                 8
               ]
             },
-            "ge-3/0/0" : {
+            "ge-2/0/0.1" : {
               "interface" : [
                 9
+              ]
+            },
+            "ge-3/0/0" : {
+              "interface" : [
+                10
               ]
             },
             "ge-3/0/0.0" : {
               "interface" : [
-                9
+                10
               ]
             },
             "ge-4/0/0" : {
               "interface" : [
-                10
+                11
               ]
             },
             "ge-4/0/0.0" : {
               "interface" : [
-                10
+                11
               ]
             },
             "ge-5/0/0" : {
               "interface" : [
-                11
+                12
               ]
             },
             "ge-5/0/0.0" : {
               "interface" : [
-                11
+                12
               ]
             },
             "irb" : {
               "interface" : [
-                14,
                 15,
                 16,
-                17
+                17,
+                18
               ]
             },
             "irb.5" : {
               "interface" : [
-                14,
                 15,
                 16,
-                17
+                17,
+                18
               ]
             },
             "xe-0/0/0:0" : {
               "interface" : [
-                12,
-                13
+                13,
+                14
               ]
             },
             "xe-0/0/0:0.0" : {
               "interface" : [
-                13
+                14
               ]
             },
             "xe-0/0/5:0" : {
               "interface" : [
-                18
+                19
               ]
             },
             "xe-0/0/5:0.0" : {
               "interface" : [
-                18
+                19
               ]
             }
           },
           "vlan" : {
             "bippetyboppety" : {
               "interface vlan" : [
-                18
+                19
               ]
             }
           }
@@ -70025,14 +70057,14 @@
           "interface" : {
             "ge-0/0/1" : {
               "routing-instance interface" : [
-                20
+                21
               ]
             }
           },
           "vlan" : {
             "bippetyboppety" : {
               "interface vlan" : [
-                18
+                19
               ]
             }
           }


### PR DESCRIPTION
It means cells, which are apparently a unit of 384bps.

Includes a little test simplification using multiple units on the same physical interface.