### PR TITLE
Simplify PrefixTrieMultiMap and check invariants

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Prefix.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Prefix.java
@@ -106,6 +106,21 @@ public final class Prefix implements Comparable<Prefix>, Serializable {
     return create(address, mask.numSubnetBits());
   }
 
+  /** Return the longest prefix that contains both input prefixes. */
+  public static Prefix longestCommonPrefix(Prefix p1, Prefix p2) {
+    if (p1.containsPrefix(p2)) {
+      return p1;
+    }
+    if (p2.containsPrefix(p1)) {
+      return p2;
+    }
+    long l1 = p1.getStartIp().asLong();
+    long l2 = p2.getStartIp().asLong();
+    long oneAtFirstDifferentBit = Long.highestOneBit(l1 ^ l2);
+    int lengthInCommon = MAX_PREFIX_LENGTH - 1 - Long.numberOfTrailingZeros(oneAtFirstDifferentBit);
+    return Prefix.create(Ip.create(l1), lengthInCommon);
+  }
+
   @Override
   public int compareTo(Prefix rhs) {
     int ret = _ip.compareTo(rhs._ip);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
@@ -66,6 +66,7 @@ public final class PrefixTrieMultiMap<DataT> implements Serializable {
   }
 
   private void setLeft(@Nullable PrefixTrieMultiMap<DataT> left) {
+    assert left == null || legalLeftChildPrefix(_prefix, left._prefix);
     _left = left;
   }
 
@@ -76,6 +77,7 @@ public final class PrefixTrieMultiMap<DataT> implements Serializable {
   }
 
   private void setRight(@Nullable PrefixTrieMultiMap<DataT> right) {
+    assert right == null || legalRightChildPrefix(_prefix, right._prefix);
     _right = right;
   }
 
@@ -90,9 +92,13 @@ public final class PrefixTrieMultiMap<DataT> implements Serializable {
   /**
    * Retrieve an immutable copy of elements for the given prefix (anywhere in the subtree). Returns
    * empty set if the prefix is not in the subtree.
+   *
+   * @throws IllegalArgumentException if {@param p} is not contained in the {@link Prefix} of this
+   *     subtree.
    */
   @Nonnull
   public Set<DataT> getElements(Prefix p) {
+    checkArgument(_prefix.containsPrefix(p), "Prefix %s does not belong to subtree %s", p, this);
     PrefixTrieMultiMap<DataT> node = findNode(p);
     return node == null ? ImmutableSet.of() : node.getElements();
   }
@@ -103,13 +109,9 @@ public final class PrefixTrieMultiMap<DataT> implements Serializable {
    * @throws IllegalArgumentException if the given prefix does not belong in this subtree
    */
   public boolean add(Prefix p, DataT e) {
+    checkArgument(_prefix.containsPrefix(p), "Prefix %s does not belong to subtree %s", p, this);
     PrefixTrieMultiMap<DataT> node = findOrCreateNode(p);
-    return node.add(e);
-  }
-
-  /** Add an element to <i>this</i> node */
-  private boolean add(DataT e) {
-    return _elements.add(e);
+    return node._elements.add(e);
   }
 
   /**
@@ -118,6 +120,7 @@ public final class PrefixTrieMultiMap<DataT> implements Serializable {
    * @throws IllegalArgumentException if the given prefix does not belong in this subtree
    */
   public boolean addAll(Prefix p, Collection<DataT> elements) {
+    checkArgument(_prefix.containsPrefix(p), "Prefix %s does not belong to subtree %s", p, this);
     PrefixTrieMultiMap<DataT> node = findOrCreateNode(p);
     return node.addAll(elements);
   }
@@ -134,6 +137,7 @@ public final class PrefixTrieMultiMap<DataT> implements Serializable {
    * @param e element to remove
    */
   public boolean remove(Prefix p, DataT e) {
+    checkArgument(_prefix.containsPrefix(p), "Prefix %s does not belong to subtree %s", p, this);
     PrefixTrieMultiMap<DataT> node = findNode(p);
     return node != null && node.remove(e);
   }
@@ -143,8 +147,13 @@ public final class PrefixTrieMultiMap<DataT> implements Serializable {
     return _elements.remove(e);
   }
 
-  /** Remove all elements associated with prefix {@code p} */
+  /**
+   * Remove all elements associated with prefix {@code p}
+   *
+   * @throws IllegalArgumentException if the given prefix does not belong to this subtree
+   */
   public boolean clear(Prefix p) {
+    checkArgument(_prefix.containsPrefix(p), "Prefix %s does not belong to subtree %s", p, this);
     PrefixTrieMultiMap<DataT> node = findNode(p);
     return node != null && node.clear();
   }
@@ -158,6 +167,7 @@ public final class PrefixTrieMultiMap<DataT> implements Serializable {
 
   /** Replace all elements associated with prefix {@code p} with a given element */
   public boolean replaceAll(Prefix p, DataT e) {
+    checkArgument(_prefix.containsPrefix(p), "Prefix %s does not belong to subtree %s", p, this);
     PrefixTrieMultiMap<DataT> node = findNode(p);
     return node != null && node.replaceAll(e);
   }
@@ -165,11 +175,12 @@ public final class PrefixTrieMultiMap<DataT> implements Serializable {
   /** Replace all elements stored at <i>this</i> node with a given element */
   private boolean replaceAll(DataT e) {
     _elements.clear();
-    return add(e);
+    return _elements.add(e);
   }
 
   /** Replace all elements associated with prefix {@code p} with a given collection of elements */
   public boolean replaceAll(Prefix p, Collection<DataT> e) {
+    checkArgument(_prefix.containsPrefix(p), "Prefix %s does not belong to subtree %s", p, this);
     PrefixTrieMultiMap<DataT> node = findNode(p);
     return node == null || node.replaceAll(e);
   }
@@ -183,18 +194,116 @@ public final class PrefixTrieMultiMap<DataT> implements Serializable {
   /** Find or create a node for a given prefix (must be an exact match) */
   @Nonnull
   private PrefixTrieMultiMap<DataT> findOrCreateNode(Prefix prefix) {
-    return findOrCreateNode(prefix, prefix.getStartIp().asLong(), 0);
+    assert _prefix.containsPrefix(prefix);
+
+    PrefixTrieMultiMap<DataT> node = findLongestPrefixMatchNode(this, prefix);
+    return node._prefix.equals(prefix) ? node : node.createChild(prefix);
   }
 
-  /** Find the node for a given prefix (must be an exact match) */
+  private @Nonnull PrefixTrieMultiMap<DataT> createChild(Prefix prefix) {
+    assert _prefix.containsPrefix(prefix);
+    boolean currentBit =
+        Ip.getBitAtPosition(prefix.getStartIp().asLong(), _prefix.getPrefixLength());
+
+    PrefixTrieMultiMap<DataT> node = new PrefixTrieMultiMap<>(prefix);
+    if (currentBit) {
+      _right = combine(node, _right);
+    } else {
+      _left = combine(node, _left);
+    }
+    return node;
+  }
+
+  /**
+   * Combine two nodes into a tree -- a newly created node, and an existing node. The existing node
+   * cannot be the parent of the new node.
+   */
+  private @Nonnull PrefixTrieMultiMap<DataT> combine(
+      @Nonnull PrefixTrieMultiMap<DataT> newNode, @Nullable PrefixTrieMultiMap<DataT> oldNode) {
+    Prefix newPrefix = newNode._prefix;
+    assert oldNode == null || !oldNode.getPrefix().containsPrefix(newPrefix);
+
+    // No existing node, newNode is the tree
+    if (oldNode == null) {
+      return newNode;
+    }
+
+    /* If the newNode's prefix contains the oldNode's prefix, the existing node is a child of
+     * the newNode.
+     */
+    Prefix oldPrefix = oldNode._prefix;
+    if (newPrefix.containsPrefix(oldPrefix)) {
+      boolean currentBit = Ip.getBitAtPosition(oldPrefix.getStartIp(), newPrefix.getPrefixLength());
+      if (currentBit) {
+        newNode._right = oldNode;
+      } else {
+        newNode._left = oldNode;
+      }
+      return newNode;
+    }
+
+    /* Find the least-upper-bound of the two prefixes, i.e. the one for which the newNode branches
+     * one way and the oldNode branches the other. This is always the newNode's prefix with
+     * a length one bit shorter.
+     */
+    Prefix lub = longestCommonPrefix(newPrefix, oldPrefix);
+    PrefixTrieMultiMap<DataT> parent = new PrefixTrieMultiMap<>(lub);
+
+    boolean newNodeRight = Ip.getBitAtPosition(newPrefix.getStartIp(), lub.getPrefixLength());
+    if (newNodeRight) {
+      parent.setRight(newNode);
+      parent.setLeft(oldNode);
+    } else {
+      parent.setRight(oldNode);
+      parent.setLeft(newNode);
+    }
+    return parent;
+  }
+
+  /** Return the longest prefix that contains both input prefixes. */
+  static Prefix longestCommonPrefix(Prefix p1, Prefix p2) {
+    long l1 = p1.getStartIp().asLong();
+    long l2 = p2.getStartIp().asLong();
+
+    int minLength = Integer.min(p1.getPrefixLength(), p2.getPrefixLength());
+
+    // non-wildcard bit mask for /0 prefixes
+    long mask = -1L ^ 0xFFFFFFFFL;
+    mask = mask >> 1; // now for /1 prefixes
+
+    int len = 0;
+    while (len < minLength && (l1 & mask) == (l2 & mask)) {
+      mask = mask >> 1;
+      len++;
+    }
+
+    return Prefix.create(Ip.create(l1), len);
+  }
+
+  @VisibleForTesting
+  static boolean legalLeftChildPrefix(Prefix parentPrefix, Prefix childPrefix) {
+    return parentPrefix.containsPrefix(childPrefix)
+        && !Ip.getBitAtPosition(childPrefix.getStartIp(), parentPrefix.getPrefixLength());
+  }
+
+  @VisibleForTesting
+  static boolean legalRightChildPrefix(Prefix parentPrefix, Prefix childPrefix) {
+    return parentPrefix.containsPrefix(childPrefix)
+        && Ip.getBitAtPosition(childPrefix.getStartIp(), parentPrefix.getPrefixLength());
+  }
+
+  /** Find the node for a given prefix (must be an exact match). */
   @Nullable
   private PrefixTrieMultiMap<DataT> findNode(Prefix prefix) {
-    return findNode(prefix, 0);
+    assert _prefix.containsPrefix(prefix);
+    return findNode(prefix, _prefix.getPrefixLength());
   }
 
   /** Find a node longest prefix match for a given IP address. */
   @Nonnull
   public Set<DataT> longestPrefixMatch(Ip address) {
+    checkArgument(
+        _prefix.containsIp(address), "Ip %s does not belong to subtree %s", address, this);
     return longestPrefixMatch(address, Prefix.MAX_PREFIX_LENGTH);
   }
 
@@ -204,9 +313,9 @@ public final class PrefixTrieMultiMap<DataT> implements Serializable {
    */
   @Nonnull
   public Set<DataT> longestPrefixMatch(Ip address, int maxPrefixLength) {
-    PrefixTrieMultiMap<DataT> node =
-        findLongestPrefixMatchNode(address, address.asLong(), maxPrefixLength);
-    return node == null ? ImmutableSet.of() : node.getElements();
+    checkArgument(
+        _prefix.containsIp(address), "Ip %s does not belong to subtree %s", address, this);
+    return findLongestPrefixMatchNode(address, maxPrefixLength).getElements();
   }
 
   /** Collect (recursively) and return all elements in this subtree. */
@@ -226,27 +335,6 @@ public final class PrefixTrieMultiMap<DataT> implements Serializable {
       _right.collect(collectionBuilder);
     }
     collectionBuilder.addAll(_elements);
-  }
-
-  @Nonnull
-  private PrefixTrieMultiMap<DataT> findOrCreateNode(
-      Prefix prefix, long bits, int firstUnmatchedBitIndex) {
-    checkArgument(
-        _prefix.containsPrefix(prefix), "Prefix %s is not contained within node %s", prefix, this);
-    /*
-     * We know we've reached the node at which to insert the element because
-     * this node's prefix equals our target prefix.
-     */
-    if (prefix.getPrefixLength() == _prefix.getPrefixLength()) {
-      return this;
-    }
-
-    /*
-     * The prefix match is not exact, do some extra insertion logic.
-     * Current bit determines which side of the tree to go down (1 = right, 0 = left)
-     */
-    boolean currentBit = Ip.getBitAtPosition(bits, firstUnmatchedBitIndex);
-    return findHelper(this, prefix, bits, firstUnmatchedBitIndex, currentBit);
   }
 
   @Nullable
@@ -280,168 +368,46 @@ public final class PrefixTrieMultiMap<DataT> implements Serializable {
     }
   }
 
-  /**
-   * Returns a node with the longest prefix match for a given IP address.
-   *
-   * @param address IP address
-   * @param bits IP address represented as a set of bits
-   * @param maxPrefixLength only return routes with prefix length less than or equal to given value
-   * @return a set of routes
-   */
-  @Nullable
-  private PrefixTrieMultiMap<DataT> findLongestPrefixMatchNode(
-      Ip address, long bits, int maxPrefixLength) {
-    // If the current subtree only contains routes that are too long, no matches.
-    int index = _prefix.getPrefixLength();
-    if (index > maxPrefixLength) {
-      return null;
-    }
-
-    // If the current subtree does not contain the destination IP, no matches.
-    if (!_prefix.containsIp(address)) {
-      return null;
-    }
-
-    // If the network of the current node is exactly the desired maximum length, stop here.
-    if (index == maxPrefixLength) {
-      return this;
-    }
-
-    // Examine the bit at the given index
-    boolean currentBit = Ip.getBitAtPosition(bits, index);
-    // If the current bit is 1, go right recursively
-    PrefixTrieMultiMap<DataT> child = currentBit ? _right : _left;
-    if (child == null) {
-      return this;
-    }
-
-    // Represents any potentially longer route matches (than ones stored at this node)
-    PrefixTrieMultiMap<DataT> candidateNode =
-        child.findLongestPrefixMatchNode(address, bits, maxPrefixLength);
-
-    // If we found no better matches, return the ones from this node
-    if (candidateNode == null) {
-      return this;
-    } else { // otherwise return longer matches
-      return candidateNode;
-    }
-  }
-
-  /**
-   * Takes care of adding new nodes to the tree and maintaining correct pointers.
-   *
-   * @param parent node that we are trying to merge an element into
-   * @param prefix the desired prefix the element should be mapped to
-   * @param bits the {@code long} representation of the desired prefix
-   * @param firstUnmatchedBitIndex the index of the first bit in the desired prefix that we haven't
-   *     checked yet
-   * @param rightBranch whether we should recurse down the right side of the tree
-   * @return the node into which an element can be added
-   */
+  /** Returns the node with the longest prefxix match for a given prefix. */
   @Nonnull
-  private static <DataT> PrefixTrieMultiMap<DataT> findHelper(
-      PrefixTrieMultiMap<DataT> parent,
-      Prefix prefix,
-      long bits,
-      int firstUnmatchedBitIndex,
-      boolean rightBranch) {
-    PrefixTrieMultiMap<DataT> node;
+  static <DataT> PrefixTrieMultiMap<DataT> findLongestPrefixMatchNode(
+      PrefixTrieMultiMap<DataT> node, Prefix prefix) {
+    assert node._prefix.containsPrefix(prefix);
 
-    // Get our node from one of the tree sides
-    if (rightBranch) {
-      node = parent._right;
-    } else {
-      node = parent._left;
-    }
-
-    // Node doesn't exist, so create one. By construction, it will be the best match
-    // for the given elementToMerge
-    if (node == null) {
-      node = new PrefixTrieMultiMap<>(prefix);
-      // don't forget to assign new node element to parent node
-      assignChild(parent, node, rightBranch);
-      return node;
-    }
-
-    // Node exists, get some helper data out of the current node we are examining
-    Prefix nodePrefix = node._prefix;
-    int nodePrefixLength = nodePrefix.getPrefixLength();
-    Ip nodeAddress = nodePrefix.getStartIp();
-    long nodeAddressBits = nodeAddress.asLong();
-    int nextUnmatchedBit;
-    // Set up two "pointers" as we scan through the bits and the node's prefixes
-    boolean currentAddressBit = false;
-    boolean currentNodeAddressBit;
-
-    /*
-     * We know we matched up to firstUnmatchedBitIndex. Continue going forward in the bits
-     * to find a longer match.
-     * At the end of this loop nextUnmatchedBit will be the first place where the elementToMerge prefix
-     * and this node's prefix diverge.
-     * Note that nextUnmatchedBit can be outside of the node's or the elementToMerge's prefix.
-     */
-    for (nextUnmatchedBit = firstUnmatchedBitIndex + 1;
-        nextUnmatchedBit < nodePrefixLength && nextUnmatchedBit < prefix.getPrefixLength();
-        nextUnmatchedBit++) {
-      currentAddressBit = Ip.getBitAtPosition(bits, nextUnmatchedBit);
-      currentNodeAddressBit = Ip.getBitAtPosition(nodeAddressBits, nextUnmatchedBit);
-      if (currentNodeAddressBit != currentAddressBit) {
-        break;
+    long prefixAsLong = prefix.getStartIp().asLong();
+    while (true) {
+      if (node._prefix.equals(prefix)) {
+        // found an exact match
+        return node;
       }
+
+      // Examine the bit at the given index
+      boolean currentBit = Ip.getBitAtPosition(prefixAsLong, node._prefix.getPrefixLength());
+
+      // If the current bit is 1, go right recursively
+      PrefixTrieMultiMap<DataT> child = currentBit ? node._right : node._left;
+      if (child == null) {
+        return node;
+      }
+
+      if (!child._prefix.containsPrefix(prefix)) {
+        return node;
+      }
+
+      // keep looking
+      node = child;
     }
-
-    /*
-     * If the next unmatched bit is the same as node prefix length, we "ran off" the node prefix.
-     * Recursively find the appropriate node that's a child of this node.
-     */
-    if (nextUnmatchedBit == nodePrefixLength) {
-      return node.findOrCreateNode(prefix, bits, nextUnmatchedBit);
-    }
-
-    /*
-     * If we reached the desired prefix length (but have not exhausted the nodes) we need to create a new node
-     * above the current node that matches the prefix and re-attach the current node to
-     * the newly created node.
-     */
-    if (nextUnmatchedBit == prefix.getPrefixLength()) {
-      currentNodeAddressBit = Ip.getBitAtPosition(nodeAddressBits, nextUnmatchedBit);
-      PrefixTrieMultiMap<DataT> oldNode = node;
-      node = new PrefixTrieMultiMap<>(prefix);
-      // Keep track of pointers
-      assignChild(parent, node, rightBranch);
-      assignChild(node, oldNode, currentNodeAddressBit);
-      return node;
-    }
-
-    /*
-     * If we are here, there is a bit difference between the node's prefix and the desired prefix,
-     * before we reach the end of either prefix. This requires the following:
-     * - Compute the max prefix match (up to nextUnmatchedBit)
-     * - Create a new node with this new prefix above the current node
-     * - Create a new node with the desired prefix and assign the newly created node.
-     * - Existing node becomes a sibling of the node with full elementToMerge prefix
-     */
-    PrefixTrieMultiMap<DataT> oldNode = node;
-
-    // newNetwork has the max prefix match up to nextUnmatchedBit
-    Prefix newNetwork = Prefix.create(prefix.getStartIp(), nextUnmatchedBit);
-    node = new PrefixTrieMultiMap<>(newNetwork); // this is the node we are inserting in the middle
-    PrefixTrieMultiMap<DataT> child = new PrefixTrieMultiMap<>(prefix);
-
-    assignChild(parent, node, rightBranch);
-    // child and old node become siblings, children of the newly inserted node
-    assignChild(node, child, currentAddressBit);
-    assignChild(node, oldNode, !currentAddressBit);
-    return child;
   }
 
-  private static <DataT> void assignChild(
-      PrefixTrieMultiMap<DataT> parent, PrefixTrieMultiMap<DataT> child, boolean branchRight) {
-    if (branchRight) {
-      parent.setRight(child);
-    } else {
-      parent.setLeft(child);
-    }
+  /**
+   * Returns the node with the longest prefix match for a given IP address.
+   *
+   * @param address IP address contained in the current node's prefix.
+   * @param maxPrefixLength only return routes with prefix length less than or equal to given value
+   */
+  private @Nonnull PrefixTrieMultiMap<DataT> findLongestPrefixMatchNode(
+      Ip address, int maxPrefixLength) {
+    return findLongestPrefixMatchNode(this, Prefix.create(address, maxPrefixLength));
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
@@ -292,13 +292,6 @@ public final class PrefixTrieMultiMap<DataT> implements Serializable {
         && Ip.getBitAtPosition(childPrefix.getStartIp(), parentPrefix.getPrefixLength());
   }
 
-  /** Find the node for a given prefix (must be an exact match). */
-  @Nullable
-  private PrefixTrieMultiMap<DataT> findNode(Prefix prefix) {
-    assert _prefix.containsPrefix(prefix);
-    return findNode(prefix, _prefix.getPrefixLength());
-  }
-
   /** Find a node longest prefix match for a given IP address. */
   @Nonnull
   public Set<DataT> longestPrefixMatch(Ip address) {
@@ -338,34 +331,10 @@ public final class PrefixTrieMultiMap<DataT> implements Serializable {
   }
 
   @Nullable
-  private PrefixTrieMultiMap<DataT> findNode(Prefix p, int firstUnmatchedBitIndex) {
-    if (!_prefix.containsPrefix(p)) {
-      return null;
-    }
-
-    // If prefix lengths match, this is the node where such element would be stored.
-    if (_prefix.getPrefixLength() == p.getPrefixLength()) {
-      return this;
-    }
-
-    boolean currentBit = Ip.getBitAtPosition(p.getStartIp().asLong(), firstUnmatchedBitIndex);
-    /*
-     * If prefixes don't match exactly, look at the current bit. That determines whether we look
-     * left or right. As long as the child is not null, recurse.
-     *
-     * Note that:
-     * 1) elements are stored in the nodes where lengths of the node prefix and the desired prefix
-     *    match exactly; and
-     * 2) prefix matches only get more specific (longer) the deeper we go in the tree
-     *
-     * Therefore, we can fast-forward the firstUnmatchedBitIndex to the prefix length of the
-     * child node
-     */
-    if (currentBit) {
-      return (_right != null) ? _right.findNode(p, _right.getPrefix().getPrefixLength()) : null;
-    } else {
-      return (_left != null) ? _left.findNode(p, _left.getPrefix().getPrefixLength()) : null;
-    }
+  private PrefixTrieMultiMap<DataT> findNode(Prefix p) {
+    assert _prefix.containsPrefix(p);
+    PrefixTrieMultiMap<DataT> node = findLongestPrefixMatchNode(this, p);
+    return node._prefix.equals(p) ? node : null;
   }
 
   /** Returns the node with the longest prefxix match for a given prefix. */

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
@@ -60,21 +60,9 @@ public final class PrefixTrieMultiMap<DataT> implements Serializable {
     return ImmutableSet.copyOf(_elements);
   }
 
-  /** Return left subtree */
-  @Nullable
-  public PrefixTrieMultiMap<DataT> getLeft() {
-    return _left;
-  }
-
   private void setLeft(@Nullable PrefixTrieMultiMap<DataT> left) {
     assert left == null || legalLeftChildPrefix(_prefix, left._prefix);
     _left = left;
-  }
-
-  /** Return right subtree */
-  @Nullable
-  public PrefixTrieMultiMap<DataT> getRight() {
-    return _right;
   }
 
   private void setRight(@Nullable PrefixTrieMultiMap<DataT> right) {
@@ -136,10 +124,11 @@ public final class PrefixTrieMultiMap<DataT> implements Serializable {
   /**
    * Remove an element from the subtree
    *
-   * @throws IllegalArgumentException if the input {@link Prefix} is not contained in the {@link
-   *     Prefix} of this subtree.
    * @param p prefix the element is mapped to
    * @param e element to remove
+   *
+   * @throws IllegalArgumentException if the input {@link Prefix} is not contained in the {@link
+   *     Prefix} of this subtree.
    */
   public boolean remove(Prefix p, DataT e) {
     checkArgument(_prefix.containsPrefix(p), "Prefix %s does not belong to subtree %s", p, this);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
@@ -126,7 +126,6 @@ public final class PrefixTrieMultiMap<DataT> implements Serializable {
    *
    * @param p prefix the element is mapped to
    * @param e element to remove
-   *
    * @throws IllegalArgumentException if the input {@link Prefix} is not contained in the {@link
    *     Prefix} of this subtree.
    */

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
@@ -93,8 +93,8 @@ public final class PrefixTrieMultiMap<DataT> implements Serializable {
    * Retrieve an immutable copy of elements for the given prefix (anywhere in the subtree). Returns
    * empty set if the prefix is not in the subtree.
    *
-   * @throws IllegalArgumentException if {@param p} is not contained in the {@link Prefix} of this
-   *     subtree.
+   * @throws IllegalArgumentException if the input {@link Prefix} is not contained in the {@link
+   *     Prefix} of this subtree.
    */
   @Nonnull
   public Set<DataT> getElements(Prefix p) {
@@ -106,7 +106,8 @@ public final class PrefixTrieMultiMap<DataT> implements Serializable {
   /**
    * Insert an element into this subtree corresponding to a prefix {@code p}
    *
-   * @throws IllegalArgumentException if the given prefix does not belong in this subtree
+   * @throws IllegalArgumentException if the input {@link Prefix} is not contained in the {@link
+   *     Prefix} of this subtree.
    */
   public boolean add(Prefix p, DataT e) {
     checkArgument(_prefix.containsPrefix(p), "Prefix %s does not belong to subtree %s", p, this);
@@ -117,7 +118,8 @@ public final class PrefixTrieMultiMap<DataT> implements Serializable {
   /**
    * Insert a collection of elements into this subtree corresponding to a prefix {@code p}
    *
-   * @throws IllegalArgumentException if the given prefix does not belong in this subtree
+   * @throws IllegalArgumentException if the input {@link Prefix} is not contained in the {@link
+   *     Prefix} of this subtree.
    */
   public boolean addAll(Prefix p, Collection<DataT> elements) {
     checkArgument(_prefix.containsPrefix(p), "Prefix %s does not belong to subtree %s", p, this);
@@ -133,6 +135,8 @@ public final class PrefixTrieMultiMap<DataT> implements Serializable {
   /**
    * Remove an element from the subtree
    *
+   * @throws IllegalArgumentException if the input {@link Prefix} is not contained in the {@link
+   *     Prefix} of this subtree.
    * @param p prefix the element is mapped to
    * @param e element to remove
    */
@@ -150,7 +154,8 @@ public final class PrefixTrieMultiMap<DataT> implements Serializable {
   /**
    * Remove all elements associated with prefix {@code p}
    *
-   * @throws IllegalArgumentException if the given prefix does not belong to this subtree
+   * @throws IllegalArgumentException if the input {@link Prefix} is not contained in the {@link
+   *     Prefix} of this subtree.
    */
   public boolean clear(Prefix p) {
     checkArgument(_prefix.containsPrefix(p), "Prefix %s does not belong to subtree %s", p, this);
@@ -165,7 +170,12 @@ public final class PrefixTrieMultiMap<DataT> implements Serializable {
     return ret;
   }
 
-  /** Replace all elements associated with prefix {@code p} with a given element */
+  /**
+   * Replace all elements associated with prefix {@code p} with a given element.
+   *
+   * @throws IllegalArgumentException if the input {@link Prefix} is not contained in the {@link
+   *     Prefix} of this subtree.
+   */
   public boolean replaceAll(Prefix p, DataT e) {
     checkArgument(_prefix.containsPrefix(p), "Prefix %s does not belong to subtree %s", p, this);
     PrefixTrieMultiMap<DataT> node = findNode(p);
@@ -178,7 +188,12 @@ public final class PrefixTrieMultiMap<DataT> implements Serializable {
     return _elements.add(e);
   }
 
-  /** Replace all elements associated with prefix {@code p} with a given collection of elements */
+  /**
+   * Replace all elements associated with prefix {@code p} with a given collection of elements
+   *
+   * @throws IllegalArgumentException if the input {@link Prefix} is not contained in the {@link
+   *     Prefix} of this subtree.
+   */
   public boolean replaceAll(Prefix p, Collection<DataT> e) {
     checkArgument(_prefix.containsPrefix(p), "Prefix %s does not belong to subtree %s", p, this);
     PrefixTrieMultiMap<DataT> node = findNode(p);
@@ -196,7 +211,7 @@ public final class PrefixTrieMultiMap<DataT> implements Serializable {
   private PrefixTrieMultiMap<DataT> findOrCreateNode(Prefix prefix) {
     assert _prefix.containsPrefix(prefix);
 
-    PrefixTrieMultiMap<DataT> node = findLongestPrefixMatchNode(this, prefix);
+    PrefixTrieMultiMap<DataT> node = findLongestPrefixMatchNode(prefix);
     return node._prefix.equals(prefix) ? node : node.createChild(prefix);
   }
 
@@ -292,7 +307,12 @@ public final class PrefixTrieMultiMap<DataT> implements Serializable {
         && Ip.getBitAtPosition(childPrefix.getStartIp(), parentPrefix.getPrefixLength());
   }
 
-  /** Find a node longest prefix match for a given IP address. */
+  /**
+   * Find a node longest prefix match for a given IP address.
+   *
+   * @throws IllegalArgumentException if the input {@link Prefix} is not contained in the {@link
+   *     Prefix} of this subtree.
+   */
   @Nonnull
   public Set<DataT> longestPrefixMatch(Ip address) {
     checkArgument(
@@ -303,6 +323,9 @@ public final class PrefixTrieMultiMap<DataT> implements Serializable {
   /**
    * Find a node longest prefix match for a given IP address, where the length of the match is
    * bounded by {@code maxPrefixLength}
+   *
+   * @throws IllegalArgumentException if the input {@link Prefix} is not contained in the {@link
+   *     Prefix} of this subtree.
    */
   @Nonnull
   public Set<DataT> longestPrefixMatch(Ip address, int maxPrefixLength) {
@@ -333,16 +356,16 @@ public final class PrefixTrieMultiMap<DataT> implements Serializable {
   @Nullable
   private PrefixTrieMultiMap<DataT> findNode(Prefix p) {
     assert _prefix.containsPrefix(p);
-    PrefixTrieMultiMap<DataT> node = findLongestPrefixMatchNode(this, p);
+    PrefixTrieMultiMap<DataT> node = findLongestPrefixMatchNode(p);
     return node._prefix.equals(p) ? node : null;
   }
 
   /** Returns the node with the longest prefxix match for a given prefix. */
   @Nonnull
-  static <DataT> PrefixTrieMultiMap<DataT> findLongestPrefixMatchNode(
-      PrefixTrieMultiMap<DataT> node, Prefix prefix) {
-    assert node._prefix.containsPrefix(prefix);
+  PrefixTrieMultiMap<DataT> findLongestPrefixMatchNode(Prefix prefix) {
+    assert this._prefix.containsPrefix(prefix);
 
+    PrefixTrieMultiMap<DataT> node = this;
     long prefixAsLong = prefix.getStartIp().asLong();
     while (true) {
       if (node._prefix.equals(prefix)) {
@@ -376,7 +399,7 @@ public final class PrefixTrieMultiMap<DataT> implements Serializable {
    */
   private @Nonnull PrefixTrieMultiMap<DataT> findLongestPrefixMatchNode(
       Ip address, int maxPrefixLength) {
-    return findLongestPrefixMatchNode(this, Prefix.create(address, maxPrefixLength));
+    return findLongestPrefixMatchNode(Prefix.create(address, maxPrefixLength));
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PrefixTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PrefixTest.java
@@ -1,5 +1,6 @@
 package org.batfish.datamodel;
 
+import static org.batfish.datamodel.Prefix.longestCommonPrefix;
 import static org.batfish.datamodel.Prefix.parse;
 import static org.batfish.datamodel.Prefix.strict;
 import static org.batfish.datamodel.matchers.IpSpaceMatchers.containsIp;
@@ -115,5 +116,32 @@ public class PrefixTest {
         "/30 host space is two IPs",
         toBDD.visit(Prefix.parse("1.2.3.4/30").toHostIpSpace()),
         equalTo(slash30Filtered));
+  }
+
+  @Test
+  public void testLongestCommonPrefix() {
+    // p1 and p2 are equal
+    Prefix p1 = Prefix.parse("1.1.1.0/24");
+    assertThat(longestCommonPrefix(p1, p1), equalTo(Prefix.parse("1.1.1.0/24")));
+
+    // p1 includes p2
+    p1 = Prefix.parse("1.1.1.0/24");
+    Prefix p2 = Prefix.parse("1.1.1.0/32");
+    assertThat(longestCommonPrefix(p1, p2), equalTo(p1));
+
+    // p2 includes p1
+    p1 = Prefix.parse("1.1.1.0/32");
+    p2 = Prefix.parse("1.1.1.0/24");
+    assertThat(longestCommonPrefix(p1, p2), equalTo(p2));
+
+    // masked bits are ignored
+    p1 = Prefix.parse("1.1.1.1/24");
+    p2 = Prefix.parse("1.1.1.1/8");
+    assertThat(longestCommonPrefix(p1, p2), equalTo(Prefix.parse("1.0.0.0/8")));
+
+    // Different /32s
+    p1 = Prefix.parse("0.0.0.0/32");
+    p2 = Prefix.parse("0.0.0.255/32");
+    assertThat(longestCommonPrefix(p1, p2), equalTo(Prefix.parse("0.0.0.0/24")));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PrefixTrieMultiMapTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PrefixTrieMultiMapTest.java
@@ -127,12 +127,14 @@ public class PrefixTrieMultiMapTest {
   public void testRemoveWrongNode() {
     PrefixTrieMultiMap<Integer> ptm1 = new PrefixTrieMultiMap<>(Prefix.parse("128.0.0.0/1"));
     ptm1.add(Prefix.parse("128.0.0.0/1"), 1);
-    assertThat("Nothing to remove", !ptm1.remove(Prefix.ZERO, 1));
+    thrown.expect(IllegalArgumentException.class);
+    ptm1.remove(Prefix.ZERO, 1);
   }
 
   @Test
   public void testReplaceWrongNode() {
     PrefixTrieMultiMap<Integer> ptm1 = new PrefixTrieMultiMap<>(Prefix.parse("128.0.0.0/1"));
-    assertThat("Nothing to replace", !ptm1.replaceAll(Prefix.ZERO, 1));
+    thrown.expect(IllegalArgumentException.class);
+    ptm1.replaceAll(Prefix.ZERO, 1);
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PrefixTrieMultiMapTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PrefixTrieMultiMapTest.java
@@ -1,8 +1,12 @@
 package org.batfish.datamodel;
 
+import static org.batfish.datamodel.PrefixTrieMultiMap.legalLeftChildPrefix;
+import static org.batfish.datamodel.PrefixTrieMultiMap.legalRightChildPrefix;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.testing.EqualsTester;
@@ -136,5 +140,45 @@ public class PrefixTrieMultiMapTest {
     PrefixTrieMultiMap<Integer> ptm1 = new PrefixTrieMultiMap<>(Prefix.parse("128.0.0.0/1"));
     thrown.expect(IllegalArgumentException.class);
     ptm1.replaceAll(Prefix.ZERO, 1);
+  }
+
+  @Test
+  public void testLegalLeftChildPrefix() {
+    Prefix parent = Prefix.parse("1.0.0.0/8");
+
+    // child prefix cannot equal parent prefix
+    assertFalse(legalLeftChildPrefix(parent, parent));
+
+    // shortest possible child prefix
+    Prefix child = Prefix.parse("1.0.0.0/9");
+    assertTrue(legalLeftChildPrefix(parent, child));
+
+    // 9th bit cannot be 1
+    child = Prefix.parse("1.128.0.0/9");
+    assertFalse(legalLeftChildPrefix(parent, child));
+
+    // longer prefixes are allowed; everything after the 9th bit can be anything
+    child = Prefix.parse("1.127.255.0/24");
+    assertTrue(legalLeftChildPrefix(parent, child));
+  }
+
+  @Test
+  public void testLegalRightChildPrefix() {
+    Prefix parent = Prefix.parse("1.0.0.0/8");
+
+    // child prefix cannot equal parent prefix
+    assertFalse(legalRightChildPrefix(parent, parent));
+
+    // shortest possible child prefix
+    Prefix child = Prefix.parse("1.128.0.0/9");
+    assertTrue(legalRightChildPrefix(parent, child));
+
+    // 9th bit cannot be 0
+    child = Prefix.parse("1.0.0.0/9");
+    assertFalse(legalRightChildPrefix(parent, child));
+
+    // longer prefixes are allowed; everything after the 9th bit can be anything
+    child = Prefix.parse("1.255.255.0/24");
+    assertTrue(legalRightChildPrefix(parent, child));
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/AbstractRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/AbstractRib.java
@@ -135,12 +135,12 @@ public abstract class AbstractRib<R extends AbstractRoute> implements GenericRib
   public abstract int comparePreference(R lhs, R rhs);
 
   @Override
-  public Set<R> longestPrefixMatch(Ip address) {
+  public @Nonnull Set<R> longestPrefixMatch(Ip address) {
     return longestPrefixMatch(address, Prefix.MAX_PREFIX_LENGTH);
   }
 
   @Override
-  public Set<R> longestPrefixMatch(Ip address, int maxPrefixLength) {
+  public @Nonnull Set<R> longestPrefixMatch(Ip address, int maxPrefixLength) {
     return _tree.getLongestPrefixMatch(address, maxPrefixLength);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/BgpRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/BgpRib.java
@@ -19,6 +19,7 @@ import org.batfish.datamodel.AsPath;
 import org.batfish.datamodel.AsSet;
 import org.batfish.datamodel.BgpRoute;
 import org.batfish.datamodel.BgpTieBreaker;
+import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.MultipathEquivalentAsPathMatchMode;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.RoutingProtocol;
@@ -263,7 +264,12 @@ public class BgpRib extends AbstractRib<BgpRoute> {
     if (_mainRib == null) {
       return Long.MAX_VALUE;
     }
-    Set<AbstractRoute> s = _mainRib.longestPrefixMatch(route.getNextHopIp());
-    return s == null || s.isEmpty() ? Long.MAX_VALUE : s.iterator().next().getMetric();
+
+    Ip nextHopIp = route.getNextHopIp();
+    if (nextHopIp == Ip.AUTO) {
+      return Long.MAX_VALUE;
+    }
+    Set<AbstractRoute> s = _mainRib.longestPrefixMatch(nextHopIp);
+    return s.isEmpty() ? Long.MAX_VALUE : s.iterator().next().getMetric();
   }
 }


### PR DESCRIPTION
- Check invariants using checkArgument on public methods and assert on
  private methods.
- Rewrite findOrCreateNode, remove findHelper