### PR TITLE
Support ordering of variables for question templates

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
@@ -119,6 +119,7 @@ public class BfConsts {
   public static final String PROP_NUM_EXCLUDED_ROWS = "numExcludedRows";
   public static final String PROP_NUM_ROWS = "numRows";
   public static final String PROP_OPTIONAL = "optional";
+  public static final String PROP_ORDERED_VARIABLE_NAMES = "orderedVariableNames";
   public static final String PROP_QUESTION = "question";
   public static final String PROP_RESULTS = "results";
   public static final String PROP_REVERSED = "reversed";

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/InstanceData.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/InstanceData.java
@@ -19,11 +19,14 @@ public final class InstanceData {
 
   private String _longDescription;
 
+  private SortedSet<String> _orderedVariableNames;
+
   private SortedSet<String> _tags;
 
   private SortedMap<String, Variable> _variables;
 
   public InstanceData() {
+    _orderedVariableNames = new TreeSet<>();
     _tags = new TreeSet<>();
     _variables = new TreeMap<>();
   }
@@ -41,6 +44,11 @@ public final class InstanceData {
   @JsonProperty(BfConsts.PROP_LONG_DESCRIPTION)
   public String getLongDescription() {
     return _longDescription;
+  }
+
+  @JsonProperty(BfConsts.PROP_ORDERED_VARIABLE_NAMES)
+  public SortedSet<String> getOrderedVariableNames() {
+    return _orderedVariableNames;
   }
 
   @JsonProperty(BfConsts.PROP_TAGS)
@@ -66,6 +74,11 @@ public final class InstanceData {
   @JsonProperty(BfConsts.PROP_LONG_DESCRIPTION)
   public void setLongDescription(String longDescription) {
     _longDescription = longDescription;
+  }
+
+  @JsonProperty(BfConsts.PROP_ORDERED_VARIABLE_NAMES)
+  public void setOrderedVariableNames(SortedSet<String> orderedVariableNames) {
+    _orderedVariableNames = orderedVariableNames;
   }
 
   @JsonProperty(BfConsts.PROP_TAGS)


### PR DESCRIPTION
This PR adds an `orderedVariableNames` property to the `InstanceData` class. `orderedVariableNames` is obtained from question templates and specifies a preferred ordering for `variables`

`orderedVariableNames` can be added to question templates under the `instance` field, for example:

<pre>
{
    "class": "org.batfish.question.traceroute.TracerouteQuestion",
    "differential": false,
    "headers": "${headers}",
    "ignoreFilters": "${ignoreFilters}",
    "maxTraces": "${maxTraces}",
    "startLocation": "${startLocation}",
    "instance": {
        "description": "Trace the path(s) for the specified flow.",
        "instanceName": "traceroute",
        "longDescription": "This question performs a virtual traceroute in the network from a starting node. A destination IP and ingress (source) node must be specified. Other IP headers are given default values if unspecified.\nUnlike a real traceroute, this traceroute is directional. That is, for it to succeed, the reverse connectivity is not needed. This feature can help debug connectivity issues by decoupling the two directions.",
        "tags": [
            "dataPlane",
            "reachability",
            "traceroute"
        ],
       <b> "orderedVariableNames": [
            "startLocation",
            "headers",
            "ignoreFilters",
            "maxTraces"
        ],</b>
        "variables": {
...
</pre>

I still need to add tests/validation.


