### PR TITLE
FilterLineReachability: proposal to simplify blocking lines reported

### DIFF
--- a/projects/question/BUILD
+++ b/projects/question/BUILD
@@ -63,6 +63,7 @@ junit_tests(
         ":question_testlib",
         "//projects/batfish-common-protocol:common",
         "//projects/batfish-common-protocol:common_testlib",
+        "//projects/lib/bdd",
         "//projects/lib/jsonpath",
         "@auto_service//:compile",
         "@guava//:compile",

--- a/projects/question/src/main/java/org/batfish/question/filterlinereachability/FilterLineReachabilityAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/filterlinereachability/FilterLineReachabilityAnswerer.java
@@ -510,9 +510,9 @@ public class FilterLineReachabilityAnswerer extends Answerer {
 
         // all lines in [0, lineNum) that match part of the blocked line's address space.
         ImmutableSortedSet.Builder<Integer> allMatchers = ImmutableSortedSet.naturalOrder();
-        // signicant lines are those that match at least satThreshhold of the address space.
+        // signicant lines are those that match at least satThreshold of the address space.
         ImmutableSortedSet.Builder<Integer> significantMatchers = ImmutableSortedSet.naturalOrder();
-        double satThreshhold = blockedLine.satCount() * SIGNIFICANCE_THRESHOLD;
+        double satThreshold = blockedLine.satCount() * SIGNIFICANCE_THRESHOLD;
 
         BDD restOfLine = blockedLine;
         BDD significantRest = blockedLine;
@@ -524,14 +524,14 @@ public class FilterLineReachabilityAnswerer extends Answerer {
           }
 
           allMatchers.add(prevLineNum);
-          if (intersection.satCount() > satThreshhold) {
+          if (prevLine.and(blockedLine).satCount() > satThreshold) {
             significantMatchers.add(prevLineNum);
             significantRest = significantRest.and(prevLine.not());
           }
           restOfLine = restOfLine.and(intersection.not());
         }
 
-        // Use the blockingLines as the answer, unless there are no
+        // Use the blockingLines as the answer, unless it is not a complete cover.
         SortedSet<Integer> answerLines =
             significantRest.isZero() ? significantMatchers.build() : allMatchers.build();
         answerRows.addUnreachableLine(aclSpec, lineNum, false, answerLines);

--- a/projects/question/src/main/java/org/batfish/question/filterlinereachability/FilterLineReachabilityAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/filterlinereachability/FilterLineReachabilityAnswerer.java
@@ -464,8 +464,7 @@ public class FilterLineReachabilityAnswerer extends Answerer {
     return aclSpecs.stream().map(AclSpecs.Builder::build).collect(Collectors.toList());
   }
 
-  @VisibleForTesting
-  static void answerAclReachability(
+  private static void answerAclReachability(
       List<AclSpecs> aclSpecs, FilterLineReachabilityRows answerRows) {
     BDDPacket bddPacket = new BDDPacket();
     BDDFactory bddFactory = bddPacket.getFactory();

--- a/projects/question/src/main/java/org/batfish/question/filterlinereachability/FilterLineReachabilityQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/filterlinereachability/FilterLineReachabilityQuestion.java
@@ -5,6 +5,7 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.VisibleForTesting;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -66,20 +67,20 @@ public class FilterLineReachabilityQuestion extends Question {
         ignoreComposites);
   }
 
-  public FilterLineReachabilityQuestion() {
+  @VisibleForTesting
+  FilterLineReachabilityQuestion() {
     this(null, null, null, null, null);
   }
 
-  public FilterLineReachabilityQuestion(String filterSpecifierInput) {
+  @VisibleForTesting
+  FilterLineReachabilityQuestion(String filterSpecifierInput) {
     this(null, filterSpecifierInput, null, null, null);
   }
 
-  public FilterLineReachabilityQuestion(String filterSpecifierInput, String nodeSpecifierInput) {
-    this(null, filterSpecifierInput, null, nodeSpecifierInput, null);
-  }
-
   public FilterLineReachabilityQuestion(
-      String filterSpecifierInput, String nodeSpecifierInput, boolean ignoreComposites) {
+      @Nullable String filterSpecifierInput,
+      @Nullable String nodeSpecifierInput,
+      boolean ignoreComposites) {
     this(null, filterSpecifierInput, null, nodeSpecifierInput, ignoreComposites);
   }
 

--- a/projects/question/src/test/java/org/batfish/question/filterlinereachability/FilterLineReachabilityAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/filterlinereachability/FilterLineReachabilityAnswererTest.java
@@ -56,6 +56,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+/** Tests of {@link FilterLineReachabilityAnswerer}. */
 public class FilterLineReachabilityAnswererTest {
 
   @Rule public TemporaryFolder _folder = new TemporaryFolder();

--- a/projects/question/src/test/java/org/batfish/question/filterlinereachability/FilterLineReachabilityAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/filterlinereachability/FilterLineReachabilityAnswererTest.java
@@ -727,11 +727,13 @@ public class FilterLineReachabilityAnswererTest {
 
     // #0 is not included despite different action when #1 already has different action.
     List<LineAction> actionsAndCover = ImmutableList.of(DENY, DENY, PERMIT);
-    assertThat(findBlockingLinesForLine(2, sameActions, bdds), contains(1));
+    assertThat(findBlockingLinesForLine(2, actionsAndCover, bdds), contains(1));
   }
 
+  // This is really a documentation test for a case where we might want #0 to be reported, but
+  // it won't be.
   @Test
-  public void testDifferenceActionsPreserved() {
+  public void testSameActionNotReported() {
     BDDPacket p = new BDDPacket();
     BDD tcp = p.getIpProtocol().value(IpProtocol.TCP.number());
     BDD tcpEstablished = p.getTcpAck().or(p.getTcpRst());

--- a/tests/basic/filterLineReachability.ref
+++ b/tests/basic/filterLineReachability.ref
@@ -76,7 +76,6 @@
         "Unreachable_Line_Action" : "PERMIT",
         "Unreachable_Line" : "permit icmp any any",
         "Blocking_Lines" : [
-          "permit ip 2.128.0.0 0.0.255.255 any",
           "deny   ip any any"
         ],
         "Different_Action" : true,


### PR DESCRIPTION
When line L is blocked and lines 1..L-1 terminate some of the flows that line L match, the old code returns all of lines 1->L-1 as blocking lines. In reality, this is usually overly conservative because many of the lines may represent "trivial" overlaps.

Prune down the list of blocked lines by building up a subset of lines 1..L-1 that:
- considers lines in decreasing order of how much they overlap with L.
- stop when we have a subset that fully covers L, hopefully much smaller than 1..L-1.
- if some line has a different action than L, includes at least the largest such line. This indicates to the user that some packets L intended to permit/deny are denied/permitted, and lets the user decide how important this is.

Refactors the internals of FilterLineReachabilityAnswerer for readability, and adds tests.