### PR TITLE
OSPF: fix neighbors and routes to key on OspfEdge

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfEdge.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfEdge.java
@@ -74,4 +74,8 @@ public final class OspfEdge implements Comparable<OspfEdge> {
   public String toString() {
     return toStringHelper(getClass()).add(PROP_NODE1, _node1).add(PROP_NODE2, _node2).toString();
   }
+
+  public OspfEdge swap() {
+    return new OspfEdge(_node2, _node1);
+  }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfEdge.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfEdge.java
@@ -46,6 +46,12 @@ public final class OspfEdge implements Comparable<OspfEdge> {
     return _node2;
   }
 
+  /** Returns an {@link OspfEdge} pointing in the reverse direction. */
+  @Nonnull
+  public OspfEdge reverse() {
+    return new OspfEdge(_node2, _node1);
+  }
+
   @Override
   public int compareTo(OspfEdge o) {
     return Comparator.comparing(OspfEdge::getNode1)
@@ -73,9 +79,5 @@ public final class OspfEdge implements Comparable<OspfEdge> {
   @Override
   public String toString() {
     return toStringHelper(getClass()).add(PROP_NODE1, _node1).add(PROP_NODE2, _node2).toString();
-  }
-
-  public OspfEdge swap() {
-    return new OspfEdge(_node2, _node1);
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfEdgeTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfEdgeTest.java
@@ -1,6 +1,7 @@
 package org.batfish.datamodel.ospf;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
@@ -25,7 +26,7 @@ public class OspfEdgeTest {
         .addEqualityGroup(new OspfEdge(node1, node3))
         .addEqualityGroup(new OspfEdge(node2, node3))
         .addEqualityGroup(new OspfEdge(node3, node2))
-        .addEqualityGroup(new OspfEdge(node3, node1))
+        .addEqualityGroup(new OspfEdge(node3, node1), new OspfEdge(node1, node3).reverse())
         .addEqualityGroup(new OspfEdge(node1, node1))
         .testEquals();
   }
@@ -48,6 +49,15 @@ public class OspfEdgeTest {
             new OspfEdge(node3, node3));
     assertThat(Ordering.natural().sortedCopy(expected), equalTo(expected));
     assertThat(Ordering.natural().sortedCopy(Lists.reverse(expected)), equalTo(expected));
+  }
+
+  @Test
+  public void testReverse() {
+    OspfNode node1 = new OspfNode("a", "i", new Ip("1.2.3.4"));
+    OspfNode node2 = new OspfNode("b", "i", new Ip("1.2.3.5"));
+    OspfEdge rev = new OspfEdge(node1, node2).reverse();
+    assertThat(rev.getNode1(), is(node2));
+    assertThat(rev.getNode2(), is(node1));
   }
 
   @Test

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -358,7 +358,7 @@ public class VirtualRouter implements Serializable {
         _ospfExternalIncomingRoutes =
             _ospfNeighbors
                 .stream()
-                .map(OspfEdge::swap)
+                .map(OspfEdge::reverse)
                 .collect(
                     ImmutableSortedMap
                         .<OspfEdge, OspfEdge, Queue<RouteAdvertisement<OspfExternalRoute>>>

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -2506,7 +2506,7 @@ public class VirtualRouter implements Serializable {
    * @return A sorted map of neighbor prefixes to links to which they correspond
    */
   @Nullable
-  List<OspfEdge> getOspfNeighbors(final Map<String, Node> allNodes, Topology topology) {
+  private List<OspfEdge> getOspfNeighbors(final Map<String, Node> allNodes, Topology topology) {
     // Check we have ospf process
     OspfProcess proc = _vrf.getOspfProcess();
     if (proc == null) {
@@ -2522,7 +2522,7 @@ public class VirtualRouter implements Serializable {
 
     ImmutableList.Builder<OspfEdge> neighbors = ImmutableList.builder();
     for (Edge edge : edges) {
-      if (!edge.getNode1().equals(node)) {
+      if (!edge.getNode1().equals(node) || !edges.contains(edge.reverse())) {
         continue;
       }
       Interface localInterface = _vrf.getInterfaces().get(edge.getInt1());

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -11,6 +11,7 @@ import static org.batfish.dataplane.rib.AbstractRib.importRib;
 import static org.batfish.dataplane.rib.RibDelta.importRibDelta;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
@@ -19,7 +20,9 @@ import com.google.common.graph.Network;
 import com.google.common.graph.ValueGraph;
 import java.io.Serializable;
 import java.util.AbstractMap.SimpleEntry;
+import java.util.Comparator;
 import java.util.IdentityHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -88,7 +91,9 @@ import org.batfish.datamodel.isis.IsisNode;
 import org.batfish.datamodel.isis.IsisProcess;
 import org.batfish.datamodel.ospf.OspfArea;
 import org.batfish.datamodel.ospf.OspfAreaSummary;
+import org.batfish.datamodel.ospf.OspfEdge;
 import org.batfish.datamodel.ospf.OspfMetricType;
+import org.batfish.datamodel.ospf.OspfNode;
 import org.batfish.datamodel.ospf.OspfProcess;
 import org.batfish.datamodel.ospf.StubType;
 import org.batfish.datamodel.routing_policy.Environment.Direction;
@@ -194,7 +199,7 @@ public class VirtualRouter implements Serializable {
   transient OspfExternalType2Rib _ospfExternalType2StagingRib;
 
   @VisibleForTesting
-  transient SortedMap<Prefix, Queue<RouteAdvertisement<OspfExternalRoute>>>
+  transient SortedMap<OspfEdge, Queue<RouteAdvertisement<OspfExternalRoute>>>
       _ospfExternalIncomingRoutes;
 
   transient OspfInterAreaRib _ospfInterAreaRib;
@@ -225,7 +230,7 @@ public class VirtualRouter implements Serializable {
 
   private transient RibDelta.Builder<OspfExternalRoute> _ospfExternalDeltaBuiler;
 
-  private transient Map<Prefix, OspfLink> _ospfNeighbors;
+  private transient List<OspfEdge> _ospfNeighbors;
 
   /** Metadata about propagated prefixes to/from neighbors */
   private PrefixTracer _prefixTracer;
@@ -352,13 +357,15 @@ public class VirtualRouter implements Serializable {
       } else {
         _ospfExternalIncomingRoutes =
             _ospfNeighbors
-                .keySet()
                 .stream()
+                .map(OspfEdge::swap)
                 .collect(
-                    ImmutableSortedMap.toImmutableSortedMap(
-                        Prefix::compareTo,
-                        Function.identity(),
-                        p -> new ConcurrentLinkedQueue<>()));
+                    ImmutableSortedMap
+                        .<OspfEdge, OspfEdge, Queue<RouteAdvertisement<OspfExternalRoute>>>
+                            toImmutableSortedMap(
+                                Comparator.naturalOrder(),
+                                Function.identity(),
+                                p -> new ConcurrentLinkedQueue<>()));
       }
     }
   }
@@ -1122,7 +1129,7 @@ public class VirtualRouter implements Serializable {
     return _virtualEigrpProcesses.get(asn);
   }
 
-  void initOspfExports() {
+  void initOspfExports(@Nonnull Map<String, Node> allNodes) {
     OspfProcess proc = _vrf.getOspfProcess();
     // Nothing to do
     if (proc == null) {
@@ -1155,7 +1162,7 @@ public class VirtualRouter implements Serializable {
         d2.from(_ospfExternalType2Rib.mergeRouteGetDelta((OspfExternalType2Route) outputRoute));
       }
     }
-    queueOutgoingOspfExternalRoutes(d1.build(), d2.build());
+    queueOutgoingOspfExternalRoutes(allNodes, d1.build(), d2.build());
   }
 
   /** Initialize all ribs on this router. All RIBs will be empty */
@@ -1458,20 +1465,14 @@ public class VirtualRouter implements Serializable {
    * our queues.
    *
    * @param allNodes map of all nodes, keyed by hostname
-   * @param topology the Layer-3 network topology
    * @return a pair of {@link RibDelta}s, for Type1 and Type2 routes
    */
   @Nullable
   public Entry<RibDelta<OspfExternalType1Route>, RibDelta<OspfExternalType2Route>>
-      propagateOspfExternalRoutes(final Map<String, Node> allNodes, Topology topology) {
+      propagateOspfExternalRoutes(final Map<String, Node> allNodes) {
     String node = _c.getHostname();
     OspfProcess proc = _vrf.getOspfProcess();
     if (proc == null) {
-      return null;
-    }
-    SortedSet<Edge> edges = topology.getNodeEdges().get(node);
-    if (edges == null) {
-      // there are no edges, so OSPF won't produce anything
       return null;
     }
 
@@ -1480,141 +1481,122 @@ public class VirtualRouter implements Serializable {
     RibDelta.Builder<OspfExternalType2Route> builderType2 =
         new RibDelta.Builder<>(_ospfExternalType2StagingRib);
 
-    for (Edge edge : edges) {
-      if (!edge.getNode1().equals(node)) {
-        continue;
-      }
-      String connectingInterfaceName = edge.getInt1();
-      Interface connectingInterface = _vrf.getInterfaces().get(connectingInterfaceName);
-      if (connectingInterface == null) {
-        // wrong vrf, so skip
-        continue;
-      }
-      String neighborName = edge.getNode2();
-      Node neighbor = allNodes.get(neighborName);
-      String neighborInterfaceName = edge.getInt2();
-      OspfArea area = connectingInterface.getOspfArea();
-      Configuration nc = neighbor.getConfiguration();
-      Interface neighborInterface = nc.getAllInterfaces().get(neighborInterfaceName);
-      String neighborVrfName = neighborInterface.getVrfName();
-      VirtualRouter neighborVirtualRouter =
-          allNodes.get(neighborName).getVirtualRouters().get(neighborVrfName);
+    _ospfExternalIncomingRoutes.forEach(
+        (ospfEdge, queue) -> {
+          if (queue.isEmpty()) {
+            // Exit early if no routes to process.
+            return;
+          }
 
-      OspfArea neighborArea = neighborInterface.getOspfArea();
-      if (connectingInterface.getOspfEnabled()
-          && !connectingInterface.getOspfPassive()
-          && neighborInterface.getOspfEnabled()
-          && !neighborInterface.getOspfPassive()
-          && area != null
-          && neighborArea != null
-          && area.getAreaNumber() == (neighborArea.getAreaNumber())) {
-        /*
-         * We have an ospf neighbor relationship on this edge. So we
-         * should add all ospf external type 1(2) routes from this
-         * neighbor into our ospf external type 1(2) staging rib. For
-         * type 1, the cost of the route increases each time. For type 2,
-         * the cost remains constant, but we must keep track of cost to
-         * advertiser as a tie-breaker.
-         */
-        long connectingInterfaceCost = connectingInterface.getOspfCost();
-        long incrementalCost =
-            proc.getMaxMetricTransitLinks() != null
-                ? proc.getMaxMetricTransitLinks()
-                : connectingInterfaceCost;
+          OspfNode localOspfNode = ospfEdge.getNode2();
+          OspfNode neighborOspfNode = ospfEdge.getNode1();
+          assert localOspfNode.getNode().equals(node); // queue invariant of how we built the queue.
 
-        Queue<RouteAdvertisement<OspfExternalRoute>> q =
-            _ospfExternalIncomingRoutes.get(connectingInterface.getAddress().getPrefix());
-        while (q.peek() != null) {
-          RouteAdvertisement<OspfExternalRoute> routeAdvert = q.remove();
-          OspfExternalRoute neighborRoute = routeAdvert.getRoute();
-          boolean withdraw = routeAdvert.isWithdrawn();
-          if (neighborRoute instanceof OspfExternalType1Route) {
-            long oldArea = neighborRoute.getArea();
-            long connectionArea = area.getAreaNumber();
-            long newArea;
-            long baseMetric = neighborRoute.getMetric();
-            long baseCostToAdvertiser = neighborRoute.getCostToAdvertiser();
-            newArea = connectionArea;
-            if (oldArea != OspfRoute.NO_AREA) {
-              Long maxMetricSummaryNetworks =
-                  neighborVirtualRouter._vrf.getOspfProcess().getMaxMetricSummaryNetworks();
-              if (connectionArea != oldArea) {
-                if (connectionArea != 0L && oldArea != 0L) {
+          Interface localInterface = _vrf.getInterfaces().get(localOspfNode.getInterfaceName());
+          assert localInterface != null; // invariant of how routes are pushed into the queue.
+          assert localInterface.getOspfArea() != null; // ^^.
+          long localArea = localInterface.getOspfArea().getAreaNumber();
+
+          Node neighbor = allNodes.get(neighborOspfNode.getNode());
+          Configuration nc = neighbor.getConfiguration();
+          Interface neighborInterface =
+              nc.getAllInterfaces().get(neighborOspfNode.getInterfaceName());
+          VirtualRouter neighborVirtualRouter =
+              neighbor.getVirtualRouters().get(neighborInterface.getVrfName());
+
+          /*
+           * We have an ospf neighbor relationship on this edge. So we
+           * should add all ospf external type 1(2) routes from this
+           * neighbor into our ospf external type 1(2) staging rib. For
+           * type 1, the cost of the route increases each time. For type 2,
+           * the cost remains constant, but we must keep track of cost to
+           * advertiser as a tie-breaker.
+           */
+          long incrementalCost =
+              proc.getMaxMetricTransitLinks() != null
+                  ? proc.getMaxMetricTransitLinks()
+                  : localInterface.getOspfCost().longValue();
+
+          while (queue.peek() != null) {
+            RouteAdvertisement<OspfExternalRoute> routeAdvert = queue.remove();
+            boolean withdraw = routeAdvert.isWithdrawn();
+            OspfExternalRoute neighborRoute = routeAdvert.getRoute();
+            long neighborArea = neighborRoute.getArea();
+            OspfExternalRoute.Builder newRouteB =
+                OspfExternalRoute.builder()
+                    .setNetwork(neighborRoute.getNetwork())
+                    .setNextHopIp(neighborOspfNode.getLocalIp())
+                    .setLsaMetric(neighborRoute.getLsaMetric())
+                    .setAdvertiser(neighborRoute.getAdvertiser())
+                    .setOspfMetricType(neighborRoute.getOspfMetricType())
+                    .setAdmin(
+                        neighborRoute
+                            .getOspfMetricType()
+                            .toRoutingProtocol()
+                            .getDefaultAdministrativeCost(_c.getConfigurationFormat()));
+
+            if (neighborRoute instanceof OspfExternalType1Route) {
+              long baseMetric = neighborRoute.getMetric();
+              long baseCostToAdvertiser = neighborRoute.getCostToAdvertiser();
+              if (neighborArea != OspfRoute.NO_AREA && localArea != neighborArea) {
+                if (localArea != 0L && neighborArea != 0L) {
                   continue;
                 }
+                Long maxMetricSummaryNetworks =
+                    neighborVirtualRouter._vrf.getOspfProcess().getMaxMetricSummaryNetworks();
                 if (maxMetricSummaryNetworks != null) {
                   baseMetric = maxMetricSummaryNetworks + neighborRoute.getLsaMetric();
                   baseCostToAdvertiser = maxMetricSummaryNetworks;
                 }
               }
-            }
-            long newMetric = baseMetric + incrementalCost;
-            long newCostToAdvertiser = baseCostToAdvertiser + incrementalCost;
-            int admin =
-                RoutingProtocol.OSPF_E1.getDefaultAdministrativeCost(_c.getConfigurationFormat());
-            OspfExternalType1Route newRoute =
-                (OspfExternalType1Route)
-                    OspfExternalRoute.builder()
-                        .setOspfMetricType(OspfMetricType.E1)
-                        .setNetwork(neighborRoute.getNetwork())
-                        .setNextHopIp(neighborInterface.getAddress().getIp())
-                        .setAdmin(admin)
-                        .setMetric(newMetric)
-                        .setLsaMetric(neighborRoute.getLsaMetric())
-                        .setArea(newArea)
-                        .setCostToAdvertiser(newCostToAdvertiser)
-                        .setAdvertiser(neighborRoute.getAdvertiser())
-                        .build();
-            if (withdraw) {
-              builderType1.remove(newRoute, Reason.WITHDRAW);
-              _ospfExternalType1Rib.removeBackupRoute(newRoute);
-            } else {
-              builderType1.from(_ospfExternalType1StagingRib.mergeRouteGetDelta(newRoute));
-              _ospfExternalType1Rib.addBackupRoute(newRoute);
-            }
+              long newMetric = baseMetric + incrementalCost;
+              long newCostToAdvertiser = baseCostToAdvertiser + incrementalCost;
+              OspfExternalType1Route newRoute =
+                  (OspfExternalType1Route)
+                      newRouteB
+                          .setMetric(newMetric)
+                          .setArea(localArea)
+                          .setCostToAdvertiser(newCostToAdvertiser)
+                          .build();
+              if (withdraw) {
+                builderType1.remove(newRoute, Reason.WITHDRAW);
+                _ospfExternalType1Rib.removeBackupRoute(newRoute);
+              } else {
+                builderType1.from(_ospfExternalType1StagingRib.mergeRouteGetDelta(newRoute));
+                _ospfExternalType1Rib.addBackupRoute(newRoute);
+              }
 
-          } else if (neighborRoute instanceof OspfExternalType2Route) {
-            long oldArea = neighborRoute.getArea();
-            long connectionArea = area.getAreaNumber();
-            long newArea;
-            long baseCostToAdvertiser = neighborRoute.getCostToAdvertiser();
-            if (oldArea == OspfRoute.NO_AREA) {
-              newArea = connectionArea;
-            } else {
-              newArea = oldArea;
-              Long maxMetricSummaryNetworks =
-                  neighborVirtualRouter._vrf.getOspfProcess().getMaxMetricSummaryNetworks();
-              if (connectionArea != oldArea && maxMetricSummaryNetworks != null) {
-                baseCostToAdvertiser = maxMetricSummaryNetworks;
+            } else if (neighborRoute instanceof OspfExternalType2Route) {
+              long newArea;
+              long baseCostToAdvertiser = neighborRoute.getCostToAdvertiser();
+              if (neighborArea == OspfRoute.NO_AREA) {
+                newArea = localArea;
+              } else {
+                newArea = neighborArea;
+                Long maxMetricSummaryNetworks =
+                    neighborVirtualRouter._vrf.getOspfProcess().getMaxMetricSummaryNetworks();
+                if (localArea != neighborArea && maxMetricSummaryNetworks != null) {
+                  baseCostToAdvertiser = maxMetricSummaryNetworks;
+                }
+              }
+              long newCostToAdvertiser = baseCostToAdvertiser + incrementalCost;
+              OspfExternalType2Route newRoute =
+                  (OspfExternalType2Route)
+                      newRouteB
+                          .setMetric(neighborRoute.getMetric())
+                          .setArea(newArea)
+                          .setCostToAdvertiser(newCostToAdvertiser)
+                          .build();
+              if (withdraw) {
+                builderType2.remove(newRoute, Reason.WITHDRAW);
+                _ospfExternalType2Rib.addBackupRoute(newRoute);
+              } else {
+                builderType2.from(_ospfExternalType2StagingRib.mergeRouteGetDelta(newRoute));
+                _ospfExternalType2Rib.addBackupRoute(newRoute);
               }
             }
-            long newCostToAdvertiser = baseCostToAdvertiser + incrementalCost;
-            int admin =
-                RoutingProtocol.OSPF_E2.getDefaultAdministrativeCost(_c.getConfigurationFormat());
-            OspfExternalType2Route newRoute =
-                (OspfExternalType2Route)
-                    OspfExternalRoute.builder()
-                        .setOspfMetricType(OspfMetricType.E2)
-                        .setNetwork(neighborRoute.getNetwork())
-                        .setNextHopIp(neighborInterface.getAddress().getIp())
-                        .setAdmin(admin)
-                        .setMetric(neighborRoute.getMetric())
-                        .setLsaMetric(neighborRoute.getLsaMetric())
-                        .setArea(newArea)
-                        .setCostToAdvertiser(newCostToAdvertiser)
-                        .setAdvertiser(neighborRoute.getAdvertiser())
-                        .build();
-            if (withdraw) {
-              builderType2.remove(newRoute, Reason.WITHDRAW);
-              _ospfExternalType2Rib.addBackupRoute(newRoute);
-            } else {
-              builderType2.from(_ospfExternalType2StagingRib.mergeRouteGetDelta(newRoute));
-              _ospfExternalType2Rib.addBackupRoute(newRoute);
-            }
           }
-        }
-      }
-    }
+        });
     return new SimpleEntry<>(builderType1.build(), builderType2.build());
   }
 
@@ -2164,12 +2146,14 @@ public class VirtualRouter implements Serializable {
   /**
    * Send out OSPF External route updates to our neighbors
    *
+   * @param allNodes all network nodes, keyed by hostname
    * @param type1delta A {@link RibDelta} containing diffs with respect to OSPF Type1 external
    *     routes
    * @param type2delta A {@link RibDelta} containing diffs with respect to OSPF Type2 external
    *     routes
    */
   private void queueOutgoingOspfExternalRoutes(
+      @Nonnull Map<String, Node> allNodes,
       @Nullable RibDelta<OspfExternalType1Route> type1delta,
       @Nullable RibDelta<OspfExternalType2Route> type2delta) {
     if (_vrf.getOspfProcess() == null) {
@@ -2177,13 +2161,26 @@ public class VirtualRouter implements Serializable {
     }
     if (_ospfNeighbors != null) {
       _ospfNeighbors.forEach(
-          (key, ospfLink) -> {
-            if (ospfLink._localOspfArea.getStubType() == StubType.STUB) {
+          ospfEdge -> {
+            OspfArea localArea =
+                _vrf.getInterfaces().get(ospfEdge.getNode1().getInterfaceName()).getOspfArea();
+            assert localArea != null; // otherwise the edge would not be built.
+            if (localArea.getStubType() == StubType.STUB) {
               return;
             }
             // Get remote neighbor's queue by prefix
+            Configuration remoteConfig =
+                allNodes.get(ospfEdge.getNode2().getNode()).getConfiguration();
+            String remoteVrf =
+                remoteConfig
+                    .getAllInterfaces()
+                    .get(ospfEdge.getNode2().getInterfaceName())
+                    .getVrfName();
+            VirtualRouter remoteRouter =
+                allNodes.get(ospfEdge.getNode2().getNode()).getVirtualRouters().get(remoteVrf);
+
             Queue<RouteAdvertisement<OspfExternalRoute>> q =
-                ospfLink._remoteVirtualRouter._ospfExternalIncomingRoutes.get(key);
+                remoteRouter._ospfExternalIncomingRoutes.get(ospfEdge);
             queueDelta(q, type1delta);
             queueDelta(q, type2delta);
           });
@@ -2260,10 +2257,12 @@ public class VirtualRouter implements Serializable {
    *     #_ospfExternalType2Rib}
    */
   boolean unstageOspfExternalRoutes(
-      RibDelta<OspfExternalType1Route> type1Delta, RibDelta<OspfExternalType2Route> type2Delta) {
+      Map<String, Node> allNodes,
+      RibDelta<OspfExternalType1Route> type1Delta,
+      RibDelta<OspfExternalType2Route> type2Delta) {
     RibDelta<OspfExternalType1Route> d1 = importRibDelta(_ospfExternalType1Rib, type1Delta);
     RibDelta<OspfExternalType2Route> d2 = importRibDelta(_ospfExternalType2Rib, type2Delta);
-    queueOutgoingOspfExternalRoutes(d1, d2);
+    queueOutgoingOspfExternalRoutes(allNodes, d1, d2);
     Builder<OspfRoute> ospfDeltaBuilder = new Builder<>(_ospfRib);
     ospfDeltaBuilder.from(importRibDelta(_ospfRib, d1));
     ospfDeltaBuilder.from(importRibDelta(_ospfRib, d2));
@@ -2510,8 +2509,7 @@ public class VirtualRouter implements Serializable {
    * @return A sorted map of neighbor prefixes to links to which they correspond
    */
   @Nullable
-  SortedMap<Prefix, OspfLink> getOspfNeighbors(
-      final Map<String, Node> allNodes, Topology topology) {
+  List<OspfEdge> getOspfNeighbors(final Map<String, Node> allNodes, Topology topology) {
     // Check we have ospf process
     OspfProcess proc = _vrf.getOspfProcess();
     if (proc == null) {
@@ -2525,42 +2523,54 @@ public class VirtualRouter implements Serializable {
       return null;
     }
 
-    SortedMap<Prefix, OspfLink> neighbors = new TreeMap<>();
+    ImmutableList.Builder<OspfEdge> neighbors = ImmutableList.builder();
     for (Edge edge : edges) {
       if (!edge.getNode1().equals(node)) {
         continue;
       }
-      String connectingInterfaceName = edge.getInt1();
-      Interface connectingInterface = _vrf.getInterfaces().get(connectingInterfaceName);
-      if (connectingInterface == null) {
+      Interface localInterface = _vrf.getInterfaces().get(edge.getInt1());
+      if (localInterface == null) {
         // wrong vrf, so skip
         continue;
       }
-      String neighborName = edge.getNode2();
-      Node neighbor = allNodes.get(neighborName);
-      String neighborInterfaceName = edge.getInt2();
-      OspfArea area = connectingInterface.getOspfArea();
-      Configuration nc = neighbor.getConfiguration();
-      Interface neighborInterface = nc.getAllInterfaces().get(neighborInterfaceName);
-      String neighborVrfName = neighborInterface.getVrfName();
-      VirtualRouter neighborVirtualRouter =
-          allNodes.get(neighborName).getVirtualRouters().get(neighborVrfName);
+      OspfArea localArea = localInterface.getOspfArea();
+      if (!localInterface.getOspfEnabled()
+          || localInterface.getOspfPassive()
+          || localArea == null) {
+        // Not OSPF active
+        continue;
+      }
+
+      Node neighbor = allNodes.get(edge.getNode2());
+      Interface neighborInterface =
+          neighbor.getConfiguration().getAllInterfaces().get(edge.getInt2());
+
+      // Verify that the primaries use distinct IPs on compatible prefixes.
+      // TODO: should this be equal? TODO: is this true for multicast sessions?
+      InterfaceAddress localPrimary = localInterface.getAddress();
+      InterfaceAddress neighborPrimary = neighborInterface.getAddress();
+      if (!localPrimary.getPrefix().containsIp(neighborPrimary.getIp())
+          || !neighborPrimary.getPrefix().containsIp(localPrimary.getIp())
+          || localPrimary.getIp().equals(neighborPrimary.getIp())) {
+        continue;
+      }
 
       OspfArea neighborArea = neighborInterface.getOspfArea();
-      if (connectingInterface.getOspfEnabled()
-          && !connectingInterface.getOspfPassive()
-          && neighborInterface.getOspfEnabled()
+      if (neighborInterface.getOspfEnabled()
           && !neighborInterface.getOspfPassive()
-          && area != null
           && neighborArea != null
-          && area.getAreaNumber() == neighborArea.getAreaNumber()) {
-        neighbors.put(
-            connectingInterface.getAddress().getPrefix(),
-            new OspfLink(area, neighborArea, neighborVirtualRouter));
+          && localArea.getAreaNumber() == neighborArea.getAreaNumber()) {
+        OspfNode localNode = new OspfNode(node, localInterface.getName(), localPrimary.getIp());
+        OspfNode neighborNode =
+            new OspfNode(
+                neighbor.getConfiguration().getHostname(),
+                neighborInterface.getName(),
+                neighborPrimary.getIp());
+        neighbors.add(new OspfEdge(localNode, neighborNode));
       }
     }
 
-    return ImmutableSortedMap.copyOf(neighbors);
+    return neighbors.build();
   }
 
   public Configuration getConfiguration() {

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -2168,19 +2168,19 @@ public class VirtualRouter implements Serializable {
             if (localArea.getStubType() == StubType.STUB) {
               return;
             }
-            // Get remote neighbor's queue by prefix
-            Configuration remoteConfig =
-                allNodes.get(ospfEdge.getNode2().getNode()).getConfiguration();
+
+            // Get remote neighbor's queue
+            Node remoteNode = allNodes.get(ospfEdge.getNode2().getNode());
             String remoteVrf =
-                remoteConfig
+                remoteNode
+                    .getConfiguration()
                     .getAllInterfaces()
                     .get(ospfEdge.getNode2().getInterfaceName())
                     .getVrfName();
-            VirtualRouter remoteRouter =
-                allNodes.get(ospfEdge.getNode2().getNode()).getVirtualRouters().get(remoteVrf);
-
+            VirtualRouter remoteRouter = remoteNode.getVirtualRouters().get(remoteVrf);
             Queue<RouteAdvertisement<OspfExternalRoute>> q =
                 remoteRouter._ospfExternalIncomingRoutes.get(ospfEdge);
+
             queueDelta(q, type1delta);
             queueDelta(q, type2delta);
           });

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/TestUtils.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/TestUtils.java
@@ -1,22 +1,30 @@
 package org.batfish.dataplane.ibdp;
 
 import static org.batfish.datamodel.matchers.AbstractRouteMatchers.hasMetric;
+import static org.batfish.datamodel.matchers.AbstractRouteMatchers.hasNextHopIp;
 import static org.batfish.datamodel.matchers.AbstractRouteMatchers.hasPrefix;
 import static org.batfish.datamodel.matchers.AbstractRouteMatchers.hasProtocol;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.not;
 
+import java.util.List;
 import java.util.SortedMap;
 import java.util.SortedSet;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.InterfaceAddress;
+import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.RoutingProtocol;
+import org.hamcrest.Matchers;
 
 public class TestUtils {
   public static void assertNoRoute(
@@ -52,15 +60,30 @@ public class TestUtils {
       String hostname,
       Prefix prefix,
       long expectedCost) {
+    assertRoute(routesByNode, protocol, hostname, prefix, expectedCost, null);
+  }
+
+  public static void assertRoute(
+      SortedMap<String, SortedMap<String, SortedSet<AbstractRoute>>> routesByNode,
+      RoutingProtocol protocol,
+      String hostname,
+      Prefix prefix,
+      long expectedCost,
+      @Nullable Ip nextHopIp) {
     assertThat(routesByNode, hasKey(hostname));
     SortedMap<String, SortedSet<AbstractRoute>> routesByVrf = routesByNode.get(hostname);
     assertThat(routesByVrf, hasKey(Configuration.DEFAULT_VRF_NAME));
     SortedSet<AbstractRoute> routes = routesByVrf.get(Configuration.DEFAULT_VRF_NAME);
     assertThat(routes, hasItem(hasPrefix(prefix)));
-    AbstractRoute route =
-        routes.stream().filter(r -> r.getNetwork().equals(prefix)).findAny().get();
-    assertThat(route, hasMetric(expectedCost));
-    assertThat(route, hasProtocol(protocol));
+    List<AbstractRoute> routesForPrefix =
+        routes.stream().filter(r -> r.getNetwork().equals(prefix)).collect(Collectors.toList());
+    assertThat(
+        routesForPrefix,
+        hasItem(
+            allOf(
+                hasMetric(expectedCost),
+                hasProtocol(protocol),
+                hasNextHopIp(nextHopIp == null ? Matchers.any(Ip.class) : equalTo(nextHopIp)))));
   }
 
   public static Node makeIosRouter(String hostname) {

--- a/projects/batfish/src/test/java/org/batfish/main/TestrigText.java
+++ b/projects/batfish/src/test/java/org/batfish/main/TestrigText.java
@@ -3,6 +3,7 @@ package org.batfish.main;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedSet;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -96,6 +97,10 @@ public class TestrigText {
     public Builder setConfigurationText(Map<String, String> configurationText) {
       _configurationText = configurationText;
       return this;
+    }
+
+    public Builder setConfigurationText(String testrigResourcePrefix, String... filenames) {
+      return setConfigurationText(testrigResourcePrefix, Arrays.asList(filenames));
     }
 
     public Builder setConfigurationText(String testrigResourcePrefix, Iterable<String> filenames) {

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/ospf-edge/configs/A1
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/ospf-edge/configs/A1
@@ -1,0 +1,17 @@
+hostname A1
+!
+interface GigabitEthernet1/0
+ ip address 10.1.1.1 255.255.255.0
+ description connection to firewall and A2
+ no shutdown
+!
+interface FastEthernet0/0
+ ip address 11.1.1.1 255.255.255.254
+ description connection to A2
+ no shutdown
+!
+router ospf 1
+ network 10.1.1.0 0.0.0.255 area 0
+ network 11.1.1.0 0.0.0.255 area 0
+!
+end

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/ospf-edge/configs/A2
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/ospf-edge/configs/A2
@@ -1,0 +1,17 @@
+hostname A2
+!
+interface GigabitEthernet1/0
+ ip address 10.1.1.2 255.255.255.0
+ description connection to firewall and A1
+ no shutdown
+!
+interface FastEthernet0/0
+ ip address 11.1.1.0 255.255.255.254
+ description connection to A1
+ no shutdown
+!
+router ospf 1
+ network 10.1.1.0 0.0.0.255 area 0
+ network 11.1.1.0 0.0.0.255 area 0
+!
+end

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/ospf-edge/configs/FWL
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/ospf-edge/configs/FWL
@@ -1,0 +1,19 @@
+hostname FWL
+!
+interface FastEthernet0/0
+ ip address 12.1.1.1 255.255.255.254
+ description connection to BOR
+ no shutdown
+!
+interface GigabitEthernet1/0
+ ip address 10.1.1.4 255.255.255.0
+ description connection to R1 and R2
+ no shutdown
+!
+router ospf 1
+ network 10.1.1.0 0.0.0.255 area 0
+ network 11.1.1.0 0.0.0.255 area 0
+ default-information originate
+!
+ip route 0.0.0.0 0.0.0.0 FastEthernet0/0 12.1.1.2
+end


### PR DESCRIPTION
* OSPF Neighbors for a VirtualRouter are now a list of OspfEdge, where this router
  is always the first node in the edge.
* OSPF incoming routes for a VirtualRouter is now a Map of OspfEdge -> Queue, where
  this router is always the *second* node in the edge. (Aka, the receiving edge).
* Stop iterating over L3 topology, just iterate over the queues.
* Some code duplication reduction between processing E1 and E2 routes.

Still needs tests, but making progress.