### PR TITLE
BooleanExpr children cleanup

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/BooleanExprs.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/BooleanExprs.java
@@ -21,7 +21,7 @@ public final class BooleanExprs {
   public static final StaticBooleanExpr FALSE = new StaticBooleanExpr(StaticExpressionType.False);
   public static final StaticBooleanExpr TRUE = new StaticBooleanExpr(StaticExpressionType.True);
 
-  public static class StaticBooleanExpr extends BooleanExpr {
+  public static final class StaticBooleanExpr extends BooleanExpr {
     /** */
     private static final long serialVersionUID = 1L;
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/BooleanExprs.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/BooleanExprs.java
@@ -1,5 +1,7 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.batfish.common.BatfishException;
@@ -14,15 +16,28 @@ public final class BooleanExprs {
     True,
   }
 
+  /**
+   * Boolean expression that evaluates to true iff the given {@link Environment} has {@link
+   * Environment#getCallExprContext() callExprContext} set.
+   */
   public static final StaticBooleanExpr CALL_EXPR_CONTEXT =
       new StaticBooleanExpr(StaticExpressionType.CallExprContext);
+
+  /**
+   * Boolean expression that evaluates to true iff the given {@link Environment} has {@link
+   * Environment#getCallStatementContext()} callStatementContext} set.
+   */
   public static final StaticBooleanExpr CALL_STATEMENT_CONTEXT =
       new StaticBooleanExpr(StaticExpressionType.CallStatementContext);
+
+  /** Boolean expression that always evaluates to false. */
   public static final StaticBooleanExpr FALSE = new StaticBooleanExpr(StaticExpressionType.False);
+
+  /** Boolean expression that always evaluates to true. */
   public static final StaticBooleanExpr TRUE = new StaticBooleanExpr(StaticExpressionType.True);
 
   public static final class StaticBooleanExpr extends BooleanExpr {
-    /** */
+
     private static final long serialVersionUID = 1L;
 
     private static final String PROP_TYPE = "type";
@@ -34,7 +49,8 @@ public final class BooleanExprs {
     }
 
     @JsonCreator
-    static StaticBooleanExpr create(@JsonProperty(PROP_TYPE) StaticExpressionType type) {
+    private static StaticBooleanExpr create(@JsonProperty(PROP_TYPE) StaticExpressionType type) {
+      checkArgument(type != null, "%s must be provided", PROP_TYPE);
       switch (type) {
         case CallExprContext:
           return CALL_EXPR_CONTEXT;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/BooleanExprs.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/BooleanExprs.java
@@ -42,7 +42,7 @@ public final class BooleanExprs {
 
     private static final String PROP_TYPE = "type";
 
-    private StaticExpressionType _type;
+    private final StaticExpressionType _type;
 
     private StaticBooleanExpr(StaticExpressionType type) {
       _type = type;
@@ -71,11 +71,6 @@ public final class BooleanExprs {
     }
 
     @Override
-    public boolean equals(Object rhs) {
-      return rhs instanceof StaticBooleanExpr && _type == ((StaticBooleanExpr) rhs)._type;
-    }
-
-    @Override
     public Result evaluate(Environment environment) {
       Result result = new Result();
       switch (_type) {
@@ -101,6 +96,11 @@ public final class BooleanExprs {
     @JsonProperty(PROP_TYPE)
     public StaticExpressionType getType() {
       return _type;
+    }
+
+    @Override
+    public boolean equals(Object rhs) {
+      return rhs instanceof StaticBooleanExpr && _type == ((StaticBooleanExpr) rhs)._type;
     }
 
     @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/CallExpr.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/CallExpr.java
@@ -10,11 +10,11 @@ import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
 
+/** Boolean expression that calls a given {@link RoutingPolicy} on an {@link Environment}. */
 public final class CallExpr extends BooleanExpr {
 
   private static final String PROP_CALLED_POLICY_NAME = "calledPolicyName";
 
-  /** */
   private static final long serialVersionUID = 1L;
 
   private String _calledPolicyName;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/CallExpr.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/CallExpr.java
@@ -1,9 +1,12 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.routing_policy.Environment;
@@ -17,10 +20,13 @@ public final class CallExpr extends BooleanExpr {
 
   private static final long serialVersionUID = 1L;
 
-  private String _calledPolicyName;
+  private final String _calledPolicyName;
 
   @JsonCreator
-  private CallExpr() {}
+  private static CallExpr create(@JsonProperty(PROP_CALLED_POLICY_NAME) String calledPolicyName) {
+    checkArgument(calledPolicyName != null, "%s must be provided", PROP_CALLED_POLICY_NAME);
+    return new CallExpr(calledPolicyName);
+  }
 
   public CallExpr(String includedPolicyName) {
     _calledPolicyName = includedPolicyName;
@@ -43,28 +49,6 @@ public final class CallExpr extends BooleanExpr {
       return Collections.emptySet();
     }
     return calledPolicy.computeSources(parentSources, routingPolicies, w);
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    CallExpr other = (CallExpr) obj;
-    if (_calledPolicyName == null) {
-      if (other._calledPolicyName != null) {
-        return false;
-      }
-    } else if (!_calledPolicyName.equals(other._calledPolicyName)) {
-      return false;
-    }
-    return true;
   }
 
   @Override
@@ -94,16 +78,20 @@ public final class CallExpr extends BooleanExpr {
   }
 
   @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((_calledPolicyName == null) ? 0 : _calledPolicyName.hashCode());
-    return result;
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof CallExpr)) {
+      return false;
+    }
+    CallExpr other = (CallExpr) obj;
+    return Objects.equals(_calledPolicyName, other._calledPolicyName);
   }
 
-  @JsonProperty(PROP_CALLED_POLICY_NAME)
-  public void setCalledPolicyName(String calledPolicyName) {
-    _calledPolicyName = calledPolicyName;
+  @Override
+  public int hashCode() {
+    return Objects.hash(_calledPolicyName);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/CallExpr.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/CallExpr.java
@@ -10,7 +10,7 @@ import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
 
-public class CallExpr extends BooleanExpr {
+public final class CallExpr extends BooleanExpr {
 
   private static final String PROP_CALLED_POLICY_NAME = "calledPolicyName";
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/Conjunction.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/Conjunction.java
@@ -17,9 +17,12 @@ import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
 
+/**
+ * Boolean expression that evaluates to true if every {@link BooleanExpr} in a given list evaluates
+ * to true. Evaluates to true if the given list is empty.
+ */
 public final class Conjunction extends BooleanExpr {
 
-  /** */
   private static final long serialVersionUID = 1L;
 
   private static final String PROP_CONJUNCTS = "conjuncts";

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/Conjunction.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/Conjunction.java
@@ -49,18 +49,6 @@ public final class Conjunction extends BooleanExpr {
   }
 
   @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (!(obj instanceof Conjunction)) {
-      return false;
-    }
-    Conjunction other = (Conjunction) obj;
-    return Objects.equals(_conjuncts, other._conjuncts);
-  }
-
-  @Override
   public Result evaluate(Environment environment) {
     for (BooleanExpr conjunct : _conjuncts) {
       Result conjunctResult = conjunct.evaluate(environment);
@@ -79,14 +67,6 @@ public final class Conjunction extends BooleanExpr {
   @JsonProperty(PROP_CONJUNCTS)
   public List<BooleanExpr> getConjuncts() {
     return _conjuncts;
-  }
-
-  @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((_conjuncts == null) ? 0 : _conjuncts.hashCode());
-    return result;
   }
 
   @JsonProperty(PROP_CONJUNCTS)
@@ -130,6 +110,23 @@ public final class Conjunction extends BooleanExpr {
       simple._simplified = _simplified;
     }
     return _simplified;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof Conjunction)) {
+      return false;
+    }
+    Conjunction other = (Conjunction) obj;
+    return Objects.equals(_conjuncts, other._conjuncts);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_conjuncts);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/ConjunctionChain.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/ConjunctionChain.java
@@ -35,7 +35,7 @@ public final class ConjunctionChain extends BooleanExpr {
 
   private static final String PROP_SUBROUTINES = "subroutines";
 
-  @Nonnull private List<BooleanExpr> _subroutines;
+  @Nonnull private final List<BooleanExpr> _subroutines;
 
   @JsonCreator
   private static ConjunctionChain create(
@@ -55,23 +55,6 @@ public final class ConjunctionChain extends BooleanExpr {
       childSources.addAll(conjunct.collectSources(parentSources, routingPolicies, w));
     }
     return childSources.build();
-  }
-
-  @Override
-  public boolean equals(@Nullable Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof ConjunctionChain)) {
-      return false;
-    }
-    ConjunctionChain that = (ConjunctionChain) o;
-    return Objects.equals(_subroutines, that._subroutines);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(_subroutines);
   }
 
   @Override
@@ -115,6 +98,23 @@ public final class ConjunctionChain extends BooleanExpr {
   @JsonProperty(PROP_SUBROUTINES)
   public List<BooleanExpr> getSubroutines() {
     return _subroutines;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ConjunctionChain)) {
+      return false;
+    }
+    ConjunctionChain that = (ConjunctionChain) o;
+    return Objects.equals(_subroutines, that._subroutines);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_subroutines);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/ConjunctionChain.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/ConjunctionChain.java
@@ -29,7 +29,7 @@ import org.batfish.datamodel.routing_policy.RoutingPolicy;
  * https://www.juniper.net/documentation/en_US/junos/topics/concept/policy-routing-policies-chain-evaluation-method.html
  */
 @ParametersAreNonnullByDefault
-public class ConjunctionChain extends BooleanExpr {
+public final class ConjunctionChain extends BooleanExpr {
 
   private static final long serialVersionUID = 1L;
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/Disjunction.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/Disjunction.java
@@ -49,18 +49,6 @@ public final class Disjunction extends BooleanExpr {
   }
 
   @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (!(obj instanceof Disjunction)) {
-      return false;
-    }
-    Disjunction other = (Disjunction) obj;
-    return Objects.equals(_disjuncts, other._disjuncts);
-  }
-
-  @Override
   public Result evaluate(Environment environment) {
     for (BooleanExpr disjunct : _disjuncts) {
       Result disjunctResult = disjunct.evaluate(environment);
@@ -79,14 +67,6 @@ public final class Disjunction extends BooleanExpr {
   @JsonProperty(PROP_DISJUNCTS)
   public List<BooleanExpr> getDisjuncts() {
     return _disjuncts;
-  }
-
-  @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((_disjuncts == null) ? 0 : _disjuncts.hashCode());
-    return result;
   }
 
   @JsonProperty(PROP_DISJUNCTS)
@@ -125,6 +105,23 @@ public final class Disjunction extends BooleanExpr {
       simple._simplified = _simplified;
     }
     return _simplified;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof Disjunction)) {
+      return false;
+    }
+    Disjunction other = (Disjunction) obj;
+    return Objects.equals(_disjuncts, other._disjuncts);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_disjuncts);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/Disjunction.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/Disjunction.java
@@ -14,11 +14,14 @@ import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
 
+/**
+ * Boolean expression that evaluates to true if any {@link BooleanExpr} in a given list evaluates to
+ * true. Evaluates to false if the given list is empty.
+ */
 public final class Disjunction extends BooleanExpr {
 
   private static final String PROP_DISJUNCTS = "disjuncts";
 
-  /** */
   private static final long serialVersionUID = 1L;
 
   private List<BooleanExpr> _disjuncts;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/FirstMatchChain.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/FirstMatchChain.java
@@ -30,7 +30,7 @@ import org.batfish.datamodel.routing_policy.RoutingPolicy;
  * https://www.juniper.net/documentation/en_US/junos/topics/concept/policy-routing-policies-chain-evaluation-method.html
  */
 @ParametersAreNonnullByDefault
-public class FirstMatchChain extends BooleanExpr {
+public final class FirstMatchChain extends BooleanExpr {
 
   private static final long serialVersionUID = 1L;
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/FirstMatchChain.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/FirstMatchChain.java
@@ -36,7 +36,7 @@ public final class FirstMatchChain extends BooleanExpr {
 
   private static final String PROP_SUBROUTINES = "subroutines";
 
-  @Nonnull private List<BooleanExpr> _subroutines;
+  @Nonnull private final List<BooleanExpr> _subroutines;
 
   @JsonCreator
   private static FirstMatchChain create(
@@ -56,23 +56,6 @@ public final class FirstMatchChain extends BooleanExpr {
       childSources.addAll(policyMatcher.collectSources(parentSources, routingPolicies, w));
     }
     return childSources.build();
-  }
-
-  @Override
-  public boolean equals(@Nullable Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof FirstMatchChain)) {
-      return false;
-    }
-    FirstMatchChain that = (FirstMatchChain) o;
-    return Objects.equals(_subroutines, that._subroutines);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(_subroutines);
   }
 
   @Override
@@ -107,6 +90,23 @@ public final class FirstMatchChain extends BooleanExpr {
   @JsonProperty(PROP_SUBROUTINES)
   public List<BooleanExpr> getSubroutines() {
     return _subroutines;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof FirstMatchChain)) {
+      return false;
+    }
+    FirstMatchChain that = (FirstMatchChain) o;
+    return Objects.equals(_subroutines, that._subroutines);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_subroutines);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/HasRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/HasRoute.java
@@ -14,7 +14,6 @@ import org.batfish.datamodel.routing_policy.Result;
 public final class HasRoute extends BooleanExpr {
   private static final String PROP_EXPR = "expr";
 
-  /** */
   private static final long serialVersionUID = 1L;
 
   @Nonnull private PrefixSetExpr _expr;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/HasRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/HasRoute.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -16,7 +17,7 @@ public final class HasRoute extends BooleanExpr {
 
   private static final long serialVersionUID = 1L;
 
-  @Nonnull private PrefixSetExpr _expr;
+  @Nonnull private final PrefixSetExpr _expr;
 
   @JsonCreator
   private static HasRoute jsonCreator(@Nullable @JsonProperty(PROP_EXPR) PrefixSetExpr expr) {
@@ -26,20 +27,6 @@ public final class HasRoute extends BooleanExpr {
 
   public HasRoute(PrefixSetExpr expr) {
     _expr = expr;
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    } else if (!(obj instanceof HasRoute)) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    HasRoute other = (HasRoute) obj;
-    return _expr.equals(other._expr);
   }
 
   @Override
@@ -54,14 +41,18 @@ public final class HasRoute extends BooleanExpr {
   }
 
   @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + _expr.hashCode();
-    return result;
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    } else if (!(obj instanceof HasRoute)) {
+      return false;
+    }
+    HasRoute other = (HasRoute) obj;
+    return Objects.equals(_expr, other._expr);
   }
 
-  public void setExpr(PrefixSetExpr expr) {
-    _expr = expr;
+  @Override
+  public int hashCode() {
+    return Objects.hash(_expr);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/HasRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/HasRoute.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.common.BatfishException;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
@@ -31,7 +32,7 @@ public final class HasRoute extends BooleanExpr {
 
   @Override
   public Result evaluate(Environment environment) {
-    throw new UnsupportedOperationException("no implementation for generated method");
+    throw new BatfishException("No implementation for HasRoute.evaluate()");
   }
 
   @JsonProperty(PROP_EXPR)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/HasRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/HasRoute.java
@@ -41,7 +41,7 @@ public final class HasRoute extends BooleanExpr {
   }
 
   @Override
-  public boolean equals(Object obj) {
+  public boolean equals(@Nullable Object obj) {
     if (this == obj) {
       return true;
     } else if (!(obj instanceof HasRoute)) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/HasRoute6.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/HasRoute6.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
+import org.batfish.common.BatfishException;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
@@ -27,7 +28,7 @@ public final class HasRoute6 extends BooleanExpr {
 
   @Override
   public Result evaluate(Environment environment) {
-    throw new UnsupportedOperationException("no implementation for generated method");
+    throw new BatfishException("No implementation for HasRoute6.evaluate()");
   }
 
   @JsonProperty(PROP_EXPR)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/HasRoute6.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/HasRoute6.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
-public class HasRoute6 extends BooleanExpr {
+public final class HasRoute6 extends BooleanExpr {
 
   /** */
   private static final long serialVersionUID = 1L;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/HasRoute6.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/HasRoute6.java
@@ -6,7 +6,6 @@ import org.batfish.datamodel.routing_policy.Result;
 
 public final class HasRoute6 extends BooleanExpr {
 
-  /** */
   private static final long serialVersionUID = 1L;
 
   private Prefix6SetExpr _expr;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/HasRoute6.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/HasRoute6.java
@@ -1,42 +1,28 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
 public final class HasRoute6 extends BooleanExpr {
 
   private static final long serialVersionUID = 1L;
+  private static final String PROP_EXPR = "expr";
 
-  private Prefix6SetExpr _expr;
+  private final Prefix6SetExpr _expr;
 
   @JsonCreator
-  private HasRoute6() {}
+  private static HasRoute6 create(@JsonProperty(PROP_EXPR) Prefix6SetExpr expr) {
+    checkArgument(expr != null, "%s must be provided", PROP_EXPR);
+    return new HasRoute6(expr);
+  }
 
   public HasRoute6(Prefix6SetExpr expr) {
     _expr = expr;
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    HasRoute6 other = (HasRoute6) obj;
-    if (_expr == null) {
-      if (other._expr != null) {
-        return false;
-      }
-    } else if (!_expr.equals(other._expr)) {
-      return false;
-    }
-    return true;
   }
 
   @Override
@@ -44,19 +30,25 @@ public final class HasRoute6 extends BooleanExpr {
     throw new UnsupportedOperationException("no implementation for generated method");
   }
 
+  @JsonProperty(PROP_EXPR)
   public Prefix6SetExpr getExpr() {
     return _expr;
   }
 
   @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((_expr == null) ? 0 : _expr.hashCode());
-    return result;
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof HasRoute6)) {
+      return false;
+    }
+    HasRoute6 other = (HasRoute6) obj;
+    return Objects.equals(_expr, other._expr);
   }
 
-  public void setExpr(Prefix6SetExpr expr) {
-    _expr = expr;
+  @Override
+  public int hashCode() {
+    return Objects.hash(_expr);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchAsPath.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchAsPath.java
@@ -6,12 +6,15 @@ import java.util.Objects;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
+/**
+ * Boolean expression that tests whether an {@link Environment} contains a BGP route with an AS path
+ * that matches a given {@link AsPathSetExpr}.
+ */
 public final class MatchAsPath extends BooleanExpr {
-  /** */
+
   private static final long serialVersionUID = 1L;
 
   private static final String PROP_EXPR = "expr";
-
   private AsPathSetExpr _expr;
 
   @JsonCreator

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchAsPath.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchAsPath.java
@@ -1,5 +1,7 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
@@ -15,25 +17,16 @@ public final class MatchAsPath extends BooleanExpr {
   private static final long serialVersionUID = 1L;
 
   private static final String PROP_EXPR = "expr";
-  private AsPathSetExpr _expr;
+  private final AsPathSetExpr _expr;
 
   @JsonCreator
-  private MatchAsPath() {}
+  private static MatchAsPath create(@JsonProperty(PROP_EXPR) AsPathSetExpr expr) {
+    checkArgument(expr != null, "%s must be provided", PROP_EXPR);
+    return new MatchAsPath(expr);
+  }
 
   public MatchAsPath(AsPathSetExpr expr) {
     _expr = expr;
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (!(obj instanceof MatchAsPath)) {
-      return false;
-    }
-    MatchAsPath other = (MatchAsPath) obj;
-    return Objects.equals(_expr, other._expr);
   }
 
   @Override
@@ -50,16 +43,20 @@ public final class MatchAsPath extends BooleanExpr {
   }
 
   @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((_expr == null) ? 0 : _expr.hashCode());
-    return result;
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof MatchAsPath)) {
+      return false;
+    }
+    MatchAsPath other = (MatchAsPath) obj;
+    return Objects.equals(_expr, other._expr);
   }
 
-  @JsonProperty(PROP_EXPR)
-  public void setExpr(AsPathSetExpr expr) {
-    _expr = expr;
+  @Override
+  public int hashCode() {
+    return Objects.hash(_expr);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchColor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchColor.java
@@ -3,6 +3,7 @@ package org.batfish.datamodel.routing_policy.expr;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
+import org.batfish.common.BatfishException;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
@@ -24,7 +25,7 @@ public final class MatchColor extends BooleanExpr {
 
   @Override
   public Result evaluate(Environment environment) {
-    throw new UnsupportedOperationException("no implementation for generated method");
+    throw new BatfishException("No implementation for MatchColor.evaluate()");
   }
 
   @JsonProperty(PROP_COLOR)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchColor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchColor.java
@@ -6,7 +6,6 @@ import org.batfish.datamodel.routing_policy.Result;
 
 public final class MatchColor extends BooleanExpr {
 
-  /** */
   private static final long serialVersionUID = 1L;
 
   private int _color;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchColor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchColor.java
@@ -1,38 +1,25 @@
 package org.batfish.datamodel.routing_policy.expr;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
 public final class MatchColor extends BooleanExpr {
 
   private static final long serialVersionUID = 1L;
+  private static final String PROP_COLOR = "color";
 
-  private int _color;
+  private final int _color;
 
   @JsonCreator
-  private MatchColor() {}
+  private static MatchColor create(@JsonProperty(PROP_COLOR) int color) {
+    return new MatchColor(color);
+  }
 
   public MatchColor(int color) {
     _color = color;
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    MatchColor other = (MatchColor) obj;
-    if (_color != other._color) {
-      return false;
-    }
-    return true;
   }
 
   @Override
@@ -40,19 +27,25 @@ public final class MatchColor extends BooleanExpr {
     throw new UnsupportedOperationException("no implementation for generated method");
   }
 
+  @JsonProperty(PROP_COLOR)
   public int getColor() {
     return _color;
   }
 
   @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + _color;
-    return result;
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof MatchColor)) {
+      return false;
+    }
+    MatchColor other = (MatchColor) obj;
+    return _color == other._color;
   }
 
-  public void setColor(int color) {
-    _color = color;
+  @Override
+  public int hashCode() {
+    return Objects.hash(_color);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchColor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchColor.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
-public class MatchColor extends BooleanExpr {
+public final class MatchColor extends BooleanExpr {
 
   /** */
   private static final long serialVersionUID = 1L;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchCommunitySet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchCommunitySet.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 import java.util.SortedSet;
 import org.batfish.datamodel.BgpRoute;
 import org.batfish.datamodel.routing_policy.Environment;
@@ -19,7 +20,7 @@ public final class MatchCommunitySet extends BooleanExpr {
 
   private static final long serialVersionUID = 1L;
 
-  private CommunitySetExpr _expr;
+  private final CommunitySetExpr _expr;
 
   @JsonCreator
   private static MatchCommunitySet create(@JsonProperty(PROP_EXPR) CommunitySetExpr expr) {
@@ -29,28 +30,6 @@ public final class MatchCommunitySet extends BooleanExpr {
 
   public MatchCommunitySet(CommunitySetExpr expr) {
     _expr = expr;
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    MatchCommunitySet other = (MatchCommunitySet) obj;
-    if (_expr == null) {
-      if (other._expr != null) {
-        return false;
-      }
-    } else if (!_expr.equals(other._expr)) {
-      return false;
-    }
-    return true;
   }
 
   @Override
@@ -81,15 +60,19 @@ public final class MatchCommunitySet extends BooleanExpr {
   }
 
   @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((_expr == null) ? 0 : _expr.hashCode());
-    return result;
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof MatchCommunitySet)) {
+      return false;
+    }
+    MatchCommunitySet other = (MatchCommunitySet) obj;
+    return Objects.equals(_expr, other._expr);
   }
 
-  @JsonProperty(PROP_EXPR)
-  public void setExpr(CommunitySetExpr expr) {
-    _expr = expr;
+  @Override
+  public int hashCode() {
+    return Objects.hash(_expr);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchCommunitySet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchCommunitySet.java
@@ -1,5 +1,7 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.SortedSet;
@@ -7,17 +9,23 @@ import org.batfish.datamodel.BgpRoute;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
+/**
+ * Boolean expression that tests whether an {@link Environment} contains a BGP route with a
+ * community matching a given {@link CommunitySetExpr}.
+ */
 public final class MatchCommunitySet extends BooleanExpr {
 
   private static final String PROP_EXPR = "expr";
 
-  /** */
   private static final long serialVersionUID = 1L;
 
   private CommunitySetExpr _expr;
 
   @JsonCreator
-  private MatchCommunitySet() {}
+  private static MatchCommunitySet create(@JsonProperty(PROP_EXPR) CommunitySetExpr expr) {
+    checkArgument(expr != null, "%s must be provided", PROP_EXPR);
+    return new MatchCommunitySet(expr);
+  }
 
   public MatchCommunitySet(CommunitySetExpr expr) {
     _expr = expr;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchCommunitySet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchCommunitySet.java
@@ -7,7 +7,7 @@ import org.batfish.datamodel.BgpRoute;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
-public class MatchCommunitySet extends BooleanExpr {
+public final class MatchCommunitySet extends BooleanExpr {
 
   private static final String PROP_EXPR = "expr";
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchEntireCommunitySet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchEntireCommunitySet.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
+import org.batfish.common.BatfishException;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
@@ -27,7 +28,7 @@ public final class MatchEntireCommunitySet extends BooleanExpr {
 
   @Override
   public Result evaluate(Environment environment) {
-    throw new UnsupportedOperationException("no implementation for generated method");
+    throw new BatfishException("No implementation for MatchEntireCommunitySet.evaluate()");
   }
 
   @JsonProperty(PROP_EXPR)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchEntireCommunitySet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchEntireCommunitySet.java
@@ -1,42 +1,28 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
 public final class MatchEntireCommunitySet extends BooleanExpr {
 
   private static final long serialVersionUID = 1L;
+  private static final String PROP_EXPR = "expr";
 
-  private CommunitySetExpr _expr;
+  private final CommunitySetExpr _expr;
 
   @JsonCreator
-  private MatchEntireCommunitySet() {}
+  private static MatchEntireCommunitySet create(@JsonProperty(PROP_EXPR) CommunitySetExpr expr) {
+    checkArgument(expr != null, "%s must be provided", PROP_EXPR);
+    return new MatchEntireCommunitySet(expr);
+  }
 
   public MatchEntireCommunitySet(CommunitySetExpr expr) {
     _expr = expr;
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    MatchEntireCommunitySet other = (MatchEntireCommunitySet) obj;
-    if (_expr == null) {
-      if (other._expr != null) {
-        return false;
-      }
-    } else if (!_expr.equals(other._expr)) {
-      return false;
-    }
-    return true;
   }
 
   @Override
@@ -44,19 +30,25 @@ public final class MatchEntireCommunitySet extends BooleanExpr {
     throw new UnsupportedOperationException("no implementation for generated method");
   }
 
+  @JsonProperty(PROP_EXPR)
   public CommunitySetExpr getExpr() {
     return _expr;
   }
 
   @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((_expr == null) ? 0 : _expr.hashCode());
-    return result;
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof MatchEntireCommunitySet)) {
+      return false;
+    }
+    MatchEntireCommunitySet other = (MatchEntireCommunitySet) obj;
+    return Objects.equals(_expr, other._expr);
   }
 
-  public void setExpr(CommunitySetExpr expr) {
-    _expr = expr;
+  @Override
+  public int hashCode() {
+    return Objects.hash(_expr);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchEntireCommunitySet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchEntireCommunitySet.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
-public class MatchEntireCommunitySet extends BooleanExpr {
+public final class MatchEntireCommunitySet extends BooleanExpr {
 
   /** */
   private static final long serialVersionUID = 1L;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchEntireCommunitySet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchEntireCommunitySet.java
@@ -6,7 +6,6 @@ import org.batfish.datamodel.routing_policy.Result;
 
 public final class MatchEntireCommunitySet extends BooleanExpr {
 
-  /** */
   private static final long serialVersionUID = 1L;
 
   private CommunitySetExpr _expr;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchIp6AccessList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchIp6AccessList.java
@@ -1,6 +1,10 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 import org.batfish.datamodel.Ip6AccessList;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
@@ -8,36 +12,18 @@ import org.batfish.datamodel.routing_policy.Result;
 public final class MatchIp6AccessList extends BooleanExpr {
 
   private static final long serialVersionUID = 1L;
+  private static final String PROP_LIST = "list";
 
-  private String _list;
+  private final String _list;
 
   @JsonCreator
-  private MatchIp6AccessList() {}
+  private static MatchIp6AccessList create(@JsonProperty(PROP_LIST) String list) {
+    checkArgument(list != null, "%s must be provided", PROP_LIST);
+    return new MatchIp6AccessList(list);
+  }
 
   public MatchIp6AccessList(String list) {
     _list = list;
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    MatchIp6AccessList other = (MatchIp6AccessList) obj;
-    if (_list == null) {
-      if (other._list != null) {
-        return false;
-      }
-    } else if (!_list.equals(other._list)) {
-      return false;
-    }
-    return true;
   }
 
   @Override
@@ -59,14 +45,19 @@ public final class MatchIp6AccessList extends BooleanExpr {
   }
 
   @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((_list == null) ? 0 : _list.hashCode());
-    return result;
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof MatchIp6AccessList)) {
+      return false;
+    }
+    MatchIp6AccessList other = (MatchIp6AccessList) obj;
+    return Objects.equals(_list, other._list);
   }
 
-  public void setList(String list) {
-    _list = list;
+  @Override
+  public int hashCode() {
+    return Objects.hash(_list);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchIp6AccessList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchIp6AccessList.java
@@ -7,7 +7,6 @@ import org.batfish.datamodel.routing_policy.Result;
 
 public final class MatchIp6AccessList extends BooleanExpr {
 
-  /** */
   private static final long serialVersionUID = 1L;
 
   private String _list;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchIp6AccessList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchIp6AccessList.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
+import org.batfish.common.BatfishException;
 import org.batfish.datamodel.Ip6AccessList;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
@@ -37,7 +38,7 @@ public final class MatchIp6AccessList extends BooleanExpr {
       result.setBooleanValue(false);
       return result;
     }
-    throw new UnsupportedOperationException("no implementation for generated method");
+    throw new BatfishException("No implementation for MatchIp6AccessList.evaluate()");
   }
 
   public String getList() {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchIp6AccessList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchIp6AccessList.java
@@ -5,7 +5,7 @@ import org.batfish.datamodel.Ip6AccessList;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
-public class MatchIp6AccessList extends BooleanExpr {
+public final class MatchIp6AccessList extends BooleanExpr {
 
   /** */
   private static final long serialVersionUID = 1L;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchIpAccessList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchIpAccessList.java
@@ -5,7 +5,7 @@ import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
-public class MatchIpAccessList extends BooleanExpr {
+public final class MatchIpAccessList extends BooleanExpr {
 
   /** */
   private static final long serialVersionUID = 1L;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchIpAccessList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchIpAccessList.java
@@ -7,7 +7,6 @@ import org.batfish.datamodel.routing_policy.Result;
 
 public final class MatchIpAccessList extends BooleanExpr {
 
-  /** */
   private static final long serialVersionUID = 1L;
 
   private String _list;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchIpAccessList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchIpAccessList.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
+import org.batfish.common.BatfishException;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
@@ -37,7 +38,7 @@ public final class MatchIpAccessList extends BooleanExpr {
       result.setBooleanValue(false);
       return result;
     }
-    throw new UnsupportedOperationException("no implementation for generated method");
+    throw new BatfishException("No implementation for MatchIpAccessList.evaluate()");
   }
 
   @JsonProperty(PROP_LIST)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchIpAccessList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchIpAccessList.java
@@ -1,6 +1,10 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
@@ -8,36 +12,18 @@ import org.batfish.datamodel.routing_policy.Result;
 public final class MatchIpAccessList extends BooleanExpr {
 
   private static final long serialVersionUID = 1L;
+  private static final String PROP_LIST = "list";
 
-  private String _list;
+  private final String _list;
 
   @JsonCreator
-  private MatchIpAccessList() {}
+  private static MatchIpAccessList create(@JsonProperty(PROP_LIST) String list) {
+    checkArgument(list != null, "%s must be provided", PROP_LIST);
+    return new MatchIpAccessList(list);
+  }
 
   public MatchIpAccessList(String list) {
     _list = list;
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    MatchIpAccessList other = (MatchIpAccessList) obj;
-    if (_list == null) {
-      if (other._list != null) {
-        return false;
-      }
-    } else if (!_list.equals(other._list)) {
-      return false;
-    }
-    return true;
   }
 
   @Override
@@ -54,19 +40,25 @@ public final class MatchIpAccessList extends BooleanExpr {
     throw new UnsupportedOperationException("no implementation for generated method");
   }
 
+  @JsonProperty(PROP_LIST)
   public String getList() {
     return _list;
   }
 
   @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((_list == null) ? 0 : _list.hashCode());
-    return result;
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof MatchIpAccessList)) {
+      return false;
+    }
+    MatchIpAccessList other = (MatchIpAccessList) obj;
+    return Objects.equals(_list, other._list);
   }
 
-  public void setList(String list) {
-    _list = list;
+  @Override
+  public int hashCode() {
+    return Objects.hash(_list);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchIpv4.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchIpv4.java
@@ -11,20 +11,6 @@ public final class MatchIpv4 extends BooleanExpr {
   public MatchIpv4() {}
 
   @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    return true;
-  }
-
-  @Override
   public Result evaluate(Environment environment) {
     boolean match = environment.getOriginalRoute() != null;
     Result result = new Result();
@@ -33,10 +19,12 @@ public final class MatchIpv4 extends BooleanExpr {
   }
 
   @Override
+  public boolean equals(Object obj) {
+    return obj instanceof MatchIpv4;
+  }
+
+  @Override
   public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + 0x12345678;
-    return result;
+    return 0;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchIpv4.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchIpv4.java
@@ -3,7 +3,7 @@ package org.batfish.datamodel.routing_policy.expr;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
-public class MatchIpv4 extends BooleanExpr {
+public final class MatchIpv4 extends BooleanExpr {
 
   /** */
   private static final long serialVersionUID = 1L;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchIpv4.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchIpv4.java
@@ -1,5 +1,6 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
@@ -8,7 +9,14 @@ public final class MatchIpv4 extends BooleanExpr {
 
   private static final long serialVersionUID = 1L;
 
-  public MatchIpv4() {}
+  private static final MatchIpv4 INSTANCE = new MatchIpv4();
+
+  private MatchIpv4() {}
+
+  @JsonCreator
+  public static MatchIpv4 instance() {
+    return INSTANCE;
+  }
 
   @Override
   public Result evaluate(Environment environment) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchIpv4.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchIpv4.java
@@ -3,9 +3,9 @@ package org.batfish.datamodel.routing_policy.expr;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
+/** Boolean expression that evaluates to true if the given {@link Environment} has an IPv4 route. */
 public final class MatchIpv4 extends BooleanExpr {
 
-  /** */
   private static final long serialVersionUID = 1L;
 
   public MatchIpv4() {}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchIpv6.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchIpv6.java
@@ -3,9 +3,9 @@ package org.batfish.datamodel.routing_policy.expr;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
+/** Boolean expression that evaluates to true if the given {@link Environment} has an IPv6 route. */
 public final class MatchIpv6 extends BooleanExpr {
 
-  /** */
   private static final long serialVersionUID = 1L;
 
   public MatchIpv6() {}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchIpv6.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchIpv6.java
@@ -11,20 +11,6 @@ public final class MatchIpv6 extends BooleanExpr {
   public MatchIpv6() {}
 
   @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    return true;
-  }
-
-  @Override
   public Result evaluate(Environment environment) {
     boolean match = environment.getOriginalRoute6() != null;
     Result result = new Result();
@@ -33,10 +19,12 @@ public final class MatchIpv6 extends BooleanExpr {
   }
 
   @Override
+  public boolean equals(Object obj) {
+    return obj instanceof MatchIpv6;
+  }
+
+  @Override
   public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + 0x12345678;
-    return result;
+    return 0;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchIpv6.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchIpv6.java
@@ -3,7 +3,7 @@ package org.batfish.datamodel.routing_policy.expr;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
-public class MatchIpv6 extends BooleanExpr {
+public final class MatchIpv6 extends BooleanExpr {
 
   /** */
   private static final long serialVersionUID = 1L;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchIpv6.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchIpv6.java
@@ -1,5 +1,6 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
@@ -8,7 +9,14 @@ public final class MatchIpv6 extends BooleanExpr {
 
   private static final long serialVersionUID = 1L;
 
-  public MatchIpv6() {}
+  private static final MatchIpv6 INSTANCE = new MatchIpv6();
+
+  private MatchIpv6() {}
+
+  @JsonCreator
+  public static MatchIpv6 instance() {
+    return INSTANCE;
+  }
 
   @Override
   public Result evaluate(Environment environment) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchLocalPreference.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchLocalPreference.java
@@ -53,7 +53,7 @@ public final class MatchLocalPreference extends BooleanExpr {
   }
 
   @Override
-  public boolean equals(Object obj) {
+  public boolean equals(@Nullable Object obj) {
     if (this == obj) {
       return true;
     } else if (!(obj instanceof MatchLocalPreference)) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchLocalPreference.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchLocalPreference.java
@@ -15,11 +15,9 @@ public final class MatchLocalPreference extends BooleanExpr {
   private static final String PROP_COMPARATOR = "comparator";
   private static final String PROP_METRIC = "metric";
 
-  /** */
   private static final long serialVersionUID = 1L;
 
   @Nonnull private IntComparator _comparator;
-
   @Nonnull private IntExpr _metric;
 
   @JsonCreator

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchLocalPreference.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchLocalPreference.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -17,8 +18,8 @@ public final class MatchLocalPreference extends BooleanExpr {
 
   private static final long serialVersionUID = 1L;
 
-  @Nonnull private IntComparator _comparator;
-  @Nonnull private IntExpr _metric;
+  @Nonnull private final IntComparator _comparator;
+  @Nonnull private final IntExpr _metric;
 
   @JsonCreator
   private static MatchLocalPreference jsonCreator(
@@ -32,17 +33,6 @@ public final class MatchLocalPreference extends BooleanExpr {
   public MatchLocalPreference(IntComparator comparator, IntExpr metric) {
     _comparator = comparator;
     _metric = metric;
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    } else if (!(obj instanceof MatchLocalPreference)) {
-      return false;
-    }
-    MatchLocalPreference other = (MatchLocalPreference) obj;
-    return _comparator == other._comparator && _metric.equals(other._metric);
   }
 
   @Override
@@ -63,19 +53,18 @@ public final class MatchLocalPreference extends BooleanExpr {
   }
 
   @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    } else if (!(obj instanceof MatchLocalPreference)) {
+      return false;
+    }
+    MatchLocalPreference other = (MatchLocalPreference) obj;
+    return _comparator == other._comparator && Objects.equals(_metric, other._metric);
+  }
+
+  @Override
   public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((_comparator == null) ? 0 : _comparator.ordinal());
-    result = prime * result + ((_metric == null) ? 0 : _metric.hashCode());
-    return result;
-  }
-
-  public void setComparator(IntComparator comparator) {
-    _comparator = comparator;
-  }
-
-  public void setMetric(IntExpr metric) {
-    _metric = metric;
+    return Objects.hash(_comparator.ordinal(), _metric);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchLocalPreference.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchLocalPreference.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.common.BatfishException;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
@@ -37,7 +38,7 @@ public final class MatchLocalPreference extends BooleanExpr {
 
   @Override
   public Result evaluate(Environment environment) {
-    throw new UnsupportedOperationException("no implementation for generated method");
+    throw new BatfishException("No implementation for MatchLocalPreference.evaluate()");
   }
 
   @JsonProperty(PROP_COMPARATOR)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchLocalRouteSourcePrefixLength.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchLocalRouteSourcePrefixLength.java
@@ -8,7 +8,7 @@ import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
-public class MatchLocalRouteSourcePrefixLength extends BooleanExpr {
+public final class MatchLocalRouteSourcePrefixLength extends BooleanExpr {
 
   private static final String PROP_MATCH_LENGTH = "matchLength";
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchLocalRouteSourcePrefixLength.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchLocalRouteSourcePrefixLength.java
@@ -2,6 +2,7 @@ package org.batfish.datamodel.routing_policy.expr;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import org.batfish.datamodel.LocalRoute;
 import org.batfish.datamodel.SubRange;
@@ -27,21 +28,6 @@ public final class MatchLocalRouteSourcePrefixLength extends BooleanExpr {
   }
 
   @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    MatchLocalRouteSourcePrefixLength other = (MatchLocalRouteSourcePrefixLength) obj;
-    return _matchLength.equals(other._matchLength);
-  }
-
-  @Override
   public Result evaluate(Environment environment) {
     LocalRoute localRoute = (LocalRoute) environment.getOriginalRoute();
     Result result = new Result();
@@ -55,7 +41,19 @@ public final class MatchLocalRouteSourcePrefixLength extends BooleanExpr {
   }
 
   @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof MatchLocalRouteSourcePrefixLength)) {
+      return false;
+    }
+    MatchLocalRouteSourcePrefixLength other = (MatchLocalRouteSourcePrefixLength) obj;
+    return Objects.equals(_matchLength, other._matchLength);
+  }
+
+  @Override
   public int hashCode() {
-    return _matchLength.hashCode();
+    return Objects.hash(_matchLength);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchLocalRouteSourcePrefixLength.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchLocalRouteSourcePrefixLength.java
@@ -8,6 +8,10 @@ import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
+/**
+ * Boolean expression that evaluates whether an {@link Environment} has a {@link LocalRoute} with a
+ * source prefix length within a given range of lengths to match.
+ */
 public final class MatchLocalRouteSourcePrefixLength extends BooleanExpr {
 
   private static final String PROP_MATCH_LENGTH = "matchLength";

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchMetric.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchMetric.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.common.BatfishException;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
@@ -37,7 +38,7 @@ public final class MatchMetric extends BooleanExpr {
 
   @Override
   public Result evaluate(Environment environment) {
-    throw new UnsupportedOperationException("no implementation for generated method");
+    throw new BatfishException("No implementation for MatchMetric.evaluate()");
   }
 
   @JsonProperty(PROP_COMPARATOR)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchMetric.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchMetric.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -35,17 +36,6 @@ public final class MatchMetric extends BooleanExpr {
   }
 
   @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    } else if (!(obj instanceof MatchMetric)) {
-      return false;
-    }
-    MatchMetric other = (MatchMetric) obj;
-    return _comparator == other._comparator && _metric.equals(other._metric);
-  }
-
-  @Override
   public Result evaluate(Environment environment) {
     throw new UnsupportedOperationException("no implementation for generated method");
   }
@@ -63,11 +53,18 @@ public final class MatchMetric extends BooleanExpr {
   }
 
   @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    } else if (!(obj instanceof MatchMetric)) {
+      return false;
+    }
+    MatchMetric other = (MatchMetric) obj;
+    return _comparator == other._comparator && Objects.equals(_metric, other._metric);
+  }
+
+  @Override
   public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + _comparator.ordinal();
-    result = prime * result + _metric.hashCode();
-    return result;
+    return Objects.hash(_comparator.ordinal(), _metric);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchMetric.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchMetric.java
@@ -53,7 +53,7 @@ public final class MatchMetric extends BooleanExpr {
   }
 
   @Override
-  public boolean equals(Object obj) {
+  public boolean equals(@Nullable Object obj) {
     if (this == obj) {
       return true;
     } else if (!(obj instanceof MatchMetric)) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchMetric.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchMetric.java
@@ -15,11 +15,9 @@ public final class MatchMetric extends BooleanExpr {
   private static final String PROP_COMPARATOR = "comparator";
   private static final String PROP_METRIC = "metric";
 
-  /** */
   private static final long serialVersionUID = 1L;
 
   @Nonnull private final IntComparator _comparator;
-
   @Nonnull private final IntExpr _metric;
 
   @JsonCreator

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchPrefix6Set.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchPrefix6Set.java
@@ -62,7 +62,7 @@ public final class MatchPrefix6Set extends BooleanExpr {
   }
 
   @Override
-  public boolean equals(Object obj) {
+  public boolean equals(@Nullable Object obj) {
     if (this == obj) {
       return true;
     } else if (!(obj instanceof MatchPrefix6Set)) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchPrefix6Set.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchPrefix6Set.java
@@ -11,15 +11,18 @@ import org.batfish.datamodel.Prefix6;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
+/**
+ * Boolean expression that tests whether an IPv6 prefix extracted from an {@link Environment} using
+ * a given {@link Prefix6Expr} matches a given {@link Prefix6SetExpr}.
+ */
 @ParametersAreNonnullByDefault
 public final class MatchPrefix6Set extends BooleanExpr {
   private static final String PROP_PREFIX = "prefix";
   private static final String PROP_PREFIX_SET = "prefixSet";
-  /** */
+
   private static final long serialVersionUID = 1L;
 
   @Nonnull private Prefix6Expr _prefix;
-
   @Nonnull private Prefix6SetExpr _prefixSet;
 
   @JsonCreator

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchPrefix6Set.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchPrefix6Set.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -22,8 +23,8 @@ public final class MatchPrefix6Set extends BooleanExpr {
 
   private static final long serialVersionUID = 1L;
 
-  @Nonnull private Prefix6Expr _prefix;
-  @Nonnull private Prefix6SetExpr _prefixSet;
+  @Nonnull private final Prefix6Expr _prefix;
+  @Nonnull private final Prefix6SetExpr _prefixSet;
 
   @JsonCreator
   private static MatchPrefix6Set jsonCreator(
@@ -37,17 +38,6 @@ public final class MatchPrefix6Set extends BooleanExpr {
   public MatchPrefix6Set(Prefix6Expr prefix, Prefix6SetExpr prefixSet) {
     _prefix = prefix;
     _prefixSet = prefixSet;
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    } else if (!(obj instanceof MatchPrefix6Set)) {
-      return false;
-    }
-    MatchPrefix6Set other = (MatchPrefix6Set) obj;
-    return _prefix.equals(other._prefix) && _prefixSet.equals(other._prefixSet);
   }
 
   @Override
@@ -72,11 +62,18 @@ public final class MatchPrefix6Set extends BooleanExpr {
   }
 
   @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    } else if (!(obj instanceof MatchPrefix6Set)) {
+      return false;
+    }
+    MatchPrefix6Set other = (MatchPrefix6Set) obj;
+    return Objects.equals(_prefix, other._prefix) && Objects.equals(_prefixSet, other._prefixSet);
+  }
+
+  @Override
   public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + _prefix.hashCode();
-    result = prime * result + _prefixSet.hashCode();
-    return result;
+    return Objects.hash(_prefix, _prefixSet);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchPrefixSet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchPrefixSet.java
@@ -11,6 +11,10 @@ import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
+/**
+ * Boolean expression that tests whether an IPv4 prefix extracted from an {@link Environment} using
+ * a given {@link PrefixExpr} matches a given {@link PrefixSetExpr}.
+ */
 @ParametersAreNonnullByDefault
 public final class MatchPrefixSet extends BooleanExpr {
 
@@ -20,7 +24,6 @@ public final class MatchPrefixSet extends BooleanExpr {
   private static final String PROP_PREFIX_SET = "prefixSet";
 
   @Nonnull private PrefixExpr _prefix;
-
   @Nonnull private PrefixSetExpr _prefixSet;
 
   @JsonCreator

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchPrefixSet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchPrefixSet.java
@@ -66,7 +66,7 @@ public final class MatchPrefixSet extends BooleanExpr {
   }
 
   @Override
-  public boolean equals(Object obj) {
+  public boolean equals(@Nullable Object obj) {
     if (this == obj) {
       return true;
     } else if (!(obj instanceof MatchPrefixSet)) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchPrefixSet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchPrefixSet.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -23,8 +24,8 @@ public final class MatchPrefixSet extends BooleanExpr {
   private static final String PROP_PREFIX = "prefix";
   private static final String PROP_PREFIX_SET = "prefixSet";
 
-  @Nonnull private PrefixExpr _prefix;
-  @Nonnull private PrefixSetExpr _prefixSet;
+  @Nonnull private final PrefixExpr _prefix;
+  @Nonnull private final PrefixSetExpr _prefixSet;
 
   @JsonCreator
   private static MatchPrefixSet jsonCreator(
@@ -41,17 +42,6 @@ public final class MatchPrefixSet extends BooleanExpr {
   public MatchPrefixSet(PrefixExpr prefix, PrefixSetExpr prefixSet) {
     _prefix = prefix;
     _prefixSet = prefixSet;
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    } else if (!(obj instanceof MatchPrefixSet)) {
-      return false;
-    }
-    MatchPrefixSet other = (MatchPrefixSet) obj;
-    return _prefix.equals(other._prefix) && _prefixSet.equals(other._prefixSet);
   }
 
   @Override
@@ -76,12 +66,19 @@ public final class MatchPrefixSet extends BooleanExpr {
   }
 
   @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    } else if (!(obj instanceof MatchPrefixSet)) {
+      return false;
+    }
+    MatchPrefixSet other = (MatchPrefixSet) obj;
+    return Objects.equals(_prefix, other._prefix) && Objects.equals(_prefixSet, other._prefixSet);
+  }
+
+  @Override
   public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + _prefix.hashCode();
-    result = prime * result + _prefixSet.hashCode();
-    return result;
+    return Objects.hash(_prefix, _prefixSet);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchProcessAsn.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchProcessAsn.java
@@ -7,6 +7,10 @@ import org.batfish.datamodel.EigrpRoute;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
+/**
+ * Boolean expression that evaluates whether an {@link Environment} has an EIGRP route with an ASN
+ * equal to some given ASN.
+ */
 public final class MatchProcessAsn extends BooleanExpr {
 
   private static final long serialVersionUID = 1L;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchProcessAsn.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchProcessAsn.java
@@ -7,7 +7,7 @@ import org.batfish.datamodel.EigrpRoute;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
-public class MatchProcessAsn extends BooleanExpr {
+public final class MatchProcessAsn extends BooleanExpr {
 
   private static final long serialVersionUID = 1L;
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchProcessAsn.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchProcessAsn.java
@@ -25,6 +25,14 @@ public final class MatchProcessAsn extends BooleanExpr {
   }
 
   @Override
+  public Result evaluate(Environment environment) {
+    Result result = new Result();
+    EigrpRoute route = (EigrpRoute) environment.getOriginalRoute();
+    result.setBooleanValue(route.getProcessAsn() == _asn);
+    return result;
+  }
+
+  @Override
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
@@ -33,14 +41,6 @@ public final class MatchProcessAsn extends BooleanExpr {
       return false;
     }
     return _asn == ((MatchProcessAsn) obj)._asn;
-  }
-
-  @Override
-  public Result evaluate(Environment environment) {
-    Result result = new Result();
-    EigrpRoute route = (EigrpRoute) environment.getOriginalRoute();
-    result.setBooleanValue(route.getProcessAsn() == _asn);
-    return result;
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchProtocol.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchProtocol.java
@@ -44,23 +44,6 @@ public final class MatchProtocol extends BooleanExpr {
   }
 
   @Override
-  public boolean equals(@Nullable Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof MatchProtocol)) {
-      return false;
-    }
-    MatchProtocol that = (MatchProtocol) o;
-    return _protocol == that._protocol;
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(_protocol.ordinal());
-  }
-
-  @Override
   public Result evaluate(Environment environment) {
     Result result = new Result();
     // Workaround: Treat ISIS_ANY as a special value
@@ -76,6 +59,23 @@ public final class MatchProtocol extends BooleanExpr {
   @JsonProperty(PROP_PROTOCOL)
   public RoutingProtocol getProtocol() {
     return _protocol;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof MatchProtocol)) {
+      return false;
+    }
+    MatchProtocol that = (MatchProtocol) o;
+    return _protocol == that._protocol;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_protocol.ordinal());
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchProtocol.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchProtocol.java
@@ -17,7 +17,10 @@ import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
-/** Match the route's routing protocol */
+/**
+ * Boolean expression that evaluates whether an {@link Environment} has a route that matches a given
+ * {@link RoutingProtocol}.
+ */
 @ParametersAreNonnullByDefault
 public final class MatchProtocol extends BooleanExpr {
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchRouteType.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchRouteType.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -17,7 +18,7 @@ public final class MatchRouteType extends BooleanExpr {
 
   private static final long serialVersionUID = 1L;
 
-  @Nonnull private RouteTypeExpr _type;
+  @Nonnull private final RouteTypeExpr _type;
 
   @JsonCreator
   private static MatchRouteType jsonCreator(@Nullable @JsonProperty(PROP_TYPE) RouteTypeExpr type) {
@@ -27,17 +28,6 @@ public final class MatchRouteType extends BooleanExpr {
 
   public MatchRouteType(RouteTypeExpr type) {
     _type = type;
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    } else if (!(obj instanceof MatchRouteType)) {
-      return false;
-    }
-    MatchRouteType other = (MatchRouteType) obj;
-    return _type.equals(other._type);
   }
 
   @Override
@@ -53,14 +43,18 @@ public final class MatchRouteType extends BooleanExpr {
   }
 
   @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + _type.hashCode();
-    return result;
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    } else if (!(obj instanceof MatchRouteType)) {
+      return false;
+    }
+    MatchRouteType other = (MatchRouteType) obj;
+    return Objects.equals(_type, other._type);
   }
 
-  public void setType(RouteTypeExpr type) {
-    _type = type;
+  @Override
+  public int hashCode() {
+    return Objects.hash(_type);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchRouteType.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchRouteType.java
@@ -15,7 +15,6 @@ import org.batfish.datamodel.routing_policy.Result;
 public final class MatchRouteType extends BooleanExpr {
   private static final String PROP_TYPE = "type";
 
-  /** */
   private static final long serialVersionUID = 1L;
 
   @Nonnull private RouteTypeExpr _type;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchRouteType.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchRouteType.java
@@ -43,7 +43,7 @@ public final class MatchRouteType extends BooleanExpr {
   }
 
   @Override
-  public boolean equals(Object obj) {
+  public boolean equals(@Nullable Object obj) {
     if (this == obj) {
       return true;
     } else if (!(obj instanceof MatchRouteType)) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchRouteType.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchRouteType.java
@@ -33,7 +33,7 @@ public final class MatchRouteType extends BooleanExpr {
   @Override
   public Result evaluate(Environment environment) {
     RouteType type = _type.evaluate(environment);
-    throw new BatfishException("unimplemented: match route type: " + type.routeTypeName());
+    throw new BatfishException("Unimplemented: match route type: " + type.routeTypeName());
   }
 
   @JsonProperty(PROP_TYPE)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchTag.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchTag.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -21,8 +22,8 @@ public final class MatchTag extends BooleanExpr {
 
   private static final long serialVersionUID = 1L;
 
-  @Nonnull private IntComparator _cmp;
-  @Nonnull private IntExpr _tag;
+  @Nonnull private final IntComparator _cmp;
+  @Nonnull private final IntExpr _tag;
 
   @JsonCreator
   private static MatchTag jsonCreator(
@@ -36,17 +37,6 @@ public final class MatchTag extends BooleanExpr {
   public MatchTag(IntComparator cmp, IntExpr tag) {
     _cmp = cmp;
     _tag = tag;
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    } else if (!(obj instanceof MatchTag)) {
-      return false;
-    }
-    MatchTag other = (MatchTag) obj;
-    return _cmp == other._cmp && _tag.equals(other._tag);
   }
 
   @Override
@@ -76,19 +66,18 @@ public final class MatchTag extends BooleanExpr {
   }
 
   @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    } else if (!(obj instanceof MatchTag)) {
+      return false;
+    }
+    MatchTag other = (MatchTag) obj;
+    return _cmp == other._cmp && Objects.equals(_tag, other._tag);
+  }
+
+  @Override
   public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + _cmp.ordinal();
-    result = prime * result + _tag.hashCode();
-    return result;
-  }
-
-  public void setCmp(IntComparator cmp) {
-    _cmp = cmp;
-  }
-
-  public void setTag(IntExpr tag) {
-    _tag = tag;
+    return Objects.hash(_cmp.ordinal(), _tag);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchTag.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchTag.java
@@ -10,16 +10,18 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
+/**
+ * Boolean expression that evaluates whether an {@link Environment}'s route's BGP tag matches a
+ * given {@link IntExpr} using a given {@link IntComparator}.
+ */
 @ParametersAreNonnullByDefault
 public final class MatchTag extends BooleanExpr {
   private static final String PROP_CMP = "cmp";
   private static final String PROP_TAG = "tag";
 
-  /** */
   private static final long serialVersionUID = 1L;
 
   @Nonnull private IntComparator _cmp;
-
   @Nonnull private IntExpr _tag;
 
   @JsonCreator

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchTag.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchTag.java
@@ -66,7 +66,7 @@ public final class MatchTag extends BooleanExpr {
   }
 
   @Override
-  public boolean equals(Object obj) {
+  public boolean equals(@Nullable Object obj) {
     if (this == obj) {
       return true;
     } else if (!(obj instanceof MatchTag)) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/NeighborIsAsPath.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/NeighborIsAsPath.java
@@ -18,11 +18,9 @@ public final class NeighborIsAsPath extends BooleanExpr {
   private static final String PROP_EXACT = "exact";
   private static final String PROP_RANGE = "range";
 
-  /** */
   private static final long serialVersionUID = 1L;
 
   private boolean _exact;
-
   @Nonnull private List<SubRangeExpr> _range;
 
   @JsonCreator

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/NeighborIsAsPath.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/NeighborIsAsPath.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -21,7 +22,7 @@ public final class NeighborIsAsPath extends BooleanExpr {
   private static final long serialVersionUID = 1L;
 
   private boolean _exact;
-  @Nonnull private List<SubRangeExpr> _range;
+  @Nonnull private final List<SubRangeExpr> _range;
 
   @JsonCreator
   private static NeighborIsAsPath jsonCreator(
@@ -34,17 +35,6 @@ public final class NeighborIsAsPath extends BooleanExpr {
   public NeighborIsAsPath(List<SubRangeExpr> range, boolean exact) {
     _range = range;
     _exact = exact;
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    } else if (!(obj instanceof NeighborIsAsPath)) {
-      return false;
-    }
-    NeighborIsAsPath other = (NeighborIsAsPath) obj;
-    return _exact == other._exact && _range.equals(other._range);
   }
 
   @Override
@@ -64,19 +54,18 @@ public final class NeighborIsAsPath extends BooleanExpr {
   }
 
   @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    } else if (!(obj instanceof NeighborIsAsPath)) {
+      return false;
+    }
+    NeighborIsAsPath other = (NeighborIsAsPath) obj;
+    return _exact == other._exact && _range.equals(other._range);
+  }
+
+  @Override
   public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + (_exact ? 1231 : 1237);
-    result = prime * result + _range.hashCode();
-    return result;
-  }
-
-  public void setExact(boolean exact) {
-    _exact = exact;
-  }
-
-  public void setRange(List<SubRangeExpr> range) {
-    _range = range;
+    return Objects.hash(_exact, _range);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/NeighborIsAsPath.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/NeighborIsAsPath.java
@@ -54,7 +54,7 @@ public final class NeighborIsAsPath extends BooleanExpr {
   }
 
   @Override
-  public boolean equals(Object obj) {
+  public boolean equals(@Nullable Object obj) {
     if (this == obj) {
       return true;
     } else if (!(obj instanceof NeighborIsAsPath)) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/NeighborIsAsPath.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/NeighborIsAsPath.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.common.BatfishException;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
@@ -39,7 +40,7 @@ public final class NeighborIsAsPath extends BooleanExpr {
 
   @Override
   public Result evaluate(Environment environment) {
-    throw new UnsupportedOperationException("no implementation for generated method");
+    throw new BatfishException("No implementation for NeighborIsAsPath.evaluate()");
   }
 
   @JsonProperty(PROP_EXACT)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/Not.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/Not.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.routing_policy.Environment;
@@ -17,10 +18,11 @@ public final class Not extends BooleanExpr {
   private static final long serialVersionUID = 1L;
 
   private static final String PROP_EXPR = "expr";
-  private BooleanExpr _expr;
+  private final BooleanExpr _expr;
 
   @JsonCreator
   private static Not create(@JsonProperty(PROP_EXPR) BooleanExpr expr) {
+    checkArgument(expr != null, "%s must be provided", PROP_EXPR);
     return new Not(expr);
   }
 
@@ -33,28 +35,6 @@ public final class Not extends BooleanExpr {
   public Set<String> collectSources(
       Set<String> parentSources, Map<String, RoutingPolicy> routingPolicies, Warnings w) {
     return _expr.collectSources(parentSources, routingPolicies, w);
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    Not other = (Not) obj;
-    if (_expr == null) {
-      if (other._expr != null) {
-        return false;
-      }
-    } else if (!_expr.equals(other._expr)) {
-      return false;
-    }
-    return true;
   }
 
   @Override
@@ -72,16 +52,20 @@ public final class Not extends BooleanExpr {
   }
 
   @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((_expr == null) ? 0 : _expr.hashCode());
-    return result;
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof Not)) {
+      return false;
+    }
+    Not other = (Not) obj;
+    return Objects.equals(_expr, other._expr);
   }
 
-  @JsonProperty(PROP_EXPR)
-  public void setExpr(BooleanExpr expr) {
-    _expr = expr;
+  @Override
+  public int hashCode() {
+    return Objects.hash(_expr);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/Not.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/Not.java
@@ -7,12 +7,15 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
 
 /** Boolean expression that evaluates to the opposite of some given {@link BooleanExpr}. */
+@ParametersAreNonnullByDefault
 public final class Not extends BooleanExpr {
 
   private static final long serialVersionUID = 1L;
@@ -21,13 +24,12 @@ public final class Not extends BooleanExpr {
   private final BooleanExpr _expr;
 
   @JsonCreator
-  private static Not create(@JsonProperty(PROP_EXPR) BooleanExpr expr) {
+  private static Not create(@Nullable @JsonProperty(PROP_EXPR) BooleanExpr expr) {
     checkArgument(expr != null, "%s must be provided", PROP_EXPR);
     return new Not(expr);
   }
 
   public Not(BooleanExpr expr) {
-    checkArgument(expr != null, "%s must be provided", PROP_EXPR);
     _expr = expr;
   }
 
@@ -52,7 +54,7 @@ public final class Not extends BooleanExpr {
   }
 
   @Override
-  public boolean equals(Object obj) {
+  public boolean equals(@Nullable Object obj) {
     if (this == obj) {
       return true;
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/Not.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/Not.java
@@ -9,7 +9,7 @@ import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
 
-public class Not extends BooleanExpr {
+public final class Not extends BooleanExpr {
 
   /** */
   private static final long serialVersionUID = 1L;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/Not.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/Not.java
@@ -1,5 +1,7 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Map;
@@ -9,19 +11,21 @@ import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
 
+/** Boolean expression that evaluates to the opposite of some given {@link BooleanExpr}. */
 public final class Not extends BooleanExpr {
 
-  /** */
   private static final long serialVersionUID = 1L;
 
   private static final String PROP_EXPR = "expr";
-
   private BooleanExpr _expr;
 
   @JsonCreator
-  private Not() {}
+  private static Not create(@JsonProperty(PROP_EXPR) BooleanExpr expr) {
+    return new Not(expr);
+  }
 
   public Not(BooleanExpr expr) {
+    checkArgument(expr != null, "%s must be provided", PROP_EXPR);
     _expr = expr;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/OriginatesFromAsPath.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/OriginatesFromAsPath.java
@@ -54,7 +54,7 @@ public final class OriginatesFromAsPath extends BooleanExpr {
   }
 
   @Override
-  public boolean equals(Object obj) {
+  public boolean equals(@Nullable Object obj) {
     if (this == obj) {
       return true;
     } else if (!(obj instanceof OriginatesFromAsPath)) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/OriginatesFromAsPath.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/OriginatesFromAsPath.java
@@ -18,11 +18,9 @@ public final class OriginatesFromAsPath extends BooleanExpr {
   private static final String PROP_AS_RANGE = "asRange";
   private static final String PROP_EXACT = "exact";
 
-  /** */
   private static final long serialVersionUID = 1L;
 
   @Nonnull private final List<SubRangeExpr> _asRange;
-
   private final boolean _exact;
 
   @JsonCreator

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/OriginatesFromAsPath.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/OriginatesFromAsPath.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -37,18 +38,6 @@ public final class OriginatesFromAsPath extends BooleanExpr {
   }
 
   @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    } else if (!(obj instanceof OriginatesFromAsPath)) {
-      return false;
-    }
-
-    OriginatesFromAsPath other = (OriginatesFromAsPath) obj;
-    return _asRange.equals(other._asRange) && _exact == other._exact;
-  }
-
-  @Override
   public Result evaluate(Environment environment) {
     throw new UnsupportedOperationException("no implementation for generated method");
   }
@@ -65,11 +54,19 @@ public final class OriginatesFromAsPath extends BooleanExpr {
   }
 
   @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    } else if (!(obj instanceof OriginatesFromAsPath)) {
+      return false;
+    }
+
+    OriginatesFromAsPath other = (OriginatesFromAsPath) obj;
+    return Objects.equals(_asRange, other._asRange) && _exact == other._exact;
+  }
+
+  @Override
   public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + _asRange.hashCode();
-    result = prime * result + (_exact ? 1231 : 1237);
-    return result;
+    return Objects.hash(_asRange, _exact);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/OriginatesFromAsPath.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/OriginatesFromAsPath.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.common.BatfishException;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
@@ -39,7 +40,7 @@ public final class OriginatesFromAsPath extends BooleanExpr {
 
   @Override
   public Result evaluate(Environment environment) {
-    throw new UnsupportedOperationException("no implementation for generated method");
+    throw new BatfishException("No implementation for OriginatesFromAsPath.evaluate()");
   }
 
   @JsonProperty(PROP_AS_RANGE)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/PassesThroughAsPath.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/PassesThroughAsPath.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -20,8 +21,8 @@ public final class PassesThroughAsPath extends BooleanExpr {
 
   private static final long serialVersionUID = 1L;
 
-  private boolean _exact;
-  @Nonnull private List<SubRangeExpr> _range;
+  private final boolean _exact;
+  @Nonnull private final List<SubRangeExpr> _range;
 
   @JsonCreator
   private static PassesThroughAsPath jsonCreator(
@@ -34,20 +35,6 @@ public final class PassesThroughAsPath extends BooleanExpr {
   public PassesThroughAsPath(List<SubRangeExpr> range, boolean exact) {
     _range = range;
     _exact = exact;
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    } else if (!(obj instanceof PassesThroughAsPath)) {
-      return false;
-    }
-    PassesThroughAsPath other = (PassesThroughAsPath) obj;
-    if (_exact != other._exact) {
-      return false;
-    }
-    return _range.equals(other._range);
   }
 
   @Override
@@ -67,19 +54,18 @@ public final class PassesThroughAsPath extends BooleanExpr {
   }
 
   @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    } else if (!(obj instanceof PassesThroughAsPath)) {
+      return false;
+    }
+    PassesThroughAsPath other = (PassesThroughAsPath) obj;
+    return _exact == other._exact && Objects.equals(_range, other._range);
+  }
+
+  @Override
   public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + (_exact ? 1231 : 1237);
-    result = prime * result + _range.hashCode();
-    return result;
-  }
-
-  public void setExact(boolean exact) {
-    _exact = exact;
-  }
-
-  public void setRange(List<SubRangeExpr> range) {
-    _range = range;
+    return Objects.hash(_exact, _range);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/PassesThroughAsPath.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/PassesThroughAsPath.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.common.BatfishException;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
@@ -39,7 +40,7 @@ public final class PassesThroughAsPath extends BooleanExpr {
 
   @Override
   public Result evaluate(Environment environment) {
-    throw new UnsupportedOperationException("no implementation for generated method");
+    throw new BatfishException("No implementation for PassesThroughAsPath.evaluate()");
   }
 
   @JsonProperty(PROP_EXACT)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/PassesThroughAsPath.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/PassesThroughAsPath.java
@@ -18,11 +18,9 @@ public final class PassesThroughAsPath extends BooleanExpr {
   private static final String PROP_EXACT = "exact";
   private static final String PROP_RANGE = "range";
 
-  /** */
   private static final long serialVersionUID = 1L;
 
   private boolean _exact;
-
   @Nonnull private List<SubRangeExpr> _range;
 
   @JsonCreator

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/PassesThroughAsPath.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/PassesThroughAsPath.java
@@ -54,7 +54,7 @@ public final class PassesThroughAsPath extends BooleanExpr {
   }
 
   @Override
-  public boolean equals(Object obj) {
+  public boolean equals(@Nullable Object obj) {
     if (this == obj) {
       return true;
     } else if (!(obj instanceof PassesThroughAsPath)) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/RouteIsClassful.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/RouteIsClassful.java
@@ -7,14 +7,11 @@ import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 
 /**
- * Returns {@code true} iff the IPv4 route is classful, aka that the distributed prefix is exactly
- * an entire subnet in its IPv4 address class.
- *
- * <p>Returns {@code true} for networks that do not have a subnet size.
+ * Boolean expression that tests whether an IPv4 route is classful, i.e. the distributed prefix is
+ * exactly an entire subnet in its IPv4 address class.
  */
 public final class RouteIsClassful extends BooleanExpr {
 
-  /** */
   private static final long serialVersionUID = 1L;
 
   private static final RouteIsClassful INSTANCE = new RouteIsClassful();
@@ -31,6 +28,12 @@ public final class RouteIsClassful extends BooleanExpr {
     return this == obj;
   }
 
+  /**
+   * Returns {@code true} iff the IPv4 route is classful, i.e. the distributed prefix is exactly an
+   * entire subnet in its IPv4 address class.
+   *
+   * <p>Returns {@code true} for networks that do not have a subnet size.
+   */
   @Override
   public Result evaluate(Environment environment) {
     AbstractRoute route = environment.getOriginalRoute();

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/RouteIsClassful.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/RouteIsClassful.java
@@ -23,11 +23,6 @@ public final class RouteIsClassful extends BooleanExpr {
     return INSTANCE;
   }
 
-  @Override
-  public boolean equals(Object obj) {
-    return this == obj;
-  }
-
   /**
    * Returns {@code true} iff the IPv4 route is classful, i.e. the distributed prefix is exactly an
    * entire subnet in its IPv4 address class.
@@ -43,6 +38,11 @@ public final class RouteIsClassful extends BooleanExpr {
     Result ret = new Result();
     ret.setBooleanValue(classSize == network.getPrefixLength());
     return ret;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return obj instanceof RouteIsClassful;
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/WithEnvironmentExpr.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/WithEnvironmentExpr.java
@@ -13,6 +13,13 @@ import org.batfish.datamodel.routing_policy.Result;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
 import org.batfish.datamodel.routing_policy.statement.Statement;
 
+/**
+ * Boolean expression that evaluates an {@link Environment} for a given {@link BooleanExpr} as well
+ * as executing additional {@link Statement}s on it. Additional statements include {@link
+ * #getPreStatements() pre statements} to execute before evaluation, {@link #getPostStatements()
+ * post statements} to execute after evaluation, and {@link #getPostTrueStatements() post true
+ * statements} to execute after post statements if the evaluation yielded true.
+ */
 public final class WithEnvironmentExpr extends BooleanExpr {
 
   private static final String PROP_EXPR = "expr";
@@ -20,15 +27,11 @@ public final class WithEnvironmentExpr extends BooleanExpr {
   private static final String PROP_POST_TRUE_STATEMENTS = "postTrueStatements";
   private static final String PROP_PRE_STATEMENTS = "preStatements";
 
-  /** */
   private static final long serialVersionUID = 1L;
 
   private BooleanExpr _expr;
-
   private List<Statement> _postStatements;
-
   private List<Statement> _postTrueStatements;
-
   private List<Statement> _preStatements;
 
   public WithEnvironmentExpr() {
@@ -73,21 +76,28 @@ public final class WithEnvironmentExpr extends BooleanExpr {
     return result;
   }
 
+  /** The {@link BooleanExpr} with which to evaluate an {@link Environment}. */
   @JsonProperty(PROP_EXPR)
   public BooleanExpr getExpr() {
     return _expr;
   }
 
+  /** List of {@link Statement}s to execute on a given {@link Environment} after evaluating it. */
   @JsonProperty(PROP_POST_STATEMENTS)
   public List<Statement> getPostStatements() {
     return _postStatements;
   }
 
+  /**
+   * List of {@link Statement}s to execute on a given {@link Environment} after the {@link
+   * #getPostStatements() post statements} iff {@link #getExpr() expr} evaluates it as true.
+   */
   @JsonProperty(PROP_POST_TRUE_STATEMENTS)
   public List<Statement> getPostTrueStatements() {
     return _postTrueStatements;
   }
 
+  /** List of {@link Statement}s to execute on a given {@link Environment} before evaluating it. */
   @JsonProperty(PROP_PRE_STATEMENTS)
   public List<Statement> getPreStatements() {
     return _preStatements;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/WithEnvironmentExpr.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/WithEnvironmentExpr.java
@@ -14,11 +14,10 @@ import org.batfish.datamodel.routing_policy.RoutingPolicy;
 import org.batfish.datamodel.routing_policy.statement.Statement;
 
 /**
- * Boolean expression that evaluates an {@link Environment} for a given {@link BooleanExpr} as well
- * as executing additional {@link Statement}s on it. Additional statements include {@link
- * #getPreStatements() pre statements} to execute before evaluation, {@link #getPostStatements()
- * post statements} to execute after evaluation, and {@link #getPostTrueStatements() post true
- * statements} to execute after post statements if the evaluation yielded true.
+ * Boolean expression used for re-distribution policies, where route attributes need to be modified
+ * before/after executing the main policy. Contains a {@link BooleanExpr} to evaluate and {@link
+ * Statement statements} to be executed before or after evaluation, including some statements to
+ * execute only after evaluations that yield true.
  */
 public final class WithEnvironmentExpr extends BooleanExpr {
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/RouteIsClassfulTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/RouteIsClassfulTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.Lists;
 import java.util.List;
+import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.ConnectedRoute;
@@ -23,6 +24,12 @@ public class RouteIsClassfulTest {
     Environment env = Environment.builder(c).setVrf("vrf").setOriginalRoute(route).build();
     Result res = RouteIsClassful.instance().evaluate(env);
     return res.getBooleanValue();
+  }
+
+  @Test
+  public void testJavaSerialization() {
+    RouteIsClassful ric = RouteIsClassful.instance();
+    assertThat(SerializationUtils.clone(ric), equalTo(ric));
   }
 
   @Test

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsFromFamily.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsFromFamily.java
@@ -23,9 +23,9 @@ public class PsFromFamily extends PsFrom {
   public BooleanExpr toBooleanExpr(JuniperConfiguration jc, Configuration c, Warnings warnings) {
     switch (_family) {
       case IPV4:
-        return new MatchIpv4();
+        return MatchIpv4.instance();
       case IPV6:
-        return new MatchIpv6();
+        return MatchIpv6.instance();
       default:
         throw new VendorConversionException("Unsupported address family: \"" + _family + "\"");
     }


### PR DESCRIPTION
- Make all child classes of `BooleanExpr` final
- Add class-level Javadocs to all child classes that have `evaluate()` implemented
- Remove unused `set` methods and replace with better JsonCreators, and make the corresponding fields final (I believe `Conjunction` and `Disjunction` are the only two left with non-final fields)
- Clean up many `equals()` and `hashCode()` methods, and put them next to each other