### PR TITLE
output suppressed exceptions during parse tree walk with haltOnParseError

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/BatfishParseTreeWalker.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/BatfishParseTreeWalker.java
@@ -21,8 +21,7 @@ public class BatfishParseTreeWalker extends ParseTreeWalker {
       ctx.enterRule(listener);
     } catch (Exception e) {
       throw new BatfishException(
-          String.format("Exception walking line '%s': %s", ctx.getText(), e.getMessage()),
-          e.getCause());
+          String.format("Exception walking line '%s': %s", ctx.getText(), e.getMessage()), e);
     }
   }
 
@@ -34,8 +33,7 @@ public class BatfishParseTreeWalker extends ParseTreeWalker {
       listener.exitEveryRule(ctx);
     } catch (Exception e) {
       throw new BatfishException(
-          String.format("Exception walking line '%s': %s", ctx.getText(), e.getMessage()),
-          e.getCause());
+          String.format("Exception walking line '%s': %s", ctx.getText(), e.getMessage()), e);
     }
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/ThrowableMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/ThrowableMatchers.java
@@ -1,0 +1,30 @@
+package org.batfish.common.util;
+
+import com.google.common.base.Throwables;
+import javax.annotation.Nonnull;
+import org.hamcrest.FeatureMatcher;
+import org.hamcrest.Matcher;
+
+public final class ThrowableMatchers {
+  private static final class HasStackTrace extends FeatureMatcher<Throwable, String> {
+    public HasStackTrace(@Nonnull Matcher<? super String> subMatcher) {
+      super(subMatcher, "A Throwable with stackTrace:", "stackTrace:");
+    }
+
+    @Override
+    protected String featureValueOf(Throwable actual) {
+      return Throwables.getStackTraceAsString(actual);
+    }
+  }
+
+  /**
+   * A matcher that matches a {@link Throwable} whose stack trace message is matched by the provided
+   * {@code subMatcher}.
+   */
+  public static @Nonnull Matcher<Throwable> hasStackTrace(
+      @Nonnull Matcher<? super String> subMatcher) {
+    return new HasStackTrace(subMatcher);
+  }
+
+  private ThrowableMatchers() {}
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/grammar/BatfishParseTreeWalkerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/grammar/BatfishParseTreeWalkerTest.java
@@ -1,9 +1,8 @@
 package org.batfish.grammar;
 
+import static org.batfish.common.util.ThrowableMatchers.hasStackTrace;
 import static org.hamcrest.Matchers.containsString;
 
-import com.google.common.base.Throwables;
-import javax.annotation.Nonnull;
 import org.antlr.v4.runtime.Parser;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.RuleContext;
@@ -15,8 +14,6 @@ import org.antlr.v4.runtime.tree.ParseTreeVisitor;
 import org.antlr.v4.runtime.tree.RuleNode;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.batfish.common.BatfishException;
-import org.hamcrest.FeatureMatcher;
-import org.hamcrest.Matcher;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -123,22 +120,6 @@ public final class BatfishParseTreeWalkerTest {
     public String getText() {
       return _text;
     }
-  }
-
-  private static final class HasStackTrace extends FeatureMatcher<Throwable, String> {
-    public HasStackTrace(@Nonnull Matcher<? super String> subMatcher) {
-      super(subMatcher, "A Throwable with stackTrace:", "stackTrace:");
-    }
-
-    @Override
-    protected String featureValueOf(Throwable actual) {
-      return Throwables.getStackTraceAsString(actual);
-    }
-  }
-
-  private static @Nonnull Matcher<Throwable> hasStackTrace(
-      @Nonnull Matcher<? super String> subMatcher) {
-    return new HasStackTrace(subMatcher);
   }
 
   private static final String LINE_TEXT = "Line text";

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -3378,7 +3378,12 @@ public class Batfish extends PluginConsumer implements IBatfish {
 
     if (_settings.getHaltOnParseError()
         && parseResults.stream().anyMatch(r -> r.getFailureCause() != null)) {
-      throw new BatfishException("Exiting due to parser errors");
+      BatfishException e = new BatfishException("Exiting due to parser errors");
+      parseResults.stream()
+          .map(ParseVendorConfigurationResult::getFailureCause)
+          .filter(Objects::nonNull)
+          .forEach(e::addSuppressed);
+      throw e;
     }
 
     _logger.infof(

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
@@ -1,5 +1,6 @@
 package org.batfish.main;
 
+import static org.batfish.common.util.ThrowableMatchers.hasStackTrace;
 import static org.batfish.main.Batfish.postProcessInterfaceDependencies;
 import static org.batfish.main.Batfish.readAllFiles;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -725,5 +726,22 @@ public class BatfishTest {
         name -> assertThat(c1.getAllInterfaces().get(name).getActive(), equalTo(true)));
     inactiveIfaces.forEach(
         name -> assertThat(c1.getAllInterfaces().get(name).getActive(), equalTo(false)));
+  }
+
+  @Test
+  public void testHaltOnParseError() throws IOException {
+    String hostname = "r1";
+    Batfish batfish =
+        BatfishTestUtils.getBatfishFromTestrigText(
+            TestrigText.builder()
+                .setConfigurationText(
+                    ImmutableMap.of(
+                        hostname,
+                        "!RANCID-CONTENT-TYPE: cisco\nhostname r1\ntotally-invalid-text\n"))
+                .build(),
+            _folder);
+    batfish.getSettings().setHaltOnParseError(true);
+    _thrown.expect(hasStackTrace(containsString("Error parsing configuration file")));
+    batfish.loadConfigurations();
   }
 }


### PR DESCRIPTION
Before:
```
org.batfish.common.BatfishException: Exiting due to parser errors
	at org.batfish.main.Batfish.serializeNetworkConfigs(Batfish.java:3381)
	at org.batfish.main.Batfish.serializeVendorConfigs(Batfish.java:3537)
	at org.batfish.main.Batfish.repairVendorConfigurations(Batfish.java:2955)
	at org.batfish.main.Batfish.loadParseVendorConfigurationAnswerElement(Batfish.java:1897)
	at org.batfish.main.Batfish.loadParseVendorConfigurationAnswerElement(Batfish.java:1882)
	at org.batfish.main.Batfish.repairConfigurations(Batfish.java:2836)
	at org.batfish.main.Batfish.parseConfigurationsAndApplyEnvironment(Batfish.java:1692)
	at org.batfish.main.Batfish.loadConfigurations(Batfish.java:1682)
	at org.batfish.main.Batfish.loadConfigurations(Batfish.java:1639)
	at org.batfish.main.BatfishTestUtils.parseTextConfigs(BatfishTestUtils.java:311)
	at org.batfish.grammar.f5_bigip_structured.F5BigipStructuredGrammarTest.parseTextConfigs(F5BigipStructuredGrammarTest.java:59)
	at org.batfish.grammar.f5_bigip_structured.F5BigipStructuredGrammarTest.parseConfig(F5BigipStructuredGrammarTest.java:52)
	at org.batfish.grammar.f5_bigip_structured.F5BigipStructuredGrammarTest.testPrefixList(F5BigipStructuredGrammarTest.java:82)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:48)
	at org.junit.rules.ExpectedException$ExpectedExceptionStatement.evaluate(ExpectedException.java:239)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.eclipse.jdt.internal.junit4.runner.JUnit4TestReference.run(JUnit4TestReference.java:86)
	at org.eclipse.jdt.internal.junit.runner.TestExecution.run(TestExecution.java:38)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:538)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:760)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:460)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.main(RemoteTestRunner.java:206)
```

After:
```
org.batfish.common.BatfishException: Exiting due to parser errors
	at org.batfish.main.Batfish.serializeNetworkConfigs(Batfish.java:3381)
	at org.batfish.main.Batfish.serializeVendorConfigs(Batfish.java:3542)
	at org.batfish.main.Batfish.repairVendorConfigurations(Batfish.java:2955)
	at org.batfish.main.Batfish.loadParseVendorConfigurationAnswerElement(Batfish.java:1897)
	at org.batfish.main.Batfish.loadParseVendorConfigurationAnswerElement(Batfish.java:1882)
	at org.batfish.main.Batfish.repairConfigurations(Batfish.java:2836)
	at org.batfish.main.Batfish.parseConfigurationsAndApplyEnvironment(Batfish.java:1692)
	at org.batfish.main.Batfish.loadConfigurations(Batfish.java:1682)
	at org.batfish.main.Batfish.loadConfigurations(Batfish.java:1639)
	at org.batfish.main.BatfishTestUtils.parseTextConfigs(BatfishTestUtils.java:311)
	at org.batfish.grammar.f5_bigip_structured.F5BigipStructuredGrammarTest.parseTextConfigs(F5BigipStructuredGrammarTest.java:59)
	at org.batfish.grammar.f5_bigip_structured.F5BigipStructuredGrammarTest.parseConfig(F5BigipStructuredGrammarTest.java:52)
	at org.batfish.grammar.f5_bigip_structured.F5BigipStructuredGrammarTest.testPrefixList(F5BigipStructuredGrammarTest.java:82)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:48)
	at org.junit.rules.ExpectedException$ExpectedExceptionStatement.evaluate(ExpectedException.java:239)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.eclipse.jdt.internal.junit4.runner.JUnit4TestReference.run(JUnit4TestReference.java:86)
	at org.eclipse.jdt.internal.junit.runner.TestExecution.run(TestExecution.java:38)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:538)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:760)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:460)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.main(RemoteTestRunner.java:206)
	Suppressed: org.batfish.common.BatfishException: Error parsing configuration file: 'configs/f5_bigip_structured_net_routing_prefix_list'
		at org.batfish.job.ParseVendorConfigurationJob.parse(ParseVendorConfigurationJob.java:395)
		at org.batfish.main.Batfish.getOrParse(Batfish.java:3309)
		at org.batfish.main.Batfish.lambda$91(Batfish.java:3372)
		at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
		at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1382)
		at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481)
		at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)
		at java.util.stream.ReduceOps$ReduceTask.doLeaf(ReduceOps.java:747)
		at java.util.stream.ReduceOps$ReduceTask.doLeaf(ReduceOps.java:721)
		at java.util.stream.AbstractTask.compute(AbstractTask.java:316)
		at java.util.concurrent.CountedCompleter.exec(CountedCompleter.java:731)
		at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
		at java.util.concurrent.ForkJoinTask.doInvoke(ForkJoinTask.java:401)
		at java.util.concurrent.ForkJoinTask.invoke(ForkJoinTask.java:734)
		at java.util.stream.ReduceOps$ReduceOp.evaluateParallel(ReduceOps.java:714)
		at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:233)
		at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:499)
		at org.batfish.main.Batfish.serializeNetworkConfigs(Batfish.java:3376)
		... 38 more
	Caused by: org.batfish.common.BatfishException: Exception walking line 'prefixdead:beef::/64
': Invalid ip string: "dead:beef::"
		at org.batfish.grammar.BatfishParseTreeWalker.exitRule(BatfishParseTreeWalker.java:36)
		at org.antlr.v4.runtime.tree.ParseTreeWalker.walk(ParseTreeWalker.java:30)
		at org.antlr.v4.runtime.tree.ParseTreeWalker.walk(ParseTreeWalker.java:28)
		at org.antlr.v4.runtime.tree.ParseTreeWalker.walk(ParseTreeWalker.java:28)
		at org.antlr.v4.runtime.tree.ParseTreeWalker.walk(ParseTreeWalker.java:28)
		at org.antlr.v4.runtime.tree.ParseTreeWalker.walk(ParseTreeWalker.java:28)
		at org.antlr.v4.runtime.tree.ParseTreeWalker.walk(ParseTreeWalker.java:28)
		at org.antlr.v4.runtime.tree.ParseTreeWalker.walk(ParseTreeWalker.java:28)
		at org.antlr.v4.runtime.tree.ParseTreeWalker.walk(ParseTreeWalker.java:28)
		at org.batfish.grammar.f5_bigip_structured.F5BigipStructuredControlPlaneExtractor.processParseTree(F5BigipStructuredControlPlaneExtractor.java:35)
		at org.batfish.job.ParseVendorConfigurationJob.parseFile(ParseVendorConfigurationJob.java:324)
		at org.batfish.job.ParseVendorConfigurationJob.parse(ParseVendorConfigurationJob.java:388)
		... 55 more
```