### PR TITLE
make all non-computed properties of SearchFiltersQuestion public

### DIFF
--- a/projects/question/src/main/java/org/batfish/question/searchfilters/SearchFiltersQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/searchfilters/SearchFiltersQuestion.java
@@ -116,7 +116,7 @@ public final class SearchFiltersQuestion extends Question {
 
   @Nullable
   @JsonProperty(PROP_FILTERS)
-  private String getFilters() {
+  public String getFilters() {
     return _filters;
   }
 


### PR DESCRIPTION
Only one of the non-computed properties of SearchFiltersQuestion was not public.  Making it public makes it easier to manipulate these questions externally.