### PR TITLE
move interface to traceroute out of dataplane plugin

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/DataPlanePlugin.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/DataPlanePlugin.java
@@ -1,18 +1,13 @@
 package org.batfish.common.plugin;
 
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DataPlane;
-import org.batfish.datamodel.Flow;
-import org.batfish.datamodel.FlowTrace;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.answers.DataPlaneAnswerElement;
-import org.batfish.datamodel.flow.Trace;
 
 /**
  * Abstract class that defines the behavior expected for a Batfish plugin that implements data plane
@@ -61,17 +56,6 @@ public abstract class DataPlanePlugin extends BatfishPlugin implements IDataPlan
     dataPlanePluginInitialize();
   }
 
-  /**
-   * Builds the {@link Trace}s for a {@link Set} of {@link Flow}s
-   *
-   * @param flows {@link Set} of {@link Flow} for which {@link Trace}s are to be found
-   * @param dataPlane {@link DataPlane} for this network snapshot
-   * @param ignoreFilters if true, will ignore filters/ACLs encountered in the network
-   * @return {@link SortedMap} of {@link Flow} to {@link List} of {@link Trace}s
-   */
-  public abstract SortedMap<Flow, List<Trace>> buildFlows(
-      Set<Flow> flows, DataPlane dataPlane, boolean ignoreFilters);
-
   public abstract ComputeDataPlaneResult computeDataPlane(boolean differentialContext);
 
   public abstract ComputeDataPlaneResult computeDataPlane(
@@ -79,16 +63,8 @@ public abstract class DataPlanePlugin extends BatfishPlugin implements IDataPlan
 
   protected void dataPlanePluginInitialize() {}
 
-  public abstract List<Flow> getHistoryFlows(DataPlane dataPlane);
-
-  public abstract List<FlowTrace> getHistoryFlowTraces(DataPlane dataPlane);
-
-  public abstract ITracerouteEngine getTracerouteEngine();
-
   public abstract SortedMap<String, SortedMap<String, SortedSet<AbstractRoute>>> getRoutes(
       DataPlane dataPlane);
-
-  public abstract void processFlows(Set<Flow> flows, DataPlane dataPlane, boolean ignoreFilters);
 
   /** Return the name of this plugin */
   public abstract String getName();

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
@@ -107,8 +107,6 @@ public interface IBatfish extends IPluginConsumer {
 
   String getFlowTag();
 
-  FlowHistory getHistory();
-
   /** Get the configuration of the major issue type {@code majorIssueType} if its present */
   MajorIssueConfig getMajorIssueConfig(String majorIssueType);
 
@@ -120,6 +118,10 @@ public interface IBatfish extends IPluginConsumer {
 
   @Nonnull
   NetworkSnapshot getNetworkSnapshot();
+
+  FlowHistory flowHistory(Set<Flow> flows, boolean ignoreFilters);
+
+  FlowHistory differentialFlowHistory(Set<Flow> flows, boolean ignoreFilters);
 
   NodeRolesData getNodeRolesData();
 
@@ -183,7 +185,7 @@ public interface IBatfish extends IPluginConsumer {
 
   Set<BgpAdvertisement> loadExternalBgpAnnouncements(Map<String, Configuration> configurations);
 
-  void processFlows(Set<Flow> flows, boolean ignoreFilters);
+  TracerouteEngine getTracerouteEngine();
 
   void pushBaseSnapshot();
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
@@ -185,6 +185,7 @@ public interface IBatfish extends IPluginConsumer {
 
   Set<BgpAdvertisement> loadExternalBgpAnnouncements(Map<String, Configuration> configurations);
 
+  /** @return a {@link TracerouteEngine} for the current snapshot. */
   TracerouteEngine getTracerouteEngine();
 
   void pushBaseSnapshot();

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/TracerouteEngine.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/TracerouteEngine.java
@@ -1,11 +1,8 @@
 package org.batfish.common.plugin;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
-import org.batfish.datamodel.DataPlane;
-import org.batfish.datamodel.Fib;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowTrace;
 import org.batfish.datamodel.flow.Trace;
@@ -14,25 +11,15 @@ import org.batfish.datamodel.flow.Trace;
  * Indicates ability to process a set of {@link Flow} objects and return a set of {@link FlowTrace},
  * performing a traceroute.
  */
-public interface ITracerouteEngine {
-  SortedMap<Flow, Set<FlowTrace>> processFlows(
-      DataPlane dataPlane,
-      Set<Flow> flows,
-      Map<String, Map<String, Fib>> fibs,
-      boolean ignoreFilters);
+public interface TracerouteEngine {
+  SortedMap<Flow, Set<FlowTrace>> processFlows(Set<Flow> flows, boolean ignoreFilters);
 
   /**
    * Builds the {@link Trace}s for a {@link Set} of {@link Flow}s
    *
-   * @param dataPlane {@link DataPlane} for this network snapshot
    * @param flows {@link Set} of {@link Flow} for which {@link Trace}s are to be found
-   * @param fibs {@link Fib} for the dataplane
    * @param ignoreFilters if true, will ignore ACLs
    * @return {@link SortedMap} of {@link Flow}s to {@link List} of {@link Trace}s
    */
-  SortedMap<Flow, List<Trace>> buildFlows(
-      DataPlane dataPlane,
-      Set<Flow> flows,
-      Map<String, Map<String, Fib>> fibs,
-      boolean ignoreFilters);
+  SortedMap<Flow, List<Trace>> buildFlows(Set<Flow> flows, boolean ignoreFilters);
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FlowHistory.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FlowHistory.java
@@ -62,6 +62,32 @@ public class FlowHistory extends AnswerElement {
     _traces = new TreeMap<>();
   }
 
+  public static FlowHistory forDifferentialTraces(
+      String baseEnvTag,
+      Environment baseEnv,
+      Map<Flow, Set<FlowTrace>> baseTraces,
+      String deltaEnvTag,
+      Environment deltaEnv,
+      Map<Flow, Set<FlowTrace>> deltaTraces) {
+    FlowHistory flowHistory = new FlowHistory();
+    baseTraces.forEach(
+        (flow, traces) ->
+            traces.forEach(trace -> flowHistory.addFlowTrace(flow, baseEnvTag, baseEnv, trace)));
+    deltaTraces.forEach(
+        (flow, traces) ->
+            traces.forEach(trace -> flowHistory.addFlowTrace(flow, deltaEnvTag, deltaEnv, trace)));
+    return flowHistory;
+  }
+
+  public static FlowHistory forTraces(
+      String envTag, Environment env, Map<Flow, Set<FlowTrace>> traces) {
+    FlowHistory flowHistory = new FlowHistory();
+    traces.forEach(
+        (flow, flowTraces) ->
+            flowTraces.forEach(trace -> flowHistory.addFlowTrace(flow, envTag, env, trace)));
+    return flowHistory;
+  }
+
   public void addFlowTrace(Flow flow, String envTag, Environment environment, FlowTrace trace) {
     String flowText = flow.toString();
     if (!_traces.containsKey(flowText)) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/BgpTopologyUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/BgpTopologyUtils.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.common.BatfishException;
-import org.batfish.common.plugin.ITracerouteEngine;
+import org.batfish.common.plugin.TracerouteEngine;
 import org.batfish.datamodel.BgpActivePeerConfig;
 import org.batfish.datamodel.BgpPassivePeerConfig;
 import org.batfish.datamodel.BgpPeerConfig;
@@ -47,7 +47,7 @@ public final class BgpTopologyUtils {
   /**
    * Compute the BGP topology -- a network of {@link BgpPeerConfig}s connected by {@link
    * BgpSessionProperties}s. See {@link #initBgpTopology(Map, Map, boolean, boolean,
-   * ITracerouteEngine, DataPlane)} for more details.
+   * TracerouteEngine, DataPlane)} for more details.
    *
    * @param configurations configuration keyed by hostname
    * @param ipOwners Ip owners (see {@link
@@ -78,7 +78,7 @@ public final class BgpTopologyUtils {
    *     reachable and sessions can be established correctly. <b>Note:</b> this is different from
    *     {@code keepInvalid=false}, which only does filters invalid neighbors at the control-plane
    *     level
-   * @param tracerouteEngine an instance of {@link ITracerouteEngine} for doing reachability checks.
+   * @param tracerouteEngine an instance of {@link TracerouteEngine} for doing reachability checks.
    * @param dp (partially) computed dataplane.
    * @return A graph ({@link Network}) representing all BGP peerings.
    */
@@ -87,7 +87,7 @@ public final class BgpTopologyUtils {
       Map<Ip, Set<String>> ipOwners,
       boolean keepInvalid,
       boolean checkReachability,
-      @Nullable ITracerouteEngine tracerouteEngine,
+      @Nullable TracerouteEngine tracerouteEngine,
       @Nullable DataPlane dp) {
     try (ActiveSpan span =
         GlobalTracer.get().buildSpan("BgpTopologyUtils.initBgpTopology").startActive()) {
@@ -173,7 +173,7 @@ public final class BgpTopologyUtils {
            */
           if (checkReachability) {
             if (isReachableBgpNeighbor(
-                neighborId, candidateNeighborId, neighbor, tracerouteEngine, dp)) {
+                neighborId, candidateNeighborId, neighbor, tracerouteEngine)) {
               graph.putEdgeValue(
                   neighborId,
                   candidateNeighborId,
@@ -249,15 +249,15 @@ public final class BgpTopologyUtils {
       BgpPeerConfigId initiator,
       BgpPeerConfigId listener,
       BgpActivePeerConfig src,
-      @Nullable ITracerouteEngine tracerouteEngine,
-      @Nullable DataPlane dp) {
+      @Nullable TracerouteEngine tracerouteEngine) {
     Ip srcAddress = src.getLocalIp();
     Ip dstAddress = src.getPeerAddress();
     if (dstAddress == null) {
       return false;
     }
-    if (tracerouteEngine == null || dp == null) {
-      throw new BatfishException("Cannot compute neighbor reachability without a dataplane");
+    if (tracerouteEngine == null) {
+      throw new BatfishException(
+          "Cannot compute neighbor reachability without a traceroute engine");
     }
 
     /*
@@ -277,7 +277,7 @@ public final class BgpTopologyUtils {
 
     // Execute the "initiate connection" traceroute
     SortedMap<Flow, List<Trace>> traces =
-        tracerouteEngine.buildFlows(dp, ImmutableSet.of(forwardFlow), dp.getFibs(), false);
+        tracerouteEngine.buildFlows(ImmutableSet.of(forwardFlow), false);
 
     boolean isEbgpSingleHop =
         SessionType.isEbgp(BgpSessionProperties.getSessionType(src)) && !src.getEbgpMultihop();
@@ -310,7 +310,7 @@ public final class BgpTopologyUtils {
     fb.setSrcPort(forwardFlow.getDstPort());
     fb.setDstPort(forwardFlow.getSrcPort());
     Flow backwardFlow = fb.build();
-    traces = tracerouteEngine.buildFlows(dp, ImmutableSet.of(backwardFlow), dp.getFibs(), false);
+    traces = tracerouteEngine.buildFlows(ImmutableSet.of(backwardFlow), false);
 
     /*
      * If backward traceroutes fail, do not consider the neighbor reachable

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/BgpTopologyUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/BgpTopologyUtils.java
@@ -31,7 +31,6 @@ import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.BgpSessionProperties;
 import org.batfish.datamodel.BgpSessionProperties.SessionType;
 import org.batfish.datamodel.Configuration;
-import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowDisposition;
 import org.batfish.datamodel.Ip;
@@ -47,7 +46,7 @@ public final class BgpTopologyUtils {
   /**
    * Compute the BGP topology -- a network of {@link BgpPeerConfig}s connected by {@link
    * BgpSessionProperties}s. See {@link #initBgpTopology(Map, Map, boolean, boolean,
-   * TracerouteEngine, DataPlane)} for more details.
+   * TracerouteEngine)} for more details.
    *
    * @param configurations configuration keyed by hostname
    * @param ipOwners Ip owners (see {@link
@@ -61,7 +60,7 @@ public final class BgpTopologyUtils {
       Map<String, Configuration> configurations,
       Map<Ip, Set<String>> ipOwners,
       boolean keepInvalid) {
-    return initBgpTopology(configurations, ipOwners, keepInvalid, false, null, null);
+    return initBgpTopology(configurations, ipOwners, keepInvalid, false, null);
   }
 
   /**
@@ -79,7 +78,6 @@ public final class BgpTopologyUtils {
    *     {@code keepInvalid=false}, which only does filters invalid neighbors at the control-plane
    *     level
    * @param tracerouteEngine an instance of {@link TracerouteEngine} for doing reachability checks.
-   * @param dp (partially) computed dataplane.
    * @return A graph ({@link Network}) representing all BGP peerings.
    */
   public static ValueGraph<BgpPeerConfigId, BgpSessionProperties> initBgpTopology(
@@ -87,8 +85,7 @@ public final class BgpTopologyUtils {
       Map<Ip, Set<String>> ipOwners,
       boolean keepInvalid,
       boolean checkReachability,
-      @Nullable TracerouteEngine tracerouteEngine,
-      @Nullable DataPlane dp) {
+      @Nullable TracerouteEngine tracerouteEngine) {
     try (ActiveSpan span =
         GlobalTracer.get().buildSpan("BgpTopologyUtils.initBgpTopology").startActive()) {
       assert span != null; // avoid unused warning

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/plugin/IBatfishTestAdapter.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/plugin/IBatfishTestAdapter.java
@@ -151,11 +151,6 @@ public class IBatfishTestAdapter implements IBatfish {
   }
 
   @Override
-  public FlowHistory getHistory() {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
   public MajorIssueConfig getMajorIssueConfig(String majorIssue) {
     throw new UnsupportedOperationException();
   }
@@ -327,7 +322,7 @@ public class IBatfishTestAdapter implements IBatfish {
   }
 
   @Override
-  public void processFlows(Set<Flow> flows, boolean ignoreFilters) {
+  public TracerouteEngine getTracerouteEngine() {
     throw new UnsupportedOperationException();
   }
 
@@ -481,5 +476,15 @@ public class IBatfishTestAdapter implements IBatfish {
   public NetworkSnapshot getNetworkSnapshot() {
     throw new UnsupportedOperationException(
         "no implementation for generated method"); // TODO Auto-generated method stub
+  }
+
+  @Override
+  public FlowHistory flowHistory(Set<Flow> flows, boolean ignoreFilters) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public FlowHistory differentialFlowHistory(Set<Flow> flows, boolean ignoreFilters) {
+    throw new UnsupportedOperationException();
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/BgpTopologyUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/BgpTopologyUtilsTest.java
@@ -103,7 +103,7 @@ public class BgpTopologyUtilsTest {
         ImmutableMap.of(ip1, ImmutableSet.of("node1"), ip2, ImmutableSet.of("node2"));
 
     ValueGraph<BgpPeerConfigId, BgpSessionProperties> bgpTopology =
-        initBgpTopology(_configs, ipOwners, true, false, null, null);
+        initBgpTopology(_configs, ipOwners, true, false, null);
     assertThat(bgpTopology.edges(), hasSize(1));
     EndpointPair<BgpPeerConfigId> edge = bgpTopology.edges().iterator().next();
     assertThat(edge.source().getHostname(), equalTo("node1"));
@@ -154,7 +154,7 @@ public class BgpTopologyUtilsTest {
             ImmutableSet.of("node3"));
 
     ValueGraph<BgpPeerConfigId, BgpSessionProperties> bgpTopology =
-        initBgpTopology(_configs, ipOwners, true, false, null, null);
+        initBgpTopology(_configs, ipOwners, true, false, null);
     assertThat(bgpTopology.edges(), hasSize(1));
     EndpointPair<BgpPeerConfigId> edge = bgpTopology.edges().iterator().next();
     assertThat(edge.source().getHostname(), equalTo("node1"));

--- a/projects/batfish/src/main/java/org/batfish/dataplane/TracerouteEngineImpl.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/TracerouteEngineImpl.java
@@ -1,53 +1,40 @@
 package org.batfish.dataplane;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
-import org.batfish.common.plugin.ITracerouteEngine;
+import org.batfish.common.plugin.TracerouteEngine;
 import org.batfish.datamodel.DataPlane;
-import org.batfish.datamodel.Fib;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowTrace;
 import org.batfish.datamodel.flow.Trace;
 import org.batfish.dataplane.traceroute.TracerouteEngineImplContext;
 
 /** The default implementation of a traceroute engine */
-public class TracerouteEngineImpl implements ITracerouteEngine {
-  private static ITracerouteEngine _instance = new TracerouteEngineImpl();
+public final class TracerouteEngineImpl implements TracerouteEngine {
+  private final DataPlane _dataPlane;
 
-  public static ITracerouteEngine getInstance() {
-    return _instance;
+  public TracerouteEngineImpl(DataPlane dataPlane) {
+    _dataPlane = dataPlane;
   }
 
-  private TracerouteEngineImpl() {}
-
   @Override
-  public SortedMap<Flow, Set<FlowTrace>> processFlows(
-      DataPlane dataPlane,
-      Set<Flow> flows,
-      Map<String, Map<String, Fib>> fibs,
-      boolean ignoreFilters) {
+  public SortedMap<Flow, Set<FlowTrace>> processFlows(Set<Flow> flows, boolean ignoreFilters) {
     return new org.batfish.dataplane.TracerouteEngineImplContext(
-            dataPlane, flows, fibs, ignoreFilters)
+            _dataPlane, flows, _dataPlane.getFibs(), ignoreFilters)
         .processFlows();
   }
 
   /**
    * Builds the {@link Trace}s for a {@link Set} of {@link Flow}s
    *
-   * @param dataPlane {@link DataPlane} for this network snapshot
    * @param flows {@link Set} of {@link Flow} for which {@link Trace}s are to be found
-   * @param fibs {@link Fib} for the dataplane
    * @param ignoreFilters if true, will ignore ACLs
    * @return {@link SortedMap} of {@link Flow}s to {@link List} of {@link Trace}s
    */
   @Override
-  public SortedMap<Flow, List<Trace>> buildFlows(
-      DataPlane dataPlane,
-      Set<Flow> flows,
-      Map<String, Map<String, Fib>> fibs,
-      boolean ignoreFilters) {
-    return new TracerouteEngineImplContext(dataPlane, flows, fibs, ignoreFilters).buildFlows();
+  public SortedMap<Flow, List<Trace>> buildFlows(Set<Flow> flows, boolean ignoreFilters) {
+    return new TracerouteEngineImplContext(_dataPlane, flows, _dataPlane.getFibs(), ignoreFilters)
+        .buildFlows();
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -192,8 +192,7 @@ class IncrementalBdpEngine {
                   ipOwners,
                   false,
                   true,
-                  new TracerouteEngineImpl(partialDataplane),
-                  partialDataplane);
+                  new TracerouteEngineImpl(partialDataplane));
 
           boolean isOscillating =
               computeNonMonotonicPortionOfDataPlane(

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -192,7 +192,7 @@ class IncrementalBdpEngine {
                   ipOwners,
                   false,
                   true,
-                  TracerouteEngineImpl.getInstance(),
+                  new TracerouteEngineImpl(partialDataplane),
                   partialDataplane);
 
           boolean isOscillating =

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePlugin.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePlugin.java
@@ -1,27 +1,18 @@
 package org.batfish.dataplane.ibdp;
 
 import com.google.auto.service.AutoService;
-import com.google.common.collect.ImmutableList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
 import org.batfish.common.plugin.DataPlanePlugin;
-import org.batfish.common.plugin.ITracerouteEngine;
 import org.batfish.common.plugin.Plugin;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.BgpAdvertisement;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DataPlane;
-import org.batfish.datamodel.Flow;
-import org.batfish.datamodel.FlowTrace;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.answers.IncrementalBdpAnswerElement;
-import org.batfish.datamodel.flow.Trace;
-import org.batfish.dataplane.TracerouteEngineImpl;
 
 /** A batfish plugin that registers the Incremental Batfish Data Plane (ibdp) Engine. */
 @AutoService(Plugin.class)
@@ -29,12 +20,9 @@ public class IncrementalDataPlanePlugin extends DataPlanePlugin {
 
   public static final String PLUGIN_NAME = "ibdp";
 
-  private final Map<IncrementalDataPlane, Map<Flow, Set<FlowTrace>>> _flowTraces;
   private IncrementalBdpEngine _engine;
 
-  public IncrementalDataPlanePlugin() {
-    _flowTraces = new HashMap<>();
-  }
+  public IncrementalDataPlanePlugin() {}
 
   @Override
   public ComputeDataPlaneResult computeDataPlane(boolean differentialContext) {
@@ -74,50 +62,8 @@ public class IncrementalDataPlanePlugin extends DataPlanePlugin {
   }
 
   @Override
-  public ITracerouteEngine getTracerouteEngine() {
-    return TracerouteEngineImpl.getInstance();
-  }
-
-  @Override
-  public List<Flow> getHistoryFlows(DataPlane dataPlane) {
-    IncrementalDataPlane dp = (IncrementalDataPlane) dataPlane;
-    Map<Flow, Set<FlowTrace>> traces = _flowTraces.get(dp);
-    if (traces == null) {
-      return ImmutableList.of();
-    }
-    return traces.entrySet().stream()
-        .flatMap(e -> Collections.nCopies(e.getValue().size(), e.getKey()).stream())
-        .collect(ImmutableList.toImmutableList());
-  }
-
-  @Override
-  public List<FlowTrace> getHistoryFlowTraces(DataPlane dataPlane) {
-    IncrementalDataPlane dp = (IncrementalDataPlane) dataPlane;
-    Map<Flow, Set<FlowTrace>> traces = _flowTraces.get(dp);
-    if (traces == null) {
-      return ImmutableList.of();
-    }
-    return traces.values().stream().flatMap(Set::stream).collect(ImmutableList.toImmutableList());
-  }
-
-  @Override
   public SortedMap<String, SortedMap<String, SortedSet<AbstractRoute>>> getRoutes(DataPlane dp) {
     return IncrementalBdpEngine.getRoutes((IncrementalDataPlane) dp);
-  }
-
-  @Override
-  public void processFlows(Set<Flow> flows, DataPlane dataPlane, boolean ignoreFilters) {
-    _flowTraces.put(
-        (IncrementalDataPlane) dataPlane,
-        TracerouteEngineImpl.getInstance()
-            .processFlows(dataPlane, flows, dataPlane.getFibs(), ignoreFilters));
-  }
-
-  @Override
-  public SortedMap<Flow, List<Trace>> buildFlows(
-      Set<Flow> flows, DataPlane dataPlane, boolean ignoreFilters) {
-    return TracerouteEngineImpl.getInstance()
-        .buildFlows(dataPlane, flows, dataPlane.getFibs(), ignoreFilters);
   }
 
   private IncrementalDataPlane loadDataPlane() {

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteEngineImplContext.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteEngineImplContext.java
@@ -66,8 +66,8 @@ import org.batfish.datamodel.transformation.TransformationEvaluator.Transformati
 
 /**
  * Class containing an implementation of {@link
- * org.batfish.dataplane.TracerouteEngineImpl#buildFlows(DataPlane, Set, Map, boolean)} and the
- * context (data) needed for it
+ * org.batfish.dataplane.TracerouteEngineImpl#buildFlows(Set, boolean)} and the context (data)
+ * needed for it
  */
 public class TracerouteEngineImplContext {
   /** Used for loop detection */

--- a/projects/batfish/src/test/java/org/batfish/dataplane/TracerouteEngineTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/TracerouteEngineTest.java
@@ -86,8 +86,7 @@ public class TracerouteEngineTest {
 
     // Compute flow traces
     SortedMap<Flow, Set<FlowTrace>> flowTraces =
-        TracerouteEngineImpl.getInstance()
-            .processFlows(dp, ImmutableSet.of(flow1, flow2), dp.getFibs(), false);
+        new TracerouteEngineImpl(dp).processFlows(ImmutableSet.of(flow1, flow2), false);
 
     assertThat(flowTraces, hasEntry(equalTo(flow1), contains(hasDisposition(NO_ROUTE))));
     assertThat(flowTraces, hasEntry(equalTo(flow2), contains(hasDisposition(ACCEPTED))));
@@ -130,9 +129,7 @@ public class TracerouteEngineTest {
             .setTag("tag")
             .build();
     Set<FlowTrace> traces =
-        TracerouteEngineImpl.getInstance()
-            .processFlows(dp, ImmutableSet.of(flow), dp.getFibs(), false)
-            .get(flow);
+        new TracerouteEngineImpl(dp).processFlows(ImmutableSet.of(flow), false).get(flow);
 
     /*
      *  Since the 'other' neighbor should not respond to ARP:
@@ -238,8 +235,7 @@ public class TracerouteEngineTest {
             .setTag(Flow.BASE_FLOW_TAG)
             .setDstIp(Ip.parse("1.0.0.1"))
             .build();
-    b.processFlows(ImmutableSet.of(flow), false);
-    FlowHistory history = b.getHistory();
+    FlowHistory history = b.flowHistory(ImmutableSet.of(flow), false);
     FlowHistoryInfo info = history.getTraces().get(flow.toString());
     FlowTrace trace = info.getPaths().get(Flow.BASE_FLOW_TAG).iterator().next();
 
@@ -286,8 +282,7 @@ public class TracerouteEngineTest {
             .setTag(Flow.BASE_FLOW_TAG)
             .setDstIp(Ip.parse("1.0.0.1"))
             .build();
-    b.processFlows(ImmutableSet.of(flow), false);
-    FlowHistory history = b.getHistory();
+    FlowHistory history = b.flowHistory(ImmutableSet.of(flow), false);
     FlowHistoryInfo info = history.getTraces().get(flow.toString());
     FlowTrace trace = info.getPaths().get(Flow.BASE_FLOW_TAG).iterator().next();
 
@@ -306,11 +301,9 @@ public class TracerouteEngineTest {
         BatfishTestUtils.getBatfish(ImmutableSortedMap.of(c1.getHostname(), c1), _tempFolder);
     batfish.computeDataPlane(false);
     DataPlane dp = batfish.loadDataPlane();
-    TracerouteEngineImpl.getInstance()
+    new TracerouteEngineImpl(dp)
         .processFlows(
-            dp,
             ImmutableSet.of(Flow.builder().setTag("tag").setIngressNode("missingNode").build()),
-            dp.getFibs(),
             false);
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePluginTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePluginTest.java
@@ -65,6 +65,7 @@ import org.batfish.datamodel.isis.IsisLevelSettings;
 import org.batfish.datamodel.isis.IsisProcess;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
 import org.batfish.datamodel.routing_policy.statement.SetDefaultPolicy;
+import org.batfish.dataplane.TracerouteEngineImpl;
 import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
 import org.batfish.main.TestrigText;
@@ -472,7 +473,7 @@ public class IncrementalDataPlanePluginTest {
     // the neighbor should be reachable because it is only one hop away from the initiator
     assertTrue(
         BgpTopologyUtils.isReachableBgpNeighbor(
-            initiator, listener, source, dataPlanePlugin.getTracerouteEngine(), dp));
+            initiator, listener, source, new TracerouteEngineImpl(dp)));
   }
 
   @Test
@@ -501,7 +502,7 @@ public class IncrementalDataPlanePluginTest {
     // the neighbor should be not be reachable because it is two hops away from the initiator
     assertFalse(
         BgpTopologyUtils.isReachableBgpNeighbor(
-            initiator, listener, source, dataPlanePlugin.getTracerouteEngine(), dp));
+            initiator, listener, source, new TracerouteEngineImpl(dp)));
   }
 
   @Test
@@ -530,7 +531,7 @@ public class IncrementalDataPlanePluginTest {
     // the neighbor should be reachable because multi-hops are allowed
     assertTrue(
         BgpTopologyUtils.isReachableBgpNeighbor(
-            initiator, listener, source, dataPlanePlugin.getTracerouteEngine(), dp));
+            initiator, listener, source, new TracerouteEngineImpl(dp)));
   }
 
   @Test
@@ -561,7 +562,7 @@ public class IncrementalDataPlanePluginTest {
     // denied in on node 3
     assertFalse(
         BgpTopologyUtils.isReachableBgpNeighbor(
-            initiator, listener, source, dataPlanePlugin.getTracerouteEngine(), dp));
+            initiator, listener, source, new TracerouteEngineImpl(dp)));
   }
 
   /**

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishBDDDetectLoopsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishBDDDetectLoopsTest.java
@@ -14,11 +14,9 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.stream.Collectors;
 import org.batfish.datamodel.Configuration;
-import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowDisposition;
 import org.batfish.datamodel.flow.Trace;
-import org.batfish.dataplane.TracerouteEngineImpl;
 import org.batfish.question.loop.LoopNetwork;
 import org.junit.Rule;
 import org.junit.Test;
@@ -49,9 +47,8 @@ public class BatfishBDDDetectLoopsTest {
     Set<Flow> flows = _batfish.bddLoopDetection();
     assertThat(flows, hasSize(2));
 
-    DataPlane dp = _batfish.loadDataPlane();
     SortedMap<Flow, List<Trace>> flowTraces =
-        TracerouteEngineImpl.getInstance().buildFlows(dp, flows, dp.getFibs(), false);
+        _batfish.getTracerouteEngine().buildFlows(flows, false);
     Set<FlowDisposition> dispositions =
         flowTraces.values().stream()
             .flatMap(Collection::stream)

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishBDDDifferentialReachabilityTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishBDDDifferentialReachabilityTest.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.stream.Stream;
 import org.batfish.common.util.TracePruner;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Flow;
@@ -119,20 +120,21 @@ public class BatfishBDDDifferentialReachabilityTest {
       Batfish batfish, Set<Flow> flows, FlowDisposition disposition) {
 
     batfish.pushBaseSnapshot();
-    batfish.processFlows(flows, false);
-    List<FlowTrace> traces =
-        batfish.getDataPlanePlugin().getHistoryFlowTraces(batfish.loadDataPlane());
+    Stream<FlowTrace> traces =
+        batfish.getTracerouteEngine().processFlows(flows, false).values().stream()
+            .flatMap(Set::stream);
     assertThat(
         String.format("all traces should have disposition %s in the base environment", disposition),
-        traces.stream().allMatch(flowTrace -> flowTrace.getDisposition().equals(disposition)));
+        traces.allMatch(flowTrace -> flowTrace.getDisposition().equals(disposition)));
     batfish.popSnapshot();
 
     batfish.pushDeltaSnapshot();
-    batfish.processFlows(flows, false);
-    traces = batfish.getDataPlanePlugin().getHistoryFlowTraces(batfish.loadDataPlane());
+    traces =
+        batfish.getTracerouteEngine().processFlows(flows, false).values().stream()
+            .flatMap(Set::stream);
     assertThat(
         String.format("no traces should have disposition %s in the delta environment", disposition),
-        traces.stream().noneMatch(flowTrace -> flowTrace.getDisposition().equals(disposition)));
+        traces.noneMatch(flowTrace -> flowTrace.getDisposition().equals(disposition)));
     batfish.popSnapshot();
   }
 

--- a/projects/batfish/src/test/java/org/batfish/z3/NodJobAclTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/NodJobAclTest.java
@@ -23,10 +23,9 @@ import com.google.common.collect.ImmutableSortedMap;
 import com.microsoft.z3.Context;
 import com.microsoft.z3.Status;
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.batfish.common.plugin.DataPlanePlugin;
+import java.util.stream.Collectors;
 import org.batfish.config.Settings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
@@ -192,9 +191,10 @@ public class NodJobAclTest {
     assertThat(fieldConstraints, hasEntry(Field.SRC_IP.getName(), Ip.parse("1.1.1.1").asLong()));
 
     Set<Flow> flows = nodJob.getFlows(ingressLocationConstraints);
-    DataPlanePlugin dpPlugin = batfish.getDataPlanePlugin();
-    dpPlugin.processFlows(flows, dataPlane, false);
-    List<FlowTrace> flowTraces = dpPlugin.getHistoryFlowTraces(dataPlane);
+    Set<FlowTrace> flowTraces =
+        batfish.getTracerouteEngine().processFlows(flows, false).values().stream()
+            .flatMap(Set::stream)
+            .collect(Collectors.toSet());
     assertThat(flowTraces, hasSize(2));
     assertThat(
         flowTraces,
@@ -333,9 +333,10 @@ public class NodJobAclTest {
     assertThat(fieldConstraints, hasEntry(Field.SRC_IP.getName(), Ip.parse("1.1.1.1").asLong()));
 
     Set<Flow> flows = nodJob.getFlows(ingressLocationConstraints);
-    DataPlanePlugin dpPlugin = batfish.getDataPlanePlugin();
-    dpPlugin.processFlows(flows, dataPlane, false);
-    List<FlowTrace> flowTraces = dpPlugin.getHistoryFlowTraces(dataPlane);
+    Set<FlowTrace> flowTraces =
+        batfish.getTracerouteEngine().processFlows(flows, false).values().stream()
+            .flatMap(Set::stream)
+            .collect(Collectors.toSet());
     assertThat(flowTraces, hasSize(1));
     assertThat(
         flowTraces,

--- a/projects/question/src/main/java/org/batfish/question/NeighborsQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/NeighborsQuestionPlugin.java
@@ -934,7 +934,7 @@ public class NeighborsQuestionPlugin extends QuestionPlugin {
       if (!_remoteBgpNeighborsInitialized) {
         Map<Ip, Set<String>> ipOwners = TopologyUtil.computeIpNodeOwners(configurations, true);
         _bgpTopology =
-            BgpTopologyUtils.initBgpTopology(configurations, ipOwners, false, false, null, null);
+            BgpTopologyUtils.initBgpTopology(configurations, ipOwners, false, false, null);
         _remoteBgpNeighborsInitialized = true;
       }
     }

--- a/projects/question/src/main/java/org/batfish/question/VIModelQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/VIModelQuestionPlugin.java
@@ -238,7 +238,7 @@ public class VIModelQuestionPlugin extends QuestionPlugin {
     private static SortedSet<VerboseBgpEdge> getBgpEdges(
         Map<String, Configuration> configs, Map<Ip, Set<String>> ipOwners) {
       ValueGraph<BgpPeerConfigId, BgpSessionProperties> bgpTopology =
-          BgpTopologyUtils.initBgpTopology(configs, ipOwners, false, false, null, null);
+          BgpTopologyUtils.initBgpTopology(configs, ipOwners, false, false, null);
       SortedSet<VerboseBgpEdge> bgpEdges = new TreeSet<>(VERBOSE_BGP_EDGE_COMPARATOR);
       for (EndpointPair<BgpPeerConfigId> session : bgpTopology.edges()) {
         BgpPeerConfigId bgpPeerConfigId = session.source();

--- a/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionStatusAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionStatusAnswerer.java
@@ -24,7 +24,6 @@ import org.batfish.datamodel.BgpPeerConfigId;
 import org.batfish.datamodel.BgpSessionProperties;
 import org.batfish.datamodel.BgpSessionProperties.SessionType;
 import org.batfish.datamodel.Configuration;
-import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.answers.AnswerElement;
 import org.batfish.datamodel.answers.Schema;
@@ -80,7 +79,6 @@ public class BgpSessionStatusAnswerer extends BgpSessionAnswerer {
         BgpTopologyUtils.initBgpTopology(configurations, ipOwners, true);
 
     ValueGraph<BgpPeerConfigId, BgpSessionProperties> establishedBgpTopology;
-    DataPlane dp = _batfish.loadDataPlane();
     establishedBgpTopology =
         BgpTopologyUtils.initBgpTopology(
             configurations, ipOwners, false, true, _batfish.getTracerouteEngine());

--- a/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionStatusAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionStatusAnswerer.java
@@ -83,7 +83,7 @@ public class BgpSessionStatusAnswerer extends BgpSessionAnswerer {
     DataPlane dp = _batfish.loadDataPlane();
     establishedBgpTopology =
         BgpTopologyUtils.initBgpTopology(
-            configurations, ipOwners, false, true, _batfish.getTracerouteEngine(), dp);
+            configurations, ipOwners, false, true, _batfish.getTracerouteEngine());
 
     Stream<Row> activePeerRows =
         configuredBgpTopology.nodes().stream()

--- a/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionStatusAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionStatusAnswerer.java
@@ -83,12 +83,7 @@ public class BgpSessionStatusAnswerer extends BgpSessionAnswerer {
     DataPlane dp = _batfish.loadDataPlane();
     establishedBgpTopology =
         BgpTopologyUtils.initBgpTopology(
-            configurations,
-            ipOwners,
-            false,
-            true,
-            _batfish.getDataPlanePlugin().getTracerouteEngine(),
-            dp);
+            configurations, ipOwners, false, true, _batfish.getTracerouteEngine(), dp);
 
     Stream<Row> activePeerRows =
         configuredBgpTopology.nodes().stream()

--- a/projects/question/src/main/java/org/batfish/question/differentialreachability/DifferentialReachabilityAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/differentialreachability/DifferentialReachabilityAnswerer.java
@@ -116,14 +116,8 @@ public class DifferentialReachabilityAnswerer extends Answerer {
     Multiset<Row> rows;
     TableAnswerElement table;
     if (_batfish.debugFlagEnabled("oldtraceroute")) {
-      _batfish.pushBaseSnapshot();
-      _batfish.processFlows(flows, parameters.getIgnoreFilters());
-      _batfish.popSnapshot();
-      _batfish.pushDeltaSnapshot();
-      _batfish.processFlows(flows, parameters.getIgnoreFilters());
-      _batfish.popSnapshot();
-
-      FlowHistory flowHistory = _batfish.getHistory();
+      FlowHistory flowHistory =
+          _batfish.differentialFlowHistory(flows, parameters.getIgnoreFilters());
       rows = flowHistoryToRows(flowHistory);
       table = new TableAnswerElement(createMetadata());
     } else {

--- a/projects/question/src/main/java/org/batfish/question/edges/EdgesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/edges/EdgesAnswerer.java
@@ -124,7 +124,7 @@ public class EdgesAnswerer extends Answerer {
     switch (edgeType) {
       case BGP:
         ValueGraph<BgpPeerConfigId, BgpSessionProperties> bgpTopology =
-            BgpTopologyUtils.initBgpTopology(configurations, ipOwners, false, false, null, null);
+            BgpTopologyUtils.initBgpTopology(configurations, ipOwners, false, false, null);
         return getBgpEdges(configurations, includeNodes, includeRemoteNodes, bgpTopology);
       case EIGRP:
         Network<EigrpInterface, EigrpEdge> eigrpTopology =

--- a/projects/question/src/main/java/org/batfish/question/loop/DetectLoopsAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/loop/DetectLoopsAnswerer.java
@@ -55,8 +55,7 @@ public final class DetectLoopsAnswerer extends Answerer {
             .collect(Collectors.toSet());
 
     if (_batfish.debugFlagEnabled("oldtraceroute")) {
-      _batfish.processFlows(flows, false);
-      FlowHistory flowHistory = _batfish.getHistory();
+      FlowHistory flowHistory = _batfish.flowHistory(flows, false);
       Multiset<Row> rows = flowHistoryToRows(flowHistory);
       TableAnswerElement table = new TableAnswerElement(createMetadata(false));
       table.postProcessAnswer(_question, rows);

--- a/projects/question/src/main/java/org/batfish/question/multipath/MultipathConsistencyAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/multipath/MultipathConsistencyAnswerer.java
@@ -51,8 +51,7 @@ public class MultipathConsistencyAnswerer extends Answerer {
     MultipathConsistencyParameters parameters = parameters();
     Set<Flow> flows = _batfish.bddMultipathConsistency(parameters);
     if (_batfish.debugFlagEnabled("oldtraceroute")) {
-      _batfish.processFlows(flows, false);
-      FlowHistory flowHistory = _batfish.getHistory();
+      FlowHistory flowHistory = _batfish.flowHistory(flows, false);
       Multiset<Row> rows = flowHistoryToRows(flowHistory);
       TableAnswerElement table = new TableAnswerElement(createMetadata(false));
       table.postProcessAnswer(_question, rows);

--- a/projects/question/src/main/java/org/batfish/question/traceroute/TracerouteAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/traceroute/TracerouteAnswerer.java
@@ -107,13 +107,12 @@ public final class TracerouteAnswerer extends Answerer {
     Multiset<Row> rows;
     TableAnswerElement table;
     if (_batfish.debugFlagEnabled("oldtraceroute")) {
-      _batfish.processFlows(flows, question.getIgnoreFilters());
-      FlowHistory flowHistory = _batfish.getHistory();
+      FlowHistory flowHistory = _batfish.flowHistory(flows, question.getIgnoreFilters());
       rows = flowHistoryToRows(flowHistory, false);
       table = new TableAnswerElement(createMetadata(false));
     } else {
       SortedMap<Flow, List<Trace>> flowTraces =
-          _batfish.buildFlows(flows, question.getIgnoreFilters());
+          _batfish.getTracerouteEngine().buildFlows(flows, question.getIgnoreFilters());
       rows = flowTracesToRows(flowTraces, question.getMaxTraces());
       table = new TableAnswerElement(metadata(false));
     }
@@ -129,15 +128,8 @@ public final class TracerouteAnswerer extends Answerer {
     Multiset<Row> rows;
     TableAnswerElement table;
     if (_batfish.debugFlagEnabled("oldtraceroute")) {
-      _batfish.pushBaseSnapshot();
-      _batfish.processFlows(flows, ignoreFilters);
-      _batfish.popSnapshot();
-
-      _batfish.pushDeltaSnapshot();
-      _batfish.processFlows(flows, ignoreFilters);
-      _batfish.popSnapshot();
-
-      FlowHistory flowHistory = _batfish.getHistory();
+      FlowHistory flowHistory =
+          _batfish.differentialFlowHistory(flows, question.getIgnoreFilters());
       rows = flowHistoryToRows(flowHistory, true);
       table = new TableAnswerElement(createMetadata(true));
     } else {


### PR DESCRIPTION
Now, rather than going through dataplane plugin or batfish, clients use the TracerouteEngine interface to run traceroutes. Removed the old `processFlows`/`getHistory*` song and dance, and the `_flowTraces` map in dataplane plugin that depended upon. Now we use a single method call on TracerouteEngine. The engine is no longer a singleton, but keeps a reference to the dataplane it will use. 

Among other benefits, this will allow us to change the interface to traceroute (e.g. add a method for bidirectional traceroute) without affecting batfish or dataplane plugin.

cc @dhalperi @arifogel 