### PR TITLE
Extract and use Juniper static route communities

### DIFF
--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpRouteMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpRouteMatchers.java
@@ -1,0 +1,20 @@
+package org.batfish.datamodel.matchers;
+
+import java.util.Set;
+import javax.annotation.Nonnull;
+import org.batfish.datamodel.matchers.BgpRouteMatchersImpl.HasCommunities;
+import org.hamcrest.Matcher;
+
+public final class BgpRouteMatchers {
+
+  /**
+   * Provides a matcher that matches when the supplied {@code subMatcher} matches the {@link
+   * org.batfish.datamodel.BgpRoute}'s communities.
+   */
+  public static @Nonnull HasCommunities hasCommunities(
+      @Nonnull Matcher<? super Set<Long>> subMatcher) {
+    return new HasCommunities(subMatcher);
+  }
+
+  private BgpRouteMatchers() {}
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpRouteMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpRouteMatchersImpl.java
@@ -1,0 +1,22 @@
+package org.batfish.datamodel.matchers;
+
+import java.util.Set;
+import javax.annotation.Nonnull;
+import org.batfish.datamodel.BgpRoute;
+import org.hamcrest.FeatureMatcher;
+import org.hamcrest.Matcher;
+
+final class BgpRouteMatchersImpl {
+  static final class HasCommunities extends FeatureMatcher<BgpRoute, Set<Long>> {
+    HasCommunities(@Nonnull Matcher<? super Set<Long>> subMatcher) {
+      super(subMatcher, "A BgpRoute with communities:", "communities");
+    }
+
+    @Override
+    protected Set<Long> featureValueOf(BgpRoute actual) {
+      return actual.getCommunities();
+    }
+  }
+
+  private BgpRouteMatchersImpl() {}
+}

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -410,6 +410,7 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ror_export_ribContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ror_import_policyContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ror_import_ribContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ros_routeContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Rosr_communityContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Rosr_discardContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Rosr_metricContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Rosr_next_hopContext;
@@ -4936,6 +4937,11 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
     if (ctx.INET6() != null) {
       todo(ctx);
     }
+  }
+
+  @Override
+  public void exitRosr_community(Rosr_communityContext ctx) {
+    _currentStaticRoute.getCommunities().add(toCommunityLong(ctx.standard_community()));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -83,6 +83,8 @@ import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.MultipathEquivalentAsPathMatchMode;
 import org.batfish.datamodel.OriginType;
 import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.PrefixRange;
+import org.batfish.datamodel.PrefixSpace;
 import org.batfish.datamodel.RegexCommunitySet;
 import org.batfish.datamodel.Route;
 import org.batfish.datamodel.Route6FilterList;
@@ -117,14 +119,19 @@ import org.batfish.datamodel.routing_policy.expr.ConjunctionChain;
 import org.batfish.datamodel.routing_policy.expr.DestinationNetwork;
 import org.batfish.datamodel.routing_policy.expr.Disjunction;
 import org.batfish.datamodel.routing_policy.expr.DisjunctionChain;
+import org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet;
+import org.batfish.datamodel.routing_policy.expr.LiteralCommunitySet;
 import org.batfish.datamodel.routing_policy.expr.LiteralOrigin;
 import org.batfish.datamodel.routing_policy.expr.MatchLocalRouteSourcePrefixLength;
 import org.batfish.datamodel.routing_policy.expr.MatchPrefixSet;
 import org.batfish.datamodel.routing_policy.expr.MatchProtocol;
 import org.batfish.datamodel.routing_policy.expr.NamedPrefixSet;
+import org.batfish.datamodel.routing_policy.expr.PrefixExpr;
+import org.batfish.datamodel.routing_policy.expr.PrefixSetExpr;
 import org.batfish.datamodel.routing_policy.statement.CallStatement;
 import org.batfish.datamodel.routing_policy.statement.Comment;
 import org.batfish.datamodel.routing_policy.statement.If;
+import org.batfish.datamodel.routing_policy.statement.SetCommunity;
 import org.batfish.datamodel.routing_policy.statement.SetDefaultPolicy;
 import org.batfish.datamodel.routing_policy.statement.SetOrigin;
 import org.batfish.datamodel.routing_policy.statement.SetOspfMetricType;
@@ -295,6 +302,27 @@ public final class JuniperConfiguration extends VendorConfiguration {
     for (IpBgpGroup ig : routingInstance.getIpBgpGroups().values()) {
       ig.cascadeInheritance();
     }
+
+    /*
+     * For new BGP advertisements, i.e. those that are created from non-BGP
+     * routes, an origin code must be set. By default, Juniper sets the origin
+     * code to IGP.
+     */
+    If setOriginForNonBgp = new If();
+    Disjunction isBgp = new Disjunction();
+    isBgp.getDisjuncts().add(new MatchProtocol(RoutingProtocol.BGP));
+    isBgp.getDisjuncts().add(new MatchProtocol(RoutingProtocol.IBGP));
+    setOriginForNonBgp.setGuard(isBgp);
+    setOriginForNonBgp
+        .getFalseStatements()
+        .add(new SetOrigin(new LiteralOrigin(OriginType.IGP, null)));
+
+    /*
+     * Juniper allows setting BGP communities for static routes. Rather than add communities to VI
+     * routes, add statements to peer export policies that set the appropriate communities.
+     */
+    List<If> staticRouteCommunitySetters = getStaticRouteCommunitySetters(routingInstance);
+
     for (Entry<Prefix, IpBgpGroup> e : routingInstance.getIpBgpGroups().entrySet()) {
       Prefix prefix = e.getKey();
       IpBgpGroup ig = e.getValue();
@@ -422,20 +450,10 @@ public final class JuniperConfiguration extends VendorConfiguration {
       peerExportPolicy.getStatements().add(new SetDefaultPolicy(DEFAULT_BGP_EXPORT_POLICY_NAME));
       applyLocalRoutePolicy(routingInstance, peerExportPolicy);
 
-      /*
-       * For new BGP advertisements, i.e. those that are created from non-BGP
-       * routes, an origin code must be set. By default, Juniper sets the origin
-       * code to IGP.
-       */
-      If setOriginForNonBgp = new If();
-      Disjunction isBgp = new Disjunction();
-      isBgp.getDisjuncts().add(new MatchProtocol(RoutingProtocol.BGP));
-      isBgp.getDisjuncts().add(new MatchProtocol(RoutingProtocol.IBGP));
-      setOriginForNonBgp.setGuard(isBgp);
-      setOriginForNonBgp
-          .getFalseStatements()
-          .add(new SetOrigin(new LiteralOrigin(OriginType.IGP, null)));
+      // Add route modifier statements
       peerExportPolicy.getStatements().add(setOriginForNonBgp);
+      peerExportPolicy.getStatements().addAll(staticRouteCommunitySetters);
+
       List<BooleanExpr> exportPolicyCalls = new ArrayList<>();
       ig.getExportPolicies()
           .forEach(
@@ -547,6 +565,37 @@ public final class JuniperConfiguration extends VendorConfiguration {
     proc.setMultipathEquivalentAsPathMatchMode(multipathEquivalentAsPathMatchMode);
 
     return proc;
+  }
+
+  /**
+   * For each static route in the given {@link RoutingInstance} that has at least one community set,
+   * creates an {@link If} that matches that route (specifically, matches static routes with that
+   * route's destination network), and sets communities for matching exported routes.
+   */
+  @Nonnull
+  private static List<If> getStaticRouteCommunitySetters(@Nonnull RoutingInstance ri) {
+    MatchProtocol matchStatic = new MatchProtocol(RoutingProtocol.STATIC);
+    return ri.getRibs().get(RoutingInformationBase.RIB_IPV4_UNICAST).getStaticRoutes().values()
+        .stream()
+        .filter(route -> !route.getCommunities().isEmpty())
+        .map(
+            route -> {
+              // Create guard that matches static routes with this route's network
+              PrefixExpr destNetworkMatcher = DestinationNetwork.instance();
+              PrefixSetExpr destNetwork =
+                  new ExplicitPrefixSet(new PrefixSpace(PrefixRange.fromPrefix(route.getPrefix())));
+              MatchPrefixSet networkMatcher = new MatchPrefixSet(destNetworkMatcher, destNetwork);
+              Conjunction guard = new Conjunction(ImmutableList.of(matchStatic, networkMatcher));
+
+              // When the guard is matched, set the matching route's communities
+              If staticRouteConditional = new If();
+              staticRouteConditional.setGuard(guard);
+              SetCommunity communityStatement =
+                  new SetCommunity(new LiteralCommunitySet(route.getCommunities()));
+              staticRouteConditional.setTrueStatements(ImmutableList.of(communityStatement));
+              return staticRouteConditional;
+            })
+        .collect(ImmutableList.toImmutableList());
   }
 
   public static String computePeerExportPolicyName(Prefix remoteAddress) {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/StaticRoute.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/StaticRoute.java
@@ -3,6 +3,8 @@ package org.batfish.representation.juniper;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
@@ -14,6 +16,8 @@ public class StaticRoute implements Serializable {
 
   /* https://www.juniper.net/documentation/en_US/junos/topics/reference/general/routing-protocols-default-route-preference-values.html */
   private static final int DEFAULT_ADMIN_DISTANCE = 5;
+
+  private Set<Long> _communities;
 
   private int _distance;
 
@@ -34,10 +38,15 @@ public class StaticRoute implements Serializable {
   private Boolean _noInstall;
 
   public StaticRoute(Prefix prefix) {
+    _communities = new TreeSet<>();
     _prefix = prefix;
     _policies = new ArrayList<>();
     // default admin costs for static routes in Juniper
     _distance = DEFAULT_ADMIN_DISTANCE;
+  }
+
+  public Set<Long> getCommunities() {
+    return _communities;
   }
 
   public int getDistance() {

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -1,5 +1,6 @@
 package org.batfish.grammar.flatjuniper;
 
+import static org.batfish.common.util.CommonUtil.communityStringToLong;
 import static org.batfish.datamodel.AuthenticationMethod.GROUP_RADIUS;
 import static org.batfish.datamodel.AuthenticationMethod.GROUP_TACACS;
 import static org.batfish.datamodel.AuthenticationMethod.PASSWORD;
@@ -20,6 +21,7 @@ import static org.batfish.datamodel.matchers.BgpProcessMatchers.hasMultipathEbgp
 import static org.batfish.datamodel.matchers.BgpProcessMatchers.hasMultipathIbgp;
 import static org.batfish.datamodel.matchers.BgpProcessMatchers.hasNeighbors;
 import static org.batfish.datamodel.matchers.BgpProcessMatchers.hasPassiveNeighbor;
+import static org.batfish.datamodel.matchers.BgpRouteMatchers.hasCommunities;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasDefaultVrf;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasHostname;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasIkePhase1Policy;
@@ -125,6 +127,7 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anything;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
@@ -167,6 +170,7 @@ import org.batfish.datamodel.BgpRoute;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.ConnectedRoute;
+import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.DiffieHellmanGroup;
 import org.batfish.datamodel.EncryptionAlgorithm;
 import org.batfish.datamodel.Flow;
@@ -597,6 +601,45 @@ public final class FlatJuniperGrammarTest {
     assertThat(c1, hasDefaultVrf(hasBgpProcess(hasActiveNeighbor(neighborPrefix, hasLocalAs(1L)))));
     assertThat(c2, hasDefaultVrf(hasBgpProcess(hasActiveNeighbor(neighborPrefix, hasLocalAs(1L)))));
     assertThat(c3, hasDefaultVrf(hasBgpProcess(hasActiveNeighbor(neighborPrefix, hasLocalAs(1L)))));
+  }
+
+  @Test
+  public void testStaticRouteCommunities() throws IOException {
+    /*
+    Setup: r1 has a BGP import policy that rejects routes with community 100:1001.
+    r2 exports:
+    - static route 10.20.20.0/24 with community 100:1001
+    - static route 10.20.20.0/23 with community 100:1002
+    - static route 10.20.22.0/24, no communities
+    r1 should reject first route, but install the others in its RIB.
+     */
+    String testrigName = "static-route-communities";
+    String c1Name = "r1";
+    String c2Name = "r2";
+    Long acceptedCommunity = communityStringToLong("100:1002");
+
+    List<String> configurationNames = ImmutableList.of(c1Name, c2Name);
+    Batfish batfish =
+        BatfishTestUtils.getBatfishFromTestrigText(
+            TestrigText.builder()
+                .setConfigurationText(TESTRIGS_PREFIX + testrigName, configurationNames)
+                .build(),
+            _folder);
+    batfish.computeDataPlane(false);
+    DataPlane dp = batfish.loadDataPlane();
+    Set<AbstractRoute> r1Routes =
+        dp.getRibs().get(c1Name).get(Configuration.DEFAULT_VRF_NAME).getRoutes();
+
+    assertThat(r1Routes, not(hasItem(hasPrefix(Prefix.parse("10.20.20.0/24")))));
+    assertThat(
+        r1Routes,
+        hasItem(
+            allOf(
+                hasPrefix(Prefix.parse("10.20.20.0/23")),
+                hasCommunities(contains(acceptedCommunity)))));
+    assertThat(
+        r1Routes,
+        hasItem(allOf(hasPrefix(Prefix.parse("10.20.22.0/24")), hasCommunities(empty()))));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testrigs/static-route-communities/configs/r1
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testrigs/static-route-communities/configs/r1
@@ -1,22 +1,16 @@
 set system host-name r1
 #
-set interfaces ge-0/0/0 unit 0 family inet address 172.16.10.1/30
-set interfaces lo0 unit 0 family inet address 1.1.1.1/32
+set interfaces ge-0/0/0 unit 0 family inet address 10.10.10.1/30
 #
 set routing-options autonomous-system 100
 #
-set protocols bgp group GROUP1 type internal
-set protocols bgp group GROUP1 local-address 1.1.1.1
-set protocols bgp group GROUP1 import IBGP-IMPORT
-set protocols bgp group GROUP1 family inet unicast
-set protocols bgp group GROUP1 peer-as 100
-set protocols bgp group GROUP1 neighbor 2.2.2.2
-#
-set protocols ospf area 0.0.0.0 interface ge-0/0/0.0
-set protocols ospf area 0.0.0.0 interface lo0.0
+set protocols bgp group EBGP-GROUP type external
+set protocols bgp group EBGP-GROUP import EBGP-IMPORT
+set protocols bgp group EBGP-GROUP peer-as 101
+set protocols bgp group EBGP-GROUP neighbor 10.10.10.2
 #
 # Reject routes with community 100:1001
 set policy-options community COMM1 members 100:1001
-set policy-options policy-statement IBGP-IMPORT term TERM01 from community COMM1
-set policy-options policy-statement IBGP-IMPORT term TERM01 then reject
-set policy-options policy-statement IBGP-IMPORT term DEFAULT then accept
+set policy-options policy-statement EBGP-IMPORT term TERM01 from community COMM1
+set policy-options policy-statement EBGP-IMPORT term TERM01 then reject
+set policy-options policy-statement EBGP-IMPORT term DEFAULT then accept

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testrigs/static-route-communities/configs/r1
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testrigs/static-route-communities/configs/r1
@@ -1,0 +1,22 @@
+set system host-name r1
+#
+set interfaces ge-0/0/0 unit 0 family inet address 172.16.10.1/30
+set interfaces lo0 unit 0 family inet address 1.1.1.1/32
+#
+set routing-options autonomous-system 100
+#
+set protocols bgp group GROUP1 type internal
+set protocols bgp group GROUP1 local-address 1.1.1.1
+set protocols bgp group GROUP1 import IBGP-IMPORT
+set protocols bgp group GROUP1 family inet unicast
+set protocols bgp group GROUP1 peer-as 100
+set protocols bgp group GROUP1 neighbor 2.2.2.2
+#
+set protocols ospf area 0.0.0.0 interface ge-0/0/0.0
+set protocols ospf area 0.0.0.0 interface lo0.0
+#
+# Reject routes with community 100:1001
+set policy-options community COMM1 members 100:1001
+set policy-options policy-statement IBGP-IMPORT term TERM01 from community COMM1
+set policy-options policy-statement IBGP-IMPORT term TERM01 then reject
+set policy-options policy-statement IBGP-IMPORT term DEFAULT then accept

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testrigs/static-route-communities/configs/r2
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testrigs/static-route-communities/configs/r2
@@ -1,0 +1,29 @@
+set system host-name r2
+#
+set interfaces ge-0/0/0 unit 0 family inet address 172.16.10.2/30
+set interfaces lo0 unit 0 family inet address 2.2.2.2/32
+#
+# This route should not appear in R1 RIB because R1 doesn't import community 100:1001
+set routing-options static route 10.20.20.0/24 discard
+set routing-options static route 10.20.20.0/24 community 100:1001
+#
+# These routes should appear in R1 RIB
+set routing-options static route 10.20.20.0/23 discard
+set routing-options static route 10.20.20.0/23 community 100:1002
+set routing-options static route 10.20.22.0/24 discard
+#
+set routing-options autonomous-system 100
+#
+set protocols bgp group GROUP1 type internal
+set protocols bgp group GROUP1 local-address 2.2.2.2
+set protocols bgp group GROUP1 family inet unicast
+set protocols bgp group GROUP1 export IBGP-EXPORT
+set protocols bgp group GROUP1 peer-as 100
+set protocols bgp group GROUP1 neighbor 1.1.1.1
+#
+set protocols ospf area 0.0.0.0 interface ge-0/0/0.0
+set protocols ospf area 0.0.0.0 interface lo0.0
+#
+set policy-options policy-statement IBGP-EXPORT term TERM01 from protocol static
+set policy-options policy-statement IBGP-EXPORT term TERM01 then accept
+set policy-options policy-statement IBGP-EXPORT then reject

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testrigs/static-route-communities/configs/r2
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testrigs/static-route-communities/configs/r2
@@ -1,7 +1,6 @@
 set system host-name r2
 #
-set interfaces ge-0/0/0 unit 0 family inet address 172.16.10.2/30
-set interfaces lo0 unit 0 family inet address 2.2.2.2/32
+set interfaces ge-0/0/0 unit 0 family inet address 10.10.10.2/30
 #
 # This route should not appear in R1 RIB because R1 doesn't import community 100:1001
 set routing-options static route 10.20.20.0/24 discard
@@ -12,18 +11,13 @@ set routing-options static route 10.20.20.0/23 discard
 set routing-options static route 10.20.20.0/23 community 100:1002
 set routing-options static route 10.20.22.0/24 discard
 #
-set routing-options autonomous-system 100
+set routing-options autonomous-system 101
 #
-set protocols bgp group GROUP1 type internal
-set protocols bgp group GROUP1 local-address 2.2.2.2
-set protocols bgp group GROUP1 family inet unicast
-set protocols bgp group GROUP1 export IBGP-EXPORT
-set protocols bgp group GROUP1 peer-as 100
-set protocols bgp group GROUP1 neighbor 1.1.1.1
+set protocols bgp group EBGP-GROUP type external
+set protocols bgp group EBGP-GROUP export EBGP-EXPORT
+set protocols bgp group EBGP-GROUP peer-as 100
+set protocols bgp group EBGP-GROUP neighbor 10.10.10.1
 #
-set protocols ospf area 0.0.0.0 interface ge-0/0/0.0
-set protocols ospf area 0.0.0.0 interface lo0.0
-#
-set policy-options policy-statement IBGP-EXPORT term TERM01 from protocol static
-set policy-options policy-statement IBGP-EXPORT term TERM01 then accept
-set policy-options policy-statement IBGP-EXPORT then reject
+set policy-options policy-statement EBGP-EXPORT term TERM01 from protocol static
+set policy-options policy-statement EBGP-EXPORT term TERM01 then accept
+set policy-options policy-statement EBGP-EXPORT then reject


### PR DESCRIPTION
Since Juniper static routes can have BGP communities but our VI routes don't (and shouldn't, since Juniper is the only vendor that does this), this PR adds statements at the beginning of BGP export policies that tack the appropriate communities onto static routes before exporting them.