### PR TITLE
FibImpl cleanup (replacing #3150)

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibImpl.java
@@ -7,8 +7,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.function.Function;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.common.BatfishException;
@@ -43,7 +43,7 @@ public class FibImpl implements Fib {
    * @throws BatfishException if resolution depth is exceeded (high likelihood of a routing loop) OR
    *     an invalid route in the RIB has been encountered.
    */
-  public static Map<String, Map<Ip, Set<AbstractRoute>>> collectNextHopInterfaces(
+  private static Map<String, Map<Ip, Set<AbstractRoute>>> collectNextHopInterfaces(
       GenericRib<AbstractRoute> rib, AbstractRoute route) {
     Map<String, Map<Ip, Set<AbstractRoute>>> nextHopInterfaces = new HashMap<>();
     collectNextHopInterfaces(
@@ -176,34 +176,16 @@ public class FibImpl implements Fib {
 
   @Override
   public @Nonnull Set<String> getNextHopInterfaces(Ip ip) {
-    Map<String, Map<Ip, Set<AbstractRoute>>> outputNextHopInterfaces = new TreeMap<>();
-    Set<AbstractRoute> nextHopRoutes = _rib.longestPrefixMatch(ip);
-    for (AbstractRoute nextHopRoute : nextHopRoutes) {
-      Map<String, Map<Ip, Set<AbstractRoute>>> currentNextHopInterfaces =
-          _nextHopInterfaces.get(nextHopRoute);
-      currentNextHopInterfaces.forEach(
-          (nextHopInterface, nextHopInterfaceRoutesByFinalNextHopIp) -> {
-            Map<Ip, Set<AbstractRoute>> outputNextHopInterfaceRoutesByFinalNextHopIp =
-                outputNextHopInterfaces.computeIfAbsent(nextHopInterface, k -> new TreeMap<>());
-            outputNextHopInterfaceRoutesByFinalNextHopIp.putAll(
-                nextHopInterfaceRoutesByFinalNextHopIp);
-          });
-    }
-    return outputNextHopInterfaces.keySet();
+    return _rib.longestPrefixMatch(ip).stream()
+        .flatMap(nextHopRoute -> _nextHopInterfaces.get(nextHopRoute).keySet().stream())
+        .collect(ImmutableSet.toImmutableSet());
   }
 
   @Override
   public @Nonnull Map<AbstractRoute, Map<String, Map<Ip, Set<AbstractRoute>>>>
       getNextHopInterfacesByRoute(Ip dstIp) {
-    Map<AbstractRoute, Map<String, Map<Ip, Set<AbstractRoute>>>> nextHopInterfacesByRoute =
-        new HashMap<>();
-    Set<AbstractRoute> nextHopRoutes = _rib.longestPrefixMatch(dstIp);
-    for (AbstractRoute nextHopRoute : nextHopRoutes) {
-      Map<String, Map<Ip, Set<AbstractRoute>>> nextHopInterfaces =
-          _nextHopInterfaces.get(nextHopRoute);
-      nextHopInterfacesByRoute.put(nextHopRoute, nextHopInterfaces);
-    }
-    return nextHopInterfacesByRoute;
+    return _rib.longestPrefixMatch(dstIp).stream()
+        .collect(ImmutableMap.toImmutableMap(Function.identity(), _nextHopInterfaces::get));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
@@ -327,6 +327,7 @@ class FlowTracer {
     }
 
     Fib fib = _tracerouteContext.getFib(currentNodeName, _vrfName);
+    // Sort so that resulting traces will be in sensible deterministic order
     SortedSet<String> nextHopInterfaces =
         ImmutableSortedSet.copyOf(fib.getNextHopInterfaces(dstIp));
     if (nextHopInterfaces.isEmpty()) {

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
@@ -19,6 +19,7 @@ import static org.batfish.dataplane.traceroute.TracerouteUtils.sessionTransforma
 import static org.batfish.specifier.DispositionSpecifier.SUCCESS_DISPOSITIONS;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Multimap;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -326,7 +327,8 @@ class FlowTracer {
     }
 
     Fib fib = _tracerouteContext.getFib(currentNodeName, _vrfName);
-    Set<String> nextHopInterfaces = fib.getNextHopInterfaces(dstIp);
+    SortedSet<String> nextHopInterfaces =
+        ImmutableSortedSet.copyOf(fib.getNextHopInterfaces(dstIp));
     if (nextHopInterfaces.isEmpty()) {
       buildNoRouteTrace();
       return;

--- a/projects/batfish/src/test/java/org/batfish/dataplane/FibImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/FibImplTest.java
@@ -1,13 +1,13 @@
 package org.batfish.dataplane;
 
 import static org.batfish.datamodel.matchers.AbstractRouteMatchers.hasPrefix;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
@@ -88,7 +88,7 @@ public class FibImplTest {
     // longer prefix match). Should see only iface1 in interfaces to ip1.
     Map<AbstractRoute, Map<String, Map<Ip, Set<AbstractRoute>>>> nextHopIfacesByRouteToIp1 =
         fib.getNextHopInterfacesByRoute(ip1);
-    assertThat(nextHopIfacesByRouteToIp1.entrySet(), hasSize(1));
+    assertThat(nextHopIfacesByRouteToIp1, aMapWithSize(1));
     Set<String> nextHopIfacesToIp1 =
         nextHopIfacesByRouteToIp1.values().stream()
             .flatMap(ifaceMap -> ifaceMap.keySet().stream())
@@ -98,7 +98,7 @@ public class FibImplTest {
     // Should see interfaces iface2 and iface3 in interfaces to ip2.
     Map<AbstractRoute, Map<String, Map<Ip, Set<AbstractRoute>>>> nextHopIfacesByRouteToIp2 =
         fib.getNextHopInterfacesByRoute(ip2);
-    assertThat(nextHopIfacesByRouteToIp2.entrySet(), hasSize(2));
+    assertThat(nextHopIfacesByRouteToIp2, aMapWithSize(2));
     Set<String> nextHopIfacesToIp2 =
         nextHopIfacesByRouteToIp2.values().stream()
             .flatMap(ifaceMap -> ifaceMap.keySet().stream())

--- a/projects/batfish/src/test/java/org/batfish/dataplane/FibImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/FibImplTest.java
@@ -2,7 +2,9 @@ package org.batfish.dataplane;
 
 import static org.batfish.datamodel.matchers.AbstractRouteMatchers.hasPrefix;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
@@ -10,10 +12,11 @@ import static org.junit.Assert.assertThat;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import java.io.IOException;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.Configuration;
-import org.batfish.datamodel.Configuration.Builder;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Fib;
 import org.batfish.datamodel.FibImpl;
@@ -45,23 +48,62 @@ public class FibImplTest {
   private static final InterfaceAddress NODE1_PHYSICAL_NETWORK = new InterfaceAddress("2.0.0.1/8");
   private static final Ip EXTERNAL_IP = Ip.parse("7.7.7.7");
 
-  private NetworkFactory _nf;
-  private Builder _cb;
   private Interface.Builder _ib;
-  private Vrf.Builder _vb;
-
   private Configuration _config;
   private Vrf _vrf;
 
   @Before
   public void setup() {
-    _nf = new NetworkFactory();
-    _cb = _nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
-    _ib = _nf.interfaceBuilder();
-    _vb = _nf.vrfBuilder();
-    _config = _cb.setHostname(NODE1).build();
-    _vrf = _vb.setOwner(_config).setName(Configuration.DEFAULT_VRF_NAME).build();
+    NetworkFactory nf = new NetworkFactory();
+    Configuration.Builder cb =
+        nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+    _ib = nf.interfaceBuilder();
+    _config = cb.setHostname(NODE1).build();
+    _vrf = nf.vrfBuilder().setOwner(_config).setName(Configuration.DEFAULT_VRF_NAME).build();
     _ib.setOwner(_config).setVrf(_vrf);
+  }
+
+  @Test
+  public void testGetNextHopInterfacesByRoute() throws IOException {
+    String iface1 = "iface1";
+    String iface2 = "iface2";
+    String iface3 = "iface3";
+    Ip ip1 = Ip.parse("1.1.1.0");
+    Ip ip2 = Ip.parse("2.2.2.0");
+    _ib.setName(iface1).setAddress(new InterfaceAddress(ip1, 24)).build();
+    _ib.setName(iface2).setAddress(new InterfaceAddress(ip2, 24)).build();
+    _ib.setName(iface3).setAddress(new InterfaceAddress(ip2, 24)).build();
+
+    Batfish batfish =
+        BatfishTestUtils.getBatfish(ImmutableSortedMap.of(_config.getHostname(), _config), folder);
+    batfish.computeDataPlane();
+    Fib fib =
+        batfish
+            .loadDataPlane()
+            .getFibs()
+            .get(_config.getHostname())
+            .get(Configuration.DEFAULT_VRF_NAME);
+
+    // Should have one LocalRoute per interface (also one ConnectedRoute, but LocalRoute will have
+    // longer prefix match). Should see only iface1 in interfaces to ip1.
+    Map<AbstractRoute, Map<String, Map<Ip, Set<AbstractRoute>>>> nextHopIfacesByRouteToIp1 =
+        fib.getNextHopInterfacesByRoute(ip1);
+    assertThat(nextHopIfacesByRouteToIp1.entrySet(), hasSize(1));
+    Set<String> nextHopIfacesToIp1 =
+        nextHopIfacesByRouteToIp1.values().stream()
+            .flatMap(ifaceMap -> ifaceMap.keySet().stream())
+            .collect(Collectors.toSet());
+    assertThat(nextHopIfacesToIp1, contains(iface1));
+
+    // Should see interfaces iface2 and iface3 in interfaces to ip2.
+    Map<AbstractRoute, Map<String, Map<Ip, Set<AbstractRoute>>>> nextHopIfacesByRouteToIp2 =
+        fib.getNextHopInterfacesByRoute(ip2);
+    assertThat(nextHopIfacesByRouteToIp2.entrySet(), hasSize(2));
+    Set<String> nextHopIfacesToIp2 =
+        nextHopIfacesByRouteToIp2.values().stream()
+            .flatMap(ifaceMap -> ifaceMap.keySet().stream())
+            .collect(Collectors.toSet());
+    assertThat(nextHopIfacesToIp2, containsInAnyOrder(iface2, iface3));
   }
 
   @Test


### PR DESCRIPTION
`FibImpl.getNextHopInterfaces()` now returns a non-sorted set, but when its return value is used to iterate through interfaces to generate traceroute traces, it gets sorted first. That way the traces are still in order of next hop interface.