### PR TITLE
Computation of Layer-1 Logical topology

### DIFF
--- a/projects/allinone/src/test/java/org/batfish/question/edges/EdgesTest.java
+++ b/projects/allinone/src/test/java/org/batfish/question/edges/EdgesTest.java
@@ -1,7 +1,9 @@
 package org.batfish.question.edges;
 
+import static org.batfish.question.edges.EdgesAnswerer.COL_INTERFACE;
 import static org.batfish.question.edges.EdgesAnswerer.COL_MULTICAST_GROUP;
 import static org.batfish.question.edges.EdgesAnswerer.COL_NODE;
+import static org.batfish.question.edges.EdgesAnswerer.COL_REMOTE_INTERFACE;
 import static org.batfish.question.edges.EdgesAnswerer.COL_REMOTE_NODE;
 import static org.batfish.question.edges.EdgesAnswerer.COL_REMOTE_VLAN;
 import static org.batfish.question.edges.EdgesAnswerer.COL_REMOTE_VTEP_ADDRESS;
@@ -12,30 +14,134 @@ import static org.batfish.question.edges.EdgesAnswerer.COL_VTEP_ADDRESS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import java.util.SortedMap;
 import org.batfish.common.NetworkSnapshot;
 import org.batfish.common.plugin.IBatfishTestAdapter;
+import org.batfish.common.topology.Layer1Edge;
+import org.batfish.common.topology.Layer1Node;
+import org.batfish.common.topology.Layer1Topology;
 import org.batfish.datamodel.BumTransportMethod;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.EdgeType;
+import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.VniSettings;
 import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.pojo.Node;
 import org.batfish.datamodel.questions.NodesSpecifier;
 import org.batfish.datamodel.table.Row;
 import org.batfish.datamodel.table.TableAnswerElement;
 import org.batfish.identifiers.NetworkId;
 import org.batfish.identifiers.SnapshotId;
+import org.junit.Before;
 import org.junit.Test;
 
 /** End-to-end tests of {@link org.batfish.question.edges}. */
 public final class EdgesTest {
+
+  private NetworkFactory _nf;
+  private Configuration.Builder _cb;
+  private Vrf.Builder _vb;
+  private Interface.Builder _ib;
+
+  @Before
+  public void setup() {
+    _nf = new NetworkFactory();
+    _cb = _nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+    _vb = _nf.vrfBuilder().setName(Configuration.DEFAULT_VRF_NAME);
+    _ib = _nf.interfaceBuilder();
+  }
+
+  @Test
+  public void testAnswerLayer1() {
+    String c1Name = "c1";
+    String c2Name = "c2";
+    String c1a1Name = "c1a1";
+    String c1i1aName = "c1i1a";
+    String c1i1bName = "c1i1b";
+    String c2a1Name = "c2a1";
+    String c2i1aName = "c2i1a";
+    String c2i1bName = "c2i1b";
+
+    Configuration c1 = _cb.setHostname(c1Name).build();
+    Vrf v1 = _vb.setOwner(c1).build();
+    _ib.setOwner(c1).setVrf(v1);
+    _ib.setName(c1i1aName).build().setChannelGroup(c1a1Name);
+    _ib.setName(c1i1bName).build().setChannelGroup(c1a1Name);
+    _ib.setName(c1a1Name).build();
+
+    Configuration c2 = _cb.setHostname(c2Name).build();
+    Vrf v2 = _vb.setOwner(c2).build();
+    _ib.setOwner(c2).setVrf(v2);
+    _ib.setName(c2a1Name).build();
+    _ib.setName(c2i1aName).build().setChannelGroup(c2a1Name);
+    _ib.setName(c2i1bName).build().setChannelGroup(c2a1Name);
+
+    SortedMap<String, Configuration> configurations = ImmutableSortedMap.of(c1Name, c1, c2Name, c2);
+    Layer1Topology layer1PhysicalTopology =
+        new Layer1Topology(
+            ImmutableSet.of(
+                new Layer1Edge(
+                    new Layer1Node(c1Name, c1i1aName), new Layer1Node(c2Name, c2i1aName)),
+                new Layer1Edge(
+                    new Layer1Node(c2Name, c2i1aName), new Layer1Node(c1Name, c1i1aName)),
+                new Layer1Edge(
+                    new Layer1Node(c1Name, c1i1bName), new Layer1Node(c2Name, c2i1bName)),
+                new Layer1Edge(
+                    new Layer1Node(c2Name, c2i1bName), new Layer1Node(c1Name, c1i1bName))));
+
+    TableAnswerElement answer =
+        (TableAnswerElement)
+            new EdgesAnswerer(
+                    new EdgesQuestion(NodesSpecifier.ALL, NodesSpecifier.ALL, EdgeType.LAYER1),
+                    new IBatfishTestAdapter() {
+                      @Override
+                      public SortedMap<String, Configuration> loadConfigurations(
+                          NetworkSnapshot snapshot) {
+                        return configurations;
+                      }
+
+                      @Override
+                      public Layer1Topology getLayer1Topology() {
+                        return layer1PhysicalTopology;
+                      }
+
+                      @Override
+                      public SortedMap<String, Configuration> loadConfigurations() {
+                        return configurations;
+                      }
+
+                      @Override
+                      public Topology getEnvironmentTopology() {
+                        return new Topology(ImmutableSortedSet.of());
+                      }
+
+                      @Override
+                      public NetworkSnapshot getNetworkSnapshot() {
+                        return new NetworkSnapshot(new NetworkId("a"), new SnapshotId("b"));
+                      }
+                    })
+                .answer();
+
+    assertThat(
+        answer.getRowsList(),
+        containsInAnyOrder(
+            Row.builder()
+                .put(COL_INTERFACE, new NodeInterfacePair(c1Name, c1a1Name))
+                .put(COL_REMOTE_INTERFACE, new NodeInterfacePair(c2Name, c2a1Name))
+                .build(),
+            Row.builder()
+                .put(COL_INTERFACE, new NodeInterfacePair(c2Name, c2a1Name))
+                .put(COL_REMOTE_INTERFACE, new NodeInterfacePair(c1Name, c1a1Name))
+                .build()));
+  }
 
   @Test
   public void testAnswerVxlan() {
@@ -48,14 +154,12 @@ public final class EdgesTest {
     int vlan1 = 1;
     int vlan2 = 2;
     int vni = 5000;
-    NetworkFactory nf = new NetworkFactory();
-    Configuration.Builder cb =
-        nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
-    Configuration c1 = cb.setHostname(node1).build();
-    Configuration c2 = cb.setHostname(node2).build();
-    Vrf.Builder vb = nf.vrfBuilder().setName(Configuration.DEFAULT_VRF_NAME);
-    Vrf v1 = vb.setOwner(c1).build();
-    Vrf v2 = vb.setOwner(c2).build();
+
+    Configuration c1 = _cb.setHostname(node1).build();
+    Configuration c2 = _cb.setHostname(node2).build();
+
+    Vrf v1 = _vb.setOwner(c1).build();
+    Vrf v2 = _vb.setOwner(c2).build();
     SortedMap<String, Configuration> configurations = ImmutableSortedMap.of(node1, c1, node2, c2);
     VniSettings.Builder vniSettingsBuilder =
         VniSettings.builder()

--- a/projects/allinone/src/test/java/org/batfish/question/edges/EdgesTest.java
+++ b/projects/allinone/src/test/java/org/batfish/question/edges/EdgesTest.java
@@ -70,6 +70,9 @@ public final class EdgesTest {
     String c2i1aName = "c2i1a";
     String c2i1bName = "c2i1b";
 
+    // A pair of physical interfaces on first node is connected to a pair of physical interfaces on
+    // second node. On each node, the pair is aggregated into a port-channel in the layer-1 logical
+    // topology.
     Configuration c1 = _cb.setHostname(c1Name).build();
     Vrf v1 = _vb.setOwner(c1).build();
     _ib.setOwner(c1).setVrf(v1);
@@ -130,6 +133,8 @@ public final class EdgesTest {
                     })
                 .answer();
 
+    // Each node should have an edge to the other node via the port-channel in the layer-1 logical
+    // topology.
     assertThat(
         answer.getRowsList(),
         containsInAnyOrder(

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/Layer1Edge.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/Layer1Edge.java
@@ -8,6 +8,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Comparator;
 import java.util.Objects;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.datamodel.NetworkConfigurations;
 
 public final class Layer1Edge implements Comparable<Layer1Edge> {
 
@@ -72,6 +74,15 @@ public final class Layer1Edge implements Comparable<Layer1Edge> {
   @Override
   public int hashCode() {
     return Objects.hash(_node1, _node2);
+  }
+
+  public @Nullable Layer1Edge toLogicalEdge(NetworkConfigurations networkConfigurations) {
+    Layer1Node node1 = _node1.toLogicalNode(networkConfigurations);
+    Layer1Node node2 = _node2.toLogicalNode(networkConfigurations);
+    if (node1 == null || node2 == null) {
+      return null;
+    }
+    return new Layer1Edge(node1, node2);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/Layer1Edge.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/Layer1Edge.java
@@ -76,6 +76,11 @@ public final class Layer1Edge implements Comparable<Layer1Edge> {
     return Objects.hash(_node1, _node2);
   }
 
+  /**
+   * Maps a layer-1 physical edge to a layer-1 logical edge by mapping its constituent layer-1
+   * physical edge to its corresponding logical edge, if possible. Returns the new layer-1 logical
+   * edge if both nodes can be successfully mapped, or else {@code null}.
+   */
   public @Nullable Layer1Edge toLogicalEdge(NetworkConfigurations networkConfigurations) {
     Layer1Node node1 = _node1.toLogicalNode(networkConfigurations);
     Layer1Node node2 = _node2.toLogicalNode(networkConfigurations);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/Layer1Edge.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/Layer1Edge.java
@@ -77,8 +77,8 @@ public final class Layer1Edge implements Comparable<Layer1Edge> {
   }
 
   /**
-   * Maps a layer-1 physical edge to a layer-1 logical edge by mapping its constituent layer-1
-   * physical edge to its corresponding logical edge, if possible. Returns the new layer-1 logical
+   * Maps a layer-1 physical edge to a layer-1 logical edge by mapping each constituent layer-1
+   * physical node to its corresponding logical node, if possible. Returns the new layer-1 logical
    * edge if both nodes can be successfully mapped, or else {@code null}.
    */
   public @Nullable Layer1Edge toLogicalEdge(NetworkConfigurations networkConfigurations) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/Layer1Node.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/Layer1Node.java
@@ -82,7 +82,7 @@ public final class Layer1Node implements Comparable<Layer1Node> {
     }
     return networkConfigurations
         .getInterface(_hostname, iface.getChannelGroup())
-        .map(c -> c.getActive() ? c : null)
+        .filter(Interface::getActive)
         .map(c -> new Layer1Node(_hostname, c.getName()))
         .orElse(null);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/Layer1Node.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/Layer1Node.java
@@ -8,6 +8,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Comparator;
 import java.util.Objects;
 import javax.annotation.Nonnull;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.NetworkConfigurations;
 
 public final class Layer1Node implements Comparable<Layer1Node> {
 
@@ -71,5 +73,17 @@ public final class Layer1Node implements Comparable<Layer1Node> {
         .add(PROP_HOSTNAME, _hostname)
         .add(PROP_INTERFACE_NAME, _interfaceName)
         .toString();
+  }
+
+  public @Nonnull Layer1Node toLogicalNode(NetworkConfigurations networkConfigurations) {
+    Interface iface = networkConfigurations.getInterface(_hostname, _interfaceName).get();
+    if (iface.getChannelGroup() == null) {
+      return this;
+    }
+    return networkConfigurations
+        .getInterface(_hostname, iface.getChannelGroup())
+        .map(c -> c.getActive() ? c : null)
+        .map(c -> new Layer1Node(_hostname, c.getName()))
+        .orElse(null);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/Layer1Node.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/Layer1Node.java
@@ -75,6 +75,12 @@ public final class Layer1Node implements Comparable<Layer1Node> {
         .toString();
   }
 
+  /**
+   * Maps a layer-1 physical node to a layer-1 logical node. If a physical node is a member of an
+   * aggregate interface, returns the node for the aggregate interface. If that aggregate interface
+   * is missing or off, returns {@code null}. If physical node is not member of an aggregate
+   * interface, the physical node is treated as a logical node and returned.
+   */
   public @Nonnull Layer1Node toLogicalNode(NetworkConfigurations networkConfigurations) {
     Interface iface = networkConfigurations.getInterface(_hostname, _interfaceName).get();
     if (iface.getChannelGroup() == null) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/TopologyProvider.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/TopologyProvider.java
@@ -18,6 +18,13 @@ public interface TopologyProvider {
   @Nonnull
   IpOwners getIpOwners(NetworkSnapshot snapshot);
 
+  /**
+   * Return the {@link Layer1Topology} with respect to logical layer-1 edges for a given {@link
+   * NetworkSnapshot}.
+   */
+  @Nonnull
+  Layer1Topology getLayer1LogicalTopology(NetworkSnapshot networkSnapshot);
+
   /** Return the {@link VxlanTopology} for a given {@link NetworkSnapshot}. */
   @Nonnull
   VxlanTopology getVxlanTopology(NetworkSnapshot snapshot);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/TopologyProvider.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/TopologyProvider.java
@@ -20,7 +20,13 @@ public interface TopologyProvider {
 
   /**
    * Return the {@link Layer1Topology} with respect to logical layer-1 edges for a given {@link
-   * NetworkSnapshot}.
+   * NetworkSnapshot}. The logical layer-1 topology is constructed from the physical layer-1
+   * topology by collapsing each set of edges betweeen physical interfaces belonging to the same
+   * aggregates on each side into a single edge between the aggregate interfaces.<br>
+   * <br>
+   * So for example the two edges (n1:i1,n2:i1), (n1:i2,n2:i2) would be aggregated into a single
+   * edge (n1:a1,n2:a1) if on both n1 and n2 the interfaces i1 and i2 are members of an aggregate
+   * interface a1.
    */
   @Nonnull
   Layer1Topology getLayer1LogicalTopology(NetworkSnapshot networkSnapshot);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/TopologyUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/TopologyUtil.java
@@ -33,6 +33,7 @@ import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpSpace;
+import org.batfish.datamodel.NetworkConfigurations;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.SwitchportMode;
 import org.batfish.datamodel.Topology;
@@ -83,7 +84,7 @@ public final class TopologyUtil {
     }
   }
 
-  public static @Nonnull Layer1Topology computeLayer1Topology(
+  public static @Nonnull Layer1Topology computeLayer1PhysicalTopology(
       @Nonnull Layer1Topology rawLayer1Topology,
       @Nonnull Map<String, Configuration> configurations) {
     /* Filter out inactive interfaces */
@@ -542,5 +543,14 @@ public final class TopologyUtil {
       }
     }
     return new Topology(edges.build());
+  }
+
+  public static Layer1Topology computeLayer1LogicalTopology(
+      Layer1Topology layer1PhysicalTopology, Map<String, Configuration> configurations) {
+    return new Layer1Topology(
+        layer1PhysicalTopology.getGraph().edges().stream()
+            .map(pEdge -> pEdge.toLogicalEdge(NetworkConfigurations.of(configurations)))
+            .filter(Objects::nonNull)
+            .collect(ImmutableSet.toImmutableSet()));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/plugin/IBatfishTestAdapter.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/plugin/IBatfishTestAdapter.java
@@ -20,6 +20,7 @@ import org.batfish.common.topology.IpOwners;
 import org.batfish.common.topology.Layer1Topology;
 import org.batfish.common.topology.Layer2Topology;
 import org.batfish.common.topology.TopologyProvider;
+import org.batfish.common.topology.TopologyUtil;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.BgpAdvertisement;
 import org.batfish.datamodel.Configuration;
@@ -219,6 +220,11 @@ public class IBatfishTestAdapter implements IBatfish {
       @Override
       public IpOwners getIpOwners(NetworkSnapshot snapshot) {
         return new IpOwners(loadConfigurations(snapshot));
+      }
+
+      @Override
+      public Layer1Topology getLayer1LogicalTopology(NetworkSnapshot networkSnapshot) {
+        return TopologyUtil.computeLayer1LogicalTopology(getLayer1Topology(), loadConfigurations());
       }
 
       @Override

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/Layer1EdgeTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/Layer1EdgeTest.java
@@ -1,0 +1,111 @@
+package org.batfish.common.topology;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+import com.google.common.collect.ImmutableSortedMap;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.NetworkConfigurations;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.Vrf;
+import org.junit.Before;
+import org.junit.Test;
+
+public final class Layer1EdgeTest {
+  private Configuration.Builder _cb;
+  private Interface.Builder _ib;
+  private NetworkFactory _nf;
+  private Vrf.Builder _vb;
+
+  @Before
+  public void setup() {
+    _nf = new NetworkFactory();
+    _cb = _nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+    _vb = _nf.vrfBuilder().setName(Configuration.DEFAULT_VRF_NAME);
+    _ib = _nf.interfaceBuilder();
+  }
+
+  @Test
+  public void testToLogicalEdgeNode1Absent() {
+    String c1Name = "c1";
+    String c2Name = "c2";
+    String iName = "i1";
+
+    Configuration c1 = _cb.setHostname(c1Name).build();
+    Vrf v1 = _vb.setOwner(c1).build();
+    _ib.setOwner(c1).setVrf(v1);
+    _ib.setName(iName).build().setChannelGroup("missing");
+
+    Configuration c2 = _cb.setHostname(c2Name).build();
+    Vrf v2 = _vb.setOwner(c2).build();
+    _ib.setOwner(c2).setVrf(v2);
+    _ib.setName(iName).build();
+
+    NetworkConfigurations networkConfigurations =
+        NetworkConfigurations.of(ImmutableSortedMap.of(c1Name, c1, c2Name, c2));
+    Layer1Edge edge = new Layer1Edge(new Layer1Node(c1Name, iName), new Layer1Node(c2Name, iName));
+
+    // If node1 of a layer-1 physical edge cannot be mapped to a layer-1 logical node, a null edge
+    // should be returned.
+    assertThat(edge.toLogicalEdge(networkConfigurations), nullValue());
+  }
+
+  @Test
+  public void testToLogicalEdgeNode2Absent() {
+    String c1Name = "c1";
+    String c2Name = "c2";
+    String iName = "i1";
+
+    Configuration c1 = _cb.setHostname(c1Name).build();
+    Vrf v1 = _vb.setOwner(c1).build();
+    _ib.setOwner(c1).setVrf(v1);
+    _ib.setName(iName).build();
+
+    Configuration c2 = _cb.setHostname(c2Name).build();
+    Vrf v2 = _vb.setOwner(c2).build();
+    _ib.setOwner(c2).setVrf(v2);
+    // force node2 to map to null
+    _ib.setName(iName).build().setChannelGroup("missing");
+
+    NetworkConfigurations networkConfigurations =
+        NetworkConfigurations.of(ImmutableSortedMap.of(c1Name, c1, c2Name, c2));
+    Layer1Edge edge = new Layer1Edge(new Layer1Node(c1Name, iName), new Layer1Node(c2Name, iName));
+
+    // If node2 of a layer-1 physical edge cannot be mapped to a layer-1 logical node, a null edge
+    // should be returned.
+    assertThat(edge.toLogicalEdge(networkConfigurations), nullValue());
+  }
+
+  @Test
+  public void testToLogicalEdgePresent() {
+    String c1Name = "c1";
+    String c2Name = "c2";
+    String iName = "i1";
+
+    Configuration c1 = _cb.setHostname(c1Name).build();
+    Vrf v1 = _vb.setOwner(c1).build();
+    _ib.setOwner(c1).setVrf(v1);
+    _ib.setName(iName).build();
+
+    Configuration c2 = _cb.setHostname(c2Name).build();
+    Vrf v2 = _vb.setOwner(c2).build();
+    _ib.setOwner(c2).setVrf(v2);
+    _ib.setName(iName).build();
+
+    NetworkConfigurations networkConfigurations =
+        NetworkConfigurations.of(ImmutableSortedMap.of(c1Name, c1, c2Name, c2));
+    Layer1Edge edge = new Layer1Edge(new Layer1Node(c1Name, iName), new Layer1Node(c2Name, iName));
+
+    // If both nodes of a layer-1 physical edge, can be mapped to a layer-1 logical node, the
+    // resulting edge should contain those logical nodes.
+    assertThat(
+        edge.toLogicalEdge(networkConfigurations),
+        equalTo(
+            new Layer1Edge(
+                edge.getNode1().toLogicalNode(networkConfigurations),
+                edge.getNode2().toLogicalNode(networkConfigurations))));
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/Layer1NodeTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/Layer1NodeTest.java
@@ -1,0 +1,108 @@
+package org.batfish.common.topology;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+import com.google.common.collect.ImmutableSortedMap;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.NetworkConfigurations;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.Vrf;
+import org.junit.Before;
+import org.junit.Test;
+
+public final class Layer1NodeTest {
+  private Configuration.Builder _cb;
+  private Interface.Builder _ib;
+  private NetworkFactory _nf;
+  private Vrf.Builder _vb;
+
+  @Before
+  public void setup() {
+    _nf = new NetworkFactory();
+    _cb = _nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+    _vb = _nf.vrfBuilder().setName(Configuration.DEFAULT_VRF_NAME);
+    _ib = _nf.interfaceBuilder();
+  }
+
+  @Test
+  public void testToLogicalNodeAggregate() {
+    String c1Name = "c1";
+    String iName = "i1";
+    String aName = "a1";
+
+    Configuration c1 = _cb.setHostname(c1Name).build();
+    Vrf v1 = _vb.setOwner(c1).build();
+    _ib.setOwner(c1).setVrf(v1);
+    _ib.setName(iName).build().setChannelGroup(aName);
+    _ib.setName(aName).build();
+
+    NetworkConfigurations networkConfigurations =
+        NetworkConfigurations.of(ImmutableSortedMap.of(c1Name, c1));
+    Layer1Node node = new Layer1Node(c1Name, iName);
+
+    // If node is member of an aggregate, the resulting logical node should be for the aggregate
+    // interface.
+    assertThat(node.toLogicalNode(networkConfigurations), equalTo(new Layer1Node(c1Name, aName)));
+  }
+
+  @Test
+  public void testToLogicalNodeInactiveAggregate() {
+    String c1Name = "c1";
+    String iName = "i1";
+    String aName = "a1";
+
+    Configuration c1 = _cb.setHostname(c1Name).build();
+    Vrf v1 = _vb.setOwner(c1).build();
+    _ib.setOwner(c1).setVrf(v1);
+    _ib.setName(iName).build().setChannelGroup(aName);
+    _ib.setName(aName).setActive(false).build();
+
+    NetworkConfigurations networkConfigurations =
+        NetworkConfigurations.of(ImmutableSortedMap.of(c1Name, c1));
+    Layer1Node node = new Layer1Node(c1Name, iName);
+
+    // If node is member of a disabled aggregate, the result should be null
+    assertThat(node.toLogicalNode(networkConfigurations), nullValue());
+  }
+
+  @Test
+  public void testToLogicalNodeMissingAggregate() {
+    String c1Name = "c1";
+    String iName = "i1";
+
+    Configuration c1 = _cb.setHostname(c1Name).build();
+    Vrf v1 = _vb.setOwner(c1).build();
+    _ib.setOwner(c1).setVrf(v1);
+    _ib.setName(iName).build().setChannelGroup("missing");
+
+    NetworkConfigurations networkConfigurations =
+        NetworkConfigurations.of(ImmutableSortedMap.of(c1Name, c1));
+    Layer1Node node = new Layer1Node(c1Name, iName);
+
+    // If node is member of a missing aggregate, the result should be null
+    assertThat(node.toLogicalNode(networkConfigurations), nullValue());
+  }
+
+  @Test
+  public void testToLogicalNodeNonAggregate() {
+    String c1Name = "c1";
+    String iName = "i1";
+
+    Configuration c1 = _cb.setHostname(c1Name).build();
+    Vrf v1 = _vb.setOwner(c1).build();
+    _ib.setOwner(c1).setVrf(v1);
+    _ib.setName(iName).build();
+
+    NetworkConfigurations networkConfigurations =
+        NetworkConfigurations.of(ImmutableSortedMap.of(c1Name, c1));
+    Layer1Node node = new Layer1Node(c1Name, iName);
+
+    // If node is not member of an aggregate, the resulting logical node should reference the
+    // physical interface name.
+    assertThat(node.toLogicalNode(networkConfigurations), equalTo(node));
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/TopologyUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/TopologyUtilTest.java
@@ -57,7 +57,200 @@ public final class TopologyUtilTest {
   }
 
   @Test
-  public void testComputeLayer1Topology() {
+  public void testComputeLayer1LogicalTopologyPhysicalNonAggregate() {
+    String c1Name = "c1";
+    String c2Name = "c2";
+    String c1i1Name = "c1i1";
+    String c2i1Name = "c2i1";
+
+    Configuration c1 = _cb.setHostname(c1Name).build();
+    Vrf v1 = _vb.setOwner(c1).build();
+    _ib.setOwner(c1).setVrf(v1);
+    _ib.setName(c1i1Name).build();
+
+    Configuration c2 = _cb.setHostname(c2Name).build();
+    Vrf v2 = _vb.setOwner(c2).build();
+    _ib.setOwner(c2).setVrf(v2);
+    _ib.setName(c2i1Name).build();
+
+    Map<String, Configuration> configurations = ImmutableMap.of(c1Name, c1, c2Name, c2);
+    Layer1Topology layer1PhysicalTopology =
+        new Layer1Topology(
+            ImmutableSet.of(
+                new Layer1Edge(new Layer1Node(c1Name, c1i1Name), new Layer1Node(c2Name, c2i1Name)),
+                new Layer1Edge(
+                    new Layer1Node(c2Name, c2i1Name), new Layer1Node(c1Name, c1i1Name))));
+
+    assertThat(
+        TopologyUtil.computeLayer1LogicalTopology(layer1PhysicalTopology, configurations)
+            .getGraph()
+            .edges(),
+        containsInAnyOrder(
+            new Layer1Edge(new Layer1Node(c1Name, c1i1Name), new Layer1Node(c2Name, c2i1Name)),
+            new Layer1Edge(new Layer1Node(c2Name, c2i1Name), new Layer1Node(c1Name, c1i1Name))));
+  }
+
+  @Test
+  public void testComputeLayer1LogicalTopologyAggregate() {
+    String c1Name = "c1";
+    String c2Name = "c2";
+    String c1a1Name = "c1a1";
+    String c1i1aName = "c1i1a";
+    String c1i1bName = "c1i1b";
+    String c2a1Name = "c2a1";
+    String c2i1aName = "c2i1a";
+    String c2i1bName = "c2i1b";
+
+    Configuration c1 = _cb.setHostname(c1Name).build();
+    Vrf v1 = _vb.setOwner(c1).build();
+    _ib.setOwner(c1).setVrf(v1);
+    _ib.setName(c1i1aName).build().setChannelGroup(c1a1Name);
+    _ib.setName(c1i1bName).build().setChannelGroup(c1a1Name);
+    _ib.setName(c1a1Name).build();
+
+    Configuration c2 = _cb.setHostname(c2Name).build();
+    Vrf v2 = _vb.setOwner(c2).build();
+    _ib.setOwner(c2).setVrf(v2);
+    _ib.setName(c2a1Name).build();
+    _ib.setName(c2i1aName).build().setChannelGroup(c2a1Name);
+    _ib.setName(c2i1bName).build().setChannelGroup(c2a1Name);
+
+    Map<String, Configuration> configurations = ImmutableMap.of(c1Name, c1, c2Name, c2);
+    Layer1Topology layer1PhysicalTopology =
+        new Layer1Topology(
+            ImmutableSet.of(
+                new Layer1Edge(
+                    new Layer1Node(c1Name, c1i1aName), new Layer1Node(c2Name, c2i1aName)),
+                new Layer1Edge(
+                    new Layer1Node(c2Name, c2i1aName), new Layer1Node(c1Name, c1i1aName)),
+                new Layer1Edge(
+                    new Layer1Node(c1Name, c1i1bName), new Layer1Node(c2Name, c2i1bName)),
+                new Layer1Edge(
+                    new Layer1Node(c2Name, c2i1bName), new Layer1Node(c1Name, c1i1bName))));
+
+    // Should be empty since aggregate disabled
+    assertThat(
+        TopologyUtil.computeLayer1LogicalTopology(layer1PhysicalTopology, configurations)
+            .getGraph()
+            .edges(),
+        containsInAnyOrder(
+            new Layer1Edge(new Layer1Node(c1Name, c1a1Name), new Layer1Node(c2Name, c2a1Name)),
+            new Layer1Edge(new Layer1Node(c2Name, c2a1Name), new Layer1Node(c1Name, c1a1Name))));
+
+    c1.getAllInterfaces().get(c1a1Name).setActive(true);
+    c2.getAllInterfaces().get(c2a1Name).setActive(false);
+
+    // Make sure same behavior occurs for node2
+    assertThat(
+        TopologyUtil.computeLayer1LogicalTopology(layer1PhysicalTopology, configurations)
+            .getGraph()
+            .edges(),
+        empty());
+  }
+
+  @Test
+  public void testComputeLayer1LogicalTopologyAggregateDisabled() {
+    String c1Name = "c1";
+    String c2Name = "c2";
+    String c1a1Name = "c1a1";
+    String c1i1aName = "c1i1a";
+    String c1i1bName = "c1i1b";
+    String c2a1Name = "c2a1";
+    String c2i1aName = "c2i1a";
+    String c2i1bName = "c2i1b";
+
+    Configuration c1 = _cb.setHostname(c1Name).build();
+    Vrf v1 = _vb.setOwner(c1).build();
+    _ib.setOwner(c1).setVrf(v1);
+    _ib.setName(c1i1aName).build().setChannelGroup(c1a1Name);
+    _ib.setName(c1i1bName).build().setChannelGroup(c1a1Name);
+    _ib.setActive(false).setName(c1a1Name).build();
+
+    Configuration c2 = _cb.setHostname(c2Name).build();
+    Vrf v2 = _vb.setOwner(c2).build();
+    _ib.setOwner(c2).setVrf(v2).setActive(true);
+    _ib.setName(c2a1Name).build();
+    _ib.setName(c2i1aName).build().setChannelGroup(c2a1Name);
+    _ib.setName(c2i1bName).build().setChannelGroup(c2a1Name);
+
+    Map<String, Configuration> configurations = ImmutableMap.of(c1Name, c1, c2Name, c2);
+    Layer1Topology layer1PhysicalTopology =
+        new Layer1Topology(
+            ImmutableSet.of(
+                new Layer1Edge(
+                    new Layer1Node(c1Name, c1i1aName), new Layer1Node(c2Name, c2i1aName)),
+                new Layer1Edge(
+                    new Layer1Node(c2Name, c2i1aName), new Layer1Node(c1Name, c1i1aName)),
+                new Layer1Edge(
+                    new Layer1Node(c1Name, c1i1bName), new Layer1Node(c2Name, c2i1bName)),
+                new Layer1Edge(
+                    new Layer1Node(c2Name, c2i1bName), new Layer1Node(c1Name, c1i1bName))));
+
+    // Should be empty since aggregate disabled
+    assertThat(
+        TopologyUtil.computeLayer1LogicalTopology(layer1PhysicalTopology, configurations)
+            .getGraph()
+            .edges(),
+        empty());
+
+    c1.getAllInterfaces().get(c1a1Name).setActive(true);
+    c2.getAllInterfaces().get(c2a1Name).setActive(false);
+
+    // Make sure same behavior occurs for node2
+    assertThat(
+        TopologyUtil.computeLayer1LogicalTopology(layer1PhysicalTopology, configurations)
+            .getGraph()
+            .edges(),
+        empty());
+  }
+
+  @Test
+  public void testComputeLayer1LogicalTopologyAggregateMissing() {
+    String c1Name = "c1";
+    String c2Name = "c2";
+    String c1a1Name = "c1a1";
+    String c1i1aName = "c1i1a";
+    String c1i1bName = "c1i1b";
+    String c2a1Name = "c2a1";
+    String c2i1aName = "c2i1a";
+    String c2i1bName = "c2i1b";
+
+    Configuration c1 = _cb.setHostname(c1Name).build();
+    Vrf v1 = _vb.setOwner(c1).build();
+    _ib.setOwner(c1).setVrf(v1);
+    _ib.setName(c1i1aName).build().setChannelGroup(c1a1Name);
+    _ib.setName(c1i1bName).build().setChannelGroup(c1a1Name);
+
+    Configuration c2 = _cb.setHostname(c2Name).build();
+    Vrf v2 = _vb.setOwner(c2).build();
+    _ib.setOwner(c2).setVrf(v2);
+    _ib.setName(c2a1Name).build();
+    _ib.setName(c2i1aName).build().setChannelGroup(c2a1Name);
+    _ib.setName(c2i1bName).build().setChannelGroup(c2a1Name);
+
+    Map<String, Configuration> configurations = ImmutableMap.of(c1Name, c1, c2Name, c2);
+    Layer1Topology layer1PhysicalTopology =
+        new Layer1Topology(
+            ImmutableSet.of(
+                new Layer1Edge(
+                    new Layer1Node(c1Name, c1i1aName), new Layer1Node(c2Name, c2i1aName)),
+                new Layer1Edge(
+                    new Layer1Node(c2Name, c2i1aName), new Layer1Node(c1Name, c1i1aName)),
+                new Layer1Edge(
+                    new Layer1Node(c1Name, c1i1bName), new Layer1Node(c2Name, c2i1bName)),
+                new Layer1Edge(
+                    new Layer1Node(c2Name, c2i1bName), new Layer1Node(c1Name, c1i1bName))));
+
+    // Should be empty since c1a1 is missing
+    assertThat(
+        TopologyUtil.computeLayer1LogicalTopology(layer1PhysicalTopology, configurations)
+            .getGraph()
+            .edges(),
+        empty());
+  }
+
+  @Test
+  public void testComputeLayer1PhysicalTopology() {
     String c1Name = "c1";
     String c2Name = "c2";
     String c1i1Name = "c1i1";
@@ -89,7 +282,9 @@ public final class TopologyUtilTest {
 
     // inactive c2i2 should break c1i2<=>c2i2 link
     assertThat(
-        TopologyUtil.computeLayer1Topology(rawLayer1Topology, configurations).getGraph().edges(),
+        TopologyUtil.computeLayer1PhysicalTopology(rawLayer1Topology, configurations)
+            .getGraph()
+            .edges(),
         containsInAnyOrder(
             new Layer1Edge(new Layer1Node(c1Name, c1i1Name), new Layer1Node(c2Name, c2i1Name)),
             new Layer1Edge(new Layer1Node(c2Name, c2i1Name), new Layer1Node(c1Name, c1i1Name))));

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -865,12 +865,15 @@ public class Batfish extends PluginConsumer implements IBatfish {
       _logger.infof(
           "Testrig:%s in container:%s has layer-1 topology file",
           getTestrigName(), getContainerName());
-      newBatch("Processing layer-1 topology", 0);
-      Layer1Topology layer1Topology =
-          TopologyUtil.computeLayer1Topology(rawLayer1Topology, configurations);
+      newBatch("Processing layer-1 physical topology", 0);
+      Layer1Topology layer1PhysicalTopology =
+          TopologyUtil.computeLayer1PhysicalTopology(rawLayer1Topology, configurations);
+      newBatch("Computing layer-1 logical topology", 0);
+      Layer1Topology layer1LogicalTopology =
+          TopologyUtil.computeLayer1LogicalTopology(layer1PhysicalTopology, configurations);
       newBatch("Computing layer-2 topology", 0);
       Layer2Topology layer2Topology =
-          TopologyUtil.computeLayer2Topology(layer1Topology, configurations);
+          TopologyUtil.computeLayer2Topology(layer1LogicalTopology, configurations);
       newBatch("Computing layer-3 topology", 0);
       return TopologyUtil.computeLayer3Topology(layer2Topology, configurations);
     }

--- a/projects/question/src/main/java/org/batfish/question/edges/EdgesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/edges/EdgesAnswerer.java
@@ -148,8 +148,9 @@ public class EdgesAnswerer extends Answerer {
             _batfish.getTopologyProvider().getVxlanTopology(_batfish.getNetworkSnapshot());
         return getVxlanEdges(includeNodes, includeRemoteNodes, vxlanTopology);
       case LAYER1:
-        Layer1Topology layer1Topology = _batfish.getLayer1Topology();
-        return getLayer1Edges(includeNodes, includeRemoteNodes, layer1Topology);
+        Layer1Topology layer1LogicalTopology =
+            _batfish.getTopologyProvider().getLayer1LogicalTopology(_batfish.getNetworkSnapshot());
+        return getLayer1Edges(includeNodes, includeRemoteNodes, layer1LogicalTopology);
       case LAYER2:
         // Unsupported until we decide how to present layer2 topology.
         return ImmutableMultiset.of();


### PR DESCRIPTION
- Logical topology replaces aggregated interfaces with the aggregate
  interface of which they are a constituent.
- Layer-2 topology computation is now based off of Layer-1 logical
  topology.
- Edges question now returns Layer-1 logical topology when edgeType is
  Layer-1.