### PR TITLE
Clean up Topology

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Topology.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Topology.java
@@ -5,17 +5,16 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
-import com.google.common.graph.ValueGraph;
+import com.google.common.collect.Ordering;
 import java.io.Serializable;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Optional;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.SortedSet;
-import java.util.TreeSet;
+import javax.annotation.Nonnull;
+import org.batfish.common.util.CommonUtil;
 import org.batfish.datamodel.collections.NodeInterfacePair;
 
 /**
@@ -33,17 +32,42 @@ public final class Topology implements Serializable {
 
   private final SortedSet<Edge> _edges;
 
-  // Mapping of interface -> set of all edges whose source or dest is that interface
-  private final Map<NodeInterfacePair, SortedSet<Edge>> _interfaceEdges;
+  // Mapping of interface -> set of all neighboring interfaces
+  private final Map<NodeInterfacePair, SortedSet<NodeInterfacePair>> _interfaceNeighbors;
 
   // Mapping of node -> set of all edges whose source or dest is on that node
   private final Map<String, SortedSet<Edge>> _nodeEdges;
 
   public Topology(SortedSet<Edge> edges) {
-    _edges = new TreeSet<>(edges);
-    _nodeEdges = new HashMap<>();
-    _interfaceEdges = new HashMap<>();
-    rebuildFromEdges();
+    _edges = ImmutableSortedSet.copyOf(edges);
+    _nodeEdges = computeNodeEdges(edges);
+    _interfaceNeighbors = computeInterfaceNeighbors(edges);
+  }
+
+  private static Map<NodeInterfacePair, SortedSet<NodeInterfacePair>> computeInterfaceNeighbors(
+      Iterable<Edge> edges) {
+    Map<NodeInterfacePair, ImmutableSortedSet.Builder<NodeInterfacePair>> builders =
+        new HashMap<>();
+    edges.forEach(
+        edge ->
+            builders
+                .computeIfAbsent(edge.getTail(), k -> ImmutableSortedSet.naturalOrder())
+                .add(edge.getHead()));
+    return CommonUtil.toImmutableSortedMap(
+        builders, Entry::getKey, entry -> entry.getValue().build());
+  }
+
+  private static Map<String, SortedSet<Edge>> computeNodeEdges(Iterable<Edge> edges) {
+    Map<String, ImmutableSortedSet.Builder<Edge>> builders = new HashMap<>();
+    for (Edge edge : edges) {
+      String node1 = edge.getNode1();
+      String node2 = edge.getNode2();
+
+      builders.computeIfAbsent(node1, k -> ImmutableSortedSet.naturalOrder()).add(edge);
+      builders.computeIfAbsent(node2, k -> ImmutableSortedSet.naturalOrder()).add(edge);
+    }
+    return CommonUtil.toImmutableSortedMap(
+        builders, Entry::getKey, entry -> entry.getValue().build());
   }
 
   @JsonIgnore
@@ -51,16 +75,9 @@ public final class Topology implements Serializable {
     return _edges;
   }
 
-  @JsonIgnore
-  public Map<NodeInterfacePair, SortedSet<Edge>> getInterfaceEdges() {
-    return _interfaceEdges;
-  }
-
-  public Set<NodeInterfacePair> getNeighbors(NodeInterfacePair iface) {
-    return getInterfaceEdges().getOrDefault(iface, ImmutableSortedSet.of()).stream()
-        .filter(e -> e.getTail().equals(iface))
-        .map(Edge::getHead)
-        .collect(ImmutableSet.toImmutableSet());
+  @Nonnull
+  public SortedSet<NodeInterfacePair> getNeighbors(NodeInterfacePair iface) {
+    return _interfaceNeighbors.getOrDefault(iface, ImmutableSortedSet.of());
   }
 
   @JsonIgnore
@@ -69,108 +86,24 @@ public final class Topology implements Serializable {
   }
 
   /** Removes the specified blacklists from the topology */
-  public void prune(
-      Set<Edge> blacklistEdges,
-      Set<String> blacklistNodes,
-      Set<NodeInterfacePair> blacklistInterfaces) {
-    if (blacklistEdges != null) {
-      _edges.removeAll(blacklistEdges);
-    }
-    if (blacklistNodes != null) {
-      for (String blacklistNode : blacklistNodes) {
-        _edges.removeAll(_nodeEdges.getOrDefault(blacklistNode, ImmutableSortedSet.of()));
-      }
-    }
-    if (blacklistInterfaces != null) {
-      for (NodeInterfacePair blacklistInterface : blacklistInterfaces) {
-        _edges.removeAll(_interfaceEdges.getOrDefault(blacklistInterface, ImmutableSortedSet.of()));
-      }
-    }
-    rebuildFromEdges();
-  }
-
-  /**
-   * Given a {@link ValueGraph} between {@link IpsecPeerConfigId}s, trims the edges in current
-   * {@link Topology} which are not fully established in the IPsec topology (e.g. they do not have a
-   * negotiated {@link IpsecPhase2Proposal})
-   *
-   * @param ipsecTopology original IPsec topology's {@link ValueGraph}
-   * @param configurations {@link Map} of {@link Configuration} to configuration names
-   */
-  public void pruneFailedIpsecSessionEdges(
-      ValueGraph<IpsecPeerConfigId, IpsecSession> ipsecTopology,
-      Map<String, Configuration> configurations) {
-    NetworkConfigurations networkConfigurations = NetworkConfigurations.of(configurations);
-
-    // Set of successful IPsec edges
-    Set<Edge> successfulIPsecEdges = new HashSet<>();
-    // NodeInterface pairs running IPsec peering on tunnel interfaces
-    Set<NodeInterfacePair> tunnelIpsecEndpoints = new HashSet<>();
-
-    for (IpsecPeerConfigId endPointU : ipsecTopology.nodes()) {
-      IpsecPeerConfig ipsecPeerU = networkConfigurations.getIpsecPeerConfig(endPointU);
-      // not considering endpoints not based on Tunnel interfaces
-      if (ipsecPeerU == null || ipsecPeerU.getTunnelInterface() == null) {
-        continue;
-      }
-
-      NodeInterfacePair tunnelEndPointU =
-          new NodeInterfacePair(endPointU.getHostName(), ipsecPeerU.getTunnelInterface());
-      tunnelIpsecEndpoints.add(tunnelEndPointU);
-
-      for (IpsecPeerConfigId endPointV : ipsecTopology.adjacentNodes(endPointU)) {
-        IpsecPeerConfig ipsecPeerV = networkConfigurations.getIpsecPeerConfig(endPointV);
-
-        // not considering endpoints not based on Tunnel interfaces
-        if (ipsecPeerV == null || ipsecPeerV.getTunnelInterface() == null) {
-          continue;
-        }
-
-        NodeInterfacePair tunnelEndPointV =
-            new NodeInterfacePair(endPointV.getHostName(), ipsecPeerV.getTunnelInterface());
-
-        // checking IPsec session and adding edge
-        Optional<IpsecSession> edgeIpsecSession = ipsecTopology.edgeValue(endPointU, endPointV);
-        if (edgeIpsecSession.isPresent()
-            && edgeIpsecSession.get().getNegotiatedIpsecP2Proposal() != null) {
-          successfulIPsecEdges.add(new Edge(tunnelEndPointU, tunnelEndPointV));
-        }
-      }
-    }
-
-    Set<Edge> failedIpsecEdges = new HashSet<>();
-
-    for (Edge edge : _edges) {
-      NodeInterfacePair tail = edge.getTail();
-      NodeInterfacePair head = edge.getHead();
-      if ((tunnelIpsecEndpoints.contains(tail) || tunnelIpsecEndpoints.contains(head))
-          && (!successfulIPsecEdges.contains(edge)
-              || !successfulIPsecEdges.contains(edge.reverse()))) {
-        failedIpsecEdges.add(edge);
-      }
-    }
-
-    prune(failedIpsecEdges, ImmutableSet.of(), ImmutableSet.of());
-  }
-
-  private void rebuildFromEdges() {
-    _nodeEdges.clear();
-    _interfaceEdges.clear();
-    for (Edge edge : _edges) {
-      String node1 = edge.getNode1();
-      String node2 = edge.getNode2();
-      NodeInterfacePair iface1 = edge.getTail();
-      NodeInterfacePair iface2 = edge.getHead();
-
-      _nodeEdges.computeIfAbsent(node1, k -> new TreeSet<>()).add(edge);
-      _nodeEdges.computeIfAbsent(node2, k -> new TreeSet<>()).add(edge);
-      _interfaceEdges.computeIfAbsent(iface1, k -> new TreeSet<>()).add(edge);
-      _interfaceEdges.computeIfAbsent(iface2, k -> new TreeSet<>()).add(edge);
-    }
+  public Topology prune(
+      @Nonnull Set<Edge> blacklistEdges,
+      @Nonnull Set<String> blacklistNodes,
+      @Nonnull Set<NodeInterfacePair> blacklistInterfaces) {
+    return new Topology(
+        _edges.stream()
+            .filter(
+                edge ->
+                    !blacklistEdges.contains(edge)
+                        && !blacklistNodes.contains(edge.getNode1())
+                        && !blacklistNodes.contains(edge.getNode2())
+                        && !blacklistInterfaces.contains(edge.getTail())
+                        && !blacklistInterfaces.contains(edge.getHead()))
+            .collect(ImmutableSortedSet.toImmutableSortedSet(Ordering.natural())));
   }
 
   @JsonValue
   public SortedSet<Edge> sortedEdges() {
-    return new TreeSet<>(_edges);
+    return _edges;
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/IpsecUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/IpsecUtilTest.java
@@ -1,9 +1,9 @@
 package org.batfish.common.util;
 
+import static org.batfish.common.util.IpsecUtil.computeFailedIpsecSessionEdges;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.graph.ImmutableValueGraph;
@@ -12,6 +12,7 @@ import com.google.common.graph.ValueGraph;
 import com.google.common.graph.ValueGraphBuilder;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Edge;
@@ -200,24 +201,21 @@ public class IpsecUtilTest {
 
   @Test
   public void testPruneFailedIpsecSessionEdges() {
-    _topology.pruneFailedIpsecSessionEdges(_ipsecTopology, _configurations);
+    Set<Edge> failedIpsecSessionEdges =
+        computeFailedIpsecSessionEdges(_topology.getEdges(), _ipsecTopology, _configurations);
 
     // Edges involving host1:Tunnel3, host2:Tunnel4, host1:Tunnel7 will be pruned
     assertThat(
-        _topology.getEdges(),
-        equalTo(
-            ImmutableSet.of(
-                new Edge(
-                    new NodeInterfacePair("host1", "Tunnel1"),
-                    new NodeInterfacePair("host2", "Tunnel2")),
-                new Edge(
-                    new NodeInterfacePair("host2", "Tunnel2"),
-                    new NodeInterfacePair("host1", "Tunnel1")),
-                new Edge(
-                    new NodeInterfacePair("host1", "interface5"),
-                    new NodeInterfacePair("host2", "interface6")),
-                new Edge(
-                    new NodeInterfacePair("host1", "Tunnel9"),
-                    new NodeInterfacePair("host2", "Tunnel10")))));
+        failedIpsecSessionEdges,
+        containsInAnyOrder(
+            new Edge(
+                new NodeInterfacePair("host1", "Tunnel3"),
+                new NodeInterfacePair("host2", "Tunnel4")),
+            new Edge(
+                new NodeInterfacePair("host1", "Tunnel7"),
+                new NodeInterfacePair("host2", "Tunnel8")),
+            new Edge(
+                new NodeInterfacePair("host2", "Tunnel4"),
+                new NodeInterfacePair("host1", "Tunnel3"))));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/TopologyTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/TopologyTest.java
@@ -30,7 +30,6 @@ public class TopologyTest {
     Topology topo = new Topology(edges);
 
     assertThat(topo.getEdges(), equalTo(ImmutableSet.of()));
-    assertThat(topo.getInterfaceEdges(), equalTo(ImmutableMap.of()));
     assertThat(topo.getNodeEdges(), equalTo(ImmutableMap.of()));
     assertThat(
         topo.getNeighbors(new NodeInterfacePair("node", "iface")), equalTo(ImmutableSet.of()));
@@ -45,7 +44,6 @@ public class TopologyTest {
     Topology topo = new Topology(edges);
 
     assertThat(topo.getEdges(), equalTo(edges));
-    assertThat(topo.getInterfaceEdges(), equalTo(ImmutableMap.of(nip1, edges, nip2, edges)));
     assertThat(topo.getNodeEdges(), equalTo(ImmutableMap.of("n1", edges, "n2", edges)));
     assertThat(topo.getNeighbors(nip1), equalTo(ImmutableSet.of(nip2)));
     assertThat(topo.getNeighbors(nip2), equalTo(ImmutableSet.of()));
@@ -57,9 +55,6 @@ public class TopologyTest {
     Topology topo = new Topology(_bothEdges);
     assertThat(topo.getEdges(), equalTo(_bothEdges));
     assertThat(
-        topo.getInterfaceEdges(),
-        equalTo(ImmutableMap.of(_nip1, _edge1to2Set, _nip2, _bothEdges, _nip3, _edge2to3Set)));
-    assertThat(
         topo.getNodeEdges(),
         equalTo(ImmutableMap.of("n1", _edge1to2Set, "n2", _bothEdges, "n3", _edge2to3Set)));
     assertThat(topo.getNeighbors(_nip1), equalTo(ImmutableSet.of(_nip2)));
@@ -69,12 +64,9 @@ public class TopologyTest {
 
   @Test
   public void testPruneEdge() {
-    Topology topo = new Topology(_bothEdges);
-    topo.prune(_edge1to2Set, null, null);
+    Topology topo =
+        new Topology(_bothEdges).prune(_edge1to2Set, ImmutableSet.of(), ImmutableSet.of());
     assertThat(topo.getEdges(), equalTo(_edge2to3Set));
-    assertThat(
-        topo.getInterfaceEdges(),
-        equalTo(ImmutableMap.of(_nip2, _edge2to3Set, _nip3, _edge2to3Set)));
     assertThat(
         topo.getNodeEdges(), equalTo(ImmutableMap.of("n2", _edge2to3Set, "n3", _edge2to3Set)));
     assertThat(topo.getNeighbors(_nip1), equalTo(ImmutableSet.of()));
@@ -84,12 +76,9 @@ public class TopologyTest {
 
   @Test
   public void testPruneNode1() {
-    Topology topo = new Topology(_bothEdges);
-    topo.prune(null, ImmutableSet.of("n1"), null);
+    Topology topo =
+        new Topology(_bothEdges).prune(ImmutableSet.of(), ImmutableSet.of("n1"), ImmutableSet.of());
     assertThat(topo.getEdges(), equalTo(_edge2to3Set));
-    assertThat(
-        topo.getInterfaceEdges(),
-        equalTo(ImmutableMap.of(_nip2, _edge2to3Set, _nip3, _edge2to3Set)));
     assertThat(
         topo.getNodeEdges(), equalTo(ImmutableMap.of("n2", _edge2to3Set, "n3", _edge2to3Set)));
     assertThat(topo.getNeighbors(_nip2), equalTo(ImmutableSet.of(_nip3)));
@@ -98,10 +87,9 @@ public class TopologyTest {
 
   @Test
   public void testPruneNode2() {
-    Topology topo = new Topology(_bothEdges);
-    topo.prune(null, ImmutableSet.of("n2"), null);
+    Topology topo =
+        new Topology(_bothEdges).prune(ImmutableSet.of(), ImmutableSet.of("n2"), ImmutableSet.of());
     assertThat(topo.getEdges(), equalTo(ImmutableSet.of()));
-    assertThat(topo.getInterfaceEdges(), equalTo(ImmutableMap.of()));
     assertThat(topo.getNodeEdges(), equalTo(ImmutableMap.of()));
     assertThat(topo.getNeighbors(_nip1), equalTo(ImmutableSet.of()));
     assertThat(topo.getNeighbors(_nip3), equalTo(ImmutableSet.of()));
@@ -109,12 +97,9 @@ public class TopologyTest {
 
   @Test
   public void testPruneNode3() {
-    Topology topo = new Topology(_bothEdges);
-    topo.prune(null, ImmutableSet.of("n3"), null);
+    Topology topo =
+        new Topology(_bothEdges).prune(ImmutableSet.of(), ImmutableSet.of("n3"), ImmutableSet.of());
     assertThat(topo.getEdges(), equalTo(_edge1to2Set));
-    assertThat(
-        topo.getInterfaceEdges(),
-        equalTo(ImmutableMap.of(_nip1, _edge1to2Set, _nip2, _edge1to2Set)));
     assertThat(
         topo.getNodeEdges(), equalTo(ImmutableMap.of("n1", _edge1to2Set, "n2", _edge1to2Set)));
     assertThat(topo.getNeighbors(_nip1), equalTo(ImmutableSet.of(_nip2)));
@@ -123,12 +108,10 @@ public class TopologyTest {
 
   @Test
   public void testPruneInterface1() {
-    Topology topo = new Topology(_bothEdges);
-    topo.prune(null, null, ImmutableSet.of(_nip1));
+    Topology topo =
+        new Topology(_bothEdges)
+            .prune(ImmutableSet.of(), ImmutableSet.of(), ImmutableSet.of(_nip1));
     assertThat(topo.getEdges(), equalTo(_edge2to3Set));
-    assertThat(
-        topo.getInterfaceEdges(),
-        equalTo(ImmutableMap.of(_nip2, _edge2to3Set, _nip3, _edge2to3Set)));
     assertThat(
         topo.getNodeEdges(), equalTo(ImmutableMap.of("n2", _edge2to3Set, "n3", _edge2to3Set)));
     assertThat(topo.getNeighbors(_nip2), equalTo(ImmutableSet.of(_nip3)));
@@ -137,10 +120,10 @@ public class TopologyTest {
 
   @Test
   public void testPruneInterface2() {
-    Topology topo = new Topology(_bothEdges);
-    topo.prune(null, null, ImmutableSet.of(_nip2));
+    Topology topo =
+        new Topology(_bothEdges)
+            .prune(ImmutableSet.of(), ImmutableSet.of(), ImmutableSet.of(_nip2));
     assertThat(topo.getEdges(), equalTo(ImmutableSet.of()));
-    assertThat(topo.getInterfaceEdges(), equalTo(ImmutableMap.of()));
     assertThat(topo.getNodeEdges(), equalTo(ImmutableMap.of()));
     assertThat(topo.getNeighbors(_nip1), equalTo(ImmutableSet.of()));
     assertThat(topo.getNeighbors(_nip3), equalTo(ImmutableSet.of()));
@@ -148,12 +131,10 @@ public class TopologyTest {
 
   @Test
   public void testPruneInterface3() {
-    Topology topo = new Topology(_bothEdges);
-    topo.prune(null, null, ImmutableSet.of(_nip3));
+    Topology topo =
+        new Topology(_bothEdges)
+            .prune(ImmutableSet.of(), ImmutableSet.of(), ImmutableSet.of(_nip3));
     assertThat(topo.getEdges(), equalTo(_edge1to2Set));
-    assertThat(
-        topo.getInterfaceEdges(),
-        equalTo(ImmutableMap.of(_nip1, _edge1to2Set, _nip2, _edge1to2Set)));
     assertThat(
         topo.getNodeEdges(), equalTo(ImmutableMap.of("n1", _edge1to2Set, "n2", _edge1to2Set)));
     assertThat(topo.getNeighbors(_nip1), equalTo(ImmutableSet.of(_nip2)));

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteEngineImplContext.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteEngineImplContext.java
@@ -1,15 +1,12 @@
 package org.batfish.dataplane.traceroute;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
 import static org.batfish.dataplane.traceroute.TracerouteUtils.buildSessionsByIngressInterface;
 import static org.batfish.dataplane.traceroute.TracerouteUtils.validateInputs;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Multimap;
-import com.google.common.collect.Ordering;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -19,10 +16,10 @@ import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
+import javax.annotation.Nonnull;
 import org.batfish.common.BatfishException;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DataPlane;
-import org.batfish.datamodel.Edge;
 import org.batfish.datamodel.Fib;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowDisposition;
@@ -206,12 +203,11 @@ public class TracerouteEngineImplContext {
         .containsIp(arpIp, ImmutableMap.of());
   }
 
-  SortedSet<Edge> getInterfaceOutEdges(String currentNodeName, String outgoingIfaceName) {
-    NodeInterfacePair nip = new NodeInterfacePair(currentNodeName, outgoingIfaceName);
-    return firstNonNull(
-            _dataPlane.getTopology().getInterfaceEdges().get(nip), ImmutableSortedSet.<Edge>of())
-        .stream()
-        .filter(edge -> edge.getTail().equals(nip))
-        .collect(ImmutableSortedSet.toImmutableSortedSet(Ordering.natural()));
+  @Nonnull
+  SortedSet<NodeInterfacePair> getInterfaceNeighbors(
+      String currentNodeName, String outgoingIfaceName) {
+    return _dataPlane
+        .getTopology()
+        .getNeighbors(new NodeInterfacePair(currentNodeName, outgoingIfaceName));
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/symbolic/Graph.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/Graph.java
@@ -4,6 +4,7 @@ import static java.util.stream.Collectors.toMap;
 import static org.batfish.symbolic.CommunityVarCollector.collectCommunityVars;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -190,7 +191,7 @@ public class Graph {
       for (String router : toRemove) {
         _configurations.remove(router);
       }
-      topology = topology.prune(null, toRemove, null);
+      topology = topology.prune(ImmutableSet.of(), toRemove, ImmutableSet.of());
     }
 
     initGraph(topology);

--- a/projects/batfish/src/main/java/org/batfish/topology/TopologyProviderImpl.java
+++ b/projects/batfish/src/main/java/org/batfish/topology/TopologyProviderImpl.java
@@ -2,6 +2,7 @@ package org.batfish.topology;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.Sets;
 import io.opentracing.ActiveSpan;
 import io.opentracing.util.GlobalTracer;
 import java.util.Map;
@@ -107,13 +108,13 @@ public final class TopologyProviderImpl implements TopologyProvider {
       assert span != null; // avoid unused warning
       Map<String, Configuration> configurations = _batfish.loadConfigurations(networkSnapshot);
       Topology topology = getRawLayer3Topology(networkSnapshot);
-      topology.prune(
-          _batfish.getEdgeBlacklist(networkSnapshot),
+      return topology.prune(
+          Sets.union(
+              IpsecUtil.computeFailedIpsecSessionEdges(
+                  topology.getEdges(), IpsecUtil.initIpsecTopology(configurations), configurations),
+              _batfish.getEdgeBlacklist(networkSnapshot)),
           _batfish.getNodeBlacklist(networkSnapshot),
           _batfish.getInterfaceBlacklist(networkSnapshot));
-      topology.pruneFailedIpsecSessionEdges(
-          IpsecUtil.initIpsecTopology(configurations), configurations);
-      return topology;
     }
   }
 

--- a/tests/aws/topology-example-aws.ref
+++ b/tests/aws/topology-example-aws.ref
@@ -43,22 +43,14 @@
         "node-igw-9b93ddfc",
         "aggregate-vpc-f8fad69d",
         "aggregate-vpc-815775e7",
-        "aggregate-vpc-925131f4",
         "node-igw-068fee63",
+        "aggregate-vpc-925131f4",
         "aggregate-vpc-b390fad5",
         "node-igw-fac5839d",
         "node-vgw-81fd279f"
       ],
       "id" : "aggregate-us-west-2",
       "type" : "REGION"
-    },
-    {
-      "name" : "vpc-815775e7",
-      "contents" : [
-        "node-vpc-815775e7"
-      ],
-      "id" : "aggregate-vpc-815775e7",
-      "type" : "VNET"
     },
     {
       "name" : "subnet-073b8061",
@@ -75,6 +67,14 @@
       ],
       "id" : "aggregate-subnet-d9cafabc",
       "type" : "SUBNET"
+    },
+    {
+      "name" : "vpc-815775e7",
+      "contents" : [
+        "node-vpc-815775e7"
+      ],
+      "id" : "aggregate-vpc-815775e7",
+      "type" : "VNET"
     },
     {
       "name" : "aws",
@@ -130,8 +130,8 @@
       "name" : "vpc-b390fad5",
       "contents" : [
         "aggregate-subnet-7044ff16",
-        "node-vpc-b390fad5",
         "aggregate-subnet-f73a8191",
+        "node-vpc-b390fad5",
         "aggregate-subnet-30398256",
         "aggregate-subnet-073b8061",
         "aggregate-subnet-1641fa70",
@@ -164,15 +164,15 @@
       "type" : "PHYSICAL"
     },
     {
-      "id" : "interface-node-vpc-f8fad69d-subnet-1f315846",
-      "name" : "subnet-1f315846",
-      "nodeId" : "node-vpc-f8fad69d",
-      "type" : "PHYSICAL"
-    },
-    {
       "id" : "interface-node-vpc-b390fad5-subnet-30398256",
       "name" : "subnet-30398256",
       "nodeId" : "node-vpc-b390fad5",
+      "type" : "PHYSICAL"
+    },
+    {
+      "id" : "interface-node-vpc-f8fad69d-subnet-1f315846",
+      "name" : "subnet-1f315846",
+      "nodeId" : "node-vpc-f8fad69d",
       "type" : "PHYSICAL"
     },
     {
@@ -200,16 +200,16 @@
       "type" : "PHYSICAL"
     },
     {
-      "id" : "interface-node-subnet-30398256-subnet-30398256",
-      "name" : "subnet-30398256",
-      "nodeId" : "node-subnet-30398256",
-      "type" : "PHYSICAL"
-    },
-    {
       "id" : "interface-node-subnet-073b8061-vpc-b390fad5",
       "name" : "vpc-b390fad5",
       "nodeId" : "node-subnet-073b8061",
       "type" : "VPN"
+    },
+    {
+      "id" : "interface-node-subnet-30398256-subnet-30398256",
+      "name" : "subnet-30398256",
+      "nodeId" : "node-subnet-30398256",
+      "type" : "PHYSICAL"
     },
     {
       "id" : "interface-node-subnet-d9cafabc-vpc-f8fad69d",
@@ -230,16 +230,16 @@
       "type" : "PHYSICAL"
     },
     {
-      "id" : "interface-node-vpc-b390fad5-vpc-b390fad5",
-      "name" : "vpc-b390fad5",
-      "nodeId" : "node-vpc-b390fad5",
-      "type" : "UNKNOWN"
-    },
-    {
       "id" : "interface-node-subnet-62f14104-subnet-62f14104",
       "name" : "subnet-62f14104",
       "nodeId" : "node-subnet-62f14104",
       "type" : "PHYSICAL"
+    },
+    {
+      "id" : "interface-node-vpc-b390fad5-vpc-b390fad5",
+      "name" : "vpc-b390fad5",
+      "nodeId" : "node-vpc-b390fad5",
+      "type" : "UNKNOWN"
     },
     {
       "id" : "interface-node-test-rds-es-domain-subnet-1641fa70",
@@ -248,9 +248,9 @@
       "type" : "UNKNOWN"
     },
     {
-      "id" : "interface-node-vpc-925131f4-vpc-925131f4",
-      "name" : "vpc-925131f4",
-      "nodeId" : "node-vpc-925131f4",
+      "id" : "interface-node-igw-068fee63-igw-068fee63",
+      "name" : "igw-068fee63",
+      "nodeId" : "node-igw-068fee63",
       "type" : "UNKNOWN"
     },
     {
@@ -260,9 +260,9 @@
       "type" : "PHYSICAL"
     },
     {
-      "id" : "interface-node-igw-068fee63-igw-068fee63",
-      "name" : "igw-068fee63",
-      "nodeId" : "node-igw-068fee63",
+      "id" : "interface-node-vpc-925131f4-vpc-925131f4",
+      "name" : "vpc-925131f4",
+      "nodeId" : "node-vpc-925131f4",
       "type" : "UNKNOWN"
     },
     {
@@ -272,16 +272,16 @@
       "type" : "UNKNOWN"
     },
     {
-      "id" : "interface-node-vpc-b390fad5-subnet-1641fa70",
-      "name" : "subnet-1641fa70",
-      "nodeId" : "node-vpc-b390fad5",
-      "type" : "PHYSICAL"
-    },
-    {
       "id" : "interface-node-vgw-81fd279f-vpn1",
       "name" : "vpn1",
       "nodeId" : "node-vgw-81fd279f",
       "type" : "VPN"
+    },
+    {
+      "id" : "interface-node-vpc-b390fad5-subnet-1641fa70",
+      "name" : "subnet-1641fa70",
+      "nodeId" : "node-vpc-b390fad5",
+      "type" : "PHYSICAL"
     },
     {
       "id" : "interface-node-vgw-81fd279f-vpn2",
@@ -368,16 +368,16 @@
       "type" : "TUNNEL"
     },
     {
-      "id" : "interface-node-vpc-925131f4-subnet-62f14104",
-      "name" : "subnet-62f14104",
-      "nodeId" : "node-vpc-925131f4",
-      "type" : "PHYSICAL"
-    },
-    {
       "id" : "interface-node-lhr-border-02-Tunnel2",
       "name" : "Tunnel2",
       "nodeId" : "node-lhr-border-02",
       "type" : "TUNNEL"
+    },
+    {
+      "id" : "interface-node-vpc-925131f4-subnet-62f14104",
+      "name" : "subnet-62f14104",
+      "nodeId" : "node-vpc-925131f4",
+      "type" : "PHYSICAL"
     },
     {
       "id" : "interface-node-igw-9b93ddfc-igw-9b93ddfc",
@@ -592,9 +592,9 @@
       "type" : "UNKNOWN"
     },
     {
-      "dstId" : "interface-node-subnet-073b8061-vpc-b390fad5",
-      "id" : "link-interface-node-vpc-b390fad5-subnet-073b8061-interface-node-subnet-073b8061-vpc-b390fad5",
-      "srcId" : "interface-node-vpc-b390fad5-subnet-073b8061",
+      "dstId" : "interface-node-test-rds-test-rds-subnet-1641fa70",
+      "id" : "link-interface-node-subnet-1641fa70-subnet-1641fa70-interface-node-test-rds-test-rds-subnet-1641fa70",
+      "srcId" : "interface-node-subnet-1641fa70-subnet-1641fa70",
       "type" : "UNKNOWN"
     },
     {
@@ -604,9 +604,9 @@
       "type" : "UNKNOWN"
     },
     {
-      "dstId" : "interface-node-test-rds-test-rds-subnet-1641fa70",
-      "id" : "link-interface-node-subnet-1641fa70-subnet-1641fa70-interface-node-test-rds-test-rds-subnet-1641fa70",
-      "srcId" : "interface-node-subnet-1641fa70-subnet-1641fa70",
+      "dstId" : "interface-node-subnet-073b8061-vpc-b390fad5",
+      "id" : "link-interface-node-vpc-b390fad5-subnet-073b8061-interface-node-subnet-073b8061-vpc-b390fad5",
+      "srcId" : "interface-node-vpc-b390fad5-subnet-073b8061",
       "type" : "UNKNOWN"
     },
     {
@@ -628,15 +628,15 @@
       "type" : "UNKNOWN"
     },
     {
-      "dstId" : "interface-node-subnet-7044ff16-vpc-b390fad5",
-      "id" : "link-interface-node-vpc-b390fad5-subnet-7044ff16-interface-node-subnet-7044ff16-vpc-b390fad5",
-      "srcId" : "interface-node-vpc-b390fad5-subnet-7044ff16",
-      "type" : "UNKNOWN"
-    },
-    {
       "dstId" : "interface-node-vpc-925131f4-subnet-8d0cbdeb",
       "id" : "link-interface-node-vpc-925131f4-vpc-925131f4-interface-node-vpc-925131f4-subnet-8d0cbdeb",
       "srcId" : "interface-node-vpc-925131f4-vpc-925131f4",
+      "type" : "UNKNOWN"
+    },
+    {
+      "dstId" : "interface-node-subnet-7044ff16-vpc-b390fad5",
+      "id" : "link-interface-node-vpc-b390fad5-subnet-7044ff16-interface-node-subnet-7044ff16-vpc-b390fad5",
+      "srcId" : "interface-node-vpc-b390fad5-subnet-7044ff16",
       "type" : "UNKNOWN"
     },
     {
@@ -664,15 +664,15 @@
       "type" : "UNKNOWN"
     },
     {
-      "dstId" : "interface-node-subnet-9c8adceb-vpc-f8fad69d",
-      "id" : "link-interface-node-subnet-9c8adceb-subnet-9c8adceb-interface-node-subnet-9c8adceb-vpc-f8fad69d",
-      "srcId" : "interface-node-subnet-9c8adceb-subnet-9c8adceb",
-      "type" : "UNKNOWN"
-    },
-    {
       "dstId" : "interface-node-subnet-1641fa70-subnet-1641fa70",
       "id" : "link-interface-node-subnet-1641fa70-es-domain-subnet-1641fa70-interface-node-subnet-1641fa70-subnet-1641fa70",
       "srcId" : "interface-node-subnet-1641fa70-es-domain-subnet-1641fa70",
+      "type" : "UNKNOWN"
+    },
+    {
+      "dstId" : "interface-node-subnet-9c8adceb-vpc-f8fad69d",
+      "id" : "link-interface-node-subnet-9c8adceb-subnet-9c8adceb-interface-node-subnet-9c8adceb-vpc-f8fad69d",
+      "srcId" : "interface-node-subnet-9c8adceb-subnet-9c8adceb",
       "type" : "UNKNOWN"
     },
     {
@@ -694,15 +694,15 @@
       "type" : "UNKNOWN"
     },
     {
-      "dstId" : "interface-node-vpc-b390fad5-subnet-f73a8191",
-      "id" : "link-interface-node-vpc-b390fad5-vpc-b390fad5-interface-node-vpc-b390fad5-subnet-f73a8191",
-      "srcId" : "interface-node-vpc-b390fad5-vpc-b390fad5",
-      "type" : "UNKNOWN"
-    },
-    {
       "dstId" : "interface-node-vpc-b390fad5-subnet-073b8061",
       "id" : "link-interface-node-subnet-073b8061-vpc-b390fad5-interface-node-vpc-b390fad5-subnet-073b8061",
       "srcId" : "interface-node-subnet-073b8061-vpc-b390fad5",
+      "type" : "UNKNOWN"
+    },
+    {
+      "dstId" : "interface-node-vpc-b390fad5-subnet-f73a8191",
+      "id" : "link-interface-node-vpc-b390fad5-vpc-b390fad5-interface-node-vpc-b390fad5-subnet-f73a8191",
+      "srcId" : "interface-node-vpc-b390fad5-vpc-b390fad5",
       "type" : "UNKNOWN"
     },
     {
@@ -760,15 +760,15 @@
       "type" : "UNKNOWN"
     },
     {
-      "dstId" : "interface-node-subnet-9c8adceb-vpc-f8fad69d",
-      "id" : "link-interface-node-vpc-f8fad69d-subnet-9c8adceb-interface-node-subnet-9c8adceb-vpc-f8fad69d",
-      "srcId" : "interface-node-vpc-f8fad69d-subnet-9c8adceb",
-      "type" : "UNKNOWN"
-    },
-    {
       "dstId" : "interface-node-vpc-b390fad5-subnet-073b8061",
       "id" : "link-interface-node-vpc-b390fad5-vpc-b390fad5-interface-node-vpc-b390fad5-subnet-073b8061",
       "srcId" : "interface-node-vpc-b390fad5-vpc-b390fad5",
+      "type" : "UNKNOWN"
+    },
+    {
+      "dstId" : "interface-node-subnet-9c8adceb-vpc-f8fad69d",
+      "id" : "link-interface-node-vpc-f8fad69d-subnet-9c8adceb-interface-node-subnet-9c8adceb-vpc-f8fad69d",
+      "srcId" : "interface-node-vpc-f8fad69d-subnet-9c8adceb",
       "type" : "UNKNOWN"
     },
     {
@@ -814,9 +814,9 @@
       "type" : "UNKNOWN"
     },
     {
-      "dstId" : "interface-node-subnet-d9cafabc-vpc-f8fad69d",
-      "id" : "link-interface-node-vpc-f8fad69d-subnet-d9cafabc-interface-node-subnet-d9cafabc-vpc-f8fad69d",
-      "srcId" : "interface-node-vpc-f8fad69d-subnet-d9cafabc",
+      "dstId" : "interface-node-vpc-b390fad5-subnet-1641fa70",
+      "id" : "link-interface-node-subnet-1641fa70-vpc-b390fad5-interface-node-vpc-b390fad5-subnet-1641fa70",
+      "srcId" : "interface-node-subnet-1641fa70-vpc-b390fad5",
       "type" : "UNKNOWN"
     },
     {
@@ -826,9 +826,9 @@
       "type" : "UNKNOWN"
     },
     {
-      "dstId" : "interface-node-vpc-b390fad5-subnet-1641fa70",
-      "id" : "link-interface-node-subnet-1641fa70-vpc-b390fad5-interface-node-vpc-b390fad5-subnet-1641fa70",
-      "srcId" : "interface-node-subnet-1641fa70-vpc-b390fad5",
+      "dstId" : "interface-node-subnet-d9cafabc-vpc-f8fad69d",
+      "id" : "link-interface-node-vpc-f8fad69d-subnet-d9cafabc-interface-node-subnet-d9cafabc-vpc-f8fad69d",
+      "srcId" : "interface-node-vpc-f8fad69d-subnet-d9cafabc",
       "type" : "UNKNOWN"
     },
     {
@@ -880,15 +880,15 @@
       "type" : "UNKNOWN"
     },
     {
-      "dstId" : "interface-node-vpc-b390fad5-subnet-30398256",
-      "id" : "link-interface-node-subnet-30398256-vpc-b390fad5-interface-node-vpc-b390fad5-subnet-30398256",
-      "srcId" : "interface-node-subnet-30398256-vpc-b390fad5",
-      "type" : "UNKNOWN"
-    },
-    {
       "dstId" : "interface-node-subnet-1f315846-vpc-f8fad69d",
       "id" : "link-interface-node-subnet-1f315846-subnet-1f315846-interface-node-subnet-1f315846-vpc-f8fad69d",
       "srcId" : "interface-node-subnet-1f315846-subnet-1f315846",
+      "type" : "UNKNOWN"
+    },
+    {
+      "dstId" : "interface-node-vpc-b390fad5-subnet-30398256",
+      "id" : "link-interface-node-subnet-30398256-vpc-b390fad5-interface-node-vpc-b390fad5-subnet-30398256",
+      "srcId" : "interface-node-subnet-30398256-vpc-b390fad5",
       "type" : "UNKNOWN"
     },
     {
@@ -916,15 +916,15 @@
       "type" : "UNKNOWN"
     },
     {
-      "dstId" : "interface-node-vpc-b390fad5-igw-9b93ddfc",
-      "id" : "link-interface-node-vpc-b390fad5-vpc-b390fad5-interface-node-vpc-b390fad5-igw-9b93ddfc",
-      "srcId" : "interface-node-vpc-b390fad5-vpc-b390fad5",
-      "type" : "UNKNOWN"
-    },
-    {
       "dstId" : "interface-node-subnet-1641fa70-subnet-1641fa70",
       "id" : "link-interface-node-subnet-1641fa70-test-rds-subnet-1641fa70-interface-node-subnet-1641fa70-subnet-1641fa70",
       "srcId" : "interface-node-subnet-1641fa70-test-rds-subnet-1641fa70",
+      "type" : "UNKNOWN"
+    },
+    {
+      "dstId" : "interface-node-vpc-b390fad5-igw-9b93ddfc",
+      "id" : "link-interface-node-vpc-b390fad5-vpc-b390fad5-interface-node-vpc-b390fad5-igw-9b93ddfc",
+      "srcId" : "interface-node-vpc-b390fad5-vpc-b390fad5",
       "type" : "UNKNOWN"
     },
     {
@@ -976,12 +976,6 @@
       "type" : "UNKNOWN"
     },
     {
-      "dstId" : "interface-node-vpc-b390fad5-subnet-7044ff16",
-      "id" : "link-interface-node-subnet-7044ff16-vpc-b390fad5-interface-node-vpc-b390fad5-subnet-7044ff16",
-      "srcId" : "interface-node-subnet-7044ff16-vpc-b390fad5",
-      "type" : "UNKNOWN"
-    },
-    {
       "dstId" : "interface-node-vpc-925131f4-igw-fac5839d",
       "id" : "link-interface-node-igw-fac5839d-vpc-925131f4-interface-node-vpc-925131f4-igw-fac5839d",
       "srcId" : "interface-node-igw-fac5839d-vpc-925131f4",
@@ -991,6 +985,12 @@
       "dstId" : "interface-node-subnet-073b8061-vpc-b390fad5",
       "id" : "link-interface-node-subnet-073b8061-subnet-073b8061-interface-node-subnet-073b8061-vpc-b390fad5",
       "srcId" : "interface-node-subnet-073b8061-subnet-073b8061",
+      "type" : "UNKNOWN"
+    },
+    {
+      "dstId" : "interface-node-vpc-b390fad5-subnet-7044ff16",
+      "id" : "link-interface-node-subnet-7044ff16-vpc-b390fad5-interface-node-vpc-b390fad5-subnet-7044ff16",
+      "srcId" : "interface-node-subnet-7044ff16-vpc-b390fad5",
       "type" : "UNKNOWN"
     },
     {
@@ -1026,14 +1026,14 @@
   ],
   "nodes" : [
     {
-      "id" : "node-vpc-b390fad5",
-      "name" : "vpc-b390fad5",
-      "type" : "SWITCH"
-    },
-    {
       "id" : "node-es-domain",
       "name" : "es-domain",
       "type" : "HOST"
+    },
+    {
+      "id" : "node-subnet-d9cafabc",
+      "name" : "subnet-d9cafabc",
+      "type" : "SWITCH"
     },
     {
       "id" : "node-vpc-925131f4",
@@ -1041,8 +1041,8 @@
       "type" : "SWITCH"
     },
     {
-      "id" : "node-subnet-d9cafabc",
-      "name" : "subnet-d9cafabc",
+      "id" : "node-vpc-b390fad5",
+      "name" : "vpc-b390fad5",
       "type" : "SWITCH"
     },
     {
@@ -1071,23 +1071,23 @@
       "type" : "SWITCH"
     },
     {
-      "id" : "node-subnet-073b8061",
-      "name" : "subnet-073b8061",
-      "type" : "SWITCH"
-    },
-    {
       "id" : "node-lhr-border-02",
       "name" : "lhr-border-02",
       "type" : "ROUTER"
     },
     {
-      "id" : "node-subnet-9c8adceb",
-      "name" : "subnet-9c8adceb",
+      "id" : "node-subnet-073b8061",
+      "name" : "subnet-073b8061",
       "type" : "SWITCH"
     },
     {
       "id" : "node-subnet-1641fa70",
       "name" : "subnet-1641fa70",
+      "type" : "SWITCH"
+    },
+    {
+      "id" : "node-subnet-9c8adceb",
+      "name" : "subnet-9c8adceb",
       "type" : "SWITCH"
     },
     {

--- a/tests/basic/topology.ref
+++ b/tests/basic/topology.ref
@@ -27,15 +27,15 @@
       "type" : "PHYSICAL"
     },
     {
-      "id" : "interface-node-as3border2-GigabitEthernet0/0",
-      "name" : "GigabitEthernet0/0",
-      "nodeId" : "node-as3border2",
-      "type" : "PHYSICAL"
-    },
-    {
       "id" : "interface-node-as3border1-GigabitEthernet1/0",
       "name" : "GigabitEthernet1/0",
       "nodeId" : "node-as3border1",
+      "type" : "PHYSICAL"
+    },
+    {
+      "id" : "interface-node-as3border2-GigabitEthernet0/0",
+      "name" : "GigabitEthernet0/0",
+      "nodeId" : "node-as3border2",
       "type" : "PHYSICAL"
     },
     {
@@ -99,14 +99,20 @@
       "type" : "PHYSICAL"
     },
     {
+      "id" : "interface-node-as2border1-GigabitEthernet2/0",
+      "name" : "GigabitEthernet2/0",
+      "nodeId" : "node-as2border1",
+      "type" : "PHYSICAL"
+    },
+    {
       "id" : "interface-node-as2core1-GigabitEthernet1/0",
       "name" : "GigabitEthernet1/0",
       "nodeId" : "node-as2core1",
       "type" : "PHYSICAL"
     },
     {
-      "id" : "interface-node-as2border1-GigabitEthernet2/0",
-      "name" : "GigabitEthernet2/0",
+      "id" : "interface-node-as2border1-GigabitEthernet1/0",
+      "name" : "GigabitEthernet1/0",
       "nodeId" : "node-as2border1",
       "type" : "PHYSICAL"
     },
@@ -123,8 +129,8 @@
       "type" : "PHYSICAL"
     },
     {
-      "id" : "interface-node-as2border1-GigabitEthernet1/0",
-      "name" : "GigabitEthernet1/0",
+      "id" : "interface-node-as2border1-GigabitEthernet0/0",
+      "name" : "GigabitEthernet0/0",
       "nodeId" : "node-as2border1",
       "type" : "PHYSICAL"
     },
@@ -138,12 +144,6 @@
       "id" : "interface-node-as2core2-GigabitEthernet2/0",
       "name" : "GigabitEthernet2/0",
       "nodeId" : "node-as2core2",
-      "type" : "PHYSICAL"
-    },
-    {
-      "id" : "interface-node-as2border1-GigabitEthernet0/0",
-      "name" : "GigabitEthernet0/0",
-      "nodeId" : "node-as2border1",
       "type" : "PHYSICAL"
     },
     {
@@ -201,15 +201,15 @@
       "type" : "PHYSICAL"
     },
     {
-      "id" : "interface-node-host1-eth0",
-      "name" : "eth0",
-      "nodeId" : "node-host1",
-      "type" : "PHYSICAL"
-    },
-    {
       "id" : "interface-node-as2dist1-GigabitEthernet0/0",
       "name" : "GigabitEthernet0/0",
       "nodeId" : "node-as2dist1",
+      "type" : "PHYSICAL"
+    },
+    {
+      "id" : "interface-node-host1-eth0",
+      "name" : "eth0",
+      "nodeId" : "node-host1",
       "type" : "PHYSICAL"
     },
     {
@@ -231,15 +231,15 @@
       "type" : "PHYSICAL"
     },
     {
-      "id" : "interface-node-as1border2-GigabitEthernet1/0",
-      "name" : "GigabitEthernet1/0",
-      "nodeId" : "node-as1border2",
-      "type" : "PHYSICAL"
-    },
-    {
       "id" : "interface-node-as1border1-GigabitEthernet1/0",
       "name" : "GigabitEthernet1/0",
       "nodeId" : "node-as1border1",
+      "type" : "PHYSICAL"
+    },
+    {
+      "id" : "interface-node-as1border2-GigabitEthernet1/0",
+      "name" : "GigabitEthernet1/0",
+      "nodeId" : "node-as1border2",
       "type" : "PHYSICAL"
     },
     {
@@ -281,16 +281,16 @@
       "type" : "UNKNOWN"
     },
     {
-      "dstId" : "interface-node-as1border2-GigabitEthernet0/0",
-      "id" : "link-interface-node-as3border2-GigabitEthernet0/0-interface-node-as1border2-GigabitEthernet0/0",
-      "srcId" : "interface-node-as3border2-GigabitEthernet0/0",
-      "type" : "PHYSICAL"
-    },
-    {
       "dstId" : "interface-node-host1-eth0",
       "id" : "link-interface-node-as2dept1-GigabitEthernet2/0-interface-node-host1-eth0",
       "srcId" : "interface-node-as2dept1-GigabitEthernet2/0",
       "type" : "UNKNOWN"
+    },
+    {
+      "dstId" : "interface-node-as1border2-GigabitEthernet0/0",
+      "id" : "link-interface-node-as3border2-GigabitEthernet0/0-interface-node-as1border2-GigabitEthernet0/0",
+      "srcId" : "interface-node-as3border2-GigabitEthernet0/0",
+      "type" : "PHYSICAL"
     },
     {
       "dstId" : "interface-node-as2dist2-GigabitEthernet2/0",
@@ -353,16 +353,16 @@
       "type" : "PHYSICAL"
     },
     {
-      "dstId" : "interface-node-host2-eth0",
-      "id" : "link-interface-node-host2-GigabitEthernet3/0-interface-node-host2-eth0",
-      "srcId" : "interface-node-host2-GigabitEthernet3/0",
-      "type" : "UNKNOWN"
-    },
-    {
       "dstId" : "interface-node-as3border2-GigabitEthernet1/0",
       "id" : "link-interface-node-as3border2-GigabitEthernet0/0-interface-node-as3border2-GigabitEthernet1/0",
       "srcId" : "interface-node-as3border2-GigabitEthernet0/0",
       "type" : "PHYSICAL"
+    },
+    {
+      "dstId" : "interface-node-host2-eth0",
+      "id" : "link-interface-node-host2-GigabitEthernet3/0-interface-node-host2-eth0",
+      "srcId" : "interface-node-host2-GigabitEthernet3/0",
+      "type" : "UNKNOWN"
     },
     {
       "dstId" : "interface-node-as2core1-GigabitEthernet3/0",
@@ -431,10 +431,10 @@
       "type" : "PHYSICAL"
     },
     {
-      "dstId" : "interface-node-as2dept1-GigabitEthernet2/0",
-      "id" : "link-interface-node-host1-eth0-interface-node-as2dept1-GigabitEthernet2/0",
-      "srcId" : "interface-node-host1-eth0",
-      "type" : "UNKNOWN"
+      "dstId" : "interface-node-as1core1-GigabitEthernet1/0",
+      "id" : "link-interface-node-as1core1-GigabitEthernet0/0-interface-node-as1core1-GigabitEthernet1/0",
+      "srcId" : "interface-node-as1core1-GigabitEthernet0/0",
+      "type" : "PHYSICAL"
     },
     {
       "dstId" : "interface-node-as2core2-GigabitEthernet1/0",
@@ -443,10 +443,10 @@
       "type" : "PHYSICAL"
     },
     {
-      "dstId" : "interface-node-as1core1-GigabitEthernet1/0",
-      "id" : "link-interface-node-as1core1-GigabitEthernet0/0-interface-node-as1core1-GigabitEthernet1/0",
-      "srcId" : "interface-node-as1core1-GigabitEthernet0/0",
-      "type" : "PHYSICAL"
+      "dstId" : "interface-node-as2dept1-GigabitEthernet2/0",
+      "id" : "link-interface-node-host1-eth0-interface-node-as2dept1-GigabitEthernet2/0",
+      "srcId" : "interface-node-host1-eth0",
+      "type" : "UNKNOWN"
     },
     {
       "dstId" : "interface-node-as3border2-GigabitEthernet0/0",
@@ -557,21 +557,27 @@
       "type" : "PHYSICAL"
     },
     {
-      "dstId" : "interface-node-host1-eth0",
-      "id" : "link-interface-node-host1-GigabitEthernet2/0-interface-node-host1-eth0",
-      "srcId" : "interface-node-host1-GigabitEthernet2/0",
-      "type" : "UNKNOWN"
-    },
-    {
       "dstId" : "interface-node-as2core2-GigabitEthernet3/0",
       "id" : "link-interface-node-as2dist1-GigabitEthernet1/0-interface-node-as2core2-GigabitEthernet3/0",
       "srcId" : "interface-node-as2dist1-GigabitEthernet1/0",
       "type" : "UNKNOWN"
     },
     {
+      "dstId" : "interface-node-host1-eth0",
+      "id" : "link-interface-node-host1-GigabitEthernet2/0-interface-node-host1-eth0",
+      "srcId" : "interface-node-host1-GigabitEthernet2/0",
+      "type" : "UNKNOWN"
+    },
+    {
       "dstId" : "interface-node-as2core1-GigabitEthernet0/0",
       "id" : "link-interface-node-as2core1-GigabitEthernet1/0-interface-node-as2core1-GigabitEthernet0/0",
       "srcId" : "interface-node-as2core1-GigabitEthernet1/0",
+      "type" : "PHYSICAL"
+    },
+    {
+      "dstId" : "interface-node-as1core1-GigabitEthernet0/0",
+      "id" : "link-interface-node-as1core1-GigabitEthernet1/0-interface-node-as1core1-GigabitEthernet0/0",
+      "srcId" : "interface-node-as1core1-GigabitEthernet1/0",
       "type" : "PHYSICAL"
     },
     {
@@ -584,12 +590,6 @@
       "dstId" : "interface-node-as3border2-GigabitEthernet0/0",
       "id" : "link-interface-node-as3border2-GigabitEthernet0/0-interface-node-as3border2-GigabitEthernet0/0",
       "srcId" : "interface-node-as3border2-GigabitEthernet0/0",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-as1core1-GigabitEthernet0/0",
-      "id" : "link-interface-node-as1core1-GigabitEthernet1/0-interface-node-as1core1-GigabitEthernet0/0",
-      "srcId" : "interface-node-as1core1-GigabitEthernet1/0",
       "type" : "PHYSICAL"
     },
     {
@@ -665,6 +665,12 @@
       "type" : "PHYSICAL"
     },
     {
+      "dstId" : "interface-node-as1border1-GigabitEthernet0/0",
+      "id" : "link-interface-node-as1border1-GigabitEthernet1/0-interface-node-as1border1-GigabitEthernet0/0",
+      "srcId" : "interface-node-as1border1-GigabitEthernet1/0",
+      "type" : "PHYSICAL"
+    },
+    {
       "dstId" : "interface-node-as2dept1-GigabitEthernet0/0",
       "id" : "link-interface-node-as2dist1-GigabitEthernet2/0-interface-node-as2dept1-GigabitEthernet0/0",
       "srcId" : "interface-node-as2dist1-GigabitEthernet2/0",
@@ -674,12 +680,6 @@
       "dstId" : "interface-node-as3core1-GigabitEthernet0/0",
       "id" : "link-interface-node-as3border2-GigabitEthernet1/0-interface-node-as3core1-GigabitEthernet0/0",
       "srcId" : "interface-node-as3border2-GigabitEthernet1/0",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-as1border1-GigabitEthernet0/0",
-      "id" : "link-interface-node-as1border1-GigabitEthernet1/0-interface-node-as1border1-GigabitEthernet0/0",
-      "srcId" : "interface-node-as1border1-GigabitEthernet1/0",
       "type" : "PHYSICAL"
     },
     {
@@ -701,15 +701,15 @@
       "type" : "PHYSICAL"
     },
     {
-      "dstId" : "interface-node-as3border1-GigabitEthernet0/0",
-      "id" : "link-interface-node-as3border1-GigabitEthernet1/0-interface-node-as3border1-GigabitEthernet0/0",
-      "srcId" : "interface-node-as3border1-GigabitEthernet1/0",
-      "type" : "PHYSICAL"
-    },
-    {
       "dstId" : "interface-node-as1core1-GigabitEthernet1/0",
       "id" : "link-interface-node-as1border1-GigabitEthernet0/0-interface-node-as1core1-GigabitEthernet1/0",
       "srcId" : "interface-node-as1border1-GigabitEthernet0/0",
+      "type" : "PHYSICAL"
+    },
+    {
+      "dstId" : "interface-node-as3border1-GigabitEthernet0/0",
+      "id" : "link-interface-node-as3border1-GigabitEthernet1/0-interface-node-as3border1-GigabitEthernet0/0",
+      "srcId" : "interface-node-as3border1-GigabitEthernet1/0",
       "type" : "PHYSICAL"
     },
     {


### PR DESCRIPTION
- Remove _interfaceEdges. All clients actually want interface node/
  interface pairs. This change simplifies client code and saves bunch of
  useless copying work.
- Make Topology immutable. prune now returns a new topology, rather than
  mutating this.
- Move Topology.pruneFailedIpsecSessionEdges to
  IpsecUtil.computeFailedIpsecSessionEdges.