### PR TITLE
ibdp: Allow policies with transformations when applying ribgroups

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -4331,4 +4331,30 @@ public final class FlatJuniperGrammarTest {
             new ConnectedRoute(Prefix.parse("2.2.2.8/31"), "ge-0/0/3.0"),
             new LocalRoute(new InterfaceAddress("2.2.2.8/31"), "ge-0/0/3.0")));
   }
+
+  @Test
+  public void testInterfaceRibGroupWithTransformation() throws IOException {
+    String hostname = "juniper-interface-ribgroup-with-transformation";
+    Configuration c = parseConfig(hostname);
+    Batfish batfish = BatfishTestUtils.getBatfish(ImmutableSortedMap.of(hostname, c), _folder);
+    batfish.computeDataPlane(false);
+    DataPlane dp = batfish.loadDataPlane();
+
+    ImmutableMap<String, Set<AbstractRoute>> routes =
+        dp.getRibs().get(hostname).entrySet().stream()
+            .collect(ImmutableMap.toImmutableMap(Entry::getKey, e -> e.getValue().getRoutes()));
+
+    assertThat(
+        routes.get(Configuration.DEFAULT_VRF_NAME),
+        containsInAnyOrder(
+            new ConnectedRoute(Prefix.parse("1.1.1.1/32"), "lo0.0"),
+            new ConnectedRoute(Prefix.parse("2.2.2.2/31"), "ge-0/0/0.0", 0),
+            new LocalRoute(new InterfaceAddress("2.2.2.2/31"), "ge-0/0/0.0")));
+    assertThat(
+        routes.get("VRF2"),
+        containsInAnyOrder(
+            new ConnectedRoute(Prefix.parse("1.1.1.1/32"), "lo0.0"),
+            new LocalRoute(new InterfaceAddress("2.2.2.2/31"), "ge-0/0/0.0"),
+            new ConnectedRoute(Prefix.parse("2.2.2.2/31"), "ge-0/0/0.0", 123)));
+  }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-interface-ribgroup-with-transformation
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-interface-ribgroup-with-transformation
@@ -1,0 +1,19 @@
+set system host-name juniper-interface-ribgroup-with-transformation
+#
+# Define rib group
+set routing-options rib-groups interface-routes-rib import-rib inet.0
+set routing-options rib-groups interface-routes-rib import-rib VRF2.inet.0
+set routing-options rib-groups interface-routes-rib import-policy RIB_IN
+# apply to interface routes
+set routing-options interface-routes rib-group inet interface-routes-rib
+#
+set interfaces lo0 unit 0 family inet address 1.1.1.1/32
+set interfaces ge-0/0/0 unit 0 family inet address 2.2.2.2/31
+#
+set routing-instances VRF2 instance-type virtual-router
+#
+set policy-options policy-statement RIB_IN term TERM1 from route-filter 2.2.2.2/31 exact
+# Override the admin cost on the route
+set policy-options policy-statement RIB_IN term TERM1 then preference 123
+set policy-options policy-statement RIB_IN term TERM1 then accept
+#


### PR DESCRIPTION
Applying a rib group to interface routes now performs full routing policy processing, which
allows transformations (not just filtering).

cc: @corinaminer 