### PR TITLE
Add line number to BatfishParseTreeWalker exceptions

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/BatfishParseTreeWalker.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/BatfishParseTreeWalker.java
@@ -1,5 +1,7 @@
 package org.batfish.grammar;
 
+import com.google.common.annotations.VisibleForTesting;
+import javax.annotation.Nullable;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.tree.ParseTreeListener;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
@@ -9,8 +11,18 @@ import org.batfish.common.BatfishException;
 /** Custom ParseTreeWalker that adds some additional context when exceptions occur */
 public class BatfishParseTreeWalker extends ParseTreeWalker {
 
+  @Nullable
+  private final BatfishCombinedParser<? extends BatfishParser, ? extends BatfishLexer> _parser;
+
+  public BatfishParseTreeWalker(
+      @Nullable BatfishCombinedParser<? extends BatfishParser, ? extends BatfishLexer> parser) {
+    super();
+    _parser = parser;
+  }
+
   public BatfishParseTreeWalker() {
     super();
+    _parser = null;
   }
 
   @Override
@@ -20,9 +32,7 @@ public class BatfishParseTreeWalker extends ParseTreeWalker {
       listener.enterEveryRule(ctx);
       ctx.enterRule(listener);
     } catch (Exception e) {
-      throw new BatfishException(
-          String.format("Exception walking line '%s': %s", ctx.getText(), e.getMessage()),
-          e.getCause());
+      throwException(e, ctx);
     }
   }
 
@@ -33,9 +43,20 @@ public class BatfishParseTreeWalker extends ParseTreeWalker {
       ctx.exitRule(listener);
       listener.exitEveryRule(ctx);
     } catch (Exception e) {
-      throw new BatfishException(
-          String.format("Exception walking line '%s': %s", ctx.getText(), e.getMessage()),
-          e.getCause());
+      throwException(e, ctx);
     }
+  }
+
+  @VisibleForTesting
+  void throwException(Exception e, ParserRuleContext ctx) {
+    int line = ctx.getStart().getLine();
+    // Handle applying line translation if applicable (for flattened or otherwise modified files)
+    if (_parser != null) {
+      line = _parser.getLine(ctx.getStart());
+    }
+    throw new BatfishException(
+        String.format(
+            "Exception walking line number %d ('%s'): %s", line, ctx.getText(), e.getMessage()),
+        e.getCause());
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/ParseTreePrettyPrinter.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/ParseTreePrettyPrinter.java
@@ -40,7 +40,7 @@ public class ParseTreePrettyPrinter implements ParseTreeListener {
 
   public static ParseTreeSentences getParseTreeSentences(
       ParserRuleContext ctx, BatfishCombinedParser<?, ?> combinedParser, boolean printLineNumbers) {
-    ParseTreeWalker walker = new BatfishParseTreeWalker();
+    ParseTreeWalker walker = new BatfishParseTreeWalker(combinedParser);
     ParseTreePrettyPrinter printer =
         new ParseTreePrettyPrinter(ctx, combinedParser, printLineNumbers);
     walker.walk(printer, ctx);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/grammar/BatfishParseTreeWalkerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/grammar/BatfishParseTreeWalkerTest.java
@@ -2,9 +2,15 @@ package org.batfish.grammar;
 
 import static org.hamcrest.Matchers.containsString;
 
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.Parser;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.RuleContext;
+import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.TokenSource;
 import org.antlr.v4.runtime.misc.Interval;
 import org.antlr.v4.runtime.tree.ErrorNode;
 import org.antlr.v4.runtime.tree.ParseTree;
@@ -13,6 +19,8 @@ import org.antlr.v4.runtime.tree.ParseTreeVisitor;
 import org.antlr.v4.runtime.tree.RuleNode;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.batfish.common.BatfishException;
+import org.batfish.grammar.recovery.RecoveryLexer;
+import org.batfish.grammar.recovery.RecoveryParser;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -38,16 +46,16 @@ public class BatfishParseTreeWalkerTest {
 
   private final class TestRuleNode implements RuleNode {
 
-    private final String _text;
+    private final RuleContext _ruleContext;
 
-    TestRuleNode(String text) {
+    TestRuleNode(RuleContext ruleContext) {
       super();
-      _text = text;
+      _ruleContext = ruleContext;
     }
 
     @Override
     public RuleContext getRuleContext() {
-      return new TestParserRuleContext(_text);
+      return _ruleContext;
     }
 
     @Override
@@ -99,12 +107,58 @@ public class BatfishParseTreeWalkerTest {
     }
   }
 
+  private final class TestParser extends BatfishCombinedParser<RecoveryParser, RecoveryLexer> {
+    Map<Integer, Integer> _lineMap;
+
+    TestParser(Map<Integer, Integer> lineMap) {
+      super(
+          RecoveryParser.class,
+          RecoveryLexer.class,
+          "",
+          new MockGrammarSettings(false, 0, 0, 0, false, false, true, true),
+          new BatfishANTLRErrorStrategy.BatfishANTLRErrorStrategyFactory(
+              RecoveryLexer.NEWLINE, "\n"),
+          BatfishLexerRecoveryStrategy.WHITESPACE_AND_NEWLINES);
+      _lineMap = lineMap;
+    }
+
+    TestParser() {
+      super(
+          RecoveryParser.class,
+          RecoveryLexer.class,
+          "",
+          new MockGrammarSettings(false, 0, 0, 0, false, false, true, true),
+          new BatfishANTLRErrorStrategy.BatfishANTLRErrorStrategyFactory(
+              RecoveryLexer.NEWLINE, "\n"),
+          BatfishLexerRecoveryStrategy.WHITESPACE_AND_NEWLINES);
+    }
+
+    @Override
+    public ParserRuleContext parse() {
+      return null;
+    }
+
+    @Override
+    public int getLine(@Nonnull Token t) {
+      int line = t.getLine();
+      return (_lineMap == null) ? line : _lineMap.get(line);
+    }
+  }
+
   private final class TestParserRuleContext extends ParserRuleContext {
+    private final Token _start;
+
     private final String _text;
 
-    TestParserRuleContext(String text) {
+    TestParserRuleContext(String text, Token start) {
       super();
       _text = text;
+      _start = start;
+    }
+
+    @Override
+    public Token getStart() {
+      return _start;
     }
 
     @Override
@@ -113,27 +167,119 @@ public class BatfishParseTreeWalkerTest {
     }
   }
 
+  private final class TestToken implements Token {
+
+    private final int _line;
+
+    TestToken(int line) {
+      _line = line;
+    }
+
+    @Override
+    public String getText() {
+      return null;
+    }
+
+    @Override
+    public int getType() {
+      return 0;
+    }
+
+    @Override
+    public int getLine() {
+      return _line;
+    }
+
+    @Override
+    public int getCharPositionInLine() {
+      return 0;
+    }
+
+    @Override
+    public int getChannel() {
+      return 0;
+    }
+
+    @Override
+    public int getTokenIndex() {
+      return 0;
+    }
+
+    @Override
+    public int getStartIndex() {
+      return 0;
+    }
+
+    @Override
+    public int getStopIndex() {
+      return 0;
+    }
+
+    @Override
+    public TokenSource getTokenSource() {
+      return null;
+    }
+
+    @Override
+    public CharStream getInputStream() {
+      return null;
+    }
+  }
+
   private static final String LINE_TEXT = "Line text";
 
   @Rule public ExpectedException _thrown = ExpectedException.none();
 
   @Test
-  public void enterRule() {
+  public void testEnterRule() {
     BatfishParseTreeWalker swimmer = new BatfishParseTreeWalker();
 
     // Make sure an exception in enterRule contains the context's text
     _thrown.expect(BatfishException.class);
     _thrown.expectMessage(containsString(LINE_TEXT));
-    swimmer.enterRule(new TestParseTreeListener(), new TestRuleNode(LINE_TEXT));
+    swimmer.enterRule(
+        new TestParseTreeListener(),
+        new TestRuleNode(new TestParserRuleContext(LINE_TEXT, new TestToken(1))));
   }
 
   @Test
-  public void exitRule() {
+  public void testExitRule() {
     BatfishParseTreeWalker swimmer = new BatfishParseTreeWalker();
 
     // Make sure an exception in exitRule contains the context's text
     _thrown.expect(BatfishException.class);
     _thrown.expectMessage(containsString(LINE_TEXT));
-    swimmer.exitRule(new TestParseTreeListener(), new TestRuleNode(LINE_TEXT));
+    swimmer.exitRule(
+        new TestParseTreeListener(),
+        new TestRuleNode(new TestParserRuleContext(LINE_TEXT, new TestToken(1))));
+  }
+
+  @Test
+  public void testThrowException() {
+    int line = 1234;
+    TestParser parser = new TestParser();
+    BatfishParseTreeWalker swimmer = new BatfishParseTreeWalker(parser);
+    ParserRuleContext ctx = new ParserRuleContext();
+    ctx.start = new TestToken(line);
+
+    // Make sure thrown exception includes line number
+    _thrown.expect(BatfishException.class);
+    _thrown.expectMessage(containsString(String.format("line number %d", line)));
+    swimmer.throwException(new BatfishException("inner exception"), ctx);
+  }
+
+  @Test
+  public void testThrowExceptionWithLineMapping() {
+    int flattenedLine = 1234;
+    int originalLine = 5678;
+    TestParser parser = new TestParser(ImmutableMap.of(flattenedLine, originalLine));
+    BatfishParseTreeWalker swimmer = new BatfishParseTreeWalker(parser);
+    ParserRuleContext ctx = new ParserRuleContext();
+    ctx.start = new TestToken(1234);
+
+    // Make sure thrown exception includes original line number, not flattened line number
+    _thrown.expect(BatfishException.class);
+    _thrown.expectMessage(containsString(String.format("line number %d", originalLine)));
+    swimmer.throwException(new BatfishException("inner exception"), ctx);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -10122,7 +10122,7 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
 
   @Override
   public void processParseTree(ParserRuleContext tree) {
-    ParseTreeWalker walker = new BatfishParseTreeWalker();
+    ParseTreeWalker walker = new BatfishParseTreeWalker(_parser);
     walker.walk(this, tree);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/f5_bigip_structured/F5BigipStructuredControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/f5_bigip_structured/F5BigipStructuredControlPlaneExtractor.java
@@ -31,7 +31,7 @@ public class F5BigipStructuredControlPlaneExtractor implements ControlPlaneExtra
   public void processParseTree(ParserRuleContext tree) {
     F5BigipStructuredConfigurationBuilder cb =
         new F5BigipStructuredConfigurationBuilder(_parser, _text, _w);
-    ParseTreeWalker walker = new BatfishParseTreeWalker();
+    ParseTreeWalker walker = new BatfishParseTreeWalker(_parser);
     walker.walk(cb, tree);
     _configuration = cb.getConfiguration();
   }

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/FlatJuniperControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/FlatJuniperControlPlaneExtractor.java
@@ -32,7 +32,7 @@ public class FlatJuniperControlPlaneExtractor implements ControlPlaneExtractor {
   @Override
   public void processParseTree(ParserRuleContext tree) {
     Hierarchy hierarchy = new Hierarchy();
-    ParseTreeWalker walker = new BatfishParseTreeWalker();
+    ParseTreeWalker walker = new BatfishParseTreeWalker(_parser);
     try (ActiveSpan span =
         GlobalTracer.get().buildSpan("FlatJuniper::DeactivateTreeBuilder").startActive()) {
       assert span != null; // avoid unused warning

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatvyos/FlatVyosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatvyos/FlatVyosControlPlaneExtractor.java
@@ -688,7 +688,7 @@ public class FlatVyosControlPlaneExtractor extends FlatVyosParserBaseListener
 
   @Override
   public void processParseTree(ParserRuleContext tree) {
-    ParseTreeWalker walker = new BatfishParseTreeWalker();
+    ParseTreeWalker walker = new BatfishParseTreeWalker(_parser);
     walker.walk(this, tree);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/iptables/IptablesControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/iptables/IptablesControlPlaneExtractor.java
@@ -228,7 +228,7 @@ public class IptablesControlPlaneExtractor extends IptablesParserBaseListener
 
   @Override
   public void processParseTree(ParserRuleContext tree) {
-    ParseTreeWalker walker = new BatfishParseTreeWalker();
+    ParseTreeWalker walker = new BatfishParseTreeWalker(_parser);
     walker.walk(this, tree);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/mrv/MrvControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/mrv/MrvControlPlaneExtractor.java
@@ -61,7 +61,7 @@ public class MrvControlPlaneExtractor extends MrvParserBaseListener
 
   @Override
   public void processParseTree(ParserRuleContext tree) {
-    ParseTreeWalker walker = new BatfishParseTreeWalker();
+    ParseTreeWalker walker = new BatfishParseTreeWalker(_parser);
     walker.walk(this, tree);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoControlPlaneExtractor.java
@@ -30,7 +30,7 @@ public class PaloAltoControlPlaneExtractor implements ControlPlaneExtractor {
   @Override
   public void processParseTree(ParserRuleContext tree) {
     PaloAltoConfigurationBuilder cb = new PaloAltoConfigurationBuilder(_parser, _text, _w);
-    ParseTreeWalker walker = new BatfishParseTreeWalker();
+    ParseTreeWalker walker = new BatfishParseTreeWalker(_parser);
     walker.walk(cb, tree);
     _configuration = cb.getConfiguration();
   }

--- a/projects/batfish/src/main/java/org/batfish/grammar/routing_table/eos/EosRoutingTableExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/routing_table/eos/EosRoutingTableExtractor.java
@@ -159,7 +159,7 @@ public class EosRoutingTableExtractor extends EosRoutingTableParserBaseListener
 
   @Override
   public void processParseTree(ParserRuleContext tree) {
-    ParseTreeWalker walker = new BatfishParseTreeWalker();
+    ParseTreeWalker walker = new BatfishParseTreeWalker(_parser);
     walker.walk(this, tree);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/routing_table/ios/IosRoutingTableExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/routing_table/ios/IosRoutingTableExtractor.java
@@ -198,7 +198,7 @@ public class IosRoutingTableExtractor extends IosRoutingTableParserBaseListener
 
   @Override
   public void processParseTree(ParserRuleContext tree) {
-    ParseTreeWalker walker = new BatfishParseTreeWalker();
+    ParseTreeWalker walker = new BatfishParseTreeWalker(_parser);
     walker.walk(this, tree);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/routing_table/nxos/NxosRoutingTableExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/routing_table/nxos/NxosRoutingTableExtractor.java
@@ -163,7 +163,7 @@ public class NxosRoutingTableExtractor extends NxosRoutingTableParserBaseListene
 
   @Override
   public void processParseTree(ParserRuleContext tree) {
-    ParseTreeWalker walker = new BatfishParseTreeWalker();
+    ParseTreeWalker walker = new BatfishParseTreeWalker(_parser);
     walker.walk(this, tree);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -330,7 +330,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
           JuniperCombinedParser parser = new JuniperCombinedParser(input, settings);
           ParserRuleContext tree = parse(parser, logger, settings);
           JuniperFlattener flattener = new JuniperFlattener(header);
-          ParseTreeWalker walker = new BatfishParseTreeWalker();
+          ParseTreeWalker walker = new BatfishParseTreeWalker(parser);
           walker.walk(flattener, tree);
           return flattener;
         }
@@ -340,7 +340,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
           VyosCombinedParser parser = new VyosCombinedParser(input, settings);
           ParserRuleContext tree = parse(parser, logger, settings);
           VyosFlattener flattener = new VyosFlattener(header);
-          ParseTreeWalker walker = new BatfishParseTreeWalker();
+          ParseTreeWalker walker = new BatfishParseTreeWalker(parser);
           walker.walk(flattener, tree);
           return flattener;
         }


### PR DESCRIPTION
Add line number to `BatfishParseTreeWalker` exceptions.
