### PR TITLE
Revert "Clean up FibImpl methods; add test (#3150)"

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FlowHistory.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FlowHistory.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
-import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import org.batfish.common.BatfishException;
@@ -29,13 +28,13 @@ public class FlowHistory extends AnswerElement {
 
     private Flow _flow;
 
-    private Map<String, SortedSet<FlowTrace>> _paths;
+    private Map<String, Set<FlowTrace>> _paths;
 
     @JsonCreator
     public FlowHistoryInfo(
         @JsonProperty(PROP_FLOW) Flow flow,
         @JsonProperty(PROP_ENVIRONMENTS) Map<String, Environment> environments,
-        @JsonProperty(PROP_PATHS) Map<String, SortedSet<FlowTrace>> paths) {
+        @JsonProperty(PROP_PATHS) Map<String, Set<FlowTrace>> paths) {
       _flow = flow;
       _environments = environments;
       _paths = paths;
@@ -52,7 +51,7 @@ public class FlowHistory extends AnswerElement {
     }
 
     @JsonProperty(PROP_PATHS)
-    public Map<String, SortedSet<FlowTrace>> getPaths() {
+    public Map<String, Set<FlowTrace>> getPaths() {
       return _paths;
     }
   }
@@ -140,7 +139,7 @@ public class FlowHistory extends AnswerElement {
     StringBuilder sb = new StringBuilder();
     for (String flowString : _traces.keySet()) {
       sb.append("Flow: " + flowString + "\n");
-      Map<String, SortedSet<FlowTrace>> envTraceSetMap = _traces.get(flowString).getPaths();
+      Map<String, Set<FlowTrace>> envTraceSetMap = _traces.get(flowString).getPaths();
       for (String environmentName : envTraceSetMap.keySet()) {
         sb.append(" Environment: " + environmentName + "\n");
         Set<FlowTrace> traces = envTraceSetMap.get(environmentName);

--- a/projects/batfish/src/test/java/org/batfish/dataplane/FibImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/FibImplTest.java
@@ -1,22 +1,19 @@
 package org.batfish.dataplane;
 
 import static org.batfish.datamodel.matchers.AbstractRouteMatchers.hasPrefix;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import java.io.IOException;
-import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.Configuration.Builder;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Fib;
 import org.batfish.datamodel.FibImpl;
@@ -48,62 +45,23 @@ public class FibImplTest {
   private static final InterfaceAddress NODE1_PHYSICAL_NETWORK = new InterfaceAddress("2.0.0.1/8");
   private static final Ip EXTERNAL_IP = Ip.parse("7.7.7.7");
 
+  private NetworkFactory _nf;
+  private Builder _cb;
   private Interface.Builder _ib;
+  private Vrf.Builder _vb;
+
   private Configuration _config;
   private Vrf _vrf;
 
   @Before
   public void setup() {
-    NetworkFactory nf = new NetworkFactory();
-    Configuration.Builder cb =
-        nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
-    _ib = nf.interfaceBuilder();
-    _config = cb.setHostname(NODE1).build();
-    _vrf = nf.vrfBuilder().setOwner(_config).setName(Configuration.DEFAULT_VRF_NAME).build();
+    _nf = new NetworkFactory();
+    _cb = _nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+    _ib = _nf.interfaceBuilder();
+    _vb = _nf.vrfBuilder();
+    _config = _cb.setHostname(NODE1).build();
+    _vrf = _vb.setOwner(_config).setName(Configuration.DEFAULT_VRF_NAME).build();
     _ib.setOwner(_config).setVrf(_vrf);
-  }
-
-  @Test
-  public void testGetNextHopInterfacesByRoute() throws IOException {
-    String iface1 = "iface1";
-    String iface2 = "iface2";
-    String iface3 = "iface3";
-    Ip ip1 = Ip.parse("1.1.1.0");
-    Ip ip2 = Ip.parse("2.2.2.0");
-    _ib.setName(iface1).setAddress(new InterfaceAddress(ip1, 24)).build();
-    _ib.setName(iface2).setAddress(new InterfaceAddress(ip2, 24)).build();
-    _ib.setName(iface3).setAddress(new InterfaceAddress(ip2, 24)).build();
-
-    Batfish batfish =
-        BatfishTestUtils.getBatfish(ImmutableSortedMap.of(_config.getHostname(), _config), folder);
-    batfish.computeDataPlane();
-    Fib fib =
-        batfish
-            .loadDataPlane()
-            .getFibs()
-            .get(_config.getHostname())
-            .get(Configuration.DEFAULT_VRF_NAME);
-
-    // Should have one LocalRoute per interface (also one ConnectedRoute, but LocalRoute will have
-    // longer prefix match). Should see only iface1 in interfaces to ip1.
-    Map<AbstractRoute, Map<String, Map<Ip, Set<AbstractRoute>>>> nextHopIfacesByRouteToIp1 =
-        fib.getNextHopInterfacesByRoute(ip1);
-    assertThat(nextHopIfacesByRouteToIp1, aMapWithSize(1));
-    Set<String> nextHopIfacesToIp1 =
-        nextHopIfacesByRouteToIp1.values().stream()
-            .flatMap(ifaceMap -> ifaceMap.keySet().stream())
-            .collect(Collectors.toSet());
-    assertThat(nextHopIfacesToIp1, contains(iface1));
-
-    // Should see interfaces iface2 and iface3 in interfaces to ip2.
-    Map<AbstractRoute, Map<String, Map<Ip, Set<AbstractRoute>>>> nextHopIfacesByRouteToIp2 =
-        fib.getNextHopInterfacesByRoute(ip2);
-    assertThat(nextHopIfacesByRouteToIp2, aMapWithSize(2));
-    Set<String> nextHopIfacesToIp2 =
-        nextHopIfacesByRouteToIp2.values().stream()
-            .flatMap(ifaceMap -> ifaceMap.keySet().stream())
-            .collect(Collectors.toSet());
-    assertThat(nextHopIfacesToIp2, containsInAnyOrder(iface2, iface3));
   }
 
   @Test

--- a/projects/question/src/main/java/org/batfish/question/loop/DetectLoopsAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/loop/DetectLoopsAnswerer.java
@@ -7,7 +7,7 @@ import static org.batfish.question.traceroute.TracerouteAnswerer.createMetadata;
 
 import com.google.common.base.Functions;
 import com.google.common.collect.HashMultimap;
-import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.LinkedHashMultiset;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
@@ -15,7 +15,6 @@ import com.google.common.collect.Multiset;
 import java.util.List;
 import java.util.Set;
 import java.util.SortedMap;
-import java.util.SortedSet;
 import java.util.stream.Collectors;
 import org.batfish.common.Answerer;
 import org.batfish.common.plugin.IBatfish;
@@ -81,8 +80,8 @@ public final class DetectLoopsAnswerer extends Answerer {
         String.format(
             "Expect only one environment in flow history info. Found %d",
             historyInfo.getPaths().size()));
-    SortedSet<FlowTrace> paths =
-        historyInfo.getPaths().values().stream().findAny().orElseGet(ImmutableSortedSet::of);
+    Set<FlowTrace> paths =
+        historyInfo.getPaths().values().stream().findAny().orElseGet(ImmutableSet::of);
     return Row.of(COL_FLOW, historyInfo.getFlow(), COL_TRACES, paths);
   }
 

--- a/projects/question/src/main/java/org/batfish/question/multipath/MultipathConsistencyAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/multipath/MultipathConsistencyAnswerer.java
@@ -10,13 +10,11 @@ import static org.batfish.question.traceroute.TracerouteAnswerer.createMetadata;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.LinkedHashMultiset;
 import com.google.common.collect.Multiset;
 import java.util.List;
 import java.util.Set;
 import java.util.SortedMap;
-import java.util.SortedSet;
 import org.batfish.common.Answerer;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.datamodel.AclIpSpace;
@@ -78,8 +76,8 @@ public class MultipathConsistencyAnswerer extends Answerer {
         String.format(
             "Expect only one environment in flow history info. Found %d",
             historyInfo.getPaths().size()));
-    SortedSet<FlowTrace> paths =
-        historyInfo.getPaths().values().stream().findAny().orElseGet(ImmutableSortedSet::of);
+    Set<FlowTrace> paths =
+        historyInfo.getPaths().values().stream().findAny().orElseGet(ImmutableSet::of);
     return Row.of(COL_FLOW, historyInfo.getFlow(), COL_TRACES, paths);
   }
 

--- a/projects/question/src/main/java/org/batfish/question/traceroute/TracerouteAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/traceroute/TracerouteAnswerer.java
@@ -3,14 +3,13 @@ package org.batfish.question.traceroute;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.LinkedHashMultiset;
 import com.google.common.collect.Multiset;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
-import java.util.SortedSet;
 import org.batfish.common.Answerer;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.common.util.TracePruner;
@@ -186,8 +185,8 @@ public final class TracerouteAnswerer extends Answerer {
         String.format(
             "Expect only one environment in flow history info. Found %d",
             historyInfo.getPaths().size()));
-    SortedSet<FlowTrace> paths =
-        historyInfo.getPaths().values().stream().findAny().orElseGet(ImmutableSortedSet::of);
+    Set<FlowTrace> paths =
+        historyInfo.getPaths().values().stream().findAny().orElseGet(ImmutableSet::of);
     return Row.of(COL_FLOW, historyInfo.getFlow(), COL_TRACES, paths);
   }
 

--- a/projects/question/src/test/java/org/batfish/question/traceroute/TracerouteAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/traceroute/TracerouteAnswererTest.java
@@ -21,13 +21,13 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
-import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Multiset;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.SortedMap;
-import java.util.SortedSet;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowDisposition;
 import org.batfish.datamodel.FlowHistory;
@@ -275,8 +275,8 @@ public class TracerouteAnswererTest {
 
   @Test
   public void flowHistoryToRow() {
-    SortedSet<FlowTrace> traces =
-        ImmutableSortedSet.of(
+    Set<FlowTrace> traces =
+        ImmutableSet.of(
             new FlowTrace(FlowDisposition.ACCEPTED, ImmutableList.of(), "notes1"),
             new FlowTrace(FlowDisposition.DENIED_OUT, ImmutableList.of(), "notes2"));
     Flow flow =

--- a/tests/basic/traceroute-1-2.ref
+++ b/tests/basic/traceroute-1-2.ref
@@ -238,7 +238,7 @@
                     "detail" : {
                       "outputInterface" : {
                         "hostname" : "as2core1",
-                        "interface" : "GigabitEthernet3/0"
+                        "interface" : "GigabitEthernet2/0"
                       }
                     }
                   }
@@ -246,8 +246,8 @@
               },
               {
                 "node" : {
-                  "id" : "node-as2dist2",
-                  "name" : "as2dist2"
+                  "id" : "node-as2dist1",
+                  "name" : "as2dist1"
                 },
                 "steps" : [
                   {
@@ -255,8 +255,8 @@
                     "action" : "RECEIVED",
                     "detail" : {
                       "inputInterface" : {
-                        "hostname" : "as2dist2",
-                        "interface" : "GigabitEthernet1/0"
+                        "hostname" : "as2dist1",
+                        "interface" : "GigabitEthernet0/0"
                       },
                       "inputVrf" : "default"
                     }
@@ -268,7 +268,7 @@
                       "routes" : [
                         {
                           "network" : "2.128.0.0/24",
-                          "nextHopIp" : "2.34.201.4",
+                          "nextHopIp" : "2.34.101.4",
                           "protocol" : "bgp"
                         }
                       ]
@@ -279,7 +279,7 @@
                     "action" : "TRANSMITTED",
                     "detail" : {
                       "outputInterface" : {
-                        "hostname" : "as2dist2",
+                        "hostname" : "as2dist1",
                         "interface" : "GigabitEthernet2/0"
                       }
                     }
@@ -298,7 +298,7 @@
                     "detail" : {
                       "inputInterface" : {
                         "hostname" : "as2dept1",
-                        "interface" : "GigabitEthernet1/0"
+                        "interface" : "GigabitEthernet0/0"
                       },
                       "inputVrf" : "default"
                     }
@@ -540,7 +540,7 @@
                     "detail" : {
                       "outputInterface" : {
                         "hostname" : "as2core1",
-                        "interface" : "GigabitEthernet2/0"
+                        "interface" : "GigabitEthernet3/0"
                       }
                     }
                   }
@@ -548,8 +548,8 @@
               },
               {
                 "node" : {
-                  "id" : "node-as2dist1",
-                  "name" : "as2dist1"
+                  "id" : "node-as2dist2",
+                  "name" : "as2dist2"
                 },
                 "steps" : [
                   {
@@ -557,8 +557,8 @@
                     "action" : "RECEIVED",
                     "detail" : {
                       "inputInterface" : {
-                        "hostname" : "as2dist1",
-                        "interface" : "GigabitEthernet0/0"
+                        "hostname" : "as2dist2",
+                        "interface" : "GigabitEthernet1/0"
                       },
                       "inputVrf" : "default"
                     }
@@ -570,7 +570,7 @@
                       "routes" : [
                         {
                           "network" : "2.128.0.0/24",
-                          "nextHopIp" : "2.34.101.4",
+                          "nextHopIp" : "2.34.201.4",
                           "protocol" : "bgp"
                         }
                       ]
@@ -581,7 +581,7 @@
                     "action" : "TRANSMITTED",
                     "detail" : {
                       "outputInterface" : {
-                        "hostname" : "as2dist1",
+                        "hostname" : "as2dist2",
                         "interface" : "GigabitEthernet2/0"
                       }
                     }
@@ -600,7 +600,7 @@
                     "detail" : {
                       "inputInterface" : {
                         "hostname" : "as2dept1",
-                        "interface" : "GigabitEthernet0/0"
+                        "interface" : "GigabitEthernet1/0"
                       },
                       "inputVrf" : "default"
                     }
@@ -1476,7 +1476,7 @@
                     "detail" : {
                       "outputInterface" : {
                         "hostname" : "as2core1",
-                        "interface" : "GigabitEthernet3/0"
+                        "interface" : "GigabitEthernet2/0"
                       }
                     }
                   }
@@ -1484,8 +1484,8 @@
               },
               {
                 "node" : {
-                  "id" : "node-as2dist2",
-                  "name" : "as2dist2"
+                  "id" : "node-as2dist1",
+                  "name" : "as2dist1"
                 },
                 "steps" : [
                   {
@@ -1493,8 +1493,8 @@
                     "action" : "RECEIVED",
                     "detail" : {
                       "inputInterface" : {
-                        "hostname" : "as2dist2",
-                        "interface" : "GigabitEthernet1/0"
+                        "hostname" : "as2dist1",
+                        "interface" : "GigabitEthernet0/0"
                       },
                       "inputVrf" : "default"
                     }
@@ -1506,7 +1506,7 @@
                       "routes" : [
                         {
                           "network" : "2.128.0.0/24",
-                          "nextHopIp" : "2.34.201.4",
+                          "nextHopIp" : "2.34.101.4",
                           "protocol" : "bgp"
                         }
                       ]
@@ -1517,7 +1517,7 @@
                     "action" : "TRANSMITTED",
                     "detail" : {
                       "outputInterface" : {
-                        "hostname" : "as2dist2",
+                        "hostname" : "as2dist1",
                         "interface" : "GigabitEthernet2/0"
                       }
                     }
@@ -1536,7 +1536,7 @@
                     "detail" : {
                       "inputInterface" : {
                         "hostname" : "as2dept1",
-                        "interface" : "GigabitEthernet1/0"
+                        "interface" : "GigabitEthernet0/0"
                       },
                       "inputVrf" : "default"
                     }
@@ -1778,7 +1778,7 @@
                     "detail" : {
                       "outputInterface" : {
                         "hostname" : "as2core1",
-                        "interface" : "GigabitEthernet2/0"
+                        "interface" : "GigabitEthernet3/0"
                       }
                     }
                   }
@@ -1786,8 +1786,8 @@
               },
               {
                 "node" : {
-                  "id" : "node-as2dist1",
-                  "name" : "as2dist1"
+                  "id" : "node-as2dist2",
+                  "name" : "as2dist2"
                 },
                 "steps" : [
                   {
@@ -1795,8 +1795,8 @@
                     "action" : "RECEIVED",
                     "detail" : {
                       "inputInterface" : {
-                        "hostname" : "as2dist1",
-                        "interface" : "GigabitEthernet0/0"
+                        "hostname" : "as2dist2",
+                        "interface" : "GigabitEthernet1/0"
                       },
                       "inputVrf" : "default"
                     }
@@ -1808,7 +1808,7 @@
                       "routes" : [
                         {
                           "network" : "2.128.0.0/24",
-                          "nextHopIp" : "2.34.101.4",
+                          "nextHopIp" : "2.34.201.4",
                           "protocol" : "bgp"
                         }
                       ]
@@ -1819,7 +1819,7 @@
                     "action" : "TRANSMITTED",
                     "detail" : {
                       "outputInterface" : {
-                        "hostname" : "as2dist1",
+                        "hostname" : "as2dist2",
                         "interface" : "GigabitEthernet2/0"
                       }
                     }
@@ -1838,7 +1838,7 @@
                     "detail" : {
                       "inputInterface" : {
                         "hostname" : "as2dept1",
-                        "interface" : "GigabitEthernet0/0"
+                        "interface" : "GigabitEthernet1/0"
                       },
                       "inputVrf" : "default"
                     }


### PR DESCRIPTION
This reverts #3150 so traceroute trace ordering can be redone more sanely