### PR TITLE
junos: parse bgp drop-path-attributes

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -1030,6 +1030,11 @@ DOMAIN_SEARCH
    'domain-search'
 ;
 
+DROP_PATH_ATTRIBUTES
+:
+   'drop-path-attributes'
+;
+
 DSA_SIGNATURES
 :
    'dsa-signatures'

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_bgp.g4
@@ -75,6 +75,7 @@ b_common
    | b_damping
    | b_description
    | b_disable_4byte_as
+   | b_drop_path_attributes
    | b_enforce_first_as
    | b_export
    | b_family
@@ -106,6 +107,11 @@ b_description
 b_disable_4byte_as
 :
    DISABLE_4BYTE_AS
+;
+
+b_drop_path_attributes
+:
+   DROP_PATH_ATTRIBUTES attr = DEC
 ;
 
 b_enable

--- a/tests/parsing-tests/networks/unit-tests/configs/juniper_bgp
+++ b/tests/parsing-tests/networks/unit-tests/configs/juniper_bgp
@@ -1,6 +1,7 @@
 #
 set system host-name juniper_bgp
 #
+set protocols bgp drop-path-attributes 128
 set protocols bgp family inet unicast
 set protocols bgp family inet6 unicast
 set protocols bgp graceful-restart

--- a/tests/parsing-tests/unit-tests-undefined.ref
+++ b/tests/parsing-tests/unit-tests-undefined.ref
@@ -2491,10 +2491,10 @@
         "Lines" : {
           "filename" : "configs/juniper_bgp",
           "lines" : [
-            8,
-            15,
-            22,
-            31
+            9,
+            16,
+            23,
+            32
           ]
         }
       },
@@ -2506,10 +2506,10 @@
         "Lines" : {
           "filename" : "configs/juniper_bgp",
           "lines" : [
-            10,
-            17,
-            24,
-            33
+            11,
+            18,
+            25,
+            34
           ]
         }
       },

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -44050,6 +44050,20 @@
             "            (p_bgp",
             "              BGP:'bgp'",
             "              (b_common",
+            "                (b_drop_path_attributes",
+            "                  DROP_PATH_ATTRIBUTES:'drop-path-attributes'",
+            "                  attr = DEC:'128')))))))",
+            "    NEWLINE:'\\n')",
+            "  (set_line",
+            "    SET:'set'",
+            "    (set_line_tail",
+            "      (statement",
+            "        (s_common",
+            "          (s_protocols",
+            "            PROTOCOLS:'protocols'",
+            "            (p_bgp",
+            "              BGP:'bgp'",
+            "              (b_common",
             "                (b_family",
             "                  FAMILY:'family'",
             "                  (bf_inet",
@@ -65603,7 +65617,6 @@
           "bgp group" : {
             "someinternalipv4group" : {
               "definitionLines" : [
-                22,
                 23,
                 24,
                 25,
@@ -65611,45 +65624,46 @@
                 27,
                 28,
                 29,
-                30
+                30,
+                31
               ],
               "numReferrers" : 2
             },
             "someinternalipv6group" : {
               "definitionLines" : [
-                31,
                 32,
                 33,
                 34,
                 35,
                 36,
                 37,
-                38
+                38,
+                39
               ],
               "numReferrers" : 1
             },
             "someipv4bgpgroup" : {
               "definitionLines" : [
-                7,
                 8,
                 9,
                 10,
                 11,
                 12,
                 13,
-                14
+                14,
+                15
               ],
               "numReferrers" : 1
             },
             "someipv6bgpgroup" : {
               "definitionLines" : [
-                15,
                 16,
                 17,
                 18,
                 19,
                 20,
-                21
+                21,
+                22
               ],
               "numReferrers" : 1
             }
@@ -69105,41 +69119,41 @@
           "bgp group" : {
             "someinternalipv4group" : {
               "bgp group neighbor" : [
-                27,
-                28
+                28,
+                29
               ]
             },
             "someinternalipv6group" : {
               "bgp group neighbor" : [
-                36
+                37
               ]
             },
             "someipv4bgpgroup" : {
               "bgp group neighbor" : [
-                12
+                13
               ]
             },
             "someipv6bgpgroup" : {
               "bgp group neighbor" : [
-                19
+                20
               ]
             }
           },
           "policy-statement" : {
             "someexportpolicy" : {
               "bgp export policy-statement" : [
-                8,
-                15,
-                22,
-                31
+                9,
+                16,
+                23,
+                32
               ]
             },
             "someimportpolicy" : {
               "bgp import policy-statement" : [
-                10,
-                17,
-                24,
-                33
+                11,
+                18,
+                25,
+                34
               ]
             }
           }
@@ -71233,18 +71247,18 @@
           "policy-statement" : {
             "someexportpolicy" : {
               "bgp export policy-statement" : [
-                8,
-                15,
-                22,
-                31
+                9,
+                16,
+                23,
+                32
               ]
             },
             "someimportpolicy" : {
               "bgp import policy-statement" : [
-                10,
-                17,
-                24,
-                33
+                11,
+                18,
+                25,
+                34
               ]
             }
           }


### PR DESCRIPTION
No actual support needed currently. See:

https://kb.juniper.net/InfoCenter/index\?page\=content\&id\=JSA10491\&cat\=SRX_SERIES\&actp\=LIST