### PR TITLE
Clean up RoutingInformationBase

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/RoutingInformationBase.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/RoutingInformationBase.java
@@ -3,32 +3,25 @@ package org.batfish.representation.juniper;
 import java.io.Serializable;
 import java.util.Map;
 import java.util.TreeMap;
+import javax.annotation.Nonnull;
 import org.batfish.datamodel.Prefix;
 
+/** A Juniper RIB */
 public class RoutingInformationBase implements Serializable {
 
   public static final String RIB_IPV4_MPLS = "inet.3";
-
   public static final String RIB_IPV4_MULTICAST = "inet.1";
-
   public static final String RIB_IPV4_UNICAST = "inet.0";
-
   public static final String RIB_IPV6_UNICAST = "inet6.0";
-
   public static final String RIB_ISIS = "iso.0";
-
   public static final String RIB_MPLS = "mpls.0";
 
-  /** */
   private static final long serialVersionUID = 1L;
 
-  private Map<Prefix, AggregateRoute> _aggregateRoutes;
-
-  private Map<Prefix, GeneratedRoute> _generatedRoutes;
-
-  private String _name;
-
-  private Map<Prefix, StaticRoute> _staticRoutes;
+  private final Map<Prefix, AggregateRoute> _aggregateRoutes;
+  private final Map<Prefix, GeneratedRoute> _generatedRoutes;
+  private final String _name;
+  private final Map<Prefix, StaticRoute> _staticRoutes;
 
   public RoutingInformationBase(String name) {
     _name = name;
@@ -37,18 +30,22 @@ public class RoutingInformationBase implements Serializable {
     _staticRoutes = new TreeMap<>();
   }
 
+  @Nonnull
   public Map<Prefix, AggregateRoute> getAggregateRoutes() {
     return _aggregateRoutes;
   }
 
+  @Nonnull
   public Map<Prefix, GeneratedRoute> getGeneratedRoutes() {
     return _generatedRoutes;
   }
 
+  @Nonnull
   public String getName() {
     return _name;
   }
 
+  @Nonnull
   public Map<Prefix, StaticRoute> getStaticRoutes() {
     return _staticRoutes;
   }


### PR DESCRIPTION
Marked some fields final and their getters `@Nonnull`, which can help reduce concern over NPEs in #2992.