### PR TITLE
Add unit test for reference bandwidth

### DIFF
--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-isis-no-reference-bandwidth
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-isis-no-reference-bandwidth
@@ -1,0 +1,9 @@
+#
+set system host-name juniper-isis-no-reference-bandwidth
+#
+set interfaces lo0 unit 0 family iso address 12.1234.1234.1234.1234.00 
+#
+set protocols isis interface lo0.0 passive
+#
+set protocols isis level 2 wide-metrics-only
+#


### PR DESCRIPTION
Tests that reference-bandwidth is applied correctly in the juniper-isis unit test and that the default Juniper IS-IS cost is used in the absence of reference-bandwidth.

Question: Is it worth making `JuniperConfiguration.DEFAULT_ISIS_COST` public and renaming to `JUNIPER_DEFAULT_ISIS_COST` rather than using a literal `10` in these tests?