### PR TITLE
AclIpSpace: simplify creation, short-circuit building

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/ipspace/IpSpaceSimplifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/ipspace/IpSpaceSimplifier.java
@@ -95,7 +95,7 @@ public class IpSpaceSimplifier implements GenericIpSpaceVisitor<IpSpace> {
       return UniverseIpSpace.INSTANCE;
     }
 
-    return AclIpSpace.builder().setLines(simplifiedLines).build();
+    return AclIpSpace.of(simplifiedLines);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/ipspace/IpSpaceSpecializer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/ipspace/IpSpaceSpecializer.java
@@ -80,7 +80,7 @@ public abstract class IpSpaceSpecializer implements GenericIpSpaceVisitor<IpSpac
       return EmptyIpSpace.INSTANCE;
     }
 
-    return AclIpSpace.builder().setLines(specializedLines).build();
+    return AclIpSpace.of(specializedLines);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/visitors/IpSpaceDereferencer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/visitors/IpSpaceDereferencer.java
@@ -1,7 +1,5 @@
 package org.batfish.datamodel.visitors;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
@@ -85,13 +83,13 @@ public class IpSpaceDereferencer implements GenericIpSpaceVisitor<IpSpace> {
   @Override
   public IpSpace visitAclIpSpace(AclIpSpace aclIpSpace)
       throws CircularReferenceException, UndefinedReferenceException {
-    List<AclIpSpaceLine> sanitizedLines = new ArrayList<>();
+    AclIpSpace.Builder sanitizedSpace = AclIpSpace.builder();
     for (AclIpSpaceLine line : aclIpSpace.getLines()) {
       IpSpace ipSpace = line.getIpSpace().accept(this);
-      sanitizedLines.add(AclIpSpaceLine.builder().setIpSpace(ipSpace).build());
+      sanitizedSpace.thenAction(line.getAction(), ipSpace);
     }
     // No cycles/undefined references in this AclIpSpace. Return reference-free version.
-    return AclIpSpace.builder().setLines(sanitizedLines).build();
+    return sanitizedSpace.build();
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/AclIpSpaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/AclIpSpaceTest.java
@@ -52,4 +52,21 @@ public class AclIpSpaceTest {
     assertThat(union(EmptyIpSpace.INSTANCE), equalTo(EmptyIpSpace.INSTANCE));
     assertThat(union(EmptyIpSpace.INSTANCE, ipSpace), equalTo(ipSpace));
   }
+
+  @Test
+  public void testStopWhenEmpty() {
+    AclIpSpace space =
+        AclIpSpace.builder()
+            .thenPermitting(Prefix.parse("1.2.3.4/32").toIpSpace())
+            .thenRejecting(UniverseIpSpace.INSTANCE)
+            .thenPermitting(Prefix.parse("2.0.0.0/8").toIpSpace())
+            .build();
+
+    AclIpSpace expected =
+        AclIpSpace.builder()
+            .thenPermitting(Prefix.parse("1.2.3.4/32").toIpSpace())
+            .thenRejecting(UniverseIpSpace.INSTANCE)
+            .build();
+    assertThat(space, equalTo(expected));
+  }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/AclTracerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/AclTracerTest.java
@@ -148,8 +148,7 @@ public class AclTracerTest {
 
   @Test
   public void testDeniedByNamedAclIpSpaceLine() {
-    AclIpSpace aclIpSpace =
-        AclIpSpace.builder().setLines(ImmutableList.of(AclIpSpaceLine.DENY_ALL)).build();
+    AclIpSpace aclIpSpace = AclIpSpace.of(AclIpSpaceLine.DENY_ALL);
     IpAccessList acl =
         IpAccessList.builder()
             .setName(ACL_NAME)

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/visitors/IpSpaceDereferencerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/visitors/IpSpaceDereferencerTest.java
@@ -1,0 +1,49 @@
+package org.batfish.datamodel.visitors;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.batfish.datamodel.AclIpSpace;
+import org.batfish.datamodel.EmptyIpSpace;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpSpace;
+import org.batfish.datamodel.IpSpaceReference;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.UniverseIpSpace;
+import org.junit.Test;
+
+public class IpSpaceDereferencerTest {
+  private static final Map<String, IpSpace> NAMED_IP_SPACES =
+      ImmutableMap.of(
+          "empty",
+          EmptyIpSpace.INSTANCE,
+          "ip",
+          new Ip("1.2.3.4").toIpSpace(),
+          "prefix",
+          Prefix.parse("1.0.0.0/8").toIpSpace(),
+          "namedIp",
+          new IpSpaceReference("ip"));
+
+  @Test
+  public void testAclIpSpace() {
+    IpSpaceDereferencer dereferencer = new IpSpaceDereferencer(NAMED_IP_SPACES);
+    AclIpSpace input =
+        AclIpSpace.builder()
+            .thenPermitting(new IpSpaceReference("empty"))
+            .thenRejecting(new IpSpaceReference("prefix"))
+            .thenPermitting(new IpSpaceReference("namedIp"))
+            .thenRejecting(UniverseIpSpace.INSTANCE)
+            .build();
+
+    AclIpSpace expected =
+        AclIpSpace.builder()
+            .thenPermitting(NAMED_IP_SPACES.get("empty"))
+            .thenRejecting(NAMED_IP_SPACES.get("prefix"))
+            .thenPermitting(NAMED_IP_SPACES.get("ip"))
+            .thenRejecting(UniverseIpSpace.INSTANCE)
+            .build();
+    assertThat(dereferencer.visitAclIpSpace(input), equalTo(expected));
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/visitors/IpSpaceDescriberTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/visitors/IpSpaceDescriberTest.java
@@ -3,7 +3,6 @@ package org.batfish.datamodel.visitors;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.batfish.datamodel.AclIpSpace;
 import org.batfish.datamodel.AclIpSpaceLine;
@@ -15,7 +14,6 @@ import org.batfish.datamodel.IpSpaceMetadata;
 import org.batfish.datamodel.IpSpaceReference;
 import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.IpWildcardSetIpSpace;
-import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.UniverseIpSpace;
 import org.batfish.datamodel.acl.AclTracer;
@@ -50,15 +48,7 @@ public final class IpSpaceDescriberTest {
     IpSpace lineIpSpace = UniverseIpSpace.INSTANCE;
     String lineIpSpaceName = "lineIpSpace";
     IpSpaceMetadata lineIpSpaceMetadata = new IpSpaceMetadata("line_space_name", "line_space_type");
-    IpSpace ipSpace =
-        AclIpSpace.builder()
-            .setLines(
-                ImmutableList.of(
-                    AclIpSpaceLine.builder()
-                        .setAction(LineAction.PERMIT)
-                        .setIpSpace(lineIpSpace)
-                        .build()))
-            .build();
+    IpSpace ipSpace = AclIpSpace.of(AclIpSpaceLine.permit(lineIpSpace));
     IpSpaceDescriber describerWithMetadata =
         new IpSpaceDescriber(
             new AclTracer(

--- a/projects/batfish/src/main/java/org/batfish/datamodel/visitors/IpSpaceRenamer.java
+++ b/projects/batfish/src/main/java/org/batfish/datamodel/visitors/IpSpaceRenamer.java
@@ -1,6 +1,5 @@
 package org.batfish.datamodel.visitors;
 
-import com.google.common.collect.ImmutableList;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
 import org.batfish.datamodel.AclIpSpace;
@@ -27,14 +26,15 @@ public class IpSpaceRenamer implements Function<IpSpace, IpSpace> {
 
     @Override
     public IpSpace visitAclIpSpace(AclIpSpace aclIpSpace) {
-      return AclIpSpace.builder()
-          .setLines(
-              aclIpSpace
-                  .getLines()
-                  .stream()
-                  .map(ln -> ln.toBuilder().setIpSpace(ln.getIpSpace().accept(this)).build())
-                  .collect(ImmutableList.toImmutableList()))
-          .build();
+      AclIpSpace.Builder renamedSpace = AclIpSpace.builder();
+      aclIpSpace
+          .getLines()
+          .forEach(
+              line -> {
+                IpSpace space = line.getIpSpace().accept(this);
+                renamedSpace.thenAction(line.getAction(), space);
+              });
+      return renamedSpace.build();
     }
 
     @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -37,7 +37,6 @@ import org.batfish.common.BatfishException;
 import org.batfish.common.VendorConversionException;
 import org.batfish.common.util.CommonUtil;
 import org.batfish.datamodel.AclIpSpace;
-import org.batfish.datamodel.AclIpSpaceLine;
 import org.batfish.datamodel.AuthenticationKey;
 import org.batfish.datamodel.AuthenticationKeyChain;
 import org.batfish.datamodel.BgpActivePeerConfig;
@@ -1857,23 +1856,16 @@ public final class JuniperConfiguration extends VendorConfiguration {
 
               // If this address book references other entries, add them to an AclIpSpace
               if (!entry.getEntries().isEmpty()) {
-                ImmutableList.Builder<AclIpSpaceLine> aclIpSpaceLineBuilder =
-                    ImmutableList.builder();
+                AclIpSpace.Builder aclIpSpaceBuilder = AclIpSpace.builder();
                 entry
                     .getEntries()
                     .keySet()
                     .forEach(
                         name -> {
                           String subEntryName = bookName + "~" + name;
-                          aclIpSpaceLineBuilder.add(
-                              AclIpSpaceLine.builder()
-                                  .setIpSpace(new IpSpaceReference(subEntryName))
-                                  .setAction(LineAction.PERMIT)
-                                  .build());
+                          aclIpSpaceBuilder.thenPermitting(new IpSpaceReference(subEntryName));
                         });
-                ipSpaces.put(
-                    entryName,
-                    AclIpSpace.builder().setLines(aclIpSpaceLineBuilder.build()).build());
+                ipSpaces.put(entryName, aclIpSpaceBuilder.build());
               } else {
                 ipSpaces.put(
                     entryName,

--- a/projects/batfish/src/test/java/org/batfish/z3/expr/visitors/IpSpaceBooleanExprTransformerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/expr/visitors/IpSpaceBooleanExprTransformerTest.java
@@ -39,8 +39,8 @@ public class IpSpaceBooleanExprTransformerTest {
   public void testVisitAclIpSpace() {
     AclIpSpace ipSpace =
         AclIpSpace.builder()
-            .thenRejecting(UniverseIpSpace.INSTANCE)
             .thenPermitting(EmptyIpSpace.INSTANCE)
+            .thenRejecting(UniverseIpSpace.INSTANCE)
             .build();
 
     BooleanExpr expr = ipSpace.accept(SRC_IP_SPACE_BOOLEAN_EXPR_TRANSFORMER);
@@ -51,15 +51,15 @@ public class IpSpaceBooleanExprTransformerTest {
             new OrExpr(
                 ImmutableList.of(
                     new IfThenElse(
-                        // Matches UniverseIpSpace
-                        TrueExpr.INSTANCE,
-                        // Reject
+                        // Matches EmptyIpSpace
                         FalseExpr.INSTANCE,
+                        // Accept
+                        TrueExpr.INSTANCE,
                         new IfThenElse(
-                            // Matches EmptyIpSpace
-                            FalseExpr.INSTANCE,
-                            // Accept
+                            // Matches UniverseIpSpace
                             TrueExpr.INSTANCE,
+                            // Reject
+                            FalseExpr.INSTANCE,
                             // Matches nothing so reject
                             FalseExpr.INSTANCE))))));
   }

--- a/projects/question/src/test/java/org/batfish/question/filterlinereachability/FilterLineReachabilityAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/filterlinereachability/FilterLineReachabilityAnswererTest.java
@@ -565,12 +565,9 @@ public class FilterLineReachabilityAnswererTest {
                 acceptingHeaderSpace(
                     HeaderSpace.builder()
                         .setSrcIps(
-                            AclIpSpace.builder()
-                                .setLines(
-                                    ImmutableList.of(
-                                        AclIpSpaceLine.permit(new IpSpaceReference("ipSpace")),
-                                        AclIpSpaceLine.permit(new IpSpaceReference("ipSpace"))))
-                                .build())
+                            AclIpSpace.of(
+                                AclIpSpaceLine.permit(new IpSpaceReference("ipSpace")),
+                                AclIpSpaceLine.permit(new IpSpaceReference("ipSpace"))))
                         .build())))
         .build();
 
@@ -586,12 +583,9 @@ public class FilterLineReachabilityAnswererTest {
                 acceptingHeaderSpace(
                     HeaderSpace.builder()
                         .setSrcIps(
-                            AclIpSpace.builder()
-                                .setLines(
-                                    ImmutableList.of(
-                                        AclIpSpaceLine.permit(new Ip("1.2.3.4").toIpSpace()),
-                                        AclIpSpaceLine.permit(new Ip("1.2.3.4").toIpSpace())))
-                                .build())
+                            AclIpSpace.of(
+                                AclIpSpaceLine.permit(new Ip("1.2.3.4").toIpSpace()),
+                                AclIpSpaceLine.permit(new Ip("1.2.3.4").toIpSpace())))
                         .build()))));
   }
 
@@ -602,13 +596,7 @@ public class FilterLineReachabilityAnswererTest {
     _c1.setIpSpaces(
         ImmutableSortedMap.of(
             "aclIpSpace",
-            AclIpSpace.builder()
-                .setLines(
-                    ImmutableList.of(
-                        AclIpSpaceLine.builder()
-                            .setIpSpace(new IpSpaceReference("aclIpSpace"))
-                            .build()))
-                .build()));
+            AclIpSpace.of(AclIpSpaceLine.permit(new IpSpaceReference("aclIpSpace")))));
     _aclb
         .setLines(
             ImmutableList.of(


### PR DESCRIPTION
- Creation: add a few new functions mimicking the Guava APIs and use them
  throughout.
- AclIpSpace.Builder: delete setLines(), make _lines final. This ensures a
  clean path to adding lines to a builder, and in fact most/all uses of
  setLines were really just to make an AclIpSpace directly with only those lines.
- AclIpSpace.Builder: short-circuit adding lines once a catch-all line
  (UniverseIpSpace) is added. This is a conservative but constant-time
  optimization. Test.
- Patch up one test that relied on the short-circuit not happening.
- Fix a bug in IpSpaceDereferencer where a line action was ignored.
  Add test.