### PR TITLE
IsisRoute cleanup

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IsisRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IsisRoute.java
@@ -113,8 +113,6 @@ public class IsisRoute extends AbstractRoute {
         false);
   }
 
-  private final int _administrativeCost;
-
   private final String _area;
 
   private final boolean _attach;
@@ -145,7 +143,6 @@ public class IsisRoute extends AbstractRoute {
       boolean nonForwarding,
       boolean nonRouting) {
     super(network, administrativeCost, nonRouting, nonForwarding);
-    _administrativeCost = administrativeCost;
     _area = area;
     _attach = attach;
     _down = down;
@@ -165,7 +162,7 @@ public class IsisRoute extends AbstractRoute {
       return false;
     }
     IsisRoute rhs = (IsisRoute) o;
-    return _administrativeCost == rhs._administrativeCost
+    return _admin == rhs._admin
         && _area.equals(rhs._area)
         && _attach == rhs._attach
         && _down == rhs._down
@@ -173,8 +170,43 @@ public class IsisRoute extends AbstractRoute {
         && _metric == rhs._metric
         && _network.equals(rhs._network)
         && _nextHopIp.equals(rhs._nextHopIp)
+        && getNonForwarding() == rhs.getNonForwarding()
+        && getNonRouting() == rhs.getNonRouting()
         && _protocol == rhs._protocol
         && _systemId.equals(rhs._systemId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        _admin,
+        _area,
+        _attach,
+        _down,
+        _level.ordinal(),
+        _metric,
+        _network,
+        _nextHopIp,
+        getNonForwarding(),
+        getNonRouting(),
+        _protocol.ordinal(),
+        _systemId);
+  }
+
+  public Builder toBuilder() {
+    return new Builder()
+        .setAdmin(_admin)
+        .setArea(_area)
+        .setAttach(_attach)
+        .setDown(_down)
+        .setLevel(_level)
+        .setMetric(_metric)
+        .setNetwork(_network)
+        .setNextHopIp(_nextHopIp)
+        .setNonForwarding(getNonForwarding())
+        .setNonRouting(getNonRouting())
+        .setProtocol(_protocol)
+        .setSystemId(_systemId);
   }
 
   @JsonProperty(PROP_AREA)
@@ -234,20 +266,6 @@ public class IsisRoute extends AbstractRoute {
   @Override
   public int getTag() {
     return NO_TAG;
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(
-        _administrativeCost,
-        _area,
-        _attach,
-        _down,
-        _level.ordinal(),
-        _metric,
-        _nextHopIp,
-        _protocol.ordinal(),
-        _systemId);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/IsisRouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/IsisRouteTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 /** Tests of {@link IsisRoute} */
 public class IsisRouteTest {
   @Test
-  public void testEqualsByValue() {
+  public void testEqualsAndToBuilder() {
     IsisRoute.Builder b =
         new IsisRoute.Builder()
             .setNetwork(Prefix.parse("1.1.1.1/32"))
@@ -20,9 +20,8 @@ public class IsisRouteTest {
             .setSystemId("id");
 
     IsisRoute original = b.build();
-    // use StringBuilder to get fresh instance
-    IsisRoute updated = b.setArea(new StringBuilder("0").toString()).build();
+    IsisRoute copy = original.toBuilder().build();
 
-    assertThat(updated, equalTo(original));
+    assertThat(copy, equalTo(original));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/IsisRouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/IsisRouteTest.java
@@ -1,8 +1,6 @@
 package org.batfish.datamodel;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-
+import com.google.common.testing.EqualsTester;
 import org.batfish.datamodel.isis.IsisLevel;
 import org.junit.Test;
 
@@ -21,7 +19,17 @@ public class IsisRouteTest {
 
     IsisRoute original = b.build();
     IsisRoute copy = original.toBuilder().build();
+    IsisRoute differentAdmin = original.toBuilder().setAdmin(9000).build();
+    IsisRoute differentMetric = original.toBuilder().setMetric(original.getMetric() + 50).build();
+    IsisRoute differentNetwork = original.toBuilder().setNetwork(Prefix.parse("1.1.1.1/8")).build();
+    IsisRoute differentNextHop = original.toBuilder().setNextHopIp(Ip.parse("3.3.3.3")).build();
 
-    assertThat(copy, equalTo(original));
+    new EqualsTester()
+        .addEqualityGroup(original, copy)
+        .addEqualityGroup(differentAdmin)
+        .addEqualityGroup(differentMetric)
+        .addEqualityGroup(differentNetwork)
+        .addEqualityGroup(differentNextHop)
+        .testEquals();
   }
 }


### PR DESCRIPTION
- add `toBuilder()` method
- check `_network` in `hashCode()`
- remove redundant variable `_administrativeCost` in favor of `AbstractRoute._admin`