### PR TITLE
buildkite: exclude javadoc

### DIFF
--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -99,7 +99,7 @@ EOF
 ###### Ensure the code still compiles with Bazel
 cat <<EOF
   - label: "Bazel compilation"
-    command: "bazel build //..."
+    command: "bazel build -- //... -projects:javadoc"
     plugins:
       - docker#${DOCKER_VERSION}:
           image: ${DOCKER_IMAGE}


### PR DESCRIPTION
It's the slow part of the pipeline, now bazel is not the slowest part.