### PR TITLE
AnswerMetadataUtil.computeColumnMax - filter null values in calculation of return value

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AnswerMetadataUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AnswerMetadataUtil.java
@@ -107,6 +107,7 @@ public final class AnswerMetadataUtil {
         .getData()
         .stream()
         .map(rowToInteger)
+        .filter(streamInteger -> streamInteger != null)
         .max(Comparator.naturalOrder())
         .orElse(null);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AnswerMetadataUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AnswerMetadataUtil.java
@@ -82,6 +82,12 @@ public final class AnswerMetadataUtil {
                 columnAggregationsByColumnEntry.getValue(), Entry::getKey, Entry::getValue));
   }
 
+  /**
+   * Return the largest non-null value in the specified column. If the column cannot be interpreted
+   * as an Integer,or has only null values, returns null.
+   *
+   * @throws IllegalArgumentException if the named column is not present in the table.
+   */
   @VisibleForTesting
   @Nullable
   static Integer computeColumnMax(

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AnswerMetadataUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AnswerMetadataUtil.java
@@ -107,7 +107,7 @@ public final class AnswerMetadataUtil {
         .getData()
         .stream()
         .map(rowToInteger)
-        .filter(streamInteger -> streamInteger != null)
+        .filter(Objects::nonNull)
         .max(Comparator.naturalOrder())
         .orElse(null);
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/answers/AnswerMetadataUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/answers/AnswerMetadataUtilTest.java
@@ -199,6 +199,20 @@ public class AnswerMetadataUtilTest {
   }
 
   @Test
+  public void testComputeColumnMaxIntegerNull() {
+    String columnName = "col";
+
+    TableAnswerElement table =
+        new TableAnswerElement(
+                new TableMetadata(
+                    ImmutableList.of(new ColumnMetadata(columnName, Schema.INTEGER, "foobar")),
+                    new DisplayHints().getTextDesc()))
+            .addRow(Row.of(columnName, null));
+
+    assertThat(AnswerMetadataUtil.computeColumnMax(table, columnName, _logger), nullValue());
+  }
+
+  @Test
   public void testComputeColumnMaxOneRowInteger() {
     String columnName = "col";
     int value = 5;

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/answers/AnswerMetadataUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/answers/AnswerMetadataUtilTest.java
@@ -199,7 +199,7 @@ public class AnswerMetadataUtilTest {
   }
 
   @Test
-  public void testComputeColumnMaxIntegerNull() {
+  public void testComputeColumnMaxNullInteger() {
     String columnName = "col";
 
     TableAnswerElement table =
@@ -210,6 +210,24 @@ public class AnswerMetadataUtilTest {
             .addRow(Row.of(columnName, null));
 
     assertThat(AnswerMetadataUtil.computeColumnMax(table, columnName, _logger), nullValue());
+  }
+
+  @Test
+  public void testComputeColumnMaxNullAndNonNullInteger() {
+    String columnName = "col";
+
+    TableAnswerElement table =
+        new TableAnswerElement(
+                new TableMetadata(
+                    ImmutableList.of(new ColumnMetadata(columnName, Schema.INTEGER, "foobar")),
+                    new DisplayHints().getTextDesc()))
+            .addRow(Row.of(columnName, 1))
+            .addRow(Row.of(columnName, null))
+            .addRow(Row.of(columnName, 3))
+            .addRow(Row.of(columnName, null))
+            .addRow(Row.of(columnName, 2));
+
+    assertThat(AnswerMetadataUtil.computeColumnMax(table, columnName, _logger), equalTo(3));
   }
 
   @Test


### PR DESCRIPTION
Prevents null pointer exception if `rowToInteger` for `Schema.INTEGER` produces `null` values.