### PR TITLE
Factor out PrefixTrieMultiMap.Node

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
@@ -297,7 +297,7 @@ public final class PrefixTrieMultiMap<T> implements Serializable {
 
   /**
    * Find the elements associated with the longest matching prefix of a given IP address, up to the
-   * given {@param maxPrefixLength}.
+   * given maximum length.
    */
   @Nonnull
   public Set<T> longestPrefixMatch(Ip address, int maxPrefixLength) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
@@ -1,11 +1,9 @@
 package org.batfish.datamodel;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static org.batfish.datamodel.Prefix.longestCommonPrefix;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
-import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSet.Builder;
@@ -17,6 +15,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -24,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 /**
  * A generic implementation of a Trie, specialized to keys being prefixes and values to being a set
- * of elements of type {@link DataT}.
+ * of elements of type {@link T}.
  *
  * <p>This trie is a more restrictive version of a ddNF (disjoint difference Normal Form), where the
  * wildcard symbols can appear only after (to-the-right-of) non wildcard symbols in the bit vector.
@@ -34,189 +33,15 @@ import javax.annotation.ParametersAreNonnullByDefault;
  * branching does not have to be done on each bit of the prefix.
  */
 @ParametersAreNonnullByDefault
-public final class PrefixTrieMultiMap<DataT> implements Serializable {
+public final class PrefixTrieMultiMap<T> implements Serializable {
 
   private static final long serialVersionUID = 1L;
-
-  @Nonnull private final Prefix _prefix;
-  @Nonnull private final Set<DataT> _elements;
-
-  @Nullable private PrefixTrieMultiMap<DataT> _left;
-  @Nullable private PrefixTrieMultiMap<DataT> _right;
-
-  public PrefixTrieMultiMap(Prefix prefix) {
-    _elements = new HashSet<>();
-    _prefix = prefix;
-  }
-
-  /** Return the key {@link Prefix} for this node */
-  @Nonnull
-  public Prefix getPrefix() {
-    return _prefix;
-  }
-
-  /** Return an immutable copy of elements at <i>this</i> node */
-  @Nonnull
-  @VisibleForTesting
-  Set<DataT> getElements() {
-    return ImmutableSet.copyOf(_elements);
-  }
-
-  private void setLeft(@Nullable PrefixTrieMultiMap<DataT> left) {
-    assert left == null || legalLeftChildPrefix(_prefix, left._prefix);
-    _left = left;
-  }
-
-  private void setRight(@Nullable PrefixTrieMultiMap<DataT> right) {
-    assert right == null || legalRightChildPrefix(_prefix, right._prefix);
-    _right = right;
-  }
-
-  /** Returns the list of non-null children for this node */
-  @Nonnull
-  private List<PrefixTrieMultiMap<DataT>> getChildren() {
-    return Stream.of(_left, _right)
-        .filter(Objects::nonNull)
-        .collect(ImmutableList.toImmutableList());
-  }
-
-  /**
-   * Post-order traversal over the entries. Entries will always contain non-null keys and values.
-   * The traversal may not mutate the entries (the values are immutable sets).
-   */
-  public void traverseEntries(BiConsumer<Prefix, Set<DataT>> consumer) {
-    Traverser.<PrefixTrieMultiMap<DataT>>forTree(PrefixTrieMultiMap::getChildren)
-        .depthFirstPostOrder(this)
-        .forEach(node -> consumer.accept(node._prefix, node.getElements()));
-  }
-
-  /**
-   * Retrieve an immutable copy of elements for the given prefix (anywhere in the subtree). Returns
-   * empty set if the prefix is not in the subtree.
-   *
-   * @throws IllegalArgumentException if the input {@link Prefix} is not contained in the {@link
-   *     Prefix} of this subtree.
-   */
-  @Nonnull
-  public Set<DataT> getElements(Prefix p) {
-    checkArgument(_prefix.containsPrefix(p), "Prefix %s does not belong to subtree %s", p, this);
-    PrefixTrieMultiMap<DataT> node = findNode(p);
-    return node == null ? ImmutableSet.of() : node.getElements();
-  }
-
-  /**
-   * Insert an element into this subtree corresponding to a prefix {@code p}
-   *
-   * @throws IllegalArgumentException if the input {@link Prefix} is not contained in the {@link
-   *     Prefix} of this subtree.
-   */
-  public boolean add(Prefix p, DataT e) {
-    checkArgument(_prefix.containsPrefix(p), "Prefix %s does not belong to subtree %s", p, this);
-    PrefixTrieMultiMap<DataT> node = findOrCreateNode(p);
-    return node._elements.add(e);
-  }
-
-  /**
-   * Insert a collection of elements into this subtree corresponding to a prefix {@code p}
-   *
-   * @throws IllegalArgumentException if the input {@link Prefix} is not contained in the {@link
-   *     Prefix} of this subtree.
-   */
-  public boolean addAll(Prefix p, Collection<DataT> elements) {
-    checkArgument(_prefix.containsPrefix(p), "Prefix %s does not belong to subtree %s", p, this);
-    PrefixTrieMultiMap<DataT> node = findOrCreateNode(p);
-    return node.addAll(elements);
-  }
-
-  /** Add a collection of elements to <i>this</i> node */
-  private boolean addAll(Collection<DataT> elements) {
-    return _elements.addAll(elements);
-  }
-
-  /**
-   * Remove an element from the subtree
-   *
-   * @param p prefix the element is mapped to
-   * @param e element to remove
-   * @throws IllegalArgumentException if the input {@link Prefix} is not contained in the {@link
-   *     Prefix} of this subtree.
-   */
-  public boolean remove(Prefix p, DataT e) {
-    checkArgument(_prefix.containsPrefix(p), "Prefix %s does not belong to subtree %s", p, this);
-    PrefixTrieMultiMap<DataT> node = findNode(p);
-    return node != null && node.remove(e);
-  }
-
-  /** Remove an element from <i>this</i> node */
-  private boolean remove(DataT e) {
-    return _elements.remove(e);
-  }
-
-  /**
-   * Replace all elements associated with prefix {@code p} with a given element.
-   *
-   * @throws IllegalArgumentException if the input {@link Prefix} is not contained in the {@link
-   *     Prefix} of this subtree.
-   */
-  public boolean replaceAll(Prefix p, DataT e) {
-    checkArgument(_prefix.containsPrefix(p), "Prefix %s does not belong to subtree %s", p, this);
-    PrefixTrieMultiMap<DataT> node = findNode(p);
-    return node != null && node.replaceAll(e);
-  }
-
-  /** Replace all elements stored at <i>this</i> node with a given element */
-  private boolean replaceAll(DataT e) {
-    _elements.clear();
-    return _elements.add(e);
-  }
-
-  /**
-   * Replace all elements associated with prefix {@code p} with a given collection of elements
-   *
-   * @throws IllegalArgumentException if the input {@link Prefix} is not contained in the {@link
-   *     Prefix} of this subtree.
-   */
-  public boolean replaceAll(Prefix p, Collection<DataT> e) {
-    checkArgument(_prefix.containsPrefix(p), "Prefix %s does not belong to subtree %s", p, this);
-    PrefixTrieMultiMap<DataT> node = findNode(p);
-    return node == null || node.replaceAll(e);
-  }
-
-  /** Replace all elements stored at <i>this</i> node with the given elements */
-  private boolean replaceAll(Collection<DataT> e) {
-    _elements.clear();
-    return addAll(e);
-  }
-
-  /** Find or create a node for a given prefix (must be an exact match) */
-  @Nonnull
-  private PrefixTrieMultiMap<DataT> findOrCreateNode(Prefix prefix) {
-    assert _prefix.containsPrefix(prefix);
-
-    PrefixTrieMultiMap<DataT> node = findLongestPrefixMatchNode(prefix);
-    return node._prefix.equals(prefix) ? node : node.createChild(prefix);
-  }
-
-  private @Nonnull PrefixTrieMultiMap<DataT> createChild(Prefix prefix) {
-    assert _prefix.containsPrefix(prefix);
-    boolean currentBit =
-        Ip.getBitAtPosition(prefix.getStartIp().asLong(), _prefix.getPrefixLength());
-
-    PrefixTrieMultiMap<DataT> node = new PrefixTrieMultiMap<>(prefix);
-    if (currentBit) {
-      _right = combine(node, _right);
-    } else {
-      _left = combine(node, _left);
-    }
-    return node;
-  }
 
   /**
    * Combine two nodes into a tree -- a newly created node, and an existing node. The existing node
    * cannot be the parent of the new node.
    */
-  private @Nonnull PrefixTrieMultiMap<DataT> combine(
-      @Nonnull PrefixTrieMultiMap<DataT> newNode, @Nullable PrefixTrieMultiMap<DataT> oldNode) {
+  static @Nonnull <T> Node<T> combine(@Nonnull Node<T> newNode, @Nullable Node<T> oldNode) {
     // No existing node, newNode is the tree
     if (oldNode == null) {
       return newNode;
@@ -244,7 +69,7 @@ public final class PrefixTrieMultiMap<DataT> implements Serializable {
      * one way and the oldNode branches the other.
      */
     Prefix lcp = longestCommonPrefix(newPrefix, oldPrefix);
-    PrefixTrieMultiMap<DataT> parent = new PrefixTrieMultiMap<>(lcp);
+    Node<T> parent = new Node<>(lcp);
 
     boolean newNodeRight = Ip.getBitAtPosition(newPrefix.getStartIp(), lcp.getPrefixLength());
     if (newNodeRight) {
@@ -271,86 +96,154 @@ public final class PrefixTrieMultiMap<DataT> implements Serializable {
         && Ip.getBitAtPosition(childPrefix.getStartIp(), parentPrefix.getPrefixLength());
   }
 
-  /**
-   * Find a node longest prefix match for a given IP address.
-   *
-   * @throws IllegalArgumentException if the input {@link Prefix} is not contained in the {@link
-   *     Prefix} of this subtree.
-   */
-  @Nonnull
-  public Set<DataT> longestPrefixMatch(Ip address) {
-    checkArgument(
-        _prefix.containsIp(address), "Ip %s does not belong to subtree %s", address, this);
-    return longestPrefixMatch(address, Prefix.MAX_PREFIX_LENGTH);
-  }
+  private static final class Node<T> implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-  /**
-   * Find a node longest prefix match for a given IP address, where the length of the match is
-   * bounded by {@code maxPrefixLength}
-   *
-   * @throws IllegalArgumentException if the input {@link Prefix} is not contained in the {@link
-   *     Prefix} of this subtree.
-   */
-  @Nonnull
-  public Set<DataT> longestPrefixMatch(Ip address, int maxPrefixLength) {
-    checkArgument(
-        _prefix.containsIp(address), "Ip %s does not belong to subtree %s", address, this);
-    return findLongestPrefixMatchNode(Prefix.create(address, maxPrefixLength)).getElements();
-  }
+    @Nonnull private final Prefix _prefix;
+    @Nonnull private final Set<T> _elements;
 
-  /** Collect (recursively) and return all elements in this subtree. */
-  @Nonnull
-  public Set<DataT> getAllElements() {
-    Builder<DataT> b = ImmutableSet.builder();
-    collect(b);
-    return b.build();
-  }
+    @Nullable private Node<T> _left;
+    @Nullable private Node<T> _right;
 
-  /** Recursively collect all elements in this trie */
-  private void collect(ImmutableCollection.Builder<DataT> collectionBuilder) {
-    if (_left != null) {
-      _left.collect(collectionBuilder);
+    Node(Prefix prefix) {
+      _prefix = prefix;
+      _elements = new HashSet<>();
     }
-    if (_right != null) {
-      _right.collect(collectionBuilder);
+
+    Node(Prefix prefix, T elem) {
+      this(prefix);
+      _elements.add(elem);
     }
-    collectionBuilder.addAll(_elements);
-  }
 
-  @Nullable
-  private PrefixTrieMultiMap<DataT> findNode(Prefix p) {
-    assert _prefix.containsPrefix(p);
-    PrefixTrieMultiMap<DataT> node = findLongestPrefixMatchNode(p);
-    return node._prefix.equals(p) ? node : null;
-  }
+    Node(Prefix prefix, Collection<T> elements) {
+      this(prefix);
+      _elements.addAll(elements);
+    }
 
-  /** Returns the node with the longest prefix match for a given prefix. */
-  @Nonnull
-  PrefixTrieMultiMap<DataT> findLongestPrefixMatchNode(Prefix prefix) {
-    assert this._prefix.containsPrefix(prefix);
+    private @Nonnull Node<T> createChild(Prefix prefix) {
+      assert _prefix.containsPrefix(prefix);
+      boolean currentBit =
+          Ip.getBitAtPosition(prefix.getStartIp().asLong(), _prefix.getPrefixLength());
 
-    PrefixTrieMultiMap<DataT> node = this;
-    long prefixAsLong = prefix.getStartIp().asLong();
-    while (true) {
-      if (node._prefix.equals(prefix)) {
-        // found an exact match
-        return node;
+      Node<T> node = new Node<>(prefix);
+      if (currentBit) {
+        _right = combine(node, _right);
+      } else {
+        _left = combine(node, _left);
       }
-
-      // Choose which child might have a longer match
-      PrefixTrieMultiMap<DataT> child =
-          Ip.getBitAtPosition(prefixAsLong, node._prefix.getPrefixLength())
-              ? node._right
-              : node._left;
-
-      // Check if the child exists and matches
-      if (child == null || !child._prefix.containsPrefix(prefix)) {
-        return node;
-      }
-
-      // Child does have a longer match, keep looking
-      node = child;
+      return node;
     }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      Node<?> that = (Node<?>) o;
+      return Objects.equals(_prefix, that._prefix)
+          && Objects.equals(_elements, that._elements)
+          && Objects.equals(_left, that._left)
+          && Objects.equals(_right, that._right);
+    }
+
+    /** Find or create a node for a given prefix (must be an exact match) */
+    @Nonnull
+    private Node<T> findOrCreateNode(Prefix prefix) {
+      assert _prefix.containsPrefix(prefix);
+
+      Node<T> node = findLongestPrefixMatchNode(prefix);
+      return node._prefix.equals(prefix) ? node : node.createChild(prefix);
+    }
+
+    /** Returns the list of non-null children for this node */
+    @Nonnull
+    List<Node<T>> getChildren() {
+      return Stream.of(_left, _right)
+          .filter(Objects::nonNull)
+          .collect(ImmutableList.toImmutableList());
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(_prefix, _elements, _left, _right);
+    }
+
+    /** Returns the node with the longest prefix match for a given prefix. */
+    @Nonnull
+    Node<T> findLongestPrefixMatchNode(Prefix prefix) {
+      assert this._prefix.containsPrefix(prefix);
+
+      Node<T> node = this;
+      long prefixAsLong = prefix.getStartIp().asLong();
+      while (true) {
+        if (node._prefix.equals(prefix)) {
+          // found an exact match
+          return node;
+        }
+
+        // Choose which child might have a longer match
+        Node<T> child =
+            Ip.getBitAtPosition(prefixAsLong, node._prefix.getPrefixLength())
+                ? node._right
+                : node._left;
+
+        // Check if the child exists and matches
+        if (child == null || !child._prefix.containsPrefix(prefix)) {
+          return node;
+        }
+
+        // Child does have a longer match, keep looking
+        node = child;
+      }
+    }
+
+    private void setLeft(@Nullable Node<T> left) {
+      assert left == null || legalLeftChildPrefix(_prefix, left._prefix);
+      _left = left;
+    }
+
+    private void setRight(@Nullable Node<T> right) {
+      assert right == null || legalRightChildPrefix(_prefix, right._prefix);
+      _right = right;
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this).add("prefix", _prefix).toString();
+    }
+  }
+
+  private @Nullable Node<T> _root;
+
+  public PrefixTrieMultiMap(Prefix prefix) {
+    _root = new Node<T>(prefix);
+  }
+
+  public PrefixTrieMultiMap() {
+    _root = null;
+  }
+
+  /**
+   * Post-order traversal over the entries. Entries will always contain non-null keys and values.
+   * The traversal may not mutate the entries (the values are immutable sets).
+   */
+  public void traverseEntries(BiConsumer<Prefix, Set<T>> consumer) {
+    traverseNodes(node -> consumer.accept(node._prefix, ImmutableSet.copyOf(node._elements)));
+  }
+
+  private void traverseNodes(Consumer<Node<T>> consumer) {
+    if (_root == null) {
+      return;
+    }
+    Traverser.<Node<T>>forTree(Node::getChildren).depthFirstPostOrder(_root).forEach(consumer);
+  }
+
+  private @Nullable Node<T> exactMatchNode(Prefix p) {
+    Node<T> node = longestMatchNode(p);
+    return node == null || !node._prefix.equals(p) ? null : node;
   }
 
   @Override
@@ -358,23 +251,109 @@ public final class PrefixTrieMultiMap<DataT> implements Serializable {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof PrefixTrieMultiMap<?>)) {
       return false;
     }
-    PrefixTrieMultiMap<?> that = (PrefixTrieMultiMap<?>) o;
-    return Objects.equals(getPrefix(), that.getPrefix())
-        && Objects.equals(_elements, that._elements)
-        && Objects.equals(_left, that._left)
-        && Objects.equals(_right, that._right);
+    PrefixTrieMultiMap<?> map = (PrefixTrieMultiMap<?>) o;
+    return Objects.equals(_root, map._root);
+  }
+
+  /**
+   * Retrieve an immutable copy of elements for the given prefix (anywhere in the subtree). Returns
+   * empty set if the prefix is not in the subtree.
+   *
+   * @return null if the prefix is not contained in the trie.
+   */
+  @Nonnull
+  public Set<T> get(Prefix p) {
+    Node<T> node = exactMatchNode(p);
+    return node == null ? ImmutableSet.of() : ImmutableSet.copyOf(node._elements);
+  }
+
+  /** @return all elements in the trie. */
+  @Nonnull
+  public Set<T> getAllElements() {
+    Builder<T> b = ImmutableSet.builder();
+    traverseNodes(node -> b.addAll(node._elements));
+    return b.build();
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(getPrefix(), _elements, _left, _right);
+    return Objects.hash(_root);
   }
 
-  @Override
-  public String toString() {
-    return MoreObjects.toStringHelper(this).add("prefix", _prefix).toString();
+  private @Nullable Node<T> longestMatchNode(Prefix p) {
+    return _root == null || !_root._prefix.containsPrefix(p)
+        ? null
+        : _root.findLongestPrefixMatchNode(p);
+  }
+
+  /** Find the elements associated with the longest matching prefix of a given IP address. */
+  @Nonnull
+  public Set<T> longestPrefixMatch(Ip address) {
+    return longestPrefixMatch(address, Prefix.MAX_PREFIX_LENGTH);
+  }
+
+  /**
+   * Find the elements associated with the longest matching prefix of a given IP address, up to the
+   * given {@param maxPrefixLength}.
+   */
+  @Nonnull
+  public Set<T> longestPrefixMatch(Ip address, int maxPrefixLength) {
+    Node<T> node = longestMatchNode(Prefix.create(address, maxPrefixLength));
+    return node == null ? ImmutableSet.of() : ImmutableSet.copyOf(node._elements);
+  }
+
+  /**
+   * Stores a key-value pair in the multimap.
+   *
+   * @return whether the multimap was modified.
+   */
+  public boolean put(Prefix p, T e) {
+    return putAll(p, ImmutableList.of(e));
+  }
+
+  /**
+   * Stores multiple key-value pairs for a single key in the multimap.
+   *
+   * @return whether the multimap was modified.
+   */
+  public boolean putAll(Prefix p, Collection<T> elements) {
+    if (_root == null || !_root._prefix.containsPrefix(p)) {
+      _root = combine(new Node<T>(p, elements), _root);
+      return true;
+    }
+    Node<T> node = _root.findOrCreateNode(p);
+    return node._elements.addAll(elements);
+  }
+
+  /**
+   * Remove a key-value pair from the multimap.
+   *
+   * @return whether the multimap was modified.
+   */
+  public boolean remove(Prefix p, T e) {
+    Node<T> node = exactMatchNode(p);
+    return node != null && node._elements.remove(e);
+  }
+
+  /**
+   * Replace any elements associated with prefix {@code p} with a given element.
+   *
+   * @return whether the multimap was modified
+   */
+  public boolean replaceAll(Prefix p, T e) {
+    Node<T> node = _root == null || !_root._prefix.containsPrefix(p) ? null : exactMatchNode(p);
+    if (node == null) {
+      return put(p, e);
+    }
+    Set<T> elems = node._elements;
+    if (elems.size() == 1 && elems.contains(e)) {
+      return false;
+    }
+    elems.clear();
+    elems.add(e);
+    return true;
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PrefixTrieMultiMapTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PrefixTrieMultiMapTest.java
@@ -118,14 +118,19 @@ public class PrefixTrieMultiMapTest {
     assertThat(ptm1.longestPrefixMatch(Ip.parse("1.1.1.130")), equalTo(ImmutableSet.of(2)));
   }
 
+  @SuppressWarnings("unchecked")
   @Test
-  public void testAddAtRoot() {
+  public void testPutAtRoot() {
     Prefix prefix = Prefix.parse("128.0.0.0/1");
     PrefixTrieMultiMap<Integer> map = new PrefixTrieMultiMap<>(prefix);
     assertThat(keysInPostOrder(map), contains(prefix));
     // true because map is modified
     assertTrue(map.put(Prefix.ZERO, 1));
-    assertThat(keysInPostOrder(map), contains(prefix, Prefix.ZERO));
+    assertThat(
+        entriesPostOrder(map),
+        contains(
+            immutableEntry(prefix, ImmutableSet.of()),
+            immutableEntry(Prefix.ZERO, ImmutableSet.of(1))));
   }
 
   @Test
@@ -145,16 +150,22 @@ public class PrefixTrieMultiMapTest {
     assertFalse(ptm1.remove(Prefix.ZERO, 1));
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testReplaceNewRoot() {
     Prefix prefix = Prefix.parse("128.0.0.0/1");
-    PrefixTrieMultiMap<Integer> map = new PrefixTrieMultiMap<>(prefix);
-    assertThat(keysInPostOrder(map), contains(prefix));
+    ImmutableSet<Integer> prefixValues = ImmutableSet.of(4, 5, 6);
+    PrefixTrieMultiMap<Integer> map = new PrefixTrieMultiMap<>();
+    map.putAll(prefix, prefixValues);
+    assertThat(entriesPostOrder(map), contains(immutableEntry(prefix, prefixValues)));
 
     // true because we modified the map
     assertTrue(map.replaceAll(Prefix.ZERO, 1));
 
-    assertThat(keysInPostOrder(map), contains(prefix, Prefix.ZERO));
+    assertThat(
+        entriesPostOrder(map),
+        contains(
+            immutableEntry(prefix, prefixValues), immutableEntry(Prefix.ZERO, ImmutableSet.of(1))));
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PrefixTrieMultiMapTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PrefixTrieMultiMapTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 /** Tests of {@link PrefixTrieMultiMap} */
+@SuppressWarnings("unchecked")
 public class PrefixTrieMultiMapTest {
 
   @Rule public ExpectedException thrown = ExpectedException.none();
@@ -118,7 +119,6 @@ public class PrefixTrieMultiMapTest {
     assertThat(ptm1.longestPrefixMatch(Ip.parse("1.1.1.130")), equalTo(ImmutableSet.of(2)));
   }
 
-  @SuppressWarnings("unchecked")
   @Test
   public void testPutAtRoot() {
     Prefix prefix = Prefix.parse("128.0.0.0/1");
@@ -137,10 +137,14 @@ public class PrefixTrieMultiMapTest {
   public void testPutAllAtRoot() {
     Prefix prefix = Prefix.parse("128.0.0.0/1");
     PrefixTrieMultiMap<Integer> map = new PrefixTrieMultiMap<>(prefix);
-    assertThat(keysInPostOrder(map), contains(prefix));
+    assertThat(entriesPostOrder(map), contains(immutableEntry(prefix, ImmutableSet.of())));
     // true because map is modified
-    assertTrue(map.putAll(Prefix.ZERO, ImmutableSet.of(1, 2)));
-    assertThat(keysInPostOrder(map), contains(prefix, Prefix.ZERO));
+    ImmutableSet<Integer> zeroValues = ImmutableSet.of(1, 2);
+    assertTrue(map.putAll(Prefix.ZERO, zeroValues));
+    assertThat(
+        entriesPostOrder(map),
+        contains(
+            immutableEntry(prefix, ImmutableSet.of()), immutableEntry(Prefix.ZERO, zeroValues)));
   }
 
   @Test
@@ -150,7 +154,6 @@ public class PrefixTrieMultiMapTest {
     assertFalse(ptm1.remove(Prefix.ZERO, 1));
   }
 
-  @SuppressWarnings("unchecked")
   @Test
   public void testReplaceNewRoot() {
     Prefix prefix = Prefix.parse("128.0.0.0/1");
@@ -231,7 +234,6 @@ public class PrefixTrieMultiMapTest {
     assertThat(prefixes, contains(ll, lr, l, rl, rr, r, Prefix.ZERO));
   }
 
-  @SuppressWarnings("unchecked")
   @Test
   public void testPutWithCombineAtRoot() {
     PrefixTrieMultiMap<Integer> map = new PrefixTrieMultiMap<>();
@@ -249,7 +251,6 @@ public class PrefixTrieMultiMapTest {
             immutableEntry(Prefix.ZERO, ImmutableSet.of())));
   }
 
-  @SuppressWarnings("unchecked")
   @Test
   public void testPutWithCombineInternal() {
     PrefixTrieMultiMap<Integer> map = new PrefixTrieMultiMap<>(Prefix.ZERO);

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/RibTree.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/RibTree.java
@@ -56,13 +56,13 @@ final class RibTree<R extends AbstractRoute> implements Serializable {
 
     Builder<R> b = RibDelta.builder();
     b.remove(route, reason);
-    if (_root.getElements(route.getNetwork()).isEmpty() && _owner._backupRoutes != null) {
+    if (_root.get(route.getNetwork()).isEmpty() && _owner._backupRoutes != null) {
       SortedSet<? extends R> backups =
           _owner._backupRoutes.getOrDefault(route.getNetwork(), ImmutableSortedSet.of());
       if (backups.isEmpty()) {
         return b.build();
       }
-      _root.add(route.getNetwork(), backups.first());
+      _root.put(route.getNetwork(), backups.first());
       b.add(backups.first());
     }
     // Return new delta
@@ -76,7 +76,7 @@ final class RibTree<R extends AbstractRoute> implements Serializable {
    * @return true if the route exists in the RIB
    */
   boolean containsRoute(R route) {
-    return _root.getElements(route.getNetwork()).contains(route);
+    return _root.get(route.getNetwork()).contains(route);
   }
 
   private boolean hasForwardingRoute(Set<R> routes) {
@@ -113,7 +113,7 @@ final class RibTree<R extends AbstractRoute> implements Serializable {
 
   /** Retrieve stored routes for a particular prefix only. */
   public Set<R> getRoutes(Prefix prefix) {
-    return _root.getElements(prefix);
+    return _root.get(prefix);
   }
 
   /**
@@ -125,9 +125,9 @@ final class RibTree<R extends AbstractRoute> implements Serializable {
    */
   @Nonnull
   RibDelta<R> mergeRoute(R route) {
-    Set<R> routes = _root.getElements(route.getNetwork());
+    Set<R> routes = _root.get(route.getNetwork());
     if (routes.isEmpty()) {
-      _root.add(route.getNetwork(), route);
+      _root.put(route.getNetwork(), route);
       return RibDelta.<R>builder().add(route).build();
     }
     /*
@@ -144,7 +144,7 @@ final class RibTree<R extends AbstractRoute> implements Serializable {
     }
     if (preferenceComparison == 0) { // equal preference, so add for multipath routing
       // Otherwise add the route
-      if (_root.add(route.getNetwork(), route)) {
+      if (_root.put(route.getNetwork(), route)) {
         return RibDelta.<R>builder().add(route).build();
       } else {
         return RibDelta.empty();


### PR DESCRIPTION
- Now that we don't expose subtries to clients, we can factor out the
  nodes as private implementation.
- Follow standard map interface idioms.
- Allow adding new nodes at the root (either directly or indirectly).