### PR TITLE
Juniper address books

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_security.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_security.g4
@@ -411,7 +411,7 @@ s_security
 
 se_address_book
 :
-   ADDRESS_BOOK GLOBAL
+   ADDRESS_BOOK name = variable
    (
        apply
        | sead_address

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -1967,7 +1967,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
     _currentRoutingInstance = _currentLogicalSystem.getDefaultRoutingInstance();
     _globalAddressBook =
         _currentLogicalSystem
-            .getGlobalAddressBooks()
+            .getAddressBooks()
             .computeIfAbsent(GLOBAL_ADDRESS_BOOK_NAME, n -> new AddressBook(n, new TreeMap<>()));
   }
 
@@ -2840,10 +2840,10 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
 
   @Override
   public void enterSe_address_book(Se_address_bookContext ctx) {
-    String name = ctx.GLOBAL().getText();
+    String name = ctx.name.getText();
     _currentAddressBook =
         _currentLogicalSystem
-            .getGlobalAddressBooks()
+            .getAddressBooks()
             .computeIfAbsent(name, n -> new AddressBook(n, new TreeMap<>()));
   }
 
@@ -3021,7 +3021,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
       if (ctx.from.JUNOS_HOST() == null) {
         _currentFromZone = _currentLogicalSystem.getZones().get(fromName);
         if (_currentFromZone == null) {
-          _currentFromZone = new Zone(fromName, _currentLogicalSystem.getGlobalAddressBooks());
+          _currentFromZone = new Zone(fromName, _currentLogicalSystem.getAddressBooks());
           _currentLogicalSystem.getZones().put(fromName, _currentFromZone);
           _currentLogicalSystem
               .getFirewallFilters()
@@ -3034,7 +3034,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
       if (ctx.to.JUNOS_HOST() == null) {
         _currentToZone = _currentLogicalSystem.getZones().get(toName);
         if (_currentToZone == null) {
-          _currentToZone = new Zone(toName, _currentLogicalSystem.getGlobalAddressBooks());
+          _currentToZone = new Zone(toName, _currentLogicalSystem.getAddressBooks());
           _currentLogicalSystem
               .getFirewallFilters()
               .put(_currentToZone.getInboundFilter().getName(), _currentToZone.getInboundFilter());
@@ -3104,7 +3104,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
     String zoneName = ctx.zone().getText();
     _currentZone = _currentLogicalSystem.getZones().get(zoneName);
     if (_currentZone == null) {
-      _currentZone = new Zone(zoneName, _currentLogicalSystem.getGlobalAddressBooks());
+      _currentZone = new Zone(zoneName, _currentLogicalSystem.getAddressBooks());
       _currentLogicalSystem
           .getFirewallFilters()
           .put(_currentZone.getInboundFilter().getName(), _currentZone.getInboundFilter());

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -2128,7 +2128,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
     _masterLogicalSystem.getDnsServers().clear();
     _masterLogicalSystem.getDnsServers().addAll(ls.getDnsServers());
     _masterLogicalSystem.getFirewallFilters().putAll(ls.getFirewallFilters());
-    _masterLogicalSystem.getGlobalAddressBooks().putAll(ls.getGlobalAddressBooks());
+    _masterLogicalSystem.getAddressBooks().putAll(ls.getAddressBooks());
     _masterLogicalSystem.getIkeGateways().clear();
     _masterLogicalSystem.getIkeGateways().putAll(ls.getIkeGateways());
     _masterLogicalSystem.getIkePolicies().clear();
@@ -2237,7 +2237,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
 
     // Convert AddressBooks to IpSpaces
     _masterLogicalSystem
-        .getGlobalAddressBooks()
+        .getAddressBooks()
         .forEach(
             (name, addressBook) -> {
               Map<String, IpSpace> ipspaces = toIpSpaces(name, addressBook);

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/LogicalSystem.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/LogicalSystem.java
@@ -19,6 +19,8 @@ public class LogicalSystem implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
+  private final Map<String, AddressBook> _addressBooks;
+
   private final Map<String, BaseApplication> _applications;
 
   private final Map<String, ApplicationSet> _applicationSets;
@@ -40,8 +42,6 @@ public class LogicalSystem implements Serializable {
   private NavigableSet<String> _dnsServers;
 
   private final Map<String, FirewallFilter> _filters;
-
-  private final Map<String, AddressBook> _globalAddressBooks;
 
   private final Map<String, IkeGateway> _ikeGateways;
 
@@ -89,6 +89,7 @@ public class LogicalSystem implements Serializable {
 
   public LogicalSystem(String name) {
     _name = name;
+    _addressBooks = new TreeMap<>();
     _applications = new TreeMap<>();
     _applicationSets = new TreeMap<>();
     _asPathGroups = new TreeMap<>();
@@ -98,7 +99,6 @@ public class LogicalSystem implements Serializable {
     _defaultRoutingInstance = new RoutingInstance(Configuration.DEFAULT_VRF_NAME);
     _dnsServers = new TreeSet<>();
     _filters = new TreeMap<>();
-    _globalAddressBooks = new TreeMap<>();
     _ikeGateways = new TreeMap<>();
     _ikePolicies = new TreeMap<>();
     _ikeProposals = new TreeMap<>();
@@ -118,6 +118,10 @@ public class LogicalSystem implements Serializable {
     _tacplusServers = new TreeSet<>();
     _vlanNameToVlan = new TreeMap<>();
     _zones = new TreeMap<>();
+  }
+
+  public Map<String, AddressBook> getAddressBooks() {
+    return _addressBooks;
   }
 
   public Map<String, BaseApplication> getApplications() {
@@ -162,10 +166,6 @@ public class LogicalSystem implements Serializable {
 
   public Map<String, FirewallFilter> getFirewallFilters() {
     return _filters;
-  }
-
-  public Map<String, AddressBook> getGlobalAddressBooks() {
-    return _globalAddressBooks;
   }
 
   public Interface getGlobalMasterInterface() {

--- a/tests/parsing-tests/networks/unit-tests/configs/juniper_security
+++ b/tests/parsing-tests/networks/unit-tests/configs/juniper_security
@@ -5,6 +5,9 @@ set security address-book global address ADDRESS description "ADDRESS descriptio
 #
 set security address-book global address-set ASET description "ASET description"
 #
+# a non-global address book
+set security address-book notglobal address-set ASET description "ASET description"
+#
 set security ike proposal PROPOSAL description "IKE proposal"
 set security ike policy 1.2.3.4 proposals [ PROPOSAL ]
 #

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -19349,10 +19349,17 @@
           "global~ASET" : {
             "sourceName" : "global~ASET",
             "sourceType" : "address-book"
+          },
+          "notglobal~ASET" : {
+            "sourceName" : "notglobal~ASET",
+            "sourceType" : "address-book"
           }
         },
         "ipSpaces" : {
           "global~ASET" : {
+            "class" : "org.batfish.datamodel.IpWildcardSetIpSpace"
+          },
+          "notglobal~ASET" : {
             "class" : "org.batfish.datamodel.IpWildcardSetIpSpace"
           }
         },

--- a/tests/parsing-tests/unit-tests-unused.ref
+++ b/tests/parsing-tests/unit-tests-unused.ref
@@ -2257,7 +2257,7 @@
         "Source_Lines" : {
           "filename" : "configs/juniper_security",
           "lines" : [
-            9
+            12
           ]
         }
       },

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -50340,7 +50340,8 @@
             "            SECURITY:'security'",
             "            (se_address_book",
             "              ADDRESS_BOOK:'address-book'",
-            "              GLOBAL:'global'",
+            "              name = (variable",
+            "                text = GLOBAL:'global')",
             "              (sead_address",
             "                ADDRESS:'address'",
             "                name = (variable",
@@ -50358,7 +50359,28 @@
             "            SECURITY:'security'",
             "            (se_address_book",
             "              ADDRESS_BOOK:'address-book'",
-            "              GLOBAL:'global'",
+            "              name = (variable",
+            "                text = GLOBAL:'global')",
+            "              (sead_address_set",
+            "                ADDRESS_SET:'address-set'",
+            "                name = (variable",
+            "                  text = VARIABLE:'ASET')",
+            "                (seada_description",
+            "                  DESCRIPTION:'description'",
+            "                  (null_filler",
+            "                    M_Description_DESCRIPTION:'\"ASET description\"'  <== mode:M_Description))))))))",
+            "    NEWLINE:'\\n'  <== mode:M_Description)",
+            "  (set_line",
+            "    SET:'set'",
+            "    (set_line_tail",
+            "      (statement",
+            "        (s_common",
+            "          (s_security",
+            "            SECURITY:'security'",
+            "            (se_address_book",
+            "              ADDRESS_BOOK:'address-book'",
+            "              name = (variable",
+            "                text = VARIABLE:'notglobal')",
             "              (sead_address_set",
             "                ADDRESS_SET:'address-set'",
             "                name = (variable",
@@ -66061,7 +66083,7 @@
           "ike policy" : {
             "1.2.3.4" : {
               "definitionLines" : [
-                9
+                12
               ],
               "numReferrers" : 0
             }
@@ -66069,7 +66091,7 @@
           "ike proposal" : {
             "PROPOSAL" : {
               "definitionLines" : [
-                8
+                11
               ],
               "numReferrers" : 1
             }
@@ -69395,7 +69417,7 @@
           "ike proposal" : {
             "PROPOSAL" : {
               "ike policy ike proposal" : [
-                9
+                12
               ]
             }
           }


### PR DESCRIPTION
Fixed what appears to be a misunderstanding in Juniper address book implementation. There is only one global address book with name "global," and there can be other non-global address books with custom names. 