### PR TITLE
Fix traces for NULL_ROUTED or DENIED by preSourceNat outgoing filters

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteEngineImplContext.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteEngineImplContext.java
@@ -658,9 +658,9 @@ public class TracerouteEngineImplContext {
                             .build());
                     Hop nullRoutedHop =
                         new Hop(new Node(currentNodeName), clonedStepsBuilder.build());
-                    transmissionContext._hopsSoFar.add(nullRoutedHop);
-                    Trace trace =
-                        new Trace(FlowDisposition.NULL_ROUTED, transmissionContext._hopsSoFar);
+                    List<Hop> hops = new ArrayList<>(transmissionContext._hopsSoFar);
+                    hops.add(nullRoutedHop);
+                    Trace trace = new Trace(FlowDisposition.NULL_ROUTED, hops);
                     transmissionContext._flowTraces.add(trace);
                     return;
                   }
@@ -689,10 +689,11 @@ public class TracerouteEngineImplContext {
                     clonedStepsBuilder.add(step);
 
                     if (step.getAction() == StepAction.DENIED) {
-                      Hop outHop = new Hop(new Node(currentNodeName), clonedStepsBuilder.build());
-                      transmissionContext._hopsSoFar.add(outHop);
-                      Trace trace =
-                          new Trace(FlowDisposition.DENIED_OUT, transmissionContext._hopsSoFar);
+                      Hop deniedOutHop =
+                          new Hop(new Node(currentNodeName), clonedStepsBuilder.build());
+                      List<Hop> hops = new ArrayList<>(transmissionContext._hopsSoFar);
+                      hops.add(deniedOutHop);
+                      Trace trace = new Trace(FlowDisposition.DENIED_OUT, hops);
                       transmissionContext._flowTraces.add(trace);
                       return;
                     }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteEngineImplContext.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteEngineImplContext.java
@@ -658,9 +658,13 @@ public class TracerouteEngineImplContext {
                             .build());
                     Hop nullRoutedHop =
                         new Hop(new Node(currentNodeName), clonedStepsBuilder.build());
-                    List<Hop> hops = new ArrayList<>(transmissionContext._hopsSoFar);
-                    hops.add(nullRoutedHop);
-                    Trace trace = new Trace(FlowDisposition.NULL_ROUTED, hops);
+                    Trace trace =
+                        new Trace(
+                            FlowDisposition.NULL_ROUTED,
+                            ImmutableList.<Hop>builder()
+                                .addAll(transmissionContext._hopsSoFar)
+                                .add(nullRoutedHop)
+                                .build());
                     transmissionContext._flowTraces.add(trace);
                     return;
                   }
@@ -691,9 +695,13 @@ public class TracerouteEngineImplContext {
                     if (step.getAction() == StepAction.DENIED) {
                       Hop deniedOutHop =
                           new Hop(new Node(currentNodeName), clonedStepsBuilder.build());
-                      List<Hop> hops = new ArrayList<>(transmissionContext._hopsSoFar);
-                      hops.add(deniedOutHop);
-                      Trace trace = new Trace(FlowDisposition.DENIED_OUT, hops);
+                      Trace trace =
+                          new Trace(
+                              FlowDisposition.DENIED_OUT,
+                              ImmutableList.<Hop>builder()
+                                  .addAll(transmissionContext._hopsSoFar)
+                                  .add(deniedOutHop)
+                                  .build());
                       transmissionContext._flowTraces.add(trace);
                       return;
                     }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TracerouteEngineImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TracerouteEngineImplTest.java
@@ -742,6 +742,22 @@ public class TracerouteEngineImplTest {
         TracerouteEngineImpl.getInstance()
             .buildFlows(dp, ImmutableSet.of(flow2), dp.getFibs(), false);
     assertThat(flowTraces.get(flow2), contains(TraceMatchers.hasDisposition(DENIED_OUT)));
+
+    traceList = flowTraces.get(flow2);
+    assertThat(traceList, hasSize(1));
+    hops = traceList.get(0).getHops();
+    assertThat(hops, hasSize(1));
+
+    steps = hops.get(0).getSteps();
+    assertThat(steps, hasSize(3));
+
+    assertThat(steps.get(0), instanceOf(EnterInputIfaceStep.class));
+    assertThat(steps.get(1), instanceOf(RoutingStep.class));
+    assertThat(steps.get(2), instanceOf(PreSourceNatOutgoingFilterStep.class));
+
+    step2 = (PreSourceNatOutgoingFilterStep) steps.get(2);
+    assertThat(step2.getAction(), equalTo(StepAction.DENIED));
+
     flowTraces =
         TracerouteEngineImpl.getInstance()
             .buildFlows(dp, ImmutableSet.of(flow2), dp.getFibs(), true);


### PR DESCRIPTION
Since these happen inside a loop, we need to copy _hopsSoFar before adding the hop.