### PR TITLE
Update fix_java_format script to use a temp file.

### DIFF
--- a/.travis/fix_java_format.sh
+++ b/.travis/fix_java_format.sh
@@ -22,29 +22,21 @@ fi
 if [ "$1" = "--diff" ]
 then
   # All java files in the diff
-  FILES_TO_CHECK=$(git diff --cached --name-only --diff-filter=ACMR | grep ".*java$" || true)
+  git diff --cached --name-only --diff-filter=ACMR | grep ".*java$" > files_to_check
 else
   # All java files in the project
-  FILES_TO_CHECK=$(${GNU_FIND} projects -regex '.*/src/main/.*\.java' -or -regex '.*/src/test/.*\.java')
-fi
-FILES_TO_CHECK=(${FILES_TO_CHECK})
-NUM_FILES_TO_CHECK=${#FILES_TO_CHECK[@]}
-
-# Exit early if no files to check
-if [[ 0 -eq ${NUM_FILES_TO_CHECK} ]]
-then
-  exit 0
+  ${GNU_FIND} projects -regex '.*/src/main/.*\.java' -or -regex '.*/src/test/.*\.java' > files_to_check
 fi
 
 # On travis, print affected filenames and fail. Locally, just fix the files.
 if [[ -z ${TRAVIS} ]]; then
   FORMAT_ARGS="--replace"
-  echo "Fixing ${NUM_FILES_TO_CHECK} misformatted java files"
+  echo "Fixing all misformatted java files"
 else
   FORMAT_ARGS="--dry-run --set-exit-if-changed"
   echo "Checking that all java files are formatted correctly"
 fi
 
 # Run the check
-java -jar ${JAR} ${FORMAT_ARGS} ${FILES_TO_CHECK[@]} \
+java -jar ${JAR} ${FORMAT_ARGS} @files_to_check && rm files_to_check \
   || (echo -e "\nThe files listed above are not formatted correctly. Use $0 to fix these issues. We recommend you install the Eclipse or IntelliJ plugin for google-java-format version ${GJF_VERSION}." && exit 1)


### PR DESCRIPTION
1. Avoids "argument list too long" error
2. Simplify script to not bother counting the files.