### PR TITLE
Juniper: simplify copying list of children

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ApplyGroupsApplicator.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ApplyGroupsApplicator.java
@@ -103,8 +103,7 @@ public class ApplyGroupsApplicator extends FlatJuniperParserBaseListener {
   @Override
   public void enterFlat_juniper_configuration(Flat_juniper_configurationContext ctx) {
     _configurationContext = ctx;
-    _newConfigurationLines = new ArrayList<>();
-    _newConfigurationLines.addAll(ctx.children);
+    _newConfigurationLines = new ArrayList<>(ctx.children);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ApplyPathApplicator.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ApplyPathApplicator.java
@@ -39,8 +39,7 @@ public class ApplyPathApplicator extends FlatJuniperParserBaseListener {
   @Override
   public void enterFlat_juniper_configuration(Flat_juniper_configurationContext ctx) {
     _configurationContext = ctx;
-    _newConfigurationLines = new ArrayList<>();
-    _newConfigurationLines.addAll(ctx.children);
+    _newConfigurationLines = new ArrayList<>(ctx.children);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/DeactivateLinePruner.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/DeactivateLinePruner.java
@@ -15,8 +15,7 @@ public class DeactivateLinePruner extends FlatJuniperParserBaseListener {
   @Override
   public void enterFlat_juniper_configuration(Flat_juniper_configurationContext ctx) {
     _configurationContext = ctx;
-    _newConfigurationLines = new ArrayList<>();
-    _newConfigurationLines.addAll(ctx.children);
+    _newConfigurationLines = new ArrayList<>(ctx.children);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/DeactivatedLinePruner.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/DeactivatedLinePruner.java
@@ -33,8 +33,7 @@ public class DeactivatedLinePruner extends FlatJuniperParserBaseListener {
   @Override
   public void enterFlat_juniper_configuration(Flat_juniper_configurationContext ctx) {
     _configurationContext = ctx;
-    _newConfigurationLines = new ArrayList<>();
-    _newConfigurationLines.addAll(ctx.children);
+    _newConfigurationLines = new ArrayList<>(ctx.children);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/GroupPruner.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/GroupPruner.java
@@ -18,8 +18,7 @@ public class GroupPruner extends FlatJuniperParserBaseListener {
   @Override
   public void enterFlat_juniper_configuration(Flat_juniper_configurationContext ctx) {
     _configurationContext = ctx;
-    _newConfigurationLines = new ArrayList<>();
-    _newConfigurationLines.addAll(ctx.children);
+    _newConfigurationLines = new ArrayList<>(ctx.children);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/GroupTreeBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/GroupTreeBuilder.java
@@ -44,8 +44,7 @@ public class GroupTreeBuilder extends FlatJuniperParserBaseListener {
   @Override
   public void enterFlat_juniper_configuration(Flat_juniper_configurationContext ctx) {
     _configurationContext = ctx;
-    _newConfigurationLines = new ArrayList<>();
-    _newConfigurationLines.addAll(ctx.children);
+    _newConfigurationLines = new ArrayList<>(ctx.children);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/WildcardApplicator.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/WildcardApplicator.java
@@ -31,8 +31,7 @@ public class WildcardApplicator extends FlatJuniperParserBaseListener {
   @Override
   public void enterFlat_juniper_configuration(Flat_juniper_configurationContext ctx) {
     _configurationContext = ctx;
-    _newConfigurationLines = new ArrayList<>();
-    _newConfigurationLines.addAll(ctx.children);
+    _newConfigurationLines = new ArrayList<>(ctx.children);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/WildcardPruner.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/WildcardPruner.java
@@ -22,8 +22,7 @@ public class WildcardPruner extends FlatJuniperParserBaseListener {
   @Override
   public void enterFlat_juniper_configuration(Flat_juniper_configurationContext ctx) {
     _configurationContext = ctx;
-    _newConfigurationLines = new ArrayList<>();
-    _newConfigurationLines.addAll(ctx.children);
+    _newConfigurationLines = new ArrayList<>(ctx.children);
   }
 
   @Override


### PR DESCRIPTION
Saves a bit of work by preallocating array size