### PR TITLE
DisjunctionChain -> FirstMatchChain

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/Result.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/Result.java
@@ -1,6 +1,5 @@
 package org.batfish.datamodel.routing_policy;
 
-import com.google.common.annotations.VisibleForTesting;
 import java.util.Objects;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.routing_policy.expr.BooleanExpr;
@@ -16,7 +15,10 @@ public class Result {
 
   public Result() {}
 
-  @VisibleForTesting
+  /**
+   * Creates a Result with the given {@link #getBooleanValue() booleanValue}, {@link #getExit()
+   * exit}, {@link #getFallThrough() fallThrough}, and {@link #getReturn() return} values.
+   */
   public Result(boolean booleanValue, boolean exit, boolean fallThrough, boolean aReturn) {
     _booleanValue = booleanValue;
     _exit = exit;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/Result.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/Result.java
@@ -17,7 +17,7 @@ public class Result {
   public Result() {}
 
   @VisibleForTesting
-  Result(boolean booleanValue, boolean exit, boolean fallThrough, boolean aReturn) {
+  public Result(boolean booleanValue, boolean exit, boolean fallThrough, boolean aReturn) {
     _booleanValue = booleanValue;
     _exit = exit;
     _fallThrough = fallThrough;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/ConjunctionChain.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/ConjunctionChain.java
@@ -86,7 +86,7 @@ public class ConjunctionChain extends BooleanExpr {
         return subroutineResult;
       } else if (!subroutineResult.getFallThrough() && !subroutineResult.getBooleanValue()) {
         // Found first match that returns false, short-circuit here
-        subroutineResult.setReturn(false);
+        subroutineResult.setReturn(true);
         return subroutineResult;
       }
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/ConjunctionChain.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/ConjunctionChain.java
@@ -76,6 +76,10 @@ public class ConjunctionChain extends BooleanExpr {
 
   @Override
   public Result evaluate(Environment environment) {
+    /* TODO
+    It is unclear what result's value for _return means here, and it doesn't currently have any
+    impact in any context where ConjunctionChain is used. For now, just set it to false.
+     */
     Result subroutineResult = new Result();
     // By default move on to the next policy
     subroutineResult.setFallThrough(true);
@@ -86,18 +90,21 @@ public class ConjunctionChain extends BooleanExpr {
         return subroutineResult;
       } else if (!subroutineResult.getFallThrough() && !subroutineResult.getBooleanValue()) {
         // Found first match that returns false, short-circuit here
-        subroutineResult.setReturn(true);
+        subroutineResult.setReturn(false);
         return subroutineResult;
       }
     }
     // Check if we are allowed to fall through to the default policy, if not, return last result
     if (!subroutineResult.getFallThrough()) {
+      subroutineResult.setReturn(false);
       return subroutineResult;
     } else {
       String defaultPolicy = environment.getDefaultPolicy();
       if (defaultPolicy != null) {
         CallExpr callDefaultPolicy = new CallExpr(environment.getDefaultPolicy());
-        return callDefaultPolicy.evaluate(environment);
+        Result defaultPolicyResult = callDefaultPolicy.evaluate(environment);
+        defaultPolicyResult.setReturn(false);
+        return defaultPolicyResult;
       } else {
         throw new BatfishException("Default policy is not set");
       }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/FirstMatchChain.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/FirstMatchChain.java
@@ -77,31 +77,29 @@ public class FirstMatchChain extends BooleanExpr {
 
   @Override
   public Result evaluate(Environment environment) {
-    Result subroutineResult = new Result();
-    // By default move on to the next policy
-    subroutineResult.setFallThrough(true);
+    /* TODO
+    It is unclear what result's value for _return means here, and it doesn't currently have any
+    impact in any context where FirstMatchChain is used. For now, just set it to false.
+     */
     for (BooleanExpr subroutine : _subroutines) {
-      subroutineResult = subroutine.evaluate(environment);
+      Result subroutineResult = subroutine.evaluate(environment);
       if (subroutineResult.getExit()) {
         // Reached an exit/terminal action. Return regardless of boolean value
         return subroutineResult;
       } else if (!subroutineResult.getFallThrough()) {
         // Found first match, short-circuit here
-        subroutineResult.setReturn(true);
+        subroutineResult.setReturn(false);
         return subroutineResult;
       }
     }
-    // Check if we are allowed to fall through to the default policy, if not, return last result
-    if (!subroutineResult.getFallThrough()) {
-      return subroutineResult;
+    String defaultPolicy = environment.getDefaultPolicy();
+    if (defaultPolicy != null) {
+      CallExpr callDefaultPolicy = new CallExpr(environment.getDefaultPolicy());
+      Result defaultPolicyResult = callDefaultPolicy.evaluate(environment);
+      defaultPolicyResult.setReturn(false);
+      return defaultPolicyResult;
     } else {
-      String defaultPolicy = environment.getDefaultPolicy();
-      if (defaultPolicy != null) {
-        CallExpr callDefaultPolicy = new CallExpr(environment.getDefaultPolicy());
-        return callDefaultPolicy.evaluate(environment);
-      } else {
-        throw new BatfishException("Default policy is not set");
-      }
+      throw new BatfishException("Default policy is not set");
     }
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/FirstMatchChain.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/FirstMatchChain.java
@@ -87,7 +87,7 @@ public class FirstMatchChain extends BooleanExpr {
         return subroutineResult;
       } else if (!subroutineResult.getFallThrough()) {
         // Found first match, short-circuit here
-        subroutineResult.setReturn(false);
+        subroutineResult.setReturn(true);
         return subroutineResult;
       }
     }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/RoutingPolicyReferenceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/RoutingPolicyReferenceTest.java
@@ -14,7 +14,7 @@ import org.batfish.datamodel.routing_policy.expr.CallExpr;
 import org.batfish.datamodel.routing_policy.expr.Conjunction;
 import org.batfish.datamodel.routing_policy.expr.ConjunctionChain;
 import org.batfish.datamodel.routing_policy.expr.Disjunction;
-import org.batfish.datamodel.routing_policy.expr.DisjunctionChain;
+import org.batfish.datamodel.routing_policy.expr.FirstMatchChain;
 import org.batfish.datamodel.routing_policy.expr.Not;
 import org.batfish.datamodel.routing_policy.expr.WithEnvironmentExpr;
 import org.batfish.datamodel.routing_policy.statement.BufferedStatement;
@@ -124,9 +124,9 @@ public class RoutingPolicyReferenceTest {
     Disjunction disjunction = new Disjunction();
     disjunction.setDisjuncts(ImmutableList.of(conjunctionChain));
 
-    DisjunctionChain disjunctionChain = new DisjunctionChain(ImmutableList.of(disjunction));
+    FirstMatchChain firstMatchChain = new FirstMatchChain(ImmutableList.of(disjunction));
 
-    Not not = new Not(disjunctionChain);
+    Not not = new Not(firstMatchChain);
 
     If if5 = new If();
     if5.setGuard(not);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/ConjunctionChainTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/ConjunctionChainTest.java
@@ -4,13 +4,31 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.testing.EqualsTester;
 import java.io.IOException;
+import java.util.NavigableMap;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.Configuration.Builder;
 import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.PrefixRange;
+import org.batfish.datamodel.PrefixSpace;
+import org.batfish.datamodel.StaticRoute;
+import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.routing_policy.Environment;
+import org.batfish.datamodel.routing_policy.Result;
+import org.batfish.datamodel.routing_policy.RoutingPolicy;
+import org.batfish.datamodel.routing_policy.statement.If;
+import org.batfish.datamodel.routing_policy.statement.SetMetric;
+import org.batfish.datamodel.routing_policy.statement.Statements;
+import org.batfish.datamodel.routing_policy.statement.Statements.StaticStatement;
+import org.hamcrest.MatcherAssert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -18,6 +36,64 @@ import org.junit.runners.JUnit4;
 /** Tests of {@link ConjunctionChain} */
 @RunWith(JUnit4.class)
 public class ConjunctionChainTest {
+
+  private static Prefix NETWORK_1 = Prefix.parse("1.1.1.0/24");
+  private static Prefix NETWORK_2 = Prefix.parse("2.2.2.0/24");
+  private static Prefix NETWORK_3 = Prefix.parse("3.3.3.0/24");
+
+  private static RoutingPolicy P1 =
+      RoutingPolicy.builder()
+          .setName("p1")
+          .setStatements(
+              ImmutableList.of(
+                  new If(
+                      new MatchTag(IntComparator.EQ, new LiteralInt(1)),
+                      ImmutableList.of(new StaticStatement(Statements.ReturnTrue))),
+                  new If(
+                      new MatchTag(IntComparator.EQ, new LiteralInt(2)),
+                      ImmutableList.of(new StaticStatement(Statements.ReturnFalse)))))
+          .build();
+  private static RoutingPolicy P2 =
+      RoutingPolicy.builder()
+          .setName("p2")
+          .setStatements(
+              ImmutableList.of(
+                  new If(
+                      new MatchPrefixSet(
+                          DestinationNetwork.instance(),
+                          new ExplicitPrefixSet(
+                              new PrefixSpace(PrefixRange.fromPrefix(NETWORK_1)))),
+                      ImmutableList.of(new StaticStatement(Statements.ReturnTrue))),
+                  new If(
+                      new MatchPrefixSet(
+                          DestinationNetwork.instance(),
+                          new ExplicitPrefixSet(
+                              new PrefixSpace(PrefixRange.fromPrefix(NETWORK_2)))),
+                      ImmutableList.of(new StaticStatement(Statements.ReturnFalse)))))
+          .build();
+  private static RoutingPolicy DEFAULT_POLICY =
+      RoutingPolicy.builder()
+          .setName("default-policy")
+          .setStatements(
+              ImmutableList.of(
+                  new If(
+                      BooleanExprs.TRUE, ImmutableList.of(new SetMetric(new LiteralLong(500L))))))
+          .build();
+
+  private Environment buildEnvironment(
+      NavigableMap<String, RoutingPolicy> policies, String defaultPolicy, AbstractRoute route) {
+    NetworkFactory nf = new NetworkFactory();
+    Builder cb = nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.JUNIPER);
+    Configuration c = cb.build();
+    c.setVrfs(
+        ImmutableMap.of(Configuration.DEFAULT_VRF_NAME, new Vrf(Configuration.DEFAULT_VRF_NAME)));
+    c.setRoutingPolicies(policies);
+    return Environment.builder(c)
+        .setDefaultPolicy(defaultPolicy)
+        .setOriginalRoute(route)
+        .setOutputRoute(route.toBuilder())
+        .build();
+  }
 
   @Test
   public void testEquals() {
@@ -45,16 +121,76 @@ public class ConjunctionChainTest {
 
   @Test
   public void testEvaluate() {
-    ConjunctionChain cc =
-        new ConjunctionChain(ImmutableList.of(BooleanExprs.FALSE, BooleanExprs.TRUE));
     // Test that AND is evaluated correctly
-    assertThat(
+    ConjunctionChain cc =
+        new ConjunctionChain(ImmutableList.of(BooleanExprs.TRUE, BooleanExprs.FALSE));
+    Result result =
         cc.evaluate(
-                Environment.builder(new Configuration("host", ConfigurationFormat.JUNIPER))
-                    .setVrf(Configuration.DEFAULT_VRF_NAME)
-                    .build())
-            .getBooleanValue(),
-        equalTo(false));
+            Environment.builder(new Configuration("host", ConfigurationFormat.JUNIPER))
+                .setVrf(Configuration.DEFAULT_VRF_NAME)
+                .build());
+    assertThat(result, equalTo(new Result(false, false, false, true)));
+
+    // result._return should not be true here because if there were more policies in the chain, it
+    // should evaluate them too.
+    cc = new ConjunctionChain(ImmutableList.of(BooleanExprs.TRUE, BooleanExprs.TRUE));
+    result =
+        cc.evaluate(
+            Environment.builder(new Configuration("host", ConfigurationFormat.JUNIPER))
+                .setVrf(Configuration.DEFAULT_VRF_NAME)
+                .build());
+    assertThat(result, equalTo(new Result(true, false, false, false)));
+  }
+
+  @Test
+  public void testWithCallExprs() {
+    /*
+    Two policies in chain, plus a default policy:
+    - P1 accepts routes with tag 1 and rejects routes with tag 2
+    - P2 accepts routes with network NETWORK_1 and rejects routes with network NETWORK_2
+    - Default policy sets route's metric to 500 (so we can ascertain whether a route has hit it)
+     */
+    ConjunctionChain conjunctionChain =
+        new ConjunctionChain(
+            ImmutableList.of(new CallExpr(P1.getName()), new CallExpr(P2.getName())));
+    NavigableMap<String, RoutingPolicy> policiesMap =
+        ImmutableSortedMap.of(
+            P1.getName(), P1, P2.getName(), P2, DEFAULT_POLICY.getName(), DEFAULT_POLICY);
+    StaticRoute.Builder srb = StaticRoute.builder().setAdmin(5).setMetric(10L);
+
+    // Route with tag 1 and NETWORK_1 should be accepted by both policies, no metric change.
+    // result._return should not be true because if there were more policies in the chain, it should
+    // evaluate them too.
+    Environment environment =
+        buildEnvironment(
+            policiesMap, DEFAULT_POLICY.getName(), srb.setTag(1).setNetwork(NETWORK_1).build());
+    Result result = conjunctionChain.evaluate(environment);
+    MatcherAssert.assertThat(environment.getOutputRoute().getMetric(), equalTo(10L));
+    MatcherAssert.assertThat(result, equalTo(new Result(true, false, false, false)));
+
+    // Route with tag 2 and NETWORK_1 should be rejected by first policy, no metric change
+    environment =
+        buildEnvironment(
+            policiesMap, DEFAULT_POLICY.getName(), srb.setTag(2).setNetwork(NETWORK_1).build());
+    result = conjunctionChain.evaluate(environment);
+    MatcherAssert.assertThat(environment.getOutputRoute().getMetric(), equalTo(10L));
+    MatcherAssert.assertThat(result, equalTo(new Result(false, false, false, true)));
+
+    // Route with tag 1 and NETWORK_2 should be rejected by second policy, no metric change
+    environment =
+        buildEnvironment(
+            policiesMap, DEFAULT_POLICY.getName(), srb.setTag(1).setNetwork(NETWORK_2).build());
+    result = conjunctionChain.evaluate(environment);
+    MatcherAssert.assertThat(environment.getOutputRoute().getMetric(), equalTo(10L));
+    MatcherAssert.assertThat(result, equalTo(new Result(false, false, false, true)));
+
+    // Route with tag 3 and NETWORK_3 should fall through both policies, hit default, update metric
+    environment =
+        buildEnvironment(
+            policiesMap, DEFAULT_POLICY.getName(), srb.setTag(3).setNetwork(NETWORK_3).build());
+    result = conjunctionChain.evaluate(environment);
+    MatcherAssert.assertThat(environment.getOutputRoute().getMetric(), equalTo(500L));
+    MatcherAssert.assertThat(result, equalTo(new Result(false, false, true, false)));
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/FirstMatchChainTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/FirstMatchChainTest.java
@@ -4,13 +4,28 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.testing.EqualsTester;
 import java.io.IOException;
+import java.util.NavigableMap;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.Configuration.Builder;
 import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.StaticRoute;
+import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.routing_policy.Environment;
+import org.batfish.datamodel.routing_policy.Result;
+import org.batfish.datamodel.routing_policy.RoutingPolicy;
+import org.batfish.datamodel.routing_policy.statement.If;
+import org.batfish.datamodel.routing_policy.statement.SetMetric;
+import org.batfish.datamodel.routing_policy.statement.Statements;
+import org.batfish.datamodel.routing_policy.statement.Statements.StaticStatement;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -18,6 +33,47 @@ import org.junit.runners.JUnit4;
 /** Tests of {@link FirstMatchChain} */
 @RunWith(JUnit4.class)
 public class FirstMatchChainTest {
+
+  private static RoutingPolicy P1 =
+      RoutingPolicy.builder()
+          .setName("p1")
+          .setStatements(
+              ImmutableList.of(
+                  new If(
+                      new MatchTag(IntComparator.EQ, new LiteralInt(1)),
+                      ImmutableList.of(new StaticStatement(Statements.ReturnTrue)))))
+          .build();
+  private static RoutingPolicy P2 =
+      RoutingPolicy.builder()
+          .setName("p2")
+          .setStatements(
+              ImmutableList.of(
+                  new If(
+                      new MatchTag(IntComparator.EQ, new LiteralInt(2)),
+                      ImmutableList.of(new StaticStatement(Statements.ReturnFalse)))))
+          .build();
+  private static RoutingPolicy DEFAULT_POLICY =
+      RoutingPolicy.builder()
+          .setName("default-policy")
+          .setStatements(
+              ImmutableList.of(
+                  new If(
+                      BooleanExprs.TRUE, ImmutableList.of(new SetMetric(new LiteralLong(500L))))))
+          .build();
+
+  private Environment buildEnvironment(
+      NavigableMap<String, RoutingPolicy> policies, String defaultPolicy, AbstractRoute route) {
+    NetworkFactory nf = new NetworkFactory();
+    Builder cb = nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.JUNIPER);
+    Configuration c = cb.build();
+    c.setVrfs(
+        ImmutableMap.of(Configuration.DEFAULT_VRF_NAME, new Vrf(Configuration.DEFAULT_VRF_NAME)));
+    c.setRoutingPolicies(policies);
+    return Environment.builder(c)
+        .setDefaultPolicy(defaultPolicy)
+        .setOutputRoute(route.toBuilder())
+        .build();
+  }
 
   @Test
   public void testEquals() {
@@ -45,25 +101,60 @@ public class FirstMatchChainTest {
 
   @Test
   public void testEvaluate() {
+    // Test that first match is used
     FirstMatchChain fmc =
         new FirstMatchChain(ImmutableList.of(BooleanExprs.FALSE, BooleanExprs.TRUE));
-    // Test that first match is used
-    assertThat(
+    Result result =
         fmc.evaluate(
-                Environment.builder(new Configuration("host", ConfigurationFormat.JUNIPER))
-                    .setVrf(Configuration.DEFAULT_VRF_NAME)
-                    .build())
-            .getBooleanValue(),
-        equalTo(false));
+            Environment.builder(new Configuration("host", ConfigurationFormat.JUNIPER))
+                .setVrf(Configuration.DEFAULT_VRF_NAME)
+                .build());
+    assertThat(result, equalTo(new Result(false, false, false, true)));
+
     fmc = new FirstMatchChain(ImmutableList.of(BooleanExprs.TRUE, BooleanExprs.FALSE));
-    // Test that first match is used
-    assertThat(
+    result =
         fmc.evaluate(
-                Environment.builder(new Configuration("host", ConfigurationFormat.JUNIPER))
-                    .setVrf(Configuration.DEFAULT_VRF_NAME)
-                    .build())
-            .getBooleanValue(),
-        equalTo(true));
+            Environment.builder(new Configuration("host", ConfigurationFormat.JUNIPER))
+                .setVrf(Configuration.DEFAULT_VRF_NAME)
+                .build());
+    assertThat(result, equalTo(new Result(true, false, false, true)));
+  }
+
+  @Test
+  public void testWithCallExprs() {
+    /*
+    Two policies in chain, plus a default policy:
+    - P1 accepts routes with tag 1
+    - P2 rejects routes with tag 2
+    - Default policy sets route's metric to 500 (so we can ascertain whether a route has hit it)
+     */
+    FirstMatchChain policiesChain =
+        new FirstMatchChain(
+            ImmutableList.of(new CallExpr(P1.getName()), new CallExpr(P2.getName())));
+    NavigableMap<String, RoutingPolicy> policiesMap =
+        ImmutableSortedMap.of(
+            P1.getName(), P1, P2.getName(), P2, DEFAULT_POLICY.getName(), DEFAULT_POLICY);
+    StaticRoute.Builder srb =
+        StaticRoute.builder().setNetwork(Prefix.parse("1.1.1.0/24")).setAdmin(5).setMetric(10L);
+
+    // Route with tag 1 should be accepted by policy 1, no metric change
+    Environment environment =
+        buildEnvironment(policiesMap, DEFAULT_POLICY.getName(), srb.setTag(1).build());
+    Result result = policiesChain.evaluate(environment);
+    assertThat(environment.getOutputRoute().getMetric(), equalTo(10L));
+    assertThat(result, equalTo(new Result(true, false, false, true)));
+
+    // Route with tag 2 should be rejected by policy 2, no metric change
+    environment = buildEnvironment(policiesMap, DEFAULT_POLICY.getName(), srb.setTag(2).build());
+    result = policiesChain.evaluate(environment);
+    assertThat(environment.getOutputRoute().getMetric(), equalTo(10L));
+    assertThat(result, equalTo(new Result(false, false, false, true)));
+
+    // Route with tag 3 should fall through policies 1 and 2, hit default policy, and update metric
+    environment = buildEnvironment(policiesMap, DEFAULT_POLICY.getName(), srb.setTag(3).build());
+    result = policiesChain.evaluate(environment);
+    assertThat(environment.getOutputRoute().getMetric(), equalTo(500L));
+    assertThat(result, equalTo(new Result(false, false, true, false)));
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/FirstMatchChainTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/FirstMatchChainTest.java
@@ -25,7 +25,6 @@ import org.batfish.datamodel.routing_policy.RoutingPolicy;
 import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.SetMetric;
 import org.batfish.datamodel.routing_policy.statement.Statements;
-import org.batfish.datamodel.routing_policy.statement.Statements.StaticStatement;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -41,7 +40,7 @@ public class FirstMatchChainTest {
               ImmutableList.of(
                   new If(
                       new MatchTag(IntComparator.EQ, new LiteralInt(1)),
-                      ImmutableList.of(new StaticStatement(Statements.ReturnTrue)))))
+                      ImmutableList.of(Statements.ReturnTrue.toStaticStatement()))))
           .build();
   private static RoutingPolicy P2 =
       RoutingPolicy.builder()
@@ -50,7 +49,7 @@ public class FirstMatchChainTest {
               ImmutableList.of(
                   new If(
                       new MatchTag(IntComparator.EQ, new LiteralInt(2)),
-                      ImmutableList.of(new StaticStatement(Statements.ReturnFalse)))))
+                      ImmutableList.of(Statements.ReturnFalse.toStaticStatement()))))
           .build();
   private static RoutingPolicy DEFAULT_POLICY =
       RoutingPolicy.builder()
@@ -109,7 +108,7 @@ public class FirstMatchChainTest {
             Environment.builder(new Configuration("host", ConfigurationFormat.JUNIPER))
                 .setVrf(Configuration.DEFAULT_VRF_NAME)
                 .build());
-    assertThat(result, equalTo(new Result(false, false, false, true)));
+    assertThat(result, equalTo(new Result(false, false, false, false)));
 
     fmc = new FirstMatchChain(ImmutableList.of(BooleanExprs.TRUE, BooleanExprs.FALSE));
     result =
@@ -117,7 +116,7 @@ public class FirstMatchChainTest {
             Environment.builder(new Configuration("host", ConfigurationFormat.JUNIPER))
                 .setVrf(Configuration.DEFAULT_VRF_NAME)
                 .build());
-    assertThat(result, equalTo(new Result(true, false, false, true)));
+    assertThat(result, equalTo(new Result(true, false, false, false)));
   }
 
   @Test
@@ -142,13 +141,13 @@ public class FirstMatchChainTest {
         buildEnvironment(policiesMap, DEFAULT_POLICY.getName(), srb.setTag(1).build());
     Result result = policiesChain.evaluate(environment);
     assertThat(environment.getOutputRoute().getMetric(), equalTo(10L));
-    assertThat(result, equalTo(new Result(true, false, false, true)));
+    assertThat(result, equalTo(new Result(true, false, false, false)));
 
     // Route with tag 2 should be rejected by policy 2, no metric change
     environment = buildEnvironment(policiesMap, DEFAULT_POLICY.getName(), srb.setTag(2).build());
     result = policiesChain.evaluate(environment);
     assertThat(environment.getOutputRoute().getMetric(), equalTo(10L));
-    assertThat(result, equalTo(new Result(false, false, false, true)));
+    assertThat(result, equalTo(new Result(false, false, false, false)));
 
     // Route with tag 3 should fall through policies 1 and 2, hit default policy, and update metric
     environment = buildEnvironment(policiesMap, DEFAULT_POLICY.getName(), srb.setTag(3).build());

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/FirstMatchChainTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/FirstMatchChainTest.java
@@ -15,17 +15,17 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Tests of {@link DisjunctionChain} */
+/** Tests of {@link FirstMatchChain} */
 @RunWith(JUnit4.class)
-public class DisjunctionChainTest {
+public class FirstMatchChainTest {
 
   @Test
   public void testEquals() {
     new EqualsTester()
         .addEqualityGroup(new Object())
         .addEqualityGroup(
-            new DisjunctionChain(ImmutableList.of(BooleanExprs.TRUE)),
-            new DisjunctionChain(ImmutableList.of(BooleanExprs.TRUE)))
+            new FirstMatchChain(ImmutableList.of(BooleanExprs.TRUE)),
+            new FirstMatchChain(ImmutableList.of(BooleanExprs.TRUE)))
         .addEqualityGroup(ImmutableList.of())
         .addEqualityGroup(ImmutableList.of(BooleanExprs.FALSE))
         .testEquals();
@@ -33,23 +33,32 @@ public class DisjunctionChainTest {
 
   @Test
   public void testJavaSerialization() {
-    DisjunctionChain dc = new DisjunctionChain(ImmutableList.of(BooleanExprs.TRUE));
-    assertThat(SerializationUtils.clone(dc), equalTo(dc));
+    FirstMatchChain fmc = new FirstMatchChain(ImmutableList.of(BooleanExprs.TRUE));
+    assertThat(SerializationUtils.clone(fmc), equalTo(fmc));
   }
 
   @Test
   public void testJsonSerialization() throws IOException {
-    DisjunctionChain dc = new DisjunctionChain(ImmutableList.of(BooleanExprs.TRUE));
-    assertThat(BatfishObjectMapper.clone(dc, DisjunctionChain.class), equalTo(dc));
+    FirstMatchChain fmc = new FirstMatchChain(ImmutableList.of(BooleanExprs.TRUE));
+    assertThat(BatfishObjectMapper.clone(fmc, FirstMatchChain.class), equalTo(fmc));
   }
 
   @Test
   public void testEvaluate() {
-    DisjunctionChain dc =
-        new DisjunctionChain(ImmutableList.of(BooleanExprs.FALSE, BooleanExprs.TRUE));
-    // Test that OR is evaluated correctly
+    FirstMatchChain fmc =
+        new FirstMatchChain(ImmutableList.of(BooleanExprs.FALSE, BooleanExprs.TRUE));
+    // Test that first match is used
     assertThat(
-        dc.evaluate(
+        fmc.evaluate(
+                Environment.builder(new Configuration("host", ConfigurationFormat.JUNIPER))
+                    .setVrf(Configuration.DEFAULT_VRF_NAME)
+                    .build())
+            .getBooleanValue(),
+        equalTo(false));
+    fmc = new FirstMatchChain(ImmutableList.of(BooleanExprs.TRUE, BooleanExprs.FALSE));
+    // Test that first match is used
+    assertThat(
+        fmc.evaluate(
                 Environment.builder(new Configuration("host", ConfigurationFormat.JUNIPER))
                     .setVrf(Configuration.DEFAULT_VRF_NAME)
                     .build())
@@ -59,7 +68,7 @@ public class DisjunctionChainTest {
 
   @Test
   public void testToString() {
-    DisjunctionChain dc = new DisjunctionChain(ImmutableList.of(BooleanExprs.TRUE));
-    assertThat(dc.toString(), equalTo("DisjunctionChain{subroutines=[StaticBooleanExpr{}]}"));
+    FirstMatchChain fmc = new FirstMatchChain(ImmutableList.of(BooleanExprs.TRUE));
+    assertThat(fmc.toString(), equalTo("FirstMatchChain{subroutines=[StaticBooleanExpr{}]}"));
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -120,8 +120,8 @@ import org.batfish.datamodel.routing_policy.expr.Conjunction;
 import org.batfish.datamodel.routing_policy.expr.ConjunctionChain;
 import org.batfish.datamodel.routing_policy.expr.DestinationNetwork;
 import org.batfish.datamodel.routing_policy.expr.Disjunction;
-import org.batfish.datamodel.routing_policy.expr.DisjunctionChain;
 import org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet;
+import org.batfish.datamodel.routing_policy.expr.FirstMatchChain;
 import org.batfish.datamodel.routing_policy.expr.LiteralCommunitySet;
 import org.batfish.datamodel.routing_policy.expr.LiteralOrigin;
 import org.batfish.datamodel.routing_policy.expr.MatchLocalRouteSourcePrefixLength;
@@ -434,7 +434,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
                 }
               });
       If peerImportPolicyConditional = new If();
-      DisjunctionChain importPolicyChain = new DisjunctionChain(importPolicyCalls);
+      FirstMatchChain importPolicyChain = new FirstMatchChain(importPolicyCalls);
       peerImportPolicyConditional.setGuard(importPolicyChain);
       peerImportPolicy.getStatements().add(peerImportPolicyConditional);
       peerImportPolicyConditional
@@ -480,7 +480,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
                 }
               });
       If peerExportPolicyConditional = new If();
-      DisjunctionChain exportPolicyChain = new DisjunctionChain(exportPolicyCalls);
+      FirstMatchChain exportPolicyChain = new FirstMatchChain(exportPolicyCalls);
       peerExportPolicyConditional.setGuard(exportPolicyChain);
       peerExportPolicyConditional
           .getTrueStatements()
@@ -1934,7 +1934,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
                 new SetDefaultPolicy(DEFAULT_IMPORT_POLICIES.get(protocol)),
                 // Construct a policy chain based on defined import policies
                 new If(
-                    new DisjunctionChain(policyCalls),
+                    new FirstMatchChain(policyCalls),
                     ImmutableList.of(Statements.ReturnTrue.toStaticStatement()),
                     ImmutableList.of(Statements.ReturnFalse.toStaticStatement()))))
         .build();

--- a/projects/batfish/src/main/java/org/batfish/symbolic/AstVisitor.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/AstVisitor.java
@@ -10,7 +10,7 @@ import org.batfish.datamodel.routing_policy.expr.CallExpr;
 import org.batfish.datamodel.routing_policy.expr.Conjunction;
 import org.batfish.datamodel.routing_policy.expr.ConjunctionChain;
 import org.batfish.datamodel.routing_policy.expr.Disjunction;
-import org.batfish.datamodel.routing_policy.expr.DisjunctionChain;
+import org.batfish.datamodel.routing_policy.expr.FirstMatchChain;
 import org.batfish.datamodel.routing_policy.expr.Not;
 import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.SetDefaultPolicy;
@@ -50,9 +50,9 @@ public class AstVisitor {
         visit(conf, be, fs, fe);
       }
 
-    } else if (e instanceof DisjunctionChain) {
-      DisjunctionChain d = (DisjunctionChain) e;
-      for (BooleanExpr be : d.getSubroutines()) {
+    } else if (e instanceof FirstMatchChain) {
+      FirstMatchChain p = (FirstMatchChain) e;
+      for (BooleanExpr be : p.getSubroutines()) {
         visit(conf, be, fs, fe);
       }
 

--- a/projects/batfish/src/main/java/org/batfish/symbolic/smt/TransferSSA.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/smt/TransferSSA.java
@@ -40,8 +40,8 @@ import org.batfish.datamodel.routing_policy.expr.ConjunctionChain;
 import org.batfish.datamodel.routing_policy.expr.DecrementLocalPreference;
 import org.batfish.datamodel.routing_policy.expr.DecrementMetric;
 import org.batfish.datamodel.routing_policy.expr.Disjunction;
-import org.batfish.datamodel.routing_policy.expr.DisjunctionChain;
 import org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet;
+import org.batfish.datamodel.routing_policy.expr.FirstMatchChain;
 import org.batfish.datamodel.routing_policy.expr.IncrementLocalPreference;
 import org.batfish.datamodel.routing_policy.expr.IncrementMetric;
 import org.batfish.datamodel.routing_policy.expr.IntExpr;
@@ -434,28 +434,28 @@ class TransferSSA {
       }
     }
 
-    if (expr instanceof DisjunctionChain) {
-      pCur.debug("DisjunctionChain");
-      DisjunctionChain d = (DisjunctionChain) expr;
-      List<BooleanExpr> disjuncts = new ArrayList<>(d.getSubroutines());
+    if (expr instanceof FirstMatchChain) {
+      pCur.debug("FirstMatchChain");
+      FirstMatchChain chain = (FirstMatchChain) expr;
+      List<BooleanExpr> chainPolicies = new ArrayList<>(chain.getSubroutines());
       if (pCur.getDefaultPolicy() != null) {
         BooleanExpr be = new CallExpr(pCur.getDefaultPolicy().getDefaultPolicy());
-        disjuncts.add(be);
+        chainPolicies.add(be);
       }
-      if (disjuncts.isEmpty()) {
+      if (chainPolicies.isEmpty()) {
         return fromExpr(_enc.mkTrue());
       } else {
         TransferResult<BoolExpr, BoolExpr> result = new TransferResult<>();
         BoolExpr acc = _enc.mkFalse();
-        for (int i = disjuncts.size() - 1; i >= 0; i--) {
-          BooleanExpr disjunct = disjuncts.get(i);
+        for (int i = chainPolicies.size() - 1; i >= 0; i--) {
+          BooleanExpr policyMatcher = chainPolicies.get(i);
           TransferParam<SymbolicRoute> param =
               pCur.setDefaultPolicy(null).setChainContext(TransferParam.ChainContext.CONJUNCTION);
-          TransferResult<BoolExpr, BoolExpr> r = compute(disjunct, param);
-          result.addChangedVariables(r);
+          TransferResult<BoolExpr, BoolExpr> r = compute(policyMatcher, param);
+          result = result.addChangedVariables(r);
           acc = _enc.mkIf(r.getFallthroughValue(), acc, r.getReturnValue());
         }
-        pCur.debug("DisjunctionChain Result: " + acc);
+        pCur.debug("FirstMatchChain Result: " + acc);
         return result.setReturnValue(acc);
       }
     }

--- a/projects/batfish/src/main/java/org/batfish/symbolic/smt/TransferSSA.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/smt/TransferSSA.java
@@ -443,21 +443,21 @@ class TransferSSA {
         chainPolicies.add(be);
       }
       if (chainPolicies.isEmpty()) {
-        return fromExpr(_enc.mkTrue());
-      } else {
-        TransferResult<BoolExpr, BoolExpr> result = new TransferResult<>();
-        BoolExpr acc = _enc.mkFalse();
-        for (int i = chainPolicies.size() - 1; i >= 0; i--) {
-          BooleanExpr policyMatcher = chainPolicies.get(i);
-          TransferParam<SymbolicRoute> param =
-              pCur.setDefaultPolicy(null).setChainContext(TransferParam.ChainContext.CONJUNCTION);
-          TransferResult<BoolExpr, BoolExpr> r = compute(policyMatcher, param);
-          result = result.addChangedVariables(r);
-          acc = _enc.mkIf(r.getFallthroughValue(), acc, r.getReturnValue());
-        }
-        pCur.debug("FirstMatchChain Result: " + acc);
-        return result.setReturnValue(acc);
+        // No identity for an empty FirstMatchChain; default policy should always be set.
+        throw new BatfishException("Default policy is not set");
       }
+      TransferResult<BoolExpr, BoolExpr> result = new TransferResult<>();
+      BoolExpr acc = _enc.mkFalse();
+      for (int i = chainPolicies.size() - 1; i >= 0; i--) {
+        BooleanExpr policyMatcher = chainPolicies.get(i);
+        TransferParam<SymbolicRoute> param =
+            pCur.setDefaultPolicy(null).setChainContext(TransferParam.ChainContext.CONJUNCTION);
+        TransferResult<BoolExpr, BoolExpr> r = compute(policyMatcher, param);
+        result = result.addChangedVariables(r);
+        acc = _enc.mkIf(r.getFallthroughValue(), acc, r.getReturnValue());
+      }
+      pCur.debug("FirstMatchChain Result: " + acc);
+      return result.setReturnValue(acc);
     }
 
     if (expr instanceof Not) {

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -2270,7 +2270,7 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.DisjunctionChain"
+                  "class" : "org.batfish.datamodel.routing_policy.expr.FirstMatchChain"
                 },
                 "trueStatements" : [
                   {
@@ -2301,7 +2301,7 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.DisjunctionChain"
+                  "class" : "org.batfish.datamodel.routing_policy.expr.FirstMatchChain"
                 },
                 "trueStatements" : [
                   {
@@ -2537,7 +2537,7 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.DisjunctionChain"
+                  "class" : "org.batfish.datamodel.routing_policy.expr.FirstMatchChain"
                 },
                 "trueStatements" : [
                   {
@@ -2568,7 +2568,7 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.DisjunctionChain"
+                  "class" : "org.batfish.datamodel.routing_policy.expr.FirstMatchChain"
                 },
                 "trueStatements" : [
                   {
@@ -15928,7 +15928,7 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.DisjunctionChain"
+                  "class" : "org.batfish.datamodel.routing_policy.expr.FirstMatchChain"
                 },
                 "trueStatements" : [
                   {
@@ -15993,7 +15993,7 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.DisjunctionChain"
+                  "class" : "org.batfish.datamodel.routing_policy.expr.FirstMatchChain"
                 },
                 "trueStatements" : [
                   {
@@ -16058,7 +16058,7 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.DisjunctionChain"
+                  "class" : "org.batfish.datamodel.routing_policy.expr.FirstMatchChain"
                 },
                 "trueStatements" : [
                   {
@@ -16089,7 +16089,7 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.DisjunctionChain"
+                  "class" : "org.batfish.datamodel.routing_policy.expr.FirstMatchChain"
                 },
                 "trueStatements" : [
                   {
@@ -16120,7 +16120,7 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.DisjunctionChain"
+                  "class" : "org.batfish.datamodel.routing_policy.expr.FirstMatchChain"
                 },
                 "trueStatements" : [
                   {
@@ -16151,7 +16151,7 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.DisjunctionChain"
+                  "class" : "org.batfish.datamodel.routing_policy.expr.FirstMatchChain"
                 },
                 "trueStatements" : [
                   {
@@ -16406,7 +16406,7 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.DisjunctionChain"
+                  "class" : "org.batfish.datamodel.routing_policy.expr.FirstMatchChain"
                 },
                 "trueStatements" : [
                   {
@@ -16471,7 +16471,7 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.DisjunctionChain"
+                  "class" : "org.batfish.datamodel.routing_policy.expr.FirstMatchChain"
                 },
                 "trueStatements" : [
                   {
@@ -16502,7 +16502,7 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.DisjunctionChain"
+                  "class" : "org.batfish.datamodel.routing_policy.expr.FirstMatchChain"
                 },
                 "trueStatements" : [
                   {
@@ -16533,7 +16533,7 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.DisjunctionChain"
+                  "class" : "org.batfish.datamodel.routing_policy.expr.FirstMatchChain"
                 },
                 "trueStatements" : [
                   {
@@ -19089,7 +19089,7 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.DisjunctionChain"
+                  "class" : "org.batfish.datamodel.routing_policy.expr.FirstMatchChain"
                 },
                 "trueStatements" : [
                   {
@@ -19120,7 +19120,7 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.DisjunctionChain"
+                  "class" : "org.batfish.datamodel.routing_policy.expr.FirstMatchChain"
                 },
                 "trueStatements" : [
                   {
@@ -19147,7 +19147,7 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.DisjunctionChain"
+                  "class" : "org.batfish.datamodel.routing_policy.expr.FirstMatchChain"
                 },
                 "trueStatements" : [
                   {
@@ -19174,7 +19174,7 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.DisjunctionChain",
+                  "class" : "org.batfish.datamodel.routing_policy.expr.FirstMatchChain",
                   "subroutines" : [
                     {
                       "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
@@ -19211,7 +19211,7 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.DisjunctionChain",
+                  "class" : "org.batfish.datamodel.routing_policy.expr.FirstMatchChain",
                   "subroutines" : [
                     {
                       "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
@@ -19471,7 +19471,7 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.DisjunctionChain"
+                  "class" : "org.batfish.datamodel.routing_policy.expr.FirstMatchChain"
                 },
                 "trueStatements" : [
                   {
@@ -19502,7 +19502,7 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.DisjunctionChain"
+                  "class" : "org.batfish.datamodel.routing_policy.expr.FirstMatchChain"
                 },
                 "trueStatements" : [
                   {
@@ -19529,7 +19529,7 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.DisjunctionChain"
+                  "class" : "org.batfish.datamodel.routing_policy.expr.FirstMatchChain"
                 },
                 "trueStatements" : [
                   {
@@ -29350,7 +29350,7 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.DisjunctionChain",
+                  "class" : "org.batfish.datamodel.routing_policy.expr.FirstMatchChain",
                   "subroutines" : [
                     {
                       "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
@@ -29421,7 +29421,7 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.DisjunctionChain",
+                  "class" : "org.batfish.datamodel.routing_policy.expr.FirstMatchChain",
                   "subroutines" : [
                     {
                       "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
@@ -29492,7 +29492,7 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.DisjunctionChain",
+                  "class" : "org.batfish.datamodel.routing_policy.expr.FirstMatchChain",
                   "subroutines" : [
                     {
                       "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
@@ -29563,7 +29563,7 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.DisjunctionChain"
+                  "class" : "org.batfish.datamodel.routing_policy.expr.FirstMatchChain"
                 },
                 "trueStatements" : [
                   {
@@ -29628,7 +29628,7 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.DisjunctionChain"
+                  "class" : "org.batfish.datamodel.routing_policy.expr.FirstMatchChain"
                 },
                 "trueStatements" : [
                   {
@@ -29693,7 +29693,7 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.DisjunctionChain"
+                  "class" : "org.batfish.datamodel.routing_policy.expr.FirstMatchChain"
                 },
                 "trueStatements" : [
                   {
@@ -29758,7 +29758,7 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.DisjunctionChain"
+                  "class" : "org.batfish.datamodel.routing_policy.expr.FirstMatchChain"
                 },
                 "trueStatements" : [
                   {
@@ -29789,7 +29789,7 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.DisjunctionChain"
+                  "class" : "org.batfish.datamodel.routing_policy.expr.FirstMatchChain"
                 },
                 "trueStatements" : [
                   {
@@ -29820,7 +29820,7 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.DisjunctionChain"
+                  "class" : "org.batfish.datamodel.routing_policy.expr.FirstMatchChain"
                 },
                 "trueStatements" : [
                   {
@@ -29851,7 +29851,7 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.DisjunctionChain"
+                  "class" : "org.batfish.datamodel.routing_policy.expr.FirstMatchChain"
                 },
                 "trueStatements" : [
                   {
@@ -29882,7 +29882,7 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.DisjunctionChain"
+                  "class" : "org.batfish.datamodel.routing_policy.expr.FirstMatchChain"
                 },
                 "trueStatements" : [
                   {
@@ -29913,7 +29913,7 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.DisjunctionChain"
+                  "class" : "org.batfish.datamodel.routing_policy.expr.FirstMatchChain"
                 },
                 "trueStatements" : [
                   {
@@ -29944,7 +29944,7 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.DisjunctionChain"
+                  "class" : "org.batfish.datamodel.routing_policy.expr.FirstMatchChain"
                 },
                 "trueStatements" : [
                   {
@@ -29975,7 +29975,7 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.DisjunctionChain"
+                  "class" : "org.batfish.datamodel.routing_policy.expr.FirstMatchChain"
                 },
                 "trueStatements" : [
                   {


### PR DESCRIPTION
DisjunctionChain took a list of routing policies and returned true for a route if any of them matched and accepted (otherwise evaluated default policy and returned that result). That behavior may be useful somewhere, but the only place it was being used was for chained Juniper BGP import and export policies (e.g. `set protocols bgp import [ POLICY-1 POLICY-2 POLICY-3 ]`). In that context, the correct behavior is to return the result of the first policy that matches the route, whether it accepts or rejects (and if none match, return default policy result as before).

This PR turns DisjunctionChain into FirstMatchChain, which matches those semantics.