### PR TITLE
Begin work on toBuilder() for routes.

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractRoute.java
@@ -156,4 +156,7 @@ public abstract class AbstractRoute implements Serializable, Comparable<Abstract
         + getNextHopInterface()
         + ">";
   }
+
+  /** Return a {@link AbstractRouteBuilder} pre-populated with the values for this route. */
+  public abstract AbstractRouteBuilder<?, ?> toBuilder();
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpRoute.java
@@ -25,11 +25,11 @@ import org.batfish.common.util.CommonUtil;
  * present only in BGP advertisements on the wire)
  */
 @ParametersAreNonnullByDefault
-public class BgpRoute extends AbstractRoute {
+public final class BgpRoute extends AbstractRoute {
 
   /** Builder for {@link BgpRoute} */
   @ParametersAreNonnullByDefault
-  public static class Builder extends AbstractRouteBuilder<Builder, BgpRoute> {
+  public static final class Builder extends AbstractRouteBuilder<Builder, BgpRoute> {
 
     @Nonnull private AsPath _asPath;
     @Nonnull private ImmutableSortedSet.Builder<Long> _clusterList;
@@ -519,7 +519,7 @@ public class BgpRoute extends AbstractRoute {
   }
 
   @Override
-  public AbstractRouteBuilder<?, ?> toBuilder() {
+  public Builder toBuilder() {
     return builder()
         .setNetwork(getNetwork())
         .setAdmin(getAdministrativeCost())

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpRoute.java
@@ -52,6 +52,9 @@ public class BgpRoute extends AbstractRoute {
 
     @Override
     public BgpRoute build() {
+      checkArgument(_originatorIp != null, "Missing %s", PROP_ORIGINATOR_IP);
+      checkArgument(_originType != null, "Missing %s", PROP_ORIGIN_TYPE);
+      checkArgument(_protocol != null, "Missing %s", PROP_PROTOCOL);
       return new BgpRoute(
           getNetwork(),
           getNextHopIp(),
@@ -325,8 +328,7 @@ public class BgpRoute extends AbstractRoute {
       long med,
       Ip originatorIp,
       @Nullable SortedSet<Long> clusterList,
-      @JsonProperty(PROP_RECEIVED_FROM_ROUTE_REFLECTOR_CLIENT)
-          boolean receivedFromRouteReflectorClient,
+      boolean receivedFromRouteReflectorClient,
       OriginType originType,
       RoutingProtocol protocol,
       @Nullable Ip receivedFromIp,
@@ -368,6 +370,8 @@ public class BgpRoute extends AbstractRoute {
     BgpRoute other = (BgpRoute) o;
     return Objects.equals(_network, other._network)
         && _admin == other._admin
+        && getNonRouting() == other.getNonRouting()
+        && getNonForwarding() == other.getNonForwarding()
         && _discard == other._discard
         && _localPreference == other._localPreference
         && _med == other._med
@@ -512,5 +516,28 @@ public class BgpRoute extends AbstractRoute {
       return 0;
     }
     return COMPARATOR.compare(this, (BgpRoute) rhs);
+  }
+
+  @Override
+  public AbstractRouteBuilder<?, ?> toBuilder() {
+    return builder()
+        .setNetwork(getNetwork())
+        .setAdmin(getAdministrativeCost())
+        .setNonRouting(getNonRouting())
+        .setNonForwarding(getNonForwarding())
+        .setAsPath(_asPath)
+        .setClusterList(_clusterList)
+        .setCommunities(_communities)
+        .setDiscard(_discard)
+        .setLocalPreference(_localPreference)
+        .setMetric(_med)
+        .setNextHopIp(_nextHopIp)
+        .setOriginatorIp(_originatorIp)
+        .setOriginType(_originType)
+        .setProtocol(_protocol)
+        .setReceivedFromIp(_receivedFromIp)
+        .setReceivedFromRouteReflectorClient(_receivedFromRouteReflectorClient)
+        .setSrcProtocol(_srcProtocol)
+        .setWeight(_weight);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ConnectedRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ConnectedRoute.java
@@ -25,12 +25,14 @@ public class ConnectedRoute extends AbstractRoute {
   @JsonCreator
   private static ConnectedRoute create(
       @Nullable @JsonProperty(PROP_NETWORK) Prefix network,
-      @Nullable @JsonProperty(PROP_NEXT_HOP_INTERFACE) String nextHopInterface) {
+      @Nullable @JsonProperty(PROP_NEXT_HOP_INTERFACE) String nextHopInterface,
+      @JsonProperty(PROP_ADMINISTRATIVE_COST) int adminCost) {
     checkArgument(network != null, "Cannot create connected route: missing %s", PROP_NETWORK);
     return new ConnectedRoute(
         network, firstNonNull(nextHopInterface, Route.UNSET_NEXT_HOP_INTERFACE));
   }
 
+  /** Create a connected route with admin cost of 0 */
   public ConnectedRoute(Prefix network, String nextHopInterface) {
     this(network, nextHopInterface, 0);
   }
@@ -88,5 +90,43 @@ public class ConnectedRoute extends AbstractRoute {
   @Override
   public int routeCompare(@Nonnull AbstractRoute rhs) {
     return 0;
+  }
+
+  @Override
+  public Builder toBuilder() {
+    return builder()
+        .setNetwork(getNetwork())
+        .setAdmin(_admin)
+        .setNonRouting(getNonRouting())
+        .setNonForwarding(getNonForwarding())
+        .setNextHopInterface(_nextHopInterface);
+  }
+
+  /** Builder for {@link ConnectedRoute} */
+  public static class Builder extends AbstractRouteBuilder<Builder, ConnectedRoute> {
+    @Nullable private String _nextHopInterface;
+
+    @Nonnull
+    @Override
+    public ConnectedRoute build() {
+      checkArgument(
+          _nextHopInterface != null, "ConnectedRoute must have %s", PROP_NEXT_HOP_INTERFACE);
+      return new ConnectedRoute(getNetwork(), _nextHopInterface, getAdmin());
+    }
+
+    @Nonnull
+    @Override
+    protected Builder getThis() {
+      return this;
+    }
+
+    public Builder setNextHopInterface(String nextHopInterface) {
+      _nextHopInterface = nextHopInterface;
+      return getThis();
+    }
+  }
+
+  public static Builder builder() {
+    return new Builder();
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ConnectedRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ConnectedRoute.java
@@ -16,7 +16,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  * adjacencies.
  */
 @ParametersAreNonnullByDefault
-public class ConnectedRoute extends AbstractRoute {
+public final class ConnectedRoute extends AbstractRoute {
 
   private static final long serialVersionUID = 1L;
 
@@ -107,7 +107,7 @@ public class ConnectedRoute extends AbstractRoute {
   }
 
   /** Builder for {@link ConnectedRoute} */
-  public static class Builder extends AbstractRouteBuilder<Builder, ConnectedRoute> {
+  public static final class Builder extends AbstractRouteBuilder<Builder, ConnectedRoute> {
     @Nullable private String _nextHopInterface;
 
     @Nonnull

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ConnectedRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ConnectedRoute.java
@@ -50,12 +50,16 @@ public class ConnectedRoute extends AbstractRoute {
       return false;
     }
     ConnectedRoute rhs = (ConnectedRoute) o;
-    return _network.equals(rhs._network) && _nextHopInterface.equals(rhs._nextHopInterface);
+    return _network.equals(rhs._network)
+        && _admin == rhs._admin
+        && getNonRouting() == rhs.getNonRouting()
+        && getNonForwarding() == rhs.getNonForwarding()
+        && _nextHopInterface.equals(rhs._nextHopInterface);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_network, _admin, _nextHopInterface);
+    return Objects.hash(_network, _admin, getNonRouting(), getNonForwarding(), _nextHopInterface);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EigrpExternalRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EigrpExternalRoute.java
@@ -95,6 +95,11 @@ public class EigrpExternalRoute extends EigrpRoute {
   }
 
   @Override
+  public AbstractRouteBuilder<?, ?> toBuilder() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public final int hashCode() {
     return hash(
         _admin, _destinationAsn, _metric.hashCode(), _network, _nextHopIp, _nextHopInterface);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EigrpInternalRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EigrpInternalRoute.java
@@ -69,6 +69,11 @@ public class EigrpInternalRoute extends EigrpRoute {
   }
 
   @Override
+  public AbstractRouteBuilder<?, ?> toBuilder() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public final int hashCode() {
     return Objects.hash(_admin, _metric.hashCode(), _network, _nextHopIp, _nextHopInterface);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/GeneratedRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/GeneratedRoute.java
@@ -324,6 +324,11 @@ public final class GeneratedRoute extends AbstractRoute {
         .compare(this, castRhs);
   }
 
+  @Override
+  public AbstractRouteBuilder<?, ?> toBuilder() {
+    throw new UnsupportedOperationException();
+  }
+
   @JsonProperty(PROP_ATTRIBUTE_POLICY_SOURCES)
   public void setAttributePolicySources(SortedSet<String> attributePolicySources) {
     _attributePolicySources = attributePolicySources;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IsisRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IsisRoute.java
@@ -209,6 +209,7 @@ public class IsisRoute extends AbstractRoute {
         _systemId);
   }
 
+  @Override
   public Builder toBuilder() {
     return new Builder()
         .setAdmin(_admin)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/LocalRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/LocalRoute.java
@@ -6,6 +6,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.VisibleForTesting;
 import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -32,7 +33,8 @@ public class LocalRoute extends AbstractRoute {
         0);
   }
 
-  private LocalRoute(Prefix network, String nextHopInterface, int sourcePrefixLength, int admin) {
+  @VisibleForTesting
+  LocalRoute(Prefix network, String nextHopInterface, int sourcePrefixLength, int admin) {
     super(network, admin, false, false);
     _nextHopInterface = firstNonNull(nextHopInterface, Route.UNSET_NEXT_HOP_INTERFACE);
     _sourcePrefixLength = sourcePrefixLength;
@@ -62,6 +64,8 @@ public class LocalRoute extends AbstractRoute {
     LocalRoute rhs = (LocalRoute) o;
     return _network.equals(rhs._network)
         && _admin == rhs._admin
+        && getNonRouting() == rhs.getNonRouting()
+        && getNonForwarding() == rhs.getNonForwarding()
         && _nextHopInterface.equals(rhs._nextHopInterface)
         && _sourcePrefixLength == rhs._sourcePrefixLength;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/LocalRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/LocalRoute.java
@@ -17,7 +17,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  * They are {@link Prefix#MAX_PREFIX_LENGTH} routes to the interface's IP address.
  */
 @ParametersAreNonnullByDefault
-public class LocalRoute extends AbstractRoute {
+public final class LocalRoute extends AbstractRoute {
 
   private static final long serialVersionUID = 1L;
   private static final String PROP_SOURCE_PREFIX_LENGTH = "sourcePrefixLength";
@@ -36,7 +36,7 @@ public class LocalRoute extends AbstractRoute {
   @VisibleForTesting
   LocalRoute(Prefix network, String nextHopInterface, int sourcePrefixLength, int admin) {
     super(network, admin, false, false);
-    _nextHopInterface = firstNonNull(nextHopInterface, Route.UNSET_NEXT_HOP_INTERFACE);
+    _nextHopInterface = nextHopInterface;
     _sourcePrefixLength = sourcePrefixLength;
   }
 
@@ -72,7 +72,13 @@ public class LocalRoute extends AbstractRoute {
 
   @Override
   public int hashCode() {
-    return Objects.hash(_network, _admin, _nextHopInterface, _sourcePrefixLength);
+    return Objects.hash(
+        _network,
+        _admin,
+        getNonRouting(),
+        getNonForwarding(),
+        _nextHopInterface,
+        _sourcePrefixLength);
   }
 
   @Override
@@ -129,7 +135,7 @@ public class LocalRoute extends AbstractRoute {
   }
 
   /** Builder for {@link org.batfish.datamodel.LocalRoute} */
-  public static class Builder extends AbstractRouteBuilder<Builder, LocalRoute> {
+  public static final class Builder extends AbstractRouteBuilder<Builder, LocalRoute> {
 
     @Nullable private String _nextHopInterface;
     @Nullable private Integer _sourcePrefixLength;
@@ -137,6 +143,7 @@ public class LocalRoute extends AbstractRoute {
     @Nonnull
     @Override
     public LocalRoute build() {
+      checkArgument(getNetwork() != null, "LocalRoute missing %s", PROP_NETWORK);
       checkArgument(
           _sourcePrefixLength != null, "LocalRoute missing %s", PROP_SOURCE_PREFIX_LENGTH);
       return new LocalRoute(

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfExternalType1Route.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfExternalType1Route.java
@@ -68,6 +68,11 @@ public class OspfExternalType1Route extends OspfExternalRoute {
   }
 
   @Override
+  public AbstractRouteBuilder<?, ?> toBuilder() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfExternalType2Route.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfExternalType2Route.java
@@ -92,4 +92,9 @@ public class OspfExternalType2Route extends OspfExternalRoute {
     OspfExternalType2Route castRhs = (OspfExternalType2Route) rhs;
     return Long.compare(getCostToAdvertiser(), castRhs.getCostToAdvertiser());
   }
+
+  @Override
+  public AbstractRouteBuilder<?, ?> toBuilder() {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfInterAreaRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfInterAreaRoute.java
@@ -68,4 +68,9 @@ public class OspfInterAreaRoute extends OspfInternalRoute {
     OspfInterAreaRoute castRhs = (OspfInterAreaRoute) rhs;
     return Comparator.comparing(OspfInterAreaRoute::getArea).compare(this, castRhs);
   }
+
+  @Override
+  public AbstractRouteBuilder<?, ?> toBuilder() {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfIntraAreaRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfIntraAreaRoute.java
@@ -67,4 +67,9 @@ public class OspfIntraAreaRoute extends OspfInternalRoute {
     OspfIntraAreaRoute castRhs = (OspfIntraAreaRoute) rhs;
     return Long.compare(_area, castRhs._area);
   }
+
+  @Override
+  public AbstractRouteBuilder<?, ?> toBuilder() {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RipInternalRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RipInternalRoute.java
@@ -68,4 +68,9 @@ public class RipInternalRoute extends RipRoute {
     }
     return 0;
   }
+
+  @Override
+  public AbstractRouteBuilder<?, ?> toBuilder() {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/StaticRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/StaticRoute.java
@@ -131,6 +131,11 @@ public class StaticRoute extends AbstractRoute {
     return 0;
   }
 
+  @Override
+  public AbstractRouteBuilder<?, ?> toBuilder() {
+    throw new UnsupportedOperationException();
+  }
+
   /** Builder for {@link StaticRoute} */
   public static final class Builder extends AbstractRouteBuilder<Builder, StaticRoute> {
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/BgpRouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/BgpRouteTest.java
@@ -1,0 +1,117 @@
+package org.batfish.datamodel;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.testing.EqualsTester;
+import java.io.IOException;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.BgpRoute.Builder;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/** Tests of {@link BgpRoute} */
+public class BgpRouteTest {
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testJavaSerialization() {
+    BgpRoute br =
+        BgpRoute.builder()
+            .setNetwork(Prefix.parse("1.1.1.0/24"))
+            .setOriginatorIp(Ip.parse("1.1.1.1"))
+            .setOriginType(OriginType.IGP)
+            .setProtocol(RoutingProtocol.BGP)
+            .build();
+    assertThat(SerializationUtils.clone(br), equalTo(br));
+  }
+
+  @Test
+  public void testJsonSerialization() throws IOException {
+    BgpRoute br =
+        BgpRoute.builder()
+            .setNetwork(Prefix.parse("1.1.1.0/24"))
+            .setOriginatorIp(Ip.parse("1.1.1.1"))
+            .setOriginType(OriginType.IGP)
+            .setProtocol(RoutingProtocol.BGP)
+            .build();
+    assertThat(BatfishObjectMapper.clone(br, BgpRoute.class), equalTo(br));
+  }
+
+  @Test
+  public void testToBuilder() {
+    BgpRoute br =
+        BgpRoute.builder()
+            .setNetwork(Prefix.parse("1.1.1.0/24"))
+            .setOriginatorIp(Ip.parse("1.1.1.1"))
+            .setOriginType(OriginType.IGP)
+            .setProtocol(RoutingProtocol.BGP)
+            .build();
+    assertThat(br, equalTo(br.toBuilder().build()));
+  }
+
+  @Test
+  public void testEquals() {
+    Builder brb =
+        BgpRoute.builder()
+            .setNetwork(Prefix.parse("1.1.1.0/24"))
+            .setOriginatorIp(Ip.parse("1.1.1.1"))
+            .setOriginType(OriginType.IGP)
+            .setProtocol(RoutingProtocol.BGP);
+    new EqualsTester()
+        .addEqualityGroup(brb.build(), brb.build())
+        .addEqualityGroup(brb.setNetwork(Prefix.parse("1.1.2.0/24")).build())
+        .addEqualityGroup(brb.setAdmin(10).build())
+        .addEqualityGroup(brb.setNonRouting(true).build())
+        .addEqualityGroup(brb.setNonForwarding(true).build())
+        .addEqualityGroup(brb.setAsPath(AsPath.ofSingletonAsSets(1L, 1L)).build())
+        .addEqualityGroup(brb.setClusterList(ImmutableSet.of(1L)).build())
+        .addEqualityGroup(brb.setCommunities(ImmutableSet.of(1L)).build())
+        .addEqualityGroup(brb.setDiscard(true).build())
+        .addEqualityGroup(brb.setLocalPreference(10).build())
+        .addEqualityGroup(brb.setMetric(10).build())
+        .addEqualityGroup(brb.setNextHopIp(Ip.parse("2.2.2.2")).build())
+        .addEqualityGroup(brb.setOriginatorIp(Ip.parse("2.2.2.2")).build())
+        .addEqualityGroup(brb.setOriginType(OriginType.INCOMPLETE).build())
+        .addEqualityGroup(brb.setReceivedFromIp(Ip.parse("1.1.1.1")).build())
+        .addEqualityGroup(brb.setReceivedFromRouteReflectorClient(true).build())
+        .addEqualityGroup(brb.setProtocol(RoutingProtocol.IBGP).build())
+        .addEqualityGroup(brb.setSrcProtocol(RoutingProtocol.STATIC).build())
+        .addEqualityGroup(brb.setWeight(1).build())
+        .addEqualityGroup(new Object())
+        .testEquals();
+  }
+
+  @Test
+  public void testThrowsWithoutOriginType() {
+    thrown.expect(IllegalArgumentException.class);
+    BgpRoute.builder()
+        .setNetwork(Prefix.parse("1.1.1.0/24"))
+        .setOriginatorIp(Ip.parse("1.1.1.1"))
+        .setProtocol(RoutingProtocol.BGP)
+        .build();
+  }
+
+  @Test
+  public void testThrowsWithoutOriginatorIp() {
+    thrown.expect(IllegalArgumentException.class);
+    BgpRoute.builder()
+        .setNetwork(Prefix.parse("1.1.1.0/24"))
+        .setProtocol(RoutingProtocol.BGP)
+        .setOriginType(OriginType.IGP)
+        .build();
+  }
+
+  @Test
+  public void testThrowsWithoutProtocol() {
+    thrown.expect(IllegalArgumentException.class);
+    BgpRoute.builder()
+        .setNetwork(Prefix.parse("1.1.1.0/24"))
+        .setOriginatorIp(Ip.parse("1.1.1.1"))
+        .setOriginType(OriginType.IGP)
+        .build();
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ConnectedRouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ConnectedRouteTest.java
@@ -1,0 +1,42 @@
+package org.batfish.datamodel;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.testing.EqualsTester;
+import java.io.IOException;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.junit.Test;
+
+/** Tests of {@link ConnectedRoute} */
+public class ConnectedRouteTest {
+  @Test
+  public void testJavaSerialization() {
+    ConnectedRoute cr = new ConnectedRoute(Prefix.parse("1.1.1.0/24"), "Ethernet0");
+    assertThat(SerializationUtils.clone(cr), equalTo(cr));
+  }
+
+  @Test
+  public void testJsonSerialization() throws IOException {
+    ConnectedRoute cr = new ConnectedRoute(Prefix.parse("1.1.1.0/24"), "Ethernet0");
+    assertThat(BatfishObjectMapper.clone(cr, ConnectedRoute.class), equalTo(cr));
+  }
+
+  @Test
+  public void testToBuilder() {
+    ConnectedRoute cr = new ConnectedRoute(Prefix.parse("1.1.1.0/24"), "Ethernet0");
+    assertThat(cr, equalTo(cr.toBuilder().build()));
+  }
+
+  @Test
+  public void testEquals() {
+    ConnectedRoute cr = new ConnectedRoute(Prefix.parse("1.1.1.0/24"), "Ethernet0");
+    new EqualsTester()
+        .addEqualityGroup(cr, cr)
+        .addEqualityGroup(new ConnectedRoute(Prefix.parse("1.1.2.0/24"), "Ethernet0"))
+        .addEqualityGroup(new ConnectedRoute(Prefix.parse("1.1.2.0/24"), "Ethernet1"))
+        .addEqualityGroup(new Object())
+        .testEquals();
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ConnectedRouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ConnectedRouteTest.java
@@ -31,9 +31,20 @@ public class ConnectedRouteTest {
 
   @Test
   public void testEquals() {
-    ConnectedRoute cr = new ConnectedRoute(Prefix.parse("1.1.1.0/24"), "Ethernet0");
+    ConnectedRoute.Builder cr =
+        ConnectedRoute.builder()
+            .setNetwork(Prefix.parse("1.1.1.0/24"))
+            .setNextHopInterface("Ethernet0");
     new EqualsTester()
-        .addEqualityGroup(cr, cr)
+        /*
+         * Note: connected routes by definition are routing and forwarding so setting these values in the
+         * builder has no effect
+         */
+        .addEqualityGroup(
+            cr.build(),
+            cr.build(),
+            cr.setNonRouting(true).build(),
+            cr.setNonForwarding(true).build())
         .addEqualityGroup(new ConnectedRoute(Prefix.parse("1.1.2.0/24"), "Ethernet0"))
         .addEqualityGroup(new ConnectedRoute(Prefix.parse("1.1.2.0/24"), "Ethernet1"))
         .addEqualityGroup(new ConnectedRoute(Prefix.parse("1.1.2.0/24"), "Ethernet1", 123))

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ConnectedRouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ConnectedRouteTest.java
@@ -36,6 +36,7 @@ public class ConnectedRouteTest {
         .addEqualityGroup(cr, cr)
         .addEqualityGroup(new ConnectedRoute(Prefix.parse("1.1.2.0/24"), "Ethernet0"))
         .addEqualityGroup(new ConnectedRoute(Prefix.parse("1.1.2.0/24"), "Ethernet1"))
+        .addEqualityGroup(new ConnectedRoute(Prefix.parse("1.1.2.0/24"), "Ethernet1", 123))
         .addEqualityGroup(new Object())
         .testEquals();
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/LocalRouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/LocalRouteTest.java
@@ -35,7 +35,11 @@ public class LocalRouteTest {
     new EqualsTester()
         .addEqualityGroup(lr, lr)
         .addEqualityGroup(new LocalRoute(new InterfaceAddress("1.1.2.1/24"), "Ethernet0"))
-        .addEqualityGroup(new LocalRoute(new InterfaceAddress("1.1.2.1/24"), "Ethernet1"))
+        .addEqualityGroup(
+            new LocalRoute(new InterfaceAddress("1.1.2.1/24"), "Ethernet1"),
+            new LocalRoute(Prefix.parse("1.1.2.1/32"), "Ethernet1", 24, 0))
+        .addEqualityGroup(new LocalRoute(Prefix.parse("1.1.2.1/32"), "Ethernet1", 24, 123))
+        .addEqualityGroup(new LocalRoute(Prefix.parse("1.1.2.1/32"), "Ethernet1", 25, 123))
         .addEqualityGroup(new Object())
         .testEquals();
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/LocalRouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/LocalRouteTest.java
@@ -1,0 +1,42 @@
+package org.batfish.datamodel;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.testing.EqualsTester;
+import java.io.IOException;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.junit.Test;
+
+/** Tests of {@link LocalRoute} */
+public class LocalRouteTest {
+  @Test
+  public void testJavaSerialization() {
+    LocalRoute lr = new LocalRoute(new InterfaceAddress("1.1.1.1/24"), "Ethernet0");
+    assertThat(SerializationUtils.clone(lr), equalTo(lr));
+  }
+
+  @Test
+  public void testJsonSerialization() throws IOException {
+    LocalRoute lr = new LocalRoute(new InterfaceAddress("1.1.1.1/24"), "Ethernet0");
+    assertThat(BatfishObjectMapper.clone(lr, LocalRoute.class), equalTo(lr));
+  }
+
+  @Test
+  public void testToBuilder() {
+    LocalRoute lr = new LocalRoute(new InterfaceAddress("1.1.1.1/24"), "Ethernet0");
+    assertThat(lr, equalTo(lr.toBuilder().build()));
+  }
+
+  @Test
+  public void testEquals() {
+    LocalRoute lr = new LocalRoute(new InterfaceAddress("1.1.1.1/24"), "Ethernet0");
+    new EqualsTester()
+        .addEqualityGroup(lr, lr)
+        .addEqualityGroup(new LocalRoute(new InterfaceAddress("1.1.2.1/24"), "Ethernet0"))
+        .addEqualityGroup(new LocalRoute(new InterfaceAddress("1.1.2.1/24"), "Ethernet1"))
+        .addEqualityGroup(new Object())
+        .testEquals();
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/LocalRouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/LocalRouteTest.java
@@ -31,9 +31,21 @@ public class LocalRouteTest {
 
   @Test
   public void testEquals() {
-    LocalRoute lr = new LocalRoute(new InterfaceAddress("1.1.1.1/24"), "Ethernet0");
+    LocalRoute.Builder lr =
+        LocalRoute.builder()
+            .setNetwork(Prefix.parse("1.1.1.1/32"))
+            .setSourcePrefixLength(24)
+            .setNextHopInterface("Ethernet0");
     new EqualsTester()
-        .addEqualityGroup(lr, lr)
+        /*
+         * Note: connected routes by definition are routing and forwarding so setting these values in the
+         * builder has no effect
+         */
+        .addEqualityGroup(
+            new LocalRoute(new InterfaceAddress("1.1.1.1/24"), "Ethernet0"),
+            lr.build(),
+            lr.setNonRouting(true).build(),
+            lr.setNonForwarding(false).build())
         .addEqualityGroup(new LocalRoute(new InterfaceAddress("1.1.2.1/24"), "Ethernet0"))
         .addEqualityGroup(
             new LocalRoute(new InterfaceAddress("1.1.2.1/24"), "Ethernet1"),

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -198,11 +198,13 @@ import org.batfish.datamodel.Line;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.LocalRoute;
 import org.batfish.datamodel.MultipathEquivalentAsPathMatchMode;
+import org.batfish.datamodel.OriginType;
 import org.batfish.datamodel.OspfExternalType2Route;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Prefix6;
 import org.batfish.datamodel.RouteFilterLine;
 import org.batfish.datamodel.RouteFilterList;
+import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.StaticRoute;
 import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.SwitchportMode;
@@ -741,7 +743,12 @@ public final class FlatJuniperGrammarTest {
     // p1
     RoutingPolicy p1 = c.getRoutingPolicies().get("p1");
     BgpRoute.Builder b1 =
-        BgpRoute.builder().setNetwork(cr.getNetwork()).setCommunities(ImmutableSet.of(5L));
+        BgpRoute.builder()
+            .setNetwork(cr.getNetwork())
+            .setCommunities(ImmutableSet.of(5L))
+            .setOriginatorIp(Ip.parse("2.2.2.2"))
+            .setOriginType(OriginType.INCOMPLETE)
+            .setProtocol(RoutingProtocol.BGP);
     p1.process(cr, b1, Ip.ZERO, Configuration.DEFAULT_VRF_NAME, Direction.OUT);
     BgpRoute br1 = b1.build();
 
@@ -756,7 +763,12 @@ public final class FlatJuniperGrammarTest {
     // p2
     RoutingPolicy p2 = c.getRoutingPolicies().get("p2");
     BgpRoute.Builder b2 =
-        BgpRoute.builder().setNetwork(cr.getNetwork()).setCommunities(ImmutableSet.of(5L));
+        BgpRoute.builder()
+            .setNetwork(cr.getNetwork())
+            .setCommunities(ImmutableSet.of(5L))
+            .setOriginatorIp(Ip.parse("2.2.2.2"))
+            .setOriginType(OriginType.INCOMPLETE)
+            .setProtocol(RoutingProtocol.BGP);
     p2.process(cr, b2, Ip.ZERO, Configuration.DEFAULT_VRF_NAME, Direction.OUT);
     BgpRoute br2 = b2.build();
 
@@ -765,7 +777,12 @@ public final class FlatJuniperGrammarTest {
     // p3
     RoutingPolicy p3 = c.getRoutingPolicies().get("p3");
     BgpRoute.Builder b3 =
-        BgpRoute.builder().setNetwork(cr.getNetwork()).setCommunities(ImmutableSet.of(5L));
+        BgpRoute.builder()
+            .setNetwork(cr.getNetwork())
+            .setCommunities(ImmutableSet.of(5L))
+            .setOriginatorIp(Ip.parse("2.2.2.2"))
+            .setOriginType(OriginType.INCOMPLETE)
+            .setProtocol(RoutingProtocol.BGP);
     p3.process(cr, b3, Ip.ZERO, Configuration.DEFAULT_VRF_NAME, Direction.OUT);
     BgpRoute br3 = b3.build();
 
@@ -781,7 +798,12 @@ public final class FlatJuniperGrammarTest {
     // p4
     RoutingPolicy p4 = c.getRoutingPolicies().get("p4");
     BgpRoute.Builder b4 =
-        BgpRoute.builder().setNetwork(cr.getNetwork()).setCommunities(ImmutableSet.of(5L));
+        BgpRoute.builder()
+            .setNetwork(cr.getNetwork())
+            .setCommunities(ImmutableSet.of(5L))
+            .setOriginatorIp(Ip.parse("2.2.2.2"))
+            .setOriginType(OriginType.INCOMPLETE)
+            .setProtocol(RoutingProtocol.BGP);
     p4.process(cr, b4, Ip.ZERO, Configuration.DEFAULT_VRF_NAME, Direction.OUT);
     BgpRoute br4 = b4.build();
 
@@ -797,7 +819,12 @@ public final class FlatJuniperGrammarTest {
     // p5
     RoutingPolicy p5 = c.getRoutingPolicies().get("p5");
     BgpRoute.Builder b5 =
-        BgpRoute.builder().setNetwork(cr.getNetwork()).setCommunities(ImmutableSet.of(5L));
+        BgpRoute.builder()
+            .setNetwork(cr.getNetwork())
+            .setCommunities(ImmutableSet.of(5L))
+            .setOriginatorIp(Ip.parse("2.2.2.2"))
+            .setOriginType(OriginType.INCOMPLETE)
+            .setProtocol(RoutingProtocol.BGP);
     p5.process(cr, b5, Ip.ZERO, Configuration.DEFAULT_VRF_NAME, Direction.OUT);
     BgpRoute br5 = b5.build();
 
@@ -806,7 +833,12 @@ public final class FlatJuniperGrammarTest {
     // p6
     RoutingPolicy p6 = c.getRoutingPolicies().get("p6");
     BgpRoute.Builder b6 =
-        BgpRoute.builder().setNetwork(cr.getNetwork()).setCommunities(ImmutableSet.of(5L));
+        BgpRoute.builder()
+            .setNetwork(cr.getNetwork())
+            .setCommunities(ImmutableSet.of(5L))
+            .setOriginatorIp(Ip.parse("2.2.2.2"))
+            .setOriginType(OriginType.INCOMPLETE)
+            .setProtocol(RoutingProtocol.BGP);
     p6.process(cr, b6, Ip.ZERO, Configuration.DEFAULT_VRF_NAME, Direction.OUT);
     BgpRoute br6 = b6.build();
 
@@ -2685,7 +2717,13 @@ public final class FlatJuniperGrammarTest {
       set policy-options policy-statement COMMUNITY_POLICY term T1 from community BGP2
     */
     RoutingPolicy communityPolicy = c.getRoutingPolicies().get("COMMUNITY_POLICY");
-    BgpRoute.Builder brb = BgpRoute.builder().setAdmin(100).setNetwork(testPrefix);
+    BgpRoute.Builder brb =
+        BgpRoute.builder()
+            .setAdmin(100)
+            .setNetwork(testPrefix)
+            .setOriginatorIp(Ip.parse("2.2.2.2"))
+            .setOriginType(OriginType.INCOMPLETE)
+            .setProtocol(RoutingProtocol.BGP);
     result = communityPolicy.call(envWithRoute(c, brb.setCommunities(ImmutableSet.of(1L)).build()));
     assertThat(result.getBooleanValue(), equalTo(true));
     result = communityPolicy.call(envWithRoute(c, brb.setCommunities(ImmutableSet.of(2L)).build()));

--- a/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererUtilTest.java
+++ b/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererUtilTest.java
@@ -207,6 +207,7 @@ public class RoutesAnswererUtilTest {
                 .setNextHopIp(ip)
                 .setCommunities(ImmutableSortedSet.of(65537L))
                 .setProtocol(RoutingProtocol.BGP)
+                .setOriginatorIp(Ip.parse("1.1.1.2"))
                 .setAsPath(AsPath.ofSingletonAsSets(ImmutableList.of(1L, 2L)))
                 .setTag(1)
                 .build()));
@@ -443,6 +444,7 @@ public class RoutesAnswererUtilTest {
             .setNetwork(Prefix.parse("1.1.1.0/24"))
             .setNextHopIp(Ip.parse("1.1.1.2"))
             .setOriginType(OriginType.IGP)
+            .setOriginatorIp(Ip.parse("1.1.1.2"))
             .setProtocol(RoutingProtocol.BGP)
             .setLocalPreference(1L)
             .setAdmin(10)
@@ -457,6 +459,7 @@ public class RoutesAnswererUtilTest {
             .setAdmin(10)
             .setMetric(20L)
             .setOriginType(OriginType.IGP)
+            .setOriginatorIp(Ip.parse("1.1.1.2"))
             .setProtocol(RoutingProtocol.BGP)
             .setLocalPreference(1L)
             .setAsPath(AsPath.ofSingletonAsSets(ImmutableList.of(1L, 2L)))


### PR DESCRIPTION
* Add toBuilder() method for Connected, Local, and BGP routes.
* Note: toBuilder() is currently unimplemented for other types for routes (not in the critical path of RibGroups)
* Add tests for route types mentioned above.