### PR TITLE
Cisco: fix interface ISIS conversion

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -127,6 +127,7 @@ import org.batfish.datamodel.acl.TrueExpr;
 import org.batfish.datamodel.eigrp.EigrpInterfaceSettings;
 import org.batfish.datamodel.eigrp.EigrpMetric;
 import org.batfish.datamodel.isis.IsisInterfaceLevelSettings;
+import org.batfish.datamodel.isis.IsisInterfaceMode;
 import org.batfish.datamodel.isis.IsisInterfaceSettings;
 import org.batfish.datamodel.ospf.OspfArea;
 import org.batfish.datamodel.ospf.OspfAreaSummary;
@@ -2134,7 +2135,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
     boolean level1 = false;
     boolean level2 = false;
     IsisProcess isisProcess = vrf.getIsisProcess();
-    if (isisProcess != null) {
+    if (isisProcess != null && iface.getIsisInterfaceMode() != IsisInterfaceMode.UNSET) {
       switch (isisProcess.getLevel()) {
         case LEVEL_1:
           level1 = true;

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -1550,7 +1550,7 @@ public class CiscoGrammarTest {
     String hostname = "ios-isis";
     Configuration c = parseConfig(hostname);
 
-    assertThat(c, hasInterface("Loopback0", hasIsis(hasLevel2(anything()))));
+    assertThat(c, hasInterface("Loopback0", hasIsis(hasLevel2(notNullValue()))));
     assertThat(c, hasInterface("Loopback100", hasIsis(nullValue())));
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -90,6 +90,7 @@ import static org.batfish.datamodel.matchers.InterfaceMatchers.hasDeclaredNames;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasEigrp;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasHsrpGroup;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasHsrpVersion;
+import static org.batfish.datamodel.matchers.InterfaceMatchers.hasIsis;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasMtu;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasOspfArea;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasVrf;
@@ -118,6 +119,7 @@ import static org.batfish.datamodel.matchers.IpsecSessionMatchers.hasNegotiatedI
 import static org.batfish.datamodel.matchers.IpsecVpnMatchers.hasBindInterface;
 import static org.batfish.datamodel.matchers.IpsecVpnMatchers.hasIkeGatewaay;
 import static org.batfish.datamodel.matchers.IpsecVpnMatchers.hasPolicy;
+import static org.batfish.datamodel.matchers.IsisInterfaceSettingsMatchers.hasLevel2;
 import static org.batfish.datamodel.matchers.LineMatchers.hasAuthenticationLoginList;
 import static org.batfish.datamodel.matchers.LineMatchers.requiresAuthentication;
 import static org.batfish.datamodel.matchers.MatchHeaderSpaceMatchers.hasHeaderSpace;
@@ -1541,6 +1543,15 @@ public class CiscoGrammarTest {
                                 .setNetwork(Prefix.ZERO)
                                 .setNextHopIp(Ip.parse("1.2.3.4"))
                                 .build()))))));
+  }
+
+  @Test
+  public void testIosIsisConfigOnInterface() throws IOException {
+    String hostname = "ios-isis";
+    Configuration c = parseConfig(hostname);
+
+    assertThat(c, hasInterface("Loopback0", hasIsis(hasLevel2(anything()))));
+    assertThat(c, hasInterface("Loopback100", hasIsis(nullValue())));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-isis
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-isis
@@ -1,0 +1,16 @@
+version 15.2
+!
+hostname ios-isis
+!
+interface Loopback0
+  description router-id
+  ip address 172.20.20.1 255.255.255.255
+  ip router isis CORE
+!
+interface Loopback100
+  ip address 153.56.0.1 255.255.255.255
+!
+router isis CORE
+  net 49.0001.1722.0020.0001.00
+  is-type level-2-only
+  metric-style wide level-2


### PR DESCRIPTION
Only add interface ISIS settings when ISIS is enabled on the interface
(as indicated by a set mode)

Fixes #2841 