### PR TITLE
Interface dependencies: use for tunnels and portchannels

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -88,6 +88,8 @@ public final class Interface extends ComparableStructure<String> {
 
     private SortedSet<Ip> _additionalArpIps;
 
+    private InterfaceType _type;
+
     private Vrf _vrf;
 
     private SortedMap<Integer, VrrpGroup> _vrrpGroups;
@@ -143,6 +145,9 @@ public final class Interface extends ComparableStructure<String> {
       iface.setPreSourceNatOutgoingFilter(_preSourceNatOutgoingFilter);
       iface.setProxyArp(_proxyArp);
       iface.setSourceNats(_sourceNats);
+      if (_type != null) {
+        iface.setInterfaceType(_type);
+      }
       iface.setVrf(_vrf);
       if (_vrf != null) {
         _vrf.getInterfaces().put(name, iface);
@@ -332,6 +337,11 @@ public final class Interface extends ComparableStructure<String> {
       return this;
     }
 
+    public Builder setType(InterfaceType type) {
+      _type = type;
+      return this;
+    }
+
     public Builder setVrf(Vrf vrf) {
       _vrf = vrf;
       return this;
@@ -395,6 +405,8 @@ public final class Interface extends ComparableStructure<String> {
   }
 
   private static final int DEFAULT_MTU = 1500;
+
+  public static final String DYNAMIC_INTERFACE_NAME = "dynamic";
 
   public static final String NULL_INTERFACE_NAME = "null_interface";
 
@@ -649,6 +661,8 @@ public final class Interface extends ComparableStructure<String> {
       return InterfaceType.VPN;
     } else if (name.startsWith("reth")) {
       return InterfaceType.REDUNDANT;
+    } else if (name.startsWith("ae") && name.contains(".")) {
+      return InterfaceType.AGGREGATE_CHILD;
     } else if (name.startsWith("ae")) {
       return InterfaceType.AGGREGATED;
     } else if (name.startsWith("lo")) {
@@ -1630,5 +1644,18 @@ public final class Interface extends ComparableStructure<String> {
   public void blacklist() {
     setActive(false);
     setBlacklisted(true);
+  }
+
+  /**
+   * Check if the given interface name is <b>not</b> one of the special values defined by batfish or
+   * virtual null interface.
+   */
+  public static boolean isRealInterfaceName(@Nonnull String name) {
+    return !ImmutableList.of(
+            UNSET_LOCAL_INTERFACE,
+            DYNAMIC_INTERFACE_NAME,
+            NULL_INTERFACE_NAME,
+            INVALID_LOCAL_INTERFACE)
+        .contains(name);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/InterfaceType.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/InterfaceType.java
@@ -4,6 +4,8 @@ package org.batfish.datamodel;
 public enum InterfaceType {
   /** Logical interface that aggregates multiple (physical) interfaces */
   AGGREGATED,
+  /** Child of a aggregate interface: logical, sub-interface of an AGGREGATED interface */
+  AGGREGATE_CHILD,
   /** Generic Logical interface, (e.g., units on Juniper devices) */
   LOGICAL,
   /** Logical loopback interface */

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/InterfaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/InterfaceTest.java
@@ -1,5 +1,7 @@
 package org.batfish.datamodel;
 
+import static org.batfish.datamodel.Interface.isRealInterfaceName;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.google.common.testing.EqualsTester;
@@ -33,5 +35,16 @@ public class InterfaceTest {
 
     assertThat("Interface is blacklisted", i.getBlacklisted());
     assertThat("Interface is disabled", !i.getActive());
+  }
+
+  @Test
+  public void testRealInterafceName() {
+    assertThat(isRealInterfaceName("Ethernet0"), equalTo(true));
+    assertThat(isRealInterfaceName("ge-0/0/0"), equalTo(true));
+    assertThat(isRealInterfaceName("asdfasdf"), equalTo(true));
+    assertThat(isRealInterfaceName("null_interface"), equalTo(false));
+    assertThat(isRealInterfaceName("unset_local_interface"), equalTo(false));
+    assertThat(isRealInterfaceName("invalid_local_interface"), equalTo(false));
+    assertThat(isRealInterfaceName("dynamic"), equalTo(false));
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/Tunnel.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/Tunnel.java
@@ -55,6 +55,7 @@ public final class Tunnel implements Serializable {
     return _sourceAddress;
   }
 
+  @Nonnull
   public String getSourceInterfaceName() {
     return _sourceInterfaceName;
   }
@@ -75,7 +76,7 @@ public final class Tunnel implements Serializable {
     _protocol = protocol;
   }
 
-  public void setSourceAddress(Ip source) {
+  public void setSourceAddress(@Nullable Ip source) {
     _sourceAddress = source;
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -258,6 +258,8 @@ import org.batfish.datamodel.IcmpType;
 import org.batfish.datamodel.IkeAuthenticationMethod;
 import org.batfish.datamodel.IkeHashingAlgorithm;
 import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.Interface.Dependency;
+import org.batfish.datamodel.Interface.DependencyType;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.InterfaceType;
 import org.batfish.datamodel.Ip;
@@ -3061,6 +3063,12 @@ public class CiscoGrammarTest {
     assertThat(c, hasInterface("Ethernet2", hasBandwidth(40E9D)));
     assertThat(c, hasInterface("Port-Channel1", hasBandwidth(80E9D)));
     assertThat(c, hasInterface("Port-Channel2", isActive(false)));
+    assertThat(
+        c.getAllInterfaces().get("Port-Channel1").getDependencies(),
+        equalTo(
+            ImmutableSet.of(
+                new Dependency("Ethernet0", DependencyType.AGGREGATE),
+                new Dependency("Ethernet1", DependencyType.AGGREGATE))));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
@@ -45,6 +45,7 @@ import org.batfish.datamodel.Edge;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Interface.Dependency;
 import org.batfish.datamodel.Interface.DependencyType;
+import org.batfish.datamodel.InterfaceType;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.Topology;
@@ -704,19 +705,21 @@ public class BatfishTest {
 
     Interface.Builder ib = nf.interfaceBuilder().setOwner(c1).setVrf(vrf);
 
-    ib.setName("eth0").setActive(false).build();
-    ib.setName("eth1").setActive(true).build();
+    ib.setName("eth0").setActive(false).setType(InterfaceType.PHYSICAL).build();
+    ib.setName("eth1").setActive(true).setType(InterfaceType.PHYSICAL).build();
     ib.setName("eth2")
         .setActive(true)
+        .setType(InterfaceType.AGGREGATED)
         .setDependencies(
             ImmutableSet.of(
                 new Dependency("eth1", DependencyType.AGGREGATE),
                 new Dependency("eth0", DependencyType.AGGREGATE)))
         .build();
 
-    ib.setName("eth3").setActive(false).build();
+    ib.setName("eth3").setActive(false).setType(InterfaceType.PHYSICAL).build();
     ib.setName("eth4")
         .setActive(true)
+        .setType(InterfaceType.AGGREGATED)
         .setDependencies(
             ImmutableSet.of(
                 new Dependency("eth0", DependencyType.AGGREGATE),

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -14881,7 +14881,7 @@
           "ae16" : {
             "name" : "ae16",
             "accessVlan" : 0,
-            "active" : true,
+            "active" : false,
             "allowedVlans" : "",
             "autostate" : true,
             "bandwidth" : 0.0,
@@ -14907,7 +14907,7 @@
           "ae16.0" : {
             "name" : "ae16.0",
             "accessVlan" : 0,
-            "active" : true,
+            "active" : false,
             "allowedVlans" : "",
             "autostate" : true,
             "bandwidth" : 0.0,
@@ -14927,7 +14927,7 @@
             "spanningTreePortfast" : false,
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "AGGREGATED",
+            "type" : "AGGREGATE_CHILD",
             "vrf" : "default"
           },
           "xe-0/0/1" : {
@@ -16879,7 +16879,7 @@
             "spanningTreePortfast" : false,
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "AGGREGATED",
+            "type" : "AGGREGATE_CHILD",
             "vrf" : "default"
           },
           "ge-0/0/0" : {


### PR DESCRIPTION
* Cisco: properly set dependencies for tunnels (source-interface)
  and portchannels
* Disable portchannels based on dependencies only
* Introduce new interface type for Juniper ae unit interfaces