### PR TITLE
AclExplainer named acls fixes

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/datamodel/acl/AclExplainer.java
+++ b/projects/batfish/src/main/java/org/batfish/datamodel/acl/AclExplainer.java
@@ -5,6 +5,7 @@ import static org.batfish.datamodel.IpAccessListLine.rejecting;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.not;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -141,6 +142,10 @@ public final class AclExplainer {
       IpAccessList acl,
       Map<String, IpAccessList> namedAcls,
       Map<String, IpSpace> namedIpSpaces) {
+    Preconditions.checkArgument(
+        namedAcls.getOrDefault(acl.getName(), acl).equals(acl),
+        "namedAcls contains a different ACL with the same name as acl");
+
     IpAccessListToBDD ipAccessListToBDD =
         MemoizedIpAccessListToBDD.create(bddPacket, mgr, namedAcls, namedIpSpaces);
 

--- a/projects/batfish/src/main/java/org/batfish/datamodel/acl/AclExplainer.java
+++ b/projects/batfish/src/main/java/org/batfish/datamodel/acl/AclExplainer.java
@@ -147,7 +147,7 @@ public final class AclExplainer {
     // add the top-level acl to the list of named acls, because we are going to create
     // a new top-level acl to take into account the given invariant
     Map<String, IpAccessList> finalNamedAcls = new TreeMap<>(namedAcls);
-    finalNamedAcls.put(acl.getName(), acl);
+    finalNamedAcls.putIfAbsent(acl.getName(), acl);
     IpAccessList aclWithInvariant = scopedAcl(invariantExpr, acl);
 
     IdentityHashMap<AclLineMatchExpr, IpAccessListLineIndex> literalsToLines =

--- a/projects/batfish/src/main/java/org/batfish/datamodel/acl/DifferentialIpAccessList.java
+++ b/projects/batfish/src/main/java/org/batfish/datamodel/acl/DifferentialIpAccessList.java
@@ -4,6 +4,7 @@ import static org.batfish.datamodel.IpAccessListLine.accepting;
 import static org.batfish.datamodel.IpAccessListLine.rejecting;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
@@ -71,6 +72,14 @@ public final class DifferentialIpAccessList {
       IpAccessList permitAcl,
       Map<String, IpAccessList> permitNamedAcls,
       Map<String, IpSpace> permitNamedIpSpaces) {
+
+    Preconditions.checkArgument(
+        denyNamedAcls.getOrDefault(denyAcl.getName(), denyAcl).equals(denyAcl),
+        "denyNamedAcls contains a different ACL with the same name as denyAcl");
+    Preconditions.checkArgument(
+        permitNamedAcls.getOrDefault(permitAcl.getName(), permitAcl).equals(permitAcl),
+        "permitNamedAcls contains a different ACL with the same name as permitAcl");
+
     IpSpaceRenamer ipSpaceRenamer = new IpSpaceRenamer(RENAMER);
     IpAccessListRenamer aclRenamer = new IpAccessListRenamer(RENAMER, ipSpaceRenamer);
     /*

--- a/projects/batfish/src/test/java/org/batfish/datamodel/acl/DifferentialIpAccessListTest.java
+++ b/projects/batfish/src/test/java/org/batfish/datamodel/acl/DifferentialIpAccessListTest.java
@@ -3,7 +3,6 @@ package org.batfish.datamodel.acl;
 import static org.batfish.datamodel.IpAccessListLine.accepting;
 import static org.batfish.datamodel.IpAccessListLine.rejecting;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.permittedByAcl;
-import static org.batfish.datamodel.acl.DifferentialIpAccessList.DENY_ACL_NAME;
 import static org.batfish.datamodel.acl.DifferentialIpAccessList.DIFFERENTIAL_ACL_NAME;
 import static org.batfish.datamodel.acl.DifferentialIpAccessList.RENAMER;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -45,6 +44,7 @@ public class DifferentialIpAccessListTest {
     String denyAclReferenceName = "deny named acl";
     String denyIpSpace = "deny named ip space";
 
+    String renamedDenyAclName = RENAMER.apply(denyAclName);
     String renamedDenyAclReferenceName = RENAMER.apply(denyAclReferenceName);
     String renamedDenyIpSpace = RENAMER.apply(denyIpSpace);
 
@@ -86,7 +86,7 @@ public class DifferentialIpAccessListTest {
             .setName(DIFFERENTIAL_ACL_NAME)
             .setLines(
                 ImmutableList.<IpAccessListLine>builder()
-                    .add(rejecting(permittedByAcl(DENY_ACL_NAME)))
+                    .add(rejecting(permittedByAcl(renamedDenyAclName)))
                     .add(accepting(permittedByAcl(permitAcl.getName())))
                     .build())
             .build();
@@ -101,8 +101,8 @@ public class DifferentialIpAccessListTest {
     assertThat(
         differential.getNamedAcls(),
         hasEntry(
-            DENY_ACL_NAME,
-            createAcl(DENY_ACL_NAME, renamedDenyAclReferenceName, renamedDenyIpSpace)));
+            renamedDenyAclName,
+            createAcl(renamedDenyAclName, renamedDenyAclReferenceName, renamedDenyIpSpace)));
     // denyNamedAcls are present and renamed
     assertThat(
         differential.getNamedAcls(),
@@ -137,7 +137,12 @@ public class DifferentialIpAccessListTest {
     assertThat(
         differential.getLiteralsToLines(),
         hasEntry(
-            differential.getNamedAcls().get(DENY_ACL_NAME).getLines().get(1).getMatchCondition(),
+            differential
+                .getNamedAcls()
+                .get(renamedDenyAclName)
+                .getLines()
+                .get(1)
+                .getMatchCondition(),
             new IpAccessListLineIndex(denyAcl, 1)));
     assertThat(
         differential.getLiteralsToLines(),


### PR DESCRIPTION
- allow the set of named ACLs given to AclExplainer to either include or not include the top-level acl being analyzed
- only include the top-level deny ACL in a differential query once in the set of deny named ACLs