### PR TITLE
Cleanup pybatfish installation via pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ We highly recommend that you install Pybatfish in a Python 3 virtual environment
 Now, you are ready to evaluate your own network with Batfish. We encourage you to use Jupyter notebooks as your starting point, but you can use other methods that you are a comfortable with, e.g., an IDE like PyCharm or an interactive Python shell. If you choose to use Jupyter notebooks as your starting point, you need to install Jupyter in your virtual environment. Jupyter documentation can be found [here](http://jupyter.org/install) - but the commands below will get you going.
 
     python3 -m pip install jupyter
-    jupyter notebook`
+    jupyter notebook
 
 Our notebooks provide a quick start guide for different use cases. Beyond that, the complete documentation is available on [readthedocs](https://pybatfish.readthedocs.io/en/latest/quickstart.html). 
 

--- a/README.md
+++ b/README.md
@@ -79,29 +79,16 @@ This starts the service after mapping the local data folder to the data folder w
 
 Next, you need to install [Pybatfish](https://www.github.com/batfish/pybatfish) (the Python SDK) in order to interact with the service.
 
-## Download and install Pybatfish
-First, clone the Github repository. Change to the directory where you would like to clone the repository and issue the git command below.
+## Install Pybatfish
+We highly recommend that you install Pybatfish in a Python 3 virtual environment. Details on how to set one up can be found [here](https://docs.python.org/3/library/venv.html). Once your virtual environment is setup and activated, upgrade `pip` and then install `pybatfish`.
 
-  `cd /path/to/directory/where/you/want/to/clone/repo`
-  
-  `git clone git@github.com:batfish/pybatfish.git`
+    python3 -m pip install --upgrade pip
+    python3 -m pip install --upgrade git+https://github.com/batfish/pybatfish.git
 
-Then, install Pybatfish. We highly recommend that you install Pybatfish in a Python 3 virtual environment. Details on how to set one up can be found [here](https://docs.python.org/3/library/venv.html). 
+Now, you are ready to evaluate your own network with Batfish. We encourage you to use Jupyter notebooks as your starting point, but you can use other methods that you are a comfortable with, e.g., an IDE like PyCharm or an interactive Python shell. If you choose to use Jupyter notebooks as your starting point, you need to install Jupyter in your virtual environment. Jupyter documentation can be found [here](http://jupyter.org/install) - but the commands below will get you going.
 
-Once your virtual environment is setup and activated, issue the following commands
-
-  `cd /path/to/directory/where/you/want/to/clone/repo/pybatfish`
-  
-  `pip install -e .`
-
-Now, you are ready to evaluate your own network with Batfish.We encourage you to use Jupyter notebooks as your starting point, but you can use other methods that you are a comfortable with, e.g., an IDE like PyCharm or an interactive Python shell.
-If you choose to use Jupyter notebooks as your starting point, you need to install Jupyter in your virtual environment. Jupyter documentation can be found [here](http://jupyter.org/install) - but the commands below will get you going.
-
-   `pip install --upgrade pip`
-   
-   `pip install jupyter`
-   
-   `jupyter notebook`
+    python3 -m pip install jupyter
+    jupyter notebook`
 
 Our notebooks provide a quick start guide for different use cases. Beyond that, the complete documentation is available on [readthedocs](https://pybatfish.readthedocs.io/en/latest/quickstart.html). 
 


### PR DESCRIPTION
Folks need not clone via git, they can just use `pip` to do that directly.