### PR TITLE
Untie RouteAdvertisement from AbstractRoute

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -294,12 +294,7 @@ public class VirtualRouter implements Serializable {
     for (RouteAdvertisement<D> r : delta.getActions()) {
       // REPLACE does not make sense across routers, update with WITHDRAW
       Reason reason = r.getReason() == Reason.REPLACE ? Reason.WITHDRAW : r.getReason();
-      queue.add(
-          RouteAdvertisement.<R>builder()
-              .setRoute(r.getRoute())
-              .setReason(reason)
-              .setWithdraw(r.isWithdrawn())
-              .build());
+      queue.add(RouteAdvertisement.<R>builder().setRoute(r.getRoute()).setReason(reason).build());
     }
   }
 
@@ -2110,7 +2105,6 @@ public class VirtualRouter implements Serializable {
                                 adv.getReason() == Reason.REPLACE
                                     ? Reason.WITHDRAW
                                     : adv.getReason())
-                            .setWithdraw(adv.isWithdrawn())
                             .setRoute(transformedRoute)
                             .build();
                   })

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/RibDelta.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/RibDelta.java
@@ -138,13 +138,7 @@ public final class RibDelta<R extends AbstractRoute> {
     public Builder<R> remove(R route, Reason reason) {
       LinkedHashMap<R, RouteAdvertisement<R>> l =
           _actions.computeIfAbsent(route.getNetwork(), p -> new LinkedHashMap<>(10, 1, true));
-      l.put(
-          route,
-          RouteAdvertisement.<R>builder()
-              .setRoute(route)
-              .setWithdraw(true)
-              .setReason(reason)
-              .build());
+      l.put(route, RouteAdvertisement.<R>builder().setRoute(route).setReason(reason).build());
       return this;
     }
 
@@ -157,13 +151,7 @@ public final class RibDelta<R extends AbstractRoute> {
       for (R route : routes) {
         LinkedHashMap<R, RouteAdvertisement<R>> l =
             _actions.computeIfAbsent(route.getNetwork(), p -> new LinkedHashMap<>(10, 1, true));
-        l.put(
-            route,
-            RouteAdvertisement.<R>builder()
-                .setRoute(route)
-                .setWithdraw(true)
-                .setReason(reason)
-                .build());
+        l.put(route, RouteAdvertisement.<R>builder().setRoute(route).setReason(reason).build());
       }
       return this;
     }
@@ -206,7 +194,6 @@ public final class RibDelta<R extends AbstractRoute> {
             a.getRoute(),
             RouteAdvertisement.<R>builder()
                 .setRoute(a.getRoute())
-                .setWithdraw(a.isWithdrawn())
                 .setReason(a.getReason())
                 .build());
       }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/RouteAdvertisement.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/RouteAdvertisement.java
@@ -8,15 +8,14 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
-import org.batfish.datamodel.AbstractRoute;
 
 /**
- * A wrapper around {@link org.batfish.datamodel.AbstractRoute} representing a route advertisement
- * action (send/withdraw) and the reason for the action
+ * A wrapper around a route object representing a route advertisement action (send/withdraw) and the
+ * reason for the action
  */
 @ParametersAreNonnullByDefault
-public final class RouteAdvertisement<R extends AbstractRoute> {
-  @Nonnull private final R _route;
+public final class RouteAdvertisement<T> {
+  @Nonnull private final T _route;
   private final boolean _withdraw;
   @Nonnull private final Reason _reason;
 
@@ -39,7 +38,7 @@ public final class RouteAdvertisement<R extends AbstractRoute> {
    * @param withdraw whether the route is being withdrawn
    */
   @VisibleForTesting
-  RouteAdvertisement(R route, boolean withdraw, Reason reason) {
+  RouteAdvertisement(T route, boolean withdraw, Reason reason) {
     _route = route;
     _withdraw = withdraw;
     _reason = reason;
@@ -50,7 +49,7 @@ public final class RouteAdvertisement<R extends AbstractRoute> {
    *
    * @param route route that is advertised
    */
-  public RouteAdvertisement(R route) {
+  public RouteAdvertisement(T route) {
     _route = route;
     _withdraw = false;
     _reason = Reason.ADD;
@@ -58,7 +57,7 @@ public final class RouteAdvertisement<R extends AbstractRoute> {
 
   /** Get the underlying route that's being advertised (or withdrawn) */
   @Nonnull
-  public R getRoute() {
+  public T getRoute() {
     return _route;
   }
 
@@ -108,43 +107,43 @@ public final class RouteAdvertisement<R extends AbstractRoute> {
   }
 
   @Nonnull
-  public static <R extends AbstractRoute> Builder<R> builder() {
+  public static <T> Builder<T> builder() {
     return new Builder<>();
   }
 
   @Nonnull
-  public Builder<R> toBuilder() {
-    return RouteAdvertisement.<R>builder()
+  public Builder<T> toBuilder() {
+    return RouteAdvertisement.<T>builder()
         .setRoute(_route)
         .setWithdraw(_withdraw)
         .setReason(_reason);
   }
 
   /** Builder for {@link RouteAdvertisement} */
-  public static final class Builder<R extends AbstractRoute> {
-    private R _route;
+  public static final class Builder<T> {
+    private T _route;
     private boolean _withdraw;
     private Reason _reason = Reason.ADD;
 
     private Builder() {}
 
-    public Builder<R> setRoute(R route) {
+    public Builder<T> setRoute(T route) {
       _route = route;
       return this;
     }
 
-    public Builder<R> setWithdraw(boolean withdraw) {
+    public Builder<T> setWithdraw(boolean withdraw) {
       _withdraw = withdraw;
       return this;
     }
 
-    public Builder<R> setReason(Reason reason) {
+    public Builder<T> setReason(Reason reason) {
       _reason = reason;
       return this;
     }
 
     @Nonnull
-    public RouteAdvertisement<R> build() {
+    public RouteAdvertisement<T> build() {
       checkArgument(_route != null, "Route advertisement missing the route");
       checkArgument(
           !_withdraw || _reason != Reason.ADD,

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
@@ -574,12 +574,7 @@ public class VirtualRouterTest {
     assertThat(q.remove(), equalTo(new RouteAdvertisement<>(sr1)));
     assertThat(
         q.remove(),
-        equalTo(
-            RouteAdvertisement.builder()
-                .setRoute(sr2)
-                .setWithdraw(true)
-                .setReason(Reason.WITHDRAW)
-                .build()));
+        equalTo(RouteAdvertisement.builder().setRoute(sr2).setReason(Reason.WITHDRAW).build()));
     assertThat(q, empty());
   }
 

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/AbstractRibTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/AbstractRibTest.java
@@ -417,7 +417,7 @@ public class AbstractRibTest {
     assertThat(_rib.getRoutes(), contains(r));
     assertThat(_rib.getRoutes(), not(contains(_mostGeneralRoute)));
     assertThat(
-        d.getActions().contains(new RouteAdvertisement<>(_mostGeneralRoute, true, Reason.WITHDRAW)),
+        d.getActions().contains(new RouteAdvertisement<>(_mostGeneralRoute, Reason.WITHDRAW)),
         equalTo(true));
 
     // Remove route r
@@ -425,7 +425,7 @@ public class AbstractRibTest {
     assertThat(_rib.getRoutes(), not(contains(r)));
     assertThat(_rib.getRoutes(), emptyIterableOf(StaticRoute.class));
     assertThat(
-        d.getActions().contains(new RouteAdvertisement<>(r, true, Reason.WITHDRAW)), equalTo(true));
+        d.getActions().contains(new RouteAdvertisement<>(r, Reason.WITHDRAW)), equalTo(true));
   }
 
   /**

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibDeltaTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibDeltaTest.java
@@ -193,8 +193,7 @@ public class RibDeltaTest {
     assertThat(delta.getActions(), hasSize(2));
     // Route withdrawn
     assertThat(
-        delta.getActions().get(0),
-        equalTo(new RouteAdvertisement<>(oldGoodRoute, true, Reason.REPLACE)));
+        delta.getActions().get(0), equalTo(new RouteAdvertisement<>(oldGoodRoute, Reason.REPLACE)));
     // Route added
     assertThat(delta.getActions().get(1), equalTo(new RouteAdvertisement<>(newGoodRoute)));
   }


### PR DESCRIPTION
RouteAdvertisement does not have any methods that rely on its generic being an AbstractRoute, so changed it to RouteAdvertisement\<T\> instead of RouteAdvertisement\<R extends AbstractRoute\>. While I was at it, also removed redundant field `_withdraw`.