### PR TITLE
process juniper irb interfaces and settings

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -669,6 +669,8 @@ public final class Interface extends ComparableStructure<String> {
       return InterfaceType.AGGREGATED;
     } else if (name.startsWith("lo")) {
       return InterfaceType.LOOPBACK;
+    } else if (name.startsWith("irb")) {
+      return InterfaceType.VLAN;
     } else if (name.contains(".")) {
       return InterfaceType.LOGICAL;
     } else {

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperParser.g4
@@ -122,17 +122,14 @@ s_vlans
 
 s_vlans_named
 :
-   name = variable s_vlans_tail
-;
-
-s_vlans_tail
-:
-//    intentional blank
-
-   | vlt_description
-   | vlt_filter
-   | vlt_l3_interface
-   | vlt_vlan_id
+  name = variable
+  (
+    apply
+    | vlt_description
+    | vlt_filter
+    | vlt_l3_interface
+    | vlt_vlan_id
+  )
 ;
 
 set_line

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -1381,21 +1382,22 @@ public final class JuniperConfiguration extends VendorConfiguration {
     newIface.setAllAddresses(iface.getAllAddresses());
     newIface.setActive(iface.getActive());
     if (iface.getSwitchportMode() == SwitchportMode.ACCESS && iface.getAccessVlan() != null) {
-      Vlan vlan = _masterLogicalSystem.getVlanNameToVlan().get(iface.getAccessVlan());
+      Vlan vlan = _masterLogicalSystem.getNamedVlans().get(iface.getAccessVlan());
       if (vlan != null) {
         newIface.setAccessVlan(vlan.getVlanId());
       }
     }
-    List<SubRange> vlanIds =
-        Stream.concat(
-                iface.getAllowedVlanNames().stream()
-                    .map(n -> _masterLogicalSystem.getVlanNameToVlan().get(n))
-                    .filter(Objects::nonNull)
-                    .map(Vlan::getVlanId)
-                    .map(SubRange::new),
-                iface.getAllowedVlans().stream())
-            .collect(Collectors.toList());
-    newIface.setAllowedVlans(IntegerSpace.unionOf(vlanIds));
+    IntegerSpace.Builder vlanIdsBuilder = IntegerSpace.builder();
+    Stream.concat(
+            iface.getAllowedVlanNames().stream()
+                .map(_masterLogicalSystem.getNamedVlans()::get)
+                .filter(Objects::nonNull) // named vlan must exist
+                .map(Vlan::getVlanId)
+                .filter(Objects::nonNull) // named vlan must have assigned numeric id
+                .map(SubRange::new),
+            iface.getAllowedVlans().stream())
+        .forEach(vlanIdsBuilder::including);
+    newIface.setAllowedVlans(vlanIdsBuilder.build());
 
     if (iface.getSwitchportMode() == SwitchportMode.TRUNK) {
       newIface.setNativeVlan(firstNonNull(iface.getNativeVlan(), 1));
@@ -2329,8 +2331,8 @@ public final class JuniperConfiguration extends VendorConfiguration {
     _masterLogicalSystem.getRoutingInstances().putAll(ls.getRoutingInstances());
     // TODO: something with syslog hosts?
     // TODO: something with tacplus servers?
-    _masterLogicalSystem.getVlanNameToVlan().clear();
-    _masterLogicalSystem.getVlanNameToVlan().putAll(ls.getVlanNameToVlan());
+    _masterLogicalSystem.getNamedVlans().clear();
+    _masterLogicalSystem.getNamedVlans().putAll(ls.getNamedVlans());
     _masterLogicalSystem.getZones().clear();
     _masterLogicalSystem.getZones().putAll(ls.getZones());
 
@@ -2843,6 +2845,26 @@ public final class JuniperConfiguration extends VendorConfiguration {
   }
 
   private void convertInterfaces() {
+    // Set IRB vlan IDs by resolving l3-interface from named VLANs.
+    // If more than one named vlan refers to a given l3-interface, we just keep the first assignment
+    // and warn.
+    Map<String, Integer> irbVlanIds = new HashMap<>();
+    for (Vlan vlan : _masterLogicalSystem.getNamedVlans().values()) {
+      Integer vlanId = vlan.getVlanId();
+      String l3Interface = vlan.getL3Interface();
+      if (l3Interface == null || vlanId == null) {
+        continue;
+      }
+      if (irbVlanIds.containsKey(l3Interface)) {
+        _w.redFlag(
+            String.format(
+                "Cannot assign '%s' as the l3-interface of vlan '%s' since it is already assigned to vlan '%s'",
+                l3Interface, vlanId, irbVlanIds.get(l3Interface)));
+        continue;
+      }
+      irbVlanIds.put(l3Interface, vlanId);
+    }
+
     // Get a stream of all interfaces (including Node interfaces)
     Stream.concat(
             _masterLogicalSystem.getInterfaces().values().stream(),
@@ -2870,8 +2892,16 @@ public final class JuniperConfiguration extends VendorConfiguration {
                       unit -> {
                         unit.inheritUnsetFields();
                         org.batfish.datamodel.Interface newUnitInterface = toInterface(unit);
-                        newUnitInterface.addDependency(
-                            new Dependency(newParentIface.getName(), DependencyType.BIND));
+                        String name = newUnitInterface.getName();
+                        // set IRB VLAN ID if assigned
+                        newUnitInterface.setVlan(irbVlanIds.get(name));
+
+                        // Don't create bind dependency for 'irb.XXX' interfcaes, since there isn't
+                        // really an 'irb' interface
+                        if (!name.startsWith("irb")) {
+                          newUnitInterface.addDependency(
+                              new Dependency(newParentIface.getName(), DependencyType.BIND));
+                        }
                         resolveInterfacePointers(unit.getName(), unit, newUnitInterface);
                       });
             });
@@ -2941,11 +2971,15 @@ public final class JuniperConfiguration extends VendorConfiguration {
   /** Ensure that the interface is placed in VI {@link Configuration} and {@link Vrf} */
   private void resolveInterfacePointers(
       String ifaceName, Interface iface, org.batfish.datamodel.Interface viIface) {
-    _c.getAllInterfaces().put(ifaceName, viIface);
     Vrf vrf = viIface.getVrf();
     String vrfName = vrf.getName();
-    vrf.getInterfaces().put(ifaceName, viIface);
     _masterLogicalSystem.getRoutingInstances().get(vrfName).getInterfaces().put(ifaceName, iface);
+    if (ifaceName.equals("irb")) {
+      // there is no 'irb' interface; it is just a namespace with no inheritable parameters
+      return;
+    }
+    _c.getAllInterfaces().put(ifaceName, viIface);
+    vrf.getInterfaces().put(ifaceName, viIface);
   }
 
   private org.batfish.datamodel.Zone toZone(Zone zone) {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperStructureUsage.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperStructureUsage.java
@@ -52,6 +52,7 @@ public enum JuniperStructureUsage implements StructureUsage {
   SECURITY_ZONES_SECURITY_ZONES_INTERFACE("security zones security-zone interfaces"),
   SNMP_COMMUNITY_PREFIX_LIST("snmp community prefix-list"),
   STATIC_ROUTE_NEXT_HOP_INTERFACE("static route next-hop"),
+  VLAN_L3_INTERFACE("vlan l3-interface"),
   VTEP_SOURCE_INTERFACE("routing-instances vtep-source-interface");
 
   private final String _description;

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/LogicalSystem.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/LogicalSystem.java
@@ -92,7 +92,7 @@ public class LogicalSystem implements Serializable {
 
   private NavigableSet<String> _tacplusServers;
 
-  private final Map<String, Vlan> _vlanNameToVlan;
+  private final Map<String, Vlan> _namedVlans;
 
   private final Map<String, Zone> _zones;
 
@@ -130,7 +130,7 @@ public class LogicalSystem implements Serializable {
     _routingInstances.put(Configuration.DEFAULT_VRF_NAME, _defaultRoutingInstance);
     _syslogHosts = new TreeSet<>();
     _tacplusServers = new TreeSet<>();
-    _vlanNameToVlan = new TreeMap<>();
+    _namedVlans = new TreeMap<>();
     _zones = new TreeMap<>();
   }
 
@@ -335,8 +335,8 @@ public class LogicalSystem implements Serializable {
     return _tacplusServers;
   }
 
-  public Map<String, Vlan> getVlanNameToVlan() {
-    return _vlanNameToVlan;
+  public Map<String, Vlan> getNamedVlans() {
+    return _namedVlans;
   }
 
   public Map<String, Zone> getZones() {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Vlan.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Vlan.java
@@ -1,19 +1,42 @@
 package org.batfish.representation.juniper;
 
 import java.io.Serializable;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 
+@ParametersAreNonnullByDefault
 public class Vlan implements Serializable {
 
-  /** */
   private static final long serialVersionUID = 1L;
 
-  private int _vlanId;
+  private final String _name;
 
-  public Vlan(int vlanId) {
+  private @Nullable Integer _vlanId;
+
+  private @Nullable String _l3Interface;
+
+  public Vlan(String name) {
+    _name = name;
+  }
+
+  public @Nullable String getL3Interface() {
+    return _l3Interface;
+  }
+
+  public @Nonnull String getName() {
+    return _name;
+  }
+
+  public @Nullable Integer getVlanId() {
+    return _vlanId;
+  }
+
+  public void setVlanId(int vlanId) {
     _vlanId = vlanId;
   }
 
-  public int getVlanId() {
-    return _vlanId;
+  public void setL3Interface(String l3Interface) {
+    _l3Interface = l3Interface;
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -189,7 +189,9 @@ import org.batfish.datamodel.IkeAuthenticationMethod;
 import org.batfish.datamodel.IkeHashingAlgorithm;
 import org.batfish.datamodel.IntegerSpace;
 import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.Interface.DependencyType;
 import org.batfish.datamodel.InterfaceAddress;
+import org.batfish.datamodel.InterfaceType;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.IpAccessListLine;
@@ -2142,6 +2144,31 @@ public final class FlatJuniperGrammarTest {
             .get(filename)
             .getOrDefault(VLAN.getDescription(), Collections.emptySortedMap()),
         allOf(hasKey("VLAN_TEST"), hasKey("VLAN_TEST_UNUSED")));
+  }
+
+  @Test
+  public void testIrbInterfaces() throws IOException {
+    String hostname = "irb-interfaces";
+    Configuration c = parseConfig(hostname);
+
+    // No parent 'irb' interface should be created
+    assertThat(c.getAllInterfaces(), not(hasKey("irb")));
+
+    // irb.0 should be created
+    assertThat(c.getAllInterfaces(), hasKey("irb.0"));
+
+    Interface irb0 = c.getAllInterfaces().get("irb.0");
+
+    // irb.0 should not have bind dependency to "irb", since it is not a real parent interface
+    assertThat(
+        irb0.getDependencies(),
+        not(hasItem(equalTo(new Interface.Dependency("irb", DependencyType.BIND)))));
+
+    // verify interface type
+    assertThat(irb0.getInterfaceType(), equalTo(InterfaceType.VLAN));
+
+    // verify vlan assignment
+    assertThat(irb0.getVlan(), equalTo(5));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/irb-interfaces
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/irb-interfaces
@@ -1,0 +1,7 @@
+#
+set system host-name irb-interfaces
+#
+set interfaces irb unit 0 family inet address 1.0.0.0/31
+set vlans V l3-interface irb.0
+set vlans V vlan-id 5
+#


### PR DESCRIPTION
- set interfaceType to VLAN
- set vlan number
- don't create parent irb interface (e.g. create 'irb.0' but not 'irb')
- don't create bind dependency to parent irb interface