### PR TITLE
IPComp -> IPCOMP

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpProtocol.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpProtocol.java
@@ -64,7 +64,7 @@ public enum IpProtocol {
   IL(40),
   /** Denotes any IP protocol, not a value defined by IANA */
   IP(256),
-  IPComp(108),
+  IPCOMP(108),
   IPCU(71),
   IPINIP(4),
   IPIP(94),

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/IpProtocolTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/IpProtocolTest.java
@@ -1,0 +1,16 @@
+package org.batfish.datamodel;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.Test;
+
+public class IpProtocolTest {
+
+  @Test
+  public void testFromString() {
+    for (IpProtocol ipProtocol : IpProtocol.values()) {
+      assertThat(IpProtocol.fromString(ipProtocol.name()), equalTo(ipProtocol));
+    }
+  }
+}


### PR DESCRIPTION
The enum value for `IpProtocol.IPComp` contained lowercase letters making `IpProtocol.fromString` fail to resolve that value since `fromString` converts its input to uppercase before calling `valueOf`