### PR TITLE
Fix eBGP MED propagation

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
@@ -169,8 +169,8 @@ public class BgpProtocolHelper {
         sessionProperties.isEbgp() ? RoutingProtocol.BGP : RoutingProtocol.IBGP);
     transformedOutgoingRouteBuilder.setNetwork(route.getNetwork());
 
-    // Outgoing metric
-    if (remoteRouteIsBgp) {
+    // Outgoing metric (MED) is preserved only if advertising to IBGP peer.
+    if (remoteRouteIsBgp & !sessionProperties.isEbgp()) {
       transformedOutgoingRouteBuilder.setMetric(route.getMetric());
     }
 

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTransformBgpRouteOnExportTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTransformBgpRouteOnExportTest.java
@@ -237,4 +237,24 @@ public final class BgpProtocolHelperTransformBgpRouteOnExportTest {
     assertThat(transformedAggregateRoute, nullValue());
     assertThat(transformedBgpRoute, nullValue());
   }
+
+  /** Test that MED is not preserved/advertised to EBGP peers. */
+  @Test
+  public void testEbgpDoesNotExportWithMEDSet() throws BgpRoutePropagationException {
+    BgpRoute bgpRoute = _baseBgpRouteBuilder.setMetric(1000).build();
+
+    setUpPeers(false);
+    BgpRoute.Builder transformedBgpRoute = runTransformBgpRouteOnExport(bgpRoute);
+    assertThat(transformedBgpRoute.getMetric(), equalTo(0L));
+  }
+
+  /** Test that MED is preserved/advertised to IBGP peers. */
+  @Test
+  public void testIbgpDoesNotExportWithMEDSet() throws BgpRoutePropagationException {
+    BgpRoute bgpRoute = _baseBgpRouteBuilder.setMetric(1000).build();
+
+    setUpPeers(true);
+    BgpRoute.Builder transformedBgpRoute = runTransformBgpRouteOnExport(bgpRoute);
+    assertThat(transformedBgpRoute.getMetric(), equalTo(1000L));
+  }
 }


### PR DESCRIPTION
MED is a non-transitive attribute (for eBGP) and must not be
re-advertised.
Fix to advertise to iBGP peers only.

cc: @haverma 