### PR TITLE
stop expecting that answers can be deserialized

### DIFF
--- a/projects/batfish-client/src/main/java/org/batfish/client/Client.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/Client.java
@@ -2213,16 +2213,14 @@ public class Client extends AbstractClient implements IClient {
       // that case
       String answerStringToPrint = answerString;
       if (outWriter == null && _settings.getPrettyPrintAnswers()) {
-        Answer answer;
         try {
-          answer = BatfishObjectMapper.mapper().readValue(answerString, Answer.class);
+          Answer answer = BatfishObjectMapper.mapper().readValue(answerString, Answer.class);
+          answerStringToPrint = answer.prettyPrint();
         } catch (IOException e) {
-          throw new BatfishException(
-              "Response does not appear to be valid JSON representation of "
-                  + Answer.class.getSimpleName(),
-              e);
+          _logger.warnf(
+              "Using Json for pretty printing because could not deserialize response as %s: %s",
+              Answer.class.getSimpleName(), e.getMessage());
         }
-        answerStringToPrint = answer.prettyPrint();
       }
 
       logOutput(outWriter, answerStringToPrint);


### PR DESCRIPTION
since we now have answerelement classes that cannot be deserialized by jackson, the client warns instead of throwing an exception when it cannot deserialize an answer. 

Fixes #2873 