### PR TITLE
clean up workitem handling and queueing

### DIFF
--- a/projects/batfish-client/src/main/java/org/batfish/client/Client.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/Client.java
@@ -2314,7 +2314,7 @@ public class Client extends AbstractClient implements IClient {
     // get the answer
     String ansFileName = wItem.getId() + BfConsts.SUFFIX_ANSWER_JSON_FILE;
     String downloadedAnsFile =
-        _workHelper.getObject(wItem.getContainerName(), wItem.getTestrigName(), ansFileName);
+        _workHelper.getObject(wItem.getNetwork(), wItem.getSnapshot(), ansFileName);
     if (downloadedAnsFile == null) {
       _logger.errorf("Failed to get answer file %s. (Was work killed?)\n", ansFileName);
     } else {
@@ -2361,7 +2361,7 @@ public class Client extends AbstractClient implements IClient {
       _logger.output("---------------- Service Log --------------\n");
       String logFileName = wItem.getId() + BfConsts.SUFFIX_LOG_FILE;
       String downloadedFileStr =
-          _workHelper.getObject(wItem.getContainerName(), wItem.getTestrigName(), logFileName);
+          _workHelper.getObject(wItem.getNetwork(), wItem.getSnapshot(), logFileName);
 
       if (downloadedFileStr == null) {
         _logger.errorf("Failed to get log file %s\n", logFileName);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/WorkItem.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/WorkItem.java
@@ -19,18 +19,18 @@ import javax.annotation.Nullable;
 
 public class WorkItem {
 
-  private static final String PROP_CONTAINER_NAME = "containerName";
+  private static final String PROP_NETWORK = "containerName";
   private static final String PROP_ID = "id";
   private static final String PROP_REQUEST_PARAMS = "requestParams";
-  private static final String PROP_TESTRIG_NAME = "testrigName";
+  private static final String PROP_SNAPSHOT = "testrigName";
 
   // used for testing to force an UUID
   private static UUID FIXED_UUID = null;
 
-  private final String _containerName;
+  private final String _network;
   private final UUID _id;
   private Map<String, String> _requestParams;
-  private final String _testrigName;
+  private final String _snapshot;
   private Map<String, String> _spanData; /* Map used by the TextMap carrier for SpanContext */
 
   public WorkItem(String containerName, String testrigName) {
@@ -44,12 +44,12 @@ public class WorkItem {
   @JsonCreator
   public WorkItem(
       @JsonProperty(PROP_ID) UUID id,
-      @JsonProperty(PROP_CONTAINER_NAME) String containerName,
-      @JsonProperty(PROP_TESTRIG_NAME) String testrigName,
+      @JsonProperty(PROP_NETWORK) String network,
+      @JsonProperty(PROP_SNAPSHOT) String snapshot,
       @JsonProperty(PROP_REQUEST_PARAMS) Map<String, String> reqParams) {
     _id = id;
-    _containerName = containerName;
-    _testrigName = testrigName;
+    _network = network;
+    _snapshot = snapshot;
     _requestParams = firstNonNull(reqParams, new HashMap<>());
     _spanData = new HashMap<>();
   }
@@ -58,9 +58,9 @@ public class WorkItem {
     _requestParams.put(key, value);
   }
 
-  @JsonProperty(PROP_CONTAINER_NAME)
-  public String getContainerName() {
-    return _containerName;
+  @JsonProperty(PROP_NETWORK)
+  public String getNetwork() {
+    return _network;
   }
 
   @JsonProperty(PROP_ID)
@@ -90,21 +90,21 @@ public class WorkItem {
     return tracer.extract(Builtin.TEXT_MAP, new TextMapExtractAdapter(_spanData));
   }
 
-  @JsonProperty(PROP_TESTRIG_NAME)
-  public String getTestrigName() {
-    return _testrigName;
+  @JsonProperty(PROP_SNAPSHOT)
+  public String getSnapshot() {
+    return _snapshot;
   }
 
   /**
-   * The supplied workItem is a match if it has the same container, testrig, and request parameters
+   * The supplied workItem is a match if it has the same network, snapshot, and request parameters
    *
    * @param workItem The workItem that should be matched
    * @return {@link boolean} that indicates whether the supplied workItem is a match
    */
   public boolean matches(WorkItem workItem) {
     return (workItem != null
-        && workItem._containerName.equals(_containerName)
-        && workItem._testrigName.equals(_testrigName)
+        && workItem._network.equals(_network)
+        && workItem._snapshot.equals(_snapshot)
         && workItem._requestParams.equals(_requestParams));
   }
 
@@ -130,6 +130,6 @@ public class WorkItem {
 
   @Override
   public String toString() {
-    return String.format("[%s %s %s %s]", _id, _containerName, _testrigName, _requestParams);
+    return String.format("[%s %s %s %s]", _id, _network, _snapshot, _requestParams);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/WorkItemBuilder.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/WorkItemBuilder.java
@@ -42,8 +42,8 @@ public class WorkItemBuilder {
     return wItem;
   }
 
-  public static WorkItem getWorkItemGenerateDataPlane(String containerName, String testrigName) {
-    WorkItem wItem = new WorkItem(containerName, testrigName);
+  public static WorkItem getWorkItemGenerateDataPlane(String network, String snapshot) {
+    WorkItem wItem = new WorkItem(network, snapshot);
     wItem.addRequestParam(BfConsts.COMMAND_DUMP_DP, "");
     return wItem;
   }
@@ -115,5 +115,9 @@ public class WorkItemBuilder {
 
   public static String getQuestionName(WorkItem workItem) {
     return workItem.getRequestParams().get(BfConsts.ARG_QUESTION_NAME);
+  }
+
+  public static String getReferenceSnapshotName(WorkItem workItem) {
+    return workItem.getRequestParams().get(BfConsts.ARG_DELTA_TESTRIG);
   }
 }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/QueuedWork.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/QueuedWork.java
@@ -1,8 +1,12 @@
 package org.batfish.coordinator;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 import javax.annotation.Nonnull;
+import org.batfish.common.BfConsts;
 import org.batfish.common.CoordConsts.WorkStatusCode;
 import org.batfish.common.Task;
 import org.batfish.common.WorkItem;
@@ -113,5 +117,26 @@ public class QueuedWork {
 
   public @Nonnull WorkStatus toWorkStatus() {
     return new WorkStatus(_workItem, _status, _lastTaskCheckResult);
+  }
+
+  /**
+   * Returns request params with names replaced with IDs. Adds SNAPSHOT_NAME for worker tasks that
+   * need it.
+   */
+  public @Nonnull Map<String, String> resolveRequestParams() {
+    Map<String, String> params = new HashMap<>(_workItem.getRequestParams());
+    params.put(BfConsts.ARG_CONTAINER, _details.getNetworkId().getId());
+    params.put(BfConsts.ARG_TESTRIG, _details.getSnapshotId().getId());
+    params.put(BfConsts.ARG_SNAPSHOT_NAME, _workItem.getSnapshot());
+    if (_details.getQuestionId() != null) {
+      params.put(BfConsts.ARG_QUESTION_NAME, _details.getQuestionId().getId());
+    }
+    if (_details.getAnalysisId() != null) {
+      params.put(BfConsts.ARG_ANALYSIS_NAME, _details.getAnalysisId().getId());
+    }
+    if (_details.getReferenceSnapshotId() != null) {
+      params.put(BfConsts.ARG_DELTA_TESTRIG, _details.getReferenceSnapshotId().getId());
+    }
+    return ImmutableMap.copyOf(params);
   }
 }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkDetails.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkDetails.java
@@ -1,37 +1,152 @@
 package org.batfish.coordinator;
 
-public class WorkDetails {
+import static com.google.common.base.Preconditions.checkState;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.identifiers.AnalysisId;
+import org.batfish.identifiers.NetworkId;
+import org.batfish.identifiers.QuestionId;
+import org.batfish.identifiers.SnapshotId;
+
+/** Resolved details about a {@link org.batfish.common.WorkItem} */
+@ParametersAreNonnullByDefault
+public final class WorkDetails {
+
+  public static final class Builder {
+
+    private @Nullable AnalysisId _analysisId;
+    private boolean _isDifferential;
+    private @Nullable NetworkId _networkId;
+    private @Nullable QuestionId _questionId;
+    private @Nullable SnapshotId _referenceSnapshotId;
+    private @Nullable SnapshotId _snapshotId;
+    private @Nullable WorkType _workType;
+
+    private Builder() {}
+
+    public @Nonnull WorkDetails build() {
+      checkState(_networkId != null, "Missing networkId");
+      checkState(_snapshotId != null, "Missing snapshotId");
+      checkState(_workType != null, "Missing workType");
+      return new WorkDetails(
+          _networkId,
+          _snapshotId,
+          _isDifferential,
+          _workType,
+          _referenceSnapshotId,
+          _analysisId,
+          _questionId);
+    }
+
+    public @Nonnull Builder setAnalysisId(@Nullable AnalysisId analysisId) {
+      _analysisId = analysisId;
+      return this;
+    }
+
+    public @Nonnull Builder setIsDifferential(boolean isDifferential) {
+      _isDifferential = isDifferential;
+      return this;
+    }
+
+    public @Nonnull Builder setNetworkId(NetworkId networkId) {
+      _networkId = networkId;
+      return this;
+    }
+
+    public @Nonnull Builder setQuestionId(@Nullable QuestionId questionId) {
+      _questionId = questionId;
+      return this;
+    }
+
+    public @Nonnull Builder setReferenceSnapshotId(@Nullable SnapshotId referenceSnapshotId) {
+      _referenceSnapshotId = referenceSnapshotId;
+      return this;
+    }
+
+    public @Nonnull Builder setSnapshotId(SnapshotId snapshotId) {
+      _snapshotId = snapshotId;
+      return this;
+    }
+
+    public @Nonnull Builder setWorkType(WorkType workType) {
+      _workType = workType;
+      return this;
+    }
+  }
 
   public enum WorkType {
-    PARSING,
+    DATAPLANE_DEPENDENT_ANSWERING,
     DATAPLANING,
     INDEPENDENT_ANSWERING, // answering includes analyzing
+    PARSING,
     PARSING_DEPENDENT_ANSWERING,
-    DATAPLANE_DEPENDENT_ANSWERING,
     UNKNOWN
   }
 
-  public final String baseTestrig;
-  public final String deltaTestrig;
-  public final boolean isDifferential;
-  public final WorkType workType;
-
-  public WorkDetails(String baseTestrig, WorkType workType) {
-    this(baseTestrig, null, false, workType);
+  public static @Nonnull Builder builder() {
+    return new Builder();
   }
 
+  private final @Nullable AnalysisId _analysisId;
+  private final boolean _isDifferential;
+  private final @Nonnull NetworkId _networkId;
+  private final @Nullable QuestionId _questionId;
+  private final @Nullable SnapshotId _referenceSnapshotId;
+  private final @Nonnull SnapshotId _snapshotId;
+  private final @Nonnull WorkType _workType;
+
   public WorkDetails(
-      String baseTestrig, String deltaTestrig, boolean isDifferential, WorkType workType) {
-    this.baseTestrig = baseTestrig;
-    this.deltaTestrig = deltaTestrig;
-    this.isDifferential = isDifferential;
-    this.workType = workType;
+      NetworkId networkId,
+      SnapshotId snapshotId,
+      boolean isDifferential,
+      WorkType workType,
+      @Nullable SnapshotId referenceSnapshotId,
+      @Nullable AnalysisId analysisId,
+      @Nullable QuestionId questionId) {
+    _networkId = networkId;
+    _snapshotId = snapshotId;
+    _isDifferential = isDifferential;
+    _workType = workType;
+    _referenceSnapshotId = referenceSnapshotId;
+    _analysisId = analysisId;
+    _questionId = questionId;
+  }
+
+  public @Nullable AnalysisId getAnalysisId() {
+    return _analysisId;
+  }
+
+  public boolean isDifferential() {
+    return _isDifferential;
+  }
+
+  public @Nonnull NetworkId getNetworkId() {
+    return _networkId;
+  }
+
+  public @Nullable QuestionId getQuestionId() {
+    return _questionId;
+  }
+
+  public @Nullable SnapshotId getReferenceSnapshotId() {
+    return _referenceSnapshotId;
+  }
+
+  public @Nonnull SnapshotId getSnapshotId() {
+    return _snapshotId;
+  }
+
+  public @Nonnull WorkType getWorkType() {
+    return _workType;
   }
 
   public boolean isOverlappingInput(WorkDetails o) {
-    return baseTestrig.equals(o.baseTestrig)
-        || baseTestrig.equals(o.deltaTestrig)
-        || isDifferential
-            && (deltaTestrig.equals(o.baseTestrig) || deltaTestrig.equals(o.deltaTestrig));
+    return _snapshotId.equals(o._snapshotId)
+        || _snapshotId.equals(o._referenceSnapshotId)
+        || _isDifferential
+            && (_referenceSnapshotId.equals(o._snapshotId)
+                || _referenceSnapshotId.equals(o._referenceSnapshotId));
   }
 }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -1052,18 +1052,6 @@ public class WorkMgr extends AbstractCoordinator {
               networkNodeRolesId,
               referenceSnapshotId,
               analysisId);
-      if (question.equals("MLAG_Analyzer")) {
-        System.err.printf(
-            "%s %s %s %s %s %s %s %s\n",
-            networkId,
-            analysisId,
-            questionId,
-            snapshotId,
-            referenceSnapshotId,
-            questionSettingsId,
-            networkNodeRolesId,
-            baseAnswerId);
-      }
       if (!_storage.hasAnswerMetadata(baseAnswerId)) {
         return AnswerMetadata.forStatus(AnswerStatus.NOTFOUND);
       }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
@@ -54,6 +54,7 @@ import org.batfish.datamodel.answers.GetAnalysisAnswerMetricsAnswer;
 import org.batfish.datamodel.pojo.WorkStatus;
 import org.batfish.datamodel.questions.Question;
 import org.batfish.datamodel.questions.Variable;
+import org.batfish.identifiers.NetworkId;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONObject;
 import org.glassfish.jersey.media.multipart.FormDataParam;
@@ -546,8 +547,8 @@ public class WorkMgrService {
 
       if (!Strings.isNullOrEmpty(workItemStr)) {
         WorkItem workItem = BatfishObjectMapper.mapper().readValue(workItemStr, WorkItem.class);
-        if (!workItem.getContainerName().equals(networkName)
-            || !workItem.getTestrigName().equals(snapshotName)) {
+        if (!workItem.getNetwork().equals(networkName)
+            || !workItem.getSnapshot().equals(snapshotName)) {
           return failureResponse(
               "Mismatch in parameters: WorkItem is not for the supplied network or snapshot");
         }
@@ -621,8 +622,8 @@ public class WorkMgrService {
 
       if (!Strings.isNullOrEmpty(workItemStr)) {
         WorkItem workItem = BatfishObjectMapper.mapper().readValue(workItemStr, WorkItem.class);
-        if (!workItem.getContainerName().equals(networkName)
-            || !workItem.getTestrigName().equals(snapshotName)) {
+        if (!workItem.getNetwork().equals(networkName)
+            || !workItem.getSnapshot().equals(snapshotName)) {
           return failureResponse(
               "Mismatch in parameters: WorkItem is not for the supplied network or snapshot");
         }
@@ -706,8 +707,8 @@ public class WorkMgrService {
 
       if (!Strings.isNullOrEmpty(workItemStr)) {
         WorkItem workItem = BatfishObjectMapper.mapper().readValue(workItemStr, WorkItem.class);
-        if (!workItem.getContainerName().equals(networkName)
-            || !workItem.getTestrigName().equals(snapshotName)) {
+        if (!workItem.getNetwork().equals(networkName)
+            || !workItem.getSnapshot().equals(snapshotName)) {
           return failureResponse(
               "Mismatch in parameters: WorkItem is not for the supplied network or snapshot");
         }
@@ -792,8 +793,8 @@ public class WorkMgrService {
 
       if (!Strings.isNullOrEmpty(workItemStr)) {
         WorkItem workItem = BatfishObjectMapper.mapper().readValue(workItemStr, WorkItem.class);
-        if (!workItem.getContainerName().equals(networkName)
-            || !workItem.getTestrigName().equals(snapshotName)) {
+        if (!workItem.getNetwork().equals(networkName)
+            || !workItem.getSnapshot().equals(snapshotName)) {
           return failureResponse(
               "Mismatch in parameters: WorkItem is not for the supplied network or snapshot");
         }
@@ -872,8 +873,8 @@ public class WorkMgrService {
 
       if (!Strings.isNullOrEmpty(workItemStr)) {
         WorkItem workItem = BatfishObjectMapper.mapper().readValue(workItemStr, WorkItem.class);
-        if (!workItem.getContainerName().equals(networkName)
-            || !workItem.getTestrigName().equals(snapshotName)) {
+        if (!workItem.getNetwork().equals(networkName)
+            || !workItem.getSnapshot().equals(snapshotName)) {
           return failureResponse(
               "Mismatch in parameters: WorkItem is not for the supplied network or snapshot");
         }
@@ -961,8 +962,8 @@ public class WorkMgrService {
 
       if (!Strings.isNullOrEmpty(workItemStr)) {
         WorkItem workItem = BatfishObjectMapper.mapper().readValue(workItemStr, WorkItem.class);
-        if (!workItem.getContainerName().equals(networkName)
-            || !workItem.getTestrigName().equals(snapshotName)) {
+        if (!workItem.getNetwork().equals(networkName)
+            || !workItem.getSnapshot().equals(snapshotName)) {
           return failureResponse(
               "Mismatch in parameters: WorkItem is not for the supplied network or snapshot");
         }
@@ -1060,8 +1061,8 @@ public class WorkMgrService {
 
       if (!Strings.isNullOrEmpty(workItemStr)) {
         WorkItem workItem = BatfishObjectMapper.mapper().readValue(workItemStr, WorkItem.class);
-        if (!workItem.getContainerName().equals(networkName)
-            || !workItem.getTestrigName().equals(snapshotName)) {
+        if (!workItem.getNetwork().equals(networkName)
+            || !workItem.getSnapshot().equals(snapshotName)) {
           return failureResponse(
               "Mismatch in parameters: WorkItem is not for the supplied network or snapshot");
         }
@@ -1147,8 +1148,8 @@ public class WorkMgrService {
 
       if (!Strings.isNullOrEmpty(workItemStr)) {
         WorkItem workItem = BatfishObjectMapper.mapper().readValue(workItemStr, WorkItem.class);
-        if (!workItem.getContainerName().equals(networkName)
-            || !workItem.getTestrigName().equals(snapshotName)) {
+        if (!workItem.getNetwork().equals(networkName)
+            || !workItem.getSnapshot().equals(snapshotName)) {
           return failureResponse(
               "Mismatch in parameters: WorkItem is not for the supplied network or snapshot");
         }
@@ -1434,11 +1435,10 @@ public class WorkMgrService {
         return failureResponse("work with the specified id does not exist or is not inaccessible");
       }
 
-      String networkId = work.getWorkItem().getContainerName();
+      NetworkId networkId = work.getDetails().getNetworkId();
       Optional<String> networkOpt =
           Main.getWorkMgr().getNetworkNames().stream()
-              .filter(
-                  n -> Main.getWorkMgr().getIdManager().getNetworkId(n).getId().equals(networkId))
+              .filter(n -> Main.getWorkMgr().getIdManager().getNetworkId(n).equals(networkId))
               .findFirst();
       checkArgument(networkOpt.isPresent(), "Invalid network ID: %s", networkId);
 
@@ -1543,7 +1543,7 @@ public class WorkMgrService {
         return failureResponse("work with the specified id does not exist or is not inaccessible");
       }
 
-      checkNetworkAccessibility(apiKey, work.getWorkItem().getContainerName());
+      checkNetworkAccessibility(apiKey, work.getWorkItem().getNetwork());
 
       boolean killed = Main.getWorkMgr().killWork(work);
 
@@ -1908,7 +1908,7 @@ public class WorkMgrService {
 
       WorkItem workItem = BatfishObjectMapper.mapper().readValue(workItemStr, WorkItem.class);
 
-      checkNetworkAccessibility(apiKey, workItem.getContainerName());
+      checkNetworkAccessibility(apiKey, workItem.getNetwork());
 
       QueuedWork work = Main.getWorkMgr().getMatchingWork(workItem, QueueType.INCOMPLETE);
       if (work != null) {

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkQueueMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkQueueMgr.java
@@ -1,6 +1,5 @@
 package org.batfish.coordinator;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
@@ -81,23 +80,31 @@ public class WorkQueueMgr {
     }
   }
 
-  private void cleanUpInitMetaDataIfNeeded(String container, String testrig) throws IOException {
-    InitializationMetadata metadata = WorkQueueMgr.getInitializationMetadata(container, testrig);
+  private void cleanUpInitMetaDataIfNeeded(NetworkId networkId, SnapshotId snapshotId)
+      throws IOException {
+    InitializationMetadata metadata =
+        SnapshotMetadataMgr.getInitializationMetadata(networkId, snapshotId);
     if (metadata.getProcessingStatus() == ProcessingStatus.PARSING
-        && getIncompleteWork(container, testrig, WorkType.PARSING) == null) {
-      WorkQueueMgr.updateInitializationStatus(
-          container, testrig, ProcessingStatus.PARSING_FAIL, null);
+        && getIncompleteWork(networkId, snapshotId, WorkType.PARSING) == null) {
+      SnapshotMetadataMgr.updateInitializationStatus(
+          networkId, snapshotId, ProcessingStatus.PARSING_FAIL, null);
     } else if (metadata.getProcessingStatus() == ProcessingStatus.DATAPLANING
-        && getIncompleteWork(container, testrig, WorkType.DATAPLANING) == null) {
-      WorkQueueMgr.updateInitializationStatus(
-          container, testrig, ProcessingStatus.DATAPLANING_FAIL, null);
+        && getIncompleteWork(networkId, snapshotId, WorkType.DATAPLANING) == null) {
+      SnapshotMetadataMgr.updateInitializationStatus(
+          networkId, snapshotId, ProcessingStatus.DATAPLANING_FAIL, null);
     }
   }
 
-  private QueuedWork generateAndQueueDataplaneWork(String container, String testrig)
+  private QueuedWork generateAndQueueDataplaneWork(
+      String network, NetworkId networkId, String snapshot, SnapshotId snapshotId)
       throws Exception {
-    WorkItem newWItem = WorkItemBuilder.getWorkItemGenerateDataPlane(container, testrig);
-    WorkDetails details = new WorkDetails(testrig, null, false, WorkType.DATAPLANING);
+    WorkItem newWItem = WorkItemBuilder.getWorkItemGenerateDataPlane(network, snapshot);
+    WorkDetails details =
+        WorkDetails.builder()
+            .setWorkType(WorkType.DATAPLANING)
+            .setSnapshotId(snapshotId)
+            .setNetworkId(networkId)
+            .build();
     QueuedWork newWork = new QueuedWork(newWItem, details);
     boolean queued = queueUnassignedWork(newWork);
     if (!queued) {
@@ -107,15 +114,14 @@ public class WorkQueueMgr {
   }
 
   private QueuedWork getBlockerForDataplaningWork(QueuedWork work) throws IOException {
-
-    WorkItem wItem = work.getWorkItem();
     WorkDetails wDetails = work.getDetails();
 
     QueuedWork currentParsingWork =
-        getIncompleteWork(wItem.getContainerName(), wDetails.baseTestrig, WorkType.PARSING);
+        getIncompleteWork(wDetails.getNetworkId(), wDetails.getSnapshotId(), WorkType.PARSING);
 
     InitializationMetadata metadata =
-        WorkQueueMgr.getInitializationMetadata(wItem.getContainerName(), wDetails.baseTestrig);
+        SnapshotMetadataMgr.getInitializationMetadata(
+            wDetails.getNetworkId(), wDetails.getSnapshotId());
 
     switch (metadata.getProcessingStatus()) {
       case UNINITIALIZED:
@@ -125,7 +131,7 @@ public class WorkQueueMgr {
           throw new BatfishException(
               String.format(
                   "Cannot queue dataplane work for %s: Status is %s but no incomplete parsing work exists",
-                  wDetails.baseTestrig, metadata.getProcessingStatus()));
+                  wDetails.getSnapshotId(), metadata.getProcessingStatus()));
         }
         return currentParsingWork;
       case PARSED:
@@ -135,7 +141,7 @@ public class WorkQueueMgr {
         throw new BatfishException(
             String.format(
                 "Cannot queue dataplane work for %s: Status is %s but no incomplete dataplaning work exists",
-                wDetails.baseTestrig, metadata.getProcessingStatus()));
+                wDetails.getSnapshotId(), metadata.getProcessingStatus()));
       case DATAPLANED:
       case DATAPLANING_FAIL:
         return null;
@@ -149,18 +155,18 @@ public class WorkQueueMgr {
    * This function has a side effect It will inject a dataplane generation work in the queue if none
    * exists
    */
-  private QueuedWork getBlockerForDataplaneDependentWork(QueuedWork work, String testrig)
-      throws Exception {
+  private QueuedWork getBlockerForDataplaneDependentWork(
+      QueuedWork work, String snapshot, SnapshotId snapshotId) throws Exception {
 
     WorkItem wItem = work.getWorkItem();
+    NetworkId networkId = work.getDetails().getNetworkId();
 
     InitializationMetadata metadata =
-        WorkQueueMgr.getInitializationMetadata(wItem.getContainerName(), testrig);
+        SnapshotMetadataMgr.getInitializationMetadata(networkId, snapshotId);
 
-    QueuedWork parsingWork = getIncompleteWork(wItem.getContainerName(), testrig, WorkType.PARSING);
+    QueuedWork parsingWork = getIncompleteWork(networkId, snapshotId, WorkType.PARSING);
 
-    QueuedWork dataplaningWork =
-        getIncompleteWork(wItem.getContainerName(), testrig, WorkType.DATAPLANING);
+    QueuedWork dataplaningWork = getIncompleteWork(networkId, snapshotId, WorkType.DATAPLANING);
 
     switch (metadata.getProcessingStatus()) {
       case UNINITIALIZED:
@@ -171,7 +177,7 @@ public class WorkQueueMgr {
               String.format(
                   "Cannot queue dataplane dependent work for %s: "
                       + "Status is %s but no incomplete parsing work exists",
-                  testrig, metadata.getProcessingStatus()));
+                  snapshotId, metadata.getProcessingStatus()));
         }
         return parsingWork;
       case PARSED:
@@ -181,7 +187,8 @@ public class WorkQueueMgr {
         if (dataplaningWork != null) {
           return dataplaningWork;
         }
-        return generateAndQueueDataplaneWork(wItem.getContainerName(), testrig);
+        return generateAndQueueDataplaneWork(
+            wItem.getNetwork(), work.getDetails().getNetworkId(), snapshot, snapshotId);
       case DATAPLANING_FAIL:
       case DATAPLANING:
         if (dataplaningWork == null) {
@@ -189,7 +196,7 @@ public class WorkQueueMgr {
               String.format(
                   "Cannot queue dataplane dependent work for %s: "
                       + "Status is %s but no incomplete dataplaning work exists",
-                  testrig, metadata.getProcessingStatus()));
+                  snapshotId, metadata.getProcessingStatus()));
         }
         return dataplaningWork;
       case DATAPLANED:
@@ -206,15 +213,15 @@ public class WorkQueueMgr {
     }
   }
 
-  private QueuedWork getBlockerForParsingDependentWork(QueuedWork work, String testrig)
-      throws IOException {
+  private QueuedWork getBlockerForParsingDependentWork(
+      QueuedWork work, String snapshot, SnapshotId snapshotId) throws IOException {
 
-    WorkItem wItem = work.getWorkItem();
+    NetworkId networkId = work.getDetails().getNetworkId();
 
     InitializationMetadata metadata =
-        WorkQueueMgr.getInitializationMetadata(wItem.getContainerName(), testrig);
+        SnapshotMetadataMgr.getInitializationMetadata(networkId, snapshotId);
 
-    QueuedWork parsingWork = getIncompleteWork(wItem.getContainerName(), testrig, WorkType.PARSING);
+    QueuedWork parsingWork = getIncompleteWork(networkId, snapshotId, WorkType.PARSING);
 
     switch (metadata.getProcessingStatus()) {
       case UNINITIALIZED:
@@ -225,7 +232,7 @@ public class WorkQueueMgr {
               String.format(
                   "Cannot queue parsing dependent work for %s: "
                       + "Status is %s but no incomplete parsing work exists",
-                  testrig, metadata.getProcessingStatus()));
+                  snapshot, metadata.getProcessingStatus()));
         }
         return parsingWork;
       case PARSED:
@@ -242,15 +249,16 @@ public class WorkQueueMgr {
   /**
    * Get all completed work for the specified network and snapshot.
    *
-   * @param network {@link NetworkId} to get completed work for.
-   * @param snapshot {@link SnapshotId} to get completed work for.
+   * @param networkId {@link NetworkId} to get completed work for.
+   * @param snapshotId {@link SnapshotId} to get completed work for.
    * @return {@link List} of completed {@link QueuedWork}.
    */
-  public synchronized List<QueuedWork> getCompletedWork(NetworkId network, SnapshotId snapshot) {
+  public synchronized List<QueuedWork> getCompletedWork(
+      NetworkId networkId, SnapshotId snapshotId) {
     ImmutableList.Builder<QueuedWork> b = ImmutableList.builder();
     for (QueuedWork work : _queueCompletedWork) {
-      if (work.getWorkItem().getContainerName().equals(network.getId())
-          && work.getWorkItem().getTestrigName().equals(snapshot.getId())) {
+      if (work.getDetails().getNetworkId().equals(networkId)
+          && work.getDetails().getSnapshotId().equals(snapshotId)) {
         b.add(work);
       }
     }
@@ -258,13 +266,14 @@ public class WorkQueueMgr {
   }
 
   private synchronized QueuedWork getIncompleteWork(
-      String container, String testrig, WorkType wType) {
+      NetworkId networkId, SnapshotId snapshotId, WorkType wType) {
     for (QueuedWork work : _queueIncompleteWork) {
       WorkDetails wDetails = work.getDetails();
-      if (container.equals(work.getWorkItem().getContainerName())
-          && ((testrig.equals(wDetails.baseTestrig))
-              || (wDetails.isDifferential && testrig.equals(wDetails.deltaTestrig)))
-          && (wType == null || wDetails.workType == wType)) {
+      if (networkId.equals(work.getDetails().getNetworkId())
+          && ((snapshotId.equals(wDetails.getSnapshotId()))
+              || (wDetails.isDifferential()
+                  && snapshotId.equals(wDetails.getReferenceSnapshotId())))
+          && (wType == null || wDetails.getWorkType() == wType)) {
         return work;
       }
     }
@@ -365,13 +374,13 @@ public class WorkQueueMgr {
   }
 
   public synchronized List<QueuedWork> listIncompleteWork(
-      String containerName, @Nullable String testrigName, @Nullable WorkType workType) {
+      NetworkId networkId, @Nullable SnapshotId snapshotId, @Nullable WorkType workType) {
     List<QueuedWork> retList = new LinkedList<>();
     for (QueuedWork work : _queueIncompleteWork) {
       // Add to queue if it matches container, testrig if provided, and work type if provided
-      if (work.getWorkItem().getContainerName().equals(containerName)
-          && (testrigName == null || work.getDetails().baseTestrig.equals(testrigName))
-          && (workType == null || work.getDetails().workType == workType)) {
+      if (work.getDetails().getNetworkId().equals(networkId)
+          && (snapshotId == null || work.getDetails().getSnapshotId().equals(snapshotId))
+          && (workType == null || work.getDetails().getWorkType() == workType)) {
         retList.add(work);
       }
     }
@@ -398,14 +407,13 @@ public class WorkQueueMgr {
     work.setAssignment(assignedWorker);
 
     // update testrig metadata
-    WorkItem wItem = work.getWorkItem();
     WorkDetails wDetails = work.getDetails();
-    if (wDetails.workType == WorkType.PARSING) {
-      WorkQueueMgr.updateInitializationStatus(
-          wItem.getContainerName(), wDetails.baseTestrig, ProcessingStatus.PARSING, null);
-    } else if (wDetails.workType == WorkType.DATAPLANING) {
-      WorkQueueMgr.updateInitializationStatus(
-          wItem.getContainerName(), wDetails.baseTestrig, ProcessingStatus.DATAPLANING, null);
+    if (wDetails.getWorkType() == WorkType.PARSING) {
+      SnapshotMetadataMgr.updateInitializationStatus(
+          wDetails.getNetworkId(), wDetails.getSnapshotId(), ProcessingStatus.PARSING, null);
+    } else if (wDetails.getWorkType() == WorkType.DATAPLANING) {
+      SnapshotMetadataMgr.updateInitializationStatus(
+          wDetails.getNetworkId(), wDetails.getSnapshotId(), ProcessingStatus.DATAPLANING, null);
     }
   }
 
@@ -434,26 +442,26 @@ public class WorkQueueMgr {
           // update testrig metadata
           WorkItem wItem = work.getWorkItem();
           WorkDetails wDetails = work.getDetails();
-          if (wDetails.workType == WorkType.PARSING) {
+          if (wDetails.getWorkType() == WorkType.PARSING) {
             ProcessingStatus status =
                 (task.getStatus() == TaskStatus.TerminatedNormally)
                     ? ProcessingStatus.PARSED
                     : ProcessingStatus.PARSING_FAIL;
-            WorkQueueMgr.updateInitializationStatus(
-                wItem.getContainerName(), wDetails.baseTestrig, status, task.getErrMessage());
-          } else if (wDetails.workType == WorkType.DATAPLANING) {
+            SnapshotMetadataMgr.updateInitializationStatus(
+                wDetails.getNetworkId(), wDetails.getSnapshotId(), status, task.getErrMessage());
+          } else if (wDetails.getWorkType() == WorkType.DATAPLANING) {
             // no change in status needed if task.getStatus() is RequeueFailure
             if (task.getStatus() == TaskStatus.TerminatedAbnormally
                 || task.getStatus() == TaskStatus.TerminatedByUser) {
-              WorkQueueMgr.updateInitializationStatus(
-                  wItem.getContainerName(),
-                  wDetails.baseTestrig,
+              SnapshotMetadataMgr.updateInitializationStatus(
+                  wDetails.getNetworkId(),
+                  wDetails.getSnapshotId(),
                   ProcessingStatus.DATAPLANING_FAIL,
                   task.getErrMessage());
             } else if (task.getStatus() == TaskStatus.TerminatedNormally) {
-              WorkQueueMgr.updateInitializationStatus(
-                  wItem.getContainerName(),
-                  wDetails.baseTestrig,
+              SnapshotMetadataMgr.updateInitializationStatus(
+                  wDetails.getNetworkId(),
+                  wDetails.getSnapshotId(),
                   ProcessingStatus.DATAPLANED,
                   null);
             }
@@ -509,35 +517,34 @@ public class WorkQueueMgr {
             work.clearAssignment();
             work.recordTaskCheckResult(task);
 
-            // update testrig metadata
-            WorkItem wItem = work.getWorkItem();
+            // update snapshot metadata
             WorkDetails wDetails = work.getDetails();
-            if (wDetails.workType == WorkType.PARSING
-                || wDetails.workType == WorkType.DATAPLANING) {
+            if (wDetails.getWorkType() == WorkType.PARSING
+                || wDetails.getWorkType() == WorkType.DATAPLANING) {
               InitializationMetadata metadata =
-                  WorkQueueMgr.getInitializationMetadata(
-                      wItem.getContainerName(), wDetails.baseTestrig);
-              if (wDetails.workType == WorkType.PARSING) {
+                  SnapshotMetadataMgr.getInitializationMetadata(
+                      wDetails.getNetworkId(), wDetails.getSnapshotId());
+              if (wDetails.getWorkType() == WorkType.PARSING) {
                 if (metadata.getProcessingStatus() != ProcessingStatus.PARSING) {
                   _logger.errorf(
                       "Unexpected status %s when parsing failed for %s",
-                      metadata.getProcessingStatus(), wDetails.baseTestrig);
+                      metadata.getProcessingStatus(), wDetails.getSnapshotId());
                 } else {
-                  WorkQueueMgr.updateInitializationStatus(
-                      wItem.getContainerName(),
-                      wDetails.baseTestrig,
+                  SnapshotMetadataMgr.updateInitializationStatus(
+                      wDetails.getNetworkId(),
+                      wDetails.getSnapshotId(),
                       ProcessingStatus.UNINITIALIZED,
                       task.getErrMessage());
                 }
-              } else { // wDetails.workType == WorkType.DATAPLANING
+              } else { // wDetails.getWorkType() == WorkType.DATAPLANING
                 if (metadata.getProcessingStatus() != ProcessingStatus.DATAPLANING) {
                   _logger.errorf(
                       "Unexpected status %s when dataplaning failed for %s",
-                      metadata.getProcessingStatus(), wDetails.baseTestrig);
+                      metadata.getProcessingStatus(), wDetails.getSnapshotId());
                 } else {
-                  WorkQueueMgr.updateInitializationStatus(
-                      wItem.getContainerName(),
-                      wDetails.baseTestrig,
+                  SnapshotMetadataMgr.updateInitializationStatus(
+                      wDetails.getNetworkId(),
+                      wDetails.getSnapshotId(),
                       ProcessingStatus.PARSED,
                       task.getErrMessage());
                 }
@@ -561,16 +568,24 @@ public class WorkQueueMgr {
 
     QueuedWork baseBlocker =
         dataplaneDependent
-            ? getBlockerForDataplaneDependentWork(work, wDetails.baseTestrig)
-            : getBlockerForParsingDependentWork(work, wDetails.baseTestrig);
+            ? getBlockerForDataplaneDependentWork(
+                work, work.getWorkItem().getSnapshot(), wDetails.getSnapshotId())
+            : getBlockerForParsingDependentWork(
+                work, work.getWorkItem().getSnapshot(), wDetails.getSnapshotId());
 
     if (baseBlocker != null) {
       return queueBlockedWork(work, baseBlocker);
-    } else if (wDetails.isDifferential) {
+    } else if (wDetails.isDifferential()) {
       QueuedWork deltaBlocker =
           dataplaneDependent
-              ? getBlockerForDataplaneDependentWork(work, wDetails.deltaTestrig)
-              : getBlockerForParsingDependentWork(work, wDetails.deltaTestrig);
+              ? getBlockerForDataplaneDependentWork(
+                  work,
+                  WorkItemBuilder.getReferenceSnapshotName(work.getWorkItem()),
+                  wDetails.getReferenceSnapshotId())
+              : getBlockerForParsingDependentWork(
+                  work,
+                  WorkItemBuilder.getReferenceSnapshotName(work.getWorkItem()),
+                  wDetails.getReferenceSnapshotId());
       if (deltaBlocker != null) {
         return queueBlockedWork(work, deltaBlocker);
       }
@@ -585,12 +600,9 @@ public class WorkQueueMgr {
   }
 
   private synchronized boolean queueDataplaningWork(QueuedWork work) throws Exception {
-
-    WorkItem wItem = work.getWorkItem();
     WorkDetails wDetails = work.getDetails();
-
     QueuedWork currentDataplaningWork =
-        getIncompleteWork(wItem.getContainerName(), wDetails.baseTestrig, WorkType.DATAPLANING);
+        getIncompleteWork(wDetails.getNetworkId(), wDetails.getSnapshotId(), WorkType.DATAPLANING);
     if (currentDataplaningWork != null) {
       throw new BatfishException("Dataplaning is already in queue/progress");
     }
@@ -598,7 +610,9 @@ public class WorkQueueMgr {
     // see comment in queueParsingWork for justification
     QueuedWork ddWork =
         getIncompleteWork(
-            wItem.getContainerName(), wDetails.baseTestrig, WorkType.DATAPLANE_DEPENDENT_ANSWERING);
+            wDetails.getNetworkId(),
+            wDetails.getSnapshotId(),
+            WorkType.DATAPLANE_DEPENDENT_ANSWERING);
     if (ddWork != null) {
       throw new BatfishException("Cannot queue dataplaning work while other dependent work exists");
     }
@@ -613,7 +627,6 @@ public class WorkQueueMgr {
 
   private synchronized boolean queueParsingWork(QueuedWork work) throws Exception {
 
-    WorkItem wItem = work.getWorkItem();
     WorkDetails wDetails = work.getDetails();
 
     // if incomplete work for this testrig exists, lets just reject this parsing work.
@@ -621,24 +634,25 @@ public class WorkQueueMgr {
     // instead of rejecting, we could have queued it as BLOCKED but we risk cycles of BLOCKED work
     // this should not be a common case anyway, so we aren't losing much by rejecting it
     QueuedWork incompleteWork =
-        getIncompleteWork(wItem.getContainerName(), wDetails.baseTestrig, null);
+        getIncompleteWork(wDetails.getNetworkId(), wDetails.getSnapshotId(), null);
     if (incompleteWork != null) {
       throw new BatfishException("Cannot queue parsing work while other work is incomplete");
     } else {
       InitializationMetadata metadata =
-          WorkQueueMgr.getInitializationMetadata(wItem.getContainerName(), wDetails.baseTestrig);
+          SnapshotMetadataMgr.getInitializationMetadata(
+              wDetails.getNetworkId(), wDetails.getSnapshotId());
       if (metadata.getProcessingStatus() == ProcessingStatus.PARSING) {
         throw new BatfishException(
             String.format(
                 "Cannot queue parsing work for %s: "
                     + "Status is PARSING but no incomplete parsing work exists",
-                wDetails.baseTestrig));
+                wDetails.getSnapshotId()));
       } else if (metadata.getProcessingStatus() == ProcessingStatus.DATAPLANING) {
         throw new BatfishException(
             String.format(
                 "Cannot queue parsing work for %s: "
                     + "Status is DATAPLANING but no incomplete dataplaning work exists",
-                wDetails.baseTestrig));
+                wDetails.getSnapshotId()));
       }
     }
 
@@ -651,11 +665,12 @@ public class WorkQueueMgr {
       throw new BatfishException("Duplicate work item");
     }
     WorkDetails wDetails = work.getDetails();
-    cleanUpInitMetaDataIfNeeded(work.getWorkItem().getContainerName(), wDetails.baseTestrig);
-    if (work.getDetails().isDifferential) {
-      cleanUpInitMetaDataIfNeeded(work.getWorkItem().getContainerName(), wDetails.deltaTestrig);
+    cleanUpInitMetaDataIfNeeded(work.getDetails().getNetworkId(), wDetails.getSnapshotId());
+    if (work.getDetails().isDifferential()) {
+      cleanUpInitMetaDataIfNeeded(
+          work.getDetails().getNetworkId(), wDetails.getReferenceSnapshotId());
     }
-    switch (work.getDetails().workType) {
+    switch (work.getDetails().getWorkType()) {
       case PARSING:
         return queueParsingWork(work);
       case DATAPLANING:
@@ -670,23 +685,7 @@ public class WorkQueueMgr {
       case UNKNOWN:
         return _queueIncompleteWork.enque(work);
       default:
-        throw new BatfishException("Unknown WorkType " + work.getDetails().workType);
+        throw new BatfishException("Unknown WorkType " + work.getDetails().getWorkType());
     }
-  }
-
-  private static void updateInitializationStatus(
-      String network, String snapshot, ProcessingStatus status, String errMessage)
-      throws IOException {
-    // already resolved
-    SnapshotMetadataMgr.updateInitializationStatus(
-        new NetworkId(network), new SnapshotId(snapshot), status, errMessage);
-  }
-
-  @VisibleForTesting
-  static InitializationMetadata getInitializationMetadata(String network, String snapshot)
-      throws IOException {
-    // already resolved
-    return SnapshotMetadataMgr.getInitializationMetadata(
-        new NetworkId(network), new SnapshotId(snapshot));
   }
 }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/resources/WorkBean.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/resources/WorkBean.java
@@ -20,6 +20,6 @@ public class WorkBean {
     dateTerminated = work.getDateTerminated();
     id = work.getId();
     status = work.getStatus();
-    workType = work.getDetails().workType;
+    workType = work.getDetails().getWorkType();
   }
 }

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/QueuedWorkTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/QueuedWorkTest.java
@@ -8,13 +8,20 @@ import static org.junit.Assert.assertThat;
 import org.batfish.common.CoordConsts.WorkStatusCode;
 import org.batfish.common.WorkItem;
 import org.batfish.coordinator.WorkDetails.WorkType;
+import org.batfish.identifiers.NetworkId;
+import org.batfish.identifiers.SnapshotId;
 import org.junit.Test;
 
 public final class QueuedWorkTest {
 
   private static QueuedWork createWork(String network, String snapshot) {
     return new QueuedWork(
-        new WorkItem(network, snapshot), new WorkDetails(snapshot, WorkType.UNKNOWN));
+        new WorkItem(network, snapshot),
+        WorkDetails.builder()
+            .setWorkType(WorkType.UNKNOWN)
+            .setNetworkId(new NetworkId(network + "-ID"))
+            .setSnapshotId(new SnapshotId(snapshot + "-ID"))
+            .build());
   }
 
   @Test

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkDetailsTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkDetailsTest.java
@@ -1,60 +1,121 @@
 package org.batfish.coordinator;
 
-import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.batfish.coordinator.WorkDetails.WorkType;
+import org.batfish.identifiers.NetworkId;
+import org.batfish.identifiers.SnapshotId;
+import org.junit.Before;
 import org.junit.Test;
 
 /** Tests for {@link WorkQueueMgr}. */
-public class WorkDetailsTest {
+public final class WorkDetailsTest {
+
+  private WorkDetails.Builder _builder;
+
+  @Before
+  public void setup() {
+    _builder =
+        WorkDetails.builder().setNetworkId(new NetworkId("foo")).setWorkType(WorkType.UNKNOWN);
+  }
 
   @Test
   public void isOverlappingInputMatchingBases() {
-    WorkDetails details1 = new WorkDetails("t1", WorkType.UNKNOWN);
-    WorkDetails details2 = new WorkDetails("t1", WorkType.UNKNOWN);
-    assertThat(details1.isOverlappingInput(details2), equalTo(true));
+    WorkDetails details1 = _builder.setSnapshotId(new SnapshotId("t1")).build();
+    WorkDetails details2 = _builder.build();
+    assertTrue(details1.isOverlappingInput(details2));
   }
 
   @Test
   public void isOverlappingInputMatchingBaseDelta() {
-    WorkDetails details1 = new WorkDetails("t1", WorkType.UNKNOWN);
-    WorkDetails details2 = new WorkDetails("t2", "t1", true, WorkType.UNKNOWN);
-    assertThat(details1.isOverlappingInput(details2), equalTo(true));
+    WorkDetails details1 = _builder.setSnapshotId(new SnapshotId("t1")).build();
+    WorkDetails details2 =
+        _builder
+            .setSnapshotId(new SnapshotId("t2"))
+            .setReferenceSnapshotId(new SnapshotId("t1"))
+            .setIsDifferential(true)
+            .build();
+    assertTrue(details1.isOverlappingInput(details2));
   }
 
   @Test
   public void isOverlappingInputMatchingDeltaBase() {
-    WorkDetails details1 = new WorkDetails("t1", "t2", true, WorkType.UNKNOWN);
-    WorkDetails details2 = new WorkDetails("t2", WorkType.UNKNOWN);
-    assertThat(details1.isOverlappingInput(details2), equalTo(true));
+    WorkDetails details1 =
+        _builder
+            .setSnapshotId(new SnapshotId("t1"))
+            .setReferenceSnapshotId(new SnapshotId("t2"))
+            .setIsDifferential(true)
+            .build();
+    WorkDetails details2 =
+        _builder
+            .setSnapshotId(new SnapshotId("t2"))
+            .setReferenceSnapshotId(null)
+            .setIsDifferential(false)
+            .build();
+
+    assertTrue(details1.isOverlappingInput(details2));
   }
 
   @Test
   public void isOverlappingInputMatchingDeltas() {
-    WorkDetails details1 = new WorkDetails("t1", "t2", true, WorkType.UNKNOWN);
-    WorkDetails details2 = new WorkDetails("t3", "t2", true, WorkType.UNKNOWN);
-    assertThat(details1.isOverlappingInput(details2), equalTo(true));
+    WorkDetails details1 =
+        _builder
+            .setSnapshotId(new SnapshotId("t1"))
+            .setReferenceSnapshotId(new SnapshotId("t2"))
+            .setIsDifferential(true)
+            .build();
+    WorkDetails details2 =
+        _builder
+            .setSnapshotId(new SnapshotId("t3"))
+            .setReferenceSnapshotId(new SnapshotId("t2"))
+            .setIsDifferential(true)
+            .build();
+
+    assertTrue(details1.isOverlappingInput(details2));
   }
 
   @Test
   public void isOverlappingInputNoMatchBase() {
-    WorkDetails details1 = new WorkDetails("t1", WorkType.UNKNOWN);
-    WorkDetails details2 = new WorkDetails("t3", WorkType.UNKNOWN);
-    assertThat(details1.isOverlappingInput(details2), equalTo(false));
+    WorkDetails details1 = _builder.setSnapshotId(new SnapshotId("t1")).build();
+    WorkDetails details2 = _builder.setSnapshotId(new SnapshotId("t3")).build();
+
+    assertFalse(details1.isOverlappingInput(details2));
   }
 
   @Test
   public void isOverlappingInputNoMatchDelta() {
-    WorkDetails details1 = new WorkDetails("t1", "t2", true, WorkType.UNKNOWN);
-    WorkDetails details2 = new WorkDetails("t3", WorkType.UNKNOWN);
-    assertThat(details1.isOverlappingInput(details2), equalTo(false));
+    WorkDetails details1 =
+        _builder
+            .setSnapshotId(new SnapshotId("t1"))
+            .setReferenceSnapshotId(new SnapshotId("t2"))
+            .setIsDifferential(true)
+            .build();
+    WorkDetails details2 =
+        _builder
+            .setSnapshotId(new SnapshotId("t3"))
+            .setReferenceSnapshotId(null)
+            .setIsDifferential(false)
+            .build();
+
+    assertFalse(details1.isOverlappingInput(details2));
   }
 
   @Test
   public void isOverlappingInputNoMatchBaseDelta() {
-    WorkDetails details1 = new WorkDetails("t1", "t2", true, WorkType.UNKNOWN);
-    WorkDetails details2 = new WorkDetails("t3", "t4", true, WorkType.UNKNOWN);
-    assertThat(details1.isOverlappingInput(details2), equalTo(false));
+    WorkDetails details1 =
+        _builder
+            .setSnapshotId(new SnapshotId("t1"))
+            .setReferenceSnapshotId(new SnapshotId("t2"))
+            .setIsDifferential(true)
+            .build();
+    WorkDetails details2 =
+        _builder
+            .setSnapshotId(new SnapshotId("t3"))
+            .setReferenceSnapshotId(new SnapshotId("t4"))
+            .setIsDifferential(true)
+            .build();
+
+    assertFalse(details1.isOverlappingInput(details2));
   }
 }

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
@@ -2775,8 +2775,10 @@ public final class WorkMgrTest {
                 analysis));
     WorkDetails workDetails = _manager.computeWorkDetails(workItem);
 
-    assertThat(workDetails.baseTestrig, equalTo(snapshot));
-    assertThat(workDetails.workType, equalTo(WorkType.PARSING_DEPENDENT_ANSWERING));
+    assertThat(
+        workDetails.getSnapshotId(),
+        equalTo(_idManager.getSnapshotId(snapshot, _idManager.getNetworkId(network))));
+    assertThat(workDetails.getWorkType(), equalTo(WorkType.PARSING_DEPENDENT_ANSWERING));
   }
 
   @Test
@@ -2795,8 +2797,10 @@ public final class WorkMgrTest {
             ImmutableMap.of(BfConsts.COMMAND_ANSWER, "", BfConsts.ARG_QUESTION_NAME, question));
     WorkDetails workDetails = _manager.computeWorkDetails(workItem);
 
-    assertThat(workDetails.baseTestrig, equalTo(snapshot));
-    assertThat(workDetails.workType, equalTo(WorkType.PARSING_DEPENDENT_ANSWERING));
+    assertThat(
+        workDetails.getSnapshotId(),
+        equalTo(_idManager.getSnapshotId(snapshot, _idManager.getNetworkId(network))));
+    assertThat(workDetails.getWorkType(), equalTo(WorkType.PARSING_DEPENDENT_ANSWERING));
   }
 
   @Test

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkQueueMgrTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkQueueMgrTest.java
@@ -129,6 +129,8 @@ public final class WorkQueueMgrTest {
 
   private NetworkId _networkId;
 
+  private IdManager _idManager;
+
   @Before
   public void init() throws Exception {
     Main.mainInit(new String[0]);
@@ -136,7 +138,8 @@ public final class WorkQueueMgrTest {
     _workQueueMgr = new WorkQueueMgr(Type.memory, Main.getLogger());
     WorkMgrTestUtils.initWorkManager(_folder);
     Main.getWorkMgr().initNetwork(NETWORK, null);
-    _networkId = Main.getWorkMgr().getIdManager().getNetworkId(NETWORK);
+    _idManager = Main.getWorkMgr().getIdManager();
+    _networkId = _idManager.getNetworkId(NETWORK);
   }
 
   private void initSnapshotMetadata(String snapshot, ProcessingStatus status) throws IOException {
@@ -150,25 +153,43 @@ public final class WorkQueueMgrTest {
         new SnapshotMetadata(Instant.now(), null).updateStatus(status, null), network, snapshot);
   }
 
-  private void queueWork(String testrig, WorkType wType) throws Exception {
+  private void queueWork(String snapshot, WorkType wType) throws Exception {
     QueuedWork work =
-        resolvedQueuedWork(new WorkItem(NETWORK, testrig), new WorkDetails(testrig, wType));
+        new QueuedWork(
+            new WorkItem(NETWORK, snapshot),
+            WorkDetails.builder()
+                .setWorkType(wType)
+                .setNetworkId(_networkId)
+                .setSnapshotId(_idManager.getSnapshotId(snapshot, _networkId))
+                .build());
     _workQueueMgr.queueUnassignedWork(work);
   }
 
   private void queueWork(String snapshot, String referenceSnapshot, WorkType wType)
       throws Exception {
     QueuedWork work =
-        resolvedQueuedWork(
+        new QueuedWork(
             new WorkItem(NETWORK, snapshot),
-            new WorkDetails(snapshot, referenceSnapshot, true, wType));
+            WorkDetails.builder()
+                .setWorkType(wType)
+                .setNetworkId(_networkId)
+                .setSnapshotId(_idManager.getSnapshotId(snapshot, _networkId))
+                .setReferenceSnapshotId(_idManager.getSnapshotId(referenceSnapshot, _networkId))
+                .setIsDifferential(true)
+                .build());
     _workQueueMgr.queueUnassignedWork(work);
   }
 
   private void workIsRejected(ProcessingStatus trStatus, WorkType wType) throws Exception {
     initSnapshotMetadata(SNAPSHOT, trStatus);
     QueuedWork work =
-        resolvedQueuedWork(new WorkItem(NETWORK, SNAPSHOT), new WorkDetails(SNAPSHOT, wType));
+        new QueuedWork(
+            new WorkItem(NETWORK, SNAPSHOT),
+            WorkDetails.builder()
+                .setNetworkId(_networkId)
+                .setSnapshotId(_idManager.getSnapshotId(SNAPSHOT, _networkId))
+                .setWorkType(wType)
+                .build());
     _thrown.expect(BatfishException.class);
     _thrown.expectMessage("Cannot queue ");
     doAction(new Action(ActionType.QUEUE, work));
@@ -180,9 +201,15 @@ public final class WorkQueueMgrTest {
     initSnapshotMetadata(SNAPSHOT, baseTrStatus);
     initSnapshotMetadata(REFERENCE_SNAPSHOT, deltaTrStatus);
     QueuedWork work =
-        resolvedQueuedWork(
+        new QueuedWork(
             new WorkItem(NETWORK, SNAPSHOT),
-            new WorkDetails(SNAPSHOT, REFERENCE_SNAPSHOT, true, wType));
+            WorkDetails.builder()
+                .setNetworkId(_networkId)
+                .setSnapshotId(_idManager.getSnapshotId(SNAPSHOT, _networkId))
+                .setReferenceSnapshotId(_idManager.getSnapshotId(REFERENCE_SNAPSHOT, _networkId))
+                .setIsDifferential(true)
+                .setWorkType(wType)
+                .build());
     _thrown.expect(BatfishException.class);
     _thrown.expectMessage("Cannot queue ");
     doAction(new Action(ActionType.QUEUE, work));
@@ -193,7 +220,13 @@ public final class WorkQueueMgrTest {
       throws Exception {
     initSnapshotMetadata(SNAPSHOT, trStatus);
     QueuedWork work =
-        resolvedQueuedWork(new WorkItem(NETWORK, SNAPSHOT), new WorkDetails(SNAPSHOT, wType));
+        new QueuedWork(
+            new WorkItem(NETWORK, SNAPSHOT),
+            WorkDetails.builder()
+                .setNetworkId(_networkId)
+                .setSnapshotId(_idManager.getSnapshotId(SNAPSHOT, _networkId))
+                .setWorkType(wType)
+                .build());
     doAction(new Action(ActionType.QUEUE, work));
     assertThat(work.getStatus(), equalTo(qwStatus));
     assertThat(_workQueueMgr.getLength(QueueType.INCOMPLETE), equalTo(queueLength));
@@ -209,9 +242,15 @@ public final class WorkQueueMgrTest {
     initSnapshotMetadata(SNAPSHOT, baseTrStatus);
     initSnapshotMetadata(REFERENCE_SNAPSHOT, deltaTrStatus);
     QueuedWork work =
-        resolvedQueuedWork(
+        new QueuedWork(
             new WorkItem(NETWORK, SNAPSHOT),
-            new WorkDetails(SNAPSHOT, REFERENCE_SNAPSHOT, true, wType));
+            WorkDetails.builder()
+                .setNetworkId(_networkId)
+                .setSnapshotId(_idManager.getSnapshotId(SNAPSHOT, _networkId))
+                .setReferenceSnapshotId(_idManager.getSnapshotId(REFERENCE_SNAPSHOT, _networkId))
+                .setIsDifferential(true)
+                .setWorkType(wType)
+                .build());
     doAction(new Action(ActionType.QUEUE, work));
     assertThat(work.getStatus(), equalTo(qwStatus));
     assertThat(_workQueueMgr.getLength(QueueType.INCOMPLETE), equalTo(queueLength));
@@ -220,32 +259,29 @@ public final class WorkQueueMgrTest {
   @Test
   public void getCompletedWork() throws Exception {
     String snapshot = "snapshot";
-    String network = "network";
-    Main.getWorkMgr().initNetwork(network, null);
-    WorkMgrTestUtils.initSnapshotWithTopology(network, snapshot, ImmutableSet.of());
-    IdManager idManager = Main.getWorkMgr().getIdManager();
-    NetworkId networkId = idManager.getNetworkId(network);
-    SnapshotId snapshot1Id = idManager.getSnapshotId(snapshot, networkId);
+    WorkMgrTestUtils.initSnapshotWithTopology(NETWORK, snapshot, ImmutableSet.of());
+    SnapshotId snapshot1Id = _idManager.getSnapshotId(snapshot, _networkId);
 
-    QueuedWork work1 =
-        resolvedQueuedWork(
-            new WorkItem(network, snapshot), new WorkDetails(snapshot, WorkType.UNKNOWN));
-    QueuedWork work2 =
-        resolvedQueuedWork(
-            new WorkItem(network, snapshot), new WorkDetails(snapshot, WorkType.UNKNOWN));
+    WorkDetails.Builder builder =
+        WorkDetails.builder()
+            .setNetworkId(_networkId)
+            .setSnapshotId(snapshot1Id)
+            .setWorkType(WorkType.UNKNOWN);
+    QueuedWork work1 = new QueuedWork(new WorkItem(NETWORK, snapshot), builder.build());
+    QueuedWork work2 = new QueuedWork(new WorkItem(NETWORK, snapshot), builder.build());
     _workQueueMgr.queueUnassignedWork(work1);
     _workQueueMgr.queueUnassignedWork(work2);
 
     // No items in complete queue yet
-    List<QueuedWork> works0 = _workQueueMgr.getCompletedWork(networkId, snapshot1Id);
+    List<QueuedWork> works0 = _workQueueMgr.getCompletedWork(_networkId, snapshot1Id);
 
     // Move one item from incomplete to complete queue
     _workQueueMgr.markAssignmentError(work1);
-    List<QueuedWork> works1 = _workQueueMgr.getCompletedWork(networkId, snapshot1Id);
+    List<QueuedWork> works1 = _workQueueMgr.getCompletedWork(_networkId, snapshot1Id);
 
     // Move a second item from incomplete to complete queue
     _workQueueMgr.markAssignmentError(work2);
-    List<QueuedWork> works2 = _workQueueMgr.getCompletedWork(networkId, snapshot1Id);
+    List<QueuedWork> works2 = _workQueueMgr.getCompletedWork(_networkId, snapshot1Id);
 
     // Confirm we don't see any work items when the complete queue is empty
     assertThat(works0, iterableWithSize(0));
@@ -282,73 +318,90 @@ public final class WorkQueueMgrTest {
     WorkMgrTestUtils.initSnapshotWithTopology(network1, snapshot2, ImmutableSet.of());
     WorkMgrTestUtils.initSnapshotWithTopology(network2, snapshot1, ImmutableSet.of());
 
-    IdManager idManager = Main.getWorkMgr().getIdManager();
-    NetworkId networkId = idManager.getNetworkId(network1);
-    SnapshotId snapshot1Id = idManager.getSnapshotId(snapshot1, networkId);
+    NetworkId network1Id = _idManager.getNetworkId(network1);
+    NetworkId network2Id = _idManager.getNetworkId(network2);
+    SnapshotId network1Snapshot1Id = _idManager.getSnapshotId(snapshot1, network1Id);
 
-    QueuedWork network1snapshot1work1 =
-        resolvedQueuedWork(
-            new WorkItem(network1, snapshot1), new WorkDetails(snapshot1, WorkType.UNKNOWN));
-    QueuedWork network1snapshot2work =
-        resolvedQueuedWork(
-            new WorkItem(network1, snapshot2), new WorkDetails(snapshot2, WorkType.UNKNOWN));
-    QueuedWork network2snapshot1work =
-        resolvedQueuedWork(
-            new WorkItem(network2, snapshot1), new WorkDetails(snapshot1, WorkType.UNKNOWN));
-    _workQueueMgr.queueUnassignedWork(network1snapshot1work1);
-    _workQueueMgr.queueUnassignedWork(network1snapshot2work);
-    _workQueueMgr.queueUnassignedWork(network2snapshot1work);
+    WorkDetails.Builder builder = WorkDetails.builder().setWorkType(WorkType.UNKNOWN);
+    QueuedWork network1Snapshot1Work1 =
+        new QueuedWork(
+            new WorkItem(network1, snapshot1),
+            builder.setNetworkId(network1Id).setSnapshotId(network1Snapshot1Id).build());
+    QueuedWork network1Snapshot2Work =
+        new QueuedWork(
+            new WorkItem(network1, snapshot2),
+            builder
+                .setNetworkId(network1Id)
+                .setSnapshotId(_idManager.getSnapshotId(snapshot2, network1Id))
+                .build());
+    QueuedWork network2Snapshot1Work =
+        new QueuedWork(
+            new WorkItem(network2, snapshot1),
+            builder
+                .setNetworkId(network2Id)
+                .setSnapshotId(_idManager.getSnapshotId(snapshot1, network2Id))
+                .build());
+    _workQueueMgr.queueUnassignedWork(network1Snapshot1Work1);
+    _workQueueMgr.queueUnassignedWork(network1Snapshot2Work);
+    _workQueueMgr.queueUnassignedWork(network2Snapshot1Work);
 
     // Move one item for each network and snapshot from incomplete to complete queue
-    _workQueueMgr.markAssignmentError(network1snapshot1work1);
-    _workQueueMgr.markAssignmentError(network1snapshot2work);
-    _workQueueMgr.markAssignmentError(network2snapshot1work);
-    List<QueuedWork> works1 = _workQueueMgr.getCompletedWork(networkId, snapshot1Id);
+    _workQueueMgr.markAssignmentError(network1Snapshot1Work1);
+    _workQueueMgr.markAssignmentError(network1Snapshot2Work);
+    _workQueueMgr.markAssignmentError(network2Snapshot1Work);
+    List<QueuedWork> works1 = _workQueueMgr.getCompletedWork(network1Id, network1Snapshot1Id);
 
     // Confirm we only see the network 1, snapshot 1 work item in the complete queue
     // i.e. make sure we don't see items from the other network or snapshot
-    assertThat(works1, contains(hasWorkItem(equalTo(network1snapshot1work1.getWorkItem()))));
+    assertThat(works1, contains(hasWorkItem(equalTo(network1Snapshot1Work1.getWorkItem()))));
   }
 
   @Test
   public void getMatchingWorkAbsent() throws Exception {
-    initSnapshotMetadata("testrig", ProcessingStatus.UNINITIALIZED);
-    WorkItem wItem = new WorkItem(NETWORK, "testrig");
+    String snapshot = "snapshot1";
+    initSnapshotMetadata(snapshot, ProcessingStatus.UNINITIALIZED);
+    WorkItem wItem = new WorkItem(NETWORK, snapshot);
     wItem.addRequestParam("key", "value");
     // get matching work should be null on an empty queue
     QueuedWork matchingWork = _workQueueMgr.getMatchingWork(wItem, QueueType.INCOMPLETE);
     assertThat(matchingWork, equalTo(null));
 
     // build two work items that do not match
-    WorkItem wItem1 = new WorkItem(NETWORK, "testrig");
+    WorkItem wItem1 = new WorkItem(NETWORK, snapshot);
     wItem1.addRequestParam("key1", "value1");
-    QueuedWork work1 = resolvedQueuedWork(wItem1, new WorkDetails("testrig", WorkType.UNKNOWN));
-    QueuedWork work2 =
-        resolvedQueuedWork(
-            new WorkItem(NETWORK, "testrig"), new WorkDetails("testrig", WorkType.UNKNOWN));
+    WorkDetails.Builder builder =
+        WorkDetails.builder()
+            .setWorkType(WorkType.UNKNOWN)
+            .setNetworkId(_networkId)
+            .setSnapshotId(_idManager.getSnapshotId(snapshot, _networkId));
+    QueuedWork work1 = new QueuedWork(wItem1, builder.build());
+    QueuedWork work2 = new QueuedWork(new WorkItem(NETWORK, snapshot), builder.build());
     _workQueueMgr.queueUnassignedWork(work1);
     _workQueueMgr.queueUnassignedWork(work2);
 
     // should be null again
-    QueuedWork matchingWorkAgain =
-        _workQueueMgr.getMatchingWork(WorkMgr.resolveIds(wItem), QueueType.INCOMPLETE);
+    QueuedWork matchingWorkAgain = _workQueueMgr.getMatchingWork(wItem, QueueType.INCOMPLETE);
     assertThat(matchingWorkAgain, equalTo(null));
   }
 
   @Test
   public void getMatchingWorkPresent() throws Exception {
-    initSnapshotMetadata("testrig", ProcessingStatus.UNINITIALIZED);
-    WorkItem wItem1 = new WorkItem(NETWORK, "testrig");
+    String snapshot = "snapshot1";
+    initSnapshotMetadata(snapshot, ProcessingStatus.UNINITIALIZED);
+    WorkItem wItem1 = new WorkItem(NETWORK, snapshot);
     wItem1.addRequestParam("key1", "value1");
-    QueuedWork work1 = resolvedQueuedWork(wItem1, new WorkDetails("testrig", WorkType.UNKNOWN));
-    QueuedWork work2 =
-        resolvedQueuedWork(
-            new WorkItem(NETWORK, "testrig"), new WorkDetails("testrig", WorkType.UNKNOWN));
+    WorkDetails.Builder builder =
+        WorkDetails.builder()
+            .setWorkType(WorkType.UNKNOWN)
+            .setNetworkId(_networkId)
+            .setSnapshotId(_idManager.getSnapshotId(snapshot, _networkId));
+    QueuedWork work1 = new QueuedWork(wItem1, builder.build());
+    QueuedWork work2 = new QueuedWork(new WorkItem(NETWORK, snapshot), builder.build());
     _workQueueMgr.queueUnassignedWork(work1);
     _workQueueMgr.queueUnassignedWork(work2);
 
     // build a work item that should match wItem1
-    WorkItem wItem3 = WorkMgr.resolveIds(new WorkItem(NETWORK, "testrig"));
+    WorkItem wItem3 = new WorkItem(NETWORK, snapshot);
     wItem3.addRequestParam("key1", "value1");
 
     QueuedWork matchingWork = _workQueueMgr.getMatchingWork(wItem3, QueueType.INCOMPLETE);
@@ -358,58 +411,80 @@ public final class WorkQueueMgrTest {
 
   @Test
   public void listIncompleteWork() throws Exception {
-    initSnapshotMetadata("testrig", ProcessingStatus.UNINITIALIZED);
-    Main.getWorkMgr().initNetwork("other", null);
-    WorkMgrTestUtils.initSnapshotWithTopology("other", "testrig", ImmutableSet.of());
-    initSnapshotMetadata("other", "testrig", ProcessingStatus.UNINITIALIZED);
+    String snapshot = "snapshot1";
+    String otherNetwork = "other";
+    initSnapshotMetadata(snapshot, ProcessingStatus.UNINITIALIZED);
+    Main.getWorkMgr().initNetwork(otherNetwork, null);
+    WorkMgrTestUtils.initSnapshotWithTopology(otherNetwork, snapshot, ImmutableSet.of());
+    initSnapshotMetadata(otherNetwork, snapshot, ProcessingStatus.UNINITIALIZED);
+    NetworkId otherNetworkId = _idManager.getNetworkId(otherNetwork);
+    WorkDetails.Builder builder = WorkDetails.builder().setWorkType(WorkType.UNKNOWN);
     QueuedWork work1 =
-        resolvedQueuedWork(
-            new WorkItem(NETWORK, "testrig"), new WorkDetails("testrig", WorkType.UNKNOWN));
+        new QueuedWork(
+            new WorkItem(NETWORK, snapshot),
+            builder
+                .setNetworkId(_networkId)
+                .setSnapshotId(_idManager.getSnapshotId(snapshot, _networkId))
+                .build());
     QueuedWork work2 =
-        resolvedQueuedWork(
-            new WorkItem("other", "testrig"), new WorkDetails("testrig", WorkType.UNKNOWN));
+        new QueuedWork(
+            new WorkItem(otherNetwork, snapshot),
+            builder
+                .setNetworkId(otherNetworkId)
+                .setSnapshotId(_idManager.getSnapshotId(snapshot, otherNetworkId))
+                .build());
     _workQueueMgr.queueUnassignedWork(work1);
     _workQueueMgr.queueUnassignedWork(work2);
 
-    List<QueuedWork> works = _workQueueMgr.listIncompleteWork(_networkId.getId(), null, null);
+    List<QueuedWork> works = _workQueueMgr.listIncompleteWork(_networkId, null, null);
 
     assertThat(works, equalTo(Collections.singletonList(work1)));
   }
 
   @Test
   public void listIncompleteWorkForSpecificStatus() throws Exception {
-    initSnapshotMetadata("testrig", ProcessingStatus.UNINITIALIZED);
+    String snapshot = "snapshot1";
+    initSnapshotMetadata(snapshot, ProcessingStatus.UNINITIALIZED);
+    WorkDetails.Builder builder =
+        WorkDetails.builder()
+            .setNetworkId(_networkId)
+            .setSnapshotId(_idManager.getSnapshotId(snapshot, _networkId));
     QueuedWork work1 =
-        resolvedQueuedWork(
-            new WorkItem(NETWORK, "testrig"), new WorkDetails("testrig", WorkType.PARSING));
+        new QueuedWork(
+            new WorkItem(NETWORK, snapshot), builder.setWorkType(WorkType.PARSING).build());
     QueuedWork work2 =
-        resolvedQueuedWork(
-            new WorkItem(NETWORK, "testrig"), new WorkDetails("testrig", WorkType.UNKNOWN));
+        new QueuedWork(
+            new WorkItem(NETWORK, snapshot), builder.setWorkType(WorkType.UNKNOWN).build());
     _workQueueMgr.queueUnassignedWork(work1);
     _workQueueMgr.queueUnassignedWork(work2);
 
     List<QueuedWork> parsingWorks =
-        _workQueueMgr.listIncompleteWork(_networkId.getId(), null, WorkType.PARSING);
+        _workQueueMgr.listIncompleteWork(_networkId, null, WorkType.PARSING);
 
     assertThat(parsingWorks, equalTo(Collections.singletonList(work1)));
   }
 
   @Test
-  public void listIncompleteWorkForSpecificTestrig() throws Exception {
-    initSnapshotMetadata("testrig", ProcessingStatus.UNINITIALIZED);
-    initSnapshotMetadata("testrig2", ProcessingStatus.UNINITIALIZED);
+  public void listIncompleteWorkForSpecificSnapshot() throws Exception {
+    String snapshot1 = "snapshot1";
+    String snapshot2 = "snapshot2";
+    initSnapshotMetadata(snapshot1, ProcessingStatus.UNINITIALIZED);
+    initSnapshotMetadata(snapshot2, ProcessingStatus.UNINITIALIZED);
+    WorkDetails.Builder builder =
+        WorkDetails.builder().setWorkType(WorkType.UNKNOWN).setNetworkId(_networkId);
     QueuedWork work1 =
-        resolvedQueuedWork(
-            new WorkItem(NETWORK, "testrig"), new WorkDetails("testrig", WorkType.UNKNOWN));
+        new QueuedWork(
+            new WorkItem(NETWORK, snapshot1),
+            builder.setSnapshotId(_idManager.getSnapshotId(snapshot1, _networkId)).build());
     QueuedWork work2 =
-        resolvedQueuedWork(
-            new WorkItem(NETWORK, "testrig2"), new WorkDetails("testrig2", WorkType.UNKNOWN));
+        new QueuedWork(
+            new WorkItem(NETWORK, snapshot1),
+            builder.setSnapshotId(_idManager.getSnapshotId(snapshot2, _networkId)).build());
     _workQueueMgr.queueUnassignedWork(work1);
     _workQueueMgr.queueUnassignedWork(work2);
 
-    SnapshotId snapshotId = Main.getWorkMgr().getIdManager().getSnapshotId("testrig", _networkId);
-    List<QueuedWork> parsingWorks =
-        _workQueueMgr.listIncompleteWork(_networkId.getId(), snapshotId.getId(), null);
+    SnapshotId snapshotId = _idManager.getSnapshotId(snapshot1, _networkId);
+    List<QueuedWork> parsingWorks = _workQueueMgr.listIncompleteWork(_networkId, snapshotId, null);
 
     assertThat(parsingWorks, equalTo(Collections.singletonList(work1)));
   }
@@ -1075,14 +1150,18 @@ public final class WorkQueueMgrTest {
 
   @Test
   public void dataplaningAfterParsingFailure() throws Exception {
-    initSnapshotMetadata("other", ProcessingStatus.UNINITIALIZED);
+    String snapshot = "snapshot1";
+    initSnapshotMetadata(snapshot, ProcessingStatus.UNINITIALIZED);
+    SnapshotId snapshotId = _idManager.getSnapshotId(snapshot, _networkId);
+    WorkDetails.Builder builder =
+        WorkDetails.builder().setNetworkId(_networkId).setSnapshotId(snapshotId);
     QueuedWork work1 =
-        resolvedQueuedWork(
-            new WorkItem(NETWORK, "other"), new WorkDetails("other", WorkType.PARSING));
+        new QueuedWork(
+            new WorkItem(NETWORK, snapshot), builder.setWorkType(WorkType.PARSING).build());
     _workQueueMgr.queueUnassignedWork(work1);
     QueuedWork work2 =
-        resolvedQueuedWork(
-            new WorkItem(NETWORK, "other"), new WorkDetails("other", WorkType.DATAPLANING));
+        new QueuedWork(
+            new WorkItem(NETWORK, snapshot), builder.setWorkType(WorkType.DATAPLANING).build());
     _workQueueMgr.queueUnassignedWork(work2);
 
     QueuedWork aWork1 =
@@ -1091,10 +1170,8 @@ public final class WorkQueueMgrTest {
 
     // work2 should be left with terminatedqueuefail status and the testrig in parsing_fail state
     assertThat(work2.getStatus(), equalTo(WorkStatusCode.REQUEUEFAILURE));
-    SnapshotId other = Main.getWorkMgr().getIdManager().getSnapshotId("other", _networkId);
     assertThat(
-        WorkQueueMgr.getInitializationMetadata(_networkId.getId(), other.getId())
-            .getProcessingStatus(),
+        SnapshotMetadataMgr.getInitializationMetadata(_networkId, snapshotId).getProcessingStatus(),
         equalTo(ProcessingStatus.PARSING_FAIL));
   }
 
@@ -1102,44 +1179,57 @@ public final class WorkQueueMgrTest {
 
   @Test
   public void queueUnassignedWork() throws Exception {
-    initSnapshotMetadata("testrig", ProcessingStatus.UNINITIALIZED);
+    String snapshot = "snapshot1";
+    initSnapshotMetadata(snapshot, ProcessingStatus.UNINITIALIZED);
+    WorkDetails.Builder builder =
+        WorkDetails.builder()
+            .setNetworkId(_networkId)
+            .setSnapshotId(_idManager.getSnapshotId(snapshot, _networkId));
     QueuedWork work1 =
-        resolvedQueuedWork(
-            new WorkItem(NETWORK, "testrig"), new WorkDetails("testrig", WorkType.PARSING));
+        new QueuedWork(
+            new WorkItem(NETWORK, snapshot), builder.setWorkType(WorkType.PARSING).build());
     _workQueueMgr.queueUnassignedWork(work1);
     assertThat(_workQueueMgr.getLength(QueueType.INCOMPLETE), equalTo(1L));
     QueuedWork work2 =
-        resolvedQueuedWork(
-            new WorkItem(NETWORK, "testrig"),
-            new WorkDetails("testrig", WorkType.PARSING_DEPENDENT_ANSWERING));
+        new QueuedWork(
+            new WorkItem(NETWORK, snapshot),
+            builder.setWorkType(WorkType.PARSING_DEPENDENT_ANSWERING).build());
     _workQueueMgr.queueUnassignedWork(work2);
     assertThat(_workQueueMgr.getLength(QueueType.INCOMPLETE), equalTo(2L));
   }
 
   @Test
   public void queueUnassignedWorkUnknown() throws Exception {
-    initSnapshotMetadata("testrig", ProcessingStatus.UNINITIALIZED);
+    String snapshot = "snapshot1";
+    initSnapshotMetadata(snapshot, ProcessingStatus.UNINITIALIZED);
     QueuedWork work1 =
-        resolvedQueuedWork(
-            new WorkItem(NETWORK, "testrig"), new WorkDetails("testrig", WorkType.UNKNOWN));
+        new QueuedWork(
+            new WorkItem(NETWORK, snapshot),
+            WorkDetails.builder()
+                .setWorkType(WorkType.UNKNOWN)
+                .setNetworkId(_networkId)
+                .setSnapshotId(_idManager.getSnapshotId(snapshot, _networkId))
+                .build());
     _workQueueMgr.queueUnassignedWork(work1);
     assertThat(_workQueueMgr.getLength(QueueType.INCOMPLETE), equalTo(1L));
   }
 
   @Test
   public void testGetWorkForChecking() throws Exception {
-    initSnapshotMetadata("testrig", ProcessingStatus.UNINITIALIZED);
+    String snapshot = "snapshot1";
+    initSnapshotMetadata(snapshot, ProcessingStatus.UNINITIALIZED);
     List<QueuedWork> workToCheck = _workQueueMgr.getWorkForChecking();
 
     // Make sure getWorkForChecking() returns no elements when the incomplete work queue is empty
     assertThat(workToCheck, empty());
 
-    QueuedWork work1 =
-        resolvedQueuedWork(
-            new WorkItem(NETWORK, "testrig"), new WorkDetails("testrig", WorkType.UNKNOWN));
-    QueuedWork work2 =
-        resolvedQueuedWork(
-            new WorkItem(NETWORK, "testrig"), new WorkDetails("testrig", WorkType.UNKNOWN));
+    WorkDetails.Builder builder =
+        WorkDetails.builder()
+            .setNetworkId(_networkId)
+            .setSnapshotId(_idManager.getSnapshotId(snapshot, _networkId))
+            .setWorkType(WorkType.UNKNOWN);
+    QueuedWork work1 = new QueuedWork(new WorkItem(NETWORK, snapshot), builder.build());
+    QueuedWork work2 = new QueuedWork(new WorkItem(NETWORK, snapshot), builder.build());
     _workQueueMgr.queueUnassignedWork(work1);
     _workQueueMgr.queueUnassignedWork(work2);
     workToCheck = _workQueueMgr.getWorkForChecking();
@@ -1176,10 +1266,16 @@ public final class WorkQueueMgrTest {
 
   @Test
   public void queueUnassignedWorkDuplicate() throws Exception {
-    initSnapshotMetadata("testrig", ProcessingStatus.UNINITIALIZED);
+    String snapshot = "snapshot1";
+    initSnapshotMetadata(snapshot, ProcessingStatus.UNINITIALIZED);
     QueuedWork work1 =
-        resolvedQueuedWork(
-            new WorkItem(NETWORK, "testrig"), new WorkDetails("testrig", WorkType.UNKNOWN));
+        new QueuedWork(
+            new WorkItem(NETWORK, snapshot),
+            WorkDetails.builder()
+                .setWorkType(WorkType.UNKNOWN)
+                .setNetworkId(_networkId)
+                .setSnapshotId(_idManager.getSnapshotId(snapshot, _networkId))
+                .build());
     _workQueueMgr.queueUnassignedWork(work1);
 
     _thrown.expect(BatfishException.class);
@@ -1190,19 +1286,24 @@ public final class WorkQueueMgrTest {
 
   @Test
   public void workIsUnblocked1() throws Exception {
-    initSnapshotMetadata("testrig", ProcessingStatus.UNINITIALIZED);
+    String snapshot = "snapshot1";
+    initSnapshotMetadata(snapshot, ProcessingStatus.UNINITIALIZED);
 
+    WorkDetails.Builder builder =
+        WorkDetails.builder()
+            .setNetworkId(_networkId)
+            .setSnapshotId(_idManager.getSnapshotId(snapshot, _networkId));
     QueuedWork work1 =
-        resolvedQueuedWork(
-            new WorkItem(NETWORK, "testrig"), new WorkDetails("testrig", WorkType.PARSING));
+        new QueuedWork(
+            new WorkItem(NETWORK, snapshot), builder.setWorkType(WorkType.PARSING).build());
     QueuedWork work2 =
-        resolvedQueuedWork(
-            new WorkItem(NETWORK, "testrig"),
-            new WorkDetails("testrig", WorkType.PARSING_DEPENDENT_ANSWERING));
+        new QueuedWork(
+            new WorkItem(NETWORK, snapshot),
+            builder.setWorkType(WorkType.PARSING_DEPENDENT_ANSWERING).build());
     QueuedWork work3 =
-        resolvedQueuedWork(
-            new WorkItem(NETWORK, "testrig"),
-            new WorkDetails("testrig", WorkType.DATAPLANE_DEPENDENT_ANSWERING));
+        new QueuedWork(
+            new WorkItem(NETWORK, snapshot),
+            builder.setWorkType(WorkType.DATAPLANE_DEPENDENT_ANSWERING).build());
 
     doAction(new Action(ActionType.QUEUE, work1));
     doAction(new Action(ActionType.QUEUE, work2));
@@ -1229,19 +1330,24 @@ public final class WorkQueueMgrTest {
 
   @Test
   public void workIsUnblocked2() throws Exception {
-    initSnapshotMetadata("testrig", ProcessingStatus.UNINITIALIZED);
+    String snapshot = "snapshot1";
+    initSnapshotMetadata(snapshot, ProcessingStatus.UNINITIALIZED);
 
+    WorkDetails.Builder builder =
+        WorkDetails.builder()
+            .setNetworkId(_networkId)
+            .setSnapshotId(_idManager.getSnapshotId(snapshot, _networkId));
     QueuedWork work1 =
-        resolvedQueuedWork(
-            new WorkItem(NETWORK, "testrig"), new WorkDetails("testrig", WorkType.PARSING));
+        new QueuedWork(
+            new WorkItem(NETWORK, snapshot), builder.setWorkType(WorkType.PARSING).build());
     QueuedWork work2 =
-        resolvedQueuedWork(
-            new WorkItem(NETWORK, "testrig"),
-            new WorkDetails("testrig", WorkType.DATAPLANE_DEPENDENT_ANSWERING));
+        new QueuedWork(
+            new WorkItem(NETWORK, snapshot),
+            builder.setWorkType(WorkType.DATAPLANE_DEPENDENT_ANSWERING).build());
     QueuedWork work3 =
-        resolvedQueuedWork(
-            new WorkItem(NETWORK, "testrig"),
-            new WorkDetails("testrig", WorkType.DATAPLANE_DEPENDENT_ANSWERING));
+        new QueuedWork(
+            new WorkItem(NETWORK, snapshot),
+            builder.setWorkType(WorkType.DATAPLANE_DEPENDENT_ANSWERING).build());
 
     doAction(new Action(ActionType.QUEUE, work1));
     doAction(new Action(ActionType.QUEUE, work2));
@@ -1268,11 +1374,17 @@ public final class WorkQueueMgrTest {
 
   @Test
   public void processTaskCheckTerminatedByUser() throws Exception {
-    initSnapshotMetadata("testrig", ProcessingStatus.UNINITIALIZED);
+    String snapshot = "snapshot1";
+    initSnapshotMetadata(snapshot, ProcessingStatus.UNINITIALIZED);
 
     QueuedWork work1 =
-        resolvedQueuedWork(
-            new WorkItem(NETWORK, "testrig"), new WorkDetails("testrig", WorkType.PARSING));
+        new QueuedWork(
+            new WorkItem(NETWORK, snapshot),
+            WorkDetails.builder()
+                .setWorkType(WorkType.PARSING)
+                .setNetworkId(_networkId)
+                .setSnapshotId(_idManager.getSnapshotId(snapshot, _networkId))
+                .build());
 
     doAction(new Action(ActionType.QUEUE, work1));
     _workQueueMgr.processTaskCheckResult(work1, new Task(TaskStatus.TerminatedByUser, "Fake"));
@@ -1284,25 +1396,5 @@ public final class WorkQueueMgrTest {
      */
     assertThat(work1.getStatus(), equalTo(WorkStatusCode.TERMINATEDBYUSER));
     assertThat(_workQueueMgr.getLength(QueueType.INCOMPLETE), equalTo(0L));
-  }
-
-  private QueuedWork resolvedQueuedWork(WorkItem workItem, WorkDetails workDetails) {
-    WorkItem resolvedWorkItem = WorkMgr.resolveIds(workItem);
-    return new QueuedWork(
-        WorkMgr.resolveIds(workItem),
-        resolveIds(new NetworkId(resolvedWorkItem.getContainerName()), workDetails));
-  }
-
-  /* Resolves IDs in workDetails independently of workItem (just for testing) */
-  private WorkDetails resolveIds(NetworkId networkId, WorkDetails workDetails) {
-    IdManager idm = Main.getWorkMgr().getIdManager();
-    SnapshotId snapshot = idm.getSnapshotId(workDetails.baseTestrig, networkId);
-    String referenceSnapshot = null;
-    if (workDetails.deltaTestrig != null) {
-      SnapshotId referenceSnapshotId = idm.getSnapshotId(workDetails.deltaTestrig, networkId);
-      referenceSnapshot = referenceSnapshotId.getId();
-    }
-    return new WorkDetails(
-        snapshot.getId(), referenceSnapshot, workDetails.isDifferential, workDetails.workType);
   }
 }


### PR DESCRIPTION
- Stop replacing WorkItem names with resolved IDs
  - Now only contains user-provided information
- Store ID-based work info in WorkDetails
  - Builder-based
  - Contains IDs for network, snapshot, referenceSnapshot, analysis,
    question
- Now mostly use just IDs in work queue management instead of names