### PR TITLE
use Transformations in traceroute

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FlowDiff.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FlowDiff.java
@@ -17,6 +17,8 @@ import java.util.Set;
 import java.util.SortedSet;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.common.BatfishException;
+import org.batfish.datamodel.transformation.IpField;
 
 /** A representation of one difference between two flows. */
 @JsonTypeName("FlowDiff")
@@ -68,6 +70,22 @@ public final class FlowDiff implements Comparable<FlowDiff> {
     checkNotNull(oldValue);
     checkNotNull(newValue);
     return new FlowDiff(fieldName, oldValue, newValue);
+  }
+
+  private static String ipFieldName(IpField ipField) {
+    switch (ipField) {
+      case DESTINATION:
+        return PROP_DST_IP;
+      case SOURCE:
+        return PROP_SRC_IP;
+      default:
+        throw new BatfishException("Unknown IpField: " + ipField);
+    }
+  }
+
+  /** Create a {@link FlowDiff} for a specific changed IpField. */
+  public static FlowDiff flowDiff(IpField ipField, Ip oldValue, Ip newValue) {
+    return new FlowDiff(ipFieldName(ipField), oldValue.toString(), newValue.toString());
   }
 
   @JsonProperty(PROP_FIELD_NAME)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/TransformationStep.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/TransformationStep.java
@@ -2,6 +2,8 @@ package org.batfish.datamodel.flow;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
+import static org.batfish.datamodel.flow.TransformationStep.TransformationType.DEST_NAT;
+import static org.batfish.datamodel.flow.TransformationStep.TransformationType.SOURCE_NAT;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -10,8 +12,10 @@ import java.util.Objects;
 import java.util.SortedSet;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.batfish.common.BatfishException;
 import org.batfish.datamodel.FlowDiff;
 import org.batfish.datamodel.flow.TransformationStep.TransformationStepDetail;
+import org.batfish.datamodel.transformation.IpField;
 
 /** A {@link Step} for packet transformations. */
 public final class TransformationStep extends Step<TransformationStepDetail> {
@@ -20,6 +24,17 @@ public final class TransformationStep extends Step<TransformationStepDetail> {
     DEST_NAT,
     /** Source nat */
     SOURCE_NAT
+  }
+
+  public static TransformationType inferTypeFromIpField(IpField ipField) {
+    switch (ipField) {
+    case DESTINATION:
+      return DEST_NAT;
+    case SOURCE:
+      return SOURCE_NAT;
+    default:
+      throw new BatfishException("Unknown IpField: " + ipField);
+    }
   }
 
   /** Step detail for {@link TransformationStep} */

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/TransformationStep.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/TransformationStep.java
@@ -28,12 +28,12 @@ public final class TransformationStep extends Step<TransformationStepDetail> {
 
   public static TransformationType inferTypeFromIpField(IpField ipField) {
     switch (ipField) {
-    case DESTINATION:
-      return DEST_NAT;
-    case SOURCE:
-      return SOURCE_NAT;
-    default:
-      throw new BatfishException("Unknown IpField: " + ipField);
+      case DESTINATION:
+        return DEST_NAT;
+      case SOURCE:
+        return SOURCE_NAT;
+      default:
+        throw new BatfishException("Unknown IpField: " + ipField);
     }
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/TransformationStep.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/TransformationStep.java
@@ -2,8 +2,6 @@ package org.batfish.datamodel.flow;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
-import static org.batfish.datamodel.flow.TransformationStep.TransformationType.DEST_NAT;
-import static org.batfish.datamodel.flow.TransformationStep.TransformationType.SOURCE_NAT;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -12,29 +10,20 @@ import java.util.Objects;
 import java.util.SortedSet;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.batfish.common.BatfishException;
 import org.batfish.datamodel.FlowDiff;
 import org.batfish.datamodel.flow.TransformationStep.TransformationStepDetail;
-import org.batfish.datamodel.transformation.IpField;
 
 /** A {@link Step} for packet transformations. */
 public final class TransformationStep extends Step<TransformationStepDetail> {
+  /**
+   * The type of transformation (i.e. what vendor-specific configuration construct) this step is
+   * (partially) encoding.
+   */
   public enum TransformationType {
     /** Destination nat */
     DEST_NAT,
     /** Source nat */
     SOURCE_NAT
-  }
-
-  public static TransformationType inferTypeFromIpField(IpField ipField) {
-    switch (ipField) {
-      case DESTINATION:
-        return DEST_NAT;
-      case SOURCE:
-        return SOURCE_NAT;
-      default:
-        throw new BatfishException("Unknown IpField: " + ipField);
-    }
   }
 
   /** Step detail for {@link TransformationStep} */

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/transformation/AssignIpAddressFromPool.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/transformation/AssignIpAddressFromPool.java
@@ -1,9 +1,12 @@
 package org.batfish.datamodel.transformation;
 
+import static org.batfish.datamodel.flow.TransformationStep.inferTypeFromIpField;
+
 import java.io.Serializable;
 import java.util.Objects;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.flow.TransformationStep.TransformationType;
 
 /** A {@link TransformationStep} that transforms the destination IP */
 @ParametersAreNonnullByDefault
@@ -11,11 +14,18 @@ public final class AssignIpAddressFromPool implements TransformationStep, Serial
   /** */
   private static final long serialVersionUID = 1L;
 
+  private final TransformationType _type;
   private final IpField _ipField;
   private final Ip _poolStart;
   private final Ip _poolEnd;
 
   public AssignIpAddressFromPool(IpField ipField, Ip poolStart, Ip poolEnd) {
+    this(inferTypeFromIpField(ipField), ipField, poolStart, poolEnd);
+  }
+
+  public AssignIpAddressFromPool(
+      TransformationType type, IpField ipField, Ip poolStart, Ip poolEnd) {
+    _type = type;
     _ipField = ipField;
     _poolStart = poolStart;
     _poolEnd = poolEnd;
@@ -36,6 +46,11 @@ public final class AssignIpAddressFromPool implements TransformationStep, Serial
 
   public Ip getPoolEnd() {
     return _poolEnd;
+  }
+
+  @Override
+  public TransformationType getType() {
+    return _type;
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/transformation/AssignIpAddressFromPool.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/transformation/AssignIpAddressFromPool.java
@@ -1,7 +1,5 @@
 package org.batfish.datamodel.transformation;
 
-import static org.batfish.datamodel.flow.TransformationStep.inferTypeFromIpField;
-
 import java.io.Serializable;
 import java.util.Objects;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -18,10 +16,6 @@ public final class AssignIpAddressFromPool implements TransformationStep, Serial
   private final IpField _ipField;
   private final Ip _poolStart;
   private final Ip _poolEnd;
-
-  public AssignIpAddressFromPool(IpField ipField, Ip poolStart, Ip poolEnd) {
-    this(inferTypeFromIpField(ipField), ipField, poolStart, poolEnd);
-  }
 
   public AssignIpAddressFromPool(
       TransformationType type, IpField ipField, Ip poolStart, Ip poolEnd) {
@@ -62,13 +56,14 @@ public final class AssignIpAddressFromPool implements TransformationStep, Serial
       return false;
     }
     AssignIpAddressFromPool that = (AssignIpAddressFromPool) o;
-    return _ipField == that._ipField
+    return _type == that._type
+        && _ipField == that._ipField
         && Objects.equals(_poolStart, that._poolStart)
         && Objects.equals(_poolEnd, that._poolEnd);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_ipField, _poolStart, _poolEnd);
+    return Objects.hash(_type, _ipField, _poolStart, _poolEnd);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/transformation/Noop.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/transformation/Noop.java
@@ -1,0 +1,63 @@
+package org.batfish.datamodel.transformation;
+
+import static org.batfish.datamodel.flow.TransformationStep.TransformationType.DEST_NAT;
+import static org.batfish.datamodel.flow.TransformationStep.TransformationType.SOURCE_NAT;
+
+import java.util.Objects;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.common.BatfishException;
+import org.batfish.datamodel.flow.TransformationStep.TransformationType;
+
+/**
+ * A {@link TransformationStep} that does nothing to the packet. It exists so we can record the noop
+ * in the trace.
+ */
+@ParametersAreNonnullByDefault
+public final class Noop implements TransformationStep {
+  private final TransformationType _type;
+
+  public static final Noop NOOP_DEST_NAT = new Noop(DEST_NAT);
+  public static final Noop NOOP_SOURCE_NAT = new Noop(SOURCE_NAT);
+
+  public Noop(TransformationType type) {
+    _type = type;
+  }
+
+  public static Noop noop(IpField field) {
+    switch (field) {
+      case DESTINATION:
+        return NOOP_DEST_NAT;
+      case SOURCE:
+        return NOOP_SOURCE_NAT;
+      default:
+        throw new BatfishException("Unknown IpField: " + field);
+    }
+  }
+
+  @Override
+  public <T> T accept(TransformationStepVisitor<T> visitor) {
+    return visitor.visitNoop(this);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Noop)) {
+      return false;
+    }
+    Noop noop = (Noop) o;
+    return _type == noop._type;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_type);
+  }
+
+  @Override
+  public TransformationType getType() {
+    return _type;
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/transformation/ShiftIpAddressIntoSubnet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/transformation/ShiftIpAddressIntoSubnet.java
@@ -1,10 +1,12 @@
 package org.batfish.datamodel.transformation;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static org.batfish.datamodel.flow.TransformationStep.inferTypeFromIpField;
 
 import java.io.Serializable;
 import java.util.Objects;
 import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.flow.TransformationStep.TransformationType;
 
 /**
  * A {@link TransformationStep} that transforms the an IP by shifting it into a subnet. For example,
@@ -24,13 +26,19 @@ public final class ShiftIpAddressIntoSubnet implements TransformationStep, Seria
 
   private final IpField _ipField;
   private final Prefix _subnet;
+  private final TransformationType _type;
 
   public ShiftIpAddressIntoSubnet(IpField ipField, Prefix subnet) {
+    this(inferTypeFromIpField(ipField), ipField, subnet);
+  }
+
+  public ShiftIpAddressIntoSubnet(TransformationType type, IpField ipField, Prefix subnet) {
     checkArgument(
         subnet.getPrefixLength() < Prefix.MAX_PREFIX_LENGTH,
         "subnet prefix must be less than the maximum prefix length");
     _ipField = ipField;
     _subnet = subnet;
+    _type = type;
   }
 
   @Override
@@ -44,6 +52,11 @@ public final class ShiftIpAddressIntoSubnet implements TransformationStep, Seria
 
   public Prefix getSubnet() {
     return _subnet;
+  }
+
+  @Override
+  public TransformationType getType() {
+    return _type;
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/transformation/ShiftIpAddressIntoSubnet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/transformation/ShiftIpAddressIntoSubnet.java
@@ -1,7 +1,6 @@
 package org.batfish.datamodel.transformation;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static org.batfish.datamodel.flow.TransformationStep.inferTypeFromIpField;
 
 import java.io.Serializable;
 import java.util.Objects;
@@ -27,10 +26,6 @@ public final class ShiftIpAddressIntoSubnet implements TransformationStep, Seria
   private final IpField _ipField;
   private final Prefix _subnet;
   private final TransformationType _type;
-
-  public ShiftIpAddressIntoSubnet(IpField ipField, Prefix subnet) {
-    this(inferTypeFromIpField(ipField), ipField, subnet);
-  }
 
   public ShiftIpAddressIntoSubnet(TransformationType type, IpField ipField, Prefix subnet) {
     checkArgument(
@@ -68,11 +63,13 @@ public final class ShiftIpAddressIntoSubnet implements TransformationStep, Seria
       return false;
     }
     ShiftIpAddressIntoSubnet that = (ShiftIpAddressIntoSubnet) o;
-    return _ipField == that._ipField && Objects.equals(_subnet, that._subnet);
+    return _type == that._type
+        && _ipField == that._ipField
+        && Objects.equals(_subnet, that._subnet);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_ipField, _subnet);
+    return Objects.hash(_type, _ipField, _subnet);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/transformation/Transformation.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/transformation/Transformation.java
@@ -1,5 +1,6 @@
 package org.batfish.datamodel.transformation;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.TRUE;
 
 import com.google.common.collect.ImmutableList;
@@ -13,6 +14,9 @@ import org.batfish.datamodel.acl.AclLineMatchExpr;
 /** A representation of a composite packet transformation. */
 @ParametersAreNonnullByDefault
 public final class Transformation {
+  private static final String ERROR_NO_STEPS =
+      "Cannot create Transformation with zero transformationSteps. Consider using Noop.";
+
   public static final class Builder {
     private @Nonnull AclLineMatchExpr _guard;
     private @Nonnull List<TransformationStep> _transformationSteps;
@@ -25,6 +29,7 @@ public final class Transformation {
     }
 
     public Builder apply(TransformationStep... transformationSteps) {
+      checkArgument(transformationSteps.length > 0, ERROR_NO_STEPS);
       _transformationSteps = ImmutableList.copyOf(transformationSteps);
       return this;
     }
@@ -72,6 +77,7 @@ public final class Transformation {
       @Nonnull List<TransformationStep> transformationSteps,
       @Nullable Transformation andThen,
       @Nullable Transformation orElse) {
+    checkArgument(!transformationSteps.isEmpty(), ERROR_NO_STEPS);
     _guard = guard;
     _transformationSteps = ImmutableList.copyOf(transformationSteps);
     _andThen = andThen;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/transformation/TransformationStep.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/transformation/TransformationStep.java
@@ -3,10 +3,14 @@ package org.batfish.datamodel.transformation;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.flow.TransformationStep.TransformationType;
 
 /** A representation of an atomic transformation step. */
 @ParametersAreNonnullByDefault
 public interface TransformationStep {
+  /** Which {@link TransformationType} this step is (partially) encoding. */
+  TransformationType getType();
+
   <T> T accept(TransformationStepVisitor<T> visitor);
 
   static AssignIpAddressFromPool assignDestinationIp(Ip poolStart, Ip poolEnd) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/transformation/TransformationStep.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/transformation/TransformationStep.java
@@ -1,5 +1,10 @@
 package org.batfish.datamodel.transformation;
 
+import static org.batfish.datamodel.flow.TransformationStep.TransformationType.DEST_NAT;
+import static org.batfish.datamodel.flow.TransformationStep.TransformationType.SOURCE_NAT;
+import static org.batfish.datamodel.transformation.IpField.DESTINATION;
+import static org.batfish.datamodel.transformation.IpField.SOURCE;
+
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
@@ -14,18 +19,18 @@ public interface TransformationStep {
   <T> T accept(TransformationStepVisitor<T> visitor);
 
   static AssignIpAddressFromPool assignDestinationIp(Ip poolStart, Ip poolEnd) {
-    return new AssignIpAddressFromPool(IpField.DESTINATION, poolStart, poolEnd);
+    return new AssignIpAddressFromPool(DEST_NAT, DESTINATION, poolStart, poolEnd);
   }
 
   static AssignIpAddressFromPool assignSourceIp(Ip poolStart, Ip poolEnd) {
-    return new AssignIpAddressFromPool(IpField.SOURCE, poolStart, poolEnd);
+    return new AssignIpAddressFromPool(SOURCE_NAT, SOURCE, poolStart, poolEnd);
   }
 
   static ShiftIpAddressIntoSubnet shiftDestinationIp(Prefix subnet) {
-    return new ShiftIpAddressIntoSubnet(IpField.DESTINATION, subnet);
+    return new ShiftIpAddressIntoSubnet(DEST_NAT, DESTINATION, subnet);
   }
 
   static ShiftIpAddressIntoSubnet shiftSourceIp(Prefix subnet) {
-    return new ShiftIpAddressIntoSubnet(IpField.SOURCE, subnet);
+    return new ShiftIpAddressIntoSubnet(SOURCE_NAT, SOURCE, subnet);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/transformation/TransformationStepVisitor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/transformation/TransformationStepVisitor.java
@@ -8,5 +8,7 @@ public interface TransformationStepVisitor<T> {
 
   T visitAssignIpAddressFromPool(AssignIpAddressFromPool assignIpAddressFromPool);
 
+  T visitNoop(Noop noop);
+
   T visitShiftIpAddressIntoSubnet(ShiftIpAddressIntoSubnet shiftIpAddressIntoSubnet);
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/transformation/TransformationUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/transformation/TransformationUtil.java
@@ -2,6 +2,10 @@ package org.batfish.datamodel.transformation;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.TRUE;
+import static org.batfish.datamodel.flow.TransformationStep.TransformationType.DEST_NAT;
+import static org.batfish.datamodel.flow.TransformationStep.TransformationType.SOURCE_NAT;
+import static org.batfish.datamodel.transformation.IpField.DESTINATION;
+import static org.batfish.datamodel.transformation.IpField.SOURCE;
 import static org.batfish.datamodel.transformation.Noop.NOOP_DEST_NAT;
 import static org.batfish.datamodel.transformation.Noop.NOOP_SOURCE_NAT;
 import static org.batfish.datamodel.transformation.Noop.noop;
@@ -19,6 +23,7 @@ import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.SourceNat;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.datamodel.acl.PermittedByAcl;
+import org.batfish.datamodel.flow.TransformationStep.TransformationType;
 
 /** Utility methods related to {@link Transformation}. */
 @ParametersAreNonnullByDefault
@@ -37,7 +42,7 @@ public final class TransformationUtil {
           when(matchCondition(nat.getAcl()))
               .apply(
                   assignFromPoolOrNoop(
-                      IpField.DESTINATION, nat.getPoolIpFirst(), nat.getPoolIpLast()))
+                      DEST_NAT, DESTINATION, nat.getPoolIpFirst(), nat.getPoolIpLast()))
               .setOrElse(transformation)
               .build();
     }
@@ -55,7 +60,8 @@ public final class TransformationUtil {
       transformation =
           when(matchCondition(nat.getAcl()))
               .apply(
-                  assignFromPoolOrNoop(IpField.SOURCE, nat.getPoolIpFirst(), nat.getPoolIpLast()))
+                  assignFromPoolOrNoop(
+                      SOURCE_NAT, SOURCE, nat.getPoolIpFirst(), nat.getPoolIpLast()))
               .setOrElse(transformation)
               .build();
     }
@@ -63,10 +69,10 @@ public final class TransformationUtil {
   }
 
   private static List<TransformationStep> assignFromPoolOrNoop(
-      IpField ipField, @Nullable Ip poolFirst, @Nullable Ip poolLast) {
+      TransformationType type, IpField ipField, @Nullable Ip poolFirst, @Nullable Ip poolLast) {
     return poolFirst == null || poolLast == null
         ? ImmutableList.of(noop(ipField))
-        : ImmutableList.of(new AssignIpAddressFromPool(ipField, poolFirst, poolLast));
+        : ImmutableList.of(new AssignIpAddressFromPool(type, ipField, poolFirst, poolLast));
   }
 
   private static AclLineMatchExpr matchCondition(@Nullable IpAccessList acl) {

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/transformation/AssignIpAddressFromPoolTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/transformation/AssignIpAddressFromPoolTest.java
@@ -1,5 +1,7 @@
 package org.batfish.datamodel.transformation;
 
+import static org.batfish.datamodel.flow.TransformationStep.TransformationType.DEST_NAT;
+import static org.batfish.datamodel.flow.TransformationStep.TransformationType.SOURCE_NAT;
 import static org.batfish.datamodel.transformation.IpField.DESTINATION;
 import static org.batfish.datamodel.transformation.IpField.SOURCE;
 
@@ -15,11 +17,12 @@ public class AssignIpAddressFromPoolTest {
     Ip ip2 = Ip.parse("2.2.2.2");
     new EqualsTester()
         .addEqualityGroup(
-            new AssignIpAddressFromPool(DESTINATION, ip1, ip2),
-            new AssignIpAddressFromPool(DESTINATION, ip1, ip2))
-        .addEqualityGroup(new AssignIpAddressFromPool(SOURCE, ip1, ip2))
-        .addEqualityGroup(new AssignIpAddressFromPool(DESTINATION, ip2, ip2))
-        .addEqualityGroup(new AssignIpAddressFromPool(DESTINATION, ip1, ip1))
+            new AssignIpAddressFromPool(DEST_NAT, DESTINATION, ip1, ip2),
+            new AssignIpAddressFromPool(DEST_NAT, DESTINATION, ip1, ip2))
+        .addEqualityGroup(new AssignIpAddressFromPool(SOURCE_NAT, DESTINATION, ip1, ip2))
+        .addEqualityGroup(new AssignIpAddressFromPool(DEST_NAT, SOURCE, ip1, ip2))
+        .addEqualityGroup(new AssignIpAddressFromPool(DEST_NAT, DESTINATION, ip2, ip2))
+        .addEqualityGroup(new AssignIpAddressFromPool(DEST_NAT, DESTINATION, ip1, ip1))
         .testEquals();
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/transformation/NoopTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/transformation/NoopTest.java
@@ -1,0 +1,18 @@
+package org.batfish.datamodel.transformation;
+
+import static org.batfish.datamodel.flow.TransformationStep.TransformationType.DEST_NAT;
+import static org.batfish.datamodel.flow.TransformationStep.TransformationType.SOURCE_NAT;
+
+import com.google.common.testing.EqualsTester;
+import org.junit.Test;
+
+/** Tests for {@link Noop}. */
+public class NoopTest {
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(new Noop(SOURCE_NAT), new Noop(SOURCE_NAT))
+        .addEqualityGroup(new Noop(DEST_NAT))
+        .testEquals();
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/transformation/ShiftIpAddressIntoSubnetTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/transformation/ShiftIpAddressIntoSubnetTest.java
@@ -1,5 +1,7 @@
 package org.batfish.datamodel.transformation;
 
+import static org.batfish.datamodel.flow.TransformationStep.TransformationType.DEST_NAT;
+import static org.batfish.datamodel.flow.TransformationStep.TransformationType.SOURCE_NAT;
 import static org.batfish.datamodel.transformation.IpField.DESTINATION;
 import static org.batfish.datamodel.transformation.IpField.SOURCE;
 
@@ -20,22 +22,23 @@ public class ShiftIpAddressIntoSubnetTest {
     Prefix subnet2 = Prefix.parse("2.2.2.2/30");
     new EqualsTester()
         .addEqualityGroup(
-            new ShiftIpAddressIntoSubnet(DESTINATION, subnet1),
-            new ShiftIpAddressIntoSubnet(DESTINATION, subnet1))
-        .addEqualityGroup(new ShiftIpAddressIntoSubnet(SOURCE, subnet1))
-        .addEqualityGroup(new ShiftIpAddressIntoSubnet(DESTINATION, subnet2))
+            new ShiftIpAddressIntoSubnet(DEST_NAT, DESTINATION, subnet1),
+            new ShiftIpAddressIntoSubnet(DEST_NAT, DESTINATION, subnet1))
+        .addEqualityGroup(new ShiftIpAddressIntoSubnet(SOURCE_NAT, DESTINATION, subnet1))
+        .addEqualityGroup(new ShiftIpAddressIntoSubnet(DEST_NAT, SOURCE, subnet1))
+        .addEqualityGroup(new ShiftIpAddressIntoSubnet(DEST_NAT, DESTINATION, subnet2))
         .testEquals();
   }
 
   @Test
   public void testPrefixLength() {
     // /31 subnets and shorter are allowed
-    new ShiftIpAddressIntoSubnet(DESTINATION, Prefix.parse("1.1.1.1/0"));
-    new ShiftIpAddressIntoSubnet(DESTINATION, Prefix.parse("1.1.1.1/10"));
-    new ShiftIpAddressIntoSubnet(DESTINATION, Prefix.parse("1.1.1.1/31"));
+    new ShiftIpAddressIntoSubnet(DEST_NAT, DESTINATION, Prefix.parse("1.1.1.1/0"));
+    new ShiftIpAddressIntoSubnet(DEST_NAT, DESTINATION, Prefix.parse("1.1.1.1/10"));
+    new ShiftIpAddressIntoSubnet(DEST_NAT, DESTINATION, Prefix.parse("1.1.1.1/31"));
 
     // /32 subnets are not allowed
     _exception.expect(IllegalArgumentException.class);
-    new ShiftIpAddressIntoSubnet(DESTINATION, Prefix.parse("1.1.1.1/32"));
+    new ShiftIpAddressIntoSubnet(DEST_NAT, DESTINATION, Prefix.parse("1.1.1.1/32"));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/transformation/TransformationTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/transformation/TransformationTest.java
@@ -1,6 +1,7 @@
 package org.batfish.datamodel.transformation;
 
 import static org.batfish.datamodel.acl.AclLineMatchExprs.FALSE;
+import static org.batfish.datamodel.transformation.Noop.NOOP_SOURCE_NAT;
 import static org.batfish.datamodel.transformation.Transformation.always;
 import static org.batfish.datamodel.transformation.Transformation.when;
 import static org.batfish.datamodel.transformation.TransformationStep.shiftDestinationIp;
@@ -13,18 +14,13 @@ import org.junit.Test;
 public class TransformationTest {
   @Test
   public void testEquals() {
+    Transformation trivial = always().apply(NOOP_SOURCE_NAT).build();
     new EqualsTester()
-        .addEqualityGroup(always().build(), always().build())
-        .addEqualityGroup(when(FALSE).build(), when(FALSE).build())
-        .addEqualityGroup(
-            always().apply(shiftDestinationIp(Prefix.ZERO)).build(),
-            always().apply(shiftDestinationIp(Prefix.ZERO)).build())
-        .addEqualityGroup(
-            always().setAndThen(always().build()).build(),
-            always().setAndThen(always().build()).build())
-        .addEqualityGroup(
-            always().setOrElse(always().build()).build(),
-            always().setOrElse(always().build()).build())
+        .addEqualityGroup(trivial, always().apply(NOOP_SOURCE_NAT).build())
+        .addEqualityGroup(when(FALSE).apply(NOOP_SOURCE_NAT).build())
+        .addEqualityGroup(always().apply(shiftDestinationIp(Prefix.ZERO)).build())
+        .addEqualityGroup(always().apply(NOOP_SOURCE_NAT).setAndThen(trivial).build())
+        .addEqualityGroup(always().apply(NOOP_SOURCE_NAT).setOrElse(trivial).build())
         .testEquals();
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
@@ -57,6 +57,7 @@ import org.batfish.datamodel.UniverseIpSpace;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.datamodel.transformation.AssignIpAddressFromPool;
 import org.batfish.datamodel.transformation.IpField;
+import org.batfish.datamodel.transformation.Noop;
 import org.batfish.datamodel.transformation.ShiftIpAddressIntoSubnet;
 import org.batfish.datamodel.transformation.TransformationStepVisitor;
 import org.batfish.specifier.InterfaceLinkLocation;
@@ -1278,6 +1279,11 @@ public final class BDDReachabilityAnalysisFactory {
                 var.geq(assignIpAddressFromPool.getPoolStart().asLong())
                     .and(var.leq(assignIpAddressFromPool.getPoolEnd().asLong()));
             ranges.merge(ipField, bdd, BDD::or);
+            return null;
+          }
+
+          @Override
+          public Void visitNoop(Noop noop) {
             return null;
           }
 

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/transition/TransformationToTransition.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/transition/TransformationToTransition.java
@@ -1,5 +1,7 @@
 package org.batfish.bddreachability.transition;
 
+import static org.batfish.bddreachability.transition.Transitions.IDENTITY;
+
 import java.util.Arrays;
 import java.util.IdentityHashMap;
 import java.util.List;
@@ -14,6 +16,7 @@ import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.transformation.AssignIpAddressFromPool;
 import org.batfish.datamodel.transformation.IpField;
+import org.batfish.datamodel.transformation.Noop;
 import org.batfish.datamodel.transformation.ShiftIpAddressIntoSubnet;
 import org.batfish.datamodel.transformation.Transformation;
 import org.batfish.datamodel.transformation.TransformationStep;
@@ -65,6 +68,11 @@ public class TransformationToTransition {
     @Override
     public Transition visitAssignIpAddressFromPool(AssignIpAddressFromPool step) {
       return assignIpFromPool(ipField(step.getIpField()), step.getPoolStart(), step.getPoolEnd());
+    }
+
+    @Override
+    public Transition visitNoop(Noop noop) {
+      return IDENTITY;
     }
 
     @Override

--- a/projects/batfish/src/main/java/org/batfish/datamodel/transformation/TransformationEvaluator.java
+++ b/projects/batfish/src/main/java/org/batfish/datamodel/transformation/TransformationEvaluator.java
@@ -4,6 +4,7 @@ import static org.batfish.datamodel.FlowDiff.flowDiff;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedSet;
 import java.util.EnumMap;
 import java.util.List;
@@ -22,27 +23,33 @@ import org.batfish.datamodel.flow.TransformationStep.TransformationType;
 
 /** Evaluates a {@link Transformation} on an input {@link Flow}. */
 public class TransformationEvaluator {
-  private final Flow.Builder _flow;
+  private final Flow.Builder _flowBuilder;
   private final String _srcInterface;
   private final Map<String, IpAccessList> _namedAcls;
   private final Map<String, IpSpace> _namedIpSpaces;
-  private final StepEvaluator _stepEvaluator;
+  private final ImmutableList.Builder<Step<?>> _traceSteps;
 
   // the ACL evaluator has to be re-initialized every time we transform the flow
   private Evaluator _aclEvaluator;
+  private Flow _currentFlow;
 
+  /**
+   * StepEvaluator returns true iff the step transforms the packet. It's possible that the step
+   * matches but doesn't transform the packet (e.g. Noop). This means transformation trace steps are
+   * generated even when the packet isn't transformed.
+   */
   @VisibleForTesting
-  class StepEvaluator implements TransformationStepVisitor<Void> {
+  class StepEvaluator implements TransformationStepVisitor<Boolean> {
     private final Map<TransformationType, ImmutableSortedSet.Builder<FlowDiff>> _flowDiffs =
         new EnumMap<>(TransformationType.class);
 
     private void set(IpField field, Ip ip) {
       switch (field) {
         case DESTINATION:
-          _flow.setDstIp(ip);
+          _flowBuilder.setDstIp(ip);
           break;
         case SOURCE:
-          _flow.setSrcIp(ip);
+          _flowBuilder.setSrcIp(ip);
           break;
         default:
           throw new IllegalArgumentException("unknown IpField " + field);
@@ -52,9 +59,9 @@ public class TransformationEvaluator {
     private Ip get(IpField field) {
       switch (field) {
         case DESTINATION:
-          return _flow.getDstIp();
+          return _flowBuilder.getDstIp();
         case SOURCE:
-          return _flow.getSrcIp();
+          return _flowBuilder.getSrcIp();
         default:
           throw new IllegalArgumentException("unknown IpField " + field);
       }
@@ -80,40 +87,40 @@ public class TransformationEvaluator {
           .collect(ImmutableList.toImmutableList());
     }
 
-    @Override
-    public Void visitAssignIpAddressFromPool(AssignIpAddressFromPool step) {
-      IpField ipField = step.getIpField();
-      Ip oldValue = get(ipField);
-      Ip newValue = step.getPoolStart();
-      set(ipField, newValue);
+    private Boolean set(TransformationType type, IpField ipField, Ip oldValue, Ip newValue) {
       if (oldValue.equals(newValue)) {
-        getFlowDiffs(step.getType());
+        getFlowDiffs(type);
+        return false;
       } else {
-        getFlowDiffs(step.getType()).add(flowDiff(ipField, oldValue, newValue));
+        set(ipField, newValue);
+        getFlowDiffs(type).add(flowDiff(ipField, oldValue, newValue));
+        return true;
       }
-      return null;
     }
 
     @Override
-    public Void visitNoop(Noop noop) {
+    public Boolean visitAssignIpAddressFromPool(AssignIpAddressFromPool step) {
+      return set(step.getType(), step.getIpField(), get(step.getIpField()), step.getPoolStart());
+    }
+
+    @Override
+    public Boolean visitNoop(Noop noop) {
       /* getFlowDiffs makes sure the type is in the key set, which signals that we went through
        * the transformation
        */
       getFlowDiffs(noop.getType());
-      return null;
+      return false;
     }
 
     @Override
-    public Void visitShiftIpAddressIntoSubnet(ShiftIpAddressIntoSubnet step) {
+    public Boolean visitShiftIpAddressIntoSubnet(ShiftIpAddressIntoSubnet step) {
       IpField field = step.getIpField();
       Ip oldValue = get(field);
       Prefix targetSubnet = step.getSubnet();
       Prefix currentSubnetPrefix = Prefix.create(oldValue, targetSubnet.getPrefixLength());
       long offset = oldValue.asLong() - currentSubnetPrefix.getStartIp().asLong();
       Ip newValue = Ip.create(targetSubnet.getStartIp().asLong() + offset);
-      set(field, newValue);
-      getFlowDiffs(step.getType()).add(flowDiff(field, oldValue, newValue));
-      return null;
+      return set(step.getType(), field, oldValue, newValue);
     }
   }
 
@@ -122,12 +129,13 @@ public class TransformationEvaluator {
       String srcInterface,
       Map<String, IpAccessList> namedAcls,
       Map<String, IpSpace> namedIpSpaces) {
-    _flow = flow.toBuilder();
+    _currentFlow = flow;
+    _flowBuilder = flow.toBuilder();
     _srcInterface = srcInterface;
-    _namedAcls = namedAcls;
-    _namedIpSpaces = namedIpSpaces;
-    _stepEvaluator = new StepEvaluator();
-    initAclEvaluator();
+    _namedAcls = ImmutableMap.copyOf(namedAcls);
+    _namedIpSpaces = ImmutableMap.copyOf(namedIpSpaces);
+    _traceSteps = ImmutableList.builder();
+    initializeAclEvaluator();
   }
 
   /** The result of evaluating a {@link Transformation}. */
@@ -158,20 +166,32 @@ public class TransformationEvaluator {
     TransformationEvaluator evaluator =
         new TransformationEvaluator(flow, srcInterface, namedAcls, namedIpSpaces);
     evaluator.eval(transformation);
-    return new TransformationResult(
-        evaluator._flow.build(), evaluator._stepEvaluator.getTraceSteps());
+    return new TransformationResult(evaluator._currentFlow, evaluator._traceSteps.build());
   }
 
-  private void initAclEvaluator() {
-    _aclEvaluator = new Evaluator(_flow.build(), _srcInterface, _namedAcls, _namedIpSpaces);
+  private void initializeAclEvaluator() {
+    _aclEvaluator = new Evaluator(_currentFlow, _srcInterface, _namedAcls, _namedIpSpaces);
   }
 
   private void eval(Transformation transformation) {
     Transformation node = transformation;
     while (node != null) {
       if (_aclEvaluator.visit(node.getGuard())) {
-        node.getTransformationSteps().forEach(_stepEvaluator::visit);
-        initAclEvaluator();
+        StepEvaluator stepEvaluator = new StepEvaluator();
+        boolean transformed =
+            node.getTransformationSteps()
+                .stream()
+                .map(stepEvaluator::visit)
+                .reduce(Boolean::logicalOr)
+                .orElse(false);
+        // noop transformation steps can generate tracesteps without transforming the flow
+        _traceSteps.addAll(stepEvaluator.getTraceSteps());
+
+        if (transformed) {
+          _currentFlow = _flowBuilder.build();
+          initializeAclEvaluator();
+        }
+
         node = node.getAndThen();
       } else {
         node = node.getOrElse();

--- a/projects/batfish/src/main/java/org/batfish/datamodel/transformation/TransformationEvaluator.java
+++ b/projects/batfish/src/main/java/org/batfish/datamodel/transformation/TransformationEvaluator.java
@@ -1,13 +1,24 @@
 package org.batfish.datamodel.transformation;
 
+import static org.batfish.datamodel.FlowDiff.flowDiff;
+
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSortedSet;
+import java.util.EnumMap;
+import java.util.List;
 import java.util.Map;
 import org.batfish.datamodel.Flow;
+import org.batfish.datamodel.FlowDiff;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.acl.Evaluator;
+import org.batfish.datamodel.flow.Step;
+import org.batfish.datamodel.flow.StepAction;
+import org.batfish.datamodel.flow.TransformationStep.TransformationStepDetail;
+import org.batfish.datamodel.flow.TransformationStep.TransformationType;
 
 /** Evaluates a {@link Transformation} on an input {@link Flow}. */
 public class TransformationEvaluator {
@@ -22,6 +33,9 @@ public class TransformationEvaluator {
 
   @VisibleForTesting
   class StepEvaluator implements TransformationStepVisitor<Void> {
+    private final Map<TransformationType, ImmutableSortedSet.Builder<FlowDiff>> _flowDiffs =
+        new EnumMap<>(TransformationType.class);
+
     private void set(IpField field, Ip ip) {
       switch (field) {
         case DESTINATION:
@@ -46,20 +60,59 @@ public class TransformationEvaluator {
       }
     }
 
+    private ImmutableSortedSet.Builder<FlowDiff> getFlowDiffs(TransformationType type) {
+      return _flowDiffs.computeIfAbsent(type, k -> ImmutableSortedSet.naturalOrder());
+    }
+
+    private List<Step<?>> getTraceSteps() {
+      return _flowDiffs
+          .entrySet()
+          .stream()
+          .map(
+              entry -> {
+                ImmutableSortedSet<FlowDiff> flowDiffs = entry.getValue().build();
+                TransformationStepDetail detail =
+                    new TransformationStepDetail(entry.getKey(), flowDiffs);
+                StepAction action =
+                    flowDiffs.isEmpty() ? StepAction.PERMITTED : StepAction.TRANSFORMED;
+                return new org.batfish.datamodel.flow.TransformationStep(detail, action);
+              })
+          .collect(ImmutableList.toImmutableList());
+    }
+
     @Override
-    public Void visitAssignIpAddressFromPool(AssignIpAddressFromPool assignIpAddressFromPool) {
-      set(assignIpAddressFromPool.getIpField(), assignIpAddressFromPool.getPoolStart());
+    public Void visitAssignIpAddressFromPool(AssignIpAddressFromPool step) {
+      IpField ipField = step.getIpField();
+      Ip oldValue = get(ipField);
+      Ip newValue = step.getPoolStart();
+      set(ipField, newValue);
+      if (oldValue.equals(newValue)) {
+        getFlowDiffs(step.getType());
+      } else {
+        getFlowDiffs(step.getType()).add(flowDiff(ipField, oldValue, newValue));
+      }
       return null;
     }
 
     @Override
-    public Void visitShiftIpAddressIntoSubnet(ShiftIpAddressIntoSubnet shiftIpAddressIntoSubnet) {
-      IpField field = shiftIpAddressIntoSubnet.getIpField();
-      Ip ip = get(field);
-      Prefix targetSubnet = shiftIpAddressIntoSubnet.getSubnet();
-      Prefix currentSubnetPrefix = Prefix.create(ip, targetSubnet.getPrefixLength());
-      long offset = ip.asLong() - currentSubnetPrefix.getStartIp().asLong();
-      set(field, Ip.create(targetSubnet.getStartIp().asLong() + offset));
+    public Void visitNoop(Noop noop) {
+      /* getFlowDiffs makes sure the type is in the key set, which signals that we went through
+       * the transformation
+       */
+      getFlowDiffs(noop.getType());
+      return null;
+    }
+
+    @Override
+    public Void visitShiftIpAddressIntoSubnet(ShiftIpAddressIntoSubnet step) {
+      IpField field = step.getIpField();
+      Ip oldValue = get(field);
+      Prefix targetSubnet = step.getSubnet();
+      Prefix currentSubnetPrefix = Prefix.create(oldValue, targetSubnet.getPrefixLength());
+      long offset = oldValue.asLong() - currentSubnetPrefix.getStartIp().asLong();
+      Ip newValue = Ip.create(targetSubnet.getStartIp().asLong() + offset);
+      set(field, newValue);
+      getFlowDiffs(step.getType()).add(flowDiff(field, oldValue, newValue));
       return null;
     }
   }
@@ -77,7 +130,26 @@ public class TransformationEvaluator {
     initAclEvaluator();
   }
 
-  public static Flow eval(
+  /** The result of evaluating a {@link Transformation}. */
+  public static final class TransformationResult {
+    private final Flow _outputFlow;
+    private final List<Step<?>> _traceSteps;
+
+    TransformationResult(Flow outputFlow, List<Step<?>> traceSteps) {
+      _outputFlow = outputFlow;
+      _traceSteps = ImmutableList.copyOf(traceSteps);
+    }
+
+    public Flow getOutputFlow() {
+      return _outputFlow;
+    }
+
+    public List<Step<?>> getTraceSteps() {
+      return _traceSteps;
+    }
+  }
+
+  public static TransformationResult eval(
       Transformation transformation,
       Flow flow,
       String srcInterface,
@@ -86,7 +158,8 @@ public class TransformationEvaluator {
     TransformationEvaluator evaluator =
         new TransformationEvaluator(flow, srcInterface, namedAcls, namedIpSpaces);
     evaluator.eval(transformation);
-    return evaluator._flow.build();
+    return new TransformationResult(
+        evaluator._flow.build(), evaluator._stepEvaluator.getTraceSteps());
   }
 
   private void initAclEvaluator() {

--- a/projects/batfish/src/main/java/org/batfish/dataplane/TracerouteEngineImplContext.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/TracerouteEngineImplContext.java
@@ -48,6 +48,7 @@ import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.Route;
 import org.batfish.datamodel.SourceNat;
 import org.batfish.datamodel.collections.NodeInterfacePair;
+import org.batfish.datamodel.transformation.TransformationEvaluator;
 
 @ParametersAreNonnullByDefault
 class TracerouteEngineImplContext {
@@ -366,12 +367,13 @@ class TracerouteEngineImplContext {
 
                 // Apply any relevant source NAT rules.
                 Flow newTransformedFlow =
-                    applySourceNat(
-                        transformedFlow,
-                        srcInterfaceName,
-                        aclDefinitions,
-                        namedIpSpaces,
-                        outgoingInterface.getSourceNats());
+                    TransformationEvaluator.eval(
+                            outgoingInterface.getOutgoingTransformation(),
+                            transformedFlow,
+                            srcInterfaceName,
+                            aclDefinitions,
+                            namedIpSpaces)
+                        .getOutputFlow();
 
                 SortedSet<Edge> edges =
                     _dataPlane.getTopology().getInterfaceEdges().get(nextHopInterface);
@@ -494,8 +496,8 @@ class TracerouteEngineImplContext {
   }
 
   @Nullable
-  private static Flow hopFlow(@Nullable Flow originalFlow, @Nullable Flow transformedFlow) {
-    if (originalFlow == transformedFlow) {
+  private static Flow hopFlow(Flow originalFlow, @Nullable Flow transformedFlow) {
+    if (originalFlow.equals(transformedFlow)) {
       return null;
     } else {
       return transformedFlow;

--- a/projects/batfish/src/main/java/org/batfish/dataplane/TracerouteEngineImplContext.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/TracerouteEngineImplContext.java
@@ -497,7 +497,7 @@ class TracerouteEngineImplContext {
 
   @Nullable
   private static Flow hopFlow(Flow originalFlow, @Nullable Flow transformedFlow) {
-    if (originalFlow.equals(transformedFlow)) {
+    if (originalFlow == transformedFlow) {
       return null;
     } else {
       return transformedFlow;

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteEngineImplContext.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteEngineImplContext.java
@@ -7,7 +7,6 @@ import static org.batfish.dataplane.traceroute.TracerouteUtils.applyFilter;
 import static org.batfish.dataplane.traceroute.TracerouteUtils.createEnterSrcIfaceStep;
 import static org.batfish.dataplane.traceroute.TracerouteUtils.getFinalActionForDisposition;
 import static org.batfish.dataplane.traceroute.TracerouteUtils.isArpSuccessful;
-import static org.batfish.dataplane.traceroute.TracerouteUtils.transformationStep;
 import static org.batfish.dataplane.traceroute.TracerouteUtils.validateInputs;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -65,8 +64,10 @@ import org.batfish.datamodel.flow.RoutingStep.RoutingStepDetail;
 import org.batfish.datamodel.flow.Step;
 import org.batfish.datamodel.flow.StepAction;
 import org.batfish.datamodel.flow.Trace;
-import org.batfish.datamodel.flow.TransformationStep.TransformationType;
 import org.batfish.datamodel.pojo.Node;
+import org.batfish.datamodel.transformation.Transformation;
+import org.batfish.datamodel.transformation.TransformationEvaluator;
+import org.batfish.datamodel.transformation.TransformationEvaluator.TransformationResult;
 
 /**
  * Class containing an implementation of {@link
@@ -430,14 +431,18 @@ public class TracerouteEngineImplContext {
         }
       }
 
-      List<DestinationNat> destinationNats =
-          currentConfiguration.getAllInterfaces().get(inputIfaceName).getDestinationNats();
-      if (destinationNats != null && !destinationNats.isEmpty()) {
-        dstNatFlow =
-            applyDestinationNat(
-                inputFlow, inputIfaceName, aclDefinitions, namedIpSpaces, destinationNats);
-        steps.add(transformationStep(TransformationType.DEST_NAT, inputFlow, dstNatFlow));
-      }
+      TransformationResult transformationResult =
+          TransformationEvaluator.eval(
+              currentConfiguration
+                  .getAllInterfaces()
+                  .get(inputIfaceName)
+                  .getIncomingTransformation(),
+              inputFlow,
+              inputIfaceName,
+              aclDefinitions,
+              namedIpSpaces);
+      dstNatFlow = transformationResult.getOutputFlow();
+      steps.addAll(transformationResult.getTraceSteps());
     } else if (inputFlow.getIngressVrf() != null) {
       // if inputIfaceName is not set for this hop, this is the originating step
       steps.add(
@@ -631,17 +636,17 @@ public class TracerouteEngineImplContext {
                     }
                   }
 
-                  // Apply any relevant source NAT rules.
-                  List<SourceNat> sourceNats = outgoingInterface.getSourceNats();
-                  Flow newTransformedFlow = currentFlow;
-                  if (sourceNats != null && !sourceNats.isEmpty()) {
-                    newTransformedFlow =
-                        applySourceNat(
-                            currentFlow, inputIfaceName, aclDefinitions, namedIpSpaces, sourceNats);
-                    clonedStepsBuilder.add(
-                        transformationStep(
-                            TransformationType.SOURCE_NAT, currentFlow, newTransformedFlow));
-                  }
+                  // Apply outgoing transformation
+                  Transformation transformation = outgoingInterface.getOutgoingTransformation();
+                  TransformationResult transformationResult =
+                      TransformationEvaluator.eval(
+                          transformation,
+                          currentFlow,
+                          inputIfaceName,
+                          aclDefinitions,
+                          namedIpSpaces);
+                  Flow newTransformedFlow = transformationResult.getOutputFlow();
+                  clonedStepsBuilder.addAll(transformationResult.getTraceSteps());
 
                   SortedSet<Edge> edges =
                       _dataPlane.getTopology().getInterfaceEdges().get(nextHopInterface);
@@ -711,8 +716,8 @@ public class TracerouteEngineImplContext {
   }
 
   @Nullable
-  private static Flow hopFlow(@Nullable Flow originalFlow, @Nullable Flow transformedFlow) {
-    if (originalFlow == transformedFlow) {
+  private static Flow hopFlow(Flow originalFlow, @Nullable Flow transformedFlow) {
+    if (originalFlow.equals(transformedFlow)) {
       return null;
     } else {
       return transformedFlow;

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteEngineImplContext.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteEngineImplContext.java
@@ -717,7 +717,7 @@ public class TracerouteEngineImplContext {
 
   @Nullable
   private static Flow hopFlow(Flow originalFlow, @Nullable Flow transformedFlow) {
-    if (originalFlow.equals(transformedFlow)) {
+    if (originalFlow == transformedFlow) {
       return null;
     } else {
       return transformedFlow;

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/NatRule.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/NatRule.java
@@ -13,6 +13,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
+import org.batfish.datamodel.flow.TransformationStep.TransformationType;
 import org.batfish.datamodel.transformation.AssignIpAddressFromPool;
 import org.batfish.datamodel.transformation.IpField;
 import org.batfish.datamodel.transformation.Transformation;
@@ -56,7 +57,7 @@ public final class NatRule implements Serializable {
 
   /** Convert to vendor-independent {@link Transformation}. */
   public Optional<Transformation.Builder> toTransformationBuilder(
-      IpField field, Map<String, NatPool> pools) {
+      TransformationType type, IpField field, Map<String, NatPool> pools) {
     Transformation.Builder builder = when(new MatchHeaderSpace(toHeaderSpace(_matches)));
 
     if (_then instanceof NatRuleThenPool) {
@@ -65,7 +66,8 @@ public final class NatRule implements Serializable {
         // pool is undefined.
         return Optional.empty();
       }
-      builder.apply(new AssignIpAddressFromPool(field, pool.getFromAddress(), pool.getToAddress()));
+      builder.apply(
+          new AssignIpAddressFromPool(type, field, pool.getFromAddress(), pool.getToAddress()));
     } else if (_then instanceof NatRuleThenOff) {
       // don't transform
       builder.apply(noop(field));

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/NatRule.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/NatRule.java
@@ -1,5 +1,6 @@
 package org.batfish.representation.juniper;
 
+import static org.batfish.datamodel.transformation.Noop.noop;
 import static org.batfish.datamodel.transformation.Transformation.when;
 import static org.batfish.representation.juniper.NatRuleMatchToHeaderSpace.toHeaderSpace;
 
@@ -67,7 +68,7 @@ public final class NatRule implements Serializable {
       builder.apply(new AssignIpAddressFromPool(field, pool.getFromAddress(), pool.getToAddress()));
     } else if (_then instanceof NatRuleThenOff) {
       // don't transform
-      builder.apply();
+      builder.apply(noop(field));
     } else {
       throw new IllegalArgumentException("Unrecognized NatRuleThen type");
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/NatRuleSet.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/NatRuleSet.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.flow.TransformationStep.TransformationType;
 import org.batfish.datamodel.transformation.IpField;
 import org.batfish.datamodel.transformation.Transformation;
 import org.batfish.datamodel.transformation.Transformation.Builder;
@@ -77,14 +78,17 @@ public final class NatRuleSet implements Serializable, Comparable<NatRuleSet> {
   /**
    * Convert to a vendor-independent {@link Transformation}.
    *
+   * @param type
    * @param andThen The next {@link Transformation} to apply after any {@link NatRule} matches and
-   *     is applied.
    */
   public Optional<Transformation> toTransformation(
-      IpField ipField, Map<String, NatPool> pools, @Nullable Transformation andThen) {
+      TransformationType type,
+      IpField ipField,
+      Map<String, NatPool> pools,
+      @Nullable Transformation andThen) {
     Transformation transformation = null;
     for (NatRule rule : Lists.reverse(_rules)) {
-      Optional<Builder> optionalBuilder = rule.toTransformationBuilder(ipField, pools);
+      Optional<Builder> optionalBuilder = rule.toTransformationBuilder(type, ipField, pools);
       if (optionalBuilder.isPresent()) {
         transformation =
             optionalBuilder.get().setAndThen(andThen).setOrElse(transformation).build();

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/NatRuleSet.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/NatRuleSet.java
@@ -78,8 +78,7 @@ public final class NatRuleSet implements Serializable, Comparable<NatRuleSet> {
   /**
    * Convert to a vendor-independent {@link Transformation}.
    *
-   * @param type
-   * @param andThen The next {@link Transformation} to apply after any {@link NatRule} matches and
+   * @param andThen The next {@link Transformation} to apply after any {@link NatRule} matches.
    */
   public Optional<Transformation> toTransformation(
       TransformationType type,

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/TransformationTransitionGenerator.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/TransformationTransitionGenerator.java
@@ -15,6 +15,7 @@ import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.transformation.AssignIpAddressFromPool;
 import org.batfish.datamodel.transformation.IpField;
+import org.batfish.datamodel.transformation.Noop;
 import org.batfish.datamodel.transformation.ShiftIpAddressIntoSubnet;
 import org.batfish.datamodel.transformation.Transformation;
 import org.batfish.datamodel.transformation.TransformationStep;
@@ -81,6 +82,11 @@ public final class TransformationTransitionGenerator {
               assignIpAddressFromPool.getPoolEnd()),
           _preState,
           _postState);
+    }
+
+    @Override
+    public BasicRuleStatement visitNoop(Noop noop) {
+      return new BasicRuleStatement(_preState, _postState);
     }
 
     @Override

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/transition/TransformationToTransitionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/transition/TransformationToTransitionTest.java
@@ -2,6 +2,7 @@ package org.batfish.bddreachability.transition;
 
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDst;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrc;
+import static org.batfish.datamodel.transformation.Noop.NOOP_SOURCE_NAT;
 import static org.batfish.datamodel.transformation.Transformation.always;
 import static org.batfish.datamodel.transformation.Transformation.when;
 import static org.batfish.datamodel.transformation.TransformationStep.assignDestinationIp;
@@ -250,13 +251,14 @@ public class TransformationToTransitionTest {
   }
 
   @Test
-  public void testMultipleTrasnformations() {
+  public void testMultipleTransformations() {
     Ip matchDstIp = Ip.parse("1.1.1.1");
     Ip matchSrcIp = Ip.parse("2.2.2.2");
     Ip truePoolIp = Ip.parse("3.3.3.3");
     Ip falsePoolIp = Ip.parse("4.4.4.4");
     Transformation transformation =
         when(matchDst(matchDstIp))
+            .apply(NOOP_SOURCE_NAT)
             .setAndThen(
                 when(matchSrc(matchSrcIp)).apply(assignSourceIp(truePoolIp, truePoolIp)).build())
             .setOrElse(

--- a/projects/batfish/src/test/java/org/batfish/datamodel/transformation/TransformationEvaluatorTest.java
+++ b/projects/batfish/src/test/java/org/batfish/datamodel/transformation/TransformationEvaluatorTest.java
@@ -2,6 +2,7 @@ package org.batfish.datamodel.transformation;
 
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDst;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrc;
+import static org.batfish.datamodel.flow.TransformationStep.TransformationType.SOURCE_NAT;
 import static org.batfish.datamodel.transformation.Transformation.always;
 import static org.batfish.datamodel.transformation.Transformation.when;
 import static org.batfish.datamodel.transformation.TransformationStep.assignDestinationIp;
@@ -29,7 +30,8 @@ public class TransformationEvaluatorTest {
 
   private static Flow eval(Transformation transformation, Flow flow) {
     return TransformationEvaluator.eval(
-        transformation, flow, "iface", ImmutableMap.of(), ImmutableMap.of());
+            transformation, flow, "iface", ImmutableMap.of(), ImmutableMap.of())
+        .getOutputFlow();
   }
 
   @Test
@@ -74,8 +76,8 @@ public class TransformationEvaluatorTest {
   }
 
   @Test
-  public void testNoSteps() {
-    Transformation transformation = always().apply().build();
+  public void testNoop() {
+    Transformation transformation = always().apply(new Noop(SOURCE_NAT)).build();
     Flow origFlow =
         _flowBuilder.setSrcIp(Ip.parse("1.1.1.1")).setDstIp(Ip.parse("2.2.2.2")).build();
     Flow transformedFlow = eval(transformation, origFlow);

--- a/projects/batfish/src/test/java/org/batfish/datamodel/transformation/TransformationEvaluatorTest.java
+++ b/projects/batfish/src/test/java/org/batfish/datamodel/transformation/TransformationEvaluatorTest.java
@@ -1,8 +1,13 @@
 package org.batfish.datamodel.transformation;
 
+import static org.batfish.datamodel.FlowDiff.flowDiff;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDst;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrc;
+import static org.batfish.datamodel.flow.StepAction.TRANSFORMED;
+import static org.batfish.datamodel.flow.TransformationStep.TransformationType.DEST_NAT;
 import static org.batfish.datamodel.flow.TransformationStep.TransformationType.SOURCE_NAT;
+import static org.batfish.datamodel.transformation.IpField.DESTINATION;
+import static org.batfish.datamodel.transformation.IpField.SOURCE;
 import static org.batfish.datamodel.transformation.Transformation.always;
 import static org.batfish.datamodel.transformation.Transformation.when;
 import static org.batfish.datamodel.transformation.TransformationStep.assignDestinationIp;
@@ -10,11 +15,18 @@ import static org.batfish.datamodel.transformation.TransformationStep.assignSour
 import static org.batfish.datamodel.transformation.TransformationStep.shiftDestinationIp;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedSet;
+import java.util.List;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.flow.Step;
+import org.batfish.datamodel.flow.StepAction;
+import org.batfish.datamodel.flow.TransformationStep.TransformationStepDetail;
+import org.batfish.datamodel.transformation.TransformationEvaluator.TransformationResult;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -29,9 +41,12 @@ public class TransformationEvaluatorTest {
   }
 
   private static Flow eval(Transformation transformation, Flow flow) {
+    return evalResult(transformation, flow).getOutputFlow();
+  }
+
+  private static TransformationResult evalResult(Transformation transformation, Flow flow) {
     return TransformationEvaluator.eval(
-            transformation, flow, "iface", ImmutableMap.of(), ImmutableMap.of())
-        .getOutputFlow();
+        transformation, flow, "iface", ImmutableMap.of(), ImmutableMap.of());
   }
 
   @Test
@@ -45,34 +60,60 @@ public class TransformationEvaluatorTest {
     _flowBuilder.setSrcIp(srcIp).setDstIp(origDstIp);
 
     Flow origFlow = _flowBuilder.build();
-    Flow transformedFlow = eval(transformation, origFlow);
-    assertThat(transformedFlow, equalTo(origFlow.toBuilder().setDstIp(poolIp).build()));
+    TransformationResult result = evalResult(transformation, origFlow);
+    assertThat(result.getOutputFlow(), equalTo(origFlow.toBuilder().setDstIp(poolIp).build()));
+
+    List<Step<?>> traceSteps = result.getTraceSteps();
+    assertThat(traceSteps, hasSize(1));
+    assertThat(
+        traceSteps.get(0),
+        equalTo(
+            new org.batfish.datamodel.flow.TransformationStep(
+                new TransformationStepDetail(
+                    DEST_NAT,
+                    ImmutableSortedSet.of(flowDiff(IpField.DESTINATION, origDstIp, poolIp))),
+                TRANSFORMED)));
 
     // test no match
     origFlow = _flowBuilder.setSrcIp(Ip.parse("1.1.1.2")).build();
-    transformedFlow = eval(transformation, origFlow);
-    assertThat(transformedFlow, equalTo(origFlow));
+    result = evalResult(transformation, origFlow);
+    assertThat(result.getOutputFlow(), equalTo(origFlow));
+    traceSteps = result.getTraceSteps();
+    assertThat(traceSteps, hasSize(0));
   }
 
   @Test
   public void testShiftIpAddressIntoSubnet() {
-    Ip dstIp = Ip.parse("1.2.3.4");
+    Ip origDstIp = Ip.parse("1.2.3.4");
     Prefix prefix = Prefix.parse("15.16.0.0/16");
 
     Transformation transformation = always().apply(shiftDestinationIp(prefix)).build();
-    Flow origFlow = _flowBuilder.setDstIp(dstIp).build();
-    Flow transformedFlow = eval(transformation, origFlow);
+    Flow origFlow = _flowBuilder.setDstIp(origDstIp).build();
+    TransformationResult result = evalResult(transformation, origFlow);
+    Ip transformedDstIp = Ip.parse("15.16.3.4");
     assertThat(
-        transformedFlow, equalTo(origFlow.toBuilder().setDstIp(Ip.parse("15.16.3.4")).build()));
+        result.getOutputFlow(), equalTo(origFlow.toBuilder().setDstIp(transformedDstIp).build()));
+    List<Step<?>> steps = result.getTraceSteps();
+    assertThat(steps, hasSize(1));
+    assertThat(
+        steps.get(0),
+        equalTo(
+            new org.batfish.datamodel.flow.TransformationStep(
+                new TransformationStepDetail(
+                    DEST_NAT,
+                    ImmutableSortedSet.of(
+                        flowDiff(IpField.DESTINATION, origDstIp, transformedDstIp))),
+                TRANSFORMED)));
 
     // less trivial example
-    dstIp = Ip.parse("1.2.3.4");
+    origDstIp = Ip.parse("1.2.3.4");
     prefix = Prefix.parse("1.2.3.32/27");
     transformation = always().apply(shiftDestinationIp(prefix)).build();
-    origFlow = _flowBuilder.setDstIp(dstIp).build();
-    transformedFlow = eval(transformation, origFlow);
+    origFlow = _flowBuilder.setDstIp(origDstIp).build();
+    result = evalResult(transformation, origFlow);
     assertThat(
-        transformedFlow, equalTo(origFlow.toBuilder().setDstIp(Ip.parse("1.2.3.36")).build()));
+        result.getOutputFlow(),
+        equalTo(origFlow.toBuilder().setDstIp(Ip.parse("1.2.3.36")).build()));
   }
 
   @Test
@@ -80,8 +121,20 @@ public class TransformationEvaluatorTest {
     Transformation transformation = always().apply(new Noop(SOURCE_NAT)).build();
     Flow origFlow =
         _flowBuilder.setSrcIp(Ip.parse("1.1.1.1")).setDstIp(Ip.parse("2.2.2.2")).build();
-    Flow transformedFlow = eval(transformation, origFlow);
-    assertThat(transformedFlow, equalTo(origFlow));
+    TransformationResult result = evalResult(transformation, origFlow);
+    assertThat(
+        "Noop transformations should return the original (==) flow",
+        result.getOutputFlow() == origFlow);
+
+    List<Step<?>> steps = result.getTraceSteps();
+
+    assertThat(steps, hasSize(1));
+    assertThat(
+        steps.get(0),
+        equalTo(
+            new org.batfish.datamodel.flow.TransformationStep(
+                new TransformationStepDetail(SOURCE_NAT, ImmutableSortedSet.of()),
+                StepAction.PERMITTED)));
   }
 
   @Test
@@ -111,12 +164,12 @@ public class TransformationEvaluatorTest {
   @Test
   public void testBranching() {
     // then branch sets destIp = 1.1.1.1
-    Ip thenIp = Ip.parse("1.1.1.1");
-    Transformation andThen = always().apply(assignDestinationIp(thenIp, thenIp)).build();
+    Ip thenDstIp = Ip.parse("1.1.1.1");
+    Transformation andThen = always().apply(assignDestinationIp(thenDstIp, thenDstIp)).build();
 
     // else branch sets destIp = 2.2.2.2
-    Ip elseIp = Ip.parse("2.2.2.2");
-    Transformation orElse = always().apply(assignDestinationIp(elseIp, elseIp)).build();
+    Ip elseDstIp = Ip.parse("2.2.2.2");
+    Transformation orElse = always().apply(assignDestinationIp(elseDstIp, elseDstIp)).build();
 
     // branch on if destIp is in 5.0.0.0/8
     Prefix matchPrefix = Prefix.parse("5.0.0.0/8");
@@ -128,16 +181,82 @@ public class TransformationEvaluatorTest {
             .setOrElse(orElse)
             .build();
 
+    Ip origDstIp = Ip.parse("5.5.5.5");
     Ip origSrcIp = Ip.parse("8.8.8.8");
-    _flowBuilder.setSrcIp(origSrcIp);
+    Flow origFlow = _flowBuilder.setDstIp(origDstIp).setSrcIp(origSrcIp).build();
 
-    Flow origFlow = _flowBuilder.setSrcIp(origSrcIp).setDstIp(Ip.parse("5.5.5.5")).build();
-    Flow transformedFlow = eval(transformation, origFlow);
+    TransformationResult result = evalResult(transformation, origFlow);
     assertThat(
-        transformedFlow, equalTo(_flowBuilder.setSrcIp(transformedSrcIp).setDstIp(thenIp).build()));
+        result.getOutputFlow(),
+        equalTo(_flowBuilder.setSrcIp(transformedSrcIp).setDstIp(thenDstIp).build()));
 
-    origFlow = _flowBuilder.setDstIp(Ip.parse("6.6.6.6")).build();
-    transformedFlow = eval(transformation, origFlow);
-    assertThat(transformedFlow, equalTo(_flowBuilder.setDstIp(elseIp).build()));
+    List<Step<?>> steps = result.getTraceSteps();
+    assertThat(steps, hasSize(2));
+
+    assertThat(
+        steps.get(0),
+        equalTo(
+            new org.batfish.datamodel.flow.TransformationStep(
+                new TransformationStepDetail(
+                    SOURCE_NAT,
+                    ImmutableSortedSet.of(flowDiff(SOURCE, origSrcIp, transformedSrcIp))),
+                TRANSFORMED)));
+    assertThat(
+        steps.get(1),
+        equalTo(
+            new org.batfish.datamodel.flow.TransformationStep(
+                new TransformationStepDetail(
+                    DEST_NAT, ImmutableSortedSet.of(flowDiff(DESTINATION, origDstIp, thenDstIp))),
+                TRANSFORMED)));
+
+    origDstIp = Ip.parse("6.6.6.6");
+    origFlow = _flowBuilder.setDstIp(origDstIp).build();
+    result = evalResult(transformation, origFlow);
+    assertThat(result.getOutputFlow(), equalTo(_flowBuilder.setDstIp(elseDstIp).build()));
+
+    steps = result.getTraceSteps();
+    assertThat(steps, hasSize(1));
+
+    assertThat(
+        steps.get(0),
+        equalTo(
+            new org.batfish.datamodel.flow.TransformationStep(
+                new TransformationStepDetail(
+                    DEST_NAT, ImmutableSortedSet.of(flowDiff(DESTINATION, origDstIp, elseDstIp))),
+                TRANSFORMED)));
+  }
+
+  @Test
+  public void testTransformedTwice() {
+    Ip ip1 = Ip.parse("1.1.1.1");
+    Ip ip2 = Ip.parse("2.2.2.2");
+    Ip ip3 = Ip.parse("3.3.3.3");
+    Transformation transformation =
+        always()
+            .apply(assignDestinationIp(ip2, ip2))
+            .setAndThen(always().apply(assignDestinationIp(ip3, ip3)).build())
+            .build();
+
+    TransformationResult result = evalResult(transformation, _flowBuilder.setDstIp(ip1).build());
+
+    assertThat(result.getOutputFlow(), equalTo(_flowBuilder.setDstIp(ip3).build()));
+
+    List<Step<?>> steps = result.getTraceSteps();
+
+    assertThat(steps, hasSize(2));
+    assertThat(
+        steps.get(0),
+        equalTo(
+            new org.batfish.datamodel.flow.TransformationStep(
+                new TransformationStepDetail(
+                    DEST_NAT, ImmutableSortedSet.of(flowDiff(IpField.DESTINATION, ip1, ip2))),
+                TRANSFORMED)));
+    assertThat(
+        steps.get(1),
+        equalTo(
+            new org.batfish.datamodel.flow.TransformationStep(
+                new TransformationStepDetail(
+                    DEST_NAT, ImmutableSortedSet.of(flowDiff(IpField.DESTINATION, ip2, ip3))),
+                TRANSFORMED)));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/datamodel/transformation/TransformationEvaluatorTest.java
+++ b/projects/batfish/src/test/java/org/batfish/datamodel/transformation/TransformationEvaluatorTest.java
@@ -14,6 +14,7 @@ import static org.batfish.datamodel.transformation.TransformationStep.assignDest
 import static org.batfish.datamodel.transformation.TransformationStep.assignSourceIp;
 import static org.batfish.datamodel.transformation.TransformationStep.shiftDestinationIp;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
@@ -126,12 +127,9 @@ public class TransformationEvaluatorTest {
         "Noop transformations should return the original (==) flow",
         result.getOutputFlow() == origFlow);
 
-    List<Step<?>> steps = result.getTraceSteps();
-
-    assertThat(steps, hasSize(1));
     assertThat(
-        steps.get(0),
-        equalTo(
+        result.getTraceSteps(),
+        contains(
             new org.batfish.datamodel.flow.TransformationStep(
                 new TransformationStepDetail(SOURCE_NAT, ImmutableSortedSet.of()),
                 StepAction.PERMITTED)));

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TracerouteEngineImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TracerouteEngineImplTest.java
@@ -654,11 +654,10 @@ public class TracerouteEngineImplTest {
                 .setNextHopInterface(i2.getName())
                 .build()));
 
-    String filterName = "preSourceFilter";
-
     IpAccessList filter =
         IpAccessList.builder()
-            .setName(filterName)
+            .setName("preSourceFilter")
+            .setOwner(c1)
             .setLines(
                 ImmutableList.of(
                     accepting(
@@ -667,7 +666,6 @@ public class TracerouteEngineImplTest {
                             matchSrc(Prefix.parse("10.0.0.1/32"))))))
             .build();
 
-    c1.getIpAccessLists().put(filterName, filter);
     i2.setPreSourceNatOutgoingFilter(filter);
 
     Batfish batfish =
@@ -786,6 +784,7 @@ public class TracerouteEngineImplTest {
     IpAccessList filter =
         IpAccessList.builder()
             .setName(filterName)
+            .setOwner(c1)
             .setLines(
                 ImmutableList.of(
                     accepting(
@@ -796,7 +795,6 @@ public class TracerouteEngineImplTest {
                         LineAction.PERMIT, OriginatingFromDevice.INSTANCE, "HOST_OUTBOUND")))
             .build();
 
-    c1.getIpAccessLists().put(filterName, filter);
     i2.setPreSourceNatOutgoingFilter(filter);
 
     Batfish batfish =

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/NatRuleSetTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/NatRuleSetTest.java
@@ -2,6 +2,8 @@ package org.batfish.representation.juniper;
 
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDst;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrcInterface;
+import static org.batfish.datamodel.flow.TransformationStep.TransformationType.SOURCE_NAT;
+import static org.batfish.datamodel.transformation.Noop.NOOP_DEST_NAT;
 import static org.batfish.datamodel.transformation.Transformation.when;
 import static org.batfish.datamodel.transformation.TransformationStep.assignDestinationIp;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -14,6 +16,7 @@ import java.util.List;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.transformation.IpField;
+import org.batfish.datamodel.transformation.Noop;
 import org.batfish.datamodel.transformation.Transformation;
 import org.junit.Test;
 
@@ -81,14 +84,14 @@ public class NatRuleSetTest {
     pool.setToAddress(poolEnd);
 
     // the transformation to apply after any NatRule transformation is applied.
-    Transformation andThen = when(matchSrcInterface("IFACE")).apply().build();
+    Transformation andThen = when(matchSrcInterface("IFACE")).apply(new Noop(SOURCE_NAT)).build();
 
     assertThat(
         ruleSet.toTransformation(IpField.DESTINATION, ImmutableMap.of("POOL", pool), andThen).get(),
         equalTo(
             // first apply natRule1
             when(matchDst(prefix1))
-                .apply()
+                .apply(NOOP_DEST_NAT)
                 .setAndThen(andThen)
                 .setOrElse(
                     // only apply natRule2 if natRule1 doesn't match

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/NatRuleSetTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/NatRuleSetTest.java
@@ -2,6 +2,7 @@ package org.batfish.representation.juniper;
 
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDst;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrcInterface;
+import static org.batfish.datamodel.flow.TransformationStep.TransformationType.DEST_NAT;
 import static org.batfish.datamodel.flow.TransformationStep.TransformationType.SOURCE_NAT;
 import static org.batfish.datamodel.transformation.Noop.NOOP_DEST_NAT;
 import static org.batfish.datamodel.transformation.Transformation.when;
@@ -87,7 +88,9 @@ public class NatRuleSetTest {
     Transformation andThen = when(matchSrcInterface("IFACE")).apply(new Noop(SOURCE_NAT)).build();
 
     assertThat(
-        ruleSet.toTransformation(IpField.DESTINATION, ImmutableMap.of("POOL", pool), andThen).get(),
+        ruleSet
+            .toTransformation(DEST_NAT, IpField.DESTINATION, ImmutableMap.of("POOL", pool), andThen)
+            .get(),
         equalTo(
             // first apply natRule1
             when(matchDst(prefix1))

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/NatRuleTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/NatRuleTest.java
@@ -2,6 +2,7 @@ package org.batfish.representation.juniper;
 
 import static org.batfish.datamodel.acl.AclLineMatchExprs.match;
 import static org.batfish.datamodel.flow.TransformationStep.TransformationType.DEST_NAT;
+import static org.batfish.datamodel.flow.TransformationStep.TransformationType.SOURCE_NAT;
 import static org.batfish.datamodel.transformation.IpField.DESTINATION;
 import static org.batfish.datamodel.transformation.IpField.SOURCE;
 import static org.batfish.datamodel.transformation.Transformation.when;
@@ -29,14 +30,14 @@ public class NatRuleTest {
     rule.setThen(NatRuleThenOff.INSTANCE);
 
     assertThat(
-        rule.toTransformationBuilder(DESTINATION, ImmutableMap.of()).map(Builder::build),
+        rule.toTransformationBuilder(DEST_NAT, DESTINATION, ImmutableMap.of()).map(Builder::build),
         equalTo(Optional.of(when(match(hs)).apply(new Noop(DEST_NAT)).build())));
 
     rule.setThen(new NatRuleThenPool("pool"));
 
     // pool is undefined
     assertThat(
-        rule.toTransformationBuilder(DESTINATION, ImmutableMap.of()).map(Builder::build),
+        rule.toTransformationBuilder(DEST_NAT, DESTINATION, ImmutableMap.of()).map(Builder::build),
         equalTo(Optional.empty()));
 
     // pool is defined
@@ -48,7 +49,7 @@ public class NatRuleTest {
 
     // destination NAT
     assertThat(
-        rule.toTransformationBuilder(DESTINATION, ImmutableMap.of("pool", pool))
+        rule.toTransformationBuilder(DEST_NAT, DESTINATION, ImmutableMap.of("pool", pool))
             .map(Builder::build),
         equalTo(
             Optional.of(
@@ -58,7 +59,8 @@ public class NatRuleTest {
 
     // source NAT
     assertThat(
-        rule.toTransformationBuilder(SOURCE, ImmutableMap.of("pool", pool)).map(Builder::build),
+        rule.toTransformationBuilder(SOURCE_NAT, SOURCE, ImmutableMap.of("pool", pool))
+            .map(Builder::build),
         equalTo(
             Optional.of(
                 when(match(hs)).apply(TransformationStep.assignSourceIp(startIp, endIp)).build())));

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/NatRuleTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/NatRuleTest.java
@@ -1,6 +1,7 @@
 package org.batfish.representation.juniper;
 
 import static org.batfish.datamodel.acl.AclLineMatchExprs.match;
+import static org.batfish.datamodel.flow.TransformationStep.TransformationType.DEST_NAT;
 import static org.batfish.datamodel.transformation.IpField.DESTINATION;
 import static org.batfish.datamodel.transformation.IpField.SOURCE;
 import static org.batfish.datamodel.transformation.Transformation.when;
@@ -12,6 +13,7 @@ import java.util.Optional;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.transformation.Noop;
 import org.batfish.datamodel.transformation.Transformation.Builder;
 import org.batfish.datamodel.transformation.TransformationStep;
 import org.junit.Test;
@@ -28,7 +30,7 @@ public class NatRuleTest {
 
     assertThat(
         rule.toTransformationBuilder(DESTINATION, ImmutableMap.of()).map(Builder::build),
-        equalTo(Optional.of(when(match(hs)).apply().build())));
+        equalTo(Optional.of(when(match(hs)).apply(new Noop(DEST_NAT)).build())));
 
     rule.setThen(new NatRuleThenPool("pool"));
 

--- a/projects/batfish/src/test/java/org/batfish/z3/expr/TransformationTransitionGeneratorTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/expr/TransformationTransitionGeneratorTest.java
@@ -1,6 +1,9 @@
 package org.batfish.z3.expr;
 
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDst;
+import static org.batfish.datamodel.flow.TransformationStep.TransformationType.SOURCE_NAT;
+import static org.batfish.datamodel.transformation.Transformation.always;
+import static org.batfish.datamodel.transformation.Transformation.when;
 import static org.batfish.datamodel.transformation.TransformationStep.assignDestinationIp;
 import static org.batfish.datamodel.transformation.TransformationStep.shiftDestinationIp;
 import static org.batfish.datamodel.transformation.TransformationStep.shiftSourceIp;
@@ -19,6 +22,7 @@ import com.google.common.collect.Range;
 import java.util.List;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.transformation.Noop;
 import org.batfish.datamodel.transformation.Transformation;
 import org.batfish.z3.AclLineMatchExprToBooleanExpr;
 import org.batfish.z3.Field;
@@ -59,24 +63,26 @@ public class TransformationTransitionGeneratorTest {
 
   @Test
   public void testSimple() {
-    Transformation transformation = Transformation.always().build();
+    Transformation transformation = always().apply(new Noop(SOURCE_NAT)).build();
     List<BasicRuleStatement> stmts = generateTransitions(transformation);
     assertThat(
         stmts,
         containsInAnyOrder(
-            new BasicRuleStatement(TrueExpr.INSTANCE, stateExpr(0), OUT_STATE),
+            new BasicRuleStatement(TrueExpr.INSTANCE, stateExpr(0), stepStateExpr(0, 0)),
+            new BasicRuleStatement(stepStateExpr(0, 0), OUT_STATE),
             new BasicRuleStatement(FalseExpr.INSTANCE, stateExpr(0), OUT_STATE)));
   }
 
   @Test
   public void testGuard() {
     Ip ip = Ip.parse("1.2.3.4");
-    Transformation transformation = Transformation.when(matchDst(ip)).build();
+    Transformation transformation = when(matchDst(ip)).apply(new Noop(SOURCE_NAT)).build();
     List<BasicRuleStatement> stmts = generateTransitions(transformation);
     assertThat(
         stmts,
         containsInAnyOrder(
-            new BasicRuleStatement(matchIp(ip, Field.DST_IP), stateExpr(0), OUT_STATE),
+            new BasicRuleStatement(matchIp(ip, Field.DST_IP), stateExpr(0), stepStateExpr(0, 0)),
+            new BasicRuleStatement(stepStateExpr(0, 0), OUT_STATE),
             new BasicRuleStatement(
                 new NotExpr(matchIp(ip, Field.DST_IP)), stateExpr(0), OUT_STATE)));
   }
@@ -84,8 +90,7 @@ public class TransformationTransitionGeneratorTest {
   @Test
   public void testShiftDestIpStep() {
     Prefix prefix = Prefix.parse("1.1.0.0/16");
-    Transformation transformation =
-        Transformation.always().apply(shiftDestinationIp(prefix)).build();
+    Transformation transformation = always().apply(shiftDestinationIp(prefix)).build();
     List<BasicRuleStatement> stmts = generateTransitions(transformation);
     assertThat(
         stmts,
@@ -100,8 +105,7 @@ public class TransformationTransitionGeneratorTest {
   public void testAssignDestIpFromPoolStep() {
     Ip startIp = Ip.parse("1.1.1.0");
     Ip endIp = Ip.parse("1.1.1.10");
-    Transformation transformation =
-        Transformation.always().apply(assignDestinationIp(startIp, endIp)).build();
+    Transformation transformation = always().apply(assignDestinationIp(startIp, endIp)).build();
     List<BasicRuleStatement> stmts = generateTransitions(transformation);
     assertThat(
         stmts,
@@ -118,9 +122,7 @@ public class TransformationTransitionGeneratorTest {
     Ip startIp = Ip.parse("1.1.1.0");
     Ip endIp = Ip.parse("1.1.1.10");
     Transformation transformation =
-        Transformation.always()
-            .apply(shiftSourceIp(prefix), assignDestinationIp(startIp, endIp))
-            .build();
+        always().apply(shiftSourceIp(prefix), assignDestinationIp(startIp, endIp)).build();
     List<BasicRuleStatement> stmts = generateTransitions(transformation);
     assertThat(
         stmts,
@@ -140,25 +142,33 @@ public class TransformationTransitionGeneratorTest {
     Ip match1 = Ip.parse("1.1.1.1");
     Ip match2 = Ip.parse("1.1.1.2");
     Ip match3 = Ip.parse("1.1.1.3");
+    Noop noop = new Noop(SOURCE_NAT);
     Transformation transformation =
-        Transformation.when(matchDst(match1))
-            .setAndThen(Transformation.when(matchDst(match2)).build())
-            .setOrElse(Transformation.when(matchDst(match3)).build())
+        when(matchDst(match1))
+            .apply(noop)
+            .setAndThen(when(matchDst(match2)).apply(noop).build())
+            .setOrElse(when(matchDst(match3)).apply(noop).build())
             .build();
     List<BasicRuleStatement> stmts = generateTransitions(transformation);
     assertThat(
         stmts,
         containsInAnyOrder(
             // root
-            new BasicRuleStatement(matchIp(match1, Field.DST_IP), stateExpr(0), stateExpr(1)),
+            new BasicRuleStatement(
+                matchIp(match1, Field.DST_IP), stateExpr(0), stepStateExpr(0, 0)),
+            new BasicRuleStatement(stepStateExpr(0, 0), stateExpr(1)),
             new BasicRuleStatement(
                 new NotExpr(matchIp(match1, Field.DST_IP)), stateExpr(0), stateExpr(2)),
             // true branch
-            new BasicRuleStatement(matchIp(match2, Field.DST_IP), stateExpr(1), OUT_STATE),
+            new BasicRuleStatement(
+                matchIp(match2, Field.DST_IP), stateExpr(1), stepStateExpr(1, 0)),
+            new BasicRuleStatement(stepStateExpr(1, 0), OUT_STATE),
             new BasicRuleStatement(
                 new NotExpr(matchIp(match2, Field.DST_IP)), stateExpr(1), OUT_STATE),
             // else branch
-            new BasicRuleStatement(matchIp(match3, Field.DST_IP), stateExpr(2), OUT_STATE),
+            new BasicRuleStatement(
+                matchIp(match3, Field.DST_IP), stateExpr(2), stepStateExpr(2, 0)),
+            new BasicRuleStatement(stepStateExpr(2, 0), OUT_STATE),
             new BasicRuleStatement(
                 new NotExpr(matchIp(match3, Field.DST_IP)), stateExpr(2), OUT_STATE)));
   }


### PR DESCRIPTION
In order to produce the same traces, also added TransformationTypes to
each TransformationStep. The transformation evaluator uses those to
generate trace steps. Also added a new Noop transformation step, which
allows us to generate steps correctly for "no-nat" style
transformations. A transformation can no longer have an empty list of
transformation steps.