### PR TITLE
Don't throw on unmatched InterfaceType

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/pojo/Link.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/pojo/Link.java
@@ -96,10 +96,8 @@ public class Link extends BfObject {
       case LOOPBACK:
       case NULL:
       case UNKNOWN:
-        return LinkType.UNKNOWN;
-
       default:
-        throw new IllegalArgumentException(String.format("Unknown InterfaceType: %s", iface1type));
+        return LinkType.UNKNOWN;
     }
   }
 


### PR DESCRIPTION
Don't throw on unmatched InterfaceType during conversion to LinkType
