### PR TITLE
ForwardingAnalysis: only look for IPs owned by interfaces that have IPs

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ForwardingAnalysisImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ForwardingAnalysisImpl.java
@@ -390,14 +390,17 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis {
 
   @VisibleForTesting
   IpSpace computeIpsAssignedToThisInterface(Interface iface) {
+    if (iface.getAllAddresses().isEmpty()) {
+      return EmptyIpSpace.INSTANCE;
+    }
+
     Set<Ip> ips = _interfaceOwnedIps.get(iface.getOwner().getHostname()).get(iface.getName());
     if (ips == null || ips.isEmpty()) {
       return EmptyIpSpace.INSTANCE;
     }
     IpWildcardSetIpSpace.Builder ipsAssignedToThisInterfaceBuilder = IpWildcardSetIpSpace.builder();
     ips.forEach(ip -> ipsAssignedToThisInterfaceBuilder.including(new IpWildcard(ip)));
-    IpWildcardSetIpSpace ipsAssignedToThisInterface = ipsAssignedToThisInterfaceBuilder.build();
-    return ipsAssignedToThisInterface;
+    return ipsAssignedToThisInterfaceBuilder.build();
   }
 
   @VisibleForTesting


### PR DESCRIPTION
This fixes a potential crash, indirectly:

* if a device has no interfaces with IPs, it will not appear in `_interfaceOwnedIps`
* when get the owned IP space for such interfaces, there's a NPE

We could replace the `.get(hostname)` with `.getOrDefault(hostname, Empty)`, but the
proposed change here is probably more efficient. Thoughts?