### PR TITLE
Check from location (interface/zone/routing instance) for outgoing transformations

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -2,6 +2,10 @@ package org.batfish.representation.juniper;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static org.batfish.datamodel.IpAccessListLine.accepting;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrcInterface;
+import static org.batfish.representation.juniper.NatPacketLocation.interfaceLocation;
+import static org.batfish.representation.juniper.NatPacketLocation.routingInstanceLocation;
+import static org.batfish.representation.juniper.NatPacketLocation.zoneLocation;
 import static org.batfish.representation.juniper.NatRuleMatchToHeaderSpace.toHeaderSpace;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -1400,6 +1404,37 @@ public final class JuniperConfiguration extends VendorConfiguration {
                                 natRule)))
         .filter(Objects::nonNull)
         .collect(ImmutableList.toImmutableList());
+  }
+
+  @VisibleForTesting
+  Map<NatPacketLocation, AclLineMatchExpr> fromNatPacketLocationMatchExprs() {
+    ImmutableMap.Builder<NatPacketLocation, AclLineMatchExpr> builder = ImmutableMap.builder();
+    _masterLogicalSystem
+        .getInterfaces()
+        .keySet()
+        .forEach(iface -> builder.put(interfaceLocation(iface), matchSrcInterface(iface)));
+    _masterLogicalSystem
+        .getZones()
+        .values()
+        .forEach(
+            zone ->
+                builder.put(
+                    zoneLocation(zone.getName()),
+                    matchSrcInterface(
+                        zone.getInterfaces()
+                            .stream()
+                            .map(Interface::getName)
+                            .toArray(String[]::new))));
+    _masterLogicalSystem
+        .getRoutingInstances()
+        .values()
+        .forEach(
+            routingInstance ->
+                builder.put(
+                    routingInstanceLocation(routingInstance.getName()),
+                    matchSrcInterface(
+                        routingInstance.getInterfaces().keySet().toArray(new String[0]))));
+    return builder.build();
   }
 
   private Map<NatPacketLocation, Set<String>> computeAllInterfacesForAllNatPacketLocation(Nat nat) {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/NatPacketLocation.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/NatPacketLocation.java
@@ -2,10 +2,28 @@ package org.batfish.representation.juniper;
 
 import java.io.Serializable;
 import java.util.Comparator;
+import java.util.Objects;
 import javax.annotation.Nullable;
 
 /** Represents how packets enter and exit a Nat */
 public final class NatPacketLocation implements Serializable, Comparable<NatPacketLocation> {
+  public static NatPacketLocation interfaceLocation(String name) {
+    NatPacketLocation loc = new NatPacketLocation();
+    loc.setInterface(name);
+    return loc;
+  }
+
+  public static NatPacketLocation routingInstanceLocation(String name) {
+    NatPacketLocation loc = new NatPacketLocation();
+    loc.setRoutingInstance(name);
+    return loc;
+  }
+
+  public static NatPacketLocation zoneLocation(String name) {
+    NatPacketLocation loc = new NatPacketLocation();
+    loc.setZone(name);
+    return loc;
+  }
 
   // The types are defined in a prioritized order
   enum Type {
@@ -60,6 +78,23 @@ public final class NatPacketLocation implements Serializable, Comparable<NatPack
 
   private Type getType() {
     return _type;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof NatPacketLocation)) {
+      return false;
+    }
+    NatPacketLocation that = (NatPacketLocation) o;
+    return Objects.equals(_name, that._name) && _type == that._type;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_name, _type);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/NatRuleSet.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/NatRuleSet.java
@@ -1,5 +1,7 @@
 package org.batfish.representation.juniper;
 
+import static org.batfish.datamodel.transformation.Transformation.when;
+
 import com.google.common.collect.Lists;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -10,8 +12,10 @@ import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.datamodel.flow.TransformationStep.TransformationType;
 import org.batfish.datamodel.transformation.IpField;
+import org.batfish.datamodel.transformation.Noop;
 import org.batfish.datamodel.transformation.Transformation;
 import org.batfish.datamodel.transformation.Transformation.Builder;
 
@@ -76,16 +80,61 @@ public final class NatRuleSet implements Serializable, Comparable<NatRuleSet> {
   }
 
   /**
-   * Convert to a vendor-independent {@link Transformation}.
+   * Convert to an outgoing {@link Transformation} in the vendor-independent model. The outgoing
+   * transformation is installed on the egress interface, so we need to encode constraints on the
+   * ingress interface using {@link AclLineMatchExpr ACL line match expressions}.
    *
+   * @param matchFromLocationExprs The {@link AclLineMatchExpr} to match traffic from each {@link
+   *     NatPacketLocation}.
    * @param andThen The next {@link Transformation} to apply after any {@link NatRule} matches.
+   * @param orElse The next {@link Transformation} to apply if no {@link NatRule} matches.
    */
-  public Optional<Transformation> toTransformation(
+  public Optional<Transformation> toOutgoingTransformation(
       TransformationType type,
       IpField ipField,
       Map<String, NatPool> pools,
-      @Nullable Transformation andThen) {
-    Transformation transformation = null;
+      Map<NatPacketLocation, AclLineMatchExpr> matchFromLocationExprs,
+      @Nullable Transformation andThen,
+      @Nullable Transformation orElse) {
+
+    AclLineMatchExpr matchFromLocation = matchFromLocationExprs.get(_fromLocation);
+
+    if (matchFromLocation == null) {
+      // non-existent NatPacketLocation
+      return Optional.empty();
+    }
+
+    return rulesTransformation(type, ipField, pools, andThen, orElse)
+        .map(
+            rulesTransformation ->
+                when(matchFromLocation)
+                    .apply(new Noop(type))
+                    .setAndThen(rulesTransformation)
+                    .setOrElse(orElse)
+                    .build());
+  }
+
+  /**
+   * Convert to an incoming {@link Transformation} in the vendor-independent model. Since the
+   * transformation is installed on the ingress interface, we don't need to use an {@link
+   * AclLineMatchExpr} to match it.
+   */
+  public Optional<Transformation> toIncomingTransformation(
+      TransformationType type,
+      IpField ipField,
+      Map<String, NatPool> pools,
+      @Nullable Transformation andThen,
+      @Nullable Transformation orElse) {
+    return rulesTransformation(type, ipField, pools, andThen, orElse);
+  }
+
+  private Optional<Transformation> rulesTransformation(
+      TransformationType type,
+      IpField ipField,
+      Map<String, NatPool> pools,
+      @Nullable Transformation andThen,
+      @Nullable Transformation orElse) {
+    Transformation transformation = orElse;
     for (NatRule rule : Lists.reverse(_rules)) {
       Optional<Builder> optionalBuilder = rule.toTransformationBuilder(type, ipField, pools);
       if (optionalBuilder.isPresent()) {

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
@@ -1,6 +1,7 @@
 package org.batfish.representation.juniper;
 
 import static org.batfish.common.Warnings.TAG_PEDANTIC;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrcInterface;
 import static org.batfish.datamodel.matchers.AndMatchExprMatchers.hasConjuncts;
 import static org.batfish.datamodel.matchers.AndMatchExprMatchers.isAndMatchExprThat;
 import static org.batfish.datamodel.matchers.HeaderSpaceMatchers.hasSrcIps;
@@ -10,6 +11,9 @@ import static org.batfish.datamodel.matchers.MatchHeaderSpaceMatchers.hasHeaderS
 import static org.batfish.datamodel.matchers.MatchHeaderSpaceMatchers.isMatchHeaderSpaceThat;
 import static org.batfish.representation.juniper.JuniperConfiguration.DEFAULT_ISIS_COST;
 import static org.batfish.representation.juniper.JuniperConfiguration.MAX_ISIS_COST_WITHOUT_WIDE_METRICS;
+import static org.batfish.representation.juniper.NatPacketLocation.interfaceLocation;
+import static org.batfish.representation.juniper.NatPacketLocation.routingInstanceLocation;
+import static org.batfish.representation.juniper.NatPacketLocation.zoneLocation;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -20,6 +24,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Iterables;
+import java.util.Map;
 import java.util.TreeMap;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -34,6 +39,7 @@ import org.batfish.datamodel.IpAccessListLine;
 import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.datamodel.acl.MatchSrcInterface;
 import org.junit.Test;
@@ -246,5 +252,45 @@ public class JuniperConfigurationTest {
     routingInstance.getIsisSettings().getLevel1Settings().setWideMetricsOnly(true);
     config.processIsisInterfaceSettings(routingInstance, true, false);
     assertThat(viIface.getIsis().getLevel1().getCost(), equalTo(100L));
+  }
+
+  @Test
+  public void testFromNatPacketLocationMatchExprs() {
+    JuniperConfiguration config = createConfig();
+
+    String interface1Name = "interface1";
+    config
+        .getMasterLogicalSystem()
+        .getInterfaces()
+        .put(interface1Name, new Interface(interface1Name));
+
+    Zone zone = new Zone("zone", new TreeMap<>());
+    String zoneInterface1Name = "zoneInterface1";
+    zone.getInterfaces().add(new Interface(zoneInterface1Name));
+    String zoneInterface2Name = "zoneInterface2";
+    zone.getInterfaces().add(new Interface(zoneInterface2Name));
+    config.getMasterLogicalSystem().getZones().put(zone.getName(), zone);
+
+    RoutingInstance routingInstance = config.getMasterLogicalSystem().getDefaultRoutingInstance();
+    String routingInstanceInterface1Name = "routingInstanceInterface1";
+    routingInstance
+        .getInterfaces()
+        .put(routingInstanceInterface1Name, new Interface(routingInstanceInterface1Name));
+    String routingInstanceInterface2Name = "routingInstanceInterface2";
+    routingInstance
+        .getInterfaces()
+        .put(routingInstanceInterface2Name, new Interface(routingInstanceInterface2Name));
+
+    Map<NatPacketLocation, AclLineMatchExpr> matchExprs = config.fromNatPacketLocationMatchExprs();
+    assertThat(
+        matchExprs,
+        equalTo(
+            ImmutableMap.of(
+                interfaceLocation(interface1Name), matchSrcInterface(interface1Name),
+                zoneLocation(zone.getName()),
+                    matchSrcInterface(zoneInterface1Name, zoneInterface2Name),
+                routingInstanceLocation(routingInstance.getName()),
+                    matchSrcInterface(
+                        routingInstanceInterface1Name, routingInstanceInterface2Name))));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/NatPacketLocationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/NatPacketLocationTest.java
@@ -1,0 +1,19 @@
+package org.batfish.representation.juniper;
+
+import static org.batfish.representation.juniper.NatPacketLocation.interfaceLocation;
+import static org.batfish.representation.juniper.NatPacketLocation.zoneLocation;
+
+import com.google.common.testing.EqualsTester;
+import org.junit.Test;
+
+/** Tests for {@link NatPacketLocation}. */
+public class NatPacketLocationTest {
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(interfaceLocation("1"), interfaceLocation("1"))
+        .addEqualityGroup(interfaceLocation("2"))
+        .addEqualityGroup(zoneLocation("1"))
+        .testEquals();
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/NatRuleSetTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/NatRuleSetTest.java
@@ -7,6 +7,7 @@ import static org.batfish.datamodel.flow.TransformationStep.TransformationType.S
 import static org.batfish.datamodel.transformation.Noop.NOOP_DEST_NAT;
 import static org.batfish.datamodel.transformation.Transformation.when;
 import static org.batfish.datamodel.transformation.TransformationStep.assignDestinationIp;
+import static org.batfish.representation.juniper.NatPacketLocation.interfaceLocation;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
@@ -16,6 +17,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.acl.MatchSrcInterface;
 import org.batfish.datamodel.transformation.IpField;
 import org.batfish.datamodel.transformation.Noop;
 import org.batfish.datamodel.transformation.Transformation;
@@ -23,7 +25,7 @@ import org.junit.Test;
 
 /** Tests for {@link NatRuleSet}. */
 public class NatRuleSetTest {
-  private void setLocation(
+  private static void setLocation(
       NatPacketLocation location, NatPacketLocation.Type type, String direction) {
     switch (type) {
       case InterfaceType:
@@ -75,6 +77,8 @@ public class NatRuleSetTest {
     natRule2.setThen(new NatRuleThenPool("POOL"));
 
     NatRuleSet ruleSet = new NatRuleSet("ruleset");
+    String fromIface = "fromLocationInterface";
+    ruleSet.getFromLocation().setInterface(fromIface);
     ruleSet.getRules().add(natRule1);
     ruleSet.getRules().add(natRule2);
 
@@ -85,23 +89,50 @@ public class NatRuleSetTest {
     pool.setToAddress(poolEnd);
 
     // the transformation to apply after any NatRule transformation is applied.
-    Transformation andThen = when(matchSrcInterface("IFACE")).apply(new Noop(SOURCE_NAT)).build();
+    Transformation andThen =
+        when(matchSrcInterface("and then")).apply(new Noop(SOURCE_NAT)).build();
+    Transformation orElse = when(matchSrcInterface("or else")).apply(new Noop(SOURCE_NAT)).build();
+
+    MatchSrcInterface matchFromIface = matchSrcInterface(fromIface);
+
+    // the transformation for the rules themselves
+    Transformation rulesTransformation =
+        // first apply natRule1
+        when(matchDst(prefix1))
+            .apply(NOOP_DEST_NAT)
+            .setAndThen(andThen)
+            .setOrElse(
+                // only apply natRule2 if natRule1 doesn't match
+                when(matchDst(prefix2))
+                    .apply(assignDestinationIp(poolStart, poolEnd))
+                    .setAndThen(andThen)
+                    .setOrElse(orElse)
+                    .build())
+            .build();
 
     assertThat(
         ruleSet
-            .toTransformation(DEST_NAT, IpField.DESTINATION, ImmutableMap.of("POOL", pool), andThen)
+            .toOutgoingTransformation(
+                DEST_NAT,
+                IpField.DESTINATION,
+                ImmutableMap.of("POOL", pool),
+                ImmutableMap.of(interfaceLocation(fromIface), matchFromIface),
+                andThen,
+                orElse)
             .get(),
         equalTo(
-            // first apply natRule1
-            when(matchDst(prefix1))
+            // first match from location
+            when(matchFromIface)
                 .apply(NOOP_DEST_NAT)
-                .setAndThen(andThen)
-                .setOrElse(
-                    // only apply natRule2 if natRule1 doesn't match
-                    when(matchDst(prefix2))
-                        .apply(assignDestinationIp(poolStart, poolEnd))
-                        .setAndThen(andThen)
-                        .build())
+                .setAndThen(rulesTransformation)
+                .setOrElse(orElse)
                 .build()));
+
+    assertThat(
+        ruleSet
+            .toIncomingTransformation(
+                DEST_NAT, IpField.DESTINATION, ImmutableMap.of("POOL", pool), andThen, orElse)
+            .get(),
+        equalTo(rulesTransformation));
   }
 }


### PR DESCRIPTION
In Juniper, outgoing transformations are applied conditionally depending
upon the source interface. We need to check the source interface before
applying the transformation. Incoming transformations do not need to do
the check, since they are installed on the source interface (i.e. we can
hard-code the value).