### PR TITLE
parser for PAT

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -4163,6 +4163,11 @@ NO_TCP_FORWARDING
    'no-tcp-forwarding'
 ;
 
+NO_TRANSLATION
+:
+   'no-translation'
+;
+
 NO_TRAPS
 :
    'no-traps'
@@ -4453,6 +4458,11 @@ POOL
    'pool'
 ;
 
+POOL_DEFAULT_PORT_RANGE
+:
+   'pool-default-port-range'
+;
+
 POOL_UTILIZATION_ALARM
 :
     'pool-utilization-alarm'
@@ -4736,6 +4746,11 @@ RADIUS_OPTIONS
 RADIUS_SERVER
 :
    'radius-server'
+;
+
+RANGE
+:
+   'range'
 ;
 
 RAS

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_security.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_security.g4
@@ -137,12 +137,18 @@ nat_pool
    (
       natp_address
       | natp_description
+      | natp_port
    )
 ;
 
 nat_pool_utilization_alarm
 :
     POOL_UTILIZATION_ALARM null_filler
+;
+
+nat_pool_default_port_range
+:
+   POOL_DEFAULT_PORT_RANGE low = DEC (TO high = DEC)?
 ;
 
 nat_port_randomization
@@ -182,6 +188,19 @@ natp_address
       (
          from = IP_PREFIX TO to = IP_PREFIX
       )
+      |
+      (
+         ip_address = IP_ADDRESS PORT port_num = DEC
+      )
+   )
+;
+
+natp_port
+:
+   PORT
+   (
+      NO_TRANSLATION
+      | RANGE from = DEC (TO to = DEC)?
    )
 ;
 
@@ -1004,6 +1023,7 @@ sen_source
       | nat_pool
       | nat_pool_utilization_alarm
       | nat_port_randomization
+      | nat_pool_default_port_range
    )
 ;
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -79,6 +79,7 @@ import static org.batfish.representation.juniper.JuniperStructureUsage.SNMP_COMM
 import static org.batfish.representation.juniper.JuniperStructureUsage.STATIC_ROUTE_NEXT_HOP_INTERFACE;
 import static org.batfish.representation.juniper.JuniperStructureUsage.VLAN_L3_INTERFACE;
 import static org.batfish.representation.juniper.JuniperStructureUsage.VTEP_SOURCE_INTERFACE;
+import static org.batfish.representation.juniper.Nat.Type.SOURCE;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -301,8 +302,10 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ist_family_shortcutsCon
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Junos_applicationContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Junos_application_setContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Nat_poolContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Nat_pool_default_port_rangeContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Nat_rule_setContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Natp_addressContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Natp_portContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.O_areaContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.O_exportContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.O_reference_bandwidthContext;
@@ -2385,6 +2388,10 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   public void enterNat_pool(Nat_poolContext ctx) {
     String poolName = ctx.name.getText();
     _currentNatPool = _currentNat.getPools().computeIfAbsent(poolName, p -> new NatPool());
+    // port address translation is enabled by default for source nat
+    if (_currentNat.getType() == SOURCE) {
+      _currentNatPool.setPortTranslation(true);
+    }
     defineStructure(NAT_POOL, poolName, ctx);
   }
 
@@ -3159,7 +3166,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
 
   @Override
   public void enterSen_source(Sen_sourceContext ctx) {
-    _currentNat = _currentLogicalSystem.getOrCreateNat(Nat.Type.SOURCE);
+    _currentNat = _currentLogicalSystem.getOrCreateNat(SOURCE);
   }
 
   @Override
@@ -4359,10 +4366,43 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
         _currentNatPool.setFromAddress(Ip.parse(ctx.from.getText()));
         _currentNatPool.setToAddress(Ip.parse(ctx.to.getText()));
       }
-    } else {
+    } else if (!ctx.IP_PREFIX().isEmpty()) {
+      // address IP_PREFIX
       Prefix prefix = Prefix.parse(ctx.prefix.getText());
       _currentNatPool.setFromAddress(prefix.getFirstHostIp());
       _currentNatPool.setToAddress(prefix.getLastHostIp());
+    } else if (ctx.PORT() != null) {
+      // this command can only happen for destination nat, and when port is given we need to enable
+      // port translation
+      _currentNatPool.setFromAddress(Ip.parse(ctx.ip_address.getText()));
+      _currentNatPool.setToAddress(Ip.parse(ctx.ip_address.getText()));
+      _currentNatPool.setFromPort(Integer.parseInt(ctx.port_num.getText()));
+      _currentNatPool.setToPort(Integer.parseInt(ctx.port_num.getText()));
+      _currentNatPool.setPortTranslation(true);
+    } else {
+      _w.redFlag(ctx.getText() + " cannot be recognized");
+    }
+  }
+
+  @Override
+  public void exitNatp_port(Natp_portContext ctx) {
+    if (ctx.NO_TRANSLATION() != null) {
+      _currentNatPool.setPortTranslation(false);
+    } else if (ctx.RANGE() != null) {
+      _currentNatPool.setFromPort(Integer.parseInt(ctx.from.getText()));
+      if (ctx.TO() != null) {
+        _currentNatPool.setToPort(Integer.parseInt(ctx.to.getText()));
+      }
+    } else {
+      _w.redFlag(ctx.getText() + " cannot be recognized");
+    }
+  }
+
+  @Override
+  public void exitNat_pool_default_port_range(Nat_pool_default_port_rangeContext ctx) {
+    _currentNat.setDefaultFromPort(Integer.parseInt(ctx.low.getText()));
+    if (ctx.TO() != null) {
+      _currentNat.setDefaultToPort(Integer.parseInt(ctx.high.getText()));
     }
   }
 
@@ -5017,7 +5057,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
     if (ctx.FROM() != null) {
       packetLocation = _currentNatRuleSet.getFromLocation();
     } else { // TO
-      if (_currentNat.getType() != Nat.Type.SOURCE) {
+      if (_currentNat.getType() != SOURCE) {
         _w.addWarning(
             ctx,
             getFullText(ctx),

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -2389,6 +2389,11 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   public void enterNat_pool(Nat_poolContext ctx) {
     String poolName = ctx.name.getText();
     _currentNatPool = _currentNat.getPools().computeIfAbsent(poolName, p -> new NatPool());
+    if (_currentNat.getType() == SOURCE && _currentNatPool.getPatPool() == null) {
+      PatPool patPool = new PatPool();
+      patPool.setPortTranslation(true);
+      _currentNatPool.setPatPool(patPool);
+    }
     defineStructure(NAT_POOL, poolName, ctx);
   }
 
@@ -4396,6 +4401,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
       if (ctx.TO() != null) {
         _currentNatPool.getPatPool().setToPort(Integer.parseInt(ctx.to.getText()));
       }
+      _currentNatPool.getPatPool().setPortTranslation(true);
     } else {
       _w.redFlag(ctx.getText() + " cannot be recognized");
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Nat.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Nat.java
@@ -24,10 +24,20 @@ public final class Nat implements Serializable {
 
   private final Type _type;
 
+  private static final int DEFAULT_FROM_PORT = 1024;
+
+  private static final int DEFAULT_TO_PORT = 63487;
+
+  private int _defaultFromPort;
+
+  private int _defaultToPort;
+
   public Nat(Type type) {
     _type = type;
     _pools = new TreeMap<>();
     _ruleSets = new TreeMap<>();
+    _defaultFromPort = DEFAULT_FROM_PORT;
+    _defaultToPort = DEFAULT_TO_PORT;
   }
 
   @Nonnull
@@ -43,5 +53,21 @@ public final class Nat implements Serializable {
   @Nonnull
   public Type getType() {
     return _type;
+  }
+
+  public int getDefaultFromPort() {
+    return _defaultFromPort;
+  }
+
+  public int getDefaultToPort() {
+    return _defaultToPort;
+  }
+
+  public void setDefaultFromPort(int fromPort) {
+    _defaultFromPort = fromPort;
+  }
+
+  public void setDefaultToPort(int toPort) {
+    _defaultToPort = toPort;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/NatPool.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/NatPool.java
@@ -16,9 +16,18 @@ public final class NatPool implements Serializable {
 
   private Ip _toAddress;
 
+  private Integer _fromPort;
+
+  private Integer _toPort;
+
+  private boolean _portTranslation;
+
   public NatPool() {
     _fromAddress = Prefix.ZERO.getStartIp();
     _toAddress = Prefix.ZERO.getEndIp();
+    _fromPort = null;
+    _toPort = null;
+    _portTranslation = false;
   }
 
   @Nonnull
@@ -31,11 +40,35 @@ public final class NatPool implements Serializable {
     return _toAddress;
   }
 
+  public Integer getFromPort() {
+    return _fromPort;
+  }
+
+  public Integer getToPort() {
+    return _toPort;
+  }
+
+  public boolean getPortTranslation() {
+    return _portTranslation;
+  }
+
   public void setFromAddress(Ip fromAddress) {
     _fromAddress = fromAddress;
   }
 
   public void setToAddress(Ip toAddress) {
     _toAddress = toAddress;
+  }
+
+  public void setFromPort(int fromPort) {
+    _fromPort = fromPort;
+  }
+
+  public void setToPort(int toPort) {
+    _toPort = toPort;
+  }
+
+  public void setPortTranslation(boolean portTranslation) {
+    _portTranslation = portTranslation;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/NatPool.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/NatPool.java
@@ -2,6 +2,7 @@ package org.batfish.representation.juniper;
 
 import java.io.Serializable;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
@@ -16,18 +17,13 @@ public final class NatPool implements Serializable {
 
   private Ip _toAddress;
 
-  private Integer _fromPort;
-
-  private Integer _toPort;
-
-  private boolean _portTranslation;
+  // null value means no pat is configured
+  @Nullable private PatPool _patPool;
 
   public NatPool() {
     _fromAddress = Prefix.ZERO.getStartIp();
     _toAddress = Prefix.ZERO.getEndIp();
-    _fromPort = null;
-    _toPort = null;
-    _portTranslation = false;
+    _patPool = null;
   }
 
   @Nonnull
@@ -40,16 +36,9 @@ public final class NatPool implements Serializable {
     return _toAddress;
   }
 
-  public Integer getFromPort() {
-    return _fromPort;
-  }
-
-  public Integer getToPort() {
-    return _toPort;
-  }
-
-  public boolean getPortTranslation() {
-    return _portTranslation;
+  @Nullable
+  public PatPool getPatPool() {
+    return _patPool;
   }
 
   public void setFromAddress(Ip fromAddress) {
@@ -60,15 +49,7 @@ public final class NatPool implements Serializable {
     _toAddress = toAddress;
   }
 
-  public void setFromPort(int fromPort) {
-    _fromPort = fromPort;
-  }
-
-  public void setToPort(int toPort) {
-    _toPort = toPort;
-  }
-
-  public void setPortTranslation(boolean portTranslation) {
-    _portTranslation = portTranslation;
+  public void setPatPool(PatPool patPool) {
+    _patPool = patPool;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/NatPool.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/NatPool.java
@@ -17,13 +17,14 @@ public final class NatPool implements Serializable {
 
   private Ip _toAddress;
 
-  // null value means no pat is configured
-  @Nullable private PatPool _patPool;
+  // null value means no pat is configured; source nat will apply pat and dest nat will not apply
+  // pat by default
+  @Nullable private PortAddressTranslation _pat;
 
   public NatPool() {
     _fromAddress = Prefix.ZERO.getStartIp();
     _toAddress = Prefix.ZERO.getEndIp();
-    _patPool = null;
+    _pat = null;
   }
 
   @Nonnull
@@ -37,8 +38,8 @@ public final class NatPool implements Serializable {
   }
 
   @Nullable
-  public PatPool getPatPool() {
-    return _patPool;
+  public PortAddressTranslation getPortAddressTranslation() {
+    return _pat;
   }
 
   public void setFromAddress(Ip fromAddress) {
@@ -49,7 +50,7 @@ public final class NatPool implements Serializable {
     _toAddress = toAddress;
   }
 
-  public void setPatPool(PatPool patPool) {
-    _patPool = patPool;
+  public void setPortAddressTranslation(PortAddressTranslation pat) {
+    _pat = pat;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/NoPortTranslation.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/NoPortTranslation.java
@@ -1,0 +1,12 @@
+package org.batfish.representation.juniper;
+
+import java.io.Serializable;
+
+public class NoPortTranslation implements PortAddressTranslation, Serializable {
+  /** */
+  private static final long serialVersionUID = 1L;
+
+  public static final NoPortTranslation INSTANCE = new NoPortTranslation();
+
+  private NoPortTranslation() {}
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PatPool.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PatPool.java
@@ -1,0 +1,47 @@
+package org.batfish.representation.juniper;
+
+import java.io.Serializable;
+
+public class PatPool implements Serializable {
+  /** */
+  private static final long serialVersionUID = 1L;
+
+  // null value means that no port is specified
+  private Integer _fromPort;
+
+  // null value means that no port is specified
+  private Integer _toPort;
+
+  // null value means that no port translation is specified
+  private Boolean _portTranslation;
+
+  public PatPool() {
+    _fromPort = null;
+    _toPort = null;
+    _portTranslation = null;
+  }
+
+  public Integer getFromPort() {
+    return _fromPort;
+  }
+
+  public Integer getToPort() {
+    return _toPort;
+  }
+
+  public Boolean getPortTranslation() {
+    return _portTranslation;
+  }
+
+  public void setFromPort(int fromPort) {
+    _fromPort = fromPort;
+  }
+
+  public void setToPort(int toPort) {
+    _toPort = toPort;
+  }
+
+  public void setPortTranslation(boolean portTranslation) {
+    _portTranslation = portTranslation;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PatPool.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PatPool.java
@@ -12,7 +12,8 @@ public class PatPool implements Serializable {
   // null value means that no port is specified
   private Integer _toPort;
 
-  // 1. null value means no PAT related configuration is given. when the value is null, source nat
+  // 1. null value means no port translation related configuration is given. when the value is null,
+  // source nat
   // will apply PAT and dest nat will not apply PAT by default
   // 2. true means that a specific PAT command is found in the configuration that requires PAT
   // 3. no means that a specific PAT command is found in the configuration that requires no PAT

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PatPool.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PatPool.java
@@ -1,25 +1,19 @@
 package org.batfish.representation.juniper;
 
 import java.io.Serializable;
+import java.util.Objects;
 
-public class PatPool implements Serializable {
+public class PatPool implements PortAddressTranslation, Serializable {
   /** */
   private static final long serialVersionUID = 1L;
 
-  // -1 means that no port is specified; so we need to apply a default value
   private int _fromPort;
 
-  // -1 means that no port is specified; so we need to apply a default value
   private int _toPort;
 
-  // 1. true means that we need to apply PAT
-  // 2. no means that we should not apply PAT
-  private boolean _portTranslation;
-
-  public PatPool() {
-    _fromPort = -1;
-    _toPort = -1;
-    _portTranslation = false;
+  public PatPool(int fromPort, int toPort) {
+    _fromPort = fromPort;
+    _toPort = toPort;
   }
 
   public Integer getFromPort() {
@@ -30,10 +24,6 @@ public class PatPool implements Serializable {
     return _toPort;
   }
 
-  public Boolean getPortTranslation() {
-    return _portTranslation;
-  }
-
   public void setFromPort(int fromPort) {
     _fromPort = fromPort;
   }
@@ -42,7 +32,19 @@ public class PatPool implements Serializable {
     _toPort = toPort;
   }
 
-  public void setPortTranslation(boolean portTranslation) {
-    _portTranslation = portTranslation;
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    } else if (!(o instanceof PatPool)) {
+      return false;
+    }
+    PatPool other = (PatPool) o;
+    return _fromPort == other.getFromPort() && _toPort == other.getToPort();
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_fromPort, _toPort);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PatPool.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PatPool.java
@@ -12,7 +12,10 @@ public class PatPool implements Serializable {
   // null value means that no port is specified
   private Integer _toPort;
 
-  // null value means that no port translation is specified
+  // 1. null value means no PAT related configuration is given. when the value is null, source nat
+  // will apply PAT and dest nat will not apply PAT by default
+  // 2. true means that a specific PAT command is found in the configuration that requires PAT
+  // 3. no means that a specific PAT command is found in the configuration that requires no PAT
   private Boolean _portTranslation;
 
   public PatPool() {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PatPool.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PatPool.java
@@ -6,23 +6,20 @@ public class PatPool implements Serializable {
   /** */
   private static final long serialVersionUID = 1L;
 
-  // null value means that no port is specified
-  private Integer _fromPort;
+  // -1 means that no port is specified; so we need to apply a default value
+  private int _fromPort;
 
-  // null value means that no port is specified
-  private Integer _toPort;
+  // -1 means that no port is specified; so we need to apply a default value
+  private int _toPort;
 
-  // 1. null value means no port translation related configuration is given. when the value is null,
-  // source nat
-  // will apply PAT and dest nat will not apply PAT by default
-  // 2. true means that a specific PAT command is found in the configuration that requires PAT
-  // 3. no means that a specific PAT command is found in the configuration that requires no PAT
-  private Boolean _portTranslation;
+  // 1. true means that we need to apply PAT
+  // 2. no means that we should not apply PAT
+  private boolean _portTranslation;
 
   public PatPool() {
-    _fromPort = null;
-    _toPort = null;
-    _portTranslation = null;
+    _fromPort = -1;
+    _toPort = -1;
+    _portTranslation = false;
   }
 
   public Integer getFromPort() {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PatPool.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PatPool.java
@@ -7,9 +7,9 @@ public class PatPool implements PortAddressTranslation, Serializable {
   /** */
   private static final long serialVersionUID = 1L;
 
-  private int _fromPort;
+  private final int _fromPort;
 
-  private int _toPort;
+  private final int _toPort;
 
   public PatPool(int fromPort, int toPort) {
     _fromPort = fromPort;
@@ -22,14 +22,6 @@ public class PatPool implements PortAddressTranslation, Serializable {
 
   public Integer getToPort() {
     return _toPort;
-  }
-
-  public void setFromPort(int fromPort) {
-    _fromPort = fromPort;
-  }
-
-  public void setToPort(int toPort) {
-    _toPort = toPort;
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PortAddressTranslation.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PortAddressTranslation.java
@@ -1,0 +1,3 @@
+package org.batfish.representation.juniper;
+
+public interface PortAddressTranslation {}

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -4477,14 +4477,14 @@ public final class FlatJuniperGrammarTest {
     assertNotNull(pool1.getPatPool());
     assertThat(pool1.getPatPool().getFromPort(), equalTo(2000));
     assertThat(pool1.getPatPool().getToPort(), equalTo(3000));
-    assertNull(pool1.getPatPool().getPortTranslation());
+    assertTrue(pool1.getPatPool().getPortTranslation());
 
     // pool2 should have a pat pool specified with port translation equal false, but port range
     // configured
     assertNotNull(pool2);
     assertNotNull(pool2.getPatPool());
-    assertNull(pool2.getPatPool().getFromPort());
-    assertNull(pool2.getPatPool().getToPort());
+    assertThat(pool2.getPatPool().getFromPort(), equalTo(-1));
+    assertThat(pool2.getPatPool().getToPort(), equalTo(-1));
     assertFalse(pool2.getPatPool().getPortTranslation());
 
     // pool3 should have a pat pool with port translation equal false and range [10000,20000]
@@ -4492,7 +4492,7 @@ public final class FlatJuniperGrammarTest {
     assertNotNull(pool3.getPatPool());
     assertThat(pool3.getPatPool().getFromPort(), equalTo(10000));
     assertThat(pool3.getPatPool().getToPort(), equalTo(20000));
-    assertFalse(pool3.getPatPool().getPortTranslation());
+    assertTrue(pool3.getPatPool().getPortTranslation());
 
     Nat destNat = juniperConfiguration.getMasterLogicalSystem().getNatDestination();
     NatPool pool4 = destNat.getPools().get("POOL4");

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -138,6 +138,9 @@ import static org.hamcrest.Matchers.iterableWithSize;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
@@ -4458,5 +4461,27 @@ public final class FlatJuniperGrammarTest {
 
     // ge-0/0/0.3 is not part of any zoone, so no firewall session interface info.
     assertThat(c.getAllInterfaces().get(i3Name).getFirewallSessionInterfaceInfo(), nullValue());
+  }
+
+  @Test
+  public void testPortAddressTranslation() {
+    JuniperConfiguration juniperConfiguration = parseJuniperConfig("juniper-nat-pat");
+    Nat sourceNat = juniperConfiguration.getMasterLogicalSystem().getNatSource();
+    NatPool pool1 = sourceNat.getPools().get("POOL1");
+    NatPool pool2 = sourceNat.getPools().get("POOL2");
+    assertNotNull(pool1);
+    assertNotNull(pool2);
+    assertThat(pool1.getFromPort(), equalTo(2000));
+    assertThat(pool1.getToPort(), equalTo(3000));
+    assertNull(pool2.getFromPort());
+    assertNull(pool2.getToPort());
+    assertFalse(pool2.getPortTranslation());
+
+    Nat destNat = juniperConfiguration.getMasterLogicalSystem().getNatDestination();
+    NatPool pool3 = destNat.getPools().get("POOL3");
+    assertNotNull(pool3);
+    assertThat(pool3.getFromPort(), equalTo(6000));
+    assertThat(pool3.getToPort(), equalTo(6000));
+    assertThat(pool3.getFromAddress(), equalTo(Ip.parse("1.0.0.1")));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -1,5 +1,6 @@
 package org.batfish.grammar.flatjuniper;
 
+import static junit.framework.TestCase.assertTrue;
 import static org.batfish.common.util.CommonUtil.communityStringToLong;
 import static org.batfish.datamodel.AuthenticationMethod.GROUP_RADIUS;
 import static org.batfish.datamodel.AuthenticationMethod.GROUP_TACACS;
@@ -4469,19 +4470,43 @@ public final class FlatJuniperGrammarTest {
     Nat sourceNat = juniperConfiguration.getMasterLogicalSystem().getNatSource();
     NatPool pool1 = sourceNat.getPools().get("POOL1");
     NatPool pool2 = sourceNat.getPools().get("POOL2");
+    NatPool pool3 = sourceNat.getPools().get("POOL3");
+
+    // pool1 should has a pat pool with range [2000,3000] with no port translation configured
     assertNotNull(pool1);
+    assertNotNull(pool1.getPatPool());
+    assertThat(pool1.getPatPool().getFromPort(), equalTo(2000));
+    assertThat(pool1.getPatPool().getToPort(), equalTo(3000));
+    assertNull(pool1.getPatPool().getPortTranslation());
+
+    // pool2 should have a pat pool specified with port translation equal false, but port range
+    // configured
     assertNotNull(pool2);
-    assertThat(pool1.getFromPort(), equalTo(2000));
-    assertThat(pool1.getToPort(), equalTo(3000));
-    assertNull(pool2.getFromPort());
-    assertNull(pool2.getToPort());
-    assertFalse(pool2.getPortTranslation());
+    assertNotNull(pool2.getPatPool());
+    assertNull(pool2.getPatPool().getFromPort());
+    assertNull(pool2.getPatPool().getToPort());
+    assertFalse(pool2.getPatPool().getPortTranslation());
+
+    // pool3 should have a pat pool with port translation equal false and range [10000,20000]
+    assertNotNull(pool3);
+    assertNotNull(pool3.getPatPool());
+    assertThat(pool3.getPatPool().getFromPort(), equalTo(10000));
+    assertThat(pool3.getPatPool().getToPort(), equalTo(20000));
+    assertFalse(pool3.getPatPool().getPortTranslation());
 
     Nat destNat = juniperConfiguration.getMasterLogicalSystem().getNatDestination();
-    NatPool pool3 = destNat.getPools().get("POOL3");
-    assertNotNull(pool3);
-    assertThat(pool3.getFromPort(), equalTo(6000));
-    assertThat(pool3.getToPort(), equalTo(6000));
-    assertThat(pool3.getFromAddress(), equalTo(Ip.parse("1.0.0.1")));
+    NatPool pool4 = destNat.getPools().get("POOL4");
+    NatPool pool5 = destNat.getPools().get("POOL5");
+
+    // pool4 should have a pat pool with port translation equal false and range [6000,6000]
+    assertNotNull(pool4);
+    assertNotNull(pool4.getPatPool());
+    assertThat(pool4.getPatPool().getFromPort(), equalTo(6000));
+    assertThat(pool4.getPatPool().getToPort(), equalTo(6000));
+    assertTrue(pool4.getPatPool().getPortTranslation());
+
+    // pool5 should not have a pat pool
+    assertNotNull(pool5);
+    assertNull(pool5.getPatPool());
   }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-nat-pat
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-nat-pat
@@ -5,6 +5,10 @@ set system host-name juniper-nat-pat
 set security nat source pool POOL1 port range 2000 to 3000
 set security nat source pool POOL2 port no-translation
 set security nat source pool-default-port-range 4000 to 5000
+set security nat source pool POOL3 port no-translation
+set security nat source pool POOL3 port range 1000 to 2000
+set security nat source pool POOL3 port range 10000 to 20000
 #
 # destination nat
-set security nat destination pool POOL3 address 1.0.0.1 port 6000
+set security nat destination pool POOL4 address 1.0.0.1 port 6000
+set security nat destination pool POOL5 address 1.0.0.2/24

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-nat-pat
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-nat-pat
@@ -1,0 +1,10 @@
+#
+set system host-name juniper-nat-pat
+#
+# source nat
+set security nat source pool POOL1 port range 2000 to 3000
+set security nat source pool POOL2 port no-translation
+set security nat source pool-default-port-range 4000 to 5000
+#
+# destination nat
+set security nat destination pool POOL3 address 1.0.0.1 port 6000

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-nat-pat
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-nat-pat
@@ -2,9 +2,13 @@
 set system host-name juniper-nat-pat
 #
 # source nat
+set security nat source pool POOL0 address 10.10.10.10/24
+set security nat source pool POOL1 address 1.1.1.1/24
 set security nat source pool POOL1 port range 2000 to 3000
+set security nat source pool POOL2 address 2.2.2.2/24
 set security nat source pool POOL2 port no-translation
 set security nat source pool-default-port-range 4000 to 5000
+set security nat source pool POOL3 address 3.3.3.3/24
 set security nat source pool POOL3 port no-translation
 set security nat source pool POOL3 port range 1000 to 2000
 set security nat source pool POOL3 port range 10000 to 20000


### PR DESCRIPTION
Adds grammar for PAT feature forJuniper.
In the grammar:
1. Changes nat_pool to handle port range definition 
2. Changes natp_addresss to handle port change in dest nat
3. Adds no-translation to support source nat without PAT
VS model
1. Updates Nat and NatPool to support port range