### PR TITLE
Palo Alto address obj support

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -426,6 +426,7 @@ public final class PaloAltoConfiguration extends VendorConfiguration {
           return IpRange.range(Ip.parse(ips[0]), Ip.parse(ips[1]));
         case REFERENCE:
           // Undefined reference
+          _w.redFlag("No matching address group/object found for RuleEndpoint: " + endpoint);
           return null;
         default:
           _w.redFlag("Could not convert RuleEndpoint to IpSpace: " + endpoint);

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -629,6 +629,7 @@ public final class PaloAltoConfiguration extends VendorConfiguration {
     }
     return null;
   }
+
   /**
    * Update referrers and/or warn for undefined structures based on references to an abstract
    * structure type existing in either the reference's namespace or shared namespace

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoStructureType.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoStructureType.java
@@ -4,6 +4,10 @@ import org.batfish.vendor.StructureType;
 
 public enum PaloAltoStructureType implements StructureType {
   ADDRESS_GROUP("address-group"),
+  ADDRESS_GROUP_OR_ADDRESS_OBJECT("address-group or address object"),
+  // Special abstract structure type to handle the fact that some things that look like references
+  // may actually refer to constants like an IP addresses
+  ADDRESS_GROUP_OR_ADDRESS_OBJECT_OR_NONE("address-group or address object or none"),
   ADDRESS_OBJECT("address object"),
   GLOBAL_PROTECT_APP_CRYPTO_PROFILE("global-protect-app-crypto-profile"),
   IKE_CRYPTO_PROFILE("ike-crypto-profile"),

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/RuleEndpoint.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/RuleEndpoint.java
@@ -11,8 +11,7 @@ public final class RuleEndpoint implements Serializable {
     IP_ADDRESS,
     IP_PREFIX,
     IP_RANGE,
-    ADDRESS_OBJECT,
-    ADDRESS_GROUP
+    REFERENCE
   }
 
   /** */
@@ -27,6 +26,7 @@ public final class RuleEndpoint implements Serializable {
     _value = value;
   }
 
+  /** Type hint from lexer */
   public Type getType() {
     return _type;
   }

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -124,6 +124,9 @@ public class PaloAltoGrammarTest {
     extractor.processParseTree(tree);
     PaloAltoConfiguration pac = (PaloAltoConfiguration) extractor.getVendorConfiguration();
     pac.setVendor(ConfigurationFormat.PALO_ALTO);
+    ConvertConfigurationAnswerElement answerElement = new ConvertConfigurationAnswerElement();
+    pac.setFilename(TESTCONFIGS_PREFIX + hostname);
+    pac.setAnswerElement(answerElement);
     return pac;
   }
 
@@ -180,10 +183,11 @@ public class PaloAltoGrammarTest {
         addressGroups.get("group0").getIpSpace(addressObjects, addressGroups),
         equalTo(EmptyIpSpace.INSTANCE));
 
-    // we parsed the description, addr3 should have been discarded
+    // we parsed the description, addr3 is undefined but should not have been discarded
     assertThat(addressGroups.get("group1").getDescription(), equalTo("group1-desc"));
     assertThat(
-        addressGroups.get("group1").getMembers(), equalTo(ImmutableSet.of("addr1", "addr2")));
+        addressGroups.get("group1").getMembers(),
+        equalTo(ImmutableSet.of("addr1", "addr2", "addr3")));
     assertThat(
         addressGroups.get("group1").getIpSpace(addressObjects, addressGroups),
         equalTo(
@@ -351,6 +355,12 @@ public class PaloAltoGrammarTest {
 
     // Confirm reference count is correct for used structure
     assertThat(ccae2, hasNumReferrers(filename2, PaloAltoStructureType.ADDRESS_OBJECT, name, 2));
+
+    // Confirm undefined reference is detected
+    assertThat(
+        ccae2,
+        hasUndefinedReference(
+            filename2, PaloAltoStructureType.ADDRESS_GROUP_OR_ADDRESS_OBJECT, "addr3"));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/address-groups-nested
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/address-groups-nested
@@ -1,8 +1,5 @@
 set deviceconfig system hostname address-objects
 
-# empty address group
-set address-group group0
-
 # nested group
 set address-group group1 static group0
 

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/address-object-group-inheritance
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/address-object-group-inheritance
@@ -4,12 +4,6 @@ set network interface ethernet ethernet1/2 layer3 ip 1.1.2.1/24
 set zone z1 network layer3 ethernet1/1
 set zone z2 network layer3 ethernet1/2
 
-# an address object named 11.11.11.11 with value 10.10.10.10
-set address 11.11.11.11 ip-netmask 10.10.10.10
-
-# an address group named 22.22.22.22 containing object above
-set address-group 22.22.22.22 static 11.11.11.11
-
 set rulebase security rules RULE1 from any
 set rulebase security rules RULE1 to any
 set rulebase security rules RULE1 source 11.11.11.11
@@ -25,4 +19,12 @@ set rulebase security rules RULE2 destination 22.22.22.22
 set rulebase security rules RULE2 service any
 set rulebase security rules RULE2 application any
 set rulebase security rules RULE2 action allow
+
+# Note: object definition comes after rules (reference) in config dump
+
+# an address object named 11.11.11.11 with value 10.10.10.10
+set address 11.11.11.11 ip-netmask 10.10.10.10
+
+# an address group named 22.22.22.22 containing object above
+set address-group 22.22.22.22 static 11.11.11.11
 


### PR DESCRIPTION
Dumping Palo Alto configs puts address group/object definitions at the end of the file - after they may have been referenced.

This PR adds support for referencing these groups/objects even if not yet declared.
