### PR TITLE
Maven: Add jacoco.skip to fast profile

### DIFF
--- a/projects/pom.xml
+++ b/projects/pom.xml
@@ -116,6 +116,7 @@
       <properties>
         <checkstyle.skip>true</checkstyle.skip>
         <findbugs.skip>true</findbugs.skip>
+        <jacoco.skip>true</jacoco.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <mdep.analyze.skip>true</mdep.analyze.skip>
         <pmd.skip>true</pmd.skip>


### PR DESCRIPTION
We only need code coverage results when running in CI, or manually.