### PR TITLE
Clean up and test HeaderSpace.matches()

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Flow.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Flow.java
@@ -15,55 +15,31 @@ import javax.annotation.Nullable;
 
 public final class Flow implements Comparable<Flow>, Serializable {
   public static class Builder {
-
     private int _dscp;
-
     private Ip _dstIp;
-
     private int _dstPort;
-
     private int _ecn;
-
     private int _fragmentOffset;
-
     private int _icmpCode;
-
     private int _icmpType;
-
     private @Nullable String _ingressInterface;
-
     // Nullable because no sensible default. User is required to specify.
     private @Nullable String _ingressNode;
-
     private @Nullable String _ingressVrf;
-
     private @Nonnull IpProtocol _ipProtocol;
-
     private int _packetLength;
-
     private @Nonnull Ip _srcIp;
-
     private int _srcPort;
-
     private @Nonnull FlowState _state;
-
     // Nullable because no sensible default. User is required to specify.
     private @Nullable String _tag;
-
     private int _tcpFlagsAck;
-
     private int _tcpFlagsCwr;
-
     private int _tcpFlagsEce;
-
     private int _tcpFlagsFin;
-
     private int _tcpFlagsPsh;
-
     private int _tcpFlagsRst;
-
     private int _tcpFlagsSyn;
-
     private int _tcpFlagsUrg;
 
     public Builder() {
@@ -383,58 +359,32 @@ public final class Flow implements Comparable<Flow>, Serializable {
   }
 
   private static final String PROP_DSCP = "dscp";
-
   static final String PROP_DST_IP = "dstIp";
-
   private static final String PROP_DST_PORT = "dstPort";
-
   private static final String PROP_ECN = "ecn";
-
   private static final String PROP_FRAGMENT_OFFSET = "fragmentOffset";
-
   private static final String PROP_ICMP_CODE = "icmpCode";
-
   private static final String PROP_ICMP_TYPE = "icmpVar";
-
   private static final String PROP_INGRESS_INTERFACE = "ingressInterface";
-
   private static final String PROP_INGRESS_NODE = "ingressNode";
-
   private static final String PROP_INGRESS_VRF = "ingressVrf";
-
   private static final String PROP_IP_PROTOCOL = "ipProtocol";
-
   private static final String PROP_PACKET_LENGTH = "packetLength";
-
   static final String PROP_SRC_IP = "srcIp";
-
   private static final String PROP_SRC_PORT = "srcPort";
-
   private static final String PROP_STATE = "state";
-
   private static final String PROP_TAG = "tag";
-
   private static final String PROP_TCP_FLAGS_ACK = "tcpFlagsAck";
-
   private static final String PROP_TCP_FLAGS_CWR = "tcpFlagsCwr";
-
   private static final String PROP_TCP_FLAGS_ECE = "tcpFlagsEce";
-
   private static final String PROP_TCP_FLAGS_FIN = "tcpFlagsFin";
-
   private static final String PROP_TCP_FLAGS_PSH = "tcpFlagsPsh";
-
   private static final String PROP_TCP_FLAGS_RST = "tcpFlagsRst";
-
   private static final String PROP_TCP_FLAGS_SYN = "tcpFlagsSyn";
-
   private static final String PROP_TCP_FLAGS_URG = "tcpFlagsUrg";
-
   public static final String BASE_FLOW_TAG = "BASE";
-
   public static final String DELTA_FLOW_TAG = "DELTA";
 
-  /** */
   private static final long serialVersionUID = 1L;
 
   public static Builder builder() {
@@ -442,37 +392,21 @@ public final class Flow implements Comparable<Flow>, Serializable {
   }
 
   private final int _dscp;
-
   private final @Nonnull Ip _dstIp;
-
   private final int _dstPort;
-
   private final int _ecn;
-
   private final int _fragmentOffset;
-
   private final int _icmpCode;
-
   private final int _icmpType;
-
   private final @Nullable String _ingressInterface;
-
   private final @Nonnull String _ingressNode;
-
   private final @Nullable String _ingressVrf;
-
   private final @Nonnull IpProtocol _ipProtocol;
-
   private final int _packetLength;
-
   private final @Nonnull Ip _srcIp;
-
   private final int _srcPort;
-
   private final @Nonnull FlowState _state;
-
   private final @Nonnull String _tag;
-
   private final @Nonnull TcpFlags _tcpFlags;
 
   private Flow(

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Flow.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Flow.java
@@ -576,13 +576,14 @@ public final class Flow implements Comparable<Flow>, Serializable {
     return _dscp;
   }
 
+  @Nonnull
   @JsonProperty(PROP_DST_IP)
   public Ip getDstIp() {
     return _dstIp;
   }
 
   @JsonProperty(PROP_DST_PORT)
-  public Integer getDstPort() {
+  public int getDstPort() {
     return _dstPort;
   }
 
@@ -606,21 +607,25 @@ public final class Flow implements Comparable<Flow>, Serializable {
     return _icmpType;
   }
 
+  @Nullable
   @JsonProperty(PROP_INGRESS_INTERFACE)
   public String getIngressInterface() {
     return _ingressInterface;
   }
 
+  @Nonnull
   @JsonProperty(PROP_INGRESS_NODE)
   public String getIngressNode() {
     return _ingressNode;
   }
 
+  @Nullable
   @JsonProperty(PROP_INGRESS_VRF)
   public String getIngressVrf() {
     return _ingressVrf;
   }
 
+  @Nonnull
   @JsonProperty(PROP_IP_PROTOCOL)
   public IpProtocol getIpProtocol() {
     return _ipProtocol;
@@ -631,21 +636,24 @@ public final class Flow implements Comparable<Flow>, Serializable {
     return _packetLength;
   }
 
+  @Nonnull
   @JsonProperty(PROP_SRC_IP)
   public Ip getSrcIp() {
     return _srcIp;
   }
 
   @JsonProperty(PROP_SRC_PORT)
-  public Integer getSrcPort() {
+  public int getSrcPort() {
     return _srcPort;
   }
 
+  @Nonnull
   @JsonProperty(PROP_STATE)
   public FlowState getState() {
     return _state;
   }
 
+  @Nonnull
   @JsonProperty(PROP_TAG)
   public String getTag() {
     return _tag;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/HeaderSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/HeaderSpace.java
@@ -872,7 +872,7 @@ public class HeaderSpace implements Serializable, Comparable<HeaderSpace> {
     if (!_dscps.isEmpty() && !_dscps.contains(flow.getDscp())) {
       return false;
     }
-    if (!_notDscps.isEmpty() && _notDscps.contains(flow.getDscp())) {
+    if (_notDscps.contains(flow.getDscp())) {
       return false;
     }
     if (_dstIps != null && !_dstIps.containsIp(flow.getDstIp(), namedIpSpaces)) {
@@ -881,10 +881,11 @@ public class HeaderSpace implements Serializable, Comparable<HeaderSpace> {
     if (_notDstIps != null && _notDstIps.containsIp(flow.getDstIp(), namedIpSpaces)) {
       return false;
     }
-    if (!_dstPorts.isEmpty() && !rangesContain(_dstPorts, flow.getDstPort())) {
+    if (!_dstPorts.isEmpty()
+        && _dstPorts.stream().noneMatch(sr -> sr.includes(flow.getDstPort()))) {
       return false;
     }
-    if (!_notDstPorts.isEmpty() && rangesContain(_notDstPorts, flow.getDstPort())) {
+    if (_notDstPorts.stream().anyMatch(sr -> sr.includes(flow.getDstPort()))) {
       return false;
     }
     if (!_dstProtocols.isEmpty()
@@ -905,38 +906,41 @@ public class HeaderSpace implements Serializable, Comparable<HeaderSpace> {
     if (!_ecns.isEmpty() && !_ecns.contains(flow.getEcn())) {
       return false;
     }
-    if (!_notEcns.isEmpty() && _notEcns.contains(flow.getEcn())) {
+    if (_notEcns.contains(flow.getEcn())) {
       return false;
     }
-    if (!_fragmentOffsets.isEmpty() && !rangesContain(_fragmentOffsets, flow.getFragmentOffset())) {
+    if (!_fragmentOffsets.isEmpty()
+        && _fragmentOffsets.stream().noneMatch(sr -> sr.includes(flow.getFragmentOffset()))) {
       return false;
     }
-    if (!_notFragmentOffsets.isEmpty()
-        && rangesContain(_notFragmentOffsets, flow.getFragmentOffset())) {
+    if (_notFragmentOffsets.stream().anyMatch(sr -> sr.includes(flow.getFragmentOffset()))) {
       return false;
     }
-    if (!_icmpCodes.isEmpty() && !rangesContain(_icmpCodes, flow.getIcmpCode())) {
+    if (!_icmpCodes.isEmpty()
+        && _icmpCodes.stream().noneMatch(sr -> sr.includes(flow.getIcmpCode()))) {
       return false;
     }
-    if (!_notIcmpCodes.isEmpty() && rangesContain(_notIcmpCodes, flow.getFragmentOffset())) {
+    if (_notIcmpCodes.stream().anyMatch(sr -> sr.includes(flow.getFragmentOffset()))) {
       return false;
     }
-    if (!_icmpTypes.isEmpty() && !rangesContain(_icmpTypes, flow.getIcmpType())) {
+    if (!_icmpTypes.isEmpty()
+        && _icmpTypes.stream().noneMatch(sr -> sr.includes(flow.getIcmpType()))) {
       return false;
     }
-    if (!_notIcmpTypes.isEmpty() && rangesContain(_notIcmpTypes, flow.getFragmentOffset())) {
+    if (_notIcmpTypes.stream().anyMatch(sr -> sr.includes(flow.getFragmentOffset()))) {
       return false;
     }
     if (!_ipProtocols.isEmpty() && !_ipProtocols.contains(flow.getIpProtocol())) {
       return false;
     }
-    if (!_notIpProtocols.isEmpty() && _notIpProtocols.contains(flow.getIpProtocol())) {
+    if (_notIpProtocols.contains(flow.getIpProtocol())) {
       return false;
     }
-    if (!_packetLengths.isEmpty() && !rangesContain(_packetLengths, flow.getPacketLength())) {
+    if (!_packetLengths.isEmpty()
+        && _packetLengths.stream().noneMatch(sr -> sr.includes(flow.getPacketLength()))) {
       return false;
     }
-    if (!_notPacketLengths.isEmpty() && rangesContain(_notPacketLengths, flow.getPacketLength())) {
+    if (_notPacketLengths.stream().anyMatch(sr -> sr.includes(flow.getPacketLength()))) {
       return false;
     }
     if (_srcOrDstIps != null
@@ -967,10 +971,11 @@ public class HeaderSpace implements Serializable, Comparable<HeaderSpace> {
     if (_notSrcIps != null && _notSrcIps.containsIp(flow.getSrcIp(), namedIpSpaces)) {
       return false;
     }
-    if (!_srcPorts.isEmpty() && !rangesContain(_srcPorts, flow.getSrcPort())) {
+    if (!_srcPorts.isEmpty()
+        && _srcPorts.stream().noneMatch(sr -> sr.includes(flow.getSrcPort()))) {
       return false;
     }
-    if (!_notSrcPorts.isEmpty() && rangesContain(_notSrcPorts, flow.getSrcPort())) {
+    if (_notSrcPorts.stream().anyMatch(sr -> sr.includes(flow.getSrcPort()))) {
       return false;
     }
     if (!_srcProtocols.isEmpty()

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/HeaderSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/HeaderSpace.java
@@ -891,15 +891,15 @@ public class HeaderSpace implements Serializable, Comparable<HeaderSpace> {
         && _dstProtocols.stream()
             .noneMatch(
                 dstProtocol ->
-                    dstProtocol.getPort().equals(flow.getDstPort())
-                        && dstProtocol.getIpProtocol().equals(flow.getIpProtocol()))) {
+                    dstProtocol.getPort() == flow.getDstPort()
+                        && dstProtocol.getIpProtocol() == flow.getIpProtocol())) {
       return false;
     }
     if (_notDstProtocols.stream()
         .anyMatch(
             notDstProtocol ->
-                notDstProtocol.getPort().equals(flow.getDstPort())
-                    && notDstProtocol.getIpProtocol().equals(flow.getIpProtocol()))) {
+                notDstProtocol.getPort() == flow.getDstPort()
+                    && notDstProtocol.getIpProtocol() == flow.getIpProtocol())) {
       return false;
     }
     if (!_ecns.isEmpty() && !_ecns.contains(flow.getEcn())) {
@@ -959,8 +959,8 @@ public class HeaderSpace implements Serializable, Comparable<HeaderSpace> {
       if (_srcOrDstProtocols.stream()
           .noneMatch(
               protocol ->
-                  (protocol.getPort().equals(flowDstPort) || protocol.getPort().equals(flowSrcPort))
-                      && protocol.getIpProtocol().equals(flowProtocol))) {
+                  (protocol.getPort() == flowDstPort || protocol.getPort() == flowSrcPort)
+                      && protocol.getIpProtocol() == flowProtocol)) {
         return false;
       }
     }
@@ -981,15 +981,15 @@ public class HeaderSpace implements Serializable, Comparable<HeaderSpace> {
         && _srcProtocols.stream()
             .noneMatch(
                 srcProtocol ->
-                    srcProtocol.getPort().equals(flow.getSrcPort())
-                        && srcProtocol.getIpProtocol().equals(flow.getIpProtocol()))) {
+                    srcProtocol.getPort() == flow.getSrcPort()
+                        && srcProtocol.getIpProtocol() == flow.getIpProtocol())) {
       return false;
     }
     if (_notSrcProtocols.stream()
         .anyMatch(
             notSrcProtocol ->
-                notSrcProtocol.getPort().equals(flow.getSrcPort())
-                    && notSrcProtocol.getIpProtocol().equals(flow.getIpProtocol()))) {
+                notSrcProtocol.getPort() == flow.getSrcPort()
+                    && notSrcProtocol.getIpProtocol() == flow.getIpProtocol())) {
       return false;
     }
     if (!_states.isEmpty() && !_states.contains(flow.getState())) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/HeaderSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/HeaderSpace.java
@@ -3,7 +3,6 @@ package org.batfish.datamodel;
 import static java.util.Comparator.naturalOrder;
 import static java.util.Comparator.nullsFirst;
 import static org.batfish.common.util.CommonUtil.nullIfEmpty;
-import static org.batfish.common.util.CommonUtil.rangesContain;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
@@ -949,14 +948,14 @@ public class HeaderSpace implements Serializable, Comparable<HeaderSpace> {
       return false;
     }
     if (!_srcOrDstPorts.isEmpty()
-        && !(rangesContain(_srcOrDstPorts, flow.getSrcPort())
-            || rangesContain(_srcOrDstPorts, flow.getDstPort()))) {
+        && _srcOrDstPorts.stream()
+            .noneMatch(sr -> sr.includes(flow.getSrcPort()) || sr.includes(flow.getDstPort()))) {
       return false;
     }
     if (!_srcOrDstProtocols.isEmpty()) {
       IpProtocol flowProtocol = flow.getIpProtocol();
-      Integer flowDstPort = flow.getDstPort();
-      Integer flowSrcPort = flow.getSrcPort();
+      int flowDstPort = flow.getDstPort();
+      int flowSrcPort = flow.getSrcPort();
       if (_srcOrDstProtocols.stream()
           .noneMatch(
               protocol ->

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/HeaderSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/HeaderSpace.java
@@ -23,69 +23,37 @@ import org.batfish.common.util.CommonUtil;
 public class HeaderSpace implements Serializable, Comparable<HeaderSpace> {
 
   public static class Builder {
-
     private SortedSet<Integer> _dscps;
-
     private @Nullable IpSpace _dstIps;
-
     private SortedSet<SubRange> _dstPorts;
-
     private SortedSet<Protocol> _dstProtocols;
-
     private SortedSet<Integer> _ecns;
-
     private SortedSet<SubRange> _fragmentOffsets;
-
     private SortedSet<SubRange> _icmpCodes;
-
     private SortedSet<SubRange> _icmpTypes;
-
     private SortedSet<IpProtocol> _ipProtocols;
-
     private boolean _negate;
-
     private SortedSet<Integer> _notDscps;
-
     private @Nullable IpSpace _notDstIps;
-
     private SortedSet<SubRange> _notDstPorts;
-
     private SortedSet<Protocol> _notDstProtocols;
-
     private SortedSet<Integer> _notEcns;
-
     private SortedSet<SubRange> _notFragmentOffsets;
-
     private SortedSet<SubRange> _notIcmpCodes;
-
     private SortedSet<SubRange> _notIcmpTypes;
-
     private SortedSet<IpProtocol> _notIpProtocols;
-
     private SortedSet<SubRange> _notPacketLengths;
-
     private @Nullable IpSpace _notSrcIps;
-
     private SortedSet<SubRange> _notSrcPorts;
-
     private SortedSet<Protocol> _notSrcProtocols;
-
     private SortedSet<SubRange> _packetLengths;
-
     private @Nullable IpSpace _srcIps;
-
     private @Nullable IpSpace _srcOrDstIps;
-
     private SortedSet<SubRange> _srcOrDstPorts;
-
     private SortedSet<Protocol> _srcOrDstProtocols;
-
     private SortedSet<SubRange> _srcPorts;
-
     private SortedSet<Protocol> _srcProtocols;
-
     private SortedSet<FlowState> _states;
-
     private List<TcpFlagsMatchConditions> _tcpFlags;
 
     private Builder() {
@@ -490,70 +458,38 @@ public class HeaderSpace implements Serializable, Comparable<HeaderSpace> {
           .thenComparing(HeaderSpace::getTcpFlags, CommonUtil::compareIterable);
 
   private static final String PROP_DSCPS = "dscps";
-
   private static final String PROP_DST_IPS = "dstIps";
-
   private static final String PROP_DST_PORTS = "dstPorts";
-
   private static final String PROP_DST_PROTOCOLS = "dstProtocols";
-
   private static final String PROP_ECNS = "ecns";
-
   private static final String PROP_FRAGMENT_OFFSETS = "fragmentOffsets";
-
   private static final String PROP_ICMP_CODES = "icmpCodes";
-
   private static final String PROP_ICMP_TYPES = "icmpTypes";
-
   private static final String PROP_IP_PROTOCOLS = "ipProtocols";
-
   private static final String PROP_NEGATE = "negate";
-
   private static final String PROP_NOT_DSCPS = "notDscps";
-
   private static final String PROP_NOT_DST_IPS = "notDstIps";
-
   private static final String PROP_NOT_DST_PORTS = "notDstPorts";
-
   private static final String PROP_NOT_DST_PROTOCOLS = "notDstProtocols";
-
   private static final String PROP_NOT_ECNS = "notEcns";
-
   private static final String PROP_NOT_FRAGMENT_OFFSETS = "notFragmentOffsets";
-
   private static final String PROP_NOT_ICMP_CODES = "notIcmpCodes";
-
   private static final String PROP_NOT_ICMP_TYPES = "notIcmpTypes";
-
   private static final String PROP_NOT_IP_PROTOCOLS = "notIpProtocols";
-
   private static final String PROP_NOT_PACKET_LENGTHS = "notPacketLengths";
-
   private static final String PROP_NOT_SRC_IPS = "notSrcIps";
-
   private static final String PROP_NOT_SRC_PORTS = "notSrcPorts";
-
   private static final String PROP_NOT_SRC_PROTOCOLS = "notSrcProtocols";
-
   private static final String PROP_PACKET_LENGTHS = "packetLengths";
-
   private static final String PROP_SRC_IPS = "srcIps";
-
   private static final String PROP_SRC_OR_DST_IPS = "srcOrDstIps";
-
   private static final String PROP_SRC_OR_DST_PORTS = "srcOrDstPorts";
-
   private static final String PROP_SRC_OR_DST_PROTOCOLS = "srcOrDstProtocols";
-
   private static final String PROP_SRC_PORTS = "srcPorts";
-
   private static final String PROP_SRC_PROTOCOLS = "srcProtocols";
-
   private static final String PROP_STATES = "states";
-
   private static final String PROP_TCP_FLAGS_MATCH_CONDITIONS = "tcpFlagsMatchConditions";
 
-  /** */
   private static final long serialVersionUID = 1L;
 
   public static Builder builder() {
@@ -561,67 +497,36 @@ public class HeaderSpace implements Serializable, Comparable<HeaderSpace> {
   }
 
   private SortedSet<Integer> _dscps;
-
   private IpSpace _dstIps;
-
   private SortedSet<SubRange> _dstPorts;
-
   private SortedSet<Protocol> _dstProtocols;
-
   private SortedSet<Integer> _ecns;
-
   private SortedSet<SubRange> _fragmentOffsets;
-
   private SortedSet<SubRange> _icmpCodes;
-
   private SortedSet<SubRange> _icmpTypes;
-
   private SortedSet<IpProtocol> _ipProtocols;
-
   private boolean _negate;
-
   private SortedSet<Integer> _notDscps;
-
   private IpSpace _notDstIps;
-
   private SortedSet<SubRange> _notDstPorts;
-
   private SortedSet<Protocol> _notDstProtocols;
-
   private SortedSet<Integer> _notEcns;
-
   private SortedSet<SubRange> _notFragmentOffsets;
-
   private SortedSet<SubRange> _notIcmpCodes;
-
   private SortedSet<SubRange> _notIcmpTypes;
-
   private SortedSet<IpProtocol> _notIpProtocols;
-
   private SortedSet<SubRange> _notPacketLengths;
-
   private IpSpace _notSrcIps;
-
   private SortedSet<SubRange> _notSrcPorts;
-
   private SortedSet<Protocol> _notSrcProtocols;
-
   private SortedSet<SubRange> _packetLengths;
-
   private IpSpace _srcIps;
-
   private IpSpace _srcOrDstIps;
-
   private SortedSet<SubRange> _srcOrDstPorts;
-
   private SortedSet<Protocol> _srcOrDstProtocols;
-
   private SortedSet<SubRange> _srcPorts;
-
   private SortedSet<Protocol> _srcProtocols;
-
   private SortedSet<FlowState> _states;
-
   private List<TcpFlagsMatchConditions> _tcpFlags;
 
   public HeaderSpace() {
@@ -982,38 +887,26 @@ public class HeaderSpace implements Serializable, Comparable<HeaderSpace> {
     if (!_notDstPorts.isEmpty() && rangesContain(_notDstPorts, flow.getDstPort())) {
       return false;
     }
-    if (!_dstProtocols.isEmpty()) {
-      boolean match = false;
-      for (Protocol dstProtocol : _dstProtocols) {
-        if (dstProtocol.getIpProtocol().equals(flow.getIpProtocol())) {
-          match = true;
-          Integer dstPort = dstProtocol.getPort();
-          if (dstPort != null && !dstPort.equals(flow.getDstPort())) {
-            match = false;
-          }
-          if (match) {
-            break;
-          }
-        }
-      }
-      if (!match) {
-        return false;
-      }
+    if (!_dstProtocols.isEmpty()
+        && _dstProtocols.stream()
+            .noneMatch(
+                dstProtocol ->
+                    dstProtocol.getPort().equals(flow.getDstPort())
+                        && dstProtocol.getIpProtocol().equals(flow.getIpProtocol()))) {
+      return false;
     }
-    if (!_notDstProtocols.isEmpty()) {
-      boolean match = false;
-      for (Protocol notDstProtocol : _notDstProtocols) {
-        if (notDstProtocol.getIpProtocol().equals(flow.getIpProtocol())) {
-          match = true;
-          Integer dstPort = notDstProtocol.getPort();
-          if (dstPort != null && !dstPort.equals(flow.getDstPort())) {
-            match = false;
-          }
-          if (match) {
-            return false;
-          }
-        }
-      }
+    if (_notDstProtocols.stream()
+        .anyMatch(
+            notDstProtocol ->
+                notDstProtocol.getPort().equals(flow.getDstPort())
+                    && notDstProtocol.getIpProtocol().equals(flow.getIpProtocol()))) {
+      return false;
+    }
+    if (!_ecns.isEmpty() && !_ecns.contains(flow.getEcn())) {
+      return false;
+    }
+    if (!_notEcns.isEmpty() && _notEcns.contains(flow.getEcn())) {
+      return false;
     }
     if (!_fragmentOffsets.isEmpty() && !rangesContain(_fragmentOffsets, flow.getFragmentOffset())) {
       return false;
@@ -1057,20 +950,14 @@ public class HeaderSpace implements Serializable, Comparable<HeaderSpace> {
       return false;
     }
     if (!_srcOrDstProtocols.isEmpty()) {
-      boolean match = false;
-      for (Protocol protocol : _srcOrDstProtocols) {
-        if (protocol.getIpProtocol().equals(flow.getIpProtocol())) {
-          match = true;
-          Integer port = protocol.getPort();
-          if (port != null && !port.equals(flow.getDstPort()) && !port.equals(flow.getSrcPort())) {
-            match = false;
-          }
-          if (match) {
-            break;
-          }
-        }
-      }
-      if (!match) {
+      IpProtocol flowProtocol = flow.getIpProtocol();
+      Integer flowDstPort = flow.getDstPort();
+      Integer flowSrcPort = flow.getSrcPort();
+      if (_srcOrDstProtocols.stream()
+          .noneMatch(
+              protocol ->
+                  (protocol.getPort().equals(flowDstPort) || protocol.getPort().equals(flowSrcPort))
+                      && protocol.getIpProtocol().equals(flowProtocol))) {
         return false;
       }
     }
@@ -1086,38 +973,20 @@ public class HeaderSpace implements Serializable, Comparable<HeaderSpace> {
     if (!_notSrcPorts.isEmpty() && rangesContain(_notSrcPorts, flow.getSrcPort())) {
       return false;
     }
-    if (!_srcProtocols.isEmpty()) {
-      boolean match = false;
-      for (Protocol srcProtocol : _srcProtocols) {
-        if (srcProtocol.getIpProtocol().equals(flow.getIpProtocol())) {
-          match = true;
-          Integer srcPort = srcProtocol.getPort();
-          if (srcPort != null && !srcPort.equals(flow.getSrcPort())) {
-            match = false;
-          }
-          if (match) {
-            break;
-          }
-        }
-      }
-      if (!match) {
-        return false;
-      }
+    if (!_srcProtocols.isEmpty()
+        && _srcProtocols.stream()
+            .noneMatch(
+                srcProtocol ->
+                    srcProtocol.getPort().equals(flow.getSrcPort())
+                        && srcProtocol.getIpProtocol().equals(flow.getIpProtocol()))) {
+      return false;
     }
-    if (!_notSrcProtocols.isEmpty()) {
-      boolean match = false;
-      for (Protocol notSrcProtocol : _notSrcProtocols) {
-        if (notSrcProtocol.getIpProtocol().equals(flow.getIpProtocol())) {
-          match = true;
-          Integer srcPort = notSrcProtocol.getPort();
-          if (srcPort != null && !srcPort.equals(flow.getSrcPort())) {
-            match = false;
-          }
-          if (match) {
-            return false;
-          }
-        }
-      }
+    if (_notSrcProtocols.stream()
+        .anyMatch(
+            notSrcProtocol ->
+                notSrcProtocol.getPort().equals(flow.getSrcPort())
+                    && notSrcProtocol.getIpProtocol().equals(flow.getIpProtocol()))) {
+      return false;
     }
     if (!_states.isEmpty() && !_states.contains(flow.getState())) {
       return false;

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/HeaderSpaceMatchesTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/HeaderSpaceMatchesTest.java
@@ -1,0 +1,280 @@
+package org.batfish.datamodel;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import java.util.Map;
+import java.util.function.Function;
+import org.junit.Test;
+
+public class HeaderSpaceMatchesTest {
+
+  private static final Map<String, IpSpace> _namedIpSpaces = ImmutableMap.of();
+
+  private static final int _dscp = 5;
+  private static final Ip _dstIp = Ip.parse("2.2.2.2");
+  private static final int _dstPort = 22;
+  private static final int _ecn = 5;
+  private static final int _fragmentOffset = 5;
+  private static final int _icmpCode = 5;
+  private static final int _icmpType = 5;
+  private static final String _ingressInterface = "ingressIface";
+  private static final String _ingressNode = "ingressNode";
+  private static final String _ingressVrf = "ingressVrf";
+  private static final IpProtocol _ipProtocol = IpProtocol.TCP;
+  private static final int _packetLength = 5;
+  private static final Ip _srcIp = Ip.parse("1.1.1.1");
+  private static final int _srcPort = 22;
+  private static final FlowState _state = FlowState.NEW;
+  private static final String _tag = "tag";
+  private static final TcpFlags _tcpFlags = TcpFlags.builder().setAck(true).build();
+
+  /**
+   * SSH {@link Flow} from 1.1.1.1 to 2.2.2.2 with more or less arbitrary values for other fields
+   */
+  private static final Flow _flow =
+      Flow.builder()
+          .setDscp(_dscp)
+          .setDstIp(_dstIp)
+          .setDstPort(_dstPort)
+          .setEcn(_ecn)
+          .setFragmentOffset(_fragmentOffset)
+          .setIcmpCode(_icmpCode)
+          .setIcmpType(_icmpType)
+          .setIngressInterface(_ingressInterface)
+          .setIngressNode(_ingressNode)
+          .setIngressVrf(_ingressVrf)
+          .setIpProtocol(_ipProtocol)
+          .setPacketLength(_packetLength)
+          .setSrcIp(_srcIp)
+          .setSrcPort(_srcPort)
+          .setState(_state)
+          .setTag(_tag)
+          .setTcpFlags(_tcpFlags)
+          .build();
+
+  @Test
+  public void testEmptyHeaderSpaceMatches() {
+    assertThat(HeaderSpace.builder().build().matches(_flow, _namedIpSpaces), equalTo(true));
+  }
+
+  @Test
+  public void testDscpsMatchers() {
+    testMatches(
+        dscps -> HeaderSpace.builder().setDscps(dscps).build(),
+        dscps -> HeaderSpace.builder().setNotDscps(dscps).build(),
+        ImmutableSet.of(_dscp),
+        ImmutableSet.of(_dscp + 1));
+  }
+
+  @Test
+  public void testDstIpsMatchers() {
+    testMatches(
+        dstIps -> HeaderSpace.builder().setDstIps(dstIps).build(),
+        dstIps -> HeaderSpace.builder().setNotDstIps(dstIps).build(),
+        new IpIpSpace(_dstIp),
+        new IpIpSpace(Ip.parse("3.3.3.3")));
+  }
+
+  @Test
+  public void testDstPortsMatchers() {
+    testMatches(
+        dstPorts -> HeaderSpace.builder().setDstPorts(dstPorts).build(),
+        dstPorts -> HeaderSpace.builder().setNotDstPorts(dstPorts).build(),
+        ImmutableSet.of(new SubRange(0, _dstPort)),
+        ImmutableSet.of(new SubRange(0, _dstPort - 1)));
+  }
+
+  @Test
+  public void testDstProtocolsMatchers() {
+    // _flow is TCP port 22, so SSH
+    testMatches(
+        dstProtocols -> HeaderSpace.builder().setDstProtocols(dstProtocols).build(),
+        dstProtocols -> HeaderSpace.builder().setNotDstProtocols(dstProtocols).build(),
+        ImmutableSet.of(Protocol.SSH),
+        ImmutableSet.of(Protocol.HTTP));
+  }
+
+  @Test
+  public void testEcnsMatchers() {
+    testMatches(
+        ecns -> HeaderSpace.builder().setEcns(ecns).build(),
+        ecns -> HeaderSpace.builder().setNotEcns(ecns).build(),
+        ImmutableSet.of(_ecn),
+        ImmutableSet.of(_ecn + 1));
+  }
+
+  @Test
+  public void testFragmentOffsetsMatchers() {
+    testMatches(
+        fragOffsets -> HeaderSpace.builder().setFragmentOffsets(fragOffsets).build(),
+        fragOffsets -> HeaderSpace.builder().setNotFragmentOffsets(fragOffsets).build(),
+        ImmutableSet.of(new SubRange(0, _fragmentOffset)),
+        ImmutableSet.of(new SubRange(0, _fragmentOffset - 1)));
+  }
+
+  @Test
+  public void testIcmpCodesMatchers() {
+    testMatches(
+        icmpCodes -> HeaderSpace.builder().setIcmpCodes(icmpCodes).build(),
+        icmpCodes -> HeaderSpace.builder().setNotIcmpCodes(icmpCodes).build(),
+        ImmutableSet.of(new SubRange(0, _icmpCode)),
+        ImmutableSet.of(new SubRange(0, _icmpCode - 1)));
+  }
+
+  @Test
+  public void testIcmpTypesMatchers() {
+    testMatches(
+        icmpTypes -> HeaderSpace.builder().setIcmpTypes(icmpTypes).build(),
+        icmpTypes -> HeaderSpace.builder().setNotIcmpTypes(icmpTypes).build(),
+        ImmutableSet.of(new SubRange(0, _icmpType)),
+        ImmutableSet.of(new SubRange(0, _icmpType - 1)));
+  }
+
+  @Test
+  public void testIpProtocolsMatchers() {
+    // _flow is TCP, so notMatching can be UDP
+    testMatches(
+        protocols -> HeaderSpace.builder().setIpProtocols(protocols).build(),
+        protocols -> HeaderSpace.builder().setNotIpProtocols(protocols).build(),
+        ImmutableSet.of(_ipProtocol),
+        ImmutableSet.of(IpProtocol.UDP));
+  }
+
+  @Test
+  public void testPacketLengthsMatchers() {
+    testMatches(
+        packetLengths -> HeaderSpace.builder().setPacketLengths(packetLengths).build(),
+        packetLengths -> HeaderSpace.builder().setNotPacketLengths(packetLengths).build(),
+        ImmutableSet.of(new SubRange(0, _packetLength)),
+        ImmutableSet.of(new SubRange(0, _packetLength - 1)));
+  }
+
+  @Test
+  public void testSrcIpsMatchers() {
+    testMatches(
+        srcIps -> HeaderSpace.builder().setSrcIps(srcIps).build(),
+        srcIps -> HeaderSpace.builder().setNotSrcIps(srcIps).build(),
+        new IpIpSpace(_srcIp),
+        new IpIpSpace(Ip.parse("3.3.3.3")));
+  }
+
+  @Test
+  public void testSrcPortsMatchers() {
+    testMatches(
+        srcPorts -> HeaderSpace.builder().setSrcPorts(srcPorts).build(),
+        srcPorts -> HeaderSpace.builder().setNotSrcPorts(srcPorts).build(),
+        ImmutableSet.of(new SubRange(0, _srcPort)),
+        ImmutableSet.of(new SubRange(0, _srcPort - 1)));
+  }
+
+  @Test
+  public void testSrcProtocolsMatchers() {
+    // _flow is TCP port 22, so SSH
+    testMatches(
+        srcProtocols -> HeaderSpace.builder().setSrcProtocols(srcProtocols).build(),
+        srcProtocols -> HeaderSpace.builder().setNotSrcProtocols(srcProtocols).build(),
+        ImmutableSet.of(Protocol.SSH),
+        ImmutableSet.of(Protocol.HTTP));
+  }
+
+  @Test
+  public void testSrcOrDestIpsMatchers() {
+    // _flow goes from 1.1.1.1 to 2.2.2.2; either should work.
+    HeaderSpace withSrcIpAsSrcOrDst =
+        HeaderSpace.builder().setSrcOrDstIps(new IpIpSpace(_srcIp)).build();
+    HeaderSpace withDstIpAsSrcOrDst =
+        HeaderSpace.builder().setSrcOrDstIps(new IpIpSpace(_dstIp)).build();
+    HeaderSpace withOtherIpAsSrcOrDst =
+        HeaderSpace.builder().setSrcOrDstIps(new IpIpSpace(Ip.parse("3.3.3.3"))).build();
+    assertThat(withSrcIpAsSrcOrDst.matches(_flow, _namedIpSpaces), equalTo(true));
+    assertThat(withDstIpAsSrcOrDst.matches(_flow, _namedIpSpaces), equalTo(true));
+    assertThat(withOtherIpAsSrcOrDst.matches(_flow, _namedIpSpaces), equalTo(false));
+  }
+
+  @Test
+  public void testSrcOrDestPortsMatchers() {
+    // Need a new flow for this because _flow has the same port for src and dst (22).
+    int newDstPort = _dstPort + 1;
+    Flow newDstPortFlow = _flow.toBuilder().setDstPort(newDstPort).build();
+    HeaderSpace withSrcPortAsSrcOrDst =
+        HeaderSpace.builder().setSrcOrDstPorts(ImmutableSet.of(new SubRange(0, _srcPort))).build();
+    HeaderSpace withDstPortAsSrcOrDst =
+        HeaderSpace.builder()
+            .setSrcOrDstPorts(ImmutableSet.of(new SubRange(newDstPort, newDstPort)))
+            .build();
+    HeaderSpace withOtherPortAsSrcOrDst =
+        HeaderSpace.builder()
+            .setSrcOrDstPorts(ImmutableSet.of(new SubRange(0, _srcPort - 1)))
+            .build();
+    assertThat(withSrcPortAsSrcOrDst.matches(newDstPortFlow, _namedIpSpaces), equalTo(true));
+    assertThat(withDstPortAsSrcOrDst.matches(newDstPortFlow, _namedIpSpaces), equalTo(true));
+    assertThat(withOtherPortAsSrcOrDst.matches(newDstPortFlow, _namedIpSpaces), equalTo(false));
+  }
+
+  @Test
+  public void testSrcOrDestProtocolsMatchers() {
+    // Need a new flow for this because _flow has the same protocol for src and dst (SSH).
+    // Set dstPort to port number for HTTP; this should work since HTTP and SSH are both TCP.
+    Flow newDstProtocolFlow = _flow.toBuilder().setDstPort(Protocol.HTTP.getPort()).build();
+    HeaderSpace withSshAsSrcOrDst =
+        HeaderSpace.builder().setSrcOrDstProtocols(ImmutableSet.of(Protocol.SSH)).build();
+    HeaderSpace withHttpAsSrcOrDst =
+        HeaderSpace.builder().setSrcOrDstProtocols(ImmutableSet.of(Protocol.HTTP)).build();
+    HeaderSpace withDnsAsSrcOrDst =
+        HeaderSpace.builder().setSrcOrDstProtocols(ImmutableSet.of(Protocol.DNS)).build();
+    assertThat(withSshAsSrcOrDst.matches(newDstProtocolFlow, _namedIpSpaces), equalTo(true));
+    assertThat(withHttpAsSrcOrDst.matches(newDstProtocolFlow, _namedIpSpaces), equalTo(true));
+    assertThat(withDnsAsSrcOrDst.matches(newDstProtocolFlow, _namedIpSpaces), equalTo(false));
+  }
+
+  /**
+   * Tests {@link HeaderSpace#matches(Flow, Map)} for matching a given property of {@link Flow}.
+   * Tests that:
+   *
+   * <ul>
+   *   <li>A HeaderSpace that is supposed to match flows with value X for the property under test
+   *       does match a flow with value X for that property
+   *   <li>A HeaderSpace that is supposed to match flows with value Y for the property under test
+   *       does NOT match flows with value X for that property
+   *   <li>A HeaderSpace that is supposed to match flows that do NOT have value X for the property
+   *       under test does NOT match flows with value X for that property
+   *   <li>A HeaderSpace that is supposed to match flows that do NOT have value X for the property
+   *       under test does match flows with value Y for that property
+   * </ul>
+   *
+   * @param matchingHeaderSpaceGenerator Function to generate a HeaderSpace that matches flows with
+   *     a given value for the property being tested (e.g., {@code x ->
+   *     HeaderSpace.builder().setDstIps(x).build()})
+   * @param notMatchingHeaderSpaceGenerator Function to generate a HeaderSpace that matches flows
+   *     that do NOT have a given value for the property being tested (e.g., {@code x ->
+   *     HeaderSpace.builder().setNotDstIps(x).build()})
+   * @param matching Value for the property under test that should match {@link #_flow}
+   * @param notMatching Value for the property under test that should NOT match {@link #_flow}
+   * @param <T> Type of the HeaderSpace property under test (e.g., if testing dstIps, it would be an
+   *     {@link IpSpace})
+   */
+  private static <T> void testMatches(
+      Function<T, HeaderSpace> matchingHeaderSpaceGenerator,
+      Function<T, HeaderSpace> notMatchingHeaderSpaceGenerator,
+      T matching,
+      T notMatching) {
+    // If HeaderSpace requires flow to match property that does match, matches() == true
+    HeaderSpace hs = matchingHeaderSpaceGenerator.apply(matching);
+    assertThat(hs.matches(_flow, _namedIpSpaces), equalTo(true));
+
+    // If HeaderSpace requires flow to match property that does not match, matches() == false
+    hs = matchingHeaderSpaceGenerator.apply(notMatching);
+    assertThat(hs.matches(_flow, _namedIpSpaces), equalTo(false));
+
+    // If HeaderSpace requires flow not to match property that does match, matches() == false
+    hs = notMatchingHeaderSpaceGenerator.apply(matching);
+    assertThat(hs.matches(_flow, _namedIpSpaces), equalTo(false));
+
+    // If HeaderSpace requires flow not to match property that does not match, matches() == true
+    hs = notMatchingHeaderSpaceGenerator.apply(notMatching);
+    assertThat(hs.matches(_flow, _namedIpSpaces), equalTo(true));
+  }
+}


### PR DESCRIPTION
- Ensure all the appropriate match conditions in HeaderSpace are actually checked in `matches()`
- Clean up implementation of `matches()` for protocol matching
- Clear out a bunch of white space