### PR TITLE
Apply source nat before arp failure dispositions in BDD reachability

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/bddreachability/Edge.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/Edge.java
@@ -14,6 +14,13 @@ final class Edge {
   private final @Nonnull Function<BDD, BDD> _traverseBackward;
   private final @Nonnull Function<BDD, BDD> _traverseForward;
 
+  Edge(StateExpr preState, StateExpr postState) {
+    _preState = preState;
+    _postState = postState;
+    _traverseBackward = Function.identity();
+    _traverseForward = Function.identity();
+  }
+
   Edge(StateExpr preState, StateExpr postState, BDD constraint) {
     _preState = preState;
     _postState = postState;


### PR DESCRIPTION
This fixes a long-standing known bug, and prepares us for implementing source NAT on juniper in a sensible way.

Some other minor changes:
- precompute BDDNat objects since they're used multiple times.
- Created a zero-argument Edge constructor for identity edges (rather than using the one BDD).
- Consolidate null-checking of ACL names.