### PR TITLE
Remove neighboring peer info from Ipsec configs

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpsecDynamicPeerConfig.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpsecDynamicPeerConfig.java
@@ -14,14 +14,10 @@ public final class IpsecDynamicPeerConfig extends IpsecPeerConfig implements Ser
 
   private static final String PROP_IKE_PHASE1_POLICIES = "ikePhase1Policies";
 
-  private static final String PROP_PEER_CONFIGS = "peerConfigs";
-
   /** */
   private static final long serialVersionUID = 1L;
 
   @Nonnull private List<String> _ikePhase1Policies;
-
-  @Nonnull private List<IpsecPeerConfig> _peerConfigs;
 
   @JsonCreator
   private IpsecDynamicPeerConfig(
@@ -30,24 +26,16 @@ public final class IpsecDynamicPeerConfig extends IpsecPeerConfig implements Ser
       @JsonProperty(PROP_POLICY_ACCESS_LIST) @Nullable IpAccessList policyAccessList,
       @JsonProperty(PROP_LOCAL_ADDRESS) @Nullable Ip localAddress,
       @JsonProperty(PROP_TUNNEL_INTERFACE) @Nullable String tunnelInterface,
-      @JsonProperty(PROP_IKE_PHASE1_POLICIES) @Nullable List<String> ikePhase1Policies,
-      @JsonProperty(PROP_PEER_CONFIGS) @Nullable List<IpsecPeerConfig> peerConfigs) {
+      @JsonProperty(PROP_IKE_PHASE1_POLICIES) @Nullable List<String> ikePhase1Policies) {
     super(ipsecPolicy, physicalInterface, policyAccessList, localAddress, tunnelInterface);
     _ikePhase1Policies =
         ikePhase1Policies == null ? ImmutableList.of() : ImmutableList.copyOf(ikePhase1Policies);
-    _peerConfigs = peerConfigs == null ? ImmutableList.of() : ImmutableList.copyOf(peerConfigs);
   }
 
   @JsonPropertyDescription("IKE phase 1 policies which can be used with this IPSec peer")
   @JsonProperty(PROP_IKE_PHASE1_POLICIES)
   public List<String> getIkePhase1Poliies() {
     return _ikePhase1Policies;
-  }
-
-  @JsonPropertyDescription("IPSec peer configurations for this IPSec peer")
-  @JsonProperty(PROP_PEER_CONFIGS)
-  public List<IpsecPeerConfig> getPeerConfigs() {
-    return _peerConfigs;
   }
 
   public static Builder builder() {
@@ -58,8 +46,6 @@ public final class IpsecDynamicPeerConfig extends IpsecPeerConfig implements Ser
       extends IpsecPeerConfig.Builder<IpsecDynamicPeerConfig.Builder, IpsecDynamicPeerConfig> {
     private List<String> _ikePhase1Polcies;
 
-    private List<IpsecPeerConfig> _peerConfigs;
-
     @Override
     public IpsecDynamicPeerConfig build() {
       return new IpsecDynamicPeerConfig(
@@ -68,8 +54,7 @@ public final class IpsecDynamicPeerConfig extends IpsecPeerConfig implements Ser
           _policyAccessList,
           _localAddress,
           _tunnelInterface,
-          _ikePhase1Polcies,
-          _peerConfigs);
+          _ikePhase1Polcies);
     }
 
     @Override
@@ -79,11 +64,6 @@ public final class IpsecDynamicPeerConfig extends IpsecPeerConfig implements Ser
 
     public IpsecDynamicPeerConfig.Builder setIkePhase1Policies(List<String> ikePhase1Policies) {
       _ikePhase1Polcies = ikePhase1Policies;
-      return this;
-    }
-
-    public IpsecDynamicPeerConfig.Builder setPeerConfigs(List<IpsecPeerConfig> peerConfigs) {
-      _peerConfigs = peerConfigs;
       return this;
     }
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpsecStaticPeerConfig.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpsecStaticPeerConfig.java
@@ -16,16 +16,12 @@ public final class IpsecStaticPeerConfig extends IpsecPeerConfig implements Seri
 
   private static final String PROP_IKE_PHASE1_POLICY = "ikePhase1Policy";
 
-  private static final String PROP_PEER_CONFIG = "peerConfig";
-
   /** */
   private static final long serialVersionUID = 1L;
 
   @Nonnull private Ip _destinationAddress;
 
   @Nullable private String _ikePhase1Policy;
-
-  @Nullable private IpsecPeerConfig _peerConfig;
 
   @JsonCreator
   private IpsecStaticPeerConfig(
@@ -35,12 +31,10 @@ public final class IpsecStaticPeerConfig extends IpsecPeerConfig implements Seri
       @JsonProperty(PROP_LOCAL_ADDRESS) @Nullable Ip localAddress,
       @JsonProperty(PROP_TUNNEL_INTERFACE) @Nullable String tunnelInterface,
       @JsonProperty(PROP_DESTINATION_ADDRESS) @Nullable Ip destinationAddress,
-      @JsonProperty(PROP_IKE_PHASE1_POLICY) @Nullable String ikePhasePolicy,
-      @JsonProperty(PROP_PEER_CONFIG) @Nullable IpsecPeerConfig peerConfig) {
+      @JsonProperty(PROP_IKE_PHASE1_POLICY) @Nullable String ikePhasePolicy) {
     super(ipsecPolicy, physicalInterface, policyAccessList, localAddress, tunnelInterface);
     _destinationAddress = firstNonNull(destinationAddress, Ip.AUTO);
     _ikePhase1Policy = ikePhasePolicy;
-    _peerConfig = peerConfig;
   }
 
   @JsonPropertyDescription("Destination address for IPSec peer")
@@ -55,12 +49,6 @@ public final class IpsecStaticPeerConfig extends IpsecPeerConfig implements Seri
     return _ikePhase1Policy;
   }
 
-  @JsonPropertyDescription("IPSec peer configuration for IPSec peer")
-  @JsonProperty(PROP_PEER_CONFIG)
-  public IpsecPeerConfig getPeerConfig() {
-    return _peerConfig;
-  }
-
   public static Builder builder() {
     return new Builder();
   }
@@ -71,8 +59,6 @@ public final class IpsecStaticPeerConfig extends IpsecPeerConfig implements Seri
 
     private String _ikePhase1Policy;
 
-    private IpsecPeerConfig _peerConfig;
-
     @Override
     public IpsecStaticPeerConfig build() {
       return new IpsecStaticPeerConfig(
@@ -82,8 +68,7 @@ public final class IpsecStaticPeerConfig extends IpsecPeerConfig implements Seri
           _localAddress,
           _tunnelInterface,
           _destinationAddress,
-          _ikePhase1Policy,
-          _peerConfig);
+          _ikePhase1Policy);
     }
 
     @Override
@@ -98,11 +83,6 @@ public final class IpsecStaticPeerConfig extends IpsecPeerConfig implements Seri
 
     public Builder setIkePhase1Policy(String ikePhase1Policy) {
       _ikePhase1Policy = ikePhase1Policy;
-      return this;
-    }
-
-    public Builder setPeerConfig(IpsecPeerConfig peerConfig) {
-      _peerConfig = peerConfig;
       return this;
     }
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/IpsecPeerConfigMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/IpsecPeerConfigMatchers.java
@@ -7,15 +7,12 @@ import javax.annotation.Nonnull;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.IpsecDynamicPeerConfig;
-import org.batfish.datamodel.IpsecPeerConfig;
 import org.batfish.datamodel.IpsecStaticPeerConfig;
 import org.batfish.datamodel.matchers.IpsecPeerConfigMatchersImpl.HasDestinationAddress;
 import org.batfish.datamodel.matchers.IpsecPeerConfigMatchersImpl.HasIkePhase1Policies;
 import org.batfish.datamodel.matchers.IpsecPeerConfigMatchersImpl.HasIkePhase1Policy;
 import org.batfish.datamodel.matchers.IpsecPeerConfigMatchersImpl.HasIpsecPolicy;
 import org.batfish.datamodel.matchers.IpsecPeerConfigMatchersImpl.HasLocalAddress;
-import org.batfish.datamodel.matchers.IpsecPeerConfigMatchersImpl.HasPeerConfig;
-import org.batfish.datamodel.matchers.IpsecPeerConfigMatchersImpl.HasPeerConfigs;
 import org.batfish.datamodel.matchers.IpsecPeerConfigMatchersImpl.HasPhysicalInterface;
 import org.batfish.datamodel.matchers.IpsecPeerConfigMatchersImpl.HasPolicyAccessList;
 import org.batfish.datamodel.matchers.IpsecPeerConfigMatchersImpl.HasTunnelInterface;
@@ -77,28 +74,10 @@ public final class IpsecPeerConfigMatchers {
 
   /**
    * Provides a matcher that matches if the provided {@code submatcher} matches the IPSec peer
-   * config's {@code peerConfigs}
-   */
-  public static @Nonnull HasPeerConfigs hasPeerConfigs(
-      @Nonnull Matcher<? super List<IpsecPeerConfig>> subMatcher) {
-    return new HasPeerConfigs(subMatcher);
-  }
-
-  /**
-   * Provides a matcher that matches if the provided {@code submatcher} matches the IPSec peer
    * config's {@code ikePhase1Policy}
    */
   public static @Nonnull HasIkePhase1Policy hasIkePhase1Policy(String ikePhase1Policy) {
     return new HasIkePhase1Policy(equalTo(ikePhase1Policy));
-  }
-
-  /**
-   * Provides a matcher that matches if the provided {@code submatcher} matches the IPSec peer
-   * config's {@code peerConfig}
-   */
-  public static @Nonnull HasPeerConfig hasPeerConfig(
-      @Nonnull Matcher<? super IpsecPeerConfig> subMatcher) {
-    return new HasPeerConfig(subMatcher);
   }
 
   /**

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/IpsecPeerConfigMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/IpsecPeerConfigMatchersImpl.java
@@ -84,19 +84,6 @@ final class IpsecPeerConfigMatchersImpl {
     }
   }
 
-  static class HasPeerConfigs
-      extends FeatureMatcher<IpsecDynamicPeerConfig, List<IpsecPeerConfig>> {
-
-    HasPeerConfigs(@Nonnull Matcher<? super List<IpsecPeerConfig>> subMatcher) {
-      super(subMatcher, "An IPSec peer config with PeerConfigs:", "PeerConfigs");
-    }
-
-    @Override
-    protected List<IpsecPeerConfig> featureValueOf(IpsecDynamicPeerConfig actual) {
-      return actual.getPeerConfigs();
-    }
-  }
-
   static class HasIkePhase1Policy extends FeatureMatcher<IpsecStaticPeerConfig, String> {
 
     HasIkePhase1Policy(@Nonnull Matcher<? super String> subMatcher) {
@@ -106,18 +93,6 @@ final class IpsecPeerConfigMatchersImpl {
     @Override
     protected String featureValueOf(IpsecStaticPeerConfig actual) {
       return actual.getIkePhase1Policy();
-    }
-  }
-
-  static class HasPeerConfig extends FeatureMatcher<IpsecStaticPeerConfig, IpsecPeerConfig> {
-
-    HasPeerConfig(@Nonnull Matcher<? super IpsecPeerConfig> subMatcher) {
-      super(subMatcher, "An IPSec peer config with PeerConfig:", "PeerConfig");
-    }
-
-    @Override
-    protected IpsecPeerConfig featureValueOf(IpsecStaticPeerConfig actual) {
-      return actual.getPeerConfig();
     }
   }
 


### PR DESCRIPTION
Edges of Ipsec topology should be the ground truth for peering information