### PR TITLE
don't use the aclDefinitions and namedIpSpaces from TransmissionContext

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteEngineImplContext.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteEngineImplContext.java
@@ -682,8 +682,8 @@ public class TracerouteEngineImplContext {
                             inputIfaceName,
                             outgoingInterface.getName(),
                             filter,
-                            transmissionContext._aclDefinitions,
-                            transmissionContext._namedIpSpaces,
+                            aclDefinitions,
+                            namedIpSpaces,
                             _ignoreFilters);
 
                     clonedStepsBuilder.add(step);


### PR DESCRIPTION
Those in TransmissionContext seem to be empty when they shouldn't be. Anyway, this fixes the problem, though I don't fully understand what's going on here, or why the unit tests didn't catch it.

cc @haverma