### PR TITLE
Partial support for ASA Object NAT in VI model

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -9160,17 +9160,19 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
       CiscoStructureUsage realStructure,
       CiscoStructureUsage mappedStructure) {
     if (ctx == null) {
+      nat.setInsideInterface(ANY_INTERFACE);
+      nat.setOutsideInterface(ANY_INTERFACE);
       return;
     }
     String inside = ctx.real_if.getText();
     String outside = ctx.mapped_if.getText();
     int line = ctx.getStart().getLine();
+    nat.setInsideInterface(inside);
     if (!inside.equals(ANY_INTERFACE)) {
-      nat.setInsideInterface(inside);
       _configuration.referenceStructure(INTERFACE, inside, realStructure, line);
     }
+    nat.setOutsideInterface(outside);
     if (!outside.equals(ANY_INTERFACE)) {
-      nat.setOutsideInterface(outside);
       _configuration.referenceStructure(INTERFACE, outside, mappedStructure, line);
     }
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoAsaNat.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoAsaNat.java
@@ -366,7 +366,7 @@ public final class CiscoAsaNat implements Comparable<CiscoAsaNat>, Serializable 
      * _insideInterface for traffic with destination matching _realSourceObject would suffice.
      */
     if (_section.equals(Section.OBJECT)) {
-      Boolean identity = isIdentityObjectNat(this, networkObjects);
+      Boolean identity = isIdentityObjectNat(this, networkObjects, w);
       if (identity == null) {
         throw new BatfishException(
             "Failed to determine if identity NAT but created Transformation");

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoAsaNatUtil.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoAsaNatUtil.java
@@ -86,7 +86,7 @@ final class CiscoAsaNatUtil {
   private static Prefix getNetworkObjectPrefix(
       NetworkObjectAddressSpecifier specifier,
       Map<String, NetworkObject> networkObjects,
-      @Nullable Warnings w) {
+      Warnings w) {
     NetworkObject object = networkObjects.get(specifier.getName());
     if (object == null) {
       // Previously warned about undefined reference
@@ -105,9 +105,7 @@ final class CiscoAsaNatUtil {
     }
     if (object instanceof RangeNetworkObject) {
       // These are supported for dynamic NAT but not static NAT
-      if (w != null) {
-        w.redFlag("Ranges are not supported for static NAT");
-      }
+      w.redFlag("Ranges are not supported for static NAT");
       return null;
     }
     throw new BatfishException("Unexpected network object type");
@@ -120,11 +118,13 @@ final class CiscoAsaNatUtil {
    *
    * @param nat An object NAT
    * @param networkObjects Mapping of network object names to {@link NetworkObject}s
+   * @param w A logger for warnings about unsupported configuration
    * @return True if the object NAT is an identity NAT, or false if it is not. If the answer could
    *     not be determined because the NAT is not supported or invalid, returns null.
    */
   @Nullable
-  static Boolean isIdentityObjectNat(CiscoAsaNat nat, Map<String, NetworkObject> networkObjects) {
+  static Boolean isIdentityObjectNat(
+      CiscoAsaNat nat, Map<String, NetworkObject> networkObjects, Warnings w) {
     checkArgument(nat.getSection().equals(Section.OBJECT), "Only supports object NATs.");
 
     if (nat.getDynamic()) {
@@ -132,7 +132,7 @@ final class CiscoAsaNatUtil {
     }
     Prefix realPrefix =
         getNetworkObjectPrefix(
-            (NetworkObjectAddressSpecifier) nat.getRealSource(), networkObjects, null);
+            (NetworkObjectAddressSpecifier) nat.getRealSource(), networkObjects, w);
     if (realPrefix == null) {
       return null;
     }
@@ -147,8 +147,7 @@ final class CiscoAsaNatUtil {
     }
     if (mappedSource instanceof NetworkObjectAddressSpecifier) {
       return realPrefix.equals(
-          getNetworkObjectPrefix(
-              (NetworkObjectAddressSpecifier) mappedSource, networkObjects, null));
+          getNetworkObjectPrefix((NetworkObjectAddressSpecifier) mappedSource, networkObjects, w));
     }
     if (mappedSource instanceof WildcardAddressSpecifier) {
       // Specified as 'any'

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -2314,13 +2314,13 @@ public final class CiscoConfiguration extends VendorConfiguration {
     }
 
     // ASA places incoming and outgoing object NATs as transformations on the outside interface.
-    // Each NAT rule specifies an outside interface or 'any'
+    // Each NAT rule specifies an outside interface or ANY_INTERFACE
     SortedSet<CiscoAsaNat> objectNats =
         ciscoAsaNats.stream()
             .filter(nat -> nat.getSection().equals(Section.OBJECT))
             .filter(
                 nat ->
-                    nat.getOutsideInterface() == null
+                    nat.getOutsideInterface().equals(CiscoAsaNat.ANY_INTERFACE)
                         || nat.getOutsideInterface().equals(ifaceName))
             .collect(Collectors.toCollection(TreeSet::new));
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -2263,13 +2263,20 @@ public final class CiscoConfiguration extends VendorConfiguration {
      * Currently, only static NATs have both incoming and outgoing transformations
      */
 
+    List<CiscoAsaNat> ciscoAsaNats = firstNonNull(_ciscoAsaNats, ImmutableList.of());
     List<CiscoIosNat> ciscoIosNats = firstNonNull(_ciscoIosNats, ImmutableList.of());
     List<AristaDynamicSourceNat> aristaDynamicSourceNats =
         firstNonNull(iface.getAristaNats(), ImmutableList.of());
-    if (!aristaDynamicSourceNats.isEmpty() && !ciscoIosNats.isEmpty()) {
-      _w.redFlag("Arista-style and IOS-style NATs should not both be present in configuration.");
+    int natTypes =
+        (aristaDynamicSourceNats.isEmpty() ? 0 : 1)
+            + (ciscoAsaNats.isEmpty() ? 0 : 1)
+            + (ciscoIosNats.isEmpty() ? 0 : 1);
+    if (natTypes > 1) {
+      _w.redFlag("Multiple NAT types should not be present in same configuration.");
     } else if (!aristaDynamicSourceNats.isEmpty()) {
       generateAristaDynamicSourceNats(newIface, aristaDynamicSourceNats);
+    } else if (!ciscoAsaNats.isEmpty()) {
+      generateCiscoAsaNatTransformations(ifaceName, newIface, ciscoAsaNats);
     } else if (!ciscoIosNats.isEmpty()) {
       generateCiscoIosNatTransformations(ifaceName, newIface, ipAccessLists, c);
     }
@@ -2277,6 +2284,13 @@ public final class CiscoConfiguration extends VendorConfiguration {
     String routingPolicyName = iface.getRoutingPolicy();
     if (routingPolicyName != null) {
       newIface.setRoutingPolicy(routingPolicyName);
+    }
+
+    if (_vendor == ConfigurationFormat.CISCO_ASA) {
+      newIface.setPostTransformationIncomingFilter(newIface.getIncomingFilter());
+      newIface.setPreTransformationOutgoingFilter(newIface.getOutgoingFilter());
+      newIface.setIncomingFilter(null);
+      newIface.setOutgoingFilter((IpAccessList) null);
     }
     return newIface;
   }
@@ -2290,6 +2304,39 @@ public final class CiscoConfiguration extends VendorConfiguration {
       next = nat.toTransformation(interfaceIp, _natPools, next).orElse(next);
     }
     newIface.setOutgoingTransformation(next);
+  }
+
+  private void generateCiscoAsaNatTransformations(
+      String ifaceName, org.batfish.datamodel.Interface newIface, List<CiscoAsaNat> ciscoAsaNats) {
+
+    if (!ciscoAsaNats.stream().map(CiscoAsaNat::getSection).allMatch(Section.OBJECT::equals)) {
+      _w.unimplemented("No support for Twice NAT");
+    }
+
+    // ASA places incoming and outgoing object NATs as transformations on the outside interface.
+    // Each NAT rule specifies an outside interface or 'any'
+    SortedSet<CiscoAsaNat> objectNats =
+        ciscoAsaNats.stream()
+            .filter(nat -> nat.getSection().equals(Section.OBJECT))
+            .filter(
+                nat ->
+                    nat.getOutsideInterface() == null
+                        || nat.getOutsideInterface().equals(ifaceName))
+            .collect(Collectors.toCollection(TreeSet::new));
+
+    newIface.setIncomingTransformation(
+        objectNats.stream()
+            .map(nat -> nat.toIncomingTransformation(_networkObjects, _w))
+            .collect(
+                Collectors.collectingAndThen(
+                    Collectors.toList(), CiscoAsaNatUtil::toTransformationChain)));
+
+    newIface.setOutgoingTransformation(
+        objectNats.stream()
+            .map(nat -> nat.toOutgoingTransformation(_networkObjects, _w))
+            .collect(
+                Collectors.collectingAndThen(
+                    Collectors.toList(), CiscoAsaNatUtil::toTransformationChain)));
   }
 
   private void generateCiscoIosNatTransformations(

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoIosNatUtil.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoIosNatUtil.java
@@ -96,7 +96,6 @@ final class CiscoIosNatUtil {
 
   private static Transformation chain(
       List<Transformation.Builder> nonEmptySortedList, @Nullable Transformation andThen) {
-
     // Start at the end of the chain and go backwards. The end of the chain should have
     // t.andThen == t.orElse
     Transformation previous = andThen;

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoIosNatUtil.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoIosNatUtil.java
@@ -96,6 +96,7 @@ final class CiscoIosNatUtil {
 
   private static Transformation chain(
       List<Transformation.Builder> nonEmptySortedList, @Nullable Transformation andThen) {
+
     // Start at the end of the chain and go backwards. The end of the chain should have
     // t.andThen == t.orElse
     Transformation previous = andThen;

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -50,13 +50,14 @@ import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasVrfs;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasAclName;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasBandwidth;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasDefinedStructure;
-import static org.batfish.datamodel.matchers.DataModelMatchers.hasIncomingFilter;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasIpProtocols;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasMemberInterfaces;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasName;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasNumReferrers;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasOutgoingFilter;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasOutgoingFilterName;
+import static org.batfish.datamodel.matchers.DataModelMatchers.hasPostTransformationIncomingFilter;
+import static org.batfish.datamodel.matchers.DataModelMatchers.hasPreTransformationOutgoingFilter;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasRedFlagWarning;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasRoute6FilterList;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasRouteFilterList;
@@ -750,8 +751,13 @@ public class CiscoGrammarTest {
     Flow flowFail = createFlow(IpProtocol.TCP, 1, 1);
 
     // Confirm access list permits only traffic matching ACL
-    assertThat(c, hasInterface(ifaceAlias, hasOutgoingFilter(accepts(flowPass, null, c))));
-    assertThat(c, hasInterface(ifaceAlias, hasOutgoingFilter(not(accepts(flowFail, null, c)))));
+    assertThat(
+        c,
+        hasInterface(ifaceAlias, hasPreTransformationOutgoingFilter(accepts(flowPass, null, c))));
+    assertThat(
+        c,
+        hasInterface(
+            ifaceAlias, hasPreTransformationOutgoingFilter(not(accepts(flowFail, null, c)))));
   }
 
   @Test
@@ -766,10 +772,20 @@ public class CiscoGrammarTest {
     Flow flowFail = createFlow(IpProtocol.TCP, 1, 1);
 
     // Confirm global ACL affects all interfaces
-    assertThat(c, hasInterface(iface1Alias, hasIncomingFilter(accepts(flowPass, null, c))));
-    assertThat(c, hasInterface(iface2Alias, hasIncomingFilter(accepts(flowPass, null, c))));
-    assertThat(c, hasInterface(iface1Alias, hasIncomingFilter(not(accepts(flowFail, null, c)))));
-    assertThat(c, hasInterface(iface2Alias, hasIncomingFilter(not(accepts(flowFail, null, c)))));
+    assertThat(
+        c,
+        hasInterface(iface1Alias, hasPostTransformationIncomingFilter(accepts(flowPass, null, c))));
+    assertThat(
+        c,
+        hasInterface(iface2Alias, hasPostTransformationIncomingFilter(accepts(flowPass, null, c))));
+    assertThat(
+        c,
+        hasInterface(
+            iface1Alias, hasPostTransformationIncomingFilter(not(accepts(flowFail, null, c)))));
+    assertThat(
+        c,
+        hasInterface(
+            iface2Alias, hasPostTransformationIncomingFilter(not(accepts(flowFail, null, c)))));
   }
 
   @Test
@@ -821,22 +837,40 @@ public class CiscoGrammarTest {
     // highIface1 has inbound filter permitting all IP traffic
     // highIface1 has outbound filter permitting only TCP port 123
     // highIface1 rejects all traffic from lowIface2 due to security level restriction
-    assertThat(c, hasInterface(highIface1, hasOutgoingFilter(rejects(anyFlow, lowIface2, c))));
+    assertThat(
+        c,
+        hasInterface(
+            highIface1, hasPreTransformationOutgoingFilter(rejects(anyFlow, lowIface2, c))));
 
     // Confirm access list permits only traffic matching both ACL and security level restrictions
     // highIface1 has a higher security level than lowIface5
     // lowIface5 has no inbound filter
     // lowIface5 rejects all outbound traffic except TCP port 123
-    assertThat(c, hasInterface(lowIface5, hasOutgoingFilter(rejects(flowFail, highIface1, c))));
-    assertThat(c, hasInterface(lowIface5, hasOutgoingFilter(accepts(flowPass, highIface1, c))));
+    assertThat(
+        c,
+        hasInterface(
+            lowIface5, hasPreTransformationOutgoingFilter(rejects(flowFail, highIface1, c))));
+    assertThat(
+        c,
+        hasInterface(
+            lowIface5, hasPreTransformationOutgoingFilter(accepts(flowPass, highIface1, c))));
 
     // lowIface4 has inbound filter permitting only TCP port 123
     // highIface3 has no explicit outbound filter
-    assertThat(c, hasInterface(lowIface4, hasIncomingFilter(accepts(flowPass, lowIface4, c))));
-    assertThat(c, hasInterface(lowIface4, hasIncomingFilter(rejects(flowFail, lowIface4, c))));
+    assertThat(
+        c,
+        hasInterface(
+            lowIface4, hasPostTransformationIncomingFilter(accepts(flowPass, lowIface4, c))));
+    assertThat(
+        c,
+        hasInterface(
+            lowIface4, hasPostTransformationIncomingFilter(rejects(flowFail, lowIface4, c))));
     // any flow outbound on highIface3 from lowIface4 is allowed, assuming it was allowed incoming
     // security level restriction is removed because lowIface4 has an inbound ACL
-    assertThat(c, hasInterface(highIface3, hasOutgoingFilter(accepts(anyFlow, lowIface4, c))));
+    assertThat(
+        c,
+        hasInterface(
+            highIface3, hasPreTransformationOutgoingFilter(accepts(anyFlow, lowIface4, c))));
   }
 
   @Test
@@ -3968,68 +4002,93 @@ public class CiscoGrammarTest {
     assertThat(
         c,
         hasInterface(
-            explicit100Interface, hasOutgoingFilter(rejects(newFlow, explicit100Interface, c))));
-    assertThat(
-        c, hasInterface(insideInterface, hasOutgoingFilter(rejects(newFlow, insideInterface, c))));
+            explicit100Interface,
+            hasPreTransformationOutgoingFilter(rejects(newFlow, explicit100Interface, c))));
     assertThat(
         c,
         hasInterface(
-            explicit45Interface, hasOutgoingFilter(rejects(newFlow, explicit45Interface, c))));
+            insideInterface,
+            hasPreTransformationOutgoingFilter(rejects(newFlow, insideInterface, c))));
     assertThat(
         c,
-        hasInterface(outsideInterface, hasOutgoingFilter(rejects(newFlow, outsideInterface, c))));
+        hasInterface(
+            explicit45Interface,
+            hasPreTransformationOutgoingFilter(rejects(newFlow, explicit45Interface, c))));
+    assertThat(
+        c,
+        hasInterface(
+            outsideInterface,
+            hasPreTransformationOutgoingFilter(rejects(newFlow, outsideInterface, c))));
 
     // No traffic between interfaces with same level
     assertThat(
         c,
         hasInterface(
-            insideInterface, hasOutgoingFilter(rejects(newFlow, explicit100Interface, c))));
+            insideInterface,
+            hasPreTransformationOutgoingFilter(rejects(newFlow, explicit100Interface, c))));
     assertThat(
         c,
         hasInterface(
-            explicit100Interface, hasOutgoingFilter(rejects(newFlow, insideInterface, c))));
+            explicit100Interface,
+            hasPreTransformationOutgoingFilter(rejects(newFlow, insideInterface, c))));
 
     // Allow traffic from 100 to others
     assertThat(
         c,
-        hasInterface(explicit45Interface, hasOutgoingFilter(accepts(newFlow, insideInterface, c))));
+        hasInterface(
+            explicit45Interface,
+            hasPreTransformationOutgoingFilter(accepts(newFlow, insideInterface, c))));
     assertThat(
-        c, hasInterface(outsideInterface, hasOutgoingFilter(accepts(newFlow, insideInterface, c))));
+        c,
+        hasInterface(
+            outsideInterface,
+            hasPreTransformationOutgoingFilter(accepts(newFlow, insideInterface, c))));
 
     // Mid level is accepted by lower, but not higher
     assertThat(
         c,
-        hasInterface(insideInterface, hasOutgoingFilter(rejects(newFlow, explicit45Interface, c))));
+        hasInterface(
+            insideInterface,
+            hasPreTransformationOutgoingFilter(rejects(newFlow, explicit45Interface, c))));
     assertThat(
         c,
         hasInterface(
-            outsideInterface, hasOutgoingFilter(accepts(newFlow, explicit45Interface, c))));
+            outsideInterface,
+            hasPreTransformationOutgoingFilter(accepts(newFlow, explicit45Interface, c))));
 
     // No traffic from outside
     assertThat(
-        c, hasInterface(insideInterface, hasOutgoingFilter(rejects(newFlow, outsideInterface, c))));
+        c,
+        hasInterface(
+            insideInterface,
+            hasPreTransformationOutgoingFilter(rejects(newFlow, outsideInterface, c))));
     assertThat(
         c,
         hasInterface(
-            explicit45Interface, hasOutgoingFilter(rejects(newFlow, outsideInterface, c))));
+            explicit45Interface,
+            hasPreTransformationOutgoingFilter(rejects(newFlow, outsideInterface, c))));
 
     // All established flows are accepted
     assertThat(
         c,
         hasInterface(
-            explicit45Interface, hasOutgoingFilter(accepts(establishedFlow, outsideInterface, c))));
+            explicit45Interface,
+            hasPreTransformationOutgoingFilter(accepts(establishedFlow, outsideInterface, c))));
     assertThat(
         c,
         hasInterface(
-            insideInterface, hasOutgoingFilter(accepts(establishedFlow, outsideInterface, c))));
+            insideInterface,
+            hasPreTransformationOutgoingFilter(accepts(establishedFlow, outsideInterface, c))));
     assertThat(
         c,
         hasInterface(
-            insideInterface, hasOutgoingFilter(accepts(establishedFlow, explicit45Interface, c))));
+            insideInterface,
+            hasPreTransformationOutgoingFilter(accepts(establishedFlow, explicit45Interface, c))));
     assertThat(
         c,
         hasInterface(
-            insideInterface, hasOutgoingFilter(accepts(establishedFlow, explicit100Interface, c))));
+            insideInterface,
+            hasPreTransformationOutgoingFilter(accepts(establishedFlow, explicit100Interface, c))));
   }
 
   @Test
@@ -4040,12 +4099,24 @@ public class CiscoGrammarTest {
     Flow newFlow = createFlow(IpProtocol.IP, 0, 0, FlowState.NEW);
 
     // Allow traffic in and out of the same interface
-    assertThat(c, hasInterface(ifaceAlias1, hasOutgoingFilter(accepts(newFlow, ifaceAlias1, c))));
-    assertThat(c, hasInterface(ifaceAlias2, hasOutgoingFilter(accepts(newFlow, ifaceAlias2, c))));
+    assertThat(
+        c,
+        hasInterface(
+            ifaceAlias1, hasPreTransformationOutgoingFilter(accepts(newFlow, ifaceAlias1, c))));
+    assertThat(
+        c,
+        hasInterface(
+            ifaceAlias2, hasPreTransformationOutgoingFilter(accepts(newFlow, ifaceAlias2, c))));
 
     // Allow traffic between interfaces with same level
-    assertThat(c, hasInterface(ifaceAlias1, hasOutgoingFilter(accepts(newFlow, ifaceAlias2, c))));
-    assertThat(c, hasInterface(ifaceAlias2, hasOutgoingFilter(accepts(newFlow, ifaceAlias1, c))));
+    assertThat(
+        c,
+        hasInterface(
+            ifaceAlias1, hasPreTransformationOutgoingFilter(accepts(newFlow, ifaceAlias2, c))));
+    assertThat(
+        c,
+        hasInterface(
+            ifaceAlias2, hasPreTransformationOutgoingFilter(accepts(newFlow, ifaceAlias1, c))));
   }
 
   @Test
@@ -4056,12 +4127,24 @@ public class CiscoGrammarTest {
     Flow newFlow = createFlow(IpProtocol.IP, 0, 0, FlowState.NEW);
 
     // No traffic in and out of the same interface
-    assertThat(c, hasInterface(ifaceAlias1, hasOutgoingFilter(rejects(newFlow, ifaceAlias1, c))));
-    assertThat(c, hasInterface(ifaceAlias2, hasOutgoingFilter(rejects(newFlow, ifaceAlias2, c))));
+    assertThat(
+        c,
+        hasInterface(
+            ifaceAlias1, hasPreTransformationOutgoingFilter(rejects(newFlow, ifaceAlias1, c))));
+    assertThat(
+        c,
+        hasInterface(
+            ifaceAlias2, hasPreTransformationOutgoingFilter(rejects(newFlow, ifaceAlias2, c))));
 
     // Allow traffic between interfaces with same level
-    assertThat(c, hasInterface(ifaceAlias1, hasOutgoingFilter(accepts(newFlow, ifaceAlias2, c))));
-    assertThat(c, hasInterface(ifaceAlias2, hasOutgoingFilter(accepts(newFlow, ifaceAlias1, c))));
+    assertThat(
+        c,
+        hasInterface(
+            ifaceAlias1, hasPreTransformationOutgoingFilter(accepts(newFlow, ifaceAlias2, c))));
+    assertThat(
+        c,
+        hasInterface(
+            ifaceAlias2, hasPreTransformationOutgoingFilter(accepts(newFlow, ifaceAlias1, c))));
   }
 
   @Test
@@ -4072,12 +4155,24 @@ public class CiscoGrammarTest {
     Flow newFlow = createFlow(IpProtocol.IP, 0, 0, FlowState.NEW);
 
     // Allow traffic in and out of the same interface
-    assertThat(c, hasInterface(ifaceAlias1, hasOutgoingFilter(accepts(newFlow, ifaceAlias1, c))));
-    assertThat(c, hasInterface(ifaceAlias2, hasOutgoingFilter(accepts(newFlow, ifaceAlias2, c))));
+    assertThat(
+        c,
+        hasInterface(
+            ifaceAlias1, hasPreTransformationOutgoingFilter(accepts(newFlow, ifaceAlias1, c))));
+    assertThat(
+        c,
+        hasInterface(
+            ifaceAlias2, hasPreTransformationOutgoingFilter(accepts(newFlow, ifaceAlias2, c))));
 
     // No traffic between interfaces with same level
-    assertThat(c, hasInterface(ifaceAlias1, hasOutgoingFilter(rejects(newFlow, ifaceAlias2, c))));
-    assertThat(c, hasInterface(ifaceAlias2, hasOutgoingFilter(rejects(newFlow, ifaceAlias1, c))));
+    assertThat(
+        c,
+        hasInterface(
+            ifaceAlias1, hasPreTransformationOutgoingFilter(rejects(newFlow, ifaceAlias2, c))));
+    assertThat(
+        c,
+        hasInterface(
+            ifaceAlias2, hasPreTransformationOutgoingFilter(rejects(newFlow, ifaceAlias1, c))));
   }
 
   @Test
@@ -4107,72 +4202,54 @@ public class CiscoGrammarTest {
   }
 
   @Test
-  public void testAsaObjectNatDynamic() {
-    // Test vendor-specific parsing of ASA dynamic object NATs
+  public void testAsaObjectNatDynamic() throws IOException {
+    // Test Transformations from ASA dynamic object NATs
     String hostname = "asa-nat-object-dynamic";
-    CiscoConfiguration config = parseCiscoConfig(hostname, ConfigurationFormat.CISCO_ASA);
+    Configuration config = parseConfig(hostname);
 
-    List<CiscoAsaNat> nats = config.getCiscoAsaNats();
-    assertThat(nats, hasSize(4));
+    Transformation.Builder nat1 =
+        when(and(
+                matchSrc(
+                    new IpSpaceReference("source-real-1", "Match network object: 'source-real-1'")),
+                matchSrcInterface("inside")))
+            .apply(assignSourceIp(Ip.parse("192.168.1.1"), Ip.parse("192.168.1.10")));
+    Transformation.Builder nat2 =
+        when(and(
+                matchSrc(
+                    new IpSpaceReference("source-real-2", "Match network object: 'source-real-2'")),
+                matchSrcInterface("outside")))
+            .apply(assignSourceIp(Ip.parse("192.168.2.1"), Ip.parse("192.168.2.10")));
+    Transformation.Builder nat3 =
+        when(and(
+                matchSrc(
+                    new IpSpaceReference("source-real-3", "Match network object: 'source-real-3'")),
+                matchSrcInterface("inside")))
+            .apply(assignSourceIp(Ip.parse("192.168.3.1"), Ip.parse("192.168.3.10")));
+    Transformation.Builder nat4 =
+        when(matchSrc(
+                new IpSpaceReference("source-real-4", "Match network object: 'source-real-4'")))
+            .apply(assignSourceIp(Ip.parse("192.168.4.1"), Ip.parse("192.168.4.10")));
 
-    // dynamic source NAT, subnet -> range
-    CiscoAsaNat nat = config.getCiscoAsaNats().get(0);
-    Optional<Transformation.Builder> builder =
-        nat.toOutgoingTransformation(config.getNetworkObjects(), new Warnings());
-    assertThat("No outgoing transformation", builder.isPresent(), equalTo(true));
-    Transformation object = builder.get().build();
-    assertThat(
-        object,
-        equalTo(
-            when(and(
-                    matchSrcInterface("inside"),
-                    matchSrc(
-                        new IpSpaceReference(
-                            "source-real-1", "Match network object: 'source-real-1'"))))
-                .apply(assignSourceIp(Ip.parse("192.168.1.1"), Ip.parse("192.168.1.10")))
-                .build()));
+    Transformation nat = config.getAllInterfaces().get("inside").getIncomingTransformation();
+    assertThat(nat, nullValue());
 
-    nat = config.getCiscoAsaNats().get(1);
-    builder = nat.toOutgoingTransformation(config.getNetworkObjects(), new Warnings());
-    assertThat("No outgoing transformation", builder.isPresent(), equalTo(true));
-    object = builder.get().build();
-    assertThat(
-        object,
-        equalTo(
-            when(and(
-                    matchSrcInterface("outside"),
-                    matchSrc(
-                        new IpSpaceReference(
-                            "source-real-2", "Match network object: 'source-real-2'"))))
-                .apply(assignSourceIp(Ip.parse("192.168.2.1"), Ip.parse("192.168.2.10")))
-                .build()));
+    // 'inside' is the mapped interface for nat rules 2, 3, and 4. Sorted as 2->3->4
+    nat = config.getAllInterfaces().get("inside").getOutgoingTransformation();
+    assertThat(nat, equalTo(nat2.setOrElse(nat3.setOrElse(nat4.build()).build()).build()));
 
-    nat = config.getCiscoAsaNats().get(2);
-    builder = nat.toOutgoingTransformation(config.getNetworkObjects(), new Warnings());
-    assertThat("No outgoing transformation", builder.isPresent(), equalTo(true));
-    object = builder.get().build();
-    assertThat(
-        object,
-        equalTo(
-            when(and(
-                    matchSrcInterface("inside"),
-                    matchSrc(
-                        new IpSpaceReference(
-                            "source-real-3", "Match network object: 'source-real-3'"))))
-                .apply(assignSourceIp(Ip.parse("192.168.3.1"), Ip.parse("192.168.3.10")))
-                .build()));
+    nat = config.getAllInterfaces().get("outside").getIncomingTransformation();
+    assertThat(nat, nullValue());
 
-    nat = config.getCiscoAsaNats().get(3);
-    builder = nat.toOutgoingTransformation(config.getNetworkObjects(), new Warnings());
-    assertThat("No outgoing transformation", builder.isPresent(), equalTo(true));
-    object = builder.get().build();
-    assertThat(
-        object,
-        equalTo(
-            when(matchSrc(
-                    new IpSpaceReference("source-real-4", "Match network object: 'source-real-4'")))
-                .apply(assignSourceIp(Ip.parse("192.168.4.1"), Ip.parse("192.168.4.10")))
-                .build()));
+    // 'outside' is the mapped interface for nat rules 1, 3, and 4. Sorted as 1->3->4
+    nat = config.getAllInterfaces().get("outside").getOutgoingTransformation();
+    assertThat(nat, equalTo(nat1.setOrElse(nat3.setOrElse(nat4.build()).build()).build()));
+
+    nat = config.getAllInterfaces().get("other").getIncomingTransformation();
+    assertThat(nat, nullValue());
+
+    // 'other' is the mapped interface for nat rules 3 and 4. Sorted as 3->4
+    nat = config.getAllInterfaces().get("other").getOutgoingTransformation();
+    assertThat(nat, equalTo(nat3.setOrElse(nat4.build()).build()));
   }
 
   @Test
@@ -4212,57 +4289,60 @@ public class CiscoGrammarTest {
   }
 
   @Test
-  public void testAsaObjectNatStatic() {
-    // Test vendor-specific parsing of ASA static object NATs
+  public void testAsaObjectNatStatic() throws IOException {
+    // Test Transformations from ASA static object NATs
     String hostname = "asa-nat-object-static";
-    CiscoConfiguration config = parseCiscoConfig(hostname, ConfigurationFormat.CISCO_ASA);
+    Configuration config = parseConfig(hostname);
 
     Prefix realSource1 = Prefix.parse("1.1.1.1/32");
     Prefix realSource2 = Prefix.parse("2.2.2.0/29");
+    Prefix realSource3 = Prefix.parse("3.3.3.3/32");
     Prefix realSource4 = Prefix.parse("4.4.4.0/24");
     Prefix mappedSource1 = Prefix.parse("192.168.1.1/32");
     Prefix mappedSource2 = Prefix.parse("192.168.2.0/29");
+    Prefix mappedSource3 = Prefix.parse("192.168.3.0/32");
     Prefix mappedSource4 = Prefix.parse("192.168.4.0/24");
 
-    // Host source NAT outgoing
-    CiscoAsaNat nat = config.getCiscoAsaNats().get(0);
-    Optional<Transformation.Builder> builder =
-        nat.toOutgoingTransformation(config.getNetworkObjects(), new Warnings());
-    assertThat("No outgoing transformation", builder.isPresent(), equalTo(true));
-    Transformation object = builder.get().build();
-    assertThat(
-        object,
-        equalTo(
-            when(and(matchSrcInterface("inside"), matchSrc(realSource1)))
-                .apply(shiftSourceIp(mappedSource1))
-                .build()));
+    Transformation.Builder natIn1 =
+        when(matchDst(mappedSource1)).apply(shiftDestinationIp(realSource1));
+    Transformation.Builder natIn2 =
+        when(matchDst(mappedSource2)).apply(shiftDestinationIp(realSource2));
+    Transformation.Builder natIn3 =
+        when(matchDst(mappedSource3)).apply(shiftDestinationIp(realSource3));
+    Transformation.Builder natIn4 =
+        when(matchDst(mappedSource4)).apply(shiftDestinationIp(realSource4));
+    Transformation.Builder natOut1 =
+        when(and(matchSrc(realSource1), matchSrcInterface("inside")))
+            .apply(shiftSourceIp(mappedSource1));
+    Transformation.Builder natOut2 =
+        when(and(matchSrc(realSource2), matchSrcInterface("outside")))
+            .apply(shiftSourceIp(mappedSource2));
+    Transformation.Builder natOut3 =
+        when(and(matchSrc(realSource3), matchSrcInterface("inside")))
+            .apply(shiftSourceIp(mappedSource3));
+    Transformation.Builder natOut4 =
+        when(matchSrc(realSource4)).apply(shiftSourceIp(mappedSource4));
 
-    // Host source NAT incoming
-    builder = nat.toIncomingTransformation(config.getNetworkObjects(), new Warnings());
-    assertThat("No incoming transformation", builder.isPresent(), equalTo(true));
-    object = builder.get().build();
-    assertThat(
-        object,
-        equalTo(when(matchDst(mappedSource1)).apply(shiftDestinationIp(realSource1)).build()));
+    // 'inside' is the mapped interface for nat rules 2, 3, and 4. Sorted as 3->2->4.
+    Transformation nat = config.getAllInterfaces().get("inside").getIncomingTransformation();
+    assertThat(nat, equalTo(natIn3.setOrElse(natIn2.setOrElse(natIn4.build()).build()).build()));
 
-    nat = config.getCiscoAsaNats().get(1);
-    builder = nat.toOutgoingTransformation(config.getNetworkObjects(), new Warnings());
-    assertThat("No outgoing transformation", builder.isPresent(), equalTo(true));
-    object = builder.get().build();
-    assertThat(
-        object,
-        equalTo(
-            when(and(matchSrcInterface("outside"), matchSrc(realSource2)))
-                .apply(shiftSourceIp(mappedSource2))
-                .build()));
+    nat = config.getAllInterfaces().get("inside").getOutgoingTransformation();
+    assertThat(nat, equalTo(natOut3.setOrElse(natOut2.setOrElse(natOut4.build()).build()).build()));
 
-    // inline IP used as subnet
-    nat = config.getCiscoAsaNats().get(3);
-    builder = nat.toOutgoingTransformation(config.getNetworkObjects(), new Warnings());
-    assertThat("No outgoing transformation", builder.isPresent(), equalTo(true));
-    object = builder.get().build();
-    assertThat(
-        object, equalTo(when(matchSrc(realSource4)).apply(shiftSourceIp(mappedSource4)).build()));
+    // 'outside' is the mapped interface for nat rules 1, 3, and 4. Sorted as 1->3->4
+    nat = config.getAllInterfaces().get("outside").getIncomingTransformation();
+    assertThat(nat, equalTo(natIn1.setOrElse(natIn3.setOrElse(natIn4.build()).build()).build()));
+
+    nat = config.getAllInterfaces().get("outside").getOutgoingTransformation();
+    assertThat(nat, equalTo(natOut1.setOrElse(natOut3.setOrElse(natOut4.build()).build()).build()));
+
+    // 'other' is the mapped interface for nat rules 3 and 4. Sorted as 3->4
+    nat = config.getAllInterfaces().get("other").getIncomingTransformation();
+    assertThat(nat, equalTo(natIn3.setOrElse(natIn4.build()).build()));
+
+    nat = config.getAllInterfaces().get("other").getOutgoingTransformation();
+    assertThat(nat, equalTo(natOut3.setOrElse(natOut4.build()).build()));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -4514,8 +4514,8 @@ public class CiscoGrammarTest {
     nat = nats.get(2);
     assertThat(nat.getDynamic(), equalTo(false));
     assertThat(nat.getTwice(), equalTo(false));
-    assertThat(nat.getInsideInterface(), nullValue());
-    assertThat(nat.getOutsideInterface(), nullValue());
+    assertThat(nat.getInsideInterface(), equalTo(CiscoAsaNat.ANY_INTERFACE));
+    assertThat(nat.getOutsideInterface(), equalTo(CiscoAsaNat.ANY_INTERFACE));
     assertThat(
         nat.getRealSource(), equalTo(new NetworkObjectGroupAddressSpecifier("source-real-group")));
     assertThat(
@@ -4525,10 +4525,10 @@ public class CiscoGrammarTest {
     nat = nats.get(3);
     MatcherAssert.assertThat("NAT is active", nat.getInactive());
     assertThat(nat.getInsideInterface(), equalTo("inside"));
-    assertThat(nat.getOutsideInterface(), nullValue());
+    assertThat(nat.getOutsideInterface(), equalTo(CiscoAsaNat.ANY_INTERFACE));
 
     nat = nats.get(4);
-    assertThat(nat.getInsideInterface(), nullValue());
+    assertThat(nat.getInsideInterface(), equalTo(CiscoAsaNat.ANY_INTERFACE));
     assertThat(nat.getOutsideInterface(), equalTo("outside"));
 
     nat = nats.get(5);

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -1933,7 +1933,7 @@
             "ospfHelloMultiplier" : 0,
             "ospfPassive" : false,
             "ospfPointToPoint" : false,
-            "outgoingFilter" : "~COMBINED_OUTGOING_ACL~blah~",
+            "preTransformationOutgoingFilter" : "~COMBINED_OUTGOING_ACL~blah~",
             "prefix" : "192.168.1.0/24",
             "proxyArp" : true,
             "ripEnabled" : false,


### PR DESCRIPTION
Adds basic support for ASA object NATs without policy routing. If NAT
rules specify interfaces for packets which differ from the FIB, they
will be transformed but routed incorrectly.

@dhalperi @anothermattbrown 