### PR TITLE
MatchProtocol: expand ISIS_ANY to multiple protocol values

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IsisRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IsisRoute.java
@@ -209,6 +209,10 @@ public class IsisRoute extends AbstractRoute {
         _systemId);
   }
 
+  public static Builder builder() {
+    return new Builder();
+  }
+
   @Override
   public Builder toBuilder() {
     return new Builder()

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RoutingProtocol.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RoutingProtocol.java
@@ -16,7 +16,7 @@ public enum RoutingProtocol {
   EVPN("evpn"),
   IBGP("ibgp"),
   IGP("igp"),
-  ISIS("isis"),
+  ISIS_ANY("isis"),
   ISIS_EL1("isisEL1"),
   ISIS_EL2("isisEL2"),
   ISIS_L1("isisL1"),
@@ -655,7 +655,7 @@ public enum RoutingProtocol {
 
       case EGP:
       case IGP:
-      case ISIS:
+      case ISIS_ANY:
       case LDP:
       case LOCAL:
       case MSDP:
@@ -758,7 +758,7 @@ public enum RoutingProtocol {
       case EIGRP_EX:
       case IBGP:
       case IGP:
-      case ISIS:
+      case ISIS_ANY:
       case ISIS_EL1:
       case ISIS_EL2:
       case ISIS_L1:

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchProtocol.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchProtocol.java
@@ -1,69 +1,79 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static org.batfish.datamodel.RoutingProtocol.ISIS_EL1;
+import static org.batfish.datamodel.RoutingProtocol.ISIS_EL2;
+import static org.batfish.datamodel.RoutingProtocol.ISIS_L1;
+import static org.batfish.datamodel.RoutingProtocol.ISIS_L2;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
+/** Match the route's routing protocol */
+@ParametersAreNonnullByDefault
 public class MatchProtocol extends BooleanExpr {
 
   private static final String PROP_PROTOCOL = "protocol";
-
-  /** */
   private static final long serialVersionUID = 1L;
 
-  private RoutingProtocol _protocol;
-
-  @JsonCreator
-  private MatchProtocol() {}
+  /** TODO: ideally, this should be a list of protocols, treated as a disjunction (match any) */
+  @Nonnull private final RoutingProtocol _protocol;
 
   public MatchProtocol(RoutingProtocol protocol) {
     _protocol = protocol;
   }
 
+  @JsonCreator
+  private static MatchProtocol create(
+      @Nullable @JsonProperty(PROP_PROTOCOL) RoutingProtocol protocol) {
+    checkArgument(protocol != null, "MatchProtocol missing %s", PROP_PROTOCOL);
+    return new MatchProtocol(protocol);
+  }
+
   @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
+  public boolean equals(Object o) {
+    if (this == o) {
       return true;
     }
-    if (obj == null) {
+    if (!(o instanceof MatchProtocol)) {
       return false;
     }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    MatchProtocol other = (MatchProtocol) obj;
-    if (_protocol != other._protocol) {
-      return false;
-    }
-    return true;
+    MatchProtocol that = (MatchProtocol) o;
+    return _protocol == that._protocol;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_protocol.ordinal());
   }
 
   @Override
   public Result evaluate(Environment environment) {
     Result result = new Result();
-    boolean value = environment.getOriginalRoute().getProtocol().equals(_protocol);
-    result.setBooleanValue(value);
+    // Workaround: Treat ISIS_ANY as a special value
+    if (_protocol == RoutingProtocol.ISIS_ANY) {
+      result.setBooleanValue(
+          Stream.of(ISIS_L1, ISIS_L2, ISIS_EL1, ISIS_EL2)
+              .anyMatch(Predicate.isEqual(environment.getOriginalRoute().getProtocol())));
+    } else {
+      result.setBooleanValue(environment.getOriginalRoute().getProtocol().equals(_protocol));
+    }
     return result;
   }
 
+  @Nonnull
   @JsonProperty(PROP_PROTOCOL)
   public RoutingProtocol getProtocol() {
     return _protocol;
-  }
-
-  @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((_protocol == null) ? 0 : _protocol.ordinal());
-    return result;
-  }
-
-  @JsonProperty(PROP_PROTOCOL)
-  public void setProtocol(RoutingProtocol protocol) {
-    _protocol = protocol;
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchProtocol.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchProtocol.java
@@ -8,9 +8,8 @@ import static org.batfish.datamodel.RoutingProtocol.ISIS_L2;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.EnumSet;
 import java.util.Objects;
-import java.util.function.Predicate;
-import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -20,10 +19,12 @@ import org.batfish.datamodel.routing_policy.Result;
 
 /** Match the route's routing protocol */
 @ParametersAreNonnullByDefault
-public class MatchProtocol extends BooleanExpr {
+public final class MatchProtocol extends BooleanExpr {
 
   private static final String PROP_PROTOCOL = "protocol";
   private static final long serialVersionUID = 1L;
+  private static final EnumSet<RoutingProtocol> ISIS_EXPANSION =
+      EnumSet.of(ISIS_L1, ISIS_L2, ISIS_EL1, ISIS_EL2);
 
   /** TODO: ideally, this should be a list of protocols, treated as a disjunction (match any) */
   @Nonnull private final RoutingProtocol _protocol;
@@ -40,7 +41,7 @@ public class MatchProtocol extends BooleanExpr {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (this == o) {
       return true;
     }
@@ -61,9 +62,7 @@ public class MatchProtocol extends BooleanExpr {
     Result result = new Result();
     // Workaround: Treat ISIS_ANY as a special value
     if (_protocol == RoutingProtocol.ISIS_ANY) {
-      result.setBooleanValue(
-          Stream.of(ISIS_L1, ISIS_L2, ISIS_EL1, ISIS_EL2)
-              .anyMatch(Predicate.isEqual(environment.getOriginalRoute().getProtocol())));
+      result.setBooleanValue(ISIS_EXPANSION.contains(environment.getOriginalRoute().getProtocol()));
     } else {
       result.setBooleanValue(environment.getOriginalRoute().getProtocol().equals(_protocol));
     }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/MatchProtocolTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/MatchProtocolTest.java
@@ -1,0 +1,122 @@
+package org.batfish.datamodel.routing_policy.expr;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+import com.google.common.testing.EqualsTester;
+import java.io.IOException;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IsisRoute;
+import org.batfish.datamodel.IsisRoute.Builder;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.RoutingProtocol;
+import org.batfish.datamodel.StaticRoute;
+import org.batfish.datamodel.isis.IsisLevel;
+import org.batfish.datamodel.routing_policy.Environment;
+import org.junit.Test;
+
+/** Tests of {@link MatchProtocol} */
+public class MatchProtocolTest {
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(
+            new MatchProtocol(RoutingProtocol.STATIC), new MatchProtocol(RoutingProtocol.STATIC))
+        .addEqualityGroup(new MatchProtocol(RoutingProtocol.BGP))
+        .addEqualityGroup(new Object())
+        .testEquals();
+  }
+
+  @Test
+  public void testJavaSerialization() {
+    MatchProtocol mp = new MatchProtocol(RoutingProtocol.STATIC);
+    assertThat(SerializationUtils.clone(mp), equalTo(mp));
+  }
+
+  @Test
+  public void testJsonSerialization() throws IOException {
+    MatchProtocol mp = new MatchProtocol(RoutingProtocol.STATIC);
+    assertThat(BatfishObjectMapper.clone(mp, MatchProtocol.class), equalTo(mp));
+  }
+
+  @Test
+  public void testMatchesIsisAny() {
+    // Setup
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c =
+        nf.configurationBuilder()
+            .setHostname("n1")
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .build();
+    nf.vrfBuilder().setName(Configuration.DEFAULT_VRF_NAME).setOwner(c).build();
+    Builder rb =
+        IsisRoute.builder()
+            .setNetwork(Prefix.parse("1.1.1.0/24"))
+            .setArea("fakeArea")
+            .setSystemId("invalidSystemId");
+
+    MatchProtocol mp = new MatchProtocol(RoutingProtocol.ISIS_ANY);
+    Environment.Builder eb = Environment.builder(c).setVrf(Configuration.DEFAULT_VRF_NAME);
+
+    assertThat(
+        "Matches ISIS_L1",
+        mp.evaluate(
+                eb.setOriginalRoute(
+                        rb.setProtocol(RoutingProtocol.ISIS_L1).setLevel(IsisLevel.LEVEL_1).build())
+                    .build())
+            .getBooleanValue());
+    assertThat(
+        "Matches ISIS_L2",
+        mp.evaluate(
+                eb.setOriginalRoute(
+                        rb.setProtocol(RoutingProtocol.ISIS_L2).setLevel(IsisLevel.LEVEL_2).build())
+                    .build())
+            .getBooleanValue());
+    assertThat(
+        "Matches ISIS_EL1",
+        mp.evaluate(
+                eb.setOriginalRoute(
+                        rb.setProtocol(RoutingProtocol.ISIS_EL1)
+                            .setLevel(IsisLevel.LEVEL_1)
+                            .build())
+                    .build())
+            .getBooleanValue());
+    assertThat(
+        "Matches ISIS_EL2",
+        mp.evaluate(
+                eb.setOriginalRoute(
+                        rb.setProtocol(RoutingProtocol.ISIS_EL2)
+                            .setLevel(IsisLevel.LEVEL_2)
+                            .build())
+                    .build())
+            .getBooleanValue());
+    assertThat(
+        "Does not match ISIS_ANY",
+        not(
+            mp.evaluate(
+                    eb.setOriginalRoute(
+                            rb.setProtocol(RoutingProtocol.ISIS_ANY)
+                                .setLevel(IsisLevel.LEVEL_1)
+                                .build())
+                        .build())
+                .getBooleanValue()));
+    assertThat(
+        "Does not match STATIC",
+        not(
+            mp.evaluate(
+                    eb.setOriginalRoute(
+                            StaticRoute.builder()
+                                .setNetwork(Prefix.parse("1.1.1.0/24"))
+                                .setAdmin(1)
+                                .setNextHopIp(Ip.parse("2.2.2.2"))
+                                .build())
+                        .build())
+                .getBooleanValue()));
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -3350,7 +3350,8 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
     String sourceTag = ctx.source_tag.getText();
     _configuration.referenceStructure(
         ROUTE_MAP, name, BGP_REDISTRIBUTE_ISIS_MAP, ctx.getStart().getLine());
-    _currentBgpNxVrfAddressFamily.setRedistributionPolicy(RoutingProtocol.ISIS, name, sourceTag);
+    _currentBgpNxVrfAddressFamily.setRedistributionPolicy(
+        RoutingProtocol.ISIS_ANY, name, sourceTag);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -1750,7 +1750,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
     } else if (ctx.DIRECT() != null) {
       return RoutingProtocol.CONNECTED;
     } else if (ctx.ISIS() != null) {
-      return RoutingProtocol.ISIS;
+      return RoutingProtocol.ISIS_ANY;
     } else if (ctx.EVPN() != null) {
       return RoutingProtocol.EVPN;
     } else if (ctx.LDP() != null) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/IsisRedistributionPolicy.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/IsisRedistributionPolicy.java
@@ -24,7 +24,7 @@ public class IsisRedistributionPolicy extends RedistributionPolicy {
   private Prefix _summaryPrefix;
 
   public IsisRedistributionPolicy(RoutingProtocol sourceProtocol) {
-    super(sourceProtocol, RoutingProtocol.ISIS);
+    super(sourceProtocol, RoutingProtocol.ISIS_ANY);
   }
 
   public IsisLevel getLevel() {

--- a/projects/question/src/main/java/org/batfish/question/NodesQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/NodesQuestionPlugin.java
@@ -124,7 +124,7 @@ public class NodesQuestionPlugin extends QuestionPlugin {
         }
         for (Vrf vrf : node.getVrfs().values()) {
           if (vrf.getIsisProcess() != null) {
-            _routingProtocols.add(RoutingProtocol.ISIS);
+            _routingProtocols.add(RoutingProtocol.ISIS_ANY);
             break;
           }
         }


### PR DESCRIPTION
Workaround to allow routing policies to match on "isis"