### PR TITLE
use Transformations in NOD reachability engine

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/z3/SynthesizerInput.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/SynthesizerInput.java
@@ -2,15 +2,14 @@ package org.batfish.z3;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import org.batfish.datamodel.Edge;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.LineAction;
+import org.batfish.datamodel.transformation.Transformation;
 import org.batfish.z3.expr.BooleanExpr;
 import org.batfish.z3.expr.IntExpr;
-import org.batfish.z3.state.AclPermit;
 import org.batfish.z3.state.StateParameter.Type;
 
 /**
@@ -88,17 +87,14 @@ public interface SynthesizerInput {
   /** Mapping: hostname -&gt; interface-&gt; outgoingAcl */
   Map<String, Map<String, String>> getOutgoingAcls();
 
+  /** Mapping: hostname -&gt; interface -&gt; outgoingTransformation */
+  Map<String, Map<String, Transformation>> getOutgoingTransformations();
+
   /** Mapping: hostname -&gt; vrfName -&gt; routableIps */
   Map<String, Map<String, BooleanExpr>> getRoutableIps();
 
   /** Whether to run simplifier on AST after rule generation */
   boolean getSimplify();
-
-  /**
-   * Mapping: hostname -&gt; interface -&gt; [(preconditionPreTransformationState,
-   * transformationToApply)]
-   */
-  Map<String, Map<String, List<Entry<AclPermit, BooleanExpr>>>> getSourceNats();
 
   /** The set of nodes for which we should track whether they are transited */
   Set<String> getTransitNodes();
@@ -126,4 +122,7 @@ public interface SynthesizerInput {
 
   /** Whether it's synthesizing data plane rules */
   boolean isDataPlane();
+
+  /** Mapping: hostname -&gt; AclLineMatchExprToBooleanExpr */
+  Map<String, AclLineMatchExprToBooleanExpr> getAclLineMatchExprToBooleanExprs();
 }

--- a/projects/batfish/src/main/java/org/batfish/z3/SynthesizerInputImpl.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/SynthesizerInputImpl.java
@@ -228,6 +228,8 @@ public final class SynthesizerInputImpl implements SynthesizerInput {
 
   private final @Nonnull Map<String, Map<String, String>> _outgoingAcls;
 
+  private final @Nonnull Map<String, Map<String, Transformation>> _outgoingTransformations;
+
   private final @Nullable Map<String, Map<String, BooleanExpr>> _routableIps;
 
   private final boolean _simplify;
@@ -275,6 +277,7 @@ public final class SynthesizerInputImpl implements SynthesizerInput {
     _incomingAcls = computeIncomingAcls();
     _srcIpConstraints = computeSrcIpConstraints(builder._srcIpConstraints);
     _outgoingAcls = computeOutgoingAcls();
+    _outgoingTransformations = computeOutgoingTransformations();
     _simplify = builder._simplify;
     _vectorizedParameters = builder._vectorizedParameters;
 
@@ -790,6 +793,23 @@ public final class SynthesizerInputImpl implements SynthesizerInput {
         });
   }
 
+  public Map<String, Map<String, Transformation>> computeOutgoingTransformations() {
+    return toImmutableMap(
+        _configurations,
+        Entry::getKey,
+        nodeEntry ->
+            nodeEntry
+                .getValue()
+                .getAllInterfaces()
+                .entrySet()
+                .stream()
+                .filter(ifaceEntry -> ifaceEntry.getValue().getOutgoingTransformation() != null)
+                .collect(
+                    ImmutableMap.toImmutableMap(
+                        Entry::getKey,
+                        ifaceEntry -> ifaceEntry.getValue().getOutgoingTransformation())));
+  }
+
   private Map<String, Map<String, BooleanExpr>> computeRoutableIps(
       Map<String, Map<String, IpSpace>> routableIps) {
     return toImmutableMap(
@@ -917,20 +937,7 @@ public final class SynthesizerInputImpl implements SynthesizerInput {
 
   @Override
   public Map<String, Map<String, Transformation>> getOutgoingTransformations() {
-    return toImmutableMap(
-        _configurations,
-        Entry::getKey,
-        nodeEntry ->
-            nodeEntry
-                .getValue()
-                .getAllInterfaces()
-                .entrySet()
-                .stream()
-                .filter(ifaceEntry -> ifaceEntry.getValue().getOutgoingTransformation() != null)
-                .collect(
-                    ImmutableMap.toImmutableMap(
-                        Entry::getKey,
-                        ifaceEntry -> ifaceEntry.getValue().getOutgoingTransformation())));
+    return _outgoingTransformations;
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/z3/SynthesizerInputImpl.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/SynthesizerInputImpl.java
@@ -10,8 +10,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import com.google.common.math.LongMath;
 import java.math.RoundingMode;
@@ -45,14 +43,12 @@ import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.datamodel.acl.AclLineMatchExprs;
+import org.batfish.datamodel.transformation.Transformation;
 import org.batfish.z3.expr.BooleanExpr;
 import org.batfish.z3.expr.IntExpr;
 import org.batfish.z3.expr.IpSpaceMatchExpr;
 import org.batfish.z3.expr.LitIntExpr;
-import org.batfish.z3.expr.RangeMatchExpr;
-import org.batfish.z3.expr.TransformedVarIntExpr;
 import org.batfish.z3.expr.visitors.IpSpaceBooleanExprTransformer;
-import org.batfish.z3.state.AclPermit;
 import org.batfish.z3.state.StateParameter.Type;
 
 public final class SynthesizerInputImpl implements SynthesizerInput {
@@ -173,6 +169,8 @@ public final class SynthesizerInputImpl implements SynthesizerInput {
 
   private final @Nonnull Map<String, Map<String, List<BooleanExpr>>> _aclConditions;
 
+  private final @Nonnull Map<String, AclLineMatchExprToBooleanExpr> _aclLineMatchExprToBooleanExprs;
+
   private final @Nullable Map<
           String, Map<String, Map<String, Map<String, Map<String, BooleanExpr>>>>>
       _arpTrueEdge;
@@ -238,8 +236,6 @@ public final class SynthesizerInputImpl implements SynthesizerInput {
 
   private final @Nonnull Map<String, Map<String, IntExpr>> _sourceInterfaceFieldValues;
 
-  private final @Nullable Map<String, Map<String, List<Entry<AclPermit, BooleanExpr>>>> _sourceNats;
-
   private final @Nonnull Map<IngressLocation, BooleanExpr> _srcIpConstraints;
 
   private final @Nullable Map<String, Set<String>> _topologyInterfaces;
@@ -296,7 +292,6 @@ public final class SynthesizerInputImpl implements SynthesizerInput {
       _edges = builder._topology.getEdges();
       _enabledEdges = computeEnabledEdges();
       _topologyInterfaces = computeTopologyInterfaces();
-      _sourceNats = computeSourceNats();
     } else {
       _arpTrueEdge = null;
       _neighborUnreachableOrExitsNetwork = null;
@@ -307,7 +302,6 @@ public final class SynthesizerInputImpl implements SynthesizerInput {
       _edges = null;
       _enabledEdges = null;
       _topologyInterfaces = null;
-      _sourceNats = null;
     }
     _aclActions = computeAclActions();
     _nodeInterfaces = computeNodeInterfaces();
@@ -316,6 +310,7 @@ public final class SynthesizerInputImpl implements SynthesizerInput {
     _sourceInterfaceFieldValues = computeSourceInterfaceFieldValues();
     _nonTransitNodes = ImmutableSortedSet.copyOf(builder._nonTransitNodes);
     _transitNodes = ImmutableSortedSet.copyOf(builder._transitNodes);
+    _aclLineMatchExprToBooleanExprs = computeAclLineMatchExprToBooleanExprs();
     _aclConditions = computeAclConditions();
   }
 
@@ -464,14 +459,6 @@ public final class SynthesizerInputImpl implements SynthesizerInput {
         Entry::getKey, /* Node name */
         e -> {
           String node = e.getKey();
-          Map<String, IpAccessList> nodeAcls =
-              _configurations.get(node).getIpAccessLists(); // e.getValue();
-          AclLineMatchExprToBooleanExpr aclLineMatchExprToBooleanExpr =
-              new AclLineMatchExprToBooleanExpr(
-                  nodeAcls,
-                  _namedIpSpaces.get(node),
-                  _sourceInterfaceField,
-                  _sourceInterfaceFieldValues.get(node));
           return toImmutableMap(
               e.getValue(),
               Entry::getKey, /* Acl name */
@@ -480,8 +467,22 @@ public final class SynthesizerInputImpl implements SynthesizerInput {
                       .getLines()
                       .stream()
                       .map(IpAccessListLine::getMatchCondition)
-                      .map(aclLineMatchExprToBooleanExpr::toBooleanExpr)
+                      .map(_aclLineMatchExprToBooleanExprs.get(node)::toBooleanExpr)
                       .collect(ImmutableList.toImmutableList()));
+        });
+  }
+
+  private Map<String, AclLineMatchExprToBooleanExpr> computeAclLineMatchExprToBooleanExprs() {
+    return toImmutableMap(
+        _configurations,
+        Entry::getKey,
+        e -> {
+          Configuration config = e.getValue();
+          return new AclLineMatchExprToBooleanExpr(
+              config.getIpAccessLists(),
+              config.getIpSpaces(),
+              _sourceInterfaceField,
+              _sourceInterfaceFieldValues.getOrDefault(e.getKey(), ImmutableMap.of()));
         });
   }
 
@@ -807,42 +808,6 @@ public final class SynthesizerInputImpl implements SynthesizerInput {
         });
   }
 
-  private Map<String, Map<String, List<Entry<AclPermit, BooleanExpr>>>> computeSourceNats() {
-    return toImmutableMap(
-        _topologyInterfaces,
-        Entry::getKey,
-        topologyInterfacesEntryByHostname -> {
-          String hostname = topologyInterfacesEntryByHostname.getKey();
-          Set<String> ifaces = topologyInterfacesEntryByHostname.getValue();
-          Configuration c = _configurations.get(hostname);
-          return toImmutableMap(
-              ifaces,
-              Function.identity(),
-              ifaceName ->
-                  c.getAllInterfaces()
-                      .get(ifaceName)
-                      .getSourceNats()
-                      .stream()
-                      .map(
-                          sourceNat -> {
-                            IpAccessList acl = sourceNat.getAcl();
-                            AclPermit preconditionPreTransformationState =
-                                acl == null ? null : new AclPermit(hostname, acl.getName());
-                            BooleanExpr transformationConstraint =
-                                new RangeMatchExpr(
-                                    new TransformedVarIntExpr(Field.SRC_IP),
-                                    Field.SRC_IP.getSize(),
-                                    ImmutableSet.of(
-                                        Range.closed(
-                                            sourceNat.getPoolIpFirst().asLong(),
-                                            sourceNat.getPoolIpLast().asLong())));
-                            return Maps.immutableEntry(
-                                preconditionPreTransformationState, transformationConstraint);
-                          })
-                      .collect(ImmutableList.toImmutableList()));
-        });
-  }
-
   private Map<String, Set<String>> computeTopologyInterfaces() {
     Map<String, Set<String>> topologyEdges = new HashMap<>();
     _enabledEdges.forEach(
@@ -867,6 +832,11 @@ public final class SynthesizerInputImpl implements SynthesizerInput {
   @Override
   public Map<String, Map<String, List<BooleanExpr>>> getAclConditions() {
     return _aclConditions;
+  }
+
+  @Override
+  public Map<String, AclLineMatchExprToBooleanExpr> getAclLineMatchExprToBooleanExprs() {
+    return _aclLineMatchExprToBooleanExprs;
   }
 
   @Override
@@ -946,6 +916,24 @@ public final class SynthesizerInputImpl implements SynthesizerInput {
   }
 
   @Override
+  public Map<String, Map<String, Transformation>> getOutgoingTransformations() {
+    return toImmutableMap(
+        _configurations,
+        Entry::getKey,
+        nodeEntry ->
+            nodeEntry
+                .getValue()
+                .getAllInterfaces()
+                .entrySet()
+                .stream()
+                .filter(ifaceEntry -> ifaceEntry.getValue().getOutgoingTransformation() != null)
+                .collect(
+                    ImmutableMap.toImmutableMap(
+                        Entry::getKey,
+                        ifaceEntry -> ifaceEntry.getValue().getOutgoingTransformation())));
+  }
+
+  @Override
   public Map<String, Map<String, BooleanExpr>> getRoutableIps() {
     return _routableIps;
   }
@@ -953,11 +941,6 @@ public final class SynthesizerInputImpl implements SynthesizerInput {
   @Override
   public boolean getSimplify() {
     return _simplify;
-  }
-
-  @Override
-  public Map<String, Map<String, List<Entry<AclPermit, BooleanExpr>>>> getSourceNats() {
-    return _sourceNats;
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/TransformationExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/TransformationExpr.java
@@ -4,7 +4,7 @@ import org.batfish.datamodel.transformation.Transformation;
 import org.batfish.z3.state.visitors.GenericStateExprVisitor;
 import org.batfish.z3.state.visitors.StateVisitor;
 
-/** A {@link StateExpr} for an outgoing {@link Transformation} on an edge. */
+/** A {@link StateExpr} for a {@link Transformation} on an edge. */
 public class TransformationExpr extends StateExpr {
   public static class State extends StateExpr.State {
 

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/TransformationExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/TransformationExpr.java
@@ -18,12 +18,10 @@ public class TransformationExpr extends StateExpr {
     }
   }
 
-  /** source edge, on which the transformation is defined. */
   private final String _node1;
 
   private final String _iface1;
 
-  /** destination edge. */
   private final String _node2;
 
   private final String _iface2;

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/TransformationExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/TransformationExpr.java
@@ -4,7 +4,7 @@ import org.batfish.datamodel.transformation.Transformation;
 import org.batfish.z3.state.visitors.GenericStateExprVisitor;
 import org.batfish.z3.state.visitors.StateVisitor;
 
-/** A {@link StateExpr} for a {@link Transformation}. */
+/** A {@link StateExpr} for an outgoing {@link Transformation} on an edge. */
 public class TransformationExpr extends StateExpr {
   public static class State extends StateExpr.State {
 
@@ -18,14 +18,25 @@ public class TransformationExpr extends StateExpr {
     }
   }
 
-  private final String _node;
-  private final String _iface;
+  /** source edge, on which the transformation is defined. */
+  private final String _node1;
+
+  private final String _iface1;
+
+  /** destination edge. */
+  private final String _node2;
+
+  private final String _iface2;
+
   private final String _tag;
   private final int _id;
 
-  public TransformationExpr(String node, String iface, String tag, int id) {
-    _node = node;
-    _iface = iface;
+  public TransformationExpr(
+      String node1, String iface1, String node2, String iface2, String tag, int id) {
+    _node1 = node1;
+    _iface1 = iface1;
+    _node2 = node2;
+    _iface2 = iface2;
     _tag = tag;
     _id = id;
   }
@@ -40,12 +51,20 @@ public class TransformationExpr extends StateExpr {
     return State.INSTANCE;
   }
 
-  public String getNode() {
-    return _node;
+  public String getNode1() {
+    return _node1;
   }
 
-  public String getIface() {
-    return _iface;
+  public String getIface1() {
+    return _iface1;
+  }
+
+  public String getNode2() {
+    return _node2;
+  }
+
+  public String getIface2() {
+    return _iface2;
   }
 
   public String getTag() {

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/TransformationStepExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/TransformationStepExpr.java
@@ -18,12 +18,10 @@ public class TransformationStepExpr extends StateExpr {
     }
   }
 
-  /** source edge, on which the transformation is defined. */
   private final String _node1;
 
   private final String _iface1;
 
-  /** destination edge */
   private final String _node2;
 
   private final String _iface2;

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/TransformationStepExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/TransformationStepExpr.java
@@ -4,7 +4,7 @@ import org.batfish.datamodel.transformation.TransformationStep;
 import org.batfish.z3.state.visitors.GenericStateExprVisitor;
 import org.batfish.z3.state.visitors.StateVisitor;
 
-/** A {@link StateExpr} for a {@link TransformationStep}. */
+/** A {@link StateExpr} for an outgoing {@link TransformationStep} on an edge. */
 public class TransformationStepExpr extends StateExpr {
   public static class State extends StateExpr.State {
 
@@ -18,16 +18,32 @@ public class TransformationStepExpr extends StateExpr {
     }
   }
 
-  private final String _node;
-  private final String _iface;
+  /** source edge, on which the transformation is defined. */
+  private final String _node1;
+
+  private final String _iface1;
+
+  /** destination edge */
+  private final String _node2;
+
+  private final String _iface2;
+
   private final String _tag;
   private final int _transformationId;
   private final int _id;
 
   public TransformationStepExpr(
-      String node, String iface, String tag, int transformationId, int id) {
-    _node = node;
-    _iface = iface;
+      String node1,
+      String iface1,
+      String node2,
+      String iface2,
+      String tag,
+      int transformationId,
+      int id) {
+    _node1 = node1;
+    _iface1 = iface1;
+    _node2 = node2;
+    _iface2 = iface2;
     _tag = tag;
     _transformationId = transformationId;
     _id = id;
@@ -43,13 +59,22 @@ public class TransformationStepExpr extends StateExpr {
     return State.INSTANCE;
   }
 
-  public String getNode() {
-    return _node;
+  public String getNode1() {
+    return _node1;
   }
 
-  public String getIface() {
-    return _iface;
+  public String getIface1() {
+    return _iface1;
   }
+
+  public String getNode2() {
+    return _node2;
+  }
+
+  public String getIface2() {
+    return _iface2;
+  }
+
 
   public String getTag() {
     return _tag;

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/TransformationStepExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/TransformationStepExpr.java
@@ -4,7 +4,7 @@ import org.batfish.datamodel.transformation.TransformationStep;
 import org.batfish.z3.state.visitors.GenericStateExprVisitor;
 import org.batfish.z3.state.visitors.StateVisitor;
 
-/** A {@link StateExpr} for an outgoing {@link TransformationStep} on an edge. */
+/** A {@link StateExpr} for a {@link TransformationStep} on an edge. */
 public class TransformationStepExpr extends StateExpr {
   public static class State extends StateExpr.State {
 
@@ -74,7 +74,6 @@ public class TransformationStepExpr extends StateExpr {
   public String getIface2() {
     return _iface2;
   }
-
 
   public String getTag() {
     return _tag;

--- a/projects/batfish/src/main/java/org/batfish/z3/expr/TransformationTransitionGenerator.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/expr/TransformationTransitionGenerator.java
@@ -11,6 +11,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.transformation.AssignIpAddressFromPool;
@@ -28,8 +29,13 @@ import org.batfish.z3.Field;
  */
 public final class TransformationTransitionGenerator {
   private int _ctr;
-  private final String _node;
-  private final String _iface;
+
+  private final String _node1;
+  private final String _iface1;
+
+  private final String _node2;
+  private final String _iface2;
+
   private final String _tag; // distinguish this transformation from others on the same interface
   private final AclLineMatchExprToBooleanExpr _aclLineMatchExprToBooleanExpr;
   private final StateExpr _outState;
@@ -38,15 +44,19 @@ public final class TransformationTransitionGenerator {
   private ImmutableList.Builder<BasicRuleStatement> _statements;
 
   private TransformationTransitionGenerator(
-      String node,
-      String iface,
+      String node1,
+      String iface1,
+      String node2,
+      String iface2,
       String tag,
       AclLineMatchExprToBooleanExpr aclLineMatchExprToBooleanExpr,
       StateExpr outState) {
     _ctr = 0;
     _statements = ImmutableList.builder();
-    _node = node;
-    _iface = iface;
+    _node1 = node1;
+    _iface1 = iface1;
+    _node2 = node2;
+    _iface2 = iface2;
     _tag = tag;
     _aclLineMatchExprToBooleanExpr = aclLineMatchExprToBooleanExpr;
     _outState = outState;
@@ -104,7 +114,7 @@ public final class TransformationTransitionGenerator {
   /** Generate a new StateExpr for this transformation, and transitions from it to the end state. */
   private StateExpr generateTransitions(Transformation transformation) {
     int id = _ctr++;
-    StateExpr state = new TransformationExpr(_node, _iface, _tag, id);
+    StateExpr state = new TransformationExpr(_node1, _iface1, _node2, _iface2, _tag, id);
 
     BooleanExpr guardExpr =
         simplifyBooleanExpr(
@@ -135,7 +145,8 @@ public final class TransformationTransitionGenerator {
     int stepId = transformationSteps.size() - 1;
     for (TransformationStep step : Lists.reverse(transformationSteps)) {
       StateExpr stepExpr =
-          new TransformationStepExpr(_node, _iface, _tag, transformationId, stepId);
+          new TransformationStepExpr(
+              _node1, _iface1, _node2, _iface2, _tag, transformationId, stepId);
       _statements.add(step.accept(new StepRuleVisitor(stepExpr, next)));
       next = stepExpr;
       stepId--;
@@ -144,16 +155,24 @@ public final class TransformationTransitionGenerator {
   }
 
   public static List<BasicRuleStatement> generateTransitions(
-      String node,
-      String iface,
+      String node1,
+      String iface1,
+      String node2,
+      String iface2,
       String tag,
       AclLineMatchExprToBooleanExpr aclLineMatchExprToBooleanExpr,
-      StateExpr outState,
-      Transformation transformation) {
+      StateExpr preState,
+      StateExpr postState,
+      @Nullable Transformation transformation) {
+    if (transformation == null) {
+      return ImmutableList.of(new BasicRuleStatement(preState, postState));
+    }
+
     TransformationTransitionGenerator gen =
         new TransformationTransitionGenerator(
-            node, iface, tag, aclLineMatchExprToBooleanExpr, outState);
-    gen.generateTransitions(transformation);
+            node1, iface1, node2, iface2, tag, aclLineMatchExprToBooleanExpr, postState);
+    StateExpr stateExpr = gen.generateTransitions(transformation);
+    gen._statements.add(new BasicRuleStatement(preState, stateExpr));
     return gen._statements.build();
   }
 

--- a/projects/batfish/src/main/java/org/batfish/z3/state/visitors/Parameterizer.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/state/visitors/Parameterizer.java
@@ -332,8 +332,10 @@ public class Parameterizer implements GenericStateExprVisitor<List<StateParamete
   @Override
   public List<StateParameter> visitTransformation(TransformationExpr transformationExpr) {
     return ImmutableList.of(
-        new StateParameter(transformationExpr.getNode(), NODE),
-        new StateParameter(transformationExpr.getIface(), INTERFACE),
+        new StateParameter(transformationExpr.getNode1(), NODE),
+        new StateParameter(transformationExpr.getIface1(), INTERFACE),
+        new StateParameter(transformationExpr.getNode2(), NODE),
+        new StateParameter(transformationExpr.getIface2(), INTERFACE),
         new StateParameter(transformationExpr.getTag(), TRANSFORMATION_TAG),
         new StateParameter(Integer.toString(transformationExpr.getId()), TRANSFORMATION_ID));
   }
@@ -342,8 +344,10 @@ public class Parameterizer implements GenericStateExprVisitor<List<StateParamete
   public List<StateParameter> visitTransformationStep(
       TransformationStepExpr transformationStepExpr) {
     return ImmutableList.of(
-        new StateParameter(transformationStepExpr.getNode(), NODE),
-        new StateParameter(transformationStepExpr.getIface(), INTERFACE),
+        new StateParameter(transformationStepExpr.getNode1(), NODE),
+        new StateParameter(transformationStepExpr.getIface1(), INTERFACE),
+        new StateParameter(transformationStepExpr.getNode2(), NODE),
+        new StateParameter(transformationStepExpr.getIface2(), INTERFACE),
         new StateParameter(transformationStepExpr.getTag(), TRANSFORMATION_TAG),
         new StateParameter(
             Integer.toString(transformationStepExpr.getTransformationId()), TRANSFORMATION_ID),

--- a/projects/batfish/src/test/java/org/batfish/z3/expr/TransformationExprTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/expr/TransformationExprTest.java
@@ -9,12 +9,14 @@ public class TransformationExprTest {
   public void testEquals() {
     new EqualsTester()
         .addEqualityGroup(
-            new TransformationExpr("node1", "iface1", "tag1", 1),
-            new TransformationExpr("node1", "iface1", "tag1", 1))
-        .addEqualityGroup(new TransformationExpr("node1", "iface1", "tag1", 2))
-        .addEqualityGroup(new TransformationExpr("node1", "iface1", "tag2", 1))
-        .addEqualityGroup(new TransformationExpr("node1", "iface2", "tag1", 1))
-        .addEqualityGroup(new TransformationExpr("node2", "iface1", "tag1", 1))
+            new TransformationExpr("node1", "iface1", "node2", "iface2", "tag1", 1),
+            new TransformationExpr("node1", "iface1", "node2", "iface2", "tag1", 1))
+        .addEqualityGroup(new TransformationExpr("node1", "iface1", "node2", "iface2", "tag1", 2))
+        .addEqualityGroup(new TransformationExpr("node1", "iface1", "node2", "iface2", "tag2", 1))
+        .addEqualityGroup(new TransformationExpr("node1", "iface1", "node2", "iface3", "tag1", 1))
+        .addEqualityGroup(new TransformationExpr("node1", "iface1", "node3", "iface2", "tag1", 1))
+        .addEqualityGroup(new TransformationExpr("node1", "iface2", "node2", "iface2", "tag1", 1))
+        .addEqualityGroup(new TransformationExpr("node2", "iface1", "node2", "iface2", "tag1", 1))
         .testEquals();
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/z3/expr/TransformationStepExprTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/expr/TransformationStepExprTest.java
@@ -10,13 +10,22 @@ public class TransformationStepExprTest {
   public void testEquals() {
     new EqualsTester()
         .addEqualityGroup(
-            new TransformationStepExpr("node1", "iface1", "tag1", 1, 1),
-            new TransformationStepExpr("node1", "iface1", "tag1", 1, 1))
-        .addEqualityGroup(new TransformationStepExpr("node1", "iface1", "tag1", 1, 2))
-        .addEqualityGroup(new TransformationStepExpr("node1", "iface1", "tag1", 2, 1))
-        .addEqualityGroup(new TransformationStepExpr("node1", "iface1", "tag2", 1, 1))
-        .addEqualityGroup(new TransformationStepExpr("node1", "iface2", "tag1", 1, 1))
-        .addEqualityGroup(new TransformationStepExpr("node2", "iface1", "tag1", 1, 1))
+            new TransformationStepExpr("node1", "iface1", "node2", "iface2", "tag1", 1, 1),
+            new TransformationStepExpr("node1", "iface1", "node2", "iface2", "tag1", 1, 1))
+        .addEqualityGroup(
+            new TransformationStepExpr("node1", "iface1", "node2", "iface2", "tag1", 1, 2))
+        .addEqualityGroup(
+            new TransformationStepExpr("node1", "iface1", "node2", "iface2", "tag1", 2, 1))
+        .addEqualityGroup(
+            new TransformationStepExpr("node1", "iface1", "node2", "iface2", "tag2", 1, 1))
+        .addEqualityGroup(
+            new TransformationStepExpr("node1", "iface1", "node2", "iface3", "tag1", 1, 1))
+        .addEqualityGroup(
+            new TransformationStepExpr("node1", "iface1", "node3", "iface2", "tag1", 1, 1))
+        .addEqualityGroup(
+            new TransformationStepExpr("node1", "iface2", "node2", "iface2", "tag1", 1, 1))
+        .addEqualityGroup(
+            new TransformationStepExpr("node2", "iface1", "node2", "iface2", "tag1", 1, 1))
         .testEquals();
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/z3/matchers/SynthesizerInputMatchers.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/matchers/SynthesizerInputMatchers.java
@@ -2,9 +2,7 @@ package org.batfish.z3.matchers;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
-import javax.annotation.Nonnull;
 import org.batfish.datamodel.Edge;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.LineAction;
@@ -18,9 +16,7 @@ import org.batfish.z3.matchers.SynthesizerInputMatchersImpl.HasEnabledNodes;
 import org.batfish.z3.matchers.SynthesizerInputMatchersImpl.HasEnabledVrfs;
 import org.batfish.z3.matchers.SynthesizerInputMatchersImpl.HasIpsByHostname;
 import org.batfish.z3.matchers.SynthesizerInputMatchersImpl.HasNeighborUnreachable;
-import org.batfish.z3.matchers.SynthesizerInputMatchersImpl.HasSourceNats;
 import org.batfish.z3.matchers.SynthesizerInputMatchersImpl.HasTopologyInterfaces;
-import org.batfish.z3.state.AclPermit;
 import org.hamcrest.Matcher;
 
 public class SynthesizerInputMatchers {
@@ -103,17 +99,6 @@ public class SynthesizerInputMatchers {
   public static HasNeighborUnreachable hasNeighborUnreachable(
       Matcher<? super Map<String, Map<String, Map<String, BooleanExpr>>>> subMatcher) {
     return new HasNeighborUnreachable(subMatcher);
-  }
-
-  /**
-   * Provides a matcher that matches if the provided {@code subMatcher} matches the
-   * SynthesizerInput's source NATs.
-   */
-  public static HasSourceNats hasSourceNats(
-      @Nonnull
-          Matcher<? super Map<String, Map<String, List<Entry<AclPermit, BooleanExpr>>>>>
-              subMatcher) {
-    return new HasSourceNats(subMatcher);
   }
 
   /**

--- a/projects/batfish/src/test/java/org/batfish/z3/matchers/SynthesizerInputMatchersImpl.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/matchers/SynthesizerInputMatchersImpl.java
@@ -2,7 +2,6 @@ package org.batfish.z3.matchers;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import org.batfish.datamodel.Edge;
@@ -10,7 +9,6 @@ import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.LineAction;
 import org.batfish.z3.SynthesizerInput;
 import org.batfish.z3.expr.BooleanExpr;
-import org.batfish.z3.state.AclPermit;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 
@@ -132,23 +130,6 @@ public class SynthesizerInputMatchersImpl {
     protected Map<String, Map<String, Map<String, BooleanExpr>>> featureValueOf(
         SynthesizerInput actual) {
       return actual.getNeighborUnreachableOrExitsNetwork();
-    }
-  }
-
-  static final class HasSourceNats
-      extends FeatureMatcher<
-          SynthesizerInput, Map<String, Map<String, List<Entry<AclPermit, BooleanExpr>>>>> {
-    HasSourceNats(
-        @Nonnull
-            Matcher<? super Map<String, Map<String, List<Entry<AclPermit, BooleanExpr>>>>>
-                subMatcher) {
-      super(subMatcher, "SynthesizerInput with source NATs", "source NATs");
-    }
-
-    @Override
-    protected Map<String, Map<String, List<Entry<AclPermit, BooleanExpr>>>> featureValueOf(
-        SynthesizerInput actual) {
-      return actual.getSourceNats();
     }
   }
 

--- a/projects/batfish/src/test/java/org/batfish/z3/state/visitors/DefaultTransitionGeneratorTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/state/visitors/DefaultTransitionGeneratorTest.java
@@ -104,10 +104,6 @@ public class DefaultTransitionGeneratorTest {
 
   private static final Ip IP4 = Ip.parse("4.4.4.4");
 
-  private static final String NAT_ACL1 = "natacl1";
-
-  private static final String NAT_ACL2 = "natacl2";
-
   private static final String NODE1 = "node1";
 
   private static final String NODE2 = "node2";


### PR DESCRIPTION
Switch NOD reachability to use the outgoing transformations instead of source nat. Incoming transformation is not (yet) integrated. Changed TransformationExpr and TransformationStepExpr to be parameterized by edge instead of interface.