### PR TITLE
Search filters hygiene

### DIFF
--- a/projects/allinone/pom.xml
+++ b/projects/allinone/pom.xml
@@ -135,6 +135,11 @@
       <artifactId>opentracing-util</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+
     <!-- Provided dependencies to be available at compile time only -->
     <dependency>
       <groupId>org.lastnpe.eea</groupId>
@@ -147,6 +152,7 @@
       <artifactId>jdk-eea</artifactId>
       <scope>provided</scope>
     </dependency>
+
 
     <!-- Test scope dependencies. -->
     <dependency>
@@ -172,12 +178,6 @@
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>java-hamcrest</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/projects/allinone/pom.xml
+++ b/projects/allinone/pom.xml
@@ -175,6 +175,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <!-- Runtime dependencies to add logging. -->
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/projects/allinone/src/test/java/org/batfish/question/searchfilters/SearchFiltersDifferentialTest.java
+++ b/projects/allinone/src/test/java/org/batfish/question/searchfilters/SearchFiltersDifferentialTest.java
@@ -101,4 +101,45 @@ public class SearchFiltersDifferentialTest {
                             equalTo(LineAction.PERMIT.toString()),
                             Schema.STRING))))));
   }
+
+  @Test
+  public void testDenyWithExplanations() throws IOException {
+    Ip ip = new Ip("1.2.3.4");
+    Configuration baseConfig = _cb.build();
+    Configuration deltaConfig = _cb.build();
+    _ib.setOwner(baseConfig).build();
+    _ib.setOwner(deltaConfig).build();
+    _ab.setOwner(baseConfig).build();
+    _ab.setOwner(deltaConfig)
+        .setLines(
+            ImmutableList.of(
+                accepting().setMatchCondition(and(matchSrcInterface(IFACE), matchDst(ip))).build()))
+        .build();
+    Batfish batfish = getBatfish(baseConfig, deltaConfig);
+    TableAnswerElement answer =
+        (TableAnswerElement)
+            new SearchFiltersAnswerer(
+                    SearchFiltersQuestion.builder()
+                        .setStartLocation("enter(.*)")
+                        .setAction("deny")
+                        .setGenerateExplanations(true)
+                        .build(),
+                    batfish)
+                .answerDiff();
+    assertThat(
+        answer,
+        hasRows(
+            contains(
+                ImmutableList.of(
+                    allOf(
+                        hasColumn(equalTo(COL_FLOW), hasDstIp(ip), Schema.FLOW),
+                        hasColumn(
+                            equalTo(TableDiff.baseColumnName(COL_ACTION)),
+                            equalTo(LineAction.DENY.toString()),
+                            Schema.STRING),
+                        hasColumn(
+                            equalTo(TableDiff.deltaColumnName(COL_ACTION)),
+                            equalTo(LineAction.PERMIT.toString()),
+                            Schema.STRING))))));
+  }
 }


### PR DESCRIPTION
searchFilters should not catch all exceptions from reachFilter -- that was causing errors to be masked.

searchFilters should rename ACLs when they are modified, so they don't conflict with the original versions of those ACLs when generating explanations.