### PR TITLE
Generic Pruner and Pruner for BidirectionalTraces

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/Pruner.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/Pruner.java
@@ -7,8 +7,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ListMultimap;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -73,12 +73,12 @@ public class Pruner<T> {
     _propertyExtractors = ImmutableList.copyOf(propertyExtractors);
   }
 
-  public Collection<T> prune(List<T> objects, int maxSize) {
+  public List<T> prune(List<T> objects, int maxSize) {
     if (objects.size() <= maxSize) {
       return objects;
     }
 
-    Set<T> selectedObjects = new HashSet<>();
+    LinkedHashSet<T> selectedObjects = new LinkedHashSet<>();
     List<Property<T, ?>> properties =
         _propertyExtractors.stream()
             .map(propertyExtractor -> new Property<>(propertyExtractor, objects))
@@ -106,7 +106,7 @@ public class Pruner<T> {
               .limit(maxSize - selectedObjects.size())
               .collect(Collectors.toList()));
     }
-    return selectedObjects;
+    return ImmutableList.copyOf(selectedObjects);
   }
 
   /** @param <T> The type of objects being pruned. */

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/Pruner.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/Pruner.java
@@ -1,0 +1,132 @@
+package org.batfish.common.util;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+
+/**
+ * Prune a set of objects to "maximize" coverage over some ranked set of properties of interest.
+ *
+ * @param <T> The type of objects being pruned.
+ */
+public class Pruner<T> {
+  private static class Property<T> {
+    private final Function<T, Object> _extractor;
+    private final Map<Object, List<T>> _objectsByPropertyValue;
+
+    Property(Function<T, Object> extractor, List<T> objects) {
+      _extractor = extractor;
+
+      _objectsByPropertyValue = new HashMap<>();
+      objects.forEach(
+          obj ->
+              _objectsByPropertyValue
+                  .computeIfAbsent(_extractor.apply(obj), k -> new ArrayList<>())
+                  .add(obj));
+    }
+
+    void picked(T obj) {
+      _objectsByPropertyValue.remove(_extractor.apply(obj));
+    }
+
+    @Nullable
+    T pick(Set<T> selectedObjects) {
+      if (_objectsByPropertyValue.isEmpty()) {
+        return null;
+      }
+      List<Object> valuesToRemove = new ArrayList<>();
+      T selected = null;
+      Iterator<Entry<Object, List<T>>> iter = _objectsByPropertyValue.entrySet().iterator();
+      while (selected == null && iter.hasNext()) {
+        Entry<Object, List<T>> entry = iter.next();
+        Object propertyValue = entry.getKey();
+        for (T obj : entry.getValue()) {
+          if (!selectedObjects.contains(obj)) {
+            selected = obj;
+            break;
+          }
+        }
+        /* Either we selected an object with this property, or all have already
+         * been selected. Either way, remove it.
+         */
+        valuesToRemove.add(propertyValue);
+      }
+      valuesToRemove.forEach(_objectsByPropertyValue::remove);
+      return selected;
+    }
+  }
+
+  // Properties in order of decreasing importance.
+  private final List<Function<T, Object>> _propertyExtractors;
+
+  private Pruner(List<Function<T, Object>> propertyExtractors) {
+    Preconditions.checkArgument(!propertyExtractors.isEmpty(), "Must define at least one property");
+    _propertyExtractors = ImmutableList.copyOf(propertyExtractors);
+  }
+
+  public Collection<T> prune(List<T> objects, int maxSize) {
+    if (objects.size() <= maxSize) {
+      return objects;
+    }
+
+    Set<T> selectedObjects = new HashSet<>();
+    List<Property<T>> properties =
+        _propertyExtractors.stream()
+            .map(propertyExtractor -> new Property<>(propertyExtractor, objects))
+            .collect(ImmutableList.toImmutableList());
+
+    boolean done = false;
+    while (selectedObjects.size() < maxSize && !done) {
+      done = true;
+      for (Property<T> property : properties) {
+        T picked = property.pick(selectedObjects);
+        if (picked != null) {
+          selectedObjects.add(picked);
+          properties.forEach(prop -> prop.picked(picked));
+          done = false;
+          break;
+        }
+      }
+    }
+
+    if (selectedObjects.size() < maxSize) {
+      // add remaining objects in input order until maxSize is reached
+      selectedObjects.addAll(
+          objects.stream()
+              .filter(obj -> !selectedObjects.contains(obj))
+              .limit(maxSize - selectedObjects.size())
+              .collect(Collectors.toList()));
+    }
+    return selectedObjects;
+  }
+
+  /** @param <T> The type of objects being pruned. */
+  public static class Builder<T> {
+    private final ImmutableList.Builder<Function<T, Object>> _propertyExtractors =
+        ImmutableList.builder();
+
+    public <U> Builder<T> addProperty(Function<T, U> extractor) {
+      _propertyExtractors.add(extractor::apply);
+      return this;
+    }
+
+    public Pruner<T> build() {
+      return new Pruner<T>(_propertyExtractors.build());
+    }
+  }
+
+  public static <T> Builder<T> builder() {
+    return new Builder<T>();
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/Pruner.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/Pruner.java
@@ -1,6 +1,7 @@
 package org.batfish.common.util;
 
-import com.google.common.base.Preconditions;
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ListMultimap;
@@ -68,7 +69,7 @@ public class Pruner<T> {
   private final List<Function<T, ?>> _propertyExtractors;
 
   private Pruner(List<Function<T, ?>> propertyExtractors) {
-    Preconditions.checkArgument(!propertyExtractors.isEmpty(), "Must define at least one property");
+    checkArgument(!propertyExtractors.isEmpty(), "Must define at least one property");
     _propertyExtractors = ImmutableList.copyOf(propertyExtractors);
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/BidirectionalTrace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/BidirectionalTrace.java
@@ -1,0 +1,63 @@
+package org.batfish.datamodel.flow;
+
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.Flow;
+
+/** A pair of forward and reverse {@link Trace Traces}. */
+@ParametersAreNonnullByDefault
+public final class BidirectionalTrace {
+  private final @Nonnull Flow _forwardFlow;
+  private final @Nonnull Trace _forwardTrace;
+  private final @Nullable Flow _reverseFlow;
+  private final @Nullable Trace _reverseTrace;
+
+  public BidirectionalTrace(
+      Flow forwardFlow,
+      Trace forwardTrace,
+      @Nullable Flow reverseFlow,
+      @Nullable Trace reverseTrace) {
+    _forwardFlow = forwardFlow;
+    _forwardTrace = forwardTrace;
+    _reverseFlow = reverseFlow;
+    _reverseTrace = reverseTrace;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof BidirectionalTrace)) {
+      return false;
+    }
+    BidirectionalTrace that = (BidirectionalTrace) o;
+    return Objects.equals(_forwardFlow, that._forwardFlow)
+        && Objects.equals(_forwardTrace, that._forwardTrace)
+        && Objects.equals(_reverseFlow, that._reverseFlow)
+        && Objects.equals(_reverseTrace, that._reverseTrace);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_forwardFlow, _forwardTrace, _reverseFlow, _reverseTrace);
+  }
+
+  public Flow getForwardFlow() {
+    return _forwardFlow;
+  }
+
+  public Trace getForwardTrace() {
+    return _forwardTrace;
+  }
+
+  public Flow getReverseFlow() {
+    return _reverseFlow;
+  }
+
+  public Trace getReverseTrace() {
+    return _reverseTrace;
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/BidirectionalTracePruner.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/BidirectionalTracePruner.java
@@ -1,0 +1,52 @@
+package org.batfish.datamodel.flow;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import java.util.Optional;
+import org.batfish.common.util.Pruner;
+import org.batfish.datamodel.FlowDisposition;
+import org.batfish.datamodel.pojo.Node;
+
+/**
+ * A {@link Pruner} for {@link BidirectionalTrace}. Choose traces to cover the range of values of
+ * each of (in order): the forward flow, the reverse flow, the forward disposition, the reverse
+ * disposition, the nodes traversed in the forward direction, and the nodes traversed in the reverse
+ * direction. Note that the flows include the start location, so the hops are mainly providing
+ * variability of intermediate hops.
+ */
+public final class BidirectionalTracePruner {
+  public static final Pruner<BidirectionalTrace> BIDIRECTIONAL_TRACE_PRUNER =
+      Pruner.<BidirectionalTrace>builder()
+          .addProperty(BidirectionalTrace::getForwardFlow)
+          .addProperty(BidirectionalTrace::getReverseFlow)
+          .addProperty(BidirectionalTracePruner::forwardDisposition)
+          .addProperty(BidirectionalTracePruner::reverseDisposition)
+          .addProperty(BidirectionalTracePruner::forwardHops)
+          .addProperty(BidirectionalTracePruner::reverseHops)
+          .build();
+
+  private static FlowDisposition forwardDisposition(BidirectionalTrace trace) {
+    return trace.getForwardTrace().getDisposition();
+  }
+
+  private static Optional<FlowDisposition> reverseDisposition(BidirectionalTrace trace) {
+    return Optional.ofNullable(trace.getReverseTrace()).map(Trace::getDisposition);
+  }
+
+  private static List<String> forwardHops(BidirectionalTrace trace) {
+    return hops(trace.getForwardTrace());
+  }
+
+  private static List<String> reverseHops(BidirectionalTrace trace) {
+    return Optional.ofNullable(trace.getReverseTrace())
+        .map(BidirectionalTracePruner::hops)
+        .orElse(ImmutableList.of());
+  }
+
+  private static List<String> hops(Trace trace) {
+    return trace.getHops().stream()
+        .map(Hop::getNode)
+        .map(Node::getName)
+        .collect(ImmutableList.toImmutableList());
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/BidirectionalTracePruner.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/BidirectionalTracePruner.java
@@ -1,7 +1,6 @@
 package org.batfish.datamodel.flow;
 
 import com.google.common.collect.ImmutableList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.batfish.common.util.Pruner;
@@ -28,8 +27,7 @@ public final class BidirectionalTracePruner {
           .addProperty(BidirectionalTracePruner::reverseHops)
           .build();
 
-  public static Collection<BidirectionalTrace> prune(
-      List<BidirectionalTrace> objects, int maxSize) {
+  public static List<BidirectionalTrace> prune(List<BidirectionalTrace> objects, int maxSize) {
     return INSTANCE.prune(objects, maxSize);
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/BidirectionalTracePruner.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/BidirectionalTracePruner.java
@@ -1,6 +1,7 @@
 package org.batfish.datamodel.flow;
 
 import com.google.common.collect.ImmutableList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.batfish.common.util.Pruner;
@@ -15,7 +16,9 @@ import org.batfish.datamodel.pojo.Node;
  * variability of intermediate hops.
  */
 public final class BidirectionalTracePruner {
-  public static final Pruner<BidirectionalTrace> BIDIRECTIONAL_TRACE_PRUNER =
+  private BidirectionalTracePruner() {}
+
+  private static final Pruner<BidirectionalTrace> INSTANCE =
       Pruner.<BidirectionalTrace>builder()
           .addProperty(BidirectionalTrace::getForwardFlow)
           .addProperty(BidirectionalTrace::getReverseFlow)
@@ -24,6 +27,11 @@ public final class BidirectionalTracePruner {
           .addProperty(BidirectionalTracePruner::forwardHops)
           .addProperty(BidirectionalTracePruner::reverseHops)
           .build();
+
+  public static Collection<BidirectionalTrace> prune(
+      List<BidirectionalTrace> objects, int maxSize) {
+    return INSTANCE.prune(objects, maxSize);
+  }
 
   private static FlowDisposition forwardDisposition(BidirectionalTrace trace) {
     return trace.getForwardTrace().getDisposition();

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/PrunerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/PrunerTest.java
@@ -1,0 +1,74 @@
+package org.batfish.common.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.junit.Test;
+
+/** Tests for {@link Pruner}. */
+public class PrunerTest {
+
+  @Test
+  public void testString() {
+    Pruner<String> pruner =
+        Pruner.<String>builder()
+            .addProperty(s -> s.charAt(0))
+            .addProperty(s -> s.charAt(1))
+            .addProperty(s -> s.charAt(2))
+            .build();
+
+    List<String> strings =
+        ImmutableList.of(
+            "aaa",
+            "aab",
+            "aac",
+            "aba",
+            "abb",
+            "abc",
+            "aca",
+            "acb",
+            "acc",
+            //
+            "baa",
+            "bab",
+            "bac",
+            "bba",
+            "bbb",
+            "bbc",
+            "bca",
+            "bcb",
+            "bcc",
+            //
+            "caa",
+            "cab",
+            "cac",
+            "cba",
+            "cbb",
+            "cbc",
+            "cca",
+            "ccb",
+            "ccc");
+
+    assertThat(pruner.prune(strings, 100), equalTo(strings));
+    assertThat(pruner.prune(strings, 5), containsInAnyOrder("aaa", "baa", "caa", "aba", "aca"));
+    assertThat(
+        pruner.prune(strings, 12),
+        containsInAnyOrder(
+            "aaa",
+            "baa",
+            "caa",
+            "aba",
+            "aca",
+            "aab",
+            "aac",
+            // All properties covered. Start picking unpicked objects in input order
+            "abb",
+            "abc",
+            "acb",
+            "acc",
+            "bab"));
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/BidirectionalTracePrunerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/BidirectionalTracePrunerTest.java
@@ -3,7 +3,7 @@ package org.batfish.datamodel.flow;
 import static org.batfish.datamodel.FlowDisposition.ACCEPTED;
 import static org.batfish.datamodel.FlowDisposition.DENIED_IN;
 import static org.batfish.datamodel.FlowDisposition.DENIED_OUT;
-import static org.batfish.datamodel.flow.BidirectionalTracePruner.BIDIRECTIONAL_TRACE_PRUNER;
+import static org.batfish.datamodel.flow.BidirectionalTracePruner.prune;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 
@@ -43,8 +43,7 @@ public class BidirectionalTracePrunerTest {
     BidirectionalTrace bTrace4 = new BidirectionalTrace(FLOW2, trace1, FLOW1, trace1);
     BidirectionalTrace bTrace5 = new BidirectionalTrace(FLOW3, trace1, FLOW1, trace1);
     Collection<BidirectionalTrace> pruned =
-        BIDIRECTIONAL_TRACE_PRUNER.prune(
-            ImmutableList.of(bTrace1, bTrace2, bTrace3, bTrace4, bTrace5), 3);
+        prune(ImmutableList.of(bTrace1, bTrace2, bTrace3, bTrace4, bTrace5), 3);
     assertThat(pruned, containsInAnyOrder(bTrace1, bTrace4, bTrace5));
   }
 
@@ -61,8 +60,7 @@ public class BidirectionalTracePrunerTest {
     BidirectionalTrace bTrace4 = new BidirectionalTrace(FLOW1, trace1, FLOW2, trace1);
     BidirectionalTrace bTrace5 = new BidirectionalTrace(FLOW1, trace1, FLOW3, trace1);
     Collection<BidirectionalTrace> pruned =
-        BIDIRECTIONAL_TRACE_PRUNER.prune(
-            ImmutableList.of(bTrace1, bTrace2, bTrace3, bTrace4, bTrace5), 3);
+        prune(ImmutableList.of(bTrace1, bTrace2, bTrace3, bTrace4, bTrace5), 3);
     assertThat(pruned, containsInAnyOrder(bTrace1, bTrace4, bTrace5));
   }
 
@@ -80,8 +78,7 @@ public class BidirectionalTracePrunerTest {
     BidirectionalTrace bTrace4 = new BidirectionalTrace(FLOW1, trace3, FLOW1, trace1);
     BidirectionalTrace bTrace5 = new BidirectionalTrace(FLOW1, trace4, FLOW1, trace1);
     Collection<BidirectionalTrace> pruned =
-        BIDIRECTIONAL_TRACE_PRUNER.prune(
-            ImmutableList.of(bTrace1, bTrace2, bTrace3, bTrace4, bTrace5), 3);
+        prune(ImmutableList.of(bTrace1, bTrace2, bTrace3, bTrace4, bTrace5), 3);
     assertThat(pruned, containsInAnyOrder(bTrace1, bTrace4, bTrace5));
   }
 
@@ -99,8 +96,7 @@ public class BidirectionalTracePrunerTest {
     BidirectionalTrace bTrace4 = new BidirectionalTrace(FLOW1, trace2, FLOW1, trace3);
     BidirectionalTrace bTrace5 = new BidirectionalTrace(FLOW1, trace1, FLOW1, trace4);
     Collection<BidirectionalTrace> pruned =
-        BIDIRECTIONAL_TRACE_PRUNER.prune(
-            ImmutableList.of(bTrace1, bTrace2, bTrace3, bTrace4, bTrace5), 3);
+        prune(ImmutableList.of(bTrace1, bTrace2, bTrace3, bTrace4, bTrace5), 3);
     assertThat(pruned, containsInAnyOrder(bTrace1, bTrace4, bTrace5));
   }
 
@@ -117,8 +113,7 @@ public class BidirectionalTracePrunerTest {
     BidirectionalTrace bTrace4 = new BidirectionalTrace(FLOW1, trace2, FLOW1, trace1);
     BidirectionalTrace bTrace5 = new BidirectionalTrace(FLOW1, trace3, FLOW1, trace1);
     Collection<BidirectionalTrace> pruned =
-        BIDIRECTIONAL_TRACE_PRUNER.prune(
-            ImmutableList.of(bTrace1, bTrace2, bTrace3, bTrace4, bTrace5), 3);
+        prune(ImmutableList.of(bTrace1, bTrace2, bTrace3, bTrace4, bTrace5), 3);
     assertThat(pruned, containsInAnyOrder(bTrace1, bTrace4, bTrace5));
   }
 
@@ -135,8 +130,7 @@ public class BidirectionalTracePrunerTest {
     BidirectionalTrace bTrace4 = new BidirectionalTrace(FLOW1, trace1, FLOW1, trace2);
     BidirectionalTrace bTrace5 = new BidirectionalTrace(FLOW1, trace1, FLOW1, trace3);
     Collection<BidirectionalTrace> pruned =
-        BIDIRECTIONAL_TRACE_PRUNER.prune(
-            ImmutableList.of(bTrace1, bTrace2, bTrace3, bTrace4, bTrace5), 3);
+        prune(ImmutableList.of(bTrace1, bTrace2, bTrace3, bTrace4, bTrace5), 3);
     assertThat(pruned, containsInAnyOrder(bTrace1, bTrace4, bTrace5));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/BidirectionalTracePrunerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/BidirectionalTracePrunerTest.java
@@ -18,14 +18,12 @@ public class BidirectionalTracePrunerTest {
   private static final Flow FLOW1;
   private static final Flow FLOW2;
   private static final Flow FLOW3;
-  private static final Flow FLOW4;
 
   static {
     Flow.Builder fb = Flow.builder().setTag("tag");
     FLOW1 = fb.setIngressNode("flow1").build();
     FLOW2 = fb.setIngressNode("flow2").build();
     FLOW3 = fb.setIngressNode("flow3").build();
-    FLOW4 = fb.setIngressNode("flow4").build();
   }
 
   private static final Hop HOP1 = new Hop(new Node("hop1"), ImmutableList.of());
@@ -70,7 +68,7 @@ public class BidirectionalTracePrunerTest {
 
   /** Test that forward dispositions are covered before reverse dispositions or hops. */
   @Test
-  public void testForwardDiposition() {
+  public void testForwardDisposition() {
     Trace trace1 = new Trace(ACCEPTED, ImmutableList.of(HOP1));
     Trace trace2 = new Trace(ACCEPTED, ImmutableList.of(HOP2));
     Trace trace3 = new Trace(DENIED_IN, ImmutableList.of(HOP3));
@@ -87,9 +85,9 @@ public class BidirectionalTracePrunerTest {
     assertThat(pruned, containsInAnyOrder(bTrace1, bTrace4, bTrace5));
   }
 
-  /** Test that reverse dipositions are covered before hops. */
+  /** Test that reverse dispositions are covered before hops. */
   @Test
-  public void testReverseDiposition() {
+  public void testReverseDisposition() {
     Trace trace1 = new Trace(ACCEPTED, ImmutableList.of(HOP1));
     Trace trace2 = new Trace(ACCEPTED, ImmutableList.of(HOP2));
     Trace trace3 = new Trace(DENIED_IN, ImmutableList.of(HOP3));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/BidirectionalTracePrunerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/BidirectionalTracePrunerTest.java
@@ -1,0 +1,144 @@
+package org.batfish.datamodel.flow;
+
+import static org.batfish.datamodel.FlowDisposition.ACCEPTED;
+import static org.batfish.datamodel.FlowDisposition.DENIED_IN;
+import static org.batfish.datamodel.FlowDisposition.DENIED_OUT;
+import static org.batfish.datamodel.flow.BidirectionalTracePruner.BIDIRECTIONAL_TRACE_PRUNER;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Collection;
+import org.batfish.datamodel.Flow;
+import org.batfish.datamodel.pojo.Node;
+import org.junit.Test;
+
+/** A test for {@link BidirectionalTracePruner}. */
+public class BidirectionalTracePrunerTest {
+  private static final Flow FLOW1;
+  private static final Flow FLOW2;
+  private static final Flow FLOW3;
+  private static final Flow FLOW4;
+
+  static {
+    Flow.Builder fb = Flow.builder().setTag("tag");
+    FLOW1 = fb.setIngressNode("flow1").build();
+    FLOW2 = fb.setIngressNode("flow2").build();
+    FLOW3 = fb.setIngressNode("flow3").build();
+    FLOW4 = fb.setIngressNode("flow4").build();
+  }
+
+  private static final Hop HOP1 = new Hop(new Node("hop1"), ImmutableList.of());
+  private static final Hop HOP2 = new Hop(new Node("hop2"), ImmutableList.of());
+  private static final Hop HOP3 = new Hop(new Node("hop3"), ImmutableList.of());
+
+  /** Test that forward flow values are covered before reverse flow, dispositions, or hops. */
+  @Test
+  public void testForwardFlow() {
+    Trace trace1 = new Trace(ACCEPTED, ImmutableList.of(HOP1));
+    Trace trace2 = new Trace(DENIED_IN, ImmutableList.of(HOP2));
+    Trace trace3 = new Trace(DENIED_OUT, ImmutableList.of(HOP3));
+
+    BidirectionalTrace bTrace1 = new BidirectionalTrace(FLOW1, trace1, FLOW1, trace1);
+    BidirectionalTrace bTrace2 = new BidirectionalTrace(FLOW1, trace2, FLOW2, trace2);
+    BidirectionalTrace bTrace3 = new BidirectionalTrace(FLOW1, trace3, FLOW3, trace3);
+    BidirectionalTrace bTrace4 = new BidirectionalTrace(FLOW2, trace1, FLOW1, trace1);
+    BidirectionalTrace bTrace5 = new BidirectionalTrace(FLOW3, trace1, FLOW1, trace1);
+    Collection<BidirectionalTrace> pruned =
+        BIDIRECTIONAL_TRACE_PRUNER.prune(
+            ImmutableList.of(bTrace1, bTrace2, bTrace3, bTrace4, bTrace5), 3);
+    assertThat(pruned, containsInAnyOrder(bTrace1, bTrace4, bTrace5));
+  }
+
+  /** Test that reverse flow values are covered before dispositions or hops. */
+  @Test
+  public void testReverseFlow() {
+    Trace trace1 = new Trace(ACCEPTED, ImmutableList.of(HOP1));
+    Trace trace2 = new Trace(DENIED_IN, ImmutableList.of(HOP2));
+    Trace trace3 = new Trace(DENIED_OUT, ImmutableList.of(HOP3));
+
+    BidirectionalTrace bTrace1 = new BidirectionalTrace(FLOW1, trace1, FLOW1, trace1);
+    BidirectionalTrace bTrace2 = new BidirectionalTrace(FLOW1, trace2, FLOW1, trace2);
+    BidirectionalTrace bTrace3 = new BidirectionalTrace(FLOW1, trace3, FLOW1, trace3);
+    BidirectionalTrace bTrace4 = new BidirectionalTrace(FLOW1, trace1, FLOW2, trace1);
+    BidirectionalTrace bTrace5 = new BidirectionalTrace(FLOW1, trace1, FLOW3, trace1);
+    Collection<BidirectionalTrace> pruned =
+        BIDIRECTIONAL_TRACE_PRUNER.prune(
+            ImmutableList.of(bTrace1, bTrace2, bTrace3, bTrace4, bTrace5), 3);
+    assertThat(pruned, containsInAnyOrder(bTrace1, bTrace4, bTrace5));
+  }
+
+  /** Test that forward dispositions are covered before reverse dispositions or hops. */
+  @Test
+  public void testForwardDiposition() {
+    Trace trace1 = new Trace(ACCEPTED, ImmutableList.of(HOP1));
+    Trace trace2 = new Trace(ACCEPTED, ImmutableList.of(HOP2));
+    Trace trace3 = new Trace(DENIED_IN, ImmutableList.of(HOP3));
+    Trace trace4 = new Trace(DENIED_OUT, ImmutableList.of(HOP3));
+
+    BidirectionalTrace bTrace1 = new BidirectionalTrace(FLOW1, trace1, FLOW1, trace1);
+    BidirectionalTrace bTrace2 = new BidirectionalTrace(FLOW1, trace2, FLOW1, trace2);
+    BidirectionalTrace bTrace3 = new BidirectionalTrace(FLOW1, trace2, FLOW1, trace3);
+    BidirectionalTrace bTrace4 = new BidirectionalTrace(FLOW1, trace3, FLOW1, trace1);
+    BidirectionalTrace bTrace5 = new BidirectionalTrace(FLOW1, trace4, FLOW1, trace1);
+    Collection<BidirectionalTrace> pruned =
+        BIDIRECTIONAL_TRACE_PRUNER.prune(
+            ImmutableList.of(bTrace1, bTrace2, bTrace3, bTrace4, bTrace5), 3);
+    assertThat(pruned, containsInAnyOrder(bTrace1, bTrace4, bTrace5));
+  }
+
+  /** Test that reverse dipositions are covered before hops. */
+  @Test
+  public void testReverseDiposition() {
+    Trace trace1 = new Trace(ACCEPTED, ImmutableList.of(HOP1));
+    Trace trace2 = new Trace(ACCEPTED, ImmutableList.of(HOP2));
+    Trace trace3 = new Trace(DENIED_IN, ImmutableList.of(HOP3));
+    Trace trace4 = new Trace(DENIED_OUT, ImmutableList.of(HOP3));
+
+    BidirectionalTrace bTrace1 = new BidirectionalTrace(FLOW1, trace1, FLOW1, trace1);
+    BidirectionalTrace bTrace2 = new BidirectionalTrace(FLOW1, trace2, FLOW1, trace2);
+    BidirectionalTrace bTrace3 = new BidirectionalTrace(FLOW1, trace1, FLOW1, trace1);
+    BidirectionalTrace bTrace4 = new BidirectionalTrace(FLOW1, trace2, FLOW1, trace3);
+    BidirectionalTrace bTrace5 = new BidirectionalTrace(FLOW1, trace1, FLOW1, trace4);
+    Collection<BidirectionalTrace> pruned =
+        BIDIRECTIONAL_TRACE_PRUNER.prune(
+            ImmutableList.of(bTrace1, bTrace2, bTrace3, bTrace4, bTrace5), 3);
+    assertThat(pruned, containsInAnyOrder(bTrace1, bTrace4, bTrace5));
+  }
+
+  /** Test that forward hops are covered before reverse hops. */
+  @Test
+  public void testForwardHops() {
+    Trace trace1 = new Trace(ACCEPTED, ImmutableList.of(HOP1));
+    Trace trace2 = new Trace(ACCEPTED, ImmutableList.of(HOP2));
+    Trace trace3 = new Trace(ACCEPTED, ImmutableList.of(HOP3));
+
+    BidirectionalTrace bTrace1 = new BidirectionalTrace(FLOW1, trace1, FLOW1, trace1);
+    BidirectionalTrace bTrace2 = new BidirectionalTrace(FLOW1, trace1, FLOW1, trace2);
+    BidirectionalTrace bTrace3 = new BidirectionalTrace(FLOW1, trace1, FLOW1, trace3);
+    BidirectionalTrace bTrace4 = new BidirectionalTrace(FLOW1, trace2, FLOW1, trace1);
+    BidirectionalTrace bTrace5 = new BidirectionalTrace(FLOW1, trace3, FLOW1, trace1);
+    Collection<BidirectionalTrace> pruned =
+        BIDIRECTIONAL_TRACE_PRUNER.prune(
+            ImmutableList.of(bTrace1, bTrace2, bTrace3, bTrace4, bTrace5), 3);
+    assertThat(pruned, containsInAnyOrder(bTrace1, bTrace4, bTrace5));
+  }
+
+  /** Test that reverse hops are covered. */
+  @Test
+  public void testReverseHops() {
+    Trace trace1 = new Trace(ACCEPTED, ImmutableList.of(HOP1));
+    Trace trace2 = new Trace(ACCEPTED, ImmutableList.of(HOP2));
+    Trace trace3 = new Trace(ACCEPTED, ImmutableList.of(HOP3));
+
+    BidirectionalTrace bTrace1 = new BidirectionalTrace(FLOW1, trace1, FLOW1, trace1);
+    BidirectionalTrace bTrace2 = new BidirectionalTrace(FLOW1, trace1, FLOW1, trace1);
+    BidirectionalTrace bTrace3 = new BidirectionalTrace(FLOW1, trace1, FLOW1, trace1);
+    BidirectionalTrace bTrace4 = new BidirectionalTrace(FLOW1, trace1, FLOW1, trace2);
+    BidirectionalTrace bTrace5 = new BidirectionalTrace(FLOW1, trace1, FLOW1, trace3);
+    Collection<BidirectionalTrace> pruned =
+        BIDIRECTIONAL_TRACE_PRUNER.prune(
+            ImmutableList.of(bTrace1, bTrace2, bTrace3, bTrace4, bTrace5), 3);
+    assertThat(pruned, containsInAnyOrder(bTrace1, bTrace4, bTrace5));
+  }
+}


### PR DESCRIPTION
Generalize TracePruner, and then instantiate for a new BidirectionalTrace class. Eventually can migrate the old TracePruner to the new framework too.