### PR TITLE
Convert Transformations to BDD Transitions

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BranchTransition.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BranchTransition.java
@@ -1,0 +1,36 @@
+package org.batfish.bddreachability;
+
+import net.sf.javabdd.BDD;
+
+/** A transition that branches to two other transitions */
+class BranchTransition implements Transition {
+  private final BDD _trueGuard;
+  private final BDD _falseGuard;
+  private final Transition _trueBranch;
+  private final Transition _falseBranch;
+
+  BranchTransition(BDD trueGuard, Transition trueBranch, Transition falseBranch) {
+    _trueGuard = trueGuard;
+    _falseGuard = trueGuard.not();
+    _trueBranch = trueBranch;
+    _falseBranch = falseBranch;
+  }
+
+  @Override
+  public BDD transitForward(BDD bdd) {
+    BDD trueIn = bdd.and(_trueGuard);
+    BDD falseIn = bdd.and(_falseGuard);
+
+    BDD trueOut = trueIn.isZero() ? trueIn : _trueBranch.transitForward(trueIn);
+    BDD falseOut = falseIn.isZero() ? falseIn : _falseBranch.transitForward(falseIn);
+
+    return trueOut.or(falseOut);
+  }
+
+  @Override
+  public BDD transitBackward(BDD bdd) {
+    BDD trueBranchIn = _trueGuard.and(_trueBranch.transitBackward(bdd));
+    BDD falseBranchIn = _falseGuard.and(_falseBranch.transitBackward(bdd));
+    return trueBranchIn.or(falseBranchIn);
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/CompositeTransition.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/CompositeTransition.java
@@ -1,0 +1,24 @@
+package org.batfish.bddreachability;
+
+import net.sf.javabdd.BDD;
+
+/** The functional composition of two transitions */
+final class CompositeTransition implements Transition {
+  private final Transition _first;
+  private final Transition _second;
+
+  CompositeTransition(Transition first, Transition second) {
+    _first = first;
+    _second = second;
+  }
+
+  @Override
+  public BDD transitForward(BDD bdd) {
+    return _second.transitForward(_first.transitForward(bdd));
+  }
+
+  @Override
+  public BDD transitBackward(BDD bdd) {
+    return _first.transitBackward(_second.transitBackward(bdd));
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/EraseAndSetTransition.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/EraseAndSetTransition.java
@@ -1,0 +1,24 @@
+package org.batfish.bddreachability;
+
+import net.sf.javabdd.BDD;
+
+/** A transition that erases a variable and then constrains it to have a new value. */
+class EraseAndSetTransition implements Transition {
+  private final BDD _eraseVars;
+  private final BDD _setValue;
+
+  EraseAndSetTransition(BDD eraseVars, BDD setValue) {
+    _eraseVars = eraseVars;
+    _setValue = setValue;
+  }
+
+  @Override
+  public BDD transitForward(BDD bdd) {
+    return bdd.exist(_eraseVars).and(_setValue);
+  }
+
+  @Override
+  public BDD transitBackward(BDD bdd) {
+    return bdd.and(_setValue).exist(_eraseVars);
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/IdentityTransition.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/IdentityTransition.java
@@ -1,0 +1,20 @@
+package org.batfish.bddreachability;
+
+import net.sf.javabdd.BDD;
+
+/** A transition that permits all flows unmodified. */
+final class IdentityTransition implements Transition {
+  public static IdentityTransition INSTANCE = new IdentityTransition();
+
+  private IdentityTransition() {}
+
+  @Override
+  public BDD transitForward(BDD bdd) {
+    return bdd;
+  }
+
+  @Override
+  public BDD transitBackward(BDD bdd) {
+    return bdd;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/TransformationToTransition.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/TransformationToTransition.java
@@ -1,0 +1,99 @@
+package org.batfish.bddreachability;
+
+import java.util.Arrays;
+import java.util.IdentityHashMap;
+import java.util.List;
+import net.sf.javabdd.BDD;
+import org.batfish.common.bdd.BDDInteger;
+import org.batfish.common.bdd.BDDPacket;
+import org.batfish.common.bdd.IpAccessListToBDD;
+import org.batfish.common.bdd.IpSpaceToBDD;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.transformation.AssignIpAddressFromPool;
+import org.batfish.datamodel.transformation.IpField;
+import org.batfish.datamodel.transformation.ShiftIpAddressIntoSubnet;
+import org.batfish.datamodel.transformation.Transformation;
+import org.batfish.datamodel.transformation.TransformationStep;
+import org.batfish.datamodel.transformation.TransformationStepVisitor;
+
+/** Convert a {@link Transformation} to a BDD reachability graph {@link Transition}. */
+public class TransformationToTransition {
+  private final BDDPacket _bddPacket;
+  private final IdentityHashMap<Transformation, Transition> _cache;
+  private final IpAccessListToBDD _ipAccessListToBDD;
+  private final TransformationStepToTransition _stepToTransition;
+
+  public TransformationToTransition(BDDPacket bddPacket, IpAccessListToBDD ipAccessListToBDD) {
+    _bddPacket = bddPacket;
+    _cache = new IdentityHashMap<>();
+    _ipAccessListToBDD = ipAccessListToBDD;
+    _stepToTransition = new TransformationStepToTransition();
+  }
+
+  private static EraseAndSetTransition assignIpFromPool(BDDInteger var, Ip poolStart, Ip poolEnd) {
+    BDD erase = Arrays.stream(var.getBitvec()).reduce(var.getFactory().one(), BDD::and);
+    BDD setValue =
+        poolStart.equals(poolEnd)
+            ? var.value(poolStart.asLong())
+            : var.geq(poolStart.asLong()).and(var.leq(poolEnd.asLong()));
+    return new EraseAndSetTransition(erase, setValue);
+  }
+
+  private static EraseAndSetTransition shiftIpIntoPrefix(BDDInteger var, Prefix prefix) {
+    int len = prefix.getPrefixLength();
+    BDD erase = Arrays.stream(var.getBitvec()).limit(len).reduce(var.getFactory().one(), BDD::and);
+    BDD setValue = new IpSpaceToBDD(var).toBDD(prefix);
+    return new EraseAndSetTransition(erase, setValue);
+  }
+
+  private class TransformationStepToTransition implements TransformationStepVisitor<Transition> {
+    private BDDInteger ipField(IpField ipField) {
+      switch (ipField) {
+        case DESTINATION:
+          return _bddPacket.getDstIp();
+        case SOURCE:
+          return _bddPacket.getSrcIp();
+        default:
+          throw new IllegalArgumentException("Unknown IpField: " + ipField);
+      }
+    }
+
+    @Override
+    public Transition visitAssignIpAddressFromPool(AssignIpAddressFromPool step) {
+      return assignIpFromPool(ipField(step.getIpField()), step.getPoolStart(), step.getPoolEnd());
+    }
+
+    @Override
+    public Transition visitShiftIpAddressIntoSubnet(ShiftIpAddressIntoSubnet step) {
+      return shiftIpIntoPrefix(ipField(step.getIpField()), step.getSubnet());
+    }
+  }
+
+  public Transition toTransition(Transformation transformation) {
+    return _cache.computeIfAbsent(transformation, this::computeTransition);
+  }
+
+  private Transition computeTransition(Transformation transformation) {
+    BDD guard = _ipAccessListToBDD.visit(transformation.getGuard());
+    Transition steps = computeSteps(transformation.getTransformationSteps());
+
+    Transition trueBranch =
+        transformation.getAndThen() == null
+            ? steps
+            : new CompositeTransition(steps, toTransition(transformation.getAndThen()));
+    Transition falseBranch =
+        transformation.getOrElse() == null
+            ? IdentityTransition.INSTANCE
+            : toTransition(transformation.getOrElse());
+    return new BranchTransition(guard, trueBranch, falseBranch);
+  }
+
+  private Transition computeSteps(List<TransformationStep> transformationSteps) {
+    return transformationSteps
+        .stream()
+        .map(_stepToTransition::visit)
+        .reduce(CompositeTransition::new)
+        .orElse(IdentityTransition.INSTANCE);
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/Transition.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/Transition.java
@@ -1,0 +1,10 @@
+package org.batfish.bddreachability;
+
+import net.sf.javabdd.BDD;
+
+/** Bidirectional transition function */
+interface Transition {
+  BDD transitForward(BDD bdd);
+
+  BDD transitBackward(BDD bdd);
+}

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/TransformationToTransitionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/TransformationToTransitionTest.java
@@ -1,0 +1,236 @@
+package org.batfish.bddreachability;
+
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDst;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrc;
+import static org.batfish.datamodel.transformation.Transformation.always;
+import static org.batfish.datamodel.transformation.Transformation.when;
+import static org.batfish.datamodel.transformation.TransformationStep.assignSourceIp;
+import static org.batfish.datamodel.transformation.TransformationStep.shiftDestinationIp;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.collect.ImmutableMap;
+import net.sf.javabdd.BDD;
+import org.batfish.common.bdd.BDDPacket;
+import org.batfish.common.bdd.IpAccessListToBDD;
+import org.batfish.common.bdd.IpSpaceToBDD;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpWildcard;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.transformation.Transformation;
+import org.junit.Before;
+import org.junit.Test;
+
+/** Tests of {@link TransformationToTransition}. */
+public class TransformationToTransitionTest {
+  private BDDPacket _pkt;
+  private IpSpaceToBDD _dstIpSpaceToBdd;
+  private IpSpaceToBDD _srcIpSpaceToBdd;
+  private TransformationToTransition _toTransition;
+  private BDD _one;
+  private BDD _zero;
+
+  @Before
+  public void setup() {
+    _pkt = new BDDPacket();
+    _one = _pkt.getFactory().one();
+    _zero = _pkt.getFactory().zero();
+    _dstIpSpaceToBdd = new IpSpaceToBDD(_pkt.getDstIp());
+    _srcIpSpaceToBdd = new IpSpaceToBDD(_pkt.getSrcIp());
+    _toTransition =
+        new TransformationToTransition(
+            _pkt, IpAccessListToBDD.create(_pkt, ImmutableMap.of(), ImmutableMap.of()));
+  }
+
+  @Test
+  public void testShiftIpAddressIntoSubnet() {
+    Prefix shiftIntoPrefix = Prefix.parse("5.5.0.0/16");
+    Transformation transformation = always().apply(shiftDestinationIp(shiftIntoPrefix)).build();
+    Transition transition = _toTransition.toTransition(transformation);
+
+    // forward -- unconstrained
+    BDD expectedOut = _dstIpSpaceToBdd.toBDD(shiftIntoPrefix);
+    BDD actualOut = transition.transitForward(_one);
+    assertThat(actualOut, equalTo(expectedOut));
+
+    // forward -- outside prefix
+    BDD in = _dstIpSpaceToBdd.toBDD(Prefix.parse("1.2.3.0/24"));
+    expectedOut = _dstIpSpaceToBdd.toBDD(Prefix.parse("5.5.3.0/24"));
+    actualOut = transition.transitForward(in);
+    assertThat(actualOut, equalTo(expectedOut));
+
+    // forward -- inside prefix
+    in = _dstIpSpaceToBdd.toBDD(Prefix.parse("5.5.3.0/24"));
+    expectedOut = in;
+    actualOut = transition.transitForward(in);
+    assertThat(actualOut, equalTo(expectedOut));
+
+    // backward -- unconstrained
+    BDD expectedIn = _one;
+    BDD actualIn = transition.transitBackward(_one);
+    assertThat(actualIn, equalTo(expectedIn));
+
+    // backward -- constrained
+    expectedIn = _dstIpSpaceToBdd.toBDD(new IpWildcard(new Ip("0.0.3.0"), new Ip("255.255.0.255")));
+    actualIn = transition.transitBackward(expectedOut);
+    assertThat(actualIn, equalTo(expectedIn));
+  }
+
+  @Test
+  public void testShiftIpAddressIntoSubnet2() {
+    Prefix shiftIntoPrefix = Prefix.parse("5.5.0.32/27");
+    Transformation transformation = always().apply(shiftDestinationIp(shiftIntoPrefix)).build();
+    Transition transition = _toTransition.toTransition(transformation);
+
+    // forward -- unconstrained
+    BDD expectedOut = _dstIpSpaceToBdd.toBDD(shiftIntoPrefix);
+    BDD actualOut = transition.transitForward(_one);
+    assertThat(actualOut, equalTo(expectedOut));
+
+    // forward -- outside prefix
+    BDD in = _dstIpSpaceToBdd.toBDD(Prefix.parse("1.2.3.12/30"));
+    expectedOut = _dstIpSpaceToBdd.toBDD(Prefix.parse("5.5.0.44/30"));
+    actualOut = transition.transitForward(in);
+    assertThat(actualOut, equalTo(expectedOut));
+
+    // forward -- inside prefix
+    actualOut = transition.transitForward(expectedOut);
+    assertThat(actualOut, equalTo(expectedOut));
+
+    // backward -- unconstrained
+    BDD expectedIn = _one;
+    BDD actualIn = transition.transitBackward(_one);
+    assertThat(actualIn, equalTo(expectedIn));
+
+    // backward -- constrained
+    Ip address = new Ip("0.0.0.12");
+    // all bits wild except 28,29,30
+    Ip mask = new Ip("255.255.255.227");
+    expectedIn = _dstIpSpaceToBdd.toBDD(new IpWildcard(address, mask));
+    actualIn = transition.transitBackward(expectedOut);
+    assertThat(actualIn, equalTo(expectedIn));
+  }
+
+  @Test
+  public void testGuardAndTransformSameField() {
+    Prefix guardPrefix = Prefix.parse("1.0.0.0/8");
+    Prefix shiftIntoPrefix = Prefix.parse("5.5.0.0/16");
+    Transformation transformation =
+        when(matchDst(guardPrefix)).apply(shiftDestinationIp(shiftIntoPrefix)).build();
+    Transition transition = _toTransition.toTransition(transformation);
+
+    BDD guardBdd = _dstIpSpaceToBdd.toBDD(guardPrefix);
+
+    // forward -- unconstrained
+    BDD expectedOut = guardBdd.not();
+    BDD actualOut = transition.transitForward(_one);
+    assertThat(actualOut, equalTo(expectedOut));
+
+    // forward -- matching guard
+    BDD in = _dstIpSpaceToBdd.toBDD(Prefix.parse("1.2.3.0/24"));
+    expectedOut = _dstIpSpaceToBdd.toBDD(Prefix.parse("5.5.3.0/24"));
+    actualOut = transition.transitForward(in);
+    assertThat(actualOut, equalTo(expectedOut));
+
+    // forward -- not matching guard
+    in = _dstIpSpaceToBdd.toBDD(Prefix.parse("2.2.3.0/24"));
+    expectedOut = in;
+    actualOut = transition.transitForward(in);
+    assertThat(actualOut, equalTo(expectedOut));
+
+    // backward -- unconstrained
+    BDD expectedIn = _one;
+    BDD actualIn = transition.transitBackward(_one);
+    assertThat(actualIn, equalTo(expectedIn));
+
+    // backward -- matched and transformed or not matched
+    BDD out = _dstIpSpaceToBdd.toBDD(Prefix.parse("5.5.3.0/24"));
+    expectedIn =
+        out.or(_dstIpSpaceToBdd.toBDD(new IpWildcard(new Ip("1.0.3.0"), new Ip("0.255.0.255"))));
+    actualIn = transition.transitBackward(out);
+    assertThat(actualIn, equalTo(expectedIn));
+  }
+
+  @Test
+  public void testGuardAndTransformDifferentFields() {
+    Prefix guardPrefix = Prefix.parse("1.0.0.0/8");
+    Prefix shiftIntoPrefix = Prefix.parse("5.5.0.0/16");
+    Transformation transformation =
+        when(matchSrc(guardPrefix)).apply(shiftDestinationIp(shiftIntoPrefix)).build();
+    Transition transition = _toTransition.toTransition(transformation);
+
+    BDD guardBdd = _srcIpSpaceToBdd.toBDD(guardPrefix);
+    BDD shiftIntoBdd = _dstIpSpaceToBdd.toBDD(shiftIntoPrefix);
+
+    // forward -- unconstrained
+    BDD expectedOut = guardBdd.imp(shiftIntoBdd);
+    BDD actualOut = transition.transitForward(_one);
+    assertThat(actualOut, equalTo(expectedOut));
+
+    // forward -- matching guard
+    BDD in = _dstIpSpaceToBdd.toBDD(Prefix.parse("1.2.3.0/24"));
+    expectedOut = guardBdd.ite(_dstIpSpaceToBdd.toBDD(Prefix.parse("5.5.3.0/24")), in);
+    actualOut = transition.transitForward(in);
+    assertThat(actualOut, equalTo(expectedOut));
+
+    // forward -- not matching guard
+    in = _srcIpSpaceToBdd.toBDD(Prefix.parse("2.2.3.0/24"));
+    expectedOut = in;
+    actualOut = transition.transitForward(in);
+    assertThat(actualOut, equalTo(expectedOut));
+
+    // backward -- unconstrained
+    BDD expectedIn = _one;
+    BDD actualIn = transition.transitBackward(_one);
+    assertThat(actualIn, equalTo(expectedIn));
+
+    // backward -- matched and transformed or not matched
+    BDD out = _dstIpSpaceToBdd.toBDD(Prefix.parse("5.5.3.0/24"));
+    IpWildcard preTransformationDestIps =
+        new IpWildcard(new Ip("0.0.3.0"), new Ip("255.255.0.255"));
+    expectedIn = guardBdd.ite(_dstIpSpaceToBdd.toBDD(preTransformationDestIps), out);
+    actualIn = transition.transitBackward(out);
+    assertThat(actualIn, equalTo(expectedIn));
+  }
+
+  @Test
+  public void testAssignFromPool() {
+    Ip poolStart = new Ip("1.1.1.5");
+    Ip poolEnd = new Ip("1.1.1.13");
+    Transformation transformation = always().apply(assignSourceIp(poolStart, poolEnd)).build();
+    Transition transition = _toTransition.toTransition(transformation);
+
+    // the entire pool as a BDD
+    BDD poolBdd =
+        _pkt.getSrcIp().geq(poolStart.asLong()).and(_pkt.getSrcIp().leq(poolEnd.asLong()));
+    // one IP in the pool as a BDD
+    BDD poolIpBdd = _pkt.getSrcIp().value(poolStart.asLong() + 2);
+    BDD nonPoolIpBdd = _pkt.getSrcIp().value(poolEnd.asLong() + 2);
+
+    // forward -- unconstrainted
+    BDD expectedOut = poolBdd;
+    BDD actualOut = transition.transitForward(_one);
+    assertThat(actualOut, equalTo(expectedOut));
+
+    // forward -- already in pool
+    expectedOut = poolBdd;
+    actualOut = transition.transitForward(poolIpBdd);
+    assertThat(actualOut, equalTo(expectedOut));
+
+    // backward -- inside of pool
+    BDD expectedIn = _one;
+    BDD actualIn = transition.transitBackward(poolIpBdd);
+    assertThat(actualIn, equalTo(expectedIn));
+
+    // backward -- outside of pool
+    expectedIn = _zero;
+    actualIn = transition.transitBackward(nonPoolIpBdd);
+    assertThat(actualIn, equalTo(expectedIn));
+  }
+
+  @Test
+  public void testMultipleSteps() {}
+
+  @Test
+  public void testMultipleTrasnformations() {}
+}


### PR DESCRIPTION
Introduce a new bidirectional `Transition` class for the BDD reachability analysis, similar to the current `Edge` class, except without identifying source and target nodes (`Edge` will later be refactored on top of `Transition`). Implement a translation from `Transformation` to `Transition`.