### PR TITLE
Handle Juniper missing address-book entry

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromDestinationAddressBookEntry.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromDestinationAddressBookEntry.java
@@ -5,6 +5,7 @@ import javax.annotation.Nullable;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.AclIpSpace;
 import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.IpSpaceReference;
@@ -36,6 +37,15 @@ public final class FwFromDestinationAddressBookEntry extends FwFrom {
       Configuration c) {
     AddressBook addressBook = _zone == null ? _globalAddressBook : _zone.getAddressBook();
     String addressBookName = addressBook.getAddressBookName(_addressBookEntryName);
+    if (addressBookName == null) {
+      w.redFlag(
+          String.format("Missing destination address-book entry '%s'", _addressBookEntryName));
+      // Leave existing constraint, otherwise match nothing
+      if (headerSpaceBuilder.getDstIps() == null) {
+        headerSpaceBuilder.setDstIps(EmptyIpSpace.INSTANCE);
+      }
+      return;
+    }
     String ipSpaceName = addressBookName + "~" + _addressBookEntryName;
     IpSpaceReference ipSpaceReference = new IpSpaceReference(ipSpaceName);
     if (headerSpaceBuilder.getDstIps() != null) {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromSourceAddressBookEntry.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromSourceAddressBookEntry.java
@@ -40,8 +40,8 @@ public final class FwFromSourceAddressBookEntry extends FwFrom {
     if (addressBookName == null) {
       w.redFlag(String.format("Missing source address-book entry '%s'", _addressBookEntryName));
       // Leave existing constraint, otherwise match nothing
-      if (headerSpaceBuilder.getDstIps() == null) {
-        headerSpaceBuilder.setDstIps(EmptyIpSpace.INSTANCE);
+      if (headerSpaceBuilder.getSrcIps() == null) {
+        headerSpaceBuilder.setSrcIps(EmptyIpSpace.INSTANCE);
       }
       return;
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromSourceAddressBookEntry.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromSourceAddressBookEntry.java
@@ -5,6 +5,7 @@ import javax.annotation.Nullable;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.AclIpSpace;
 import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.IpSpaceReference;
@@ -36,6 +37,14 @@ public final class FwFromSourceAddressBookEntry extends FwFrom {
       Configuration c) {
     AddressBook addressBook = _zone == null ? _globalAddressBook : _zone.getAddressBook();
     String addressBookName = addressBook.getAddressBookName(_addressBookEntryName);
+    if (addressBookName == null) {
+      w.redFlag(String.format("Missing source address-book entry '%s'", _addressBookEntryName));
+      // Leave existing constraint, otherwise match nothing
+      if (headerSpaceBuilder.getDstIps() == null) {
+        headerSpaceBuilder.setDstIps(EmptyIpSpace.INSTANCE);
+      }
+      return;
+    }
     String ipSpaceName = addressBookName + "~" + _addressBookEntryName;
     IpSpaceReference ipSpaceReference = new IpSpaceReference(ipSpaceName);
     if (headerSpaceBuilder.getSrcIps() != null) {

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/firewall-zone-address-book-attach-and-global
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/firewall-zone-address-book-attach-and-global
@@ -1,0 +1,14 @@
+#
+set system host-name firewall-zone-address-book-attach-and-global
+#
+set security address-book global address ADDR1 3.3.3.3/32
+set security address-book trust-book address ADDR2 2.2.2.2/32
+set security address-book trust-book attach zone untrust
+set security policies from-zone trust to-zone untrust policy PNAME match source-address ADDR1
+set security policies from-zone trust to-zone untrust policy PNAME match destination-address ADDR2
+set security policies from-zone trust to-zone untrust policy PNAME match application any
+set security policies from-zone trust to-zone untrust policy PNAME then permit
+set security zones security-zone trust interfaces ge-0/0/0.0
+set security zones security-zone untrust interfaces ge-0/0/1.0
+set interfaces ge-0/0/1 unit 0 family inet address 1.2.4.4/24
+set interfaces ge-0/0/0 unit 0 family inet address 1.2.3.4/24

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/firewall-zone-address-undefined
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/firewall-zone-address-undefined
@@ -1,10 +1,18 @@
 #
 set system host-name firewall-zone-address-undefined
 #
-set security policies from-zone trust to-zone untrust policy PNAME match source-address DEFINED_ADDR
-set security policies from-zone trust to-zone untrust policy PNAME match destination-address UNDEFINED_ADDR
-set security policies from-zone trust to-zone untrust policy PNAME match application any
-set security policies from-zone trust to-zone untrust policy PNAME then permit
+set security policies from-zone trust to-zone untrust policy UNDEF_DEST match source-address DEFINED_ADDR
+set security policies from-zone trust to-zone untrust policy UNDEF_DEST match destination-address UNDEFINED_ADDR
+set security policies from-zone trust to-zone untrust policy UNDEF_DEST match destination-address DEFINED_ADDR
+set security policies from-zone trust to-zone untrust policy UNDEF_DEST match application any
+set security policies from-zone trust to-zone untrust policy UNDEF_DEST then permit
+#
+set security policies from-zone untrust to-zone trust policy UNDEF_SRC_DEST match source-address DEFINED_ADDR
+set security policies from-zone untrust to-zone trust policy UNDEF_SRC_DEST match source-address UNDEFINED_ADDR
+set security policies from-zone untrust to-zone trust policy UNDEF_SRC_DEST match destination-address UNDEFINED_ADDR
+set security policies from-zone untrust to-zone trust policy UNDEF_SRC_DEST match application any
+set security policies from-zone untrust to-zone trust policy UNDEF_SRC_DEST then permit
+#
 set security address-book global address DEFINED_ADDR 2.2.2.2
 set security zones security-zone trust interfaces ge-0/0/0.0
 set security zones security-zone untrust interfaces ge-0/0/1.0

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/firewall-zone-address-undefined
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/firewall-zone-address-undefined
@@ -1,0 +1,12 @@
+#
+set system host-name firewall-zone-address-undefined
+#
+set security policies from-zone trust to-zone untrust policy PNAME match source-address DEFINED_ADDR
+set security policies from-zone trust to-zone untrust policy PNAME match destination-address UNDEFINED_ADDR
+set security policies from-zone trust to-zone untrust policy PNAME match application any
+set security policies from-zone trust to-zone untrust policy PNAME then permit
+set security address-book global address DEFINED_ADDR 2.2.2.2
+set security zones security-zone trust interfaces ge-0/0/0.0
+set security zones security-zone untrust interfaces ge-0/0/1.0
+set interfaces ge-0/0/1 unit 0 family inet address 1.2.4.4/24
+set interfaces ge-0/0/0 unit 0 family inet address 1.2.3.4/24


### PR DESCRIPTION
On encountering undefined address-book entries, warn and handle to prevent undefined references in future processing.
