### PR TITLE
Parse Juniper level-specific passive IS-IS setting

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_isis.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_isis.g4
@@ -128,6 +128,7 @@ isi_level
     | isil_hello_interval
     | isil_hold_time
     | isil_metric
+    | isil_passive
     | isil_priority
     | isil_te_metric
   )
@@ -197,6 +198,11 @@ isil_hold_time
 isil_metric
 :
   METRIC DEC
+;
+
+isil_passive
+:
+  PASSIVE
 ;
 
 isil_priority

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -284,6 +284,7 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Isil_hello_authenticati
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Isil_hello_intervalContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Isil_hold_timeContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Isil_metricContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Isil_passiveContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Isil_priorityContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Isil_te_metricContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Isl_disableContext;
@@ -4115,7 +4116,8 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
 
   @Override
   public void exitIsi_passive(Isi_passiveContext ctx) {
-    _currentIsisInterface.getIsisSettings().setPassive(true);
+    _currentIsisInterface.getIsisSettings().getLevel1Settings().setPassive(true);
+    _currentIsisInterface.getIsisSettings().getLevel2Settings().setPassive(true);
   }
 
   @Override
@@ -4172,6 +4174,11 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   public void exitIsil_metric(Isil_metricContext ctx) {
     int metric = toInt(ctx.DEC());
     _currentIsisInterfaceLevelSettings.setMetric(metric);
+  }
+
+  @Override
+  public void exitIsil_passive(Isil_passiveContext ctx) {
+    _currentIsisInterfaceLevelSettings.setPassive(true);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/IsisInterfaceLevelSettings.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/IsisInterfaceLevelSettings.java
@@ -20,6 +20,8 @@ public class IsisInterfaceLevelSettings implements Serializable {
 
   @Nullable private Long _metric;
 
+  private boolean _passive;
+
   @Nullable private Long _teMetric;
 
   public boolean getEnabled() {
@@ -51,6 +53,10 @@ public class IsisInterfaceLevelSettings implements Serializable {
     return _metric;
   }
 
+  public boolean getPassive() {
+    return _passive;
+  }
+
   @Nullable
   public Long getTeMetric() {
     return _teMetric;
@@ -78,6 +84,10 @@ public class IsisInterfaceLevelSettings implements Serializable {
 
   public void setMetric(long metric) {
     _metric = metric;
+  }
+
+  public void setPassive(boolean passive) {
+    _passive = passive;
   }
 
   public void setTeMetric(long teMetric) {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/IsisInterfaceSettings.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/IsisInterfaceSettings.java
@@ -17,8 +17,6 @@ public class IsisInterfaceSettings implements Serializable {
 
   private final IsisInterfaceLevelSettings _level2Settings;
 
-  private boolean _passive;
-
   private boolean _pointToPoint;
 
   public IsisInterfaceSettings() {
@@ -46,10 +44,6 @@ public class IsisInterfaceSettings implements Serializable {
     return _level2Settings;
   }
 
-  public boolean getPassive() {
-    return _passive;
-  }
-
   public boolean getPointToPoint() {
     return _pointToPoint;
   }
@@ -64,10 +58,6 @@ public class IsisInterfaceSettings implements Serializable {
 
   public void setEnabled(boolean enabled) {
     _enabled = enabled;
-  }
-
-  public void setPassive(boolean passive) {
-    _passive = passive;
   }
 
   public void setPointToPoint(boolean pointToPoint) {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -627,18 +627,12 @@ public final class JuniperConfiguration extends VendorConfiguration {
     if (level1) {
       newInterfaceSettingsBuilder.setLevel1(
           toIsisInterfaceLevelSettings(
-              settings.getLevel1Settings(),
-              interfaceSettings,
-              interfaceSettings.getLevel1Settings(),
-              defaultCost));
+              settings.getLevel1Settings(), interfaceSettings.getLevel1Settings(), defaultCost));
     }
     if (level2) {
       newInterfaceSettingsBuilder.setLevel2(
           toIsisInterfaceLevelSettings(
-              settings.getLevel2Settings(),
-              interfaceSettings,
-              interfaceSettings.getLevel2Settings(),
-              defaultCost));
+              settings.getLevel2Settings(), interfaceSettings.getLevel2Settings(), defaultCost));
     }
     return newInterfaceSettingsBuilder
         .setBfdLivenessDetectionMinimumInterval(
@@ -651,7 +645,6 @@ public final class JuniperConfiguration extends VendorConfiguration {
 
   private org.batfish.datamodel.isis.IsisInterfaceLevelSettings toIsisInterfaceLevelSettings(
       IsisLevelSettings levelSettings,
-      IsisInterfaceSettings interfaceSettings,
       IsisInterfaceLevelSettings interfaceLevelSettings,
       long defaultCost) {
     long cost = firstNonNull(interfaceLevelSettings.getMetric(), defaultCost);

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -665,7 +665,9 @@ public final class JuniperConfiguration extends VendorConfiguration {
         .setHelloInterval(interfaceLevelSettings.getHelloInterval())
         .setHoldTime(interfaceLevelSettings.getHoldTime())
         .setMode(
-            interfaceSettings.getPassive() ? IsisInterfaceMode.PASSIVE : IsisInterfaceMode.ACTIVE)
+            interfaceLevelSettings.getPassive()
+                ? IsisInterfaceMode.PASSIVE
+                : IsisInterfaceMode.ACTIVE)
         .build();
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -2723,6 +2723,19 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testJuniperIsisPassiveLevel() throws IOException {
+    Configuration c = parseConfig("juniper-isis-passive-level");
+    assertThat(
+        c,
+        hasInterface(
+            "ge-1/2/0.0",
+            hasIsis(
+                allOf(
+                    hasLevel1(hasMode(IsisInterfaceMode.PASSIVE)),
+                    hasLevel2(hasMode(IsisInterfaceMode.ACTIVE))))));
+  }
+
+  @Test
   public void testJuniperOspfStubSettings() throws IOException {
     Configuration c = parseConfig("juniper-ospf-stub-settings");
 

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-isis-passive-level
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-isis-passive-level
@@ -1,0 +1,13 @@
+#
+set system host-name juniper-isis-passive-level
+#
+set interfaces ge-1/2/0 unit 0 family inet address 10.0.0.1/30
+set interfaces ge-1/2/0 unit 0 family iso
+#
+set interfaces lo0 unit 0 family inet address 192.168.0.1/32
+set interfaces lo0 unit 0 family iso address 49.0002.0192.0168.0001.00
+#
+set protocols isis interface ge-1/2/0.0 level 1 passive
+set protocols isis interface lo0.0 passive
+set protocols isis level 1 wide-metrics-only
+set protocols isis level 2 wide-metrics-only

--- a/tests/parsing-tests/networks/unit-tests/configs/juniper_isis
+++ b/tests/parsing-tests/networks/unit-tests/configs/juniper_isis
@@ -3,8 +3,12 @@ set system host-name juniper_isis
 #
 set groups gname protocols isis interface <*.*> family inet bfd-liveness-detection minimum-interval 100
 #
+set interfaces ge-0/0/0 unit 0
+#
 set protocols isis interface ge-0/0/0.0 disable
 set protocols isis interface ge-0/0/0.0 level 1 disable
+set protocols isis interface ge-0/0/0.0 passive
+set protocols isis interface ge-0/0/0.0 level 1 passive
 set protocols isis interface ge-0/0/0.0 level 2 priority 65
 set protocols isis interface ge-0/0/0.0 ldp-synchronization
 set protocols isis interface ge-0/0/0.0 node-link-protection

--- a/tests/parsing-tests/unit-tests-undefined.ref
+++ b/tests/parsing-tests/unit-tests-undefined.ref
@@ -2611,22 +2611,6 @@
         }
       },
       {
-        "File_Name" : "configs/juniper_isis",
-        "Struct_Type" : "interface",
-        "Ref_Name" : "ge-0/0/0.0",
-        "Context" : "isis interface",
-        "Lines" : {
-          "filename" : "configs/juniper_isis",
-          "lines" : [
-            6,
-            7,
-            8,
-            9,
-            10
-          ]
-        }
-      },
-      {
         "File_Name" : "configs/juniper_misc",
         "Struct_Type" : "interface",
         "Ref_Name" : "lo0.0",
@@ -3176,10 +3160,10 @@
       }
     ],
     "summary" : {
-      "notes" : "Found 257 results",
+      "notes" : "Found 256 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 257
+      "numResults" : 256
     }
   }
 ]

--- a/tests/parsing-tests/unit-tests-warnings.ref
+++ b/tests/parsing-tests/unit-tests-warnings.ref
@@ -555,7 +555,7 @@
       },
       {
         "Filename" : "juniper_isis",
-        "Line" : 8,
+        "Line" : 12,
         "Text" : "priority 65",
         "Parser_Context" : "[isil_priority isi_level is_interface p_isis s_protocols s_common statement set_line_tail set_line flat_juniper_configuration]",
         "Comment" : "This feature is not currently supported"

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -48853,6 +48853,22 @@
             "    (set_line_tail",
             "      (statement",
             "        (s_common",
+            "          (s_interfaces",
+            "            INTERFACES:'interfaces'",
+            "            (int_named",
+            "              (interface_id",
+            "                name = INTERFACE_NAME:'ge-0/0/0'  <== mode:M_Interface)",
+            "              (i_unit",
+            "                UNIT:'unit'",
+            "                num = DEC:'0'",
+            "                (i_common",
+            "                  (apply))))))))",
+            "    NEWLINE:'\\n')",
+            "  (set_line",
+            "    SET:'set'",
+            "    (set_line_tail",
+            "      (statement",
+            "        (s_common",
             "          (s_protocols",
             "            PROTOCOLS:'protocols'",
             "            (p_isis",
@@ -48886,6 +48902,45 @@
             "                  DEC:'1'",
             "                  (isil_disable",
             "                    DISABLE:'disable'))))))))",
+            "    NEWLINE:'\\n')",
+            "  (set_line",
+            "    SET:'set'",
+            "    (set_line_tail",
+            "      (statement",
+            "        (s_common",
+            "          (s_protocols",
+            "            PROTOCOLS:'protocols'",
+            "            (p_isis",
+            "              ISIS:'isis'",
+            "              (is_interface",
+            "                INTERFACE:'interface'",
+            "                id = (interface_id",
+            "                  name = INTERFACE_NAME:'ge-0/0/0'  <== mode:M_Interface",
+            "                  PERIOD:'.'",
+            "                  unit = DEC:'0')",
+            "                (isi_passive",
+            "                  PASSIVE:'passive')))))))",
+            "    NEWLINE:'\\n')",
+            "  (set_line",
+            "    SET:'set'",
+            "    (set_line_tail",
+            "      (statement",
+            "        (s_common",
+            "          (s_protocols",
+            "            PROTOCOLS:'protocols'",
+            "            (p_isis",
+            "              ISIS:'isis'",
+            "              (is_interface",
+            "                INTERFACE:'interface'",
+            "                id = (interface_id",
+            "                  name = INTERFACE_NAME:'ge-0/0/0'  <== mode:M_Interface",
+            "                  PERIOD:'.'",
+            "                  unit = DEC:'0')",
+            "                (isi_level",
+            "                  LEVEL:'level'",
+            "                  DEC:'1'",
+            "                  (isil_passive",
+            "                    PASSIVE:'passive'))))))))",
             "    NEWLINE:'\\n')",
             "  (set_line",
             "    SET:'set'",
@@ -62943,7 +62998,7 @@
           "Parse warnings" : [
             {
               "Comment" : "This feature is not currently supported",
-              "Line" : 8,
+              "Line" : 12,
               "Parser_Context" : "[isil_priority isi_level is_interface p_isis s_protocols s_common statement set_line_tail set_line flat_juniper_configuration]",
               "Text" : "priority 65"
             }
@@ -67121,7 +67176,22 @@
             }
           }
         },
-        "configs/juniper_isis" : { },
+        "configs/juniper_isis" : {
+          "interface" : {
+            "ge-0/0/0" : {
+              "definitionLines" : [
+                6
+              ],
+              "numReferrers" : 1
+            },
+            "ge-0/0/0.0" : {
+              "definitionLines" : [
+                6
+              ],
+              "numReferrers" : 8
+            }
+          }
+        },
         "configs/juniper_l2_learning" : { },
         "configs/juniper_misc" : { },
         "configs/juniper_nat" : {
@@ -70607,13 +70677,23 @@
         },
         "configs/juniper_isis" : {
           "interface" : {
+            "ge-0/0/0" : {
+              "interface" : [
+                6
+              ]
+            },
             "ge-0/0/0.0" : {
+              "interface" : [
+                6
+              ],
               "isis interface" : [
-                6,
-                7,
                 8,
                 9,
-                10
+                10,
+                11,
+                12,
+                13,
+                14
               ]
             }
           }
@@ -72591,19 +72671,6 @@
             "bippetyboppety" : {
               "interface vlan" : [
                 19
-              ]
-            }
-          }
-        },
-        "configs/juniper_isis" : {
-          "interface" : {
-            "ge-0/0/0.0" : {
-              "isis interface" : [
-                6,
-                7,
-                8,
-                9,
-                10
               ]
             }
           }


### PR DESCRIPTION
Adding the ability to parse:
`set protocols isis interface ge-1/2/0.0 level 1 passive`
in addition to setting the whole interface passive:
`set protocols isis interface ge-1/2/0.0 passive`