### PR TITLE
 Stop IS-IS route propagation if level is passive

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/isis/IsisEdge.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/isis/IsisEdge.java
@@ -6,10 +6,11 @@ import static java.util.Optional.empty;
 import static org.batfish.datamodel.isis.IsisLevel.LEVEL_1;
 import static org.batfish.datamodel.isis.IsisLevel.LEVEL_1_2;
 import static org.batfish.datamodel.isis.IsisLevel.LEVEL_2;
+import static org.batfish.datamodel.isis.IsisLevel.intersection;
+import static org.batfish.datamodel.isis.IsisLevel.union;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.annotations.VisibleForTesting;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Map;
@@ -29,33 +30,6 @@ public final class IsisEdge implements Comparable<IsisEdge> {
     return union(
         settings.getLevel1() != null ? LEVEL_1 : null,
         settings.getLevel2() != null ? LEVEL_2 : null);
-  }
-
-  @VisibleForTesting
-  @Nullable
-  public static IsisLevel intersection(IsisLevel... levels) {
-    if (levels.length == 0) {
-      return null;
-    }
-    IsisLevel overlap = LEVEL_1_2;
-    for (IsisLevel level : levels) {
-      overlap = intersection(overlap, level);
-    }
-    return overlap;
-  }
-
-  @Nullable
-  private static IsisLevel intersection(@Nullable IsisLevel first, @Nullable IsisLevel second) {
-    if (first == second) {
-      return first;
-    }
-    if (first == LEVEL_1_2) {
-      return second;
-    }
-    if (second == LEVEL_1_2) {
-      return first;
-    }
-    return null;
   }
 
   /** Return an {@link IsisEdge} if there is an IS-IS circuit on {@code edge}. */
@@ -120,26 +94,6 @@ public final class IsisEdge implements Comparable<IsisEdge> {
     return union(
         isisProcess.getLevel1() != null ? LEVEL_1 : null,
         isisProcess.getLevel2() != null ? LEVEL_2 : null);
-  }
-
-  @Nullable
-  private static IsisLevel union(@Nullable IsisLevel level1, @Nullable IsisLevel level2) {
-    if (level1 == level2) {
-      return level1;
-    }
-    if (level1 == LEVEL_1_2 || level2 == LEVEL_1_2) {
-      return LEVEL_1_2;
-    }
-    if (level1 == LEVEL_1 || level2 == LEVEL_1) {
-      // other is null or LEVEL_2
-      if (level1 == LEVEL_2 || level2 == LEVEL_2) {
-        return LEVEL_1_2;
-      }
-      // other is null
-      return LEVEL_1;
-    }
-    // one is null and one is LEVEL_2
-    return LEVEL_2;
   }
 
   private static final String PROP_CIRCUIT_TYPE = "circuitType";

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/isis/IsisLevel.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/isis/IsisLevel.java
@@ -1,7 +1,59 @@
 package org.batfish.datamodel.isis;
 
+import javax.annotation.Nullable;
+
 public enum IsisLevel {
   LEVEL_1,
   LEVEL_1_2,
-  LEVEL_2
+  LEVEL_2;
+
+  public boolean includes(@Nullable IsisLevel other) {
+    return this.equals(union(this, other));
+  }
+
+  @Nullable
+  public static IsisLevel intersection(IsisLevel... levels) {
+    if (levels.length == 0) {
+      return null;
+    }
+    IsisLevel overlap = LEVEL_1_2;
+    for (IsisLevel level : levels) {
+      overlap = intersection(overlap, level);
+    }
+    return overlap;
+  }
+
+  @Nullable
+  private static IsisLevel intersection(@Nullable IsisLevel first, @Nullable IsisLevel second) {
+    if (first == second) {
+      return first;
+    }
+    if (first == LEVEL_1_2) {
+      return second;
+    }
+    if (second == LEVEL_1_2) {
+      return first;
+    }
+    return null;
+  }
+
+  @Nullable
+  public static IsisLevel union(@Nullable IsisLevel level1, @Nullable IsisLevel level2) {
+    if (level1 == level2) {
+      return level1;
+    }
+    if (level1 == LEVEL_1_2 || level2 == LEVEL_1_2) {
+      return LEVEL_1_2;
+    }
+    if (level1 == LEVEL_1 || level2 == LEVEL_1) {
+      // other is null or LEVEL_2
+      if (level1 == LEVEL_2 || level2 == LEVEL_2) {
+        return LEVEL_1_2;
+      }
+      // other is null
+      return LEVEL_1;
+    }
+    // one is null and one is LEVEL_2
+    return LEVEL_2;
+  }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/isis/IsisLevelTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/isis/IsisLevelTest.java
@@ -1,0 +1,41 @@
+package org.batfish.datamodel.isis;
+
+import static org.batfish.datamodel.isis.IsisLevel.LEVEL_1;
+import static org.batfish.datamodel.isis.IsisLevel.LEVEL_1_2;
+import static org.batfish.datamodel.isis.IsisLevel.LEVEL_2;
+import static org.batfish.datamodel.isis.IsisLevel.intersection;
+import static org.batfish.datamodel.isis.IsisLevel.union;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class IsisLevelTest {
+
+  @Test
+  public void testIncludes() {
+    assertThat(LEVEL_1_2.includes(LEVEL_1), is(true));
+    assertThat(LEVEL_1_2.includes(LEVEL_2), is(true));
+    assertThat(LEVEL_1.includes(LEVEL_1), is(true));
+    assertThat(LEVEL_2.includes(LEVEL_1), is(false));
+  }
+
+  @Test
+  public void testIntersection() {
+    assertThat(intersection(), nullValue());
+    assertThat(intersection(LEVEL_1), equalTo(LEVEL_1));
+    assertThat(intersection(LEVEL_1, LEVEL_2), nullValue());
+    assertThat(intersection(LEVEL_1, LEVEL_1_2), equalTo(LEVEL_1));
+    assertThat(intersection(LEVEL_1, LEVEL_1_2, LEVEL_2), nullValue());
+    assertThat(intersection(LEVEL_1, null), nullValue());
+  }
+
+  @Test
+  public void testUnion() {
+    assertThat(union(null, null), nullValue());
+    assertThat(union(null, LEVEL_1), equalTo(LEVEL_1));
+    assertThat(union(LEVEL_1, LEVEL_2), equalTo(LEVEL_1_2));
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/IsisRouteMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/IsisRouteMatchers.java
@@ -1,5 +1,6 @@
 package org.batfish.datamodel.matchers;
 
+import static org.batfish.datamodel.matchers.AbstractRouteMatchers.hasMetric;
 import static org.batfish.datamodel.matchers.AbstractRouteMatchers.hasNextHopIp;
 import static org.batfish.datamodel.matchers.AbstractRouteMatchers.hasPrefix;
 import static org.hamcrest.Matchers.allOf;
@@ -21,9 +22,11 @@ public final class IsisRouteMatchers {
   }
 
   /** Matches with a route with the given prefix and next hop IP */
-  public static Matcher<AbstractRoute> isisRouteTo(Prefix prefix, Ip nextHopIp) {
+  public static Matcher<AbstractRoute> isisRouteTo(Prefix prefix, Ip nextHopIp, long metric) {
     return allOf(
-        isIsisRouteThat(hasPrefix(prefix)), isIsisRouteThat(hasNextHopIp(equalTo(nextHopIp))));
+        isIsisRouteThat(hasPrefix(prefix)),
+        isIsisRouteThat(hasNextHopIp(equalTo(nextHopIp))),
+        isIsisRouteThat(hasMetric(metric)));
   }
 
   public static @Nonnull Matcher<AbstractRoute> isIsisRouteThat(

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/IsisRouteMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/IsisRouteMatchers.java
@@ -1,10 +1,15 @@
 package org.batfish.datamodel.matchers;
 
+import static org.batfish.datamodel.matchers.AbstractRouteMatchers.hasNextHopIp;
+import static org.batfish.datamodel.matchers.AbstractRouteMatchers.hasPrefix;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;
 
 import javax.annotation.Nonnull;
 import org.batfish.datamodel.AbstractRoute;
+import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IsisRoute;
+import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.matchers.IsisRouteMatchersImpl.HasDown;
 import org.batfish.datamodel.matchers.IsisRouteMatchersImpl.IsIsisRouteThat;
 import org.hamcrest.Matcher;
@@ -13,6 +18,12 @@ public final class IsisRouteMatchers {
 
   public static @Nonnull Matcher<IsisRoute> hasDown() {
     return new HasDown(equalTo(true));
+  }
+
+  /** Matches with a route with the given prefix and next hop IP */
+  public static Matcher<AbstractRoute> isisRouteTo(Prefix prefix, Ip nextHopIp) {
+    return allOf(
+        isIsisRouteThat(hasPrefix(prefix)), isIsisRouteThat(hasNextHopIp(equalTo(nextHopIp))));
   }
 
   public static @Nonnull Matcher<AbstractRoute> isIsisRouteThat(

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -1411,9 +1411,17 @@ public class VirtualRouter implements Serializable {
                     ? iface.getIsis().getLevel1()
                     : iface.getIsis().getLevel2();
 
-            // Do not propagate route if ISIS interface is passive at this level
-            if (isisLevelSettings.getMode() == IsisInterfaceMode.PASSIVE) {
-              continue;
+            // Do not propagate route if ISIS interface is not active at this level
+            switch (isisLevelSettings.getMode()) {
+              case PASSIVE:
+              case SUPPRESSED:
+              case UNSET:
+                continue;
+              case ACTIVE:
+                break;
+              default:
+                throw new BatfishException(
+                    String.format("Unrecognized IS-IS mode %s", isisLevelSettings.getMode()));
             }
             routeBuilder
                 .setNetwork(neighborRoute.getNetwork())

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IsisTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IsisTest.java
@@ -17,6 +17,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasKey;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Sets;
 import java.util.Collections;
@@ -167,32 +168,36 @@ public class IsisTest {
     assertThat(
         r1L1RibRoutes,
         containsInAnyOrder(
-            isisRouteTo(r1LoopbackPrefix, R1_LOOPBACK_IP),
-            isisRouteTo(isisInterfacePrefix, R1_INTERFACE_IP),
-            isisRouteTo(Prefix.ZERO, R1_INTERFACE_IP)));
+            ImmutableList.of(
+                isisRouteTo(r1LoopbackPrefix, R1_LOOPBACK_IP, 0),
+                isisRouteTo(isisInterfacePrefix, R1_INTERFACE_IP, 0), // 0 because passive
+                isisRouteTo(Prefix.ZERO, R1_INTERFACE_IP, 0))));
     assertThat(
         r2L1RibRoutes,
         containsInAnyOrder(
-            isisRouteTo(r2LoopbackPrefix, R2_LOOPBACK_IP),
-            isisRouteTo(isisInterfacePrefix, R2_INTERFACE_IP),
-            isisRouteTo(Prefix.ZERO, R2_INTERFACE_IP)));
+            ImmutableList.of(
+                isisRouteTo(r2LoopbackPrefix, R2_LOOPBACK_IP, 0),
+                isisRouteTo(isisInterfacePrefix, R2_INTERFACE_IP, 10),
+                isisRouteTo(Prefix.ZERO, R2_INTERFACE_IP, 0))));
 
     // L2 RIBs have the other's loopback
     assertThat(
         r1L2RibRoutes,
         containsInAnyOrder(
-            isisRouteTo(r1LoopbackPrefix, R1_LOOPBACK_IP),
-            isisRouteTo(r2LoopbackPrefix, R2_INTERFACE_IP),
-            isisRouteTo(isisInterfacePrefix, R1_INTERFACE_IP)));
+            ImmutableList.of(
+                isisRouteTo(r1LoopbackPrefix, R1_LOOPBACK_IP, 0),
+                isisRouteTo(r2LoopbackPrefix, R2_INTERFACE_IP, 10),
+                isisRouteTo(isisInterfacePrefix, R1_INTERFACE_IP, 10))));
     assertThat(
         r2L2RibRoutes,
         containsInAnyOrder(
-            isisRouteTo(r1LoopbackPrefix, R1_INTERFACE_IP),
-            isisRouteTo(r2LoopbackPrefix, R2_LOOPBACK_IP),
-            isisRouteTo(isisInterfacePrefix, R2_INTERFACE_IP),
-            // This route comes from r1's route on the passive L1 interface level. That route starts
-            // with cost 0, then gets upgraded and sent to r2 with cost 10, same as previous route.
-            isisRouteTo(isisInterfacePrefix, R1_INTERFACE_IP)));
+            ImmutableList.of(
+                isisRouteTo(r1LoopbackPrefix, R1_INTERFACE_IP, 10),
+                isisRouteTo(r2LoopbackPrefix, R2_LOOPBACK_IP, 0),
+                isisRouteTo(isisInterfacePrefix, R2_INTERFACE_IP, 10),
+                // This route comes from r1's passive L1 interface level. It starts with cost 0,
+                // then gets upgraded to L2 and sent to r2 with cost 10 (same as previous route).
+                isisRouteTo(isisInterfacePrefix, R1_INTERFACE_IP, 10))));
 
     // Both nodes have an L2 route to the other's loopback
     SortedMap<String, SortedMap<String, SortedSet<AbstractRoute>>> routes =
@@ -223,29 +228,33 @@ public class IsisTest {
     assertThat(
         r1L1RibRoutes,
         containsInAnyOrder(
-            isisRouteTo(r1LoopbackPrefix, R1_LOOPBACK_IP),
-            isisRouteTo(r2LoopbackPrefix, R2_INTERFACE_IP),
-            isisRouteTo(isisInterfacePrefix, R1_INTERFACE_IP),
-            isisRouteTo(Prefix.ZERO, R1_INTERFACE_IP)));
+            ImmutableList.of(
+                isisRouteTo(r1LoopbackPrefix, R1_LOOPBACK_IP, 0),
+                isisRouteTo(r2LoopbackPrefix, R2_INTERFACE_IP, 10),
+                isisRouteTo(isisInterfacePrefix, R1_INTERFACE_IP, 10),
+                isisRouteTo(Prefix.ZERO, R1_INTERFACE_IP, 0))));
     assertThat(
         r2L1RibRoutes,
         containsInAnyOrder(
-            isisRouteTo(r1LoopbackPrefix, R1_INTERFACE_IP),
-            isisRouteTo(r2LoopbackPrefix, R2_LOOPBACK_IP),
-            isisRouteTo(isisInterfacePrefix, R2_INTERFACE_IP),
-            isisRouteTo(Prefix.ZERO, R2_INTERFACE_IP)));
+            ImmutableList.of(
+                isisRouteTo(r1LoopbackPrefix, R1_INTERFACE_IP, 10),
+                isisRouteTo(r2LoopbackPrefix, R2_LOOPBACK_IP, 0),
+                isisRouteTo(isisInterfacePrefix, R2_INTERFACE_IP, 10),
+                isisRouteTo(Prefix.ZERO, R2_INTERFACE_IP, 0))));
 
     // L2 RIBs lack the other's loopback
     assertThat(
         r1L2RibRoutes,
         containsInAnyOrder(
-            isisRouteTo(r1LoopbackPrefix, R1_LOOPBACK_IP),
-            isisRouteTo(isisInterfacePrefix, R1_INTERFACE_IP)));
+            ImmutableList.of(
+                isisRouteTo(r1LoopbackPrefix, R1_LOOPBACK_IP, 0),
+                isisRouteTo(isisInterfacePrefix, R1_INTERFACE_IP, 0)))); // 0 because passive
     assertThat(
         r2L2RibRoutes,
         containsInAnyOrder(
-            isisRouteTo(r2LoopbackPrefix, R2_LOOPBACK_IP),
-            isisRouteTo(isisInterfacePrefix, R2_INTERFACE_IP)));
+            ImmutableList.of(
+                isisRouteTo(r2LoopbackPrefix, R2_LOOPBACK_IP, 0),
+                isisRouteTo(isisInterfacePrefix, R2_INTERFACE_IP, 10))));
 
     // Both nodes have an L1 route to the other's loopback
     SortedMap<String, SortedMap<String, SortedSet<AbstractRoute>>> routes =

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IsisTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IsisTest.java
@@ -1,5 +1,6 @@
 package org.batfish.dataplane.ibdp;
 
+import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
 import static org.batfish.datamodel.RoutingProtocol.ISIS_L1;
 import static org.batfish.datamodel.RoutingProtocol.ISIS_L2;
 import static org.batfish.datamodel.matchers.AbstractRouteMatchers.hasMetric;
@@ -7,9 +8,11 @@ import static org.batfish.datamodel.matchers.AbstractRouteMatchers.hasPrefix;
 import static org.batfish.datamodel.matchers.AbstractRouteMatchers.hasProtocol;
 import static org.batfish.datamodel.matchers.IsisRouteMatchers.hasDown;
 import static org.batfish.datamodel.matchers.IsisRouteMatchers.isIsisRouteThat;
+import static org.batfish.datamodel.matchers.IsisRouteMatchers.isisRouteTo;
 import static org.batfish.dataplane.ibdp.TestUtils.assertNoRoute;
 import static org.batfish.dataplane.ibdp.TestUtils.assertRoute;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasKey;
@@ -17,6 +20,7 @@ import static org.hamcrest.Matchers.hasKey;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Sets;
 import java.util.Collections;
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -27,6 +31,8 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.InterfaceAddress;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IsisRoute;
 import org.batfish.datamodel.IsoAddress;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.Prefix;
@@ -48,6 +54,11 @@ public class IsisTest {
   private static final String R4 = "r4";
   private static final String R5 = "r5";
 
+  private static final Ip R1_LOOPBACK_IP = Ip.parse("10.1.1.1");
+  private static final Ip R2_LOOPBACK_IP = Ip.parse("10.2.2.2");
+  private static final Ip R1_INTERFACE_IP = Ip.parse("10.1.2.1");
+  private static final Ip R2_INTERFACE_IP = Ip.parse("10.1.2.2");
+
   private static void assertInterAreaRoute(
       SortedMap<String, SortedMap<String, SortedSet<AbstractRoute>>> routesByNode,
       String hostname,
@@ -55,8 +66,8 @@ public class IsisTest {
       long expectedCost) {
     assertThat(routesByNode, hasKey(hostname));
     SortedMap<String, SortedSet<AbstractRoute>> routesByVrf = routesByNode.get(hostname);
-    assertThat(routesByVrf, hasKey(Configuration.DEFAULT_VRF_NAME));
-    SortedSet<AbstractRoute> routes = routesByVrf.get(Configuration.DEFAULT_VRF_NAME);
+    assertThat(routesByVrf, hasKey(DEFAULT_VRF_NAME));
+    SortedSet<AbstractRoute> routes = routesByVrf.get(DEFAULT_VRF_NAME);
     assertThat(routes, hasItem(hasPrefix(prefix)));
     AbstractRoute route =
         routes.stream().filter(r -> r.getNetwork().equals(prefix)).findAny().get();
@@ -65,11 +76,189 @@ public class IsisTest {
     assertThat(route, isIsisRouteThat(hasDown()));
   }
 
+  /**
+   * Builds dataplane for a pair of devices r1 and r2 with IS-IS set up on both. Interface levels on
+   * r1 are customizable to be passive or not.
+   *
+   * @param r1Level1Passive Whether to make IS-IS passive on level 1 of r1's interface to r2
+   * @param r1Level2Passive Whether to make IS-IS passive on level 2 of r1's interface to r2
+   * @return
+   */
+  private IncrementalDataPlane setUpPassiveIsis(boolean r1Level1Passive, boolean r1Level2Passive) {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration.Builder cb =
+        nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+    Vrf.Builder vb = nf.vrfBuilder().setName(DEFAULT_VRF_NAME);
+    IsisProcess.Builder ipb = IsisProcess.builder();
+    Interface.Builder ib = nf.interfaceBuilder();
+    IsisInterfaceSettings.Builder iib = IsisInterfaceSettings.builder().setPointToPoint(true);
+    IsisInterfaceLevelSettings activeIls =
+        IsisInterfaceLevelSettings.builder().setMode(IsisInterfaceMode.ACTIVE).build();
+    IsisInterfaceLevelSettings passiveIls =
+        IsisInterfaceLevelSettings.builder().setMode(IsisInterfaceMode.PASSIVE).build();
+    IsisLevelSettings levelSettings = IsisLevelSettings.builder().build();
+
+    // r1
+    Configuration r1 = cb.setHostname(R1).build();
+    Vrf v1 = vb.setOwner(r1).build();
+    ib.setOwner(r1).setVrf(v1);
+    ipb.setVrf(v1)
+        .setNetAddress(new IsoAddress("49.0001.0100.0100.1001.00"))
+        .setLevel1(levelSettings)
+        .setLevel2(levelSettings)
+        .build();
+    // r1 loopback
+    ib.setAddress(new InterfaceAddress(R1_LOOPBACK_IP, 32))
+        .setIsis(iib.setLevel1(passiveIls).setLevel2(passiveIls).build())
+        .build();
+    // r1 interface to r2
+    ib.setAddress(new InterfaceAddress(R1_INTERFACE_IP, 24))
+        .setIsis(
+            iib.setLevel1(r1Level1Passive ? passiveIls : activeIls)
+                .setLevel2(r1Level2Passive ? passiveIls : activeIls)
+                .build())
+        .build();
+
+    // r2
+    Configuration r2 = cb.setHostname(R2).build();
+    Vrf v2 = vb.setOwner(r2).build();
+    ib.setOwner(r2).setVrf(v2);
+    ipb.setVrf(v2).setNetAddress(new IsoAddress("49.0001.0100.0200.2002.00")).build();
+    // r2 loopback
+    ib.setAddress(new InterfaceAddress(R2_LOOPBACK_IP, 32))
+        .setIsis(iib.setLevel1(passiveIls).setLevel2(passiveIls).build())
+        .build();
+    // r2 interface to r1
+    ib.setAddress(new InterfaceAddress(R2_INTERFACE_IP, 24))
+        .setIsis(iib.setLevel1(activeIls).setLevel2(activeIls).build())
+        .build();
+
+    SortedMap<String, Configuration> configurations =
+        ImmutableSortedMap.of(r1.getHostname(), r1, r2.getHostname(), r2);
+    IncrementalBdpEngine engine =
+        new IncrementalBdpEngine(
+            new IncrementalDataPlaneSettings(),
+            new BatfishLogger(BatfishLogger.LEVELSTR_OUTPUT, false),
+            (s, i) -> new AtomicInteger());
+    Topology topology = CommonUtil.synthesizeTopology(configurations);
+    return (IncrementalDataPlane)
+        engine.computeDataPlane(configurations, topology, Collections.emptySet())._dataPlane;
+  }
+
+  @Test
+  public void testIsisPassiveL1() {
+    // Test with passive level 1 on r1. Should see each other's loopback addresses in L2 RIB, but
+    // not L1, and both should have routes to the other's loopback with ISIS_L2 protocol.
+    IncrementalDataPlane dp = setUpPassiveIsis(true, false);
+    Prefix r1LoopbackPrefix = Prefix.create(R1_LOOPBACK_IP, 32);
+    Prefix r2LoopbackPrefix = Prefix.create(R2_LOOPBACK_IP, 32);
+    Prefix isisInterfacePrefix = Prefix.create(R1_INTERFACE_IP, 24);
+
+    Set<IsisRoute> r1L1RibRoutes =
+        dp.getNodes().get(R1).getVirtualRouters().get(DEFAULT_VRF_NAME)._isisL1Rib.getRoutes();
+    Set<IsisRoute> r2L1RibRoutes =
+        dp.getNodes().get(R2).getVirtualRouters().get(DEFAULT_VRF_NAME)._isisL1Rib.getRoutes();
+    Set<IsisRoute> r1L2RibRoutes =
+        dp.getNodes().get(R1).getVirtualRouters().get(DEFAULT_VRF_NAME)._isisL2Rib.getRoutes();
+    Set<IsisRoute> r2L2RibRoutes =
+        dp.getNodes().get(R2).getVirtualRouters().get(DEFAULT_VRF_NAME)._isisL2Rib.getRoutes();
+
+    // L1 RIBs lack the other's loopback, but have default route (see VirtualRouter.initIsisImports)
+    assertThat(
+        r1L1RibRoutes,
+        containsInAnyOrder(
+            isisRouteTo(r1LoopbackPrefix, R1_LOOPBACK_IP),
+            isisRouteTo(isisInterfacePrefix, R1_INTERFACE_IP),
+            isisRouteTo(Prefix.ZERO, R1_INTERFACE_IP)));
+    assertThat(
+        r2L1RibRoutes,
+        containsInAnyOrder(
+            isisRouteTo(r2LoopbackPrefix, R2_LOOPBACK_IP),
+            isisRouteTo(isisInterfacePrefix, R2_INTERFACE_IP),
+            isisRouteTo(Prefix.ZERO, R2_INTERFACE_IP)));
+
+    // L2 RIBs have the other's loopback
+    assertThat(
+        r1L2RibRoutes,
+        containsInAnyOrder(
+            isisRouteTo(r1LoopbackPrefix, R1_LOOPBACK_IP),
+            isisRouteTo(r2LoopbackPrefix, R2_INTERFACE_IP),
+            isisRouteTo(isisInterfacePrefix, R1_INTERFACE_IP)));
+    assertThat(
+        r2L2RibRoutes,
+        containsInAnyOrder(
+            isisRouteTo(r1LoopbackPrefix, R1_INTERFACE_IP),
+            isisRouteTo(r2LoopbackPrefix, R2_LOOPBACK_IP),
+            isisRouteTo(isisInterfacePrefix, R2_INTERFACE_IP),
+            // This route comes from r1's route on the passive L1 interface level. That route starts
+            // with cost 0, then gets upgraded and sent to r2 with cost 10, same as previous route.
+            isisRouteTo(isisInterfacePrefix, R1_INTERFACE_IP)));
+
+    // Both nodes have an L2 route to the other's loopback
+    SortedMap<String, SortedMap<String, SortedSet<AbstractRoute>>> routes =
+        IncrementalBdpEngine.getRoutes(dp);
+    assertRoute(routes, ISIS_L2, R1, r2LoopbackPrefix, 10L);
+    assertRoute(routes, ISIS_L2, R2, r1LoopbackPrefix, 10L);
+  }
+
+  @Test
+  public void testIsisPassiveL2() {
+    // Test with passive level 2 on r1. Should see each other's loopback addresses in L1 RIB, but
+    // not L2, and both should have routes to the other's loopback with ISIS_L1 protocol.
+    IncrementalDataPlane dp = setUpPassiveIsis(false, true);
+    Prefix r1LoopbackPrefix = Prefix.create(R1_LOOPBACK_IP, 32);
+    Prefix r2LoopbackPrefix = Prefix.create(R2_LOOPBACK_IP, 32);
+    Prefix isisInterfacePrefix = Prefix.parse("10.1.2.0/24");
+
+    Set<IsisRoute> r1L1RibRoutes =
+        dp.getNodes().get(R1).getVirtualRouters().get(DEFAULT_VRF_NAME)._isisL1Rib.getRoutes();
+    Set<IsisRoute> r2L1RibRoutes =
+        dp.getNodes().get(R2).getVirtualRouters().get(DEFAULT_VRF_NAME)._isisL1Rib.getRoutes();
+    Set<IsisRoute> r1L2RibRoutes =
+        dp.getNodes().get(R1).getVirtualRouters().get(DEFAULT_VRF_NAME)._isisL2Rib.getRoutes();
+    Set<IsisRoute> r2L2RibRoutes =
+        dp.getNodes().get(R2).getVirtualRouters().get(DEFAULT_VRF_NAME)._isisL2Rib.getRoutes();
+
+    // L1 RIBs have the other's loopback and default route (see VirtualRouter.initIsisImports)
+    assertThat(
+        r1L1RibRoutes,
+        containsInAnyOrder(
+            isisRouteTo(r1LoopbackPrefix, R1_LOOPBACK_IP),
+            isisRouteTo(r2LoopbackPrefix, R2_INTERFACE_IP),
+            isisRouteTo(isisInterfacePrefix, R1_INTERFACE_IP),
+            isisRouteTo(Prefix.ZERO, R1_INTERFACE_IP)));
+    assertThat(
+        r2L1RibRoutes,
+        containsInAnyOrder(
+            isisRouteTo(r1LoopbackPrefix, R1_INTERFACE_IP),
+            isisRouteTo(r2LoopbackPrefix, R2_LOOPBACK_IP),
+            isisRouteTo(isisInterfacePrefix, R2_INTERFACE_IP),
+            isisRouteTo(Prefix.ZERO, R2_INTERFACE_IP)));
+
+    // L2 RIBs lack the other's loopback
+    assertThat(
+        r1L2RibRoutes,
+        containsInAnyOrder(
+            isisRouteTo(r1LoopbackPrefix, R1_LOOPBACK_IP),
+            isisRouteTo(isisInterfacePrefix, R1_INTERFACE_IP)));
+    assertThat(
+        r2L2RibRoutes,
+        containsInAnyOrder(
+            isisRouteTo(r2LoopbackPrefix, R2_LOOPBACK_IP),
+            isisRouteTo(isisInterfacePrefix, R2_INTERFACE_IP)));
+
+    // Both nodes have an L1 route to the other's loopback
+    SortedMap<String, SortedMap<String, SortedSet<AbstractRoute>>> routes =
+        IncrementalBdpEngine.getRoutes(dp);
+    assertRoute(routes, ISIS_L1, R1, r2LoopbackPrefix, 10L);
+    assertRoute(routes, ISIS_L1, R2, r1LoopbackPrefix, 10L);
+  }
+
   private IncrementalDataPlane computeDataPlane() {
     NetworkFactory nf = new NetworkFactory();
     Configuration.Builder cb =
         nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
-    Vrf.Builder vb = nf.vrfBuilder().setName(Configuration.DEFAULT_VRF_NAME);
+    Vrf.Builder vb = nf.vrfBuilder().setName(DEFAULT_VRF_NAME);
     IsisProcess.Builder ipb = IsisProcess.builder();
     Interface.Builder ib = nf.interfaceBuilder();
     IsisInterfaceSettings.Builder iib = IsisInterfaceSettings.builder().setPointToPoint(true);
@@ -276,25 +465,14 @@ public class IsisTest {
 
     // Assert r1/r2 have empty l1 rib
     assertThat(
-        dp.getNodes()
-            .get("r1")
-            .getVirtualRouters()
-            .get(Configuration.DEFAULT_VRF_NAME)
-            ._isisL1Rib
-            .getRoutes(),
+        dp.getNodes().get("r1").getVirtualRouters().get(DEFAULT_VRF_NAME)._isisL1Rib.getRoutes(),
         empty());
     assertThat(
-        dp.getNodes()
-            .get("r2")
-            .getVirtualRouters()
-            .get(Configuration.DEFAULT_VRF_NAME)
-            ._isisL1Rib
-            .getRoutes(),
+        dp.getNodes().get("r2").getVirtualRouters().get(DEFAULT_VRF_NAME)._isisL1Rib.getRoutes(),
         empty());
 
     // Assert r3 has disjoint l1/l2 ribs
-    VirtualRouter r3Vr =
-        dp.getNodes().get("r3").getVirtualRouters().get(Configuration.DEFAULT_VRF_NAME);
+    VirtualRouter r3Vr = dp.getNodes().get("r3").getVirtualRouters().get(DEFAULT_VRF_NAME);
     assertThat(
         Sets.intersection(r3Vr._isisL1Rib.getRoutes(), r3Vr._isisL2Rib.getRoutes()), empty());
   }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IsisTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IsisTest.java
@@ -59,6 +59,7 @@ public class IsisTest {
   private static final Ip R2_LOOPBACK_IP = Ip.parse("10.2.2.2");
   private static final Ip R1_INTERFACE_IP = Ip.parse("10.1.2.1");
   private static final Ip R2_INTERFACE_IP = Ip.parse("10.1.2.2");
+  private static final int INTERFACE_PREFIX_LENGTH = 24;
 
   private static void assertInterAreaRoute(
       SortedMap<String, SortedMap<String, SortedSet<AbstractRoute>>> routesByNode,
@@ -83,7 +84,6 @@ public class IsisTest {
    *
    * @param r1Level1Passive Whether to make IS-IS passive on level 1 of r1's interface to r2
    * @param r1Level2Passive Whether to make IS-IS passive on level 2 of r1's interface to r2
-   * @return
    */
   private IncrementalDataPlane setUpPassiveIsis(boolean r1Level1Passive, boolean r1Level2Passive) {
     NetworkFactory nf = new NetworkFactory();
@@ -151,9 +151,9 @@ public class IsisTest {
     // Test with passive level 1 on r1. Should see each other's loopback addresses in L2 RIB, but
     // not L1, and both should have routes to the other's loopback with ISIS_L2 protocol.
     IncrementalDataPlane dp = setUpPassiveIsis(true, false);
-    Prefix r1LoopbackPrefix = Prefix.create(R1_LOOPBACK_IP, 32);
-    Prefix r2LoopbackPrefix = Prefix.create(R2_LOOPBACK_IP, 32);
-    Prefix isisInterfacePrefix = Prefix.create(R1_INTERFACE_IP, 24);
+    Prefix r1LoopbackPrefix = Prefix.create(R1_LOOPBACK_IP, Prefix.MAX_PREFIX_LENGTH);
+    Prefix r2LoopbackPrefix = Prefix.create(R2_LOOPBACK_IP, Prefix.MAX_PREFIX_LENGTH);
+    Prefix isisInterfacePrefix = Prefix.create(R1_INTERFACE_IP, INTERFACE_PREFIX_LENGTH);
 
     Set<IsisRoute> r1L1RibRoutes =
         dp.getNodes().get(R1).getVirtualRouters().get(DEFAULT_VRF_NAME)._isisL1Rib.getRoutes();
@@ -211,9 +211,9 @@ public class IsisTest {
     // Test with passive level 2 on r1. Should see each other's loopback addresses in L1 RIB, but
     // not L2, and both should have routes to the other's loopback with ISIS_L1 protocol.
     IncrementalDataPlane dp = setUpPassiveIsis(false, true);
-    Prefix r1LoopbackPrefix = Prefix.create(R1_LOOPBACK_IP, 32);
-    Prefix r2LoopbackPrefix = Prefix.create(R2_LOOPBACK_IP, 32);
-    Prefix isisInterfacePrefix = Prefix.parse("10.1.2.0/24");
+    Prefix r1LoopbackPrefix = Prefix.create(R1_LOOPBACK_IP, Prefix.MAX_PREFIX_LENGTH);
+    Prefix r2LoopbackPrefix = Prefix.create(R2_LOOPBACK_IP, Prefix.MAX_PREFIX_LENGTH);
+    Prefix isisInterfacePrefix = Prefix.create(R1_INTERFACE_IP, INTERFACE_PREFIX_LENGTH);
 
     Set<IsisRoute> r1L1RibRoutes =
         dp.getNodes().get(R1).getVirtualRouters().get(DEFAULT_VRF_NAME)._isisL1Rib.getRoutes();

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IsisTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IsisTest.java
@@ -109,11 +109,11 @@ public class IsisTest {
         .setLevel2(levelSettings)
         .build();
     // r1 loopback
-    ib.setAddress(new InterfaceAddress(R1_LOOPBACK_IP, 32))
+    ib.setAddress(new InterfaceAddress(R1_LOOPBACK_IP, Prefix.MAX_PREFIX_LENGTH))
         .setIsis(iib.setLevel1(passiveIls).setLevel2(passiveIls).build())
         .build();
     // r1 interface to r2
-    ib.setAddress(new InterfaceAddress(R1_INTERFACE_IP, 24))
+    ib.setAddress(new InterfaceAddress(R1_INTERFACE_IP, INTERFACE_PREFIX_LENGTH))
         .setIsis(
             iib.setLevel1(r1Level1Passive ? passiveIls : activeIls)
                 .setLevel2(r1Level2Passive ? passiveIls : activeIls)
@@ -126,11 +126,11 @@ public class IsisTest {
     ib.setOwner(r2).setVrf(v2);
     ipb.setVrf(v2).setNetAddress(new IsoAddress("49.0001.0100.0200.2002.00")).build();
     // r2 loopback
-    ib.setAddress(new InterfaceAddress(R2_LOOPBACK_IP, 32))
+    ib.setAddress(new InterfaceAddress(R2_LOOPBACK_IP, Prefix.MAX_PREFIX_LENGTH))
         .setIsis(iib.setLevel1(passiveIls).setLevel2(passiveIls).build())
         .build();
     // r2 interface to r1
-    ib.setAddress(new InterfaceAddress(R2_INTERFACE_IP, 24))
+    ib.setAddress(new InterfaceAddress(R2_INTERFACE_IP, INTERFACE_PREFIX_LENGTH))
         .setIsis(iib.setLevel1(activeIls).setLevel2(activeIls).build())
         .build();
 

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
@@ -14,7 +14,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.collection.IsEmptyIterable.emptyIterableOf;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
@@ -22,7 +21,6 @@ import static org.junit.Assert.assertThat;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.graph.ImmutableValueGraph;
 import com.google.common.graph.Network;
@@ -48,10 +46,8 @@ import org.batfish.datamodel.ConnectedRoute;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
-import org.batfish.datamodel.IsisRoute;
 import org.batfish.datamodel.IsoAddress;
 import org.batfish.datamodel.LocalRoute;
-import org.batfish.datamodel.NetworkConfigurations;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.OspfExternalType1Route;
 import org.batfish.datamodel.OspfExternalType2Route;
@@ -771,137 +767,5 @@ public class VirtualRouterTest {
                     IsisLevel.LEVEL_1_2,
                     new IsisNode(c1.getHostname(), i1.getName()),
                     new IsisNode(c2.getHostname(), i2.getName())))));
-  }
-
-  /*
-   * Setup:
-   * - Node R1 with ISIS interface with active L1 and passive L2
-   * - Node R2 with ISIS interface with passive L1 and active L2
-   * Manually send route advertisements to both routers at both levels. Should see:
-   * - R1 propagate advertisements at L1 but not L2
-   * - R2 propagate advertisements at L2 but not L1
-   */
-  @Test
-  public void testIsisRoutePropagationWithPassiveInterfaceLevels() {
-    NetworkFactory nf = new NetworkFactory();
-    Configuration.Builder cb =
-        nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
-    Configuration c1 = cb.build();
-    Configuration c2 = cb.build();
-
-    Vrf.Builder vb = nf.vrfBuilder().setName(DEFAULT_VRF_NAME);
-    Vrf v1 = vb.setOwner(c1).build();
-    Vrf v2 = vb.setOwner(c2).build();
-
-    IsisLevelSettings levelSettings = IsisLevelSettings.builder().build();
-    IsisProcess.Builder isb =
-        IsisProcess.builder().setLevel1(levelSettings).setLevel2(levelSettings);
-    Interface.Builder ib = nf.interfaceBuilder();
-
-    // Area: 0001, SystemID: 0100.0000.0000
-    isb.setVrf(v1).setNetAddress(new IsoAddress("49.0001.0100.0000.0000.00")).build();
-    Interface i1 =
-        ib.setOwner(c1).setVrf(v1).setAddress(new InterfaceAddress("10.0.0.0/31")).build();
-
-    // Area: 0001, SystemID: 0100.0000.0001
-    isb.setVrf(v2).setNetAddress(new IsoAddress("49.0001.0100.0000.0001.00")).build();
-    Interface i2 =
-        ib.setOwner(c2).setVrf(v2).setAddress(new InterfaceAddress("10.0.0.1/31")).build();
-
-    Map<String, Configuration> configs =
-        ImmutableMap.of(c1.getHostname(), c1, c2.getHostname(), c2);
-    Map<String, Node> nodes =
-        ImmutableMap.of(c1.getHostname(), new Node(c1), c2.getHostname(), new Node(c2));
-    Map<String, VirtualRouter> vrs =
-        nodes
-            .values()
-            .stream()
-            .map(n -> n.getVirtualRouters().get(DEFAULT_VRF_NAME))
-            .collect(
-                ImmutableMap.toImmutableMap(
-                    vr -> vr.getConfiguration().getHostname(), Function.identity()));
-
-    // Set IS-IS on interfaces. Set cost to 0 for convenience - this way route advertisements in rib
-    // delta should be equal to incoming route advertisements because the metrics won't increase.
-    IsisInterfaceLevelSettings activeLevelSettings =
-        IsisInterfaceLevelSettings.builder().setMode(IsisInterfaceMode.ACTIVE).setCost(0L).build();
-    IsisInterfaceLevelSettings passiveLevelSettings =
-        IsisInterfaceLevelSettings.builder().setMode(IsisInterfaceMode.PASSIVE).setCost(0L).build();
-    i1.setIsis(
-        IsisInterfaceSettings.builder()
-            .setPointToPoint(true)
-            .setLevel1(activeLevelSettings)
-            .setLevel2(passiveLevelSettings)
-            .build());
-    i2.setIsis(
-        IsisInterfaceSettings.builder()
-            .setPointToPoint(true)
-            .setLevel1(passiveLevelSettings)
-            .setLevel2(activeLevelSettings)
-            .build());
-
-    // Build route advertisements.
-    IsisRoute.Builder routeBuilder =
-        new IsisRoute.Builder()
-            .setAdmin(115)
-            .setArea("1")
-            .setSystemId("id")
-            .setNetwork(Prefix.parse("1.1.1.1/24"))
-            .setNextHopIp(Ip.parse("10.0.0.0"));
-
-    RouteAdvertisement<IsisRoute> level1AdvertToR2 =
-        new RouteAdvertisement<>(
-            routeBuilder.setLevel(IsisLevel.LEVEL_1).setProtocol(RoutingProtocol.ISIS_L1).build());
-    RouteAdvertisement<IsisRoute> level2AdvertToR2 =
-        new RouteAdvertisement<>(
-            routeBuilder.setLevel(IsisLevel.LEVEL_2).setProtocol(RoutingProtocol.ISIS_L2).build());
-
-    routeBuilder.setNetwork(Prefix.parse("2.2.2.2/24")).setNextHopIp(Ip.parse("10.0.0.1"));
-
-    RouteAdvertisement<IsisRoute> level1AdvertToR1 =
-        new RouteAdvertisement<>(
-            routeBuilder.setLevel(IsisLevel.LEVEL_1).setProtocol(RoutingProtocol.ISIS_L1).build());
-    RouteAdvertisement<IsisRoute> level2AdvertToR1 =
-        new RouteAdvertisement<>(
-            routeBuilder.setLevel(IsisLevel.LEVEL_2).setProtocol(RoutingProtocol.ISIS_L2).build());
-
-    IsisEdge edge1To2 =
-        new IsisEdge(
-            IsisLevel.LEVEL_1_2,
-            new IsisNode(c2.getHostname(), i2.getName()),
-            new IsisNode(c1.getHostname(), i1.getName()));
-    IsisEdge edge2To1 =
-        new IsisEdge(
-            IsisLevel.LEVEL_1_2,
-            new IsisNode(c1.getHostname(), i1.getName()),
-            new IsisNode(c2.getHostname(), i2.getName()));
-
-    Queue<RouteAdvertisement<IsisRoute>> routeAdvertsToR1 = new ConcurrentLinkedQueue<>();
-    Queue<RouteAdvertisement<IsisRoute>> routeAdvertsToR2 = new ConcurrentLinkedQueue<>();
-    routeAdvertsToR1.addAll(ImmutableList.of(level1AdvertToR1, level2AdvertToR1));
-    routeAdvertsToR2.addAll(ImmutableList.of(level1AdvertToR2, level2AdvertToR2));
-    vrs.get(c1.getHostname())._isisIncomingRoutes =
-        ImmutableSortedMap.of(edge1To2, routeAdvertsToR1);
-    vrs.get(c2.getHostname())._isisIncomingRoutes =
-        ImmutableSortedMap.of(edge2To1, routeAdvertsToR2);
-
-    NetworkConfigurations nc = NetworkConfigurations.of(configs);
-
-    // Tests for R1
-    Entry<RibDelta<IsisRoute>, RibDelta<IsisRoute>> ribDelta =
-        vrs.get(c1.getHostname()).propagateIsisRoutes(nc);
-    assertThat(ribDelta, notNullValue());
-    RibDelta<IsisRoute> l1Delta = ribDelta.getKey();
-    RibDelta<IsisRoute> l2Delta = ribDelta.getValue();
-    assertThat(l1Delta.getActions(), equalTo(ImmutableList.of(level1AdvertToR1)));
-    assertThat(l2Delta, nullValue());
-
-    // Tests for R2
-    ribDelta = vrs.get(c2.getHostname()).propagateIsisRoutes(nc);
-    assertThat(ribDelta, notNullValue());
-    l1Delta = ribDelta.getKey();
-    l2Delta = ribDelta.getValue();
-    assertThat(l1Delta, nullValue());
-    assertThat(l2Delta.getActions(), equalTo(ImmutableList.of(level2AdvertToR2)));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
@@ -890,16 +890,18 @@ public class VirtualRouterTest {
     // Tests for R1
     Entry<RibDelta<IsisRoute>, RibDelta<IsisRoute>> ribDelta =
         vrs.get(c1.getHostname()).propagateIsisRoutes(nc);
-    RibDelta<IsisRoute> L1Delta = ribDelta.getKey();
-    RibDelta<IsisRoute> L2Delta = ribDelta.getValue();
-    assertThat(L1Delta.getActions(), contains(level1AdvertToR1));
-    assertThat(L2Delta, nullValue());
+    assertThat(ribDelta, notNullValue());
+    RibDelta<IsisRoute> l1Delta = ribDelta.getKey();
+    RibDelta<IsisRoute> l2Delta = ribDelta.getValue();
+    assertThat(l1Delta.getActions(), equalTo(ImmutableList.of(level1AdvertToR1)));
+    assertThat(l2Delta, nullValue());
 
     // Tests for R2
     ribDelta = vrs.get(c2.getHostname()).propagateIsisRoutes(nc);
-    L1Delta = ribDelta.getKey();
-    L2Delta = ribDelta.getValue();
-    assertThat(L1Delta, nullValue());
-    assertThat(L2Delta.getActions(), contains(level2AdvertToR2));
+    assertThat(ribDelta, notNullValue());
+    l1Delta = ribDelta.getKey();
+    l2Delta = ribDelta.getValue();
+    assertThat(l1Delta, nullValue());
+    assertThat(l2Delta.getActions(), equalTo(ImmutableList.of(level2AdvertToR2)));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/topology/IsisEdgeTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/topology/IsisEdgeTest.java
@@ -1,15 +1,12 @@
 package org.batfish.dataplane.topology;
 
 import static org.batfish.common.util.CommonUtil.synthesizeTopology;
-import static org.batfish.datamodel.isis.IsisLevel.LEVEL_1;
 import static org.batfish.datamodel.isis.IsisLevel.LEVEL_1_2;
 import static org.batfish.datamodel.isis.IsisLevel.LEVEL_2;
 import static org.batfish.dataplane.topology.matchers.IsisEdgeMatchers.hasCircuitType;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.nullValue;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -115,15 +112,5 @@ public final class IsisEdgeTest {
     assertThat(
         isisEdgesDifferentSystemId,
         contains(ImmutableList.of(hasCircuitType(LEVEL_1_2), hasCircuitType(LEVEL_1_2))));
-  }
-
-  @Test
-  public void testLevelIntersection() {
-    assertThat(IsisEdge.intersection(), nullValue());
-    assertThat(IsisEdge.intersection(LEVEL_1), equalTo(LEVEL_1));
-    assertThat(IsisEdge.intersection(LEVEL_1, LEVEL_2), nullValue());
-    assertThat(IsisEdge.intersection(LEVEL_1, LEVEL_1_2), equalTo(LEVEL_1));
-    assertThat(IsisEdge.intersection(LEVEL_1, LEVEL_1_2, LEVEL_2), nullValue());
-    assertThat(IsisEdge.intersection(LEVEL_1, null), nullValue());
   }
 }


### PR DESCRIPTION
Only functional change is line 1422 in VirtualRouter, which stops route propagation if the ISIS interface level that received the advertised route is passive.

Very open to suggestions for simplifying the test.