### PR TITLE
Add a postIncomingTransformationFilter

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -85,6 +85,8 @@ public final class Interface extends ComparableStructure<String> {
 
     private Configuration _owner;
 
+    private IpAccessList _postTransformationIncomingFilter;
+
     private boolean _proxyArp;
 
     private IpAccessList _preTransformationOutgoingFilter;
@@ -148,6 +150,7 @@ public final class Interface extends ComparableStructure<String> {
       if (_owner != null) {
         _owner.getAllInterfaces().put(name, iface);
       }
+      iface.setPostTransformationIncomingFilter(_postTransformationIncomingFilter);
       iface.setPreTransformationOutgoingFilter(_preTransformationOutgoingFilter);
       iface.setProxyArp(_proxyArp);
       if (_type != null) {
@@ -325,6 +328,12 @@ public final class Interface extends ComparableStructure<String> {
 
     public Builder setOwner(Configuration owner) {
       _owner = owner;
+      return this;
+    }
+
+    public Builder setPostTransformationIncomingFilter(
+        IpAccessList postTransformationIncomingFilter) {
+      _postTransformationIncomingFilter = postTransformationIncomingFilter;
       return this;
     }
 
@@ -506,6 +515,9 @@ public final class Interface extends ComparableStructure<String> {
   private static final String PROP_OUTGOING_FILTER = "outgoingFilter";
 
   private static final String PROP_OUTGOING_TRANSFORMATION = "outgoingTransformation";
+
+  private static final String PROP_POST_TRANSFORMATION_INCOMING_FILTER =
+      "postTransformationIncomingFilter";
 
   private static final String PROP_PREFIX = "prefix";
 
@@ -809,6 +821,10 @@ public final class Interface extends ComparableStructure<String> {
 
   private InterfaceAddress _address;
 
+  private IpAccessList _postTransformationIncomingFilter;
+
+  private transient String _postTransformationIncomingFilterName;
+
   private boolean _proxyArp;
 
   private IpAccessList _preTransformationOutgoingFilter;
@@ -970,6 +986,10 @@ public final class Interface extends ComparableStructure<String> {
       return false;
     }
     if (!Objects.equals(this._zoneName, other._zoneName)) {
+      return false;
+    }
+    if (!IpAccessList.bothNullOrSameName(
+        this._postTransformationIncomingFilter, other._postTransformationIncomingFilter)) {
       return false;
     }
     if (!IpAccessList.bothNullOrSameName(
@@ -1273,6 +1293,22 @@ public final class Interface extends ComparableStructure<String> {
   @JsonPropertyDescription("The primary IPV4 address/network of this interface")
   public InterfaceAddress getAddress() {
     return _address;
+  }
+
+  @JsonIgnore
+  public IpAccessList getPostTransformationIncomingFilter() {
+    return _postTransformationIncomingFilter;
+  }
+
+  @JsonProperty(PROP_POST_TRANSFORMATION_INCOMING_FILTER)
+  @JsonPropertyDescription(
+      "The IPV4 access-list used to filter incoming traffic after applying destination NAT.")
+  public String getPostTransformationIncomingFilterName() {
+    if (_postTransformationIncomingFilter != null) {
+      return _postTransformationIncomingFilter.getName();
+    } else {
+      return _postTransformationIncomingFilterName;
+    }
   }
 
   @JsonIgnore
@@ -1646,6 +1682,16 @@ public final class Interface extends ComparableStructure<String> {
   @JsonProperty(PROP_PREFIX)
   public void setAddress(InterfaceAddress address) {
     _address = address;
+  }
+
+  @JsonIgnore
+  public void setPostTransformationIncomingFilter(IpAccessList postTransformationIncomingFilter) {
+    _postTransformationIncomingFilter = postTransformationIncomingFilter;
+  }
+
+  @JsonProperty(PROP_POST_TRANSFORMATION_INCOMING_FILTER)
+  public void setPostTransformationIncomingFilter(String postTransformationIncomingFilterName) {
+    _postTransformationIncomingFilterName = postTransformationIncomingFilterName;
   }
 
   @JsonIgnore

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/FilterStep.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/FilterStep.java
@@ -20,6 +20,8 @@ public class FilterStep extends Step<FilterStepDetail> {
     INGRESS_FILTER,
     /** egress filter */
     EGRESS_FILTER,
+    /** postDestinationNat filter */
+    POST_DESTINATION_NAT_FILTER,
     /** preSourceNat filter */
     PRE_SOURCE_NAT_FILTER;
 
@@ -28,6 +30,7 @@ public class FilterStep extends Step<FilterStepDetail> {
         case INGRESS_FILTER:
           return FlowDisposition.DENIED_IN;
         case EGRESS_FILTER:
+        case POST_DESTINATION_NAT_FILTER:
         case PRE_SOURCE_NAT_FILTER:
           return FlowDisposition.DENIED_OUT;
         default:

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/FilterStep.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/FilterStep.java
@@ -20,18 +20,18 @@ public class FilterStep extends Step<FilterStepDetail> {
     INGRESS_FILTER,
     /** egress filter */
     EGRESS_FILTER,
-    /** postDestinationNat filter */
-    POST_DESTINATION_NAT_FILTER,
-    /** preSourceNat filter */
-    PRE_SOURCE_NAT_FILTER;
+    /** post-transformation ingress filter */
+    POST_TRANSFORMATION_INGRESS_FILTER,
+    /** pre-transformation egress filter */
+    PRE_TRANSFORMATION_EGRESS_FILTER;
 
     public FlowDisposition deniedDisposition() {
       switch (this) {
         case INGRESS_FILTER:
+        case POST_TRANSFORMATION_INGRESS_FILTER:
           return FlowDisposition.DENIED_IN;
         case EGRESS_FILTER:
-        case POST_DESTINATION_NAT_FILTER:
-        case PRE_SOURCE_NAT_FILTER:
+        case PRE_TRANSFORMATION_EGRESS_FILTER:
           return FlowDisposition.DENIED_OUT;
         default:
           throw new IllegalArgumentException("Unexpected FilterType: " + this);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/DataModelMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/DataModelMatchers.java
@@ -136,6 +136,24 @@ public final class DataModelMatchers {
   }
 
   /**
+   * Provides a matcher that matches if the provided {@code subMatcher} matches the {@link
+   * Interface}'s {@code postTransformationIncomingFilterName}.
+   */
+  public static @Nonnull Matcher<Interface> hasPostTransformationIncomingFilter(
+      @Nonnull Matcher<? super IpAccessList> subMatcher) {
+    return new InterfaceMatchersImpl.HasPostTransformationIncomingFilter(subMatcher);
+  }
+
+  /**
+   * Provides a matcher that matches if the provided {@code subMatcher} matches the {@link
+   * Interface}'s {@code preTransformationOutgoingFilterName}.
+   */
+  public static @Nonnull Matcher<Interface> hasPreTransformationOutgoingFilter(
+      @Nonnull Matcher<? super IpAccessList> subMatcher) {
+    return new InterfaceMatchersImpl.HasPreTransformationOutgoingFilter(subMatcher);
+  }
+
+  /**
    * Provides a matcher that matches if the provided {@code subMatcher} matches the configuration's
    * {@link RouteFilterList} with specified name.
    */

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchersImpl.java
@@ -272,6 +272,36 @@ final class InterfaceMatchersImpl {
     }
   }
 
+  static final class HasPostTransformationIncomingFilter
+      extends FeatureMatcher<Interface, IpAccessList> {
+    HasPostTransformationIncomingFilter(@Nonnull Matcher<? super IpAccessList> subMatcher) {
+      super(
+          subMatcher,
+          "an Interface with postTransformationIncomingFilter:",
+          "postTransformationIncomingFilter");
+    }
+
+    @Override
+    protected IpAccessList featureValueOf(Interface actual) {
+      return actual.getPostTransformationIncomingFilter();
+    }
+  }
+
+  static final class HasPreTransformationOutgoingFilter
+      extends FeatureMatcher<Interface, IpAccessList> {
+    HasPreTransformationOutgoingFilter(@Nonnull Matcher<? super IpAccessList> subMatcher) {
+      super(
+          subMatcher,
+          "an Interface with preTransformationOutgoingFilter:",
+          "preTransformationOutgoingFilter");
+    }
+
+    @Override
+    protected IpAccessList featureValueOf(Interface actual) {
+      return actual.getPreTransformationOutgoingFilter();
+    }
+  }
+
   static final class HasOutgoingFilterName extends FeatureMatcher<Interface, String> {
     HasOutgoingFilterName(@Nonnull Matcher<? super String> subMatcher) {
       super(subMatcher, "an Interface with outgoingFilterName:", "outgoingFilterName");

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysis.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysis.java
@@ -149,15 +149,16 @@ public class BDDReachabilityAnalysis {
    */
   public Map<IngressLocation, BDD> detectLoops() {
     /*
-     * Run enough rounds to exceed the max TTL (255). It takes at most 5 iterations to go between
+     * Run enough rounds to exceed the max TTL (255). It takes at most 6 iterations to go between
      * hops:
-     * PreInInterface -> PostInVrf -> PreOutVrf -> PreOutEdge -> PreOutEdgePostNat -> PreInInterface
+     * PreInInterface -> PostInInterface -> PostInVrf -> PreOutVrf -> PreOutEdge ->
+     * PreOutEdgePostNat -> PreInInterface
      *
      * Since we don't model TTL, all packets on loops will loop forever. But most paths will stop
      * long before numRounds. What's left will be a few candidate location/headerspace pairs that
      * may be on loops. In practice this is most likely way more iterations than necessary.
      */
-    int numRounds = 256 * 5;
+    int numRounds = 256 * 6;
     Map<StateExpr, BDD> reachableInNRounds = reachableInNRounds(numRounds);
 
     /*

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
@@ -530,8 +530,9 @@ class FlowTracer {
 
   private void forwardOutInterface(Interface outgoingInterface, Ip nextHopIp) {
     // Apply preSourceNatOutgoingFilter
-    if (applyFilter(outgoingInterface.getPreTransformationOutgoingFilter(),
-        PRE_TRANSFORMATION_EGRESS_FILTER)
+    if (applyFilter(
+            outgoingInterface.getPreTransformationOutgoingFilter(),
+            PRE_TRANSFORMATION_EGRESS_FILTER)
         == DENIED) {
       return;
     }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
@@ -6,8 +6,8 @@ import static com.google.common.base.Preconditions.checkState;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.match5Tuple;
 import static org.batfish.datamodel.flow.FilterStep.FilterType.EGRESS_FILTER;
 import static org.batfish.datamodel.flow.FilterStep.FilterType.INGRESS_FILTER;
-import static org.batfish.datamodel.flow.FilterStep.FilterType.POST_DESTINATION_NAT_FILTER;
-import static org.batfish.datamodel.flow.FilterStep.FilterType.PRE_SOURCE_NAT_FILTER;
+import static org.batfish.datamodel.flow.FilterStep.FilterType.POST_TRANSFORMATION_INGRESS_FILTER;
+import static org.batfish.datamodel.flow.FilterStep.FilterType.PRE_TRANSFORMATION_EGRESS_FILTER;
 import static org.batfish.datamodel.flow.StepAction.DENIED;
 import static org.batfish.datamodel.flow.StepAction.TRANSMITTED;
 import static org.batfish.dataplane.traceroute.TracerouteUtils.buildEnterSrcIfaceStep;
@@ -306,7 +306,7 @@ class FlowTracer {
       _currentFlow = transformationResult.getOutputFlow();
 
       inputFilter = incomingInterface.getPostTransformationIncomingFilter();
-      if (applyFilter(inputFilter, POST_DESTINATION_NAT_FILTER) == DENIED) {
+      if (applyFilter(inputFilter, POST_TRANSFORMATION_INGRESS_FILTER) == DENIED) {
         return;
       }
     } else {
@@ -530,7 +530,8 @@ class FlowTracer {
 
   private void forwardOutInterface(Interface outgoingInterface, Ip nextHopIp) {
     // Apply preSourceNatOutgoingFilter
-    if (applyFilter(outgoingInterface.getPreTransformationOutgoingFilter(), PRE_SOURCE_NAT_FILTER)
+    if (applyFilter(outgoingInterface.getPreTransformationOutgoingFilter(),
+        PRE_TRANSFORMATION_EGRESS_FILTER)
         == DENIED) {
       return;
     }

--- a/projects/batfish/src/main/java/org/batfish/z3/SynthesizerInput.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/SynthesizerInput.java
@@ -87,13 +87,13 @@ public interface SynthesizerInput {
   /** Mapping: hostname -&gt; interface -&gt; outgoingTransformation */
   Map<String, Map<String, Transformation>> getOutgoingTransformations();
 
-  /** Mapping: hostname -&gt; interface-&gt; postOutgoingAcl */
+  /** Mapping: hostname -&gt; interface-&gt; postTransformationIncomingAcl */
   Map<String, Map<String, String>> getPostTransformationIncomingAcls();
 
   /** Mapping: hostname -&gt; interface-&gt; postTransformationOutgoingAcl */
   Map<String, Map<String, String>> getPostTransformationOutgoingAcls();
 
-  /** Mapping: hostname -&gt; interface-&gt; incomingAcl */
+  /** Mapping: hostname -&gt; interface-&gt; preTransformationIncomingAcl */
   Map<String, Map<String, String>> getPreTransformationIncomingAcls();
 
   /** Mapping: hostname -&gt; interface-&gt; preTransformationOutgoingAcl */

--- a/projects/batfish/src/main/java/org/batfish/z3/SynthesizerInput.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/SynthesizerInput.java
@@ -55,9 +55,6 @@ public interface SynthesizerInput {
   /** Mapping: hostname -&gt; vrfs */
   Map<String, Set<String>> getEnabledVrfs();
 
-  /** Mapping: hostname -&gt; interface-&gt; incomingAcl */
-  Map<String, Map<String, String>> getIncomingAcls();
-
   /** Mapping: hostname -&gt; interface -&gt; incomingTransformation */
   Map<String, Map<String, Transformation>> getIncomingTransformations();
 
@@ -90,8 +87,14 @@ public interface SynthesizerInput {
   /** Mapping: hostname -&gt; interface -&gt; outgoingTransformation */
   Map<String, Map<String, Transformation>> getOutgoingTransformations();
 
+  /** Mapping: hostname -&gt; interface-&gt; postOutgoingAcl */
+  Map<String, Map<String, String>> getPostTransformationIncomingAcls();
+
   /** Mapping: hostname -&gt; interface-&gt; postTransformationOutgoingAcl */
   Map<String, Map<String, String>> getPostTransformationOutgoingAcls();
+
+  /** Mapping: hostname -&gt; interface-&gt; incomingAcl */
+  Map<String, Map<String, String>> getPreTransformationIncomingAcls();
 
   /** Mapping: hostname -&gt; interface-&gt; preTransformationOutgoingAcl */
   Map<String, Map<String, String>> getPreTransformationOutgoingAcls();

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
@@ -97,7 +97,7 @@ import org.batfish.z3.state.NodeInterfaceNeighborUnreachable;
 import org.batfish.z3.state.NodeInterfaceNeighborUnreachableOrExitsNetwork;
 import org.batfish.z3.state.OriginateInterfaceLink;
 import org.batfish.z3.state.OriginateVrf;
-import org.batfish.z3.state.PostInVrf;
+import org.batfish.z3.state.PostInInterface;
 import org.batfish.z3.state.PreInInterface;
 import org.batfish.z3.state.PreOutEdge;
 import org.batfish.z3.state.PreOutEdgePostNat;
@@ -564,7 +564,7 @@ public final class BDDReachabilityAnalysisFactoryTest {
         analysis
             .getEdges()
             .get(new PreInInterface(config.getHostname(), iface.getName()))
-            .get(new PostInVrf(config.getHostname(), vrf.getName()));
+            .get(new PostInInterface(config.getHostname(), iface.getName()));
 
     HeaderSpaceToBDD toBDD = new HeaderSpaceToBDD(PKT, ImmutableMap.of());
     BDD ingressAclBdd = toBDD.toBDD(ingressAclHeaderSpace);
@@ -635,7 +635,7 @@ public final class BDDReachabilityAnalysisFactoryTest {
         analysis
             .getEdges()
             .get(new PreInInterface(config.getHostname(), iface.getName()))
-            .get(new PostInVrf(config.getHostname(), vrf.getName()));
+            .get(new PostInInterface(config.getHostname(), iface.getName()));
 
     HeaderSpaceToBDD toBDD = new HeaderSpaceToBDD(PKT, ImmutableMap.of());
     BDD ingressAclBdd = toBDD.toBDD(ingressAclHeaderSpace);

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisTest.java
@@ -47,6 +47,7 @@ import org.batfish.z3.state.NodeInterfaceExitsNetwork;
 import org.batfish.z3.state.NodeInterfaceInsufficientInfo;
 import org.batfish.z3.state.NodeInterfaceNeighborUnreachable;
 import org.batfish.z3.state.OriginateVrf;
+import org.batfish.z3.state.PostInInterface;
 import org.batfish.z3.state.PostInVrf;
 import org.batfish.z3.state.PreInInterface;
 import org.batfish.z3.state.PreOutEdge;
@@ -76,6 +77,8 @@ public final class BDDReachabilityAnalysisTest {
   private String _dstIface2Name;
   private String _dstName;
   private NodeAccept _dstNodeAccept;
+  private PostInInterface _dstPostInInterface1;
+  private PostInInterface _dstPostInInterface2;
   private PostInVrf _dstPostInVrf;
   private PreInInterface _dstPreInInterface1;
   private PreInInterface _dstPreInInterface2;
@@ -150,6 +153,9 @@ public final class BDDReachabilityAnalysisTest {
     _srcName = _net._srcNode.getHostname();
     _srcNodeAccept = new NodeAccept(_srcName);
     _srcPostInVrf = new PostInVrf(_srcName, DEFAULT_VRF_NAME);
+
+    _dstPostInInterface1 = new PostInInterface(_dstName, _link1DstName);
+    _dstPostInInterface2 = new PostInInterface(_dstName, _link2DstName);
 
     _dstPreInInterface1 = new PreInInterface(_dstName, _link1DstName);
     _dstPreInInterface2 = new PreInInterface(_dstName, _link2DstName);
@@ -261,12 +267,13 @@ public final class BDDReachabilityAnalysisTest {
   }
 
   @Test
-  public void testBDDTransitions_PreInInterface_PostInVrf() {
+  public void testBDDTransitions_PreInInterface_PostInInterface() {
     // link1: not(_dstIface2Ip)
     assertThat(
-        bddTransition(_dstPreInInterface1, _dstPostInVrf), equalTo(dstIpBDD(_dstIface2Ip).not()));
+        bddTransition(_dstPreInInterface1, _dstPostInInterface1),
+        equalTo(dstIpBDD(_dstIface2Ip).not()));
     // link2: universe
-    assertThat(bddTransition(_dstPreInInterface2, _dstPostInVrf), isOne());
+    assertThat(bddTransition(_dstPreInInterface2, _dstPostInInterface2), isOne());
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/z3/MockSynthesizerInput.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/MockSynthesizerInput.java
@@ -40,8 +40,6 @@ public class MockSynthesizerInput implements SynthesizerInput {
 
     private Map<String, Set<String>> _enabledVrfs;
 
-    private Map<String, Map<String, String>> _incomingAcls;
-
     private Map<String, Map<String, Transformation>> _incomingTransformations;
 
     private Map<IngressLocation, BooleanExpr> _srcIpConstraints;
@@ -62,9 +60,13 @@ public class MockSynthesizerInput implements SynthesizerInput {
 
     private Map<String, Map<String, BooleanExpr>> _nullRoutedIps;
 
+    private Map<String, Map<String, Transformation>> _outgoingTransformations;
+
+    private Map<String, Map<String, String>> _postTransformationIncomingAcls;
+
     private Map<String, Map<String, String>> _postTransformationOutgoingAcls;
 
-    private Map<String, Map<String, Transformation>> _outgoingTransformations;
+    private Map<String, Map<String, String>> _preTransformationIncomingAcls;
 
     private Map<String, Map<String, String>> _preTransformationOutgoingAcls;
 
@@ -92,7 +94,6 @@ public class MockSynthesizerInput implements SynthesizerInput {
       _enabledInterfacesByNodeVrf = ImmutableMap.of();
       _enabledNodes = ImmutableSet.of();
       _enabledVrfs = ImmutableMap.of();
-      _incomingAcls = ImmutableMap.of();
       _incomingTransformations = ImmutableMap.of();
       _srcIpConstraints = ImmutableMap.of();
       _ipsByHostname = ImmutableMap.of();
@@ -104,7 +105,9 @@ public class MockSynthesizerInput implements SynthesizerInput {
       _nonTransitNodes = ImmutableSortedSet.of();
       _nullRoutedIps = ImmutableMap.of();
       _outgoingTransformations = ImmutableMap.of();
+      _postTransformationIncomingAcls = ImmutableMap.of();
       _postTransformationOutgoingAcls = ImmutableMap.of();
+      _preTransformationIncomingAcls = ImmutableMap.of();
       _preTransformationOutgoingAcls = ImmutableMap.of();
       _routableIps = ImmutableMap.of();
       _srcInterfaceField = null;
@@ -157,11 +160,6 @@ public class MockSynthesizerInput implements SynthesizerInput {
 
     public Builder setEnabledVrfs(Map<String, Set<String>> enabledVrfs) {
       _enabledVrfs = enabledVrfs;
-      return this;
-    }
-
-    public Builder setIncomingAcls(Map<String, Map<String, String>> incomingAcls) {
-      _incomingAcls = incomingAcls;
       return this;
     }
 
@@ -224,9 +222,21 @@ public class MockSynthesizerInput implements SynthesizerInput {
       return this;
     }
 
+    public Builder setPostTransformationIncomingAcls(
+        Map<String, Map<String, String>> postTransformationIncomingAcls) {
+      _postTransformationIncomingAcls = postTransformationIncomingAcls;
+      return this;
+    }
+
     public Builder setPostTransformationOutgoingAcls(
         Map<String, Map<String, String>> postTransformationOutgoingAcls) {
       _postTransformationOutgoingAcls = postTransformationOutgoingAcls;
+      return this;
+    }
+
+    public Builder setPreTransformationIncomingAcls(
+        Map<String, Map<String, String>> preTransformationIncomingAcls) {
+      _preTransformationIncomingAcls = preTransformationIncomingAcls;
       return this;
     }
 
@@ -309,8 +319,6 @@ public class MockSynthesizerInput implements SynthesizerInput {
 
   private final Map<String, Set<String>> _enabledVrfs;
 
-  private final Map<String, Map<String, String>> _incomingAcls;
-
   private Map<String, Map<String, Transformation>> _incomingTransformations;
 
   private final Map<IngressLocation, BooleanExpr> _srcIpConstraints;
@@ -334,7 +342,11 @@ public class MockSynthesizerInput implements SynthesizerInput {
 
   private Map<String, Map<String, Transformation>> _outgoingTransformations;
 
+  private final Map<String, Map<String, String>> _postTransformationIncomingAcls;
+
   private final Map<String, Map<String, String>> _postTransformationOutgoingAcls;
+
+  private final Map<String, Map<String, String>> _preTransformationIncomingAcls;
 
   private final Map<String, Map<String, String>> _preTransformationOutgoingAcls;
 
@@ -363,7 +375,6 @@ public class MockSynthesizerInput implements SynthesizerInput {
     _enabledInterfacesByNodeVrf = builder._enabledInterfacesByNodeVrf;
     _enabledNodes = builder._enabledNodes;
     _enabledVrfs = builder._enabledVrfs;
-    _incomingAcls = builder._incomingAcls;
     _incomingTransformations = builder._incomingTransformations;
     _srcIpConstraints = builder._srcIpConstraints;
     _ipsByHostname = builder._ipsByHostname;
@@ -374,7 +385,9 @@ public class MockSynthesizerInput implements SynthesizerInput {
     _nullRoutedIps = builder._nullRoutedIps;
     _nonTransitNodes = builder._nonTransitNodes;
     _outgoingTransformations = builder._outgoingTransformations;
+    _postTransformationIncomingAcls = builder._postTransformationIncomingAcls;
     _postTransformationOutgoingAcls = builder._postTransformationOutgoingAcls;
+    _preTransformationIncomingAcls = builder._preTransformationIncomingAcls;
     _preTransformationOutgoingAcls = builder._preTransformationOutgoingAcls;
     _routableIps = builder._routableIps;
     _simplify = builder._simplify;
@@ -433,8 +446,8 @@ public class MockSynthesizerInput implements SynthesizerInput {
   }
 
   @Override
-  public Map<String, Map<String, String>> getIncomingAcls() {
-    return _incomingAcls;
+  public Map<String, Map<String, String>> getPreTransformationIncomingAcls() {
+    return _preTransformationIncomingAcls;
   }
 
   @Override
@@ -485,6 +498,11 @@ public class MockSynthesizerInput implements SynthesizerInput {
   @Override
   public Map<String, Map<String, Transformation>> getOutgoingTransformations() {
     return _outgoingTransformations;
+  }
+
+  @Override
+  public Map<String, Map<String, String>> getPostTransformationIncomingAcls() {
+    return _postTransformationIncomingAcls;
   }
 
   @Override


### PR DESCRIPTION
Filters traffic after the incoming transformation, similar to how
preOutgoingTransformationFilter filters traffic before the outgoing
transformation.

Includes support in traceroute, BDD reachability, and NoD reachability.

@dhalperi @anothermattbrown 