### PR TITLE
Remove vrfOwnedIps from specifier context

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/SpecifierContext.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/SpecifierContext.java
@@ -51,23 +51,4 @@ public interface SpecifierContext {
 
   /** @return the {@link IpSpace} of IP addresses owned any device in the network. */
   IpSpace getSnapshotDeviceOwnedIps();
-
-  /**
-   * @return the {@link IpSpace}s owned by each VRF in the network. Mapping: hostname -&gt; VRF name
-   *     -&gt; IpSpace.
-   */
-  Map<String, Map<String, IpSpace>> getVrfOwnedIps();
-
-  /**
-   * Get the {@link IpSpace} owned by the input VRF.
-   *
-   * @param hostname The node the VRF belongs to.
-   * @param vrf The name of the VRF.
-   * @return The combined space of IPs owned by the VRF's interfaces.
-   */
-  default IpSpace getVrfOwnedIps(String hostname, String vrf) {
-    return getVrfOwnedIps()
-        .getOrDefault(hostname, ImmutableMap.of())
-        .getOrDefault(vrf, EmptyIpSpace.INSTANCE);
-  }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/SpecifierContextImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/SpecifierContextImpl.java
@@ -28,8 +28,6 @@ public class SpecifierContextImpl implements SpecifierContext {
 
   private final @Nonnull IpSpace _snapshotDeviceOwnedIps;
 
-  private final @Nonnull Map<String, Map<String, IpSpace>> _vrfOwnedIps;
-
   public SpecifierContextImpl(
       @Nonnull IBatfish batfish, @Nonnull Map<String, Configuration> configs) {
     _batfish = batfish;
@@ -53,9 +51,6 @@ public class SpecifierContextImpl implements SpecifierContext {
     Map<Ip, Map<String, Set<String>>> ipInterfaceOwners =
         TopologyUtil.computeIpInterfaceOwners(nodeInterfaces, true);
     _interfaceOwnedIps = TopologyUtil.computeInterfaceOwnedIpSpaces(ipInterfaceOwners);
-    _vrfOwnedIps =
-        TopologyUtil.computeVrfOwnedIpSpaces(
-            TopologyUtil.computeIpVrfOwners(ipInterfaceOwners, configs));
   }
 
   @Nonnull
@@ -78,11 +73,6 @@ public class SpecifierContextImpl implements SpecifierContext {
   @Override
   public Map<String, Map<String, IpSpace>> getInterfaceOwnedIps() {
     return _interfaceOwnedIps;
-  }
-
-  @Override
-  public Map<String, Map<String, IpSpace>> getVrfOwnedIps() {
-    return _vrfOwnedIps;
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/MockSpecifierContext.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/MockSpecifierContext.java
@@ -23,11 +23,6 @@ public class MockSpecifierContext implements SpecifierContext {
     return _interfaceOwnedIps;
   }
 
-  @Nonnull
-  public Map<String, Map<String, IpSpace>> get_vrfOwnedIps() {
-    return _vrfOwnedIps;
-  }
-
   public static final class Builder {
     private @Nonnull SortedSet<ReferenceBook> _referenceBooks = ImmutableSortedSet.of();
 
@@ -88,15 +83,12 @@ public class MockSpecifierContext implements SpecifierContext {
 
   private final @Nonnull IpSpace _snapshotOwnedIps;
 
-  private final @Nonnull Map<String, Map<String, IpSpace>> _vrfOwnedIps;
-
   private MockSpecifierContext(Builder builder) {
     _referenceBooks = builder._referenceBooks;
     _configs = builder._configs;
     _interfaceOwnedIps = builder._interfaceOwnedIps;
     _nodeRoleDimensions = builder._nodeRoleDimensions;
     _snapshotOwnedIps = builder._snapshotOwnedIps;
-    _vrfOwnedIps = builder._vrfOwnedIps;
   }
 
   @Override
@@ -125,11 +117,5 @@ public class MockSpecifierContext implements SpecifierContext {
   @Override
   public Optional<ReferenceBook> getReferenceBook(String bookName) {
     return _referenceBooks.stream().filter(book -> book.getName().equals(bookName)).findAny();
-  }
-
-  @Override
-  @Nonnull
-  public Map<String, Map<String, IpSpace>> getVrfOwnedIps() {
-    return _vrfOwnedIps;
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/TestSpecifierContext.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/TestSpecifierContext.java
@@ -33,9 +33,4 @@ public class TestSpecifierContext implements SpecifierContext {
   public IpSpace getSnapshotDeviceOwnedIps() {
     throw new UnsupportedOperationException();
   }
-
-  @Override
-  public Map<String, Map<String, IpSpace>> getVrfOwnedIps() {
-    throw new UnsupportedOperationException();
-  }
 }


### PR DESCRIPTION
Simplifies future work on caching results of ipOwners