### PR TITLE
Juniper: parse routing-options aggregate route discard

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_routing_instances.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_routing_instances.g4
@@ -296,6 +296,7 @@ roa_common
   | roa_active
   | roa_as_path
   | roa_community
+  | roa_discard
   | roa_passive
   | roa_policy
   | roa_preference
@@ -310,6 +311,11 @@ roa_community
 roa_defaults
 :
   DEFAULTS roa_common
+;
+
+roa_discard
+:
+  DISCARD
 ;
 
 roa_passive

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -377,6 +377,7 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ro_staticContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Roa_activeContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Roa_communityContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Roa_defaultsContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Roa_discardContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Roa_passiveContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Roa_policyContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Roa_preferenceContext;
@@ -388,6 +389,7 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Rof_exportContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Rog_activeContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Rog_communityContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Rog_defaultsContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Rog_discardContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Rog_metricContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Rog_passiveContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Rog_policyContext;
@@ -2751,6 +2753,11 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   }
 
   @Override
+  public void exitRog_discard(Rog_discardContext ctx) {
+    _currentGeneratedRoute.setDrop(true);
+  }
+
+  @Override
   public void exitRog_passive(Rog_passiveContext ctx) {
     _currentGeneratedRoute.setActive(false);
   }
@@ -4653,6 +4660,11 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
     long community = CommonUtil.communityStringToLong(ctx.COMMUNITY_LITERAL().getText());
     _configuration.getAllStandardCommunities().add(community);
     _currentAggregateRoute.getCommunities().add(community);
+  }
+
+  @Override
+  public void exitRoa_discard(Roa_discardContext ctx) {
+    _currentAggregateRoute.setDrop(true);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/AbstractAggregateRoute.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/AbstractAggregateRoute.java
@@ -28,6 +28,8 @@ public abstract class AbstractAggregateRoute implements Serializable {
 
   private Set<Long> _communities;
 
+  private Boolean _drop;
+
   private Integer _metric;
 
   private final List<String> _policies;
@@ -54,6 +56,10 @@ public abstract class AbstractAggregateRoute implements Serializable {
 
   public final @Nonnull Set<Long> getCommunities() {
     return _communities;
+  }
+
+  public final @Nullable Boolean getDrop() {
+    return _drop;
   }
 
   public final @Nullable Integer getMetric() {
@@ -89,6 +95,10 @@ public abstract class AbstractAggregateRoute implements Serializable {
 
   public final void setAsPath(@Nullable AsPath asPath) {
     _asPath = asPath;
+  }
+
+  public final void setDrop(@Nullable Boolean drop) {
+    _drop = drop;
   }
 
   public final void setMetric(@Nullable Integer metric) {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -959,6 +959,8 @@ public final class JuniperConfiguration extends VendorConfiguration {
       newRoute.setTag(route.getTag());
     }
 
+    newRoute.setDiscard(firstNonNull(route.getDrop(), Boolean.FALSE));
+
     return newRoute.build();
   }
 
@@ -978,7 +980,9 @@ public final class JuniperConfiguration extends VendorConfiguration {
       newRoute.setTag(route.getTag());
     }
 
-    // sole semantic difference from generated route
+    // sole semantic difference from generated route: aggregate routes are "reject" by default.
+    // Note that this can be overridden to "discard", but we model both as discard in Batfish
+    // semantics since the sole difference is whether ICMP unreachables are sent.
     newRoute.setDiscard(true);
 
     return newRoute.build();

--- a/tests/parsing-tests/networks/unit-tests/configs/juniper_routing_options
+++ b/tests/parsing-tests/networks/unit-tests/configs/juniper_routing_options
@@ -5,10 +5,12 @@ set system host-name juniper_routing_options
 set routing-options aggregate route 10.0.0.0/8 as-path aggregator 65500 10.0.0.1
 set routing-options aggregate route 20.0.0.0/8 as-path path 123.4
 set routing-options aggregate route 30.0.0.0/8 as-path path "[ 123.4 456.7 ]"
+set routing-options aggregate route 35.0.0.0/8 discard
 set routing-options aggregate route 40.0.0.0/8 policy AGGREGATE_ROUTE_POLICY
 set routing-options confederation 11111 members 22222
 set routing-options forwarding-table no-ecmp-fast-reroute
 #
-set routing-options generate route 10.0.1.0/24 community 2:6
 set routing-options generate route 10.0.1.0/24 active
+set routing-options generate route 10.0.1.0/24 community 2:6
+set routing-options generate route 10.0.1.0/24 discard
 #

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -18729,6 +18729,16 @@
             ],
             "name" : "~CONTRIBUTOR_TO_30.0.0.0/8~"
           },
+          "~CONTRIBUTOR_TO_35.0.0.0/8~" : {
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "ipWildcard" : "35.0.0.0/8",
+                "lengthRange" : "9-32"
+              }
+            ],
+            "name" : "~CONTRIBUTOR_TO_35.0.0.0/8~"
+          },
           "~CONTRIBUTOR_TO_40.0.0.0/8~" : {
             "lines" : [
               {
@@ -18816,6 +18826,34 @@
                   "prefixSet" : {
                     "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
                     "name" : "~CONTRIBUTOR_TO_30.0.0.0/8~"
+                  }
+                }
+              },
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                "type" : "SetDefaultActionAccept"
+              }
+            ]
+          },
+          "~AGGREGATE_ROUTE_POLICY:35.0.0.0/8~" : {
+            "name" : "~AGGREGATE_ROUTE_POLICY:35.0.0.0/8~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                    "name" : "~CONTRIBUTOR_TO_35.0.0.0/8~"
                   }
                 }
               },
@@ -18940,7 +18978,7 @@
                 "communities" : [
                   131078
                 ],
-                "discard" : false,
+                "discard" : true,
                 "generationPolicy" : "~GENERATED_ROUTE_POLICY:10.0.1.0/24~",
                 "metric" : 0,
                 "network" : "10.0.1.0/24",
@@ -18973,6 +19011,16 @@
                 "generationPolicy" : "~AGGREGATE_ROUTE_POLICY:30.0.0.0/8~",
                 "metric" : 0,
                 "network" : "30.0.0.0/8",
+                "nextHopIp" : "AUTO/NONE(-1l)"
+              },
+              {
+                "class" : "org.batfish.datamodel.GeneratedRoute",
+                "administrativeCost" : 130,
+                "asPath" : [ ],
+                "discard" : true,
+                "generationPolicy" : "~AGGREGATE_ROUTE_POLICY:35.0.0.0/8~",
+                "metric" : 0,
+                "network" : "35.0.0.0/8",
                 "nextHopIp" : "AUTO/NONE(-1l)"
               },
               {

--- a/tests/parsing-tests/unit-tests-warnings.ref
+++ b/tests/parsing-tests/unit-tests-warnings.ref
@@ -555,16 +555,16 @@
       },
       {
         "Filename" : "juniper_routing_options",
-        "Line" : 8,
-        "Text" : "policy AGGREGATE_ROUTE_POLICY",
-        "Parser_Context" : "[roa_policy roa_common roa_route ro_aggregate s_routing_options s_common statement set_line_tail set_line flat_juniper_configuration]",
+        "Line" : 10,
+        "Text" : "confederation 11111 members 22222",
+        "Parser_Context" : "[ro_confederation s_routing_options s_common statement set_line_tail set_line flat_juniper_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {
         "Filename" : "juniper_routing_options",
         "Line" : 9,
-        "Text" : "confederation 11111 members 22222",
-        "Parser_Context" : "[ro_confederation s_routing_options s_common statement set_line_tail set_line flat_juniper_configuration]",
+        "Text" : "policy AGGREGATE_ROUTE_POLICY",
+        "Parser_Context" : "[roa_policy roa_common roa_route ro_aggregate s_routing_options s_common statement set_line_tail set_line flat_juniper_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -50166,6 +50166,22 @@
             "              AGGREGATE:'aggregate'",
             "              (roa_route",
             "                ROUTE:'route'",
+            "                prefix = IP_PREFIX:'35.0.0.0/8'",
+            "                (roa_common",
+            "                  (roa_discard",
+            "                    DISCARD:'discard'))))))))",
+            "    NEWLINE:'\\n')",
+            "  (set_line",
+            "    SET:'set'",
+            "    (set_line_tail",
+            "      (statement",
+            "        (s_common",
+            "          (s_routing_options",
+            "            ROUTING_OPTIONS:'routing-options'",
+            "            (ro_aggregate",
+            "              AGGREGATE:'aggregate'",
+            "              (roa_route",
+            "                ROUTE:'route'",
             "                prefix = IP_PREFIX:'40.0.0.0/8'",
             "                (roa_common",
             "                  (roa_policy",
@@ -50211,6 +50227,22 @@
             "                ROUTE:'route'",
             "                IP_PREFIX:'10.0.1.0/24'",
             "                (rog_common",
+            "                  (rog_active",
+            "                    ACTIVE:'active'))))))))",
+            "    NEWLINE:'\\n')",
+            "  (set_line",
+            "    SET:'set'",
+            "    (set_line_tail",
+            "      (statement",
+            "        (s_common",
+            "          (s_routing_options",
+            "            ROUTING_OPTIONS:'routing-options'",
+            "            (ro_generate",
+            "              GENERATE:'generate'",
+            "              (rog_route",
+            "                ROUTE:'route'",
+            "                IP_PREFIX:'10.0.1.0/24'",
+            "                (rog_common",
             "                  (rog_community",
             "                    COMMUNITY:'community'",
             "                    (standard_community",
@@ -50230,8 +50262,8 @@
             "                ROUTE:'route'",
             "                IP_PREFIX:'10.0.1.0/24'",
             "                (rog_common",
-            "                  (rog_active",
-            "                    ACTIVE:'active'))))))))",
+            "                  (rog_discard",
+            "                    DISCARD:'discard'))))))))",
             "    NEWLINE:'\\n')",
             "  EOF:<EOF>)"
           ]
@@ -61915,13 +61947,13 @@
           "Parse warnings" : [
             {
               "Comment" : "This feature is not currently supported",
-              "Line" : 8,
+              "Line" : 9,
               "Parser_Context" : "[roa_policy roa_common roa_route ro_aggregate s_routing_options s_common statement set_line_tail set_line flat_juniper_configuration]",
               "Text" : "policy AGGREGATE_ROUTE_POLICY"
             },
             {
               "Comment" : "This feature is not currently supported",
-              "Line" : 9,
+              "Line" : 10,
               "Parser_Context" : "[ro_confederation s_routing_options s_common statement set_line_tail set_line flat_juniper_configuration]",
               "Text" : "confederation 11111 members 22222"
             }
@@ -69481,7 +69513,7 @@
           "policy-statement" : {
             "AGGREGATE_ROUTE_POLICY" : {
               "aggregate route policy" : [
-                8
+                9
               ]
             }
           }


### PR DESCRIPTION
And implement semantics. Note that Juniper has both 'reject' and 'discard' semantics,
but Batfish does not yet distinguish between them. So aggregate routes overridden from
reject to discard are still dropped.