### PR TITLE
Make multipath in bidirectional traces more apparent.

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/BidirectionalTrace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/BidirectionalTrace.java
@@ -1,6 +1,8 @@
 package org.batfish.datamodel.flow;
 
+import com.google.common.collect.ImmutableSet;
 import java.util.Objects;
+import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -11,16 +13,68 @@ import org.batfish.datamodel.Flow;
 public final class BidirectionalTrace {
   private final @Nonnull Flow _forwardFlow;
   private final @Nonnull Trace _forwardTrace;
+  private final @Nonnull Set<FirewallSessionTraceInfo> _newSessions;
   private final @Nullable Flow _reverseFlow;
   private final @Nullable Trace _reverseTrace;
+
+  public final class Key {
+    private final @Nonnull Flow _forwardFlow;
+    private final @Nonnull Set<FirewallSessionTraceInfo> _newSessions;
+    private final @Nullable Flow _reverseFlow;
+
+    public Key(
+        @Nonnull Flow forwardFlow,
+        @Nonnull Set<FirewallSessionTraceInfo> newSessions,
+        @Nullable Flow reverseFlow) {
+      _forwardFlow = forwardFlow;
+      _newSessions = ImmutableSet.copyOf(newSessions);
+      _reverseFlow = reverseFlow;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof Key)) {
+        return false;
+      }
+      Key key = (Key) o;
+      return Objects.equals(_forwardFlow, key._forwardFlow)
+          && Objects.equals(_newSessions, key._newSessions)
+          && Objects.equals(_reverseFlow, key._reverseFlow);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(_forwardFlow, _newSessions, _reverseFlow);
+    }
+
+    @Nonnull
+    public Flow getForwardFlow() {
+      return _forwardFlow;
+    }
+
+    @Nonnull
+    public Set<FirewallSessionTraceInfo> getNewSessions() {
+      return _newSessions;
+    }
+
+    @Nullable
+    public Flow getReverseFlow() {
+      return _reverseFlow;
+    }
+  }
 
   public BidirectionalTrace(
       Flow forwardFlow,
       Trace forwardTrace,
+      @Nonnull Set<FirewallSessionTraceInfo> newSessions,
       @Nullable Flow reverseFlow,
       @Nullable Trace reverseTrace) {
     _forwardFlow = forwardFlow;
     _forwardTrace = forwardTrace;
+    _newSessions = ImmutableSet.copyOf(newSessions);
     _reverseFlow = reverseFlow;
     _reverseTrace = reverseTrace;
   }
@@ -36,27 +90,42 @@ public final class BidirectionalTrace {
     BidirectionalTrace that = (BidirectionalTrace) o;
     return Objects.equals(_forwardFlow, that._forwardFlow)
         && Objects.equals(_forwardTrace, that._forwardTrace)
+        && Objects.equals(_newSessions, that._newSessions)
         && Objects.equals(_reverseFlow, that._reverseFlow)
         && Objects.equals(_reverseTrace, that._reverseTrace);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_forwardFlow, _forwardTrace, _reverseFlow, _reverseTrace);
+    return Objects.hash(_forwardFlow, _forwardTrace, _newSessions, _reverseFlow, _reverseTrace);
   }
 
+  @Nonnull
   public Flow getForwardFlow() {
     return _forwardFlow;
   }
 
+  @Nonnull
   public Trace getForwardTrace() {
     return _forwardTrace;
   }
 
+  @Nonnull
+  public Key getKey() {
+    return new Key(_forwardFlow, _newSessions, _reverseFlow);
+  }
+
+  @Nonnull
+  public Set<FirewallSessionTraceInfo> getNewSessions() {
+    return _newSessions;
+  }
+
+  @Nullable
   public Flow getReverseFlow() {
     return _reverseFlow;
   }
 
+  @Nullable
   public Trace getReverseTrace() {
     return _reverseTrace;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/BidirectionalTrace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/BidirectionalTrace.java
@@ -17,7 +17,7 @@ public final class BidirectionalTrace {
   private final @Nullable Flow _reverseFlow;
   private final @Nullable Trace _reverseTrace;
 
-  public final class Key {
+  public static final class Key {
     private final @Nonnull Flow _forwardFlow;
     private final @Nonnull Set<FirewallSessionTraceInfo> _newSessions;
     private final @Nullable Flow _reverseFlow;

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/BidirectionalTracePrunerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/BidirectionalTracePrunerTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import java.util.Collection;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.pojo.Node;
@@ -37,11 +38,16 @@ public class BidirectionalTracePrunerTest {
     Trace trace2 = new Trace(DENIED_IN, ImmutableList.of(HOP2));
     Trace trace3 = new Trace(DENIED_OUT, ImmutableList.of(HOP3));
 
-    BidirectionalTrace bTrace1 = new BidirectionalTrace(FLOW1, trace1, FLOW1, trace1);
-    BidirectionalTrace bTrace2 = new BidirectionalTrace(FLOW1, trace2, FLOW2, trace2);
-    BidirectionalTrace bTrace3 = new BidirectionalTrace(FLOW1, trace3, FLOW3, trace3);
-    BidirectionalTrace bTrace4 = new BidirectionalTrace(FLOW2, trace1, FLOW1, trace1);
-    BidirectionalTrace bTrace5 = new BidirectionalTrace(FLOW3, trace1, FLOW1, trace1);
+    BidirectionalTrace bTrace1 =
+        new BidirectionalTrace(FLOW1, trace1, ImmutableSet.of(), FLOW1, trace1);
+    BidirectionalTrace bTrace2 =
+        new BidirectionalTrace(FLOW1, trace2, ImmutableSet.of(), FLOW2, trace2);
+    BidirectionalTrace bTrace3 =
+        new BidirectionalTrace(FLOW1, trace3, ImmutableSet.of(), FLOW3, trace3);
+    BidirectionalTrace bTrace4 =
+        new BidirectionalTrace(FLOW2, trace1, ImmutableSet.of(), FLOW1, trace1);
+    BidirectionalTrace bTrace5 =
+        new BidirectionalTrace(FLOW3, trace1, ImmutableSet.of(), FLOW1, trace1);
     Collection<BidirectionalTrace> pruned =
         prune(ImmutableList.of(bTrace1, bTrace2, bTrace3, bTrace4, bTrace5), 3);
     assertThat(pruned, containsInAnyOrder(bTrace1, bTrace4, bTrace5));
@@ -54,11 +60,16 @@ public class BidirectionalTracePrunerTest {
     Trace trace2 = new Trace(DENIED_IN, ImmutableList.of(HOP2));
     Trace trace3 = new Trace(DENIED_OUT, ImmutableList.of(HOP3));
 
-    BidirectionalTrace bTrace1 = new BidirectionalTrace(FLOW1, trace1, FLOW1, trace1);
-    BidirectionalTrace bTrace2 = new BidirectionalTrace(FLOW1, trace2, FLOW1, trace2);
-    BidirectionalTrace bTrace3 = new BidirectionalTrace(FLOW1, trace3, FLOW1, trace3);
-    BidirectionalTrace bTrace4 = new BidirectionalTrace(FLOW1, trace1, FLOW2, trace1);
-    BidirectionalTrace bTrace5 = new BidirectionalTrace(FLOW1, trace1, FLOW3, trace1);
+    BidirectionalTrace bTrace1 =
+        new BidirectionalTrace(FLOW1, trace1, ImmutableSet.of(), FLOW1, trace1);
+    BidirectionalTrace bTrace2 =
+        new BidirectionalTrace(FLOW1, trace2, ImmutableSet.of(), FLOW1, trace2);
+    BidirectionalTrace bTrace3 =
+        new BidirectionalTrace(FLOW1, trace3, ImmutableSet.of(), FLOW1, trace3);
+    BidirectionalTrace bTrace4 =
+        new BidirectionalTrace(FLOW1, trace1, ImmutableSet.of(), FLOW2, trace1);
+    BidirectionalTrace bTrace5 =
+        new BidirectionalTrace(FLOW1, trace1, ImmutableSet.of(), FLOW3, trace1);
     Collection<BidirectionalTrace> pruned =
         prune(ImmutableList.of(bTrace1, bTrace2, bTrace3, bTrace4, bTrace5), 3);
     assertThat(pruned, containsInAnyOrder(bTrace1, bTrace4, bTrace5));
@@ -72,11 +83,16 @@ public class BidirectionalTracePrunerTest {
     Trace trace3 = new Trace(DENIED_IN, ImmutableList.of(HOP3));
     Trace trace4 = new Trace(DENIED_OUT, ImmutableList.of(HOP3));
 
-    BidirectionalTrace bTrace1 = new BidirectionalTrace(FLOW1, trace1, FLOW1, trace1);
-    BidirectionalTrace bTrace2 = new BidirectionalTrace(FLOW1, trace2, FLOW1, trace2);
-    BidirectionalTrace bTrace3 = new BidirectionalTrace(FLOW1, trace2, FLOW1, trace3);
-    BidirectionalTrace bTrace4 = new BidirectionalTrace(FLOW1, trace3, FLOW1, trace1);
-    BidirectionalTrace bTrace5 = new BidirectionalTrace(FLOW1, trace4, FLOW1, trace1);
+    BidirectionalTrace bTrace1 =
+        new BidirectionalTrace(FLOW1, trace1, ImmutableSet.of(), FLOW1, trace1);
+    BidirectionalTrace bTrace2 =
+        new BidirectionalTrace(FLOW1, trace2, ImmutableSet.of(), FLOW1, trace2);
+    BidirectionalTrace bTrace3 =
+        new BidirectionalTrace(FLOW1, trace2, ImmutableSet.of(), FLOW1, trace3);
+    BidirectionalTrace bTrace4 =
+        new BidirectionalTrace(FLOW1, trace3, ImmutableSet.of(), FLOW1, trace1);
+    BidirectionalTrace bTrace5 =
+        new BidirectionalTrace(FLOW1, trace4, ImmutableSet.of(), FLOW1, trace1);
     Collection<BidirectionalTrace> pruned =
         prune(ImmutableList.of(bTrace1, bTrace2, bTrace3, bTrace4, bTrace5), 3);
     assertThat(pruned, containsInAnyOrder(bTrace1, bTrace4, bTrace5));
@@ -90,11 +106,16 @@ public class BidirectionalTracePrunerTest {
     Trace trace3 = new Trace(DENIED_IN, ImmutableList.of(HOP3));
     Trace trace4 = new Trace(DENIED_OUT, ImmutableList.of(HOP3));
 
-    BidirectionalTrace bTrace1 = new BidirectionalTrace(FLOW1, trace1, FLOW1, trace1);
-    BidirectionalTrace bTrace2 = new BidirectionalTrace(FLOW1, trace2, FLOW1, trace2);
-    BidirectionalTrace bTrace3 = new BidirectionalTrace(FLOW1, trace1, FLOW1, trace1);
-    BidirectionalTrace bTrace4 = new BidirectionalTrace(FLOW1, trace2, FLOW1, trace3);
-    BidirectionalTrace bTrace5 = new BidirectionalTrace(FLOW1, trace1, FLOW1, trace4);
+    BidirectionalTrace bTrace1 =
+        new BidirectionalTrace(FLOW1, trace1, ImmutableSet.of(), FLOW1, trace1);
+    BidirectionalTrace bTrace2 =
+        new BidirectionalTrace(FLOW1, trace2, ImmutableSet.of(), FLOW1, trace2);
+    BidirectionalTrace bTrace3 =
+        new BidirectionalTrace(FLOW1, trace1, ImmutableSet.of(), FLOW1, trace1);
+    BidirectionalTrace bTrace4 =
+        new BidirectionalTrace(FLOW1, trace2, ImmutableSet.of(), FLOW1, trace3);
+    BidirectionalTrace bTrace5 =
+        new BidirectionalTrace(FLOW1, trace1, ImmutableSet.of(), FLOW1, trace4);
     Collection<BidirectionalTrace> pruned =
         prune(ImmutableList.of(bTrace1, bTrace2, bTrace3, bTrace4, bTrace5), 3);
     assertThat(pruned, containsInAnyOrder(bTrace1, bTrace4, bTrace5));
@@ -107,11 +128,16 @@ public class BidirectionalTracePrunerTest {
     Trace trace2 = new Trace(ACCEPTED, ImmutableList.of(HOP2));
     Trace trace3 = new Trace(ACCEPTED, ImmutableList.of(HOP3));
 
-    BidirectionalTrace bTrace1 = new BidirectionalTrace(FLOW1, trace1, FLOW1, trace1);
-    BidirectionalTrace bTrace2 = new BidirectionalTrace(FLOW1, trace1, FLOW1, trace2);
-    BidirectionalTrace bTrace3 = new BidirectionalTrace(FLOW1, trace1, FLOW1, trace3);
-    BidirectionalTrace bTrace4 = new BidirectionalTrace(FLOW1, trace2, FLOW1, trace1);
-    BidirectionalTrace bTrace5 = new BidirectionalTrace(FLOW1, trace3, FLOW1, trace1);
+    BidirectionalTrace bTrace1 =
+        new BidirectionalTrace(FLOW1, trace1, ImmutableSet.of(), FLOW1, trace1);
+    BidirectionalTrace bTrace2 =
+        new BidirectionalTrace(FLOW1, trace1, ImmutableSet.of(), FLOW1, trace2);
+    BidirectionalTrace bTrace3 =
+        new BidirectionalTrace(FLOW1, trace1, ImmutableSet.of(), FLOW1, trace3);
+    BidirectionalTrace bTrace4 =
+        new BidirectionalTrace(FLOW1, trace2, ImmutableSet.of(), FLOW1, trace1);
+    BidirectionalTrace bTrace5 =
+        new BidirectionalTrace(FLOW1, trace3, ImmutableSet.of(), FLOW1, trace1);
     Collection<BidirectionalTrace> pruned =
         prune(ImmutableList.of(bTrace1, bTrace2, bTrace3, bTrace4, bTrace5), 3);
     assertThat(pruned, containsInAnyOrder(bTrace1, bTrace4, bTrace5));
@@ -124,11 +150,16 @@ public class BidirectionalTracePrunerTest {
     Trace trace2 = new Trace(ACCEPTED, ImmutableList.of(HOP2));
     Trace trace3 = new Trace(ACCEPTED, ImmutableList.of(HOP3));
 
-    BidirectionalTrace bTrace1 = new BidirectionalTrace(FLOW1, trace1, FLOW1, trace1);
-    BidirectionalTrace bTrace2 = new BidirectionalTrace(FLOW1, trace1, FLOW1, trace1);
-    BidirectionalTrace bTrace3 = new BidirectionalTrace(FLOW1, trace1, FLOW1, trace1);
-    BidirectionalTrace bTrace4 = new BidirectionalTrace(FLOW1, trace1, FLOW1, trace2);
-    BidirectionalTrace bTrace5 = new BidirectionalTrace(FLOW1, trace1, FLOW1, trace3);
+    BidirectionalTrace bTrace1 =
+        new BidirectionalTrace(FLOW1, trace1, ImmutableSet.of(), FLOW1, trace1);
+    BidirectionalTrace bTrace2 =
+        new BidirectionalTrace(FLOW1, trace1, ImmutableSet.of(), FLOW1, trace1);
+    BidirectionalTrace bTrace3 =
+        new BidirectionalTrace(FLOW1, trace1, ImmutableSet.of(), FLOW1, trace1);
+    BidirectionalTrace bTrace4 =
+        new BidirectionalTrace(FLOW1, trace1, ImmutableSet.of(), FLOW1, trace2);
+    BidirectionalTrace bTrace5 =
+        new BidirectionalTrace(FLOW1, trace1, ImmutableSet.of(), FLOW1, trace3);
     Collection<BidirectionalTrace> pruned =
         prune(ImmutableList.of(bTrace1, bTrace2, bTrace3, bTrace4, bTrace5), 3);
     assertThat(pruned, containsInAnyOrder(bTrace1, bTrace4, bTrace5));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/BidirectionalTraceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/BidirectionalTraceTest.java
@@ -1,0 +1,49 @@
+package org.batfish.datamodel.flow;
+
+import static org.batfish.datamodel.FlowDisposition.ACCEPTED;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.TRUE;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.testing.EqualsTester;
+import org.batfish.datamodel.Flow;
+import org.batfish.datamodel.flow.BidirectionalTrace.Key;
+import org.junit.Test;
+
+/** Tests for {@link BidirectionalTrace}. */
+public final class BidirectionalTraceTest {
+  @Test
+  public void testKeyEquals() {
+    Flow flow1 = Flow.builder().setIngressNode("ingressNode").setTag("tag1").build();
+    Flow flow2 = Flow.builder().setIngressNode("ingressNode").setTag("tag2").build();
+    FirewallSessionTraceInfo session =
+        new FirewallSessionTraceInfo("hostname", null, null, ImmutableSet.of(), TRUE, null);
+    new EqualsTester()
+        .addEqualityGroup(
+            new Key(flow1, ImmutableSet.of(), flow1), new Key(flow1, ImmutableSet.of(), flow1))
+        .addEqualityGroup(new Key(flow2, ImmutableSet.of(), flow1))
+        .addEqualityGroup(new Key(flow1, ImmutableSet.of(session), flow1))
+        .addEqualityGroup(new Key(flow1, ImmutableSet.of(), null))
+        .testEquals();
+  }
+
+  @Test
+  public void testKey() {
+    Flow flow1 = Flow.builder().setIngressNode("ingressNode").setTag("tag1").build();
+    Flow flow2 = Flow.builder().setIngressNode("ingressNode").setTag("tag2").build();
+    Trace trace = new Trace(ACCEPTED, ImmutableList.of());
+    assertThat(
+        new BidirectionalTrace(flow1, trace, ImmutableSet.of(), flow2, trace).getKey(),
+        equalTo(new Key(flow1, ImmutableSet.of(), flow2)));
+    assertThat(
+        new BidirectionalTrace(flow2, trace, ImmutableSet.of(), flow1, trace).getKey(),
+        equalTo(new Key(flow2, ImmutableSet.of(), flow1)));
+    FirewallSessionTraceInfo session =
+        new FirewallSessionTraceInfo("hostname", null, null, ImmutableSet.of(), TRUE, null);
+    assertThat(
+        new BidirectionalTrace(flow1, trace, ImmutableSet.of(session), null, null).getKey(),
+        equalTo(new Key(flow1, ImmutableSet.of(session), null)));
+  }
+}

--- a/projects/question/src/main/java/org/batfish/question/traceroute/BidirectionalTracerouteAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/traceroute/BidirectionalTracerouteAnswerer.java
@@ -207,19 +207,24 @@ public class BidirectionalTracerouteAnswerer extends Answerer {
         .collect(Collectors.groupingBy(BidirectionalTrace::getKey, Collectors.toList()));
   }
 
-  // Invariant: each trace has getKey() equal to key.
-  private static Row toRow(BidirectionalTrace.Key key, List<BidirectionalTrace> traces) {
+  @VisibleForTesting
+  static Row toRow(BidirectionalTrace.Key key, List<BidirectionalTrace> traces) {
+    // Invariant: each trace has getKey() equal to key.
+    assert traces.stream().allMatch(trace -> trace.getKey().equals(key));
+
     List<Trace> forwardTraces =
         traces.stream()
             .map(BidirectionalTrace::getForwardTrace)
-            .collect(ImmutableList.toImmutableList());
-    List<String> sessionHops =
-        key.getNewSessions().stream()
-            .map(FirewallSessionTraceInfo::getHostname)
+            .distinct()
             .collect(ImmutableList.toImmutableList());
     List<Trace> reverseTraces =
         traces.stream()
             .map(BidirectionalTrace::getReverseTrace)
+            .distinct()
+            .collect(ImmutableList.toImmutableList());
+    List<String> sessionHops =
+        key.getNewSessions().stream()
+            .map(FirewallSessionTraceInfo::getHostname)
             .collect(ImmutableList.toImmutableList());
     return Row.of(
         COL_FORWARD_FLOW,

--- a/projects/question/src/main/java/org/batfish/question/traceroute/BidirectionalTracerouteAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/traceroute/BidirectionalTracerouteAnswerer.java
@@ -200,7 +200,8 @@ public class BidirectionalTracerouteAnswerer extends Answerer {
         columnMetadata, String.format("Bidirectional paths for flow ${%s}", COL_FORWARD_FLOW));
   }
 
-  private static Map<BidirectionalTrace.Key, List<BidirectionalTrace>> groupTraces(
+  @VisibleForTesting
+  static Map<BidirectionalTrace.Key, List<BidirectionalTrace>> groupTraces(
       List<BidirectionalTrace> traces) {
     return traces.stream()
         .collect(Collectors.groupingBy(BidirectionalTrace::getKey, Collectors.toList()));

--- a/projects/question/src/test/java/org/batfish/question/traceroute/BidirectionalTracerouteAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/traceroute/BidirectionalTracerouteAnswererTest.java
@@ -60,7 +60,8 @@ public final class BidirectionalTracerouteAnswererTest {
 
     assertThat(
         bidirectionalTraces,
-        contains(new BidirectionalTrace(FORWARD_FLOW, forwardTrace, null, null)));
+        contains(
+            new BidirectionalTrace(FORWARD_FLOW, forwardTrace, ImmutableSet.of(), null, null)));
   }
 
   @Test
@@ -83,7 +84,9 @@ public final class BidirectionalTracerouteAnswererTest {
 
     assertThat(
         bidirectionalTraces,
-        contains(new BidirectionalTrace(FORWARD_FLOW, forwardTrace, REVERSE_FLOW, reverseTrace)));
+        contains(
+            new BidirectionalTrace(
+                FORWARD_FLOW, forwardTrace, ImmutableSet.of(), REVERSE_FLOW, reverseTrace)));
   }
 
   @Test
@@ -113,11 +116,15 @@ public final class BidirectionalTracerouteAnswererTest {
     assertThat(
         bidirectionalTraces,
         contains(
-            new BidirectionalTrace(FORWARD_FLOW, forwardTrace1, REVERSE_FLOW, reverseTrace1),
-            new BidirectionalTrace(FORWARD_FLOW, forwardTrace1, REVERSE_FLOW, reverseTrace2),
-            new BidirectionalTrace(FORWARD_FLOW, forwardTrace2, null, null),
-            new BidirectionalTrace(FORWARD_FLOW, forwardTrace3, REVERSE_FLOW, reverseTrace1),
-            new BidirectionalTrace(FORWARD_FLOW, forwardTrace3, REVERSE_FLOW, reverseTrace2)));
+            new BidirectionalTrace(
+                FORWARD_FLOW, forwardTrace1, ImmutableSet.of(), REVERSE_FLOW, reverseTrace1),
+            new BidirectionalTrace(
+                FORWARD_FLOW, forwardTrace1, ImmutableSet.of(), REVERSE_FLOW, reverseTrace2),
+            new BidirectionalTrace(FORWARD_FLOW, forwardTrace2, ImmutableSet.of(), null, null),
+            new BidirectionalTrace(
+                FORWARD_FLOW, forwardTrace3, ImmutableSet.of(), REVERSE_FLOW, reverseTrace1),
+            new BidirectionalTrace(
+                FORWARD_FLOW, forwardTrace3, ImmutableSet.of(), REVERSE_FLOW, reverseTrace2)));
   }
 
   @Test
@@ -141,7 +148,9 @@ public final class BidirectionalTracerouteAnswererTest {
         computeBidirectionalTraces(ImmutableSet.of(FORWARD_FLOW), tracerouteEngine, false);
     assertThat(
         bidirectionalTraces,
-        contains(new BidirectionalTrace(FORWARD_FLOW, forwardTrace, REVERSE_FLOW, reverseTrace)));
+        contains(
+            new BidirectionalTrace(
+                FORWARD_FLOW, forwardTrace, ImmutableSet.of(session), REVERSE_FLOW, reverseTrace)));
   }
 
   /** Make sure we don't mix traces and sessions. */
@@ -178,8 +187,16 @@ public final class BidirectionalTracerouteAnswererTest {
         bidirectionalTraces,
         containsInAnyOrder(
             new BidirectionalTrace(
-                FORWARD_FLOW, sessionForwardTrace, REVERSE_FLOW, sessionReverseTrace),
+                FORWARD_FLOW,
+                sessionForwardTrace,
+                ImmutableSet.of(session),
+                REVERSE_FLOW,
+                sessionReverseTrace),
             new BidirectionalTrace(
-                FORWARD_FLOW, noSessionForwardTrace, REVERSE_FLOW, noSessionReverseTrace)));
+                FORWARD_FLOW,
+                noSessionForwardTrace,
+                ImmutableSet.of(),
+                REVERSE_FLOW,
+                noSessionReverseTrace)));
   }
 }

--- a/projects/question/src/test/java/org/batfish/question/traceroute/BidirectionalTracerouteAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/traceroute/BidirectionalTracerouteAnswererTest.java
@@ -27,7 +27,6 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.not;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -39,7 +38,6 @@ import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.answers.Schema;
 import org.batfish.datamodel.flow.BidirectionalTrace;
-import org.batfish.datamodel.flow.BidirectionalTrace.Key;
 import org.batfish.datamodel.flow.FirewallSessionTraceInfo;
 import org.batfish.datamodel.flow.Trace;
 import org.batfish.datamodel.flow.TraceAndReverseFlow;
@@ -240,13 +238,8 @@ public final class BidirectionalTracerouteAnswererTest {
       BidirectionalTrace bt4 =
           new BidirectionalTrace(FORWARD_FLOW, t2, ImmutableSet.of(), REVERSE_FLOW, t4);
 
-      Key key = bt1.getKey();
-      assertThat(key, equalTo(bt2.getKey()));
-      assertThat(key, equalTo(bt3.getKey()));
-      assertThat(key, equalTo(bt4.getKey()));
-
       List<BidirectionalTrace> bts = ImmutableList.of(bt1, bt2, bt3, bt4);
-      assertThat(groupTraces(bts), hasEntry(equalTo(key), equalTo(bts)));
+      assertThat(groupTraces(bts), hasEntry(equalTo(bt1.getKey()), equalTo(bts)));
     }
 
     {
@@ -256,7 +249,6 @@ public final class BidirectionalTracerouteAnswererTest {
       BidirectionalTrace bt2 =
           new BidirectionalTrace(REVERSE_FLOW, t1, ImmutableSet.of(), REVERSE_FLOW, t2);
 
-      assertThat(bt1.getKey(), not(equalTo(bt2.getKey())));
       assertThat(
           groupTraces(ImmutableList.of(bt1, bt2)),
           equalTo(
@@ -271,7 +263,6 @@ public final class BidirectionalTracerouteAnswererTest {
       BidirectionalTrace bt2 =
           new BidirectionalTrace(FORWARD_FLOW, t1, ImmutableSet.of(session1), REVERSE_FLOW, t2);
 
-      assertThat(bt1.getKey(), not(equalTo(bt2.getKey())));
       assertThat(
           groupTraces(ImmutableList.of(bt1, bt2)),
           equalTo(
@@ -286,7 +277,6 @@ public final class BidirectionalTracerouteAnswererTest {
       BidirectionalTrace bt2 =
           new BidirectionalTrace(FORWARD_FLOW, t1, ImmutableSet.of(session2), REVERSE_FLOW, t2);
 
-      assertThat(bt1.getKey(), not(equalTo(bt2.getKey())));
       assertThat(
           groupTraces(ImmutableList.of(bt1, bt2)),
           equalTo(
@@ -300,8 +290,6 @@ public final class BidirectionalTracerouteAnswererTest {
           new BidirectionalTrace(FORWARD_FLOW, t1, ImmutableSet.of(), REVERSE_FLOW, t2);
       BidirectionalTrace bt2 =
           new BidirectionalTrace(FORWARD_FLOW, t1, ImmutableSet.of(), FORWARD_FLOW, t2);
-
-      assertThat(bt1.getKey(), not(equalTo(bt2.getKey())));
 
       assertThat(
           groupTraces(ImmutableList.of(bt1, bt2)),


### PR DESCRIPTION
Group bidirectional traces by forward/reverse flow and sessions
(established by the forward flow/used for the reverse flow). This makes
it easier to see range of multipath behavior, including any multipath
inconsistency.