### PR TITLE
AbstractRoute: add nonForwarding/nonRouting to builder

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractRouteBuilder.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractRouteBuilder.java
@@ -16,6 +16,10 @@ public abstract class AbstractRouteBuilder<
 
   private Ip _nextHopIp = Route.UNSET_ROUTE_NEXT_HOP_IP;
 
+  private boolean _nonForwarding;
+
+  private boolean _nonRouting;
+
   private int _tag = Route.UNSET_ROUTE_TAG;
 
   public abstract T build();
@@ -59,6 +63,24 @@ public abstract class AbstractRouteBuilder<
 
   public final S setNextHopIp(@Nullable Ip nextHopIp) {
     _nextHopIp = firstNonNull(nextHopIp, Route.UNSET_ROUTE_NEXT_HOP_IP);
+    return getThis();
+  }
+
+  public final boolean getNonForwarding() {
+    return _nonForwarding;
+  }
+
+  public final S setNonForwarding(boolean nonForwarding) {
+    _nonForwarding = nonForwarding;
+    return getThis();
+  }
+
+  public final boolean getNonRouting() {
+    return _nonRouting;
+  }
+
+  public final S setNonRouting(boolean nonRouting) {
+    _nonRouting = nonRouting;
     return getThis();
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpRoute.java
@@ -68,7 +68,9 @@ public class BgpRoute extends AbstractRoute {
           _protocol,
           _receivedFromIp,
           _srcProtocol,
-          _weight);
+          _weight,
+          getNonForwarding(),
+          getNonRouting());
     }
 
     @Nonnull
@@ -269,7 +271,7 @@ public class BgpRoute extends AbstractRoute {
   private final int _weight;
 
   @JsonCreator
-  private BgpRoute(
+  private static BgpRoute jsonCreator(
       @Nullable @JsonProperty(PROP_NETWORK) Prefix network,
       @Nullable @JsonProperty(PROP_NEXT_HOP_IP) Ip nextHopIp,
       @JsonProperty(PROP_ADMINISTRATIVE_COST) int admin,
@@ -287,10 +289,53 @@ public class BgpRoute extends AbstractRoute {
       @Nullable @JsonProperty(PROP_RECEIVED_FROM_IP) Ip receivedFromIp,
       @Nullable @JsonProperty(PROP_SRC_PROTOCOL) RoutingProtocol srcProtocol,
       @JsonProperty(PROP_WEIGHT) int weight) {
-    super(network);
     checkArgument(originatorIp != null, "Missing %s", PROP_ORIGINATOR_IP);
     checkArgument(originType != null, "Missing %s", PROP_ORIGIN_TYPE);
     checkArgument(protocol != null, "Missing %s", PROP_PROTOCOL);
+    return new BgpRoute(
+        network,
+        nextHopIp,
+        admin,
+        asPath,
+        communities,
+        discard,
+        localPreference,
+        med,
+        originatorIp,
+        clusterList,
+        receivedFromRouteReflectorClient,
+        originType,
+        protocol,
+        receivedFromIp,
+        srcProtocol,
+        weight,
+        false,
+        false);
+  }
+
+  private BgpRoute(
+      @Nullable Prefix network,
+      @Nullable Ip nextHopIp,
+      int admin,
+      @Nullable AsPath asPath,
+      @Nullable SortedSet<Long> communities,
+      boolean discard,
+      int localPreference,
+      long med,
+      Ip originatorIp,
+      @Nullable SortedSet<Long> clusterList,
+      @JsonProperty(PROP_RECEIVED_FROM_ROUTE_REFLECTOR_CLIENT)
+          boolean receivedFromRouteReflectorClient,
+      OriginType originType,
+      RoutingProtocol protocol,
+      @Nullable Ip receivedFromIp,
+      @Nullable RoutingProtocol srcProtocol,
+      int weight,
+      boolean nonForwarding,
+      boolean nonRouting) {
+    super(network);
+    setNonForwarding(nonForwarding);
+    setNonRouting(nonRouting);
     _admin = admin;
     _asPath = firstNonNull(asPath, AsPath.empty());
     _clusterList =

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EigrpExternalRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EigrpExternalRoute.java
@@ -30,8 +30,11 @@ public class EigrpExternalRoute extends EigrpRoute {
       @Nullable String nextHopInterface,
       @Nullable Ip nextHopIp,
       @Nonnull EigrpMetric metric,
-      long processAsn) {
-    super(admin, network, nextHopInterface, nextHopIp, metric, processAsn);
+      long processAsn,
+      boolean nonForwarding,
+      boolean nonRouting) {
+    super(
+        admin, network, nextHopInterface, nextHopIp, metric, processAsn, nonForwarding, nonRouting);
     _destinationAsn = destinationAsn;
   }
 
@@ -45,7 +48,15 @@ public class EigrpExternalRoute extends EigrpRoute {
       @JsonProperty(PROP_EIGRP_METRIC) EigrpMetric metric,
       @JsonProperty(PROP_PROCESS_ASN) long processAsn) {
     return new EigrpExternalRoute(
-        admin, destinationAsn, network, nextHopInterface, nextHopIp, metric, processAsn);
+        admin,
+        destinationAsn,
+        network,
+        nextHopInterface,
+        nextHopIp,
+        metric,
+        processAsn,
+        false,
+        false);
   }
 
   @Override
@@ -106,7 +117,9 @@ public class EigrpExternalRoute extends EigrpRoute {
           _nextHopInterface,
           getNextHopIp(),
           requireNonNull(_eigrpMetric),
-          _processAsn);
+          _processAsn,
+          getNonForwarding(),
+          getNonRouting());
     }
 
     @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EigrpInternalRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EigrpInternalRoute.java
@@ -20,8 +20,11 @@ public class EigrpInternalRoute extends EigrpRoute {
       @Nonnull Prefix network,
       @Nullable String nextHopInterface,
       @Nullable Ip nextHopIp,
-      @Nonnull EigrpMetric metric) {
-    super(admin, network, nextHopInterface, nextHopIp, metric, processAsn);
+      @Nonnull EigrpMetric metric,
+      boolean nonForwarding,
+      boolean nonRouting) {
+    super(
+        admin, network, nextHopInterface, nextHopIp, metric, processAsn, nonForwarding, nonRouting);
   }
 
   @JsonCreator
@@ -32,7 +35,8 @@ public class EigrpInternalRoute extends EigrpRoute {
       @JsonProperty(PROP_NEXT_HOP_INTERFACE) String nextHopInterface,
       @JsonProperty(PROP_NEXT_HOP_IP) Ip nextHopIp,
       @JsonProperty(PROP_EIGRP_METRIC) EigrpMetric metric) {
-    return new EigrpInternalRoute(admin, processAsn, network, nextHopInterface, nextHopIp, metric);
+    return new EigrpInternalRoute(
+        admin, processAsn, network, nextHopInterface, nextHopIp, metric, false, false);
   }
 
   public static Builder builder() {
@@ -87,7 +91,9 @@ public class EigrpInternalRoute extends EigrpRoute {
           _nextHopInterface,
           getNextHopIp(),
           // Metric required to build route
-          requireNonNull(_eigrpMetric));
+          requireNonNull(_eigrpMetric),
+          getNonForwarding(),
+          getNonRouting());
     }
 
     @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EigrpRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EigrpRoute.java
@@ -3,7 +3,6 @@ package org.batfish.datamodel;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static java.util.Objects.requireNonNull;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import javax.annotation.Nonnull;
@@ -30,15 +29,18 @@ public abstract class EigrpRoute extends AbstractRoute {
   /** AS number of the EIGRP process that installed this route in the RIB */
   final long _processAsn;
 
-  @JsonCreator
-  protected EigrpRoute(
-      @JsonProperty(PROP_ADMINISTRATIVE_COST) int admin,
-      @JsonProperty(PROP_NETWORK) Prefix network,
-      @Nullable @JsonProperty(PROP_NEXT_HOP_INTERFACE) String nextHopInterface,
-      @Nullable @JsonProperty(PROP_NEXT_HOP_IP) Ip nextHopIp,
-      @JsonProperty(PROP_METRIC) EigrpMetric metric,
-      @JsonProperty long processAsn) {
+  EigrpRoute(
+      int admin,
+      Prefix network,
+      @Nullable String nextHopInterface,
+      @Nullable Ip nextHopIp,
+      EigrpMetric metric,
+      long processAsn,
+      boolean nonForwarding,
+      boolean nonRouting) {
     super(network);
+    setNonForwarding(nonForwarding);
+    setNonRouting(nonRouting);
     _admin = admin;
     _metric = requireNonNull(metric);
     _nextHopInterface = firstNonNull(nextHopInterface, Route.UNSET_NEXT_HOP_INTERFACE);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/GeneratedRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/GeneratedRoute.java
@@ -48,7 +48,9 @@ public final class GeneratedRoute extends AbstractRoute {
           _discard,
           _generationPolicy,
           getMetric(),
-          _nextHopInterface);
+          _nextHopInterface,
+          getNonForwarding(),
+          getNonRouting());
     }
 
     @Override
@@ -143,7 +145,7 @@ public final class GeneratedRoute extends AbstractRoute {
   private final Ip _nextHopIp;
 
   @JsonCreator
-  public GeneratedRoute(
+  private static GeneratedRoute jsonCreator(
       @JsonProperty(PROP_NETWORK) Prefix network,
       @JsonProperty(PROP_ADMINISTRATIVE_COST) int administrativeCost,
       @JsonProperty(PROP_NEXT_HOP_IP) Ip nextHopIp,
@@ -154,7 +156,37 @@ public final class GeneratedRoute extends AbstractRoute {
       @JsonProperty(PROP_GENERATION_POLICY) String generationPolicy,
       @JsonProperty(PROP_METRIC) Long metric,
       @JsonProperty(PROP_NEXT_HOP_INTERFACE) String nextHopInterface) {
+    return new GeneratedRoute(
+        network,
+        administrativeCost,
+        nextHopIp,
+        asPath,
+        attributePolicy,
+        communities,
+        discard,
+        generationPolicy,
+        metric,
+        nextHopInterface,
+        false,
+        false);
+  }
+
+  private GeneratedRoute(
+      Prefix network,
+      int administrativeCost,
+      Ip nextHopIp,
+      AsPath asPath,
+      String attributePolicy,
+      SortedSet<Long> communities,
+      boolean discard,
+      String generationPolicy,
+      Long metric,
+      String nextHopInterface,
+      boolean nonForwarding,
+      boolean nonRouting) {
     super(network);
+    setNonForwarding(nonForwarding);
+    setNonRouting(nonRouting);
     _administrativeCost = administrativeCost;
     _asPath = asPath;
     _attributePolicy = attributePolicy;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IsisRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IsisRoute.java
@@ -38,7 +38,9 @@ public class IsisRoute extends AbstractRoute {
           requireNonNull(getNetwork()),
           requireNonNull(getNextHopIp()),
           requireNonNull(_protocol),
-          requireNonNull(_systemId));
+          requireNonNull(_systemId),
+          getNonForwarding(),
+          getNonRouting());
     }
 
     @Override
@@ -113,7 +115,9 @@ public class IsisRoute extends AbstractRoute {
         requireNonNull(network),
         requireNonNull(nextHopIp),
         requireNonNull(protocol),
-        requireNonNull(systemId));
+        requireNonNull(systemId),
+        false,
+        false);
   }
 
   private final int _administrativeCost;
@@ -144,8 +148,12 @@ public class IsisRoute extends AbstractRoute {
       @Nonnull Prefix network,
       @Nonnull Ip nextHopIp,
       @Nonnull RoutingProtocol protocol,
-      @Nonnull String systemId) {
+      @Nonnull String systemId,
+      boolean nonForwarding,
+      boolean nonRouting) {
     super(network);
+    setNonForwarding(nonForwarding);
+    setNonRouting(nonRouting);
     _administrativeCost = administrativeCost;
     _area = area;
     _attach = attach;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfExternalRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfExternalRoute.java
@@ -1,6 +1,5 @@
 package org.batfish.datamodel;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import javax.annotation.Nonnull;
@@ -8,7 +7,7 @@ import org.batfish.datamodel.ospf.OspfMetricType;
 
 public abstract class OspfExternalRoute extends OspfRoute {
 
-  public static class Builder extends AbstractRouteBuilder<Builder, OspfExternalRoute> {
+  public static final class Builder extends AbstractRouteBuilder<Builder, OspfExternalRoute> {
 
     private String _advertiser;
 
@@ -34,7 +33,9 @@ public abstract class OspfExternalRoute extends OspfRoute {
                 _lsaMetric,
                 _area,
                 _costToAdvertiser,
-                _advertiser);
+                _advertiser,
+                getNonForwarding(),
+                getNonRouting());
       } else {
         route =
             new OspfExternalType2Route(
@@ -45,7 +46,9 @@ public abstract class OspfExternalRoute extends OspfRoute {
                 _lsaMetric,
                 _area,
                 _costToAdvertiser,
-                _advertiser);
+                _advertiser,
+                getNonForwarding(),
+                getNonRouting());
       }
       return route;
     }
@@ -67,25 +70,32 @@ public abstract class OspfExternalRoute extends OspfRoute {
       return this;
     }
 
-    public void setAdvertiser(String advertiser) {
+    public Builder setAdvertiser(String advertiser) {
       _advertiser = advertiser;
+      return getThis();
     }
 
-    public void setArea(long area) {
+    public Builder setArea(long area) {
       _area = area;
+      return getThis();
     }
 
-    public void setCostToAdvertiser(long costToAdvertiser) {
+    public Builder setCostToAdvertiser(long costToAdvertiser) {
       _costToAdvertiser = costToAdvertiser;
+      return getThis();
     }
 
-    public void setLsaMetric(long lsaMetric) {
+    public Builder setLsaMetric(long lsaMetric) {
       _lsaMetric = lsaMetric;
+      return getThis();
     }
 
-    public void setOspfMetricType(OspfMetricType ospfMetricType) {
+    public Builder setOspfMetricType(OspfMetricType ospfMetricType) {
       _ospfMetricType = ospfMetricType;
+      return getThis();
     }
+
+    private Builder() {} // only for use by #builder()
   }
 
   protected static final String PROP_ADVERTISER = "advertiser";
@@ -105,17 +115,24 @@ public abstract class OspfExternalRoute extends OspfRoute {
 
   private final long _lsaMetric;
 
-  @JsonCreator
-  public OspfExternalRoute(
-      @JsonProperty(PROP_NETWORK) Prefix prefix,
-      @JsonProperty(PROP_NEXT_HOP_IP) Ip nextHopIp,
-      @JsonProperty(PROP_ADMINISTRATIVE_COST) int admin,
-      @JsonProperty(PROP_METRIC) long metric,
-      @JsonProperty(PROP_LSA_METRIC) long lsaMetric,
-      @JsonProperty(PROP_AREA) long area,
-      @JsonProperty(PROP_ADVERTISER) String advertiser,
-      @JsonProperty(PROP_COST_TO_ADVERTISER) long costToAdvertiser) {
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  OspfExternalRoute(
+      Prefix prefix,
+      Ip nextHopIp,
+      int admin,
+      long metric,
+      long lsaMetric,
+      long area,
+      String advertiser,
+      long costToAdvertiser,
+      boolean nonForwarding,
+      boolean nonRouting) {
     super(prefix, nextHopIp, admin, metric, area);
+    setNonForwarding(nonForwarding);
+    setNonRouting(nonRouting);
     _advertiser = advertiser;
     _costToAdvertiser = costToAdvertiser;
     _lsaMetric = lsaMetric;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfExternalType1Route.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfExternalType1Route.java
@@ -11,7 +11,7 @@ public class OspfExternalType1Route extends OspfExternalRoute {
   private static final long serialVersionUID = 1L;
 
   @JsonCreator
-  public OspfExternalType1Route(
+  private static OspfExternalType1Route jsonCreator(
       @JsonProperty(PROP_NETWORK) Prefix prefix,
       @JsonProperty(PROP_NEXT_HOP_IP) Ip nextHopIp,
       @JsonProperty(PROP_ADMINISTRATIVE_COST) int admin,
@@ -20,7 +20,41 @@ public class OspfExternalType1Route extends OspfExternalRoute {
       @JsonProperty(PROP_AREA) long area,
       @JsonProperty(PROP_COST_TO_ADVERTISER) long costToAdvertiser,
       @JsonProperty(PROP_ADVERTISER) String advertiser) {
-    super(prefix, nextHopIp, admin, metric, lsaMetric, area, advertiser, costToAdvertiser);
+    return new OspfExternalType1Route(
+        prefix,
+        nextHopIp,
+        admin,
+        metric,
+        lsaMetric,
+        area,
+        costToAdvertiser,
+        advertiser,
+        false,
+        false);
+  }
+
+  OspfExternalType1Route(
+      Prefix prefix,
+      Ip nextHopIp,
+      int admin,
+      long metric,
+      long lsaMetric,
+      long area,
+      long costToAdvertiser,
+      String advertiser,
+      boolean nonForwarding,
+      boolean nonRouting) {
+    super(
+        prefix,
+        nextHopIp,
+        admin,
+        metric,
+        lsaMetric,
+        area,
+        advertiser,
+        costToAdvertiser,
+        nonForwarding,
+        nonRouting);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfExternalType2Route.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfExternalType2Route.java
@@ -11,7 +11,7 @@ public class OspfExternalType2Route extends OspfExternalRoute {
   private static final long serialVersionUID = 1L;
 
   @JsonCreator
-  public OspfExternalType2Route(
+  private static OspfExternalType2Route jsonCreator(
       @JsonProperty(PROP_NETWORK) Prefix network,
       @JsonProperty(PROP_NEXT_HOP_IP) Ip nextHopIp,
       @JsonProperty(PROP_ADMINISTRATIVE_COST) int admin,
@@ -20,7 +20,41 @@ public class OspfExternalType2Route extends OspfExternalRoute {
       @JsonProperty(PROP_AREA) long area,
       @JsonProperty(PROP_COST_TO_ADVERTISER) long costToAdvertiser,
       @JsonProperty(PROP_ADVERTISER) String advertiser) {
-    super(network, nextHopIp, admin, metric, lsaMetric, area, advertiser, costToAdvertiser);
+    return new OspfExternalType2Route(
+        network,
+        nextHopIp,
+        admin,
+        metric,
+        lsaMetric,
+        area,
+        costToAdvertiser,
+        advertiser,
+        false,
+        false);
+  }
+
+  OspfExternalType2Route(
+      Prefix network,
+      Ip nextHopIp,
+      int admin,
+      long metric,
+      long lsaMetric,
+      long area,
+      long costToAdvertiser,
+      String advertiser,
+      boolean nonForwarding,
+      boolean nonRouting) {
+    super(
+        network,
+        nextHopIp,
+        admin,
+        metric,
+        lsaMetric,
+        area,
+        advertiser,
+        costToAdvertiser,
+        nonForwarding,
+        nonRouting);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfInterAreaRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfInterAreaRoute.java
@@ -10,13 +10,24 @@ public class OspfInterAreaRoute extends OspfInternalRoute {
   private static final long serialVersionUID = 1L;
 
   @JsonCreator
-  public OspfInterAreaRoute(
+  private static OspfInterAreaRoute jsonCreator(
       @JsonProperty(PROP_NETWORK) Prefix network,
       @JsonProperty(PROP_NEXT_HOP_IP) Ip nextHopIp,
       @JsonProperty(PROP_ADMINISTRATIVE_COST) int admin,
       @JsonProperty(PROP_METRIC) long metric,
       @JsonProperty(PROP_AREA) long area) {
-    super(network, nextHopIp, admin, metric, area);
+    return new OspfInterAreaRoute(network, nextHopIp, admin, metric, area, false, false);
+  }
+
+  OspfInterAreaRoute(
+      Prefix network,
+      Ip nextHopIp,
+      int admin,
+      long metric,
+      long area,
+      boolean nonForwarding,
+      boolean nonRouting) {
+    super(network, nextHopIp, admin, metric, area, nonForwarding, nonRouting);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfInternalRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfInternalRoute.java
@@ -7,7 +7,7 @@ public abstract class OspfInternalRoute extends OspfRoute {
   /** */
   private static final long serialVersionUID = 1L;
 
-  public static class Builder extends AbstractRouteBuilder<Builder, OspfInternalRoute> {
+  public static final class Builder extends AbstractRouteBuilder<Builder, OspfInternalRoute> {
 
     private Long _area;
 
@@ -16,9 +16,23 @@ public abstract class OspfInternalRoute extends OspfRoute {
     @Override
     public OspfInternalRoute build() {
       if (_protocol == RoutingProtocol.OSPF) {
-        return new OspfIntraAreaRoute(getNetwork(), getNextHopIp(), getAdmin(), getMetric(), _area);
+        return new OspfIntraAreaRoute(
+            getNetwork(),
+            getNextHopIp(),
+            getAdmin(),
+            getMetric(),
+            _area,
+            getNonForwarding(),
+            getNonRouting());
       } else {
-        return new OspfInterAreaRoute(getNetwork(), getNextHopIp(), getAdmin(), getMetric(), _area);
+        return new OspfInterAreaRoute(
+            getNetwork(),
+            getNextHopIp(),
+            getAdmin(),
+            getMetric(),
+            _area,
+            getNonForwarding(),
+            getNonRouting());
       }
     }
 
@@ -36,10 +50,25 @@ public abstract class OspfInternalRoute extends OspfRoute {
       _protocol = protocol;
       return this;
     }
+
+    private Builder() {} // Only used in this OspfInternalRoute.builder()
   }
 
-  public OspfInternalRoute(Prefix network, Ip nextHopIp, int admin, long metric, long area) {
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  OspfInternalRoute(
+      Prefix network,
+      Ip nextHopIp,
+      int admin,
+      long metric,
+      long area,
+      boolean nonForwarding,
+      boolean nonRouting) {
     super(network, nextHopIp, admin, metric, area);
+    setNonForwarding(nonForwarding);
+    setNonRouting(nonRouting);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfIntraAreaRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfIntraAreaRoute.java
@@ -10,13 +10,24 @@ public class OspfIntraAreaRoute extends OspfInternalRoute {
   private static final long serialVersionUID = 1L;
 
   @JsonCreator
-  public OspfIntraAreaRoute(
+  private static OspfIntraAreaRoute jsonCreator(
       @JsonProperty(PROP_NETWORK) Prefix network,
       @Nullable @JsonProperty(PROP_NEXT_HOP_IP) Ip nextHopIp,
       @JsonProperty(PROP_ADMINISTRATIVE_COST) int admin,
       @JsonProperty(PROP_METRIC) long metric,
       @JsonProperty(PROP_AREA) long area) {
-    super(network, nextHopIp, admin, metric, area);
+    return new OspfIntraAreaRoute(network, nextHopIp, admin, metric, area, false, false);
+  }
+
+  OspfIntraAreaRoute(
+      Prefix network,
+      @Nullable Ip nextHopIp,
+      int admin,
+      long metric,
+      long area,
+      boolean nonForwarding,
+      boolean nonRouting) {
+    super(network, nextHopIp, admin, metric, area, nonForwarding, nonRouting);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/StaticRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/StaticRoute.java
@@ -38,7 +38,14 @@ public class StaticRoute extends AbstractRoute {
       @JsonProperty(PROP_METRIC) long metric,
       @JsonProperty(PROP_TAG) int tag) {
     return new StaticRoute(
-        requireNonNull(network), nextHopIp, nextHopInterface, administrativeCost, metric, tag);
+        requireNonNull(network),
+        nextHopIp,
+        nextHopInterface,
+        administrativeCost,
+        metric,
+        tag,
+        false,
+        false);
   }
 
   private StaticRoute(
@@ -47,8 +54,12 @@ public class StaticRoute extends AbstractRoute {
       @Nullable String nextHopInterface,
       int administrativeCost,
       long metric,
-      int tag) {
+      int tag,
+      boolean nonForwarding,
+      boolean nonRouting) {
     super(network);
+    setNonForwarding(nonForwarding);
+    setNonRouting(nonRouting);
     checkArgument(
         administrativeCost >= 0, "Invalid admin distance for static route: %d", administrativeCost);
     _administrativeCost = administrativeCost;
@@ -66,11 +77,13 @@ public class StaticRoute extends AbstractRoute {
       return false;
     }
     StaticRoute rhs = (StaticRoute) o;
-    return Objects.equals(_network, rhs._network)
-        && _administrativeCost == rhs._administrativeCost
+    return _administrativeCost == rhs._administrativeCost
+        && _tag == rhs._tag
+        && getNonForwarding() == rhs.getNonForwarding()
+        && getNonRouting() == rhs.getNonRouting()
+        && Objects.equals(_network, rhs._network)
         && Objects.equals(_nextHopIp, rhs._nextHopIp)
-        && Objects.equals(_nextHopInterface, rhs._nextHopInterface)
-        && _tag == rhs._tag;
+        && Objects.equals(_nextHopInterface, rhs._nextHopInterface);
   }
 
   @Override
@@ -121,7 +134,15 @@ public class StaticRoute extends AbstractRoute {
 
   @Override
   public int hashCode() {
-    return Objects.hash(_administrativeCost, _metric, _nextHopInterface, _nextHopIp, _tag);
+    return Objects.hash(
+        _administrativeCost,
+        getNonForwarding(),
+        getNonRouting(),
+        _metric,
+        _network,
+        _nextHopInterface,
+        _nextHopIp,
+        _tag);
   }
 
   @Override
@@ -150,7 +171,9 @@ public class StaticRoute extends AbstractRoute {
           _nextHopInterface,
           _administrativeCost,
           getMetric(),
-          getTag());
+          getTag(),
+          getNonForwarding(),
+          getNonRouting());
     }
 
     @Override

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/OspfExternalType1RouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/OspfExternalType1RouteTest.java
@@ -1,10 +1,7 @@
 package org.batfish.datamodel;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-
+import com.google.common.testing.EqualsTester;
+import org.batfish.datamodel.ospf.OspfMetricType;
 import org.junit.Test;
 
 /** Test for {@link OspfExternalType1Route} */
@@ -13,23 +10,27 @@ public class OspfExternalType1RouteTest {
   @Test
   public void testEquals() {
 
-    OspfExternalType1Route r1 =
-        new OspfExternalType1Route(new Prefix(new Ip("1.1.1.1"), 32), Ip.ZERO, 1, 1, 1, 1, 1, "");
-    OspfExternalType1Route r1DiffObj =
-        new OspfExternalType1Route(new Prefix(new Ip("1.1.1.1"), 32), Ip.ZERO, 1, 1, 1, 1, 1, "");
-    OspfExternalType1Route r2 =
-        new OspfExternalType1Route(new Prefix(new Ip("1.1.1.1"), 32), Ip.ZERO, 1, 1, 1, 1, 2, "");
-    OspfExternalType2Route type2Route =
-        new OspfExternalType2Route(new Prefix(new Ip("1.1.1.1"), 32), Ip.ZERO, 1, 1, 1, 1, 2, "");
+    OspfExternalType2Route.Builder b =
+        OspfExternalRoute.builder()
+            .setNetwork(new Prefix(new Ip("1.1.1.1"), 32))
+            .setNextHopIp(Ip.ZERO)
+            .setAdmin(1)
+            .setMetric(1)
+            .setLsaMetric(1)
+            .setArea(1)
+            .setCostToAdvertiser(1)
+            .setAdvertiser("")
+            .setOspfMetricType(OspfMetricType.E1);
 
-    // Simple equality checks
-    assertThat(r1, equalTo(r1));
-    assertThat(r1, equalTo(r1DiffObj));
-    assertThat(r1, not(equalTo(nullValue())));
+    OspfExternalRoute r1 = b.build();
+    OspfExternalRoute r1DiffObj = b.build();
+    OspfExternalRoute r2 = b.setCostToAdvertiser(2).build();
+    OspfExternalRoute r2t2 = b.setOspfMetricType(OspfMetricType.E2).build();
 
-    // Cost to advertiser differs
-    assertThat(r1, not(equalTo(r2)));
-    // Not the same type
-    assertThat(r1, not(equalTo(type2Route)));
+    new EqualsTester()
+        .addEqualityGroup(r1, r1DiffObj)
+        .addEqualityGroup(r2)
+        .addEqualityGroup(r2t2)
+        .testEquals();
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/OspfExternalType2RouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/OspfExternalType2RouteTest.java
@@ -1,10 +1,7 @@
 package org.batfish.datamodel;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-
+import com.google.common.testing.EqualsTester;
+import org.batfish.datamodel.ospf.OspfMetricType;
 import org.junit.Test;
 
 /** Test for {@link OspfExternalType2Route} */
@@ -12,24 +9,27 @@ public class OspfExternalType2RouteTest {
 
   @Test
   public void testEquals() {
+    OspfExternalType2Route.Builder b =
+        OspfExternalRoute.builder()
+            .setNetwork(new Prefix(new Ip("1.1.1.1"), 32))
+            .setNextHopIp(Ip.ZERO)
+            .setAdmin(1)
+            .setMetric(1)
+            .setLsaMetric(1)
+            .setArea(1)
+            .setCostToAdvertiser(1)
+            .setAdvertiser("")
+            .setOspfMetricType(OspfMetricType.E2);
 
-    OspfExternalType2Route r1 =
-        new OspfExternalType2Route(new Prefix(new Ip("1.1.1.1"), 32), Ip.ZERO, 1, 1, 1, 1, 1, "");
-    OspfExternalType2Route r1DiffObj =
-        new OspfExternalType2Route(new Prefix(new Ip("1.1.1.1"), 32), Ip.ZERO, 1, 1, 1, 1, 1, "");
-    OspfExternalType2Route r2 =
-        new OspfExternalType2Route(new Prefix(new Ip("1.1.1.1"), 32), Ip.ZERO, 1, 1, 1, 1, 2, "");
-    OspfExternalType1Route type1Route =
-        new OspfExternalType1Route(new Prefix(new Ip("1.1.1.1"), 32), Ip.ZERO, 1, 1, 1, 1, 2, "");
+    OspfExternalRoute r1 = b.build();
+    OspfExternalRoute r1DiffObj = b.build();
+    OspfExternalRoute r2 = b.setCostToAdvertiser(2).build();
+    OspfExternalRoute r2t1 = b.setOspfMetricType(OspfMetricType.E1).build();
 
-    // Simple equality checks
-    assertThat(r1, equalTo(r1));
-    assertThat(r1, equalTo(r1DiffObj));
-    assertThat(r1, not(equalTo(nullValue())));
-
-    // Cost to advertiser differs
-    assertThat(r1, not(equalTo(r2)));
-    // Not the same type
-    assertThat(r1, not(equalTo(type1Route)));
+    new EqualsTester()
+        .addEqualityGroup(r1, r1DiffObj)
+        .addEqualityGroup(r2)
+        .addEqualityGroup(r2t1)
+        .testEquals();
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/OspfProtocolHelperTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/OspfProtocolHelperTest.java
@@ -15,6 +15,7 @@ import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.OspfInterAreaRoute;
+import org.batfish.datamodel.OspfInternalRoute;
 import org.batfish.datamodel.OspfIntraAreaRoute;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.RouteFilterLine;
@@ -38,12 +39,17 @@ public class OspfProtocolHelperTest {
     long definedMetric = 5;
     long definedArea = 1;
     OspfInterAreaRoute route =
-        new OspfInterAreaRoute(
-            ospfInterAreaRoutePrefix,
-            Ip.MAX,
-            RoutingProtocol.OSPF_IA.getDefaultAdministrativeCost(ConfigurationFormat.CISCO_IOS),
-            definedMetric,
-            definedArea);
+        (OspfInterAreaRoute)
+            OspfInternalRoute.builder()
+                .setProtocol(RoutingProtocol.OSPF_IA)
+                .setNetwork(ospfInterAreaRoutePrefix)
+                .setNextHopIp(Ip.MAX)
+                .setAdmin(
+                    RoutingProtocol.OSPF_IA.getDefaultAdministrativeCost(
+                        ConfigurationFormat.CISCO_IOS))
+                .setMetric(definedMetric)
+                .setArea(definedArea)
+                .build();
 
     // The route is in the prefix and existing metric is null, so return the route's metric
     assertThat(
@@ -77,12 +83,17 @@ public class OspfProtocolHelperTest {
         equalTo(4L));
 
     OspfInterAreaRoute sameAreaRoute =
-        new OspfInterAreaRoute(
-            ospfInterAreaRoutePrefix,
-            Ip.MAX,
-            RoutingProtocol.OSPF_IA.getDefaultAdministrativeCost(ConfigurationFormat.CISCO_IOS),
-            definedMetric,
-            99);
+        (OspfInterAreaRoute)
+            OspfInternalRoute.builder()
+                .setProtocol(RoutingProtocol.OSPF_IA)
+                .setNetwork(ospfInterAreaRoutePrefix)
+                .setNextHopIp(Ip.MAX)
+                .setAdmin(
+                    RoutingProtocol.OSPF_IA.getDefaultAdministrativeCost(
+                        ConfigurationFormat.CISCO_IOS))
+                .setArea(99L)
+                .setMetric(definedMetric)
+                .build();
     // The area is different from definedArea thus the metric should remain null
     assertThat(
         OspfProtocolHelper.computeUpdatedOspfSummaryMetric(
@@ -151,7 +162,16 @@ public class OspfProtocolHelperTest {
                         new SubRange(0, Prefix.MAX_PREFIX_LENGTH))))));
 
     Prefix network = Prefix.parse("1.1.1.1/32");
-    OspfIntraAreaRoute route = new OspfIntraAreaRoute(network, new Ip("9.9.9.9"), 20, 10, 0);
+    OspfIntraAreaRoute route =
+        (OspfIntraAreaRoute)
+            OspfInternalRoute.builder()
+                .setProtocol(RoutingProtocol.OSPF)
+                .setNetwork(network)
+                .setNextHopIp(new Ip("9.9.9.9"))
+                .setAdmin(20)
+                .setMetric(10)
+                .setArea(0L)
+                .build();
 
     // Test: Area-0 route going from area 0 to area 1. Area 0 has a filter list suppressing routes.
     // Denied propagation because of the filter list.
@@ -180,7 +200,16 @@ public class OspfProtocolHelperTest {
             .build();
 
     Prefix network = Prefix.parse("1.1.1.1/32");
-    OspfInterAreaRoute route = new OspfInterAreaRoute(network, new Ip("9.9.9.9"), 20, 10, 1);
+    OspfIntraAreaRoute route =
+        (OspfIntraAreaRoute)
+            OspfInternalRoute.builder()
+                .setProtocol(RoutingProtocol.OSPF)
+                .setNetwork(network)
+                .setNextHopIp(new Ip("9.9.9.9"))
+                .setAdmin(20)
+                .setMetric(10)
+                .setArea(1L)
+                .build();
 
     // Test: route going from 0 to 1, no filter lists; denied propagation because of type3
     // suppression.

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/AbstractRibTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/AbstractRibTest.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Set;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.OspfInternalRoute;
 import org.batfish.datamodel.OspfIntraAreaRoute;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.RipInternalRoute;
@@ -273,16 +274,43 @@ public class AbstractRibTest {
     // Use OSPF RIBs for this, as routes with better metric can replace other routes
     OspfIntraAreaRib rib = new OspfIntraAreaRib();
     Prefix prefix = Prefix.parse("1.1.1.1/32");
-    rib.mergeRouteGetDelta(new OspfIntraAreaRoute(prefix, null, 100, 30, 1));
+    rib.mergeRouteGetDelta(
+        (OspfIntraAreaRoute)
+            OspfInternalRoute.builder()
+                .setProtocol(RoutingProtocol.OSPF)
+                .setNetwork(prefix)
+                .setNextHopIp(null)
+                .setAdmin(100)
+                .setMetric(30)
+                .setArea(1L)
+                .build());
 
     assertThat(rib.getRoutes(), hasSize(1));
     // This new route replaces old route
-    OspfIntraAreaRoute newRoute = new OspfIntraAreaRoute(prefix, null, 100, 10, 1);
+    OspfIntraAreaRoute newRoute =
+        (OspfIntraAreaRoute)
+            OspfInternalRoute.builder()
+                .setProtocol(RoutingProtocol.OSPF)
+                .setNetwork(prefix)
+                .setNextHopIp(null)
+                .setAdmin(100)
+                .setMetric(10)
+                .setArea(1L)
+                .build();
     rib.mergeRouteGetDelta(newRoute);
     assertThat(rib.getRoutes(), contains(newRoute));
 
     // Add completely new route and check that the size increases
-    rib.mergeRouteGetDelta(new OspfIntraAreaRoute(Prefix.parse("2.2.2.2/32"), null, 100, 30, 1));
+    rib.mergeRouteGetDelta(
+        (OspfIntraAreaRoute)
+            OspfInternalRoute.builder()
+                .setProtocol(RoutingProtocol.OSPF)
+                .setNetwork(Prefix.parse("2.2.2.2/32"))
+                .setNextHopIp(null)
+                .setAdmin(100)
+                .setMetric(30)
+                .setArea(1L)
+                .build());
     assertThat(rib.getRoutes(), hasSize(2));
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -272,13 +272,14 @@ import org.batfish.datamodel.Line;
 import org.batfish.datamodel.LineType;
 import org.batfish.datamodel.MultipathEquivalentAsPathMatchMode;
 import org.batfish.datamodel.NamedPort;
-import org.batfish.datamodel.OspfIntraAreaRoute;
+import org.batfish.datamodel.OspfInternalRoute;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Prefix6;
 import org.batfish.datamodel.PrefixRange;
 import org.batfish.datamodel.PrefixSpace;
 import org.batfish.datamodel.RegexCommunitySet;
 import org.batfish.datamodel.RipInternalRoute;
+import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.StaticRoute;
 import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.Vrf;
@@ -1276,7 +1277,13 @@ public class CiscoGrammarTest {
     // Check if routingPolicy accepts OSPF route and sets correct default metric
     assertTrue(
         routingPolicy.process(
-            new OspfIntraAreaRoute(Prefix.parse("4.4.4.4/32"), null, 1, 1, 1),
+            OspfInternalRoute.builder()
+                .setProtocol(RoutingProtocol.OSPF)
+                .setNetwork(Prefix.parse("4.4.4.4/32"))
+                .setAdmin(1)
+                .setMetric(1)
+                .setArea(1L)
+                .build(),
             outputRouteBuilder,
             null,
             DEFAULT_VRF_NAME,

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -1639,9 +1639,7 @@ public class FlatJuniperGrammarTest {
     Environment.Builder eb = Environment.builder(c).setDirection(Direction.IN);
     eb.setVrf("vrf1");
     policyPreference.call(
-        eb.setOriginalRoute(staticRoute)
-            .setOutputRoute(new OspfExternalType2Route.Builder())
-            .build());
+        eb.setOriginalRoute(staticRoute).setOutputRoute(OspfExternalType2Route.builder()).build());
 
     // Checking admin cost set on the output route
     assertThat(eb.build().getOutputRoute().getAdmin(), equalTo(123));
@@ -2748,7 +2746,7 @@ public class FlatJuniperGrammarTest {
         vrf1RejectAllLocal
             .call(
                 eb.setOriginalRoute(localRoutePtp)
-                    .setOutputRoute(new OspfExternalType2Route.Builder())
+                    .setOutputRoute(OspfExternalType2Route.builder())
                     .build())
             .getBooleanValue(),
         equalTo(false));
@@ -2756,7 +2754,7 @@ public class FlatJuniperGrammarTest {
         vrf1RejectAllLocal
             .call(
                 eb.setOriginalRoute(localRouteLan)
-                    .setOutputRoute(new OspfExternalType2Route.Builder())
+                    .setOutputRoute(OspfExternalType2Route.builder())
                     .build())
             .getBooleanValue(),
         equalTo(false));
@@ -2766,7 +2764,7 @@ public class FlatJuniperGrammarTest {
         vrf2RejectPtpLocal
             .call(
                 eb.setOriginalRoute(localRoutePtp)
-                    .setOutputRoute(new OspfExternalType2Route.Builder())
+                    .setOutputRoute(OspfExternalType2Route.builder())
                     .build())
             .getBooleanValue(),
         equalTo(false));
@@ -2774,7 +2772,7 @@ public class FlatJuniperGrammarTest {
         vrf2RejectPtpLocal
             .call(
                 eb.setOriginalRoute(localRouteLan)
-                    .setOutputRoute(new OspfExternalType2Route.Builder())
+                    .setOutputRoute(OspfExternalType2Route.builder())
                     .build())
             .getBooleanValue(),
         equalTo(true));
@@ -2784,7 +2782,7 @@ public class FlatJuniperGrammarTest {
         vrf3RejectLanLocal
             .call(
                 eb.setOriginalRoute(localRoutePtp)
-                    .setOutputRoute(new OspfExternalType2Route.Builder())
+                    .setOutputRoute(OspfExternalType2Route.builder())
                     .build())
             .getBooleanValue(),
         equalTo(true));
@@ -2792,7 +2790,7 @@ public class FlatJuniperGrammarTest {
         vrf3RejectLanLocal
             .call(
                 eb.setOriginalRoute(localRouteLan)
-                    .setOutputRoute(new OspfExternalType2Route.Builder())
+                    .setOutputRoute(OspfExternalType2Route.builder())
                     .build())
             .getBooleanValue(),
         equalTo(false));
@@ -2802,7 +2800,7 @@ public class FlatJuniperGrammarTest {
         vrf4AllowAllLocal
             .call(
                 eb.setOriginalRoute(localRoutePtp)
-                    .setOutputRoute(new OspfExternalType2Route.Builder())
+                    .setOutputRoute(OspfExternalType2Route.builder())
                     .build())
             .getBooleanValue(),
         equalTo(true));
@@ -2810,7 +2808,7 @@ public class FlatJuniperGrammarTest {
         vrf4AllowAllLocal
             .call(
                 eb.setOriginalRoute(localRouteLan)
-                    .setOutputRoute(new OspfExternalType2Route.Builder())
+                    .setOutputRoute(OspfExternalType2Route.builder())
                     .build())
             .getBooleanValue(),
         equalTo(true));

--- a/projects/question/src/main/java/org/batfish/question/OspfStatusQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/OspfStatusQuestionPlugin.java
@@ -171,7 +171,7 @@ public class OspfStatusQuestionPlugin extends QuestionPlugin {
                                 interfaceName);
                         if (exportPolicy.process(
                             route,
-                            new OspfExternalRoute.Builder(),
+                            OspfExternalRoute.builder(),
                             null,
                             vrf.getName(),
                             Direction.OUT)) {


### PR DESCRIPTION
This also made me add them to all child builders, which was a far-reaching but brainless change.

In the process, I found that StaticRoute did not compare these properties when checking equality, and I found that it did not hash on the network. Fix both of these changes.