### PR TITLE
JNPR policy-statement: OR all prefix-lists

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -1964,7 +1964,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
           }
         }
         if (!prefixListsDisjunction.getDisjuncts().isEmpty()) {
-          conj.getConjuncts().add(prefixListsDisjunction.simplify());
+          conj.getConjuncts().add(prefixListsDisjunction);
         }
         if (!subroutines.isEmpty()) {
           ConjunctionChain chain = new ConjunctionChain(subroutines);

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -1925,6 +1925,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
         If ifStatement = new If();
         ifStatement.setComment(term.getName());
         Conjunction conj = new Conjunction();
+        Disjunction prefixListsDisjunction = new Disjunction();
         List<BooleanExpr> subroutines = new ArrayList<>();
         for (PsFrom from : term.getFroms()) {
           if (from instanceof PsFromRouteFilter) {
@@ -1956,9 +1957,14 @@ public final class JuniperConfiguration extends VendorConfiguration {
           if (from instanceof PsFromPolicyStatement
               || from instanceof PsFromPolicyStatementConjunction) {
             subroutines.add(booleanExpr);
+          } else if (from instanceof PsFromPrefixList) {
+            prefixListsDisjunction.getDisjuncts().add(booleanExpr);
           } else {
             conj.getConjuncts().add(booleanExpr);
           }
+        }
+        if (!prefixListsDisjunction.getDisjuncts().isEmpty()) {
+          conj.getConjuncts().add(prefixListsDisjunction.simplify());
         }
         if (!subroutines.isEmpty()) {
           ConjunctionChain chain = new ConjunctionChain(subroutines);

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -2768,7 +2768,7 @@ public final class FlatJuniperGrammarTest {
     // Configuration has policy statement with term that checks two prefix lists.
     Configuration c = parseConfig("juniper-from-prefix-list");
 
-    // Accept if network matches EITHER prefix list
+    // Accept if network matches either prefix list
     for (Prefix p : ImmutableList.of(Prefix.parse("1.1.1.0/24"), Prefix.parse("2.2.2.0/24"))) {
       Result result =
           c.getRoutingPolicies()
@@ -2781,8 +2781,23 @@ public final class FlatJuniperGrammarTest {
       assertThat(result.getBooleanValue(), equalTo(true));
     }
 
-    // Reject if network is missing from both prefix lists
+    // Reject if network does not match protocol
     Result result =
+        c.getRoutingPolicies()
+            .get("POLICY-NAME")
+            .call(
+                Environment.builder(c)
+                    .setVrf(Configuration.DEFAULT_VRF_NAME)
+                    .setOriginalRoute(
+                        StaticRoute.builder()
+                            .setAdministrativeCost(0)
+                            .setNetwork(Prefix.parse("1.1.1.0/24"))
+                            .build())
+                    .build());
+    assertThat(result.getBooleanValue(), equalTo(false));
+
+    // Reject if network is missing from both prefix lists
+    result =
         c.getRoutingPolicies()
             .get("POLICY-NAME")
             .call(

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -2764,6 +2764,36 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testJuniperPolicyStatementPrefixListDisjunction() throws IOException {
+    // Configuration has policy statement with term that checks two prefix lists.
+    Configuration c = parseConfig("juniper-from-prefix-list");
+
+    // Accept if network matches EITHER prefix list
+    for (Prefix p : ImmutableList.of(Prefix.parse("1.1.1.0/24"), Prefix.parse("2.2.2.0/24"))) {
+      Result result =
+          c.getRoutingPolicies()
+              .get("POLICY-NAME")
+              .call(
+                  Environment.builder(c)
+                      .setVrf(Configuration.DEFAULT_VRF_NAME)
+                      .setOriginalRoute(new ConnectedRoute(p, "nextHop"))
+                      .build());
+      assertThat(result.getBooleanValue(), equalTo(true));
+    }
+
+    // Reject if network is missing from both prefix lists
+    Result result =
+        c.getRoutingPolicies()
+            .get("POLICY-NAME")
+            .call(
+                Environment.builder(c)
+                    .setVrf(Configuration.DEFAULT_VRF_NAME)
+                    .setOriginalRoute(new ConnectedRoute(Prefix.parse("3.3.3.0/24"), "nextHop"))
+                    .build());
+    assertThat(result.getBooleanValue(), equalTo(false));
+  }
+
+  @Test
   public void testJuniperWildcards() throws IOException {
     String hostname = "juniper-wildcards";
     String loopback = "lo0.0";

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-from-prefix-list
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-from-prefix-list
@@ -1,0 +1,9 @@
+#
+set system host-name juniper-from-prefix-list
+#
+set policy-options prefix-list PREFIX-LIST1 1.1.1.1/24
+set policy-options prefix-list PREFIX-LIST2 2.2.2.0/24
+#
+set policy-options policy-statement POLICY-NAME term TERM1 from prefix-list PREFIX-LIST1
+set policy-options policy-statement POLICY-NAME term TERM1 from prefix-list PREFIX-LIST2
+set policy-options policy-statement POLICY-NAME term TERM1 then accept

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-from-prefix-list
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-from-prefix-list
@@ -1,9 +1,10 @@
 #
 set system host-name juniper-from-prefix-list
 #
-set policy-options prefix-list PREFIX-LIST1 1.1.1.1/24
+set policy-options prefix-list PREFIX-LIST1 1.1.1.0/24
 set policy-options prefix-list PREFIX-LIST2 2.2.2.0/24
 #
+set policy-options policy-statement POLICY-NAME term TERM1 from protocol direct
 set policy-options policy-statement POLICY-NAME term TERM1 from prefix-list PREFIX-LIST1
 set policy-options policy-statement POLICY-NAME term TERM1 from prefix-list PREFIX-LIST2
 set policy-options policy-statement POLICY-NAME term TERM1 then accept


### PR DESCRIPTION
Fixes a bug where routes were required to match every prefix list within a policy statement term instead of any one of them.