### PR TITLE
Juniper: support bgp loops in more stanzas

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_bgp.g4
@@ -348,6 +348,7 @@ bfi_unicast
    (
       apply
       | bfiu_add_path
+      | bfiu_loops
       | bfiu_prefix_limit
       | bfiu_rib_group
    )
@@ -387,6 +388,11 @@ bfiu_add_path
       bfiua_receive
       | bfiua_send
    )
+;
+
+bfiu_loops
+:
+   LOOPS count = DEC
 ;
 
 bfiu_prefix_limit

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -175,6 +175,7 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.B_neighborContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.B_remove_privateContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.B_typeContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.BandwidthContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Bfiu_loopsContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Bgp_asnContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Bl_loopsContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Bl_numberContext;
@@ -3430,6 +3431,15 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
     } else if (ctx.EXTERNAL() != null) {
       _currentBgpGroup.setType(BgpGroupType.EXTERNAL);
     }
+  }
+
+  @Override
+  public void exitBfiu_loops(Bfiu_loopsContext ctx) {
+    BgpGroup group = _currentBgpGroup;
+    if (group == null) {
+      group = _currentRoutingInstance.getMasterBgpGroup();
+    }
+    group.setLoops(toInt(ctx.DEC()));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -3435,11 +3435,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
 
   @Override
   public void exitBfiu_loops(Bfiu_loopsContext ctx) {
-    BgpGroup group = _currentBgpGroup;
-    if (group == null) {
-      group = _currentRoutingInstance.getMasterBgpGroup();
-    }
-    group.setLoops(toInt(ctx.DEC()));
+    _currentBgpGroup.setLoops(toInt(ctx.DEC()));
   }
 
   @Override

--- a/tests/parsing-tests/networks/unit-tests/configs/juniper_bgp
+++ b/tests/parsing-tests/networks/unit-tests/configs/juniper_bgp
@@ -5,12 +5,15 @@ set protocols bgp drop-path-attributes 128
 set protocols bgp family inet unicast
 set protocols bgp family inet6 unicast
 set protocols bgp graceful-restart
+set protocols bgp family inet unicast loops 2
 set protocols bgp group someipv4bgpgroup advertise-inactive
 set protocols bgp group someipv4bgpgroup export someexportpolicy
 set protocols bgp group someipv4bgpgroup family inet unicast accepted-prefix-limit maximum 1000
+set protocols bgp group someipv4bgpgroup family inet unicast loops 2
 set protocols bgp group someipv4bgpgroup import someimportpolicy
 set protocols bgp group someipv4bgpgroup multipath
 set protocols bgp group someipv4bgpgroup neighbor 3.4.5.6 description bippety
+set protocols bgp group someipv4bgpgroup neighbor 3.4.5.7 family inet unicast loops 3
 set protocols bgp group someipv4bgpgroup peer-as 12345
 set protocols bgp group someipv4bgpgroup type external
 set protocols bgp group someipv6bgpgroup export someexportpolicy

--- a/tests/parsing-tests/networks/unit-tests/configs/juniper_bgp
+++ b/tests/parsing-tests/networks/unit-tests/configs/juniper_bgp
@@ -13,6 +13,7 @@ set protocols bgp group someipv4bgpgroup family inet unicast loops 2
 set protocols bgp group someipv4bgpgroup import someimportpolicy
 set protocols bgp group someipv4bgpgroup multipath
 set protocols bgp group someipv4bgpgroup neighbor 3.4.5.6 description bippety
+set protocols bgp group someipv4bgpgroup neighbor 3.4.5.7 local-as 1
 set protocols bgp group someipv4bgpgroup neighbor 3.4.5.7 family inet unicast loops 3
 set protocols bgp group someipv4bgpgroup peer-as 12345
 set protocols bgp group someipv4bgpgroup type external

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -15911,9 +15911,36 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
-              "multipathEbgp" : false,
+              "multipathEbgp" : true,
               "multipathEquivalentAsPathMatchMode" : "FIRST_AS",
               "multipathIbgp" : false,
+              "neighbors" : {
+                "3.4.5.7/32" : {
+                  "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "additionalPathsReceive" : false,
+                  "additionalPathsSelectAll" : false,
+                  "additionalPathsSend" : false,
+                  "advertiseExternal" : false,
+                  "advertiseInactive" : true,
+                  "allowLocalAsIn" : true,
+                  "allowRemoteAsOut" : false,
+                  "authenticationSettings" : {
+                    "authenticationAlgorithm" : "HMAC_SHA_1_96"
+                  },
+                  "clusterId" : 0,
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "exportPolicy" : "~PEER_EXPORT_POLICY:3.4.5.7/32~",
+                  "group" : "someipv4bgpgroup",
+                  "importPolicy" : "~PEER_IMPORT_POLICY:3.4.5.7/32~",
+                  "localAs" : 1,
+                  "peerAddress" : "3.4.5.7",
+                  "remoteAs" : 12345,
+                  "routeReflectorClient" : false,
+                  "sendCommunity" : true
+                }
+              },
               "routerId" : "0.0.0.0",
               "tieBreaker" : "ARRIVAL_ORDER"
             }

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -15715,6 +15715,71 @@
               }
             ]
           },
+          "~PEER_EXPORT_POLICY:3.4.5.7/32~" : {
+            "name" : "~PEER_EXPORT_POLICY:3.4.5.7/32~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.SetDefaultPolicy",
+                "defaultPolicy" : "~DEFAULT_BGP_EXPORT_POLICY~"
+              },
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                  "protocol" : "local"
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ]
+              },
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetOrigin",
+                    "originType" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralOrigin",
+                      "originType" : "igp"
+                    }
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
+                  "disjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "bgp"
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "ibgp"
+                    }
+                  ]
+                }
+              },
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.DisjunctionChain"
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          },
           "~PEER_IMPORT_POLICY:1.2.3.5/32~" : {
             "name" : "~PEER_IMPORT_POLICY:1.2.3.5/32~",
             "statements" : [
@@ -15748,6 +15813,37 @@
           },
           "~PEER_IMPORT_POLICY:3.4.5.6/32~" : {
             "name" : "~PEER_IMPORT_POLICY:3.4.5.6/32~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.SetDefaultPolicy",
+                "defaultPolicy" : "~DEFAULT_BGP_IMPORT_POLICY~"
+              },
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                "type" : "SetDefaultActionAccept"
+              },
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.DisjunctionChain"
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          },
+          "~PEER_IMPORT_POLICY:3.4.5.7/32~" : {
+            "name" : "~PEER_IMPORT_POLICY:3.4.5.7/32~",
             "statements" : [
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.SetDefaultPolicy",

--- a/tests/parsing-tests/unit-tests-undefined.ref
+++ b/tests/parsing-tests/unit-tests-undefined.ref
@@ -2492,9 +2492,9 @@
           "filename" : "configs/juniper_bgp",
           "lines" : [
             10,
-            19,
-            26,
-            35
+            20,
+            27,
+            36
           ]
         }
       },
@@ -2507,9 +2507,9 @@
           "filename" : "configs/juniper_bgp",
           "lines" : [
             13,
-            21,
-            28,
-            37
+            22,
+            29,
+            38
           ]
         }
       },

--- a/tests/parsing-tests/unit-tests-undefined.ref
+++ b/tests/parsing-tests/unit-tests-undefined.ref
@@ -2491,10 +2491,10 @@
         "Lines" : {
           "filename" : "configs/juniper_bgp",
           "lines" : [
-            9,
-            16,
-            23,
-            32
+            10,
+            19,
+            26,
+            35
           ]
         }
       },
@@ -2506,10 +2506,10 @@
         "Lines" : {
           "filename" : "configs/juniper_bgp",
           "lines" : [
-            11,
-            18,
-            25,
-            34
+            13,
+            21,
+            28,
+            37
           ]
         }
       },

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -44365,6 +44365,29 @@
             "                  NEIGHBOR:'neighbor'",
             "                  IP_ADDRESS:'3.4.5.7'",
             "                  (b_common",
+            "                    (b_local_as",
+            "                      LOCAL_AS:'local-as'",
+            "                      (bl_number",
+            "                        asn = (bgp_asn",
+            "                          asn = DEC:'1')))))))))))",
+            "    NEWLINE:'\\n')",
+            "  (set_line",
+            "    SET:'set'",
+            "    (set_line_tail",
+            "      (statement",
+            "        (s_common",
+            "          (s_protocols",
+            "            PROTOCOLS:'protocols'",
+            "            (p_bgp",
+            "              BGP:'bgp'",
+            "              (b_group",
+            "                GROUP:'group'",
+            "                name = (variable",
+            "                  text = VARIABLE:'someipv4bgpgroup'  <== mode:M_VarOrWildcard)",
+            "                (b_neighbor",
+            "                  NEIGHBOR:'neighbor'",
+            "                  IP_ADDRESS:'3.4.5.7'",
+            "                  (b_common",
             "                    (b_family",
             "                      FAMILY:'family'",
             "                      (bf_inet",
@@ -66102,7 +66125,6 @@
           "bgp group" : {
             "someinternalipv4group" : {
               "definitionLines" : [
-                26,
                 27,
                 28,
                 29,
@@ -66110,20 +66132,21 @@
                 31,
                 32,
                 33,
-                34
+                34,
+                35
               ],
               "numReferrers" : 2
             },
             "someinternalipv6group" : {
               "definitionLines" : [
-                35,
                 36,
                 37,
                 38,
                 39,
                 40,
                 41,
-                42
+                42,
+                43
               ],
               "numReferrers" : 1
             },
@@ -66138,19 +66161,20 @@
                 15,
                 16,
                 17,
-                18
+                18,
+                19
               ],
-              "numReferrers" : 2
+              "numReferrers" : 3
             },
             "someipv6bgpgroup" : {
               "definitionLines" : [
-                19,
                 20,
                 21,
                 22,
                 23,
                 24,
-                25
+                25,
+                26
               ],
               "numReferrers" : 1
             }
@@ -69618,24 +69642,25 @@
           "bgp group" : {
             "someinternalipv4group" : {
               "bgp group neighbor" : [
-                31,
-                32
+                32,
+                33
               ]
             },
             "someinternalipv6group" : {
               "bgp group neighbor" : [
-                40
+                41
               ]
             },
             "someipv4bgpgroup" : {
               "bgp group neighbor" : [
                 15,
-                16
+                16,
+                17
               ]
             },
             "someipv6bgpgroup" : {
               "bgp group neighbor" : [
-                23
+                24
               ]
             }
           },
@@ -69643,17 +69668,17 @@
             "someexportpolicy" : {
               "bgp export policy-statement" : [
                 10,
-                19,
-                26,
-                35
+                20,
+                27,
+                36
               ]
             },
             "someimportpolicy" : {
               "bgp import policy-statement" : [
                 13,
-                21,
-                28,
-                37
+                22,
+                29,
+                38
               ]
             }
           }
@@ -71751,17 +71776,17 @@
             "someexportpolicy" : {
               "bgp export policy-statement" : [
                 10,
-                19,
-                26,
-                35
+                20,
+                27,
+                36
               ]
             },
             "someimportpolicy" : {
               "bgp import policy-statement" : [
                 13,
-                21,
-                28,
-                37
+                22,
+                29,
+                38
               ]
             }
           }
@@ -72334,7 +72359,7 @@
             },
             {
               "tag" : "MISCELLANEOUS",
-              "text" : "Missing local-as for neighbor: 3.4.5.7/32"
+              "text" : "Could not determine local ip for bgp peering with neighbor ip: 3.4.5.7"
             }
           ]
         },

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -44191,6 +44191,26 @@
             "            PROTOCOLS:'protocols'",
             "            (p_bgp",
             "              BGP:'bgp'",
+            "              (b_common",
+            "                (b_family",
+            "                  FAMILY:'family'",
+            "                  (bf_inet",
+            "                    INET:'inet'",
+            "                    (bfi_unicast",
+            "                      UNICAST:'unicast'",
+            "                      (bfiu_loops",
+            "                        LOOPS:'loops'",
+            "                        count = DEC:'2'))))))))))",
+            "    NEWLINE:'\\n')",
+            "  (set_line",
+            "    SET:'set'",
+            "    (set_line_tail",
+            "      (statement",
+            "        (s_common",
+            "          (s_protocols",
+            "            PROTOCOLS:'protocols'",
+            "            (p_bgp",
+            "              BGP:'bgp'",
             "              (b_group",
             "                GROUP:'group'",
             "                name = (variable",
@@ -44259,6 +44279,30 @@
             "                name = (variable",
             "                  text = VARIABLE:'someipv4bgpgroup'  <== mode:M_VarOrWildcard)",
             "                (b_common",
+            "                  (b_family",
+            "                    FAMILY:'family'",
+            "                    (bf_inet",
+            "                      INET:'inet'",
+            "                      (bfi_unicast",
+            "                        UNICAST:'unicast'",
+            "                        (bfiu_loops",
+            "                          LOOPS:'loops'",
+            "                          count = DEC:'2')))))))))))",
+            "    NEWLINE:'\\n')",
+            "  (set_line",
+            "    SET:'set'",
+            "    (set_line_tail",
+            "      (statement",
+            "        (s_common",
+            "          (s_protocols",
+            "            PROTOCOLS:'protocols'",
+            "            (p_bgp",
+            "              BGP:'bgp'",
+            "              (b_group",
+            "                GROUP:'group'",
+            "                name = (variable",
+            "                  text = VARIABLE:'someipv4bgpgroup'  <== mode:M_VarOrWildcard)",
+            "                (b_common",
             "                  (b_import",
             "                    IMPORT:'import'",
             "                    expr = (policy_expression",
@@ -44304,6 +44348,33 @@
             "                        DESCRIPTION:'description'",
             "                        text = M_Description_DESCRIPTION:'bippety'  <== mode:M_Description))))))))))",
             "    NEWLINE:'\\n'  <== mode:M_Description)",
+            "  (set_line",
+            "    SET:'set'",
+            "    (set_line_tail",
+            "      (statement",
+            "        (s_common",
+            "          (s_protocols",
+            "            PROTOCOLS:'protocols'",
+            "            (p_bgp",
+            "              BGP:'bgp'",
+            "              (b_group",
+            "                GROUP:'group'",
+            "                name = (variable",
+            "                  text = VARIABLE:'someipv4bgpgroup'  <== mode:M_VarOrWildcard)",
+            "                (b_neighbor",
+            "                  NEIGHBOR:'neighbor'",
+            "                  IP_ADDRESS:'3.4.5.7'",
+            "                  (b_common",
+            "                    (b_family",
+            "                      FAMILY:'family'",
+            "                      (bf_inet",
+            "                        INET:'inet'",
+            "                        (bfi_unicast",
+            "                          UNICAST:'unicast'",
+            "                          (bfiu_loops",
+            "                            LOOPS:'loops'",
+            "                            count = DEC:'3'))))))))))))",
+            "    NEWLINE:'\\n')",
             "  (set_line",
             "    SET:'set'",
             "    (set_line_tail",
@@ -66031,53 +66102,55 @@
           "bgp group" : {
             "someinternalipv4group" : {
               "definitionLines" : [
-                23,
-                24,
-                25,
                 26,
                 27,
                 28,
                 29,
                 30,
-                31
+                31,
+                32,
+                33,
+                34
               ],
               "numReferrers" : 2
             },
             "someinternalipv6group" : {
               "definitionLines" : [
-                32,
-                33,
-                34,
                 35,
                 36,
                 37,
                 38,
-                39
+                39,
+                40,
+                41,
+                42
               ],
               "numReferrers" : 1
             },
             "someipv4bgpgroup" : {
               "definitionLines" : [
-                8,
                 9,
                 10,
                 11,
                 12,
                 13,
                 14,
-                15
+                15,
+                16,
+                17,
+                18
               ],
-              "numReferrers" : 1
+              "numReferrers" : 2
             },
             "someipv6bgpgroup" : {
               "definitionLines" : [
-                16,
-                17,
-                18,
                 19,
                 20,
                 21,
-                22
+                22,
+                23,
+                24,
+                25
               ],
               "numReferrers" : 1
             }
@@ -69545,41 +69618,42 @@
           "bgp group" : {
             "someinternalipv4group" : {
               "bgp group neighbor" : [
-                28,
-                29
+                31,
+                32
               ]
             },
             "someinternalipv6group" : {
               "bgp group neighbor" : [
-                37
+                40
               ]
             },
             "someipv4bgpgroup" : {
               "bgp group neighbor" : [
-                13
+                15,
+                16
               ]
             },
             "someipv6bgpgroup" : {
               "bgp group neighbor" : [
-                20
+                23
               ]
             }
           },
           "policy-statement" : {
             "someexportpolicy" : {
               "bgp export policy-statement" : [
-                9,
-                16,
-                23,
-                32
+                10,
+                19,
+                26,
+                35
               ]
             },
             "someimportpolicy" : {
               "bgp import policy-statement" : [
-                11,
-                18,
-                25,
-                34
+                13,
+                21,
+                28,
+                37
               ]
             }
           }
@@ -71676,18 +71750,18 @@
           "policy-statement" : {
             "someexportpolicy" : {
               "bgp export policy-statement" : [
-                9,
-                16,
-                23,
-                32
+                10,
+                19,
+                26,
+                35
               ]
             },
             "someimportpolicy" : {
               "bgp import policy-statement" : [
-                11,
-                18,
-                25,
-                34
+                13,
+                21,
+                28,
+                37
               ]
             }
           }
@@ -72257,6 +72331,10 @@
             {
               "tag" : "MISCELLANEOUS",
               "text" : "Missing local-as for neighbor: 3.4.5.6/32"
+            },
+            {
+              "tag" : "MISCELLANEOUS",
+              "text" : "Missing local-as for neighbor: 3.4.5.7/32"
             }
           ]
         },


### PR DESCRIPTION
`loops` were only handled at the autonomous system level before, but apparently can also be specified as config for the address family:
https://www.juniper.net/documentation/en_US/junos/topics/reference/configuration-statement/loops-edit-protocols-bgp-family.html