### PR TITLE
ibdp: add a topology fixed point

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/BdpOscillationException.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/BdpOscillationException.java
@@ -1,8 +1,8 @@
 package org.batfish.common;
 
+/** Indicates that there is no stable dataplane solution */
 public class BdpOscillationException extends BatfishException {
 
-  /** */
   private static final long serialVersionUID = 1L;
 
   public BdpOscillationException(String msg) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpSessionProperties.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpSessionProperties.java
@@ -1,5 +1,6 @@
 package org.batfish.datamodel;
 
+import java.util.Objects;
 import javax.annotation.Nonnull;
 
 /** Represents properties of a peering session between two {@link BgpPeerConfig}s. */
@@ -93,6 +94,26 @@ public final class BgpSessionProperties {
         SessionType.isEbgp(sessionType) && initiator.getAdvertiseInactive(),
         !SessionType.isEbgp(sessionType) && initiator.getAdvertiseExternal(),
         sessionType);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof BgpSessionProperties)) {
+      return false;
+    }
+    BgpSessionProperties that = (BgpSessionProperties) o;
+    return _additionalPaths == that._additionalPaths
+        && _advertiseExternal == that._advertiseExternal
+        && _advertiseInactive == that._advertiseInactive
+        && _sessionType == that._sessionType;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_additionalPaths, _advertiseExternal, _advertiseInactive, _sessionType);
   }
 
   public enum SessionType {

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -2073,15 +2073,14 @@ public class VirtualRouter implements Serializable {
     So to get session properties, we might need to flip the src/dst edge
      */
     Optional<BgpSessionProperties> session = bgpTopology.edgeValue(edge.src(), edge.dst());
-    if (session.isPresent()) {
-      return session.get();
-    }
-    return bgpTopology
-        .edgeValue(edge.dst(), edge.src())
-        .orElseThrow(
-            () ->
-                new IllegalArgumentException(
-                    String.format("No BGP edge %s in BGP topology", edge)));
+    return session.orElseGet(
+        () ->
+            bgpTopology
+                .edgeValue(edge.dst(), edge.src())
+                .orElseThrow(
+                    () ->
+                        new IllegalArgumentException(
+                            String.format("No BGP edge %s in BGP topology", edge))));
   }
 
   private void queueOutgoingIsisRoutes(

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -2556,12 +2556,11 @@ public class Batfish extends PluginConsumer implements IBatfish {
   @Override
   public Set<BgpAdvertisement> loadExternalBgpAnnouncements(
       Map<String, Configuration> configurations) {
-    Set<BgpAdvertisement> advertSet = new LinkedHashSet<>();
-    for (ExternalBgpAdvertisementPlugin plugin : _externalBgpAdvertisementPlugins) {
-      Set<BgpAdvertisement> currentAdvertisements = plugin.loadExternalBgpAdvertisements();
-      advertSet.addAll(currentAdvertisements);
-    }
-    return advertSet;
+    return _externalBgpAdvertisementPlugins
+        .stream()
+        .map(ExternalBgpAdvertisementPlugin::loadExternalBgpAdvertisements)
+        .flatMap(Set::stream)
+        .collect(ImmutableSet.toImmutableSet());
   }
 
   /**


### PR DESCRIPTION
Add a fixed-point computation for topology (wraps the route fixed point) in ibdp.
Currently only takes into account the BGP topology.

Fixes #2842, since BGP sessions not coming up is the true root cause of that bug.