### PR TITLE
Fix and test loopback, tunnel delay and bandwidth

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/eigrp/EigrpMetric.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/eigrp/EigrpMetric.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 import java.util.stream.LongStream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNullableByDefault;
 
 /** Handles EIGRP metric information. */
 public class EigrpMetric implements Serializable {
@@ -241,11 +242,12 @@ public class EigrpMetric implements Serializable {
     }
   }
 
+  @ParametersAreNullableByDefault
   public static class Builder {
     @Nullable private Double _bandwidth;
+    @Nullable private Double _defaultBandwidth;
+    @Nullable private Double _defaultDelay;
     @Nullable private Double _delay;
-    private Double _defaultDelay;
-    private Double _defaultBandwidth;
     private EigrpProcessMode _mode;
 
     @Nullable
@@ -259,27 +261,27 @@ public class EigrpMetric implements Serializable {
       return new EigrpMetric(bandwidth, delay, _mode);
     }
 
-    public Builder setBandwidth(@Nullable Double bandwidth) {
+    public Builder setBandwidth(Double bandwidth) {
       _bandwidth = bandwidth;
       return this;
     }
 
-    public Builder setDefaultDelay(double defaultDelay) {
+    public Builder setDefaultDelay(Double defaultDelay) {
       _defaultDelay = defaultDelay;
       return this;
     }
 
-    public Builder setDefaultBandwidth(double defaultBandwidth) {
+    public Builder setDefaultBandwidth(Double defaultBandwidth) {
       _defaultBandwidth = defaultBandwidth;
       return this;
     }
 
-    public Builder setDelay(@Nullable Double delay) {
+    public Builder setDelay(Double delay) {
       _delay = delay;
       return this;
     }
 
-    public Builder setMode(EigrpProcessMode mode) {
+    public Builder setMode(@Nonnull EigrpProcessMode mode) {
       _mode = mode;
       return this;
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/Interface.java
@@ -46,18 +46,18 @@ public class Interface implements Serializable {
 
   private static final double DEFAULT_TEN_GIGABIT_ETHERNET_SPEED = 10E9D;
 
-  /** Loopback delay for IOS */
+  /** Loopback delay in picoseconds for IOS */
   private static final double LOOPBACK_IOS_DELAY = 5E9D;
 
   /**
-   * Tunnel bandwidth for IOS (checked in IOS 16.4)
+   * Tunnel bandwidth in bps for IOS (checked in IOS 16.4)
    *
    * <p>See https://bst.cloudapps.cisco.com/bugsearch/bug/CSCse69736
    */
   private static final double TUNNEL_IOS_BANDWIDTH = 100E3D;
 
   /**
-   * Tunnel delay for IOS (checked in IOS 16.4)
+   * Tunnel delay in picoseconds for IOS (checked in IOS 16.4)
    *
    * <p>See https://bst.cloudapps.cisco.com/bugsearch/bug/CSCse69736
    */
@@ -242,6 +242,7 @@ public class Interface implements Serializable {
 
   private @Nullable Double _speed;
 
+  /** Returns the default interface delay in picoseconds for the given {@code format}. */
   public static double getDefaultDelay(String name, ConfigurationFormat format) {
     if (format == ConfigurationFormat.CISCO_IOS && name.startsWith("Loopback")) {
       // TODO Cisco NX whitepaper says to use the formula, not this value. Confirm?

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/Interface.java
@@ -46,6 +46,10 @@ public class Interface implements Serializable {
 
   private static final double DEFAULT_TEN_GIGABIT_ETHERNET_SPEED = 10E9D;
 
+  private static final double DEFAULT_TUNNEL_BANDWIDTH = 1E5D;
+
+  private static final double DEFAULT_TUNNEL_DELAY = 5E10D;
+
   /** Loopback delay for IOS */
   private static final double LOOPBACK_IOS_DELAY = 5E9D;
 
@@ -64,6 +68,8 @@ public class Interface implements Serializable {
     } else if (name.startsWith("Port-Channel")) {
       // Derived from member interfaces
       return null;
+    } else if (name.startsWith("Tunnel")) {
+      return DEFAULT_TUNNEL_BANDWIDTH;
     } else {
       // Use default bandwidth for other interface types that have no speed
       return DEFAULT_INTERFACE_BANDWIDTH;
@@ -232,8 +238,12 @@ public class Interface implements Serializable {
       // Enhanced Interior Gateway Routing Protocol (EIGRP) Wide Metrics White Paper
       return LOOPBACK_IOS_DELAY;
     }
-    double bandwidth = getDefaultBandwidth(name, format);
-    if (bandwidth == 0D) {
+    if (name.startsWith("Tunnel")) {
+      return DEFAULT_TUNNEL_DELAY;
+    }
+
+    Double bandwidth = getDefaultBandwidth(name, format);
+    if (bandwidth == null) {
       // TODO EIGRP will not use this interface because cost is proportional to bandwidth^-1
       return 0D;
     }
@@ -242,8 +252,7 @@ public class Interface implements Serializable {
      * Delay is only relevant on routers that support EIGRP (Cisco).
      *
      * When bandwidth > 1Gb, this formula is used. The interface may report a different value.
-     * For bandwidths < 1Gb, the delay is interface type-specific. However, all of the specific cases
-     * handled in getDefaultBandwidth also match this formula.
+     * For bandwidths < 1Gb, the delay may be interface type-specific.
      * See https://tools.ietf.org/html/rfc7868#section-5.6.1.2
      */
     return 1E16 / bandwidth;

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/Interface.java
@@ -243,7 +243,8 @@ public class Interface implements Serializable {
   private @Nullable Double _speed;
 
   /** Returns the default interface delay in picoseconds for the given {@code format}. */
-  public static double getDefaultDelay(String name, ConfigurationFormat format) {
+  @Nullable
+  public static Double getDefaultDelay(String name, ConfigurationFormat format) {
     if (format == ConfigurationFormat.CISCO_IOS && name.startsWith("Loopback")) {
       // TODO Cisco NX whitepaper says to use the formula, not this value. Confirm?
       // Enhanced Interior Gateway Routing Protocol (EIGRP) Wide Metrics White Paper
@@ -254,9 +255,8 @@ public class Interface implements Serializable {
     }
 
     Double bandwidth = getDefaultBandwidth(name, format);
-    if (bandwidth == null) {
-      // TODO EIGRP will not use this interface because cost is proportional to bandwidth^-1
-      return 0D;
+    if (bandwidth == null || bandwidth == 0D) {
+      return null;
     }
 
     /*

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/Interface.java
@@ -46,12 +46,22 @@ public class Interface implements Serializable {
 
   private static final double DEFAULT_TEN_GIGABIT_ETHERNET_SPEED = 10E9D;
 
-  private static final double DEFAULT_TUNNEL_BANDWIDTH = 1E5D;
-
-  private static final double DEFAULT_TUNNEL_DELAY = 5E10D;
-
   /** Loopback delay for IOS */
   private static final double LOOPBACK_IOS_DELAY = 5E9D;
+
+  /**
+   * Tunnel bandwidth for IOS (checked in IOS 16.4)
+   *
+   * <p>See https://bst.cloudapps.cisco.com/bugsearch/bug/CSCse69736
+   */
+  private static final double TUNNEL_IOS_BANDWIDTH = 100E3D;
+
+  /**
+   * Tunnel delay for IOS (checked in IOS 16.4)
+   *
+   * <p>See https://bst.cloudapps.cisco.com/bugsearch/bug/CSCse69736
+   */
+  private static final double TUNNEL_IOS_DELAY = 50E9D;
 
   private static final long serialVersionUID = 1L;
 
@@ -68,8 +78,8 @@ public class Interface implements Serializable {
     } else if (name.startsWith("Port-Channel")) {
       // Derived from member interfaces
       return null;
-    } else if (name.startsWith("Tunnel")) {
-      return DEFAULT_TUNNEL_BANDWIDTH;
+    } else if (format == ConfigurationFormat.CISCO_IOS && name.startsWith("Tunnel")) {
+      return TUNNEL_IOS_BANDWIDTH;
     } else {
       // Use default bandwidth for other interface types that have no speed
       return DEFAULT_INTERFACE_BANDWIDTH;
@@ -238,8 +248,8 @@ public class Interface implements Serializable {
       // Enhanced Interior Gateway Routing Protocol (EIGRP) Wide Metrics White Paper
       return LOOPBACK_IOS_DELAY;
     }
-    if (name.startsWith("Tunnel")) {
-      return DEFAULT_TUNNEL_DELAY;
+    if (format == ConfigurationFormat.CISCO_IOS && name.startsWith("Tunnel")) {
+      return TUNNEL_IOS_DELAY;
     }
 
     Double bandwidth = getDefaultBandwidth(name, format);

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -1527,6 +1527,14 @@ public class CiscoGrammarTest {
         hasInterface(
             "FastEthernet0/1",
             hasEigrp(EigrpInterfaceSettingsMatchers.hasEigrpMetric(hasDelay(1E8)))));
+    assertThat(
+        c,
+        hasInterface(
+            "Loopback0", hasEigrp(EigrpInterfaceSettingsMatchers.hasEigrpMetric(hasDelay(5E9)))));
+    assertThat(
+        c,
+        hasInterface(
+            "Tunnel0", hasEigrp(EigrpInterfaceSettingsMatchers.hasEigrpMetric(hasDelay(5E10)))));
   }
 
   @Test
@@ -1539,6 +1547,8 @@ public class CiscoGrammarTest {
     assertThat(c, hasInterface("GigabitEthernet0/1", hasSpeed(1E9D)));
     assertThat(c, hasInterface("GigabitEthernet0/2", hasBandwidth(100E6D)));
     assertThat(c, hasInterface("GigabitEthernet0/2", hasSpeed(100E6D)));
+    assertThat(c, hasInterface("Loopback0", hasBandwidth(8E9D)));
+    assertThat(c, hasInterface("Tunnel0", hasBandwidth(1E5D)));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-interface-delay
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-interface-delay
@@ -14,6 +14,12 @@ interface FastEthernet0/1
  ip address 10.0.2.1 255.255.255.0
  no shutdown
 !
+interface Loopback0
+ ip address 10.0.3.1 255.255.255.255
+!
+interface Tunnel0
+ ip address 10.0.4.1 255.255.255.0
+!
 router eigrp 1
  network 10.0.0.0 
 !

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-interface-speed
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-interface-speed
@@ -9,4 +9,7 @@ interface GigabitEthernet0/1
 interface GigabitEthernet0/2
  speed 100
 !
+interface Loopback0
+!
+interface Tunnel0
 !

--- a/tests/aws/nodes-example-aws.ref
+++ b/tests/aws/nodes-example-aws.ref
@@ -843,7 +843,7 @@
             ],
             "allowedVlans" : "",
             "autostate" : true,
-            "bandwidth" : 1.0E12,
+            "bandwidth" : 100000.0,
             "declaredNames" : [
               "Tunnel1"
             ],
@@ -872,7 +872,7 @@
             ],
             "allowedVlans" : "",
             "autostate" : true,
-            "bandwidth" : 1.0E12,
+            "bandwidth" : 100000.0,
             "declaredNames" : [
               "Tunnel2"
             ],

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -7411,7 +7411,7 @@
             "active" : true,
             "allowedVlans" : "",
             "autostate" : true,
-            "bandwidth" : 1.0E12,
+            "bandwidth" : 100000.0,
             "declaredNames" : [
               "tunnel0"
             ],


### PR DESCRIPTION
Fix delay and bandwidth for tunnel interfaces on Cisco and add tests. Add tests for loopback delay and bandwidth.

@dhalperi 