### PR TITLE
Juniper: honor configured routing-instance

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -5691,7 +5691,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
     Interface iface = interfaces.get(name);
     if (iface == null) {
       iface = new Interface(name);
-      iface.setRoutingInstance(currentRoutingInstance);
+      iface.setRoutingInstance(_currentLogicalSystem.getDefaultRoutingInstance().getName());
       interfaces.put(name, iface);
     }
     if (unit != null) {
@@ -5699,7 +5699,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
       iface = units.get(unitFullName);
       if (iface == null) {
         iface = new Interface(unitFullName);
-        iface.setRoutingInstance(currentRoutingInstance);
+        iface.setRoutingInstance(_currentLogicalSystem.getDefaultRoutingInstance().getName());
         units.put(unitFullName, iface);
       }
     }

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -27793,7 +27793,7 @@
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
             "type" : "LOOPBACK",
-            "vrf" : "fabric"
+            "vrf" : "default"
           },
           "lo0.1" : {
             "name" : "lo0.1",
@@ -29251,10 +29251,7 @@
             ]
           },
           "fabric" : {
-            "name" : "fabric",
-            "interfaces" : [
-              "lo0.0"
-            ]
+            "name" : "fabric"
           },
           "vr" : {
             "name" : "vr",


### PR DESCRIPTION
In an unlikely corner case, we could end up with an interface in the wrong RI (or 2 RIs)
because we initialized it not in the default routing instance. It should be initialized
in the default RI, and only set to the current RI in the

    set routing-instance <RI> interface <I>

syntax by which interface RI membership is configured.