### PR TITLE
Tweak parser

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AutoCompleteUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AutoCompleteUtils.java
@@ -299,7 +299,7 @@ public final class AutoCompleteUtils {
   /**
    * Returns a list of suggestions based on query strings.
    *
-   * <p>The query is considered to be a strict prefix and the search is case-insensitive
+   * <p>The search is case-insensitive
    *
    * <p>The returned list contains the tail of the match. If the query is "ab" and the matching
    * string is "abcd", "cd" is returned.
@@ -312,7 +312,7 @@ public final class AutoCompleteUtils {
     String testQuery = query == null ? "" : query.toLowerCase();
 
     return strings.stream()
-        .filter(s -> testQuery.length() < s.length() && s.toLowerCase().startsWith(testQuery))
+        .filter(s -> s.toLowerCase().startsWith(testQuery))
         .map(s -> new AutocompleteSuggestion(s.substring(testQuery.length()), false))
         .collect(ImmutableList.toImmutableList());
   }
@@ -336,7 +336,7 @@ public final class AutoCompleteUtils {
 
     return pairs.stream()
         .map(p -> String.join(",", p.s1, p.s2).toLowerCase())
-        .filter(p -> testQuery.length() < p.length() && p.startsWith(testQuery))
+        .filter(p -> p.startsWith(testQuery))
         .map(p -> new AutocompleteSuggestion(p.substring(testQuery.length()), false))
         .collect(ImmutableList.toImmutableList());
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AutoCompleteUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AutoCompleteUtils.java
@@ -299,7 +299,7 @@ public final class AutoCompleteUtils {
   /**
    * Returns a list of suggestions based on query strings.
    *
-   * <p>The query is considered to be a prefix of the string and the search is case-insensitive
+   * <p>The query is considered to be a strict prefix and the search is case-insensitive
    *
    * <p>The returned list contains the tail of the match. If the query is "ab" and the matching
    * string is "abcd", "cd" is returned.
@@ -312,7 +312,7 @@ public final class AutoCompleteUtils {
     String testQuery = query == null ? "" : query.toLowerCase();
 
     return strings.stream()
-        .filter(s -> s.toLowerCase().startsWith(testQuery))
+        .filter(s -> testQuery.length() < s.length() && s.toLowerCase().startsWith(testQuery))
         .map(s -> new AutocompleteSuggestion(s.substring(testQuery.length()), false))
         .collect(ImmutableList.toImmutableList());
   }
@@ -336,7 +336,7 @@ public final class AutoCompleteUtils {
 
     return pairs.stream()
         .map(p -> String.join(",", p.s1, p.s2).toLowerCase())
-        .filter(p -> p.startsWith(testQuery))
+        .filter(p -> testQuery.length() < p.length() && p.startsWith(testQuery))
         .map(p -> new AutocompleteSuggestion(p.substring(testQuery.length()), false))
         .collect(ImmutableList.toImmutableList());
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Anchor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Anchor.java
@@ -6,12 +6,12 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * This annotation is applied to rules that we expect to auto complete. The value of the annotation
- * is the auto completion type.
+ * This annotation is applied to rules that we expect to be the basis of error reporting and auto
+ * completion. The value of the annotation is the auto completion type.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
-@interface Completion {
+@interface Anchor {
 
   enum Type {
     ADDRESS_GROUP_AND_BOOK,

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/CommonParser.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/CommonParser.java
@@ -1,11 +1,11 @@
 package org.batfish.specifier.parboiled;
 
-import static org.batfish.specifier.parboiled.Completion.Type.STRING_LITERAL;
+import static org.batfish.specifier.parboiled.Anchor.Type.STRING_LITERAL;
 
 import com.google.common.collect.ImmutableMap;
 import java.lang.reflect.Method;
 import java.util.Map;
-import org.batfish.specifier.parboiled.Completion.Type;
+import org.batfish.specifier.parboiled.Anchor.Type;
 import org.parboiled.BaseParser;
 import org.parboiled.Rule;
 
@@ -13,6 +13,9 @@ import org.parboiled.Rule;
  * This class contains common matchers for different types of expressions.
  *
  * <p>The rules in this class should not put anything on the stack.
+ *
+ * <p>They should also not contain any explicit of implicit anchors. Because character literals are
+ * implicit anchors, we implement them using a character range below.
  */
 @SuppressWarnings({
   "checkstyle:methodname", // this class uses idiomatic names
@@ -21,12 +24,12 @@ import org.parboiled.Rule;
 abstract class CommonParser extends BaseParser<AstNode> {
 
   static Map<String, Type> initCompletionTypes(Class<?> parserClass) {
-    ImmutableMap.Builder<String, Completion.Type> completionTypes = ImmutableMap.builder();
+    ImmutableMap.Builder<String, Anchor.Type> completionTypes = ImmutableMap.builder();
     // Explicitly add WHITESPACE and EOI
     completionTypes.put("WhiteSpace", Type.WHITESPACE);
-    completionTypes.put("EOI", Completion.Type.EOI);
+    completionTypes.put("EOI", Anchor.Type.EOI);
     for (Method method : parserClass.getMethods()) {
-      Completion annotation = method.getAnnotation(Completion.class);
+      Anchor annotation = method.getAnnotation(Anchor.class);
       if (annotation != null) {
         completionTypes.put(method.getName(), annotation.value());
       }
@@ -41,6 +44,10 @@ abstract class CommonParser extends BaseParser<AstNode> {
    */
   public Rule input(Rule expression) {
     return Sequence(WhiteSpace(), expression, WhiteSpace(), EOI);
+  }
+
+  public Rule Dash() {
+    return CharRange('-', '-');
   }
 
   /** [a-z] + [A-Z] */
@@ -73,8 +80,12 @@ abstract class CommonParser extends BaseParser<AstNode> {
    */
   public Rule ReferenceObjectNameLiteral() {
     return Sequence(
-        FirstOf(AlphabetChar(), Ch('_')),
-        ZeroOrMore(FirstOf(AlphabetChar(), Ch('_'), Digit(), Ch('-'))));
+        FirstOf(AlphabetChar(), Underscore()),
+        ZeroOrMore(FirstOf(AlphabetChar(), Underscore(), Digit(), Dash())));
+  }
+
+  public Rule Underscore() {
+    return CharRange('_', '_');
   }
 
   public Rule WhiteSpace() {
@@ -87,7 +98,7 @@ abstract class CommonParser extends BaseParser<AstNode> {
    * <p>We automatically match trailing whitespace, so we don't have to insert extra Whitespace()
    * rules after each character or string literal
    */
-  @Completion(STRING_LITERAL)
+  @Anchor(STRING_LITERAL)
   @Override
   protected Rule fromStringLiteral(String string) {
     return string.endsWith(" ")

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/CommonParser.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/CommonParser.java
@@ -14,8 +14,8 @@ import org.parboiled.Rule;
  *
  * <p>The rules in this class should not put anything on the stack.
  *
- * <p>They should also not contain any explicit of implicit anchors. Because character literals are
- * implicit anchors, we implement them using a character range below.
+ * <p>They should also not contain any explicit of implicit anchors. One implication of this:
+ * because character literals are implicit anchors, we implement them using a character range below.
  */
 @SuppressWarnings({
   "checkstyle:methodname", // this class uses idiomatic names
@@ -23,7 +23,7 @@ import org.parboiled.Rule;
 })
 abstract class CommonParser extends BaseParser<AstNode> {
 
-  static Map<String, Type> initCompletionTypes(Class<?> parserClass) {
+  static Map<String, Type> initAnchors(Class<?> parserClass) {
     ImmutableMap.Builder<String, Anchor.Type> completionTypes = ImmutableMap.builder();
     // Explicitly add WHITESPACE and EOI
     completionTypes.put("WhiteSpace", Type.WHITESPACE);
@@ -46,6 +46,7 @@ abstract class CommonParser extends BaseParser<AstNode> {
     return Sequence(WhiteSpace(), expression, WhiteSpace(), EOI);
   }
 
+  /** See class JavaDoc for why this is a CharRange and not Ch */
   public Rule Dash() {
     return CharRange('-', '-');
   }
@@ -84,6 +85,7 @@ abstract class CommonParser extends BaseParser<AstNode> {
         ZeroOrMore(FirstOf(AlphabetChar(), Underscore(), Digit(), Dash())));
   }
 
+  /** See class JavaDoc for why this is a CharRange and not Ch */
   public Rule Underscore() {
     return CharRange('_', '_');
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Completion.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Completion.java
@@ -17,6 +17,7 @@ import java.lang.annotation.Target;
     ADDRESS_GROUP_AND_BOOK,
     EOI,
     IP_ADDRESS,
+    IP_ADDRESS_MASK,
     IP_PREFIX,
     IP_RANGE,
     IP_WILDCARD,

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/IpWildcardAstNode.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/IpWildcardAstNode.java
@@ -1,6 +1,7 @@
 package org.batfish.specifier.parboiled;
 
 import java.util.Objects;
+import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpWildcard;
 
 final class IpWildcardAstNode implements IpSpaceAstNode {
@@ -13,6 +14,12 @@ final class IpWildcardAstNode implements IpSpaceAstNode {
 
   IpWildcardAstNode(String ipWildcard) {
     _ipWildcard = new IpWildcard(ipWildcard);
+  }
+
+  IpWildcardAstNode(AstNode addressNode, AstNode maskNode) {
+    Ip address = ((IpAstNode) addressNode).getIp();
+    Ip mask = ((IpAstNode) maskNode).getIp();
+    _ipWildcard = new IpWildcard(address, mask);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParboiledAutoComplete.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParboiledAutoComplete.java
@@ -73,7 +73,7 @@ public final class ParboiledAutoComplete {
     return new ParboiledAutoComplete(
             Parser.INSTANCE,
             Parser.INSTANCE.IpSpaceExpression(),
-            Parser.COMPLETION_TYPES,
+            Parser.ANCHORS,
             network,
             snapshot,
             query,

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParboiledAutoComplete.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParboiledAutoComplete.java
@@ -8,7 +8,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.common.CompletionMetadata;
 import org.batfish.datamodel.answers.AutoCompleteUtils;
@@ -101,11 +100,12 @@ public final class ParboiledAutoComplete {
 
     InvalidInputError error = (InvalidInputError) result.parseErrors.get(0);
 
-    Set<PartialMatch> partialMatches = ParserUtils.getPartialMatches(error, _completionTypes);
+    Set<PotentialMatch> potentialMatches =
+        ParserUtils.getPotentialMatches(error, _completionTypes, false);
 
     Set<AutocompleteSuggestion> allSuggestions =
-        partialMatches.stream()
-            .map(pm -> autoCompletePartialMatch(pm, error.getStartIndex()))
+        potentialMatches.stream()
+            .map(pm -> autoCompletePotentialMatch(pm, error.getStartIndex()))
             .flatMap(Collection::stream)
             .collect(ImmutableSet.toImmutableSet());
 
@@ -115,7 +115,7 @@ public final class ParboiledAutoComplete {
   }
 
   @VisibleForTesting
-  List<AutocompleteSuggestion> autoCompletePartialMatch(PartialMatch pm, int startIndex) {
+  List<AutocompleteSuggestion> autoCompletePotentialMatch(PotentialMatch pm, int startIndex) {
 
     List<AutocompleteSuggestion> suggestions = null;
     switch (pm.getCompletionType()) {
@@ -141,54 +141,17 @@ public final class ParboiledAutoComplete {
                 _nodeRolesData,
                 _referenceLibrary);
         break;
-        /*
-         IP ranges are address1  - address2. If address1 is not fully present in the query, it will
-         get auto completed by IP_ADDRESS autocompletion. If we are past the '-', we do
-         IP_ADDRESS autocompletion for address2.
-        */
       case IP_RANGE:
-        if (pm.getMatchPrefix().contains("-")) {
-          String matchPrefix = pm.getMatchPrefix().replaceAll("\\s+", "");
-          // pull out address2 portion for autocompletion
-          int dashIndex = matchPrefix.indexOf("-");
-          String address2Part =
-              dashIndex == matchPrefix.length() - 1 ? "" : matchPrefix.substring(dashIndex + 1);
-          List<AutocompleteSuggestion> address2Suggestions =
-              AutoCompleteUtils.autoComplete(
-                  _network,
-                  _snapshot,
-                  Variable.Type.IP,
-                  address2Part,
-                  _maxSuggestions,
-                  _completionMetadata,
-                  _nodeRolesData,
-                  _referenceLibrary);
-          // put back the "address1 -" part
-          suggestions =
-              address2Suggestions.stream()
-                  .map(
-                      s ->
-                          new AutocompleteSuggestion(
-                              matchPrefix + s.getText(),
-                              s.getIsPartial(),
-                              s.getDescription(),
-                              s.getRank(),
-                              s.getInsertionIndex()))
-                  .collect(Collectors.toList());
-        } else {
-          return ImmutableList.of();
-        }
-        break;
-        /*
-         IP wildcards are address:mask. If the address is not fully present in the query, it will
-         get auto completed by IP_ADDRESS autocompletion. If we are past the ';', we expect mask but we
-         can't help autocomplete that. So, net net, we don't need to do anything.
-        */
       case IP_WILDCARD:
+        // These depend on other completion types that should be kicking in
+        throw new IllegalStateException(
+            "Unexpected auto completion for type " + pm.getCompletionType());
       case EOI:
+      case IP_ADDRESS_MASK:
       case WHITESPACE:
+        // nothing useful to suggest for these completion types
         return ImmutableList.of();
-      default: // ignore things we do not know how to auto complete
+      default:
         throw new IllegalArgumentException("Unhandled completion type " + pm.getCompletionType());
     }
     return suggestions.stream()

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParboiledAutoComplete.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParboiledAutoComplete.java
@@ -28,7 +28,7 @@ public final class ParboiledAutoComplete {
 
   private final CommonParser _parser;
   private final Rule _expression;
-  private final Map<String, Completion.Type> _completionTypes;
+  private final Map<String, Anchor.Type> _completionTypes;
 
   private final String _network;
   private final String _snapshot;
@@ -41,7 +41,7 @@ public final class ParboiledAutoComplete {
   ParboiledAutoComplete(
       CommonParser parser,
       Rule expression,
-      Map<String, Completion.Type> completionTypes,
+      Map<String, Anchor.Type> completionTypes,
       String network,
       String snapshot,
       String query,
@@ -118,7 +118,7 @@ public final class ParboiledAutoComplete {
   List<AutocompleteSuggestion> autoCompletePotentialMatch(PotentialMatch pm, int startIndex) {
 
     List<AutocompleteSuggestion> suggestions = null;
-    switch (pm.getCompletionType()) {
+    switch (pm.getAnchorType()) {
       case STRING_LITERAL:
         /*
          String literals get a lower rank because there can be many suggestions for dynamic values
@@ -134,7 +134,7 @@ public final class ParboiledAutoComplete {
             AutoCompleteUtils.autoComplete(
                 _network,
                 _snapshot,
-                completionTypeToVariableType(pm.getCompletionType()),
+                anchorTypeToVariableType(pm.getAnchorType()),
                 pm.getMatchPrefix(),
                 _maxSuggestions,
                 _completionMetadata,
@@ -144,15 +144,14 @@ public final class ParboiledAutoComplete {
       case IP_RANGE:
       case IP_WILDCARD:
         // These depend on other completion types that should be kicking in
-        throw new IllegalStateException(
-            "Unexpected auto completion for type " + pm.getCompletionType());
+        throw new IllegalStateException(String.format("Unexpected auto completion for %s", pm));
       case EOI:
       case IP_ADDRESS_MASK:
       case WHITESPACE:
         // nothing useful to suggest for these completion types
         return ImmutableList.of();
       default:
-        throw new IllegalArgumentException("Unhandled completion type " + pm.getCompletionType());
+        throw new IllegalArgumentException("Unhandled completion type " + pm.getAnchorType());
     }
     return suggestions.stream()
         .map(
@@ -170,8 +169,8 @@ public final class ParboiledAutoComplete {
    * Converts completion type to variable type for cases. Throws an exception when the mapping does
    * not exist
    */
-  private static Variable.Type completionTypeToVariableType(Completion.Type cType) {
-    switch (cType) {
+  private static Variable.Type anchorTypeToVariableType(Anchor.Type anchorType) {
+    switch (anchorType) {
       case ADDRESS_GROUP_AND_BOOK:
         return Variable.Type.ADDRESS_GROUP_AND_BOOK;
       case IP_ADDRESS:
@@ -179,7 +178,7 @@ public final class ParboiledAutoComplete {
       case IP_PREFIX:
         return Variable.Type.PREFIX;
       default:
-        throw new IllegalArgumentException("No valid Variable type for Completion type" + cType);
+        throw new IllegalArgumentException("No valid Variable type for Anchor type" + anchorType);
     }
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParboiledIpSpaceSpecifierFactory.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParboiledIpSpaceSpecifierFactory.java
@@ -30,7 +30,7 @@ public class ParboiledIpSpaceSpecifierFactory implements IpSpaceSpecifierFactory
               (String) input,
               "IpSpace",
               (InvalidInputError) result.parseErrors.get(0),
-              Parser.COMPLETION_TYPES);
+              Parser.ANCHORS);
       throw new IllegalArgumentException(error);
     }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Parser.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Parser.java
@@ -19,7 +19,7 @@ import org.parboiled.support.MatcherPath;
  * <p>@Anchor annotation: For each path from the top-level rule of an expression to leaf values,
  * there should be at least one rule with a Anchor annotation. This annotation is used for error
  * messages and generating auto completion suggestions. Character and string literals are treated as
- * implicit anchors (see {@link ParserUtils#findAnchor(MatcherPath, int, Map, boolean)}
+ * implicit anchors (see {@link ParserUtils#findPathAnchor(MatcherPath, int, Map, boolean)}
  */
 @SuppressWarnings({
   "checkstyle:methodname", // this class uses idiomatic names

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Parser.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Parser.java
@@ -16,10 +16,11 @@ import org.parboiled.support.MatcherPath;
  * A parboiled-based parser for flexible specifiers. The rules for all types of expressions are in
  * this file (not sure how to put them in different files when they point to each other).
  *
- * <p>@Anchor annotation: For each path from the top-level rule of an expression to leaf values,
- * there should be at least one rule with a Anchor annotation. This annotation is used for error
- * messages and generating auto completion suggestions. Character and string literals are treated as
- * implicit anchors (see {@link ParserUtils#findPathAnchor(MatcherPath, int, Map, boolean)}
+ * <p>{@link Anchor} annotation: For each path from the top-level rule of an expression to leaf
+ * values, there should be at least one rule with a Anchor annotation. This annotation is used for
+ * error messages and generating auto completion suggestions. Character and string literals are
+ * treated as implicit anchors (see {@link ParserUtils#findPathAnchor(MatcherPath, int, Map,
+ * boolean)}
  */
 @SuppressWarnings({
   "checkstyle:methodname", // this class uses idiomatic names
@@ -29,7 +30,7 @@ class Parser extends CommonParser {
 
   static final Parser INSTANCE = Parboiled.createParser(Parser.class);
 
-  static final Map<String, Anchor.Type> COMPLETION_TYPES = initCompletionTypes(Parser.class);
+  static final Map<String, Anchor.Type> ANCHORS = initAnchors(Parser.class);
 
   /**
    * IpSpace grammar

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Parser.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Parser.java
@@ -10,7 +10,6 @@ import static org.batfish.specifier.parboiled.Anchor.Type.IP_WILDCARD;
 import java.util.Map;
 import org.parboiled.Parboiled;
 import org.parboiled.Rule;
-import org.parboiled.support.MatcherPath;
 
 /**
  * A parboiled-based parser for flexible specifiers. The rules for all types of expressions are in
@@ -19,8 +18,7 @@ import org.parboiled.support.MatcherPath;
  * <p>{@link Anchor} annotation: For each path from the top-level rule of an expression to leaf
  * values, there should be at least one rule with a Anchor annotation. This annotation is used for
  * error messages and generating auto completion suggestions. Character and string literals are
- * treated as implicit anchors (see {@link ParserUtils#findPathAnchor(MatcherPath, int, Map,
- * boolean)}
+ * treated as implicit anchors (see findPathAnchor() in {@link ParserUtils}.
  */
 @SuppressWarnings({
   "checkstyle:methodname", // this class uses idiomatic names

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Parser.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Parser.java
@@ -1,23 +1,25 @@
 package org.batfish.specifier.parboiled;
 
-import static org.batfish.specifier.parboiled.Completion.Type.ADDRESS_GROUP_AND_BOOK;
-import static org.batfish.specifier.parboiled.Completion.Type.IP_ADDRESS;
-import static org.batfish.specifier.parboiled.Completion.Type.IP_ADDRESS_MASK;
-import static org.batfish.specifier.parboiled.Completion.Type.IP_PREFIX;
-import static org.batfish.specifier.parboiled.Completion.Type.IP_RANGE;
-import static org.batfish.specifier.parboiled.Completion.Type.IP_WILDCARD;
+import static org.batfish.specifier.parboiled.Anchor.Type.ADDRESS_GROUP_AND_BOOK;
+import static org.batfish.specifier.parboiled.Anchor.Type.IP_ADDRESS;
+import static org.batfish.specifier.parboiled.Anchor.Type.IP_ADDRESS_MASK;
+import static org.batfish.specifier.parboiled.Anchor.Type.IP_PREFIX;
+import static org.batfish.specifier.parboiled.Anchor.Type.IP_RANGE;
+import static org.batfish.specifier.parboiled.Anchor.Type.IP_WILDCARD;
 
 import java.util.Map;
 import org.parboiled.Parboiled;
 import org.parboiled.Rule;
+import org.parboiled.support.MatcherPath;
 
 /**
  * A parboiled-based parser for flexible specifiers. The rules for all types of expressions are in
  * this file (not sure how to put them in different files when they point to each other).
  *
- * <p>Completion annotation: For each path from the top-level rule of an expression to leaf values,
- * there should be at least one rule with a Completion annotation. This annotation is used for both
- * error messages and generating auto completion suggestions.
+ * <p>@Anchor annotation: For each path from the top-level rule of an expression to leaf values,
+ * there should be at least one rule with a Anchor annotation. This annotation is used for error
+ * messages and generating auto completion suggestions. Character and string literals are treated as
+ * implicit anchors (see {@link ParserUtils#findAnchor(MatcherPath, int, Map, boolean)}
  */
 @SuppressWarnings({
   "checkstyle:methodname", // this class uses idiomatic names
@@ -27,7 +29,7 @@ class Parser extends CommonParser {
 
   static final Parser INSTANCE = Parboiled.createParser(Parser.class);
 
-  static final Map<String, Completion.Type> COMPLETION_TYPES = initCompletionTypes(Parser.class);
+  static final Map<String, Anchor.Type> COMPLETION_TYPES = initCompletionTypes(Parser.class);
 
   /**
    * IpSpace grammar
@@ -69,7 +71,7 @@ class Parser extends CommonParser {
   }
 
   /** Matches AddressGroup, ReferenceBook pair. Puts two values on stack */
-  @Completion(ADDRESS_GROUP_AND_BOOK)
+  @Anchor(ADDRESS_GROUP_AND_BOOK)
   public Rule AddressGroupAndBook() {
     return Sequence(
         ReferenceObjectNameLiteral(),
@@ -85,7 +87,7 @@ class Parser extends CommonParser {
    * Matched IP addresses. Throws an exception if something matches syntactically but is invalid
    * (e.g., 1.1.1.256)
    */
-  @Completion(IP_ADDRESS)
+  @Anchor(IP_ADDRESS)
   public Rule IpAddress() {
     return Sequence(IpAddressUnchecked(), push(new IpAstNode(match())));
   }
@@ -94,7 +96,7 @@ class Parser extends CommonParser {
    * Matched IP address mask (e.g., 255.255.255.0). It is syntactically similar to IP addresses but
    * we have a separate rule that helps with error messages and auto completion.
    */
-  @Completion(IP_ADDRESS_MASK)
+  @Anchor(IP_ADDRESS_MASK)
   public Rule IpAddressMask() {
     return Sequence(IpAddressUnchecked(), push(new IpAstNode(match())));
   }
@@ -103,13 +105,13 @@ class Parser extends CommonParser {
    * Matched IP prefixes. Throws an exception if something matches syntactically but is invalid
    * (e.g., 1.1.1.2/33)
    */
-  @Completion(IP_PREFIX)
+  @Anchor(IP_PREFIX)
   public Rule IpPrefix() {
     return Sequence(IpPrefixUnchecked(), push(new PrefixAstNode(match())));
   }
 
   /** Matches Ip ranges (e.g., 1.1.1.1 - 1.1.1.2) */
-  @Completion(IP_RANGE)
+  @Anchor(IP_RANGE)
   public Rule IpRange() {
     return Sequence(
         IpAddress(),
@@ -121,7 +123,7 @@ class Parser extends CommonParser {
   }
 
   /** Matches Ip wildcards (e.g., 1.1.1.1:255.255.255.255) */
-  @Completion(IP_WILDCARD)
+  @Anchor(IP_WILDCARD)
   public Rule IpWildcard() {
     return Sequence(IpAddress(), ':', IpAddressMask(), push(new IpWildcardAstNode(pop(1), pop())));
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParserUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParserUtils.java
@@ -3,12 +3,11 @@ package org.batfish.specifier.parboiled;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.specifier.parboiled.Completion.Type;
@@ -21,12 +20,12 @@ import org.parboiled.support.ParsingResult;
 @ParametersAreNonnullByDefault
 final class ParserUtils {
 
-  /** A helper class that captures where in the matching path we can build auto completion off of */
-  private static class UsefulPointInPath {
-    public final Completion.Type completionType;
-    public final Element element;
+  /** Captures where in the matching path we can anchor errors reporting and auto completion. */
+  private static class Anchor {
+    final Completion.Type completionType;
+    final Element element;
 
-    public UsefulPointInPath(Element element, Completion.Type completionType) {
+    Anchor(Element element, Completion.Type completionType) {
       this.element = element;
       this.completionType = completionType;
     }
@@ -47,20 +46,20 @@ final class ParserUtils {
       InvalidInputError error,
       Map<String, Completion.Type> completionTypes) {
     return getErrorString(
-        input, inputType, error.getStartIndex(), getPartialMatches(error, completionTypes));
+        input, inputType, error.getStartIndex(), getPotentialMatches(error, completionTypes, true));
   }
 
   /** Generates a friendly message to explain what might be wrong with parser input */
   static String getErrorString(
-      String input, String inputType, int startIndex, Set<PartialMatch> partialMatches) {
+      String input, String inputType, int startIndex, Set<PotentialMatch> potentialMatches) {
     StringBuilder retString =
         new StringBuilder(
             String.format(
                 "Error parsing '%s' as %s after index %d. ", input, inputType, startIndex));
-    if (!partialMatches.isEmpty()) {
+    if (!potentialMatches.isEmpty()) {
       retString.append("Valid continuations are ");
       retString.append(
-          partialMatches.stream()
+          potentialMatches.stream()
               .map(ParserUtils::getErrorString)
               .collect(Collectors.joining(" or ")));
       retString.append(".");
@@ -70,7 +69,7 @@ final class ParserUtils {
 
   /** Generates a friendly message to explain what might be wrong with a particular partial match */
   @VisibleForTesting
-  static String getErrorString(PartialMatch pm) {
+  static String getErrorString(PotentialMatch pm) {
     if (pm.getCompletionType().equals(Completion.Type.STRING_LITERAL)) {
       return String.format("'%s'", pm.getMatchCompletion());
     }
@@ -78,8 +77,15 @@ final class ParserUtils {
   }
 
   /**
-   * When parsing fails, given its error, this function returns the set of matches that could have
-   * made things work.
+   * When parsing fails, this function returns potential matches that could have made things work.
+   *
+   * <p>Potential matches are anchored around either elements in the path (rules) that correspond to
+   * completion types or those that represent string/character literals.
+   *
+   * <p>The parameter {@code fromTop} determines if we find anchors from top of the rule hierarchy
+   * or the bottom. The former is useful for error reporting and the latter for auto completion. For
+   * example, if a potential matching path is input->ip_range->ip_address, we want to tell the user
+   * that we expect an ip_range but when auto completing we want to use ip_address.
    *
    * <p>This function has been tested with only {@link
    * org.parboiled.parserunners.ReportingParseRunner}. When using {@link
@@ -87,96 +93,75 @@ final class ParserUtils {
    * respect to indices. See
    * https://github.com/sirthias/parboiled/blob/07b6e2b5c583c7e258599650157a3b0d2b63667a/parboiled-core/src/main/java/org/parboiled/errors/DefaultInvalidInputErrorFormatter.java#L60.
    */
-  static Set<PartialMatch> getPartialMatches(
-      InvalidInputError error, Map<String, Completion.Type> completionTypes) {
+  static Set<PotentialMatch> getPotentialMatches(
+      InvalidInputError error, Map<String, Completion.Type> completionTypes, boolean fromTop) {
+    ImmutableSet.Builder<PotentialMatch> potentialMatches = ImmutableSet.builder();
 
-    Set<PartialMatch> partialMatches = new HashSet<>();
-
-    /*
-     For each path that failed to match we identify a useful point in the path that is closest to
-     the end and can provide the basis for error reporting and completion suggestions.
-    */
     for (MatcherPath path : error.getFailedMatchers()) {
-      UsefulPointInPath usefulPoint =
-          getUsefulPointInPath(path, path.length() - 1, completionTypes);
+      Anchor anchor = findAnchor(path, fromTop ? 0 : path.length() - 1, completionTypes, fromTop);
 
-      if (usefulPoint == null) {
-        /*
-         If you get here, that means the grammar is missing a Completion annotation on one or more
-         rules. For each path from the top-level rule to the leaf, there should be at least one
-         rule with a Completion annotation.
-        */
+      if (anchor == null) {
+        // Getting here means the grammar is missing a Completion annotation. See Parser's JavaDoc.
         throw new IllegalStateException(
             String.format("Useful completion not found in path %s", path));
       }
 
-      /*
-       Ignore paths that end in WHITESPACE -- nothing interesting to report there because our
-       grammar is not sensitive to whitespace
-      */
-      if (usefulPoint.completionType.equals(Type.WHITESPACE)) {
+      // Ignore paths whose anchor is WHITESPACE -- nothing interesting to report there
+      if (anchor.completionType.equals(Type.WHITESPACE)) {
         continue;
       }
 
-      partialMatches.add(
-          getPartialMatch(error, path, usefulPoint.element, usefulPoint.completionType));
-    }
+      /*
+       The PotentialMatch object is straightforward given the anchor. Except that for string
+       literals, we remove the quotes inserted by parboiled.
+      */
+      String matchPrefix =
+          error.getInputBuffer().extract(anchor.element.startIndex, path.element.startIndex);
 
-    return partialMatches;
-  }
-
-  /**
-   * Build a {@link PartialMatch} object from the inputs. This is straightforwward for everything
-   * else, but for string literals, we remove the quotes inserted by parboiled.
-   */
-  @Nonnull
-  private static PartialMatch getPartialMatch(
-      InvalidInputError error, MatcherPath path, Element element, Completion.Type type) {
-
-    String matchPrefix =
-        error.getInputBuffer().extract(element.startIndex, path.element.startIndex);
-
-    if (type.equals(Type.STRING_LITERAL)) {
-      String fullToken = element.matcher.getLabel();
-      if (fullToken.length() >= 2) {
-        fullToken = fullToken.substring(1, fullToken.length() - 1);
+      if (anchor.completionType.equals(Type.STRING_LITERAL)) {
+        String fullToken = anchor.element.matcher.getLabel();
+        if (fullToken.length() >= 2) { // remove surrounding quotes
+          fullToken = fullToken.substring(1, fullToken.length() - 1);
+        }
+        potentialMatches.add(
+            new PotentialMatch(
+                anchor.completionType, matchPrefix, fullToken.substring(matchPrefix.length())));
+      } else {
+        potentialMatches.add(new PotentialMatch(anchor.completionType, matchPrefix, null));
       }
-      String matchCompletion = fullToken.substring(matchPrefix.length());
-
-      return new PartialMatch(type, matchPrefix, matchCompletion);
-
-    } else {
-      return new PartialMatch(type, matchPrefix, null);
     }
+
+    return potentialMatches.build();
   }
 
-  /**
-   * Working backwards from level, tries to find a useful label for error messages and auto
-   * completion. Returns null if none is found.
-   */
+  /** Finds the anchor in the path. Returns null if none is found. */
   @Nullable
-  private static UsefulPointInPath getUsefulPointInPath(
-      MatcherPath path, int level, Map<String, Completion.Type> completionTypes) {
+  private static Anchor findAnchor(
+      MatcherPath path, int level, Map<String, Type> completionTypes, boolean fromTop) {
 
     MatcherPath.Element element = path.getElementAtLevel(level);
     String label = element.matcher.getLabel();
 
     if (completionTypes.containsKey(label)) {
-      return new UsefulPointInPath(element, completionTypes.get(label));
+      return new Anchor(element, completionTypes.get(label));
     } else if (isStringLiteralLabel(label)) {
-      return new UsefulPointInPath(element, Type.STRING_LITERAL);
+      return new Anchor(element, Type.STRING_LITERAL);
     } else if (isCharLiteralLabel(label)) {
-      if (level == 0) {
-        return new UsefulPointInPath(element, Type.STRING_LITERAL);
+      // char literals appear at the bottom; if we are iterating from top, we've reached the end
+      if (fromTop || level == 0) {
+        return new Anchor(element, Type.STRING_LITERAL);
       }
-      UsefulPointInPath usefulParent = getUsefulPointInPath(path, level - 1, completionTypes);
-      return usefulParent == null
-          ? new UsefulPointInPath(element, Type.STRING_LITERAL)
-          : usefulParent;
-    } else if (level == 0) {
+      // don't go up if the parent matcher is the one used to build string literals
+      if ("fromStringLiteral".equals(path.getElementAtLevel(level - 1).matcher.getLabel())) {
+        return new Anchor(element, Type.STRING_LITERAL);
+      }
+      Anchor usefulParent = findAnchor(path, level - 1, completionTypes, fromTop);
+      return usefulParent == null ? new Anchor(element, Type.STRING_LITERAL) : usefulParent;
+    } else if ((fromTop && level == path.length() - 1) || (!fromTop && level == 0)) {
+      // we have reached the last element in the path
       return null;
     }
-    return getUsefulPointInPath(path, level - 1, completionTypes);
+    return findAnchor(path, fromTop ? level + 1 : level - 1, completionTypes, fromTop);
   }
 
   private static boolean isCharLiteralLabel(String label) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParserUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParserUtils.java
@@ -22,12 +22,20 @@ final class ParserUtils {
 
   /** Captures where in the matching path we can anchor errors reporting and auto completion. */
   private static class PathAnchor {
-    final org.batfish.specifier.parboiled.Anchor.Type completionType;
-    final Element element;
+    private final Anchor.Type _anchorType;
+    private final Element _element;
 
-    PathAnchor(Element element, org.batfish.specifier.parboiled.Anchor.Type completionType) {
-      this.element = element;
-      this.completionType = completionType;
+    PathAnchor(Element element, Anchor.Type anchorType) {
+      this._element = element;
+      this._anchorType = anchorType;
+    }
+
+    Anchor.Type getAnchorType() {
+      return _anchorType;
+    }
+
+    Element getElement() {
+      return _element;
     }
   }
 
@@ -110,7 +118,7 @@ final class ParserUtils {
       }
 
       // Ignore paths whose anchor is WHITESPACE -- nothing interesting to report there
-      if (pathAnchor.completionType.equals(Type.WHITESPACE)) {
+      if (pathAnchor._anchorType.equals(Type.WHITESPACE)) {
         continue;
       }
 
@@ -119,18 +127,22 @@ final class ParserUtils {
        literals, we remove the quotes inserted by parboiled.
       */
       String matchPrefix =
-          error.getInputBuffer().extract(pathAnchor.element.startIndex, path.element.startIndex);
+          error
+              .getInputBuffer()
+              .extract(pathAnchor.getElement().startIndex, path.element.startIndex);
 
-      if (pathAnchor.completionType.equals(Type.STRING_LITERAL)) {
-        String fullToken = pathAnchor.element.matcher.getLabel();
+      if (pathAnchor._anchorType.equals(Type.STRING_LITERAL)) {
+        String fullToken = pathAnchor.getElement().matcher.getLabel();
         if (fullToken.length() >= 2) { // remove surrounding quotes
           fullToken = fullToken.substring(1, fullToken.length() - 1);
         }
         potentialMatches.add(
             new PotentialMatch(
-                pathAnchor.completionType, matchPrefix, fullToken.substring(matchPrefix.length())));
+                pathAnchor.getAnchorType(),
+                matchPrefix,
+                fullToken.substring(matchPrefix.length())));
       } else {
-        potentialMatches.add(new PotentialMatch(pathAnchor.completionType, matchPrefix, null));
+        potentialMatches.add(new PotentialMatch(pathAnchor.getAnchorType(), matchPrefix, null));
       }
     }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/PotentialMatch.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/PotentialMatch.java
@@ -7,7 +7,7 @@ import java.util.Objects;
 class PotentialMatch {
 
   /** The type of completion this match indicates */
-  private final Completion.Type _completionType;
+  private final Anchor.Type _anchorType;
 
   /** The current rule would have matched if the input was followed by this */
   private final String _matchCompletion;
@@ -15,8 +15,8 @@ class PotentialMatch {
   /** What matched thus far when trying to match the current rule */
   private final String _matchPrefix;
 
-  PotentialMatch(Completion.Type completionType, String matchPrefix, String matchCompletion) {
-    _completionType = completionType;
+  PotentialMatch(Anchor.Type anchorType, String matchPrefix, String matchCompletion) {
+    _anchorType = anchorType;
     _matchPrefix = matchPrefix;
     _matchCompletion = matchCompletion;
   }
@@ -26,13 +26,13 @@ class PotentialMatch {
     if (!(o instanceof PotentialMatch)) {
       return false;
     }
-    return Objects.equals(_completionType, ((PotentialMatch) o)._completionType)
+    return Objects.equals(_anchorType, ((PotentialMatch) o)._anchorType)
         && Objects.equals(_matchCompletion, ((PotentialMatch) o)._matchCompletion)
         && Objects.equals(_matchPrefix, ((PotentialMatch) o)._matchPrefix);
   }
 
-  Completion.Type getCompletionType() {
-    return _completionType;
+  Anchor.Type getAnchorType() {
+    return _anchorType;
   }
 
   String getMatchCompletion() {
@@ -45,13 +45,13 @@ class PotentialMatch {
 
   @Override
   public int hashCode() {
-    return Objects.hash(_completionType, _matchCompletion, _matchPrefix);
+    return Objects.hash(_anchorType, _matchCompletion, _matchPrefix);
   }
 
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this.getClass())
-        .add("completionType", _completionType)
+        .add("anchorType", _anchorType)
         .add("matchingPrefix", _matchPrefix)
         .add("matchingCompletion", _matchCompletion)
         .toString();

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/PotentialMatch.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/PotentialMatch.java
@@ -4,7 +4,7 @@ import com.google.common.base.MoreObjects;
 import java.util.Objects;
 
 /** Represents one (of possibly multiple) potential matches when the parser input does not match */
-class PartialMatch {
+class PotentialMatch {
 
   /** The type of completion this match indicates */
   private final Completion.Type _completionType;
@@ -15,7 +15,7 @@ class PartialMatch {
   /** What matched thus far when trying to match the current rule */
   private final String _matchPrefix;
 
-  PartialMatch(Completion.Type completionType, String matchPrefix, String matchCompletion) {
+  PotentialMatch(Completion.Type completionType, String matchPrefix, String matchCompletion) {
     _completionType = completionType;
     _matchPrefix = matchPrefix;
     _matchCompletion = matchCompletion;
@@ -23,12 +23,12 @@ class PartialMatch {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof PartialMatch)) {
+    if (!(o instanceof PotentialMatch)) {
       return false;
     }
-    return Objects.equals(_completionType, ((PartialMatch) o)._completionType)
-        && Objects.equals(_matchCompletion, ((PartialMatch) o)._matchCompletion)
-        && Objects.equals(_matchPrefix, ((PartialMatch) o)._matchPrefix);
+    return Objects.equals(_completionType, ((PotentialMatch) o)._completionType)
+        && Objects.equals(_matchCompletion, ((PotentialMatch) o)._matchCompletion)
+        && Objects.equals(_matchPrefix, ((PotentialMatch) o)._matchPrefix);
   }
 
   Completion.Type getCompletionType() {

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/CommonParserTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/CommonParserTest.java
@@ -5,7 +5,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableMap;
-import org.batfish.specifier.parboiled.Completion.Type;
+import org.batfish.specifier.parboiled.Anchor.Type;
 import org.junit.Test;
 
 public class CommonParserTest {

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/CommonParserTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/CommonParserTest.java
@@ -1,6 +1,6 @@
 package org.batfish.specifier.parboiled;
 
-import static org.batfish.specifier.parboiled.Parser.initCompletionTypes;
+import static org.batfish.specifier.parboiled.Parser.initAnchors;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
@@ -11,9 +11,9 @@ import org.junit.Test;
 public class CommonParserTest {
 
   @Test
-  public void testInitCompletionTypes() {
+  public void testInitAnchors() {
     assertThat(
-        initCompletionTypes(TestParser.class),
+        initAnchors(TestParser.class),
         equalTo(
             ImmutableMap.of(
                 "TestSpecifierInput",

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/CommonParserTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/CommonParserTest.java
@@ -7,56 +7,8 @@ import static org.junit.Assert.assertThat;
 import com.google.common.collect.ImmutableMap;
 import org.batfish.specifier.parboiled.Completion.Type;
 import org.junit.Test;
-import org.parboiled.Rule;
 
 public class CommonParserTest {
-
-  @SuppressWarnings({
-    "checkstyle:methodname", // this class uses idiomatic names
-    "WeakerAccess", // access of Rule methods is needed for parser auto-generation.
-  })
-  static class TestParser extends CommonParser {
-
-    /**
-     * Test grammar
-     *
-     * <pre>
-     * testExpr := testTerm [, testTerm]*
-     *
-     * testTerm := @specifier(argument)
-     *               | (testTerm)
-     *               | testBase
-     * </pre>
-     */
-
-    /* An Test expression is a comma-separated list of TestTerms */
-    public Rule TestExpression() {
-      return Sequence(TestTerm(), WhiteSpace(), ZeroOrMore(", ", TestTerm(), WhiteSpace()));
-    }
-
-    /* An Test term is one of these things */
-    public Rule TestTerm() {
-      return FirstOf(TestParens(), TestSpecifier(), TestBase());
-    }
-
-    public Rule TestParens() {
-      return Sequence("( ", TestTerm(), ") ");
-    }
-
-    public Rule TestSpecifier() {
-      return Sequence("@specifier ", "( ", TestSpecifierInput(), ") ");
-    }
-
-    @Completion(Type.ADDRESS_GROUP_AND_BOOK)
-    public Rule TestSpecifierInput() {
-      return Sequence(ReferenceObjectNameLiteral(), WhiteSpace());
-    }
-
-    @Completion(Type.IP_ADDRESS)
-    public Rule TestBase() {
-      return IpAddressUnchecked();
-    }
-  }
 
   @Test
   public void testInitCompletionTypes() {
@@ -68,8 +20,10 @@ public class CommonParserTest {
                 Type.ADDRESS_GROUP_AND_BOOK,
                 "EOI",
                 Type.EOI,
-                "TestBase",
+                "TestIpAddress",
                 Type.IP_ADDRESS,
+                "TestIpRange",
+                Type.IP_RANGE,
                 "WhiteSpace",
                 Type.WHITESPACE)));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParboiledAutoCompleteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParboiledAutoCompleteTest.java
@@ -101,6 +101,7 @@ public class ParboiledAutoCompleteTest {
         ImmutableSet.copyOf(getTestPAC(query, completionMetadata).run()),
         equalTo(
             ImmutableSet.of(
+                new AutocompleteSuggestion("", true, null, AutocompleteSuggestion.DEFAULT_RANK, 7),
                 new AutocompleteSuggestion("0", true, null, AutocompleteSuggestion.DEFAULT_RANK, 7),
                 new AutocompleteSuggestion("-", true, null, RANK_STRING_LITERAL, 7),
                 new AutocompleteSuggestion(",", true, null, RANK_STRING_LITERAL, 7))));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParboiledAutoCompleteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParboiledAutoCompleteTest.java
@@ -14,7 +14,7 @@ import org.batfish.referencelibrary.AddressGroup;
 import org.batfish.referencelibrary.ReferenceBook;
 import org.batfish.referencelibrary.ReferenceLibrary;
 import org.batfish.role.NodeRolesData;
-import org.batfish.specifier.parboiled.Completion.Type;
+import org.batfish.specifier.parboiled.Anchor.Type;
 import org.junit.Test;
 import org.parboiled.parserunners.ReportingParseRunner;
 import org.parboiled.support.ParsingResult;
@@ -77,11 +77,12 @@ public class ParboiledAutoCompleteTest {
 
     // 1.1.1.1 matches, but 2.2.2.2 does not
     assertThat(
-        getTestPAC(query, completionMetadata).run(),
+        ImmutableSet.copyOf(getTestPAC(query, completionMetadata).run()),
         equalTo(
-            ImmutableList.of(
+            ImmutableSet.of(
                 new AutocompleteSuggestion(
-                    ".1", true, null, AutocompleteSuggestion.DEFAULT_RANK, 5))));
+                    ".1", true, null, AutocompleteSuggestion.DEFAULT_RANK, 5),
+                new AutocompleteSuggestion(".", true, null, RANK_STRING_LITERAL, 5))));
   }
 
   /**
@@ -90,12 +91,12 @@ public class ParboiledAutoCompleteTest {
    */
   @Test
   public void testRunDynamicValueComplex() {
-    String query = "1.1.1.1"; // this should auto complete to 1.1.1.10, '-' (range), and ',' (list)
+    String query = "1.1.1.1";
 
     CompletionMetadata completionMetadata =
         CompletionMetadata.builder().setIps(ImmutableSet.of("1.1.1.1", "1.1.1.10")).build();
 
-    // 1.1.1.1 matches, but 2.2.2.2 does not
+    // this should auto complete to 1.1.1.10, '-' (range), and ',' (list)
     assertThat(
         ImmutableSet.copyOf(getTestPAC(query, completionMetadata).run()),
         equalTo(

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParboiledAutoCompleteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParboiledAutoCompleteTest.java
@@ -25,7 +25,7 @@ public class ParboiledAutoCompleteTest {
     return new ParboiledAutoComplete(
         TestParser.INSTANCE,
         TestParser.INSTANCE.input(TestParser.INSTANCE.TestExpression()),
-        TestParser.COMPLETION_TYPES,
+        TestParser.ANCHORS,
         "network",
         "snapshot",
         query,
@@ -40,7 +40,7 @@ public class ParboiledAutoCompleteTest {
     return new ParboiledAutoComplete(
         TestParser.INSTANCE,
         TestParser.INSTANCE.input(TestParser.INSTANCE.TestExpression()),
-        TestParser.COMPLETION_TYPES,
+        TestParser.ANCHORS,
         "network",
         "snapshot",
         query,
@@ -54,7 +54,7 @@ public class ParboiledAutoCompleteTest {
     return new ParboiledAutoComplete(
         TestParser.INSTANCE,
         TestParser.INSTANCE.input(TestParser.INSTANCE.TestExpression()),
-        TestParser.COMPLETION_TYPES,
+        TestParser.ANCHORS,
         "network",
         "snapshot",
         query,

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParboiledAutoCompleteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParboiledAutoCompleteTest.java
@@ -8,7 +8,6 @@ import static org.junit.Assert.assertThat;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.util.List;
-import java.util.Map;
 import org.batfish.common.CompletionMetadata;
 import org.batfish.datamodel.answers.AutocompleteSuggestion;
 import org.batfish.referencelibrary.AddressGroup;
@@ -17,79 +16,12 @@ import org.batfish.referencelibrary.ReferenceLibrary;
 import org.batfish.role.NodeRolesData;
 import org.batfish.specifier.parboiled.Completion.Type;
 import org.junit.Test;
-import org.parboiled.Parboiled;
-import org.parboiled.Rule;
 import org.parboiled.parserunners.ReportingParseRunner;
 import org.parboiled.support.ParsingResult;
 
 public class ParboiledAutoCompleteTest {
 
-  @SuppressWarnings({
-    "checkstyle:methodname", // this class uses idiomatic names
-    "WeakerAccess", // access of Rule methods is needed for parser auto-generation.
-  })
-  static class TestParser extends CommonParser {
-
-    public static final TestParser INSTANCE = Parboiled.createParser(TestParser.class);
-
-    public static final Map<String, Type> COMPLETION_TYPES = initCompletionTypes(TestParser.class);
-
-    /**
-     * Test grammar
-     *
-     * <pre>
-     * testExpr := testTerm [, testTerm]*
-     *
-     * testTerm := @specifier(specifierInput)
-     *               | (testTerm)
-     *               | ! testTerm
-     *               | testBase
-     *
-     * specifierInput := REFERENCE_OBJECT_NAME_LITERAL
-     *
-     * testBase := IP_ADDRESS
-     * </pre>
-     */
-
-    /* An Test expression is a comma-separated list of TestTerms */
-    public Rule TestExpression() {
-      return Sequence(TestTerm(), WhiteSpace(), ZeroOrMore(", ", TestTerm(), WhiteSpace()));
-    }
-
-    /* An Test term is one of these things */
-    public Rule TestTerm() {
-      return FirstOf(TestParens(), TestSpecifier(), TestNotOp(), TestBase());
-    }
-
-    public Rule TestParens() {
-      return Sequence("( ", TestTerm(), ") ");
-    }
-
-    public Rule TestSpecifier() {
-      return Sequence("@specifier ", "( ", TestSpecifierInput(), ") ");
-    }
-
-    public Rule TestNotOp() {
-      return Sequence("! ", TestNot("! "), TestTerm());
-    }
-
-    @Completion(Type.ADDRESS_GROUP_AND_BOOK)
-    public Rule TestSpecifierInput() {
-      return Sequence(
-          ReferenceObjectNameLiteral(),
-          WhiteSpace(),
-          ", ",
-          ReferenceObjectNameLiteral(),
-          WhiteSpace());
-    }
-
-    @Completion(Type.IP_ADDRESS)
-    public Rule TestBase() {
-      return IpAddressUnchecked();
-    }
-  }
-
-  static ParboiledAutoComplete getTestPAC(String query) {
+  private static ParboiledAutoComplete getTestPAC(String query) {
     return new ParboiledAutoComplete(
         TestParser.INSTANCE,
         TestParser.INSTANCE.input(TestParser.INSTANCE.TestExpression()),
@@ -103,7 +35,8 @@ public class ParboiledAutoCompleteTest {
         new ReferenceLibrary(null));
   }
 
-  static ParboiledAutoComplete getTestPAC(String query, CompletionMetadata completionMetadata) {
+  private static ParboiledAutoComplete getTestPAC(
+      String query, CompletionMetadata completionMetadata) {
     return new ParboiledAutoComplete(
         TestParser.INSTANCE,
         TestParser.INSTANCE.input(TestParser.INSTANCE.TestExpression()),
@@ -117,7 +50,7 @@ public class ParboiledAutoCompleteTest {
         new ReferenceLibrary(null));
   }
 
-  static ParboiledAutoComplete getTestPAC(String query, ReferenceLibrary referenceLibrary) {
+  private static ParboiledAutoComplete getTestPAC(String query, ReferenceLibrary referenceLibrary) {
     return new ParboiledAutoComplete(
         TestParser.INSTANCE,
         TestParser.INSTANCE.input(TestParser.INSTANCE.TestExpression()),
@@ -131,10 +64,13 @@ public class ParboiledAutoCompleteTest {
         referenceLibrary);
   }
 
-  /** Test that we produce auto complete snapshot-based dynamic values like IP addresses */
+  /**
+   * Test that we produce auto complete snapshot-based base (i.e., those that do not depend on other
+   * values) dynamic values like IP addresses
+   */
   @Test
-  public void testRunDynamicValues() {
-    String query = "1.1.1.";
+  public void testRunDynamicValueBase() {
+    String query = "1.1.1";
 
     CompletionMetadata completionMetadata =
         CompletionMetadata.builder().setIps(ImmutableSet.of("1.1.1.1", "2.2.2.2")).build();
@@ -145,7 +81,28 @@ public class ParboiledAutoCompleteTest {
         equalTo(
             ImmutableList.of(
                 new AutocompleteSuggestion(
-                    "1", true, null, AutocompleteSuggestion.DEFAULT_RANK, 6))));
+                    ".1", true, null, AutocompleteSuggestion.DEFAULT_RANK, 5))));
+  }
+
+  /**
+   * Test that we produce auto complete snapshot-based complex dynamic values (i.e., those that
+   * depend on other dynamic values) like IP ranges
+   */
+  @Test
+  public void testRunDynamicValueComplex() {
+    String query = "1.1.1.1"; // this should auto complete to 1.1.1.10, '-' (range), and ',' (list)
+
+    CompletionMetadata completionMetadata =
+        CompletionMetadata.builder().setIps(ImmutableSet.of("1.1.1.1", "1.1.1.10")).build();
+
+    // 1.1.1.1 matches, but 2.2.2.2 does not
+    assertThat(
+        ImmutableSet.copyOf(getTestPAC(query, completionMetadata).run()),
+        equalTo(
+            ImmutableSet.of(
+                new AutocompleteSuggestion("0", true, null, AutocompleteSuggestion.DEFAULT_RANK, 7),
+                new AutocompleteSuggestion("-", true, null, RANK_STRING_LITERAL, 7),
+                new AutocompleteSuggestion(",", true, null, RANK_STRING_LITERAL, 7))));
   }
 
   /** Test that we produce auto complete snapshot-based dynamic values like IP addresses */
@@ -215,7 +172,7 @@ public class ParboiledAutoCompleteTest {
   /** Test that we produce auto completion suggestions even for valid inputs */
   @Test
   public void testRunValidInput() {
-    String query = "1.1.1.1 "; // space at the end means that ip addresses won't match
+    String query = "(1.1.1.1)"; //
 
     // first ensure that the query is valid input
     ParsingResult<?> result =
@@ -227,51 +184,20 @@ public class ParboiledAutoCompleteTest {
     assertThat(
         getTestPAC(query).run(),
         equalTo(
-            ImmutableList.of(new AutocompleteSuggestion(",", true, null, RANK_STRING_LITERAL, 8))));
+            ImmutableList.of(new AutocompleteSuggestion(",", true, null, RANK_STRING_LITERAL, 9))));
   }
 
   @Test
-  public void testAutoCompletePartialMatchIpRange() {
-    CompletionMetadata completionMetadata =
-        CompletionMetadata.builder().setIps(ImmutableSet.of("1.1.1.1", "2.2.2.2")).build();
-
+  public void testAutoCompletePotentialMatchStringLiteral() {
+    PotentialMatch pm = new PotentialMatch(Type.STRING_LITERAL, "pfx", "comp");
     assertThat(
-        getTestPAC("1.1.1.", completionMetadata)
-            .autoCompletePartialMatch(new PartialMatch(Type.IP_RANGE, "1.1.1.", null), 2),
-        equalTo(ImmutableList.of()));
-
-    assertThat(
-        ImmutableSet.copyOf(
-            getTestPAC("1.1.1.", completionMetadata)
-                .autoCompletePartialMatch(new PartialMatch(Type.IP_RANGE, "1.1.1.1 - ", null), 2)),
-        equalTo(
-            ImmutableSet.of(
-                new AutocompleteSuggestion(
-                    "1.1.1.1-1.1.1.1", true, null, AutocompleteSuggestion.DEFAULT_RANK, 2),
-                new AutocompleteSuggestion(
-                    "1.1.1.1-2.2.2.2", true, null, AutocompleteSuggestion.DEFAULT_RANK, 2))));
-
-    assertThat(
-        ImmutableSet.copyOf(
-            getTestPAC("1.1.1.", completionMetadata)
-                .autoCompletePartialMatch(new PartialMatch(Type.IP_RANGE, "1.1.1.1 - 2", null), 2)),
-        equalTo(
-            ImmutableSet.of(
-                new AutocompleteSuggestion(
-                    "1.1.1.1-2.2.2.2", true, null, AutocompleteSuggestion.DEFAULT_RANK, 2))));
-  }
-
-  @Test
-  public void testAutoCompletePartialMatchStringLiteral() {
-    PartialMatch pm = new PartialMatch(Type.STRING_LITERAL, "pfx", "comp");
-    assertThat(
-        getTestPAC(null).autoCompletePartialMatch(pm, 2),
+        getTestPAC(null).autoCompletePotentialMatch(pm, 2),
         equalTo(ImmutableList.of(new AutocompleteSuggestion("comp", true, null, -1, 2))));
   }
 
   @Test
-  public void testAutoCompletePartialMatchSkipLabel() {
-    PartialMatch pm = new PartialMatch(Type.IP_WILDCARD, "pfx", "comp");
-    assertThat(getTestPAC(null).autoCompletePartialMatch(pm, 2), equalTo(ImmutableList.of()));
+  public void testAutoCompletePotentialMatchSkipLabel() {
+    PotentialMatch pm = new PotentialMatch(Type.IP_ADDRESS_MASK, "pfx", "comp");
+    assertThat(getTestPAC(null).autoCompletePotentialMatch(pm, 2), equalTo(ImmutableList.of()));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserIpSpaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserIpSpaceTest.java
@@ -32,7 +32,7 @@ public class ParserIpSpaceTest {
 
     // not barfing means all potential paths have completion annotation at least for empty input
     ParserUtils.getPotentialMatches(
-        (InvalidInputError) result.parseErrors.get(0), Parser.COMPLETION_TYPES, false);
+        (InvalidInputError) result.parseErrors.get(0), Parser.ANCHORS, false);
   }
 
   /** This is a complex completion test that exercises a bunch of the grammar */
@@ -51,7 +51,7 @@ public class ParserIpSpaceTest {
         new ParboiledAutoComplete(
             Parser.INSTANCE,
             Parser.INSTANCE.input(Parser.INSTANCE.IpSpaceExpression()),
-            Parser.COMPLETION_TYPES,
+            Parser.ANCHORS,
             "network",
             "snapshot",
             query,

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserIpSpaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserIpSpaceTest.java
@@ -64,6 +64,7 @@ public class ParserIpSpaceTest {
         ImmutableSet.copyOf(pac.run()),
         equalTo(
             ImmutableSet.of(
+                new AutocompleteSuggestion("", true, null, AutocompleteSuggestion.DEFAULT_RANK, 7),
                 new AutocompleteSuggestion("0", true, null, AutocompleteSuggestion.DEFAULT_RANK, 7),
                 new AutocompleteSuggestion("-", true, null, RANK_STRING_LITERAL, 7),
                 new AutocompleteSuggestion(":", true, null, RANK_STRING_LITERAL, 7),

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserIpSpaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserIpSpaceTest.java
@@ -7,7 +7,6 @@ import static org.junit.Assert.assertThat;
 import com.google.common.collect.ImmutableSet;
 import org.batfish.common.CompletionMetadata;
 import org.batfish.datamodel.answers.AutocompleteSuggestion;
-import org.hamcrest.CoreMatchers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -63,7 +62,7 @@ public class ParserIpSpaceTest {
 
     assertThat(
         ImmutableSet.copyOf(pac.run()),
-        CoreMatchers.equalTo(
+        equalTo(
             ImmutableSet.of(
                 new AutocompleteSuggestion("0", true, null, AutocompleteSuggestion.DEFAULT_RANK, 7),
                 new AutocompleteSuggestion("-", true, null, RANK_STRING_LITERAL, 7),

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserIpSpaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserIpSpaceTest.java
@@ -3,9 +3,6 @@ package org.batfish.specifier.parboiled;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
-import com.google.common.collect.ImmutableSet;
-import java.util.Set;
-import org.batfish.specifier.parboiled.Completion.Type;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -26,23 +23,12 @@ public class ParserIpSpaceTest {
 
   /** This tests if we have proper completion annotations on the rules */
   @Test
-  public void testCompletions() {
+  public void testCompletionAnnotations() {
     ParsingResult<?> result = getRunner().run("");
 
-    Set<PartialMatch> partialMatches =
-        ParserUtils.getPartialMatches(
-            (InvalidInputError) result.parseErrors.get(0), Parser.COMPLETION_TYPES);
-
-    assertThat(
-        partialMatches,
-        equalTo(
-            ImmutableSet.of(
-                new PartialMatch(Type.STRING_LITERAL, "", "@addressgroup"),
-                new PartialMatch(Type.STRING_LITERAL, "", "ref.addressgroup"),
-                new PartialMatch(Type.IP_ADDRESS, "", null),
-                new PartialMatch(Type.IP_WILDCARD, "", null),
-                new PartialMatch(Type.IP_PREFIX, "", null),
-                new PartialMatch(Type.IP_RANGE, "", null))));
+    // not barfing = at least for empty input, all potential paths have completion annotation
+    ParserUtils.getPotentialMatches(
+        (InvalidInputError) result.parseErrors.get(0), Parser.COMPLETION_TYPES, false);
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserUtilsTest.java
@@ -1,18 +1,15 @@
 package org.batfish.specifier.parboiled;
 
 import static org.batfish.specifier.parboiled.ParserUtils.getErrorString;
-import static org.batfish.specifier.parboiled.ParserUtils.getPartialMatches;
+import static org.batfish.specifier.parboiled.ParserUtils.getPotentialMatches;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableSet;
-import java.util.Map;
 import java.util.Set;
 import org.batfish.specifier.parboiled.Completion.Type;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.parboiled.Parboiled;
-import org.parboiled.Rule;
 import org.parboiled.errors.InvalidInputError;
 import org.parboiled.parserunners.AbstractParseRunner;
 import org.parboiled.parserunners.ReportingParseRunner;
@@ -27,75 +24,19 @@ public class ParserUtilsTest {
         TestParser.INSTANCE.input(TestParser.INSTANCE.TestExpression()));
   }
 
-  @SuppressWarnings({
-    "checkstyle:methodname", // this class uses idiomatic names
-    "WeakerAccess", // access of Rule methods is needed for parser auto-generation.
-  })
-  static class TestParser extends CommonParser {
-
-    public static final TestParser INSTANCE = Parboiled.createParser(TestParser.class);
-
-    public static final Map<String, Type> COMPLETION_TYPES = initCompletionTypes(TestParser.class);
-
-    /**
-     * Test grammar
-     *
-     * <pre>
-     * testExpr := testTerm [, testTerm]*
-     *
-     * testTerm := specifier(argument)
-     *               | (testTerm)
-     *               | ! testTerm
-     *               | testBase
-     * </pre>
-     */
-
-    /* An Test expression is a comma-separated list of TestTerms */
-    public Rule TestExpression() {
-      return Sequence(TestTerm(), WhiteSpace(), ZeroOrMore(", ", TestTerm(), WhiteSpace()));
-    }
-
-    /* An Test term is one of these things */
-    public Rule TestTerm() {
-      return FirstOf(TestParens(), TestSpecifier(), TestNotOp(), TestBase());
-    }
-
-    public Rule TestParens() {
-      return Sequence("( ", TestTerm(), ") ");
-    }
-
-    public Rule TestSpecifier() {
-      return Sequence("@specifier ", "( ", TestSpecifierInput(), ") ");
-    }
-
-    public Rule TestNotOp() {
-      return Sequence("! ", TestNot("! "), TestTerm());
-    }
-
-    @Completion(Type.ADDRESS_GROUP_AND_BOOK)
-    public Rule TestSpecifierInput() {
-      return Sequence(ReferenceObjectNameLiteral(), WhiteSpace());
-    }
-
-    @Completion(Type.IP_ADDRESS)
-    public Rule TestBase() {
-      return IpAddressUnchecked();
-    }
-  }
-
   /** These represent all the ways valid input can start */
-  private Set<PartialMatch> _validStarts =
+  private Set<PotentialMatch> _validStarts =
       ImmutableSet.of(
-          new PartialMatch(Completion.Type.STRING_LITERAL, "", "@specifier"),
-          new PartialMatch(Completion.Type.STRING_LITERAL, "", "!"),
-          new PartialMatch(Type.IP_ADDRESS, "", null),
-          new PartialMatch(Completion.Type.STRING_LITERAL, "", "("));
+          new PotentialMatch(Completion.Type.STRING_LITERAL, "", "@specifier"),
+          new PotentialMatch(Completion.Type.STRING_LITERAL, "", "!"),
+          new PotentialMatch(Type.IP_ADDRESS, "", null),
+          new PotentialMatch(Completion.Type.STRING_LITERAL, "", "("));
 
   @Test
   public void testGetErrorString() {
-    assertThat(getErrorString(new PartialMatch(Type.STRING_LITERAL, "a", "b")), equalTo("'b'"));
+    assertThat(getErrorString(new PotentialMatch(Type.STRING_LITERAL, "a", "b")), equalTo("'b'"));
     assertThat(
-        getErrorString(new PartialMatch(Type.IP_ADDRESS, "", "b")),
+        getErrorString(new PotentialMatch(Type.IP_ADDRESS, "", "b")),
         equalTo(Type.IP_ADDRESS.toString()));
   }
 
@@ -103,8 +44,8 @@ public class ParserUtilsTest {
   public void testGetPartialMatchesEmpty() {
     ParsingResult<?> resultEmpty = getRunner().run("");
     assertThat(
-        getPartialMatches(
-            (InvalidInputError) resultEmpty.parseErrors.get(0), TestParser.COMPLETION_TYPES),
+        getPotentialMatches(
+            (InvalidInputError) resultEmpty.parseErrors.get(0), TestParser.COMPLETION_TYPES, false),
         equalTo(_validStarts));
   }
 
@@ -112,8 +53,8 @@ public class ParserUtilsTest {
   public void testGetPartialMatchesBadStart() {
     ParsingResult<?> resultEmpty = getRunner().run("[");
     assertThat(
-        getPartialMatches(
-            (InvalidInputError) resultEmpty.parseErrors.get(0), TestParser.COMPLETION_TYPES),
+        getPotentialMatches(
+            (InvalidInputError) resultEmpty.parseErrors.get(0), TestParser.COMPLETION_TYPES, false),
         equalTo(_validStarts));
   }
 
@@ -121,17 +62,17 @@ public class ParserUtilsTest {
   public void testGetPartialMatchesIncompleteBase() {
     ParsingResult<?> result = getRunner().run("(1.1.1");
     assertThat(
-        getPartialMatches(
-            (InvalidInputError) result.parseErrors.get(0), TestParser.COMPLETION_TYPES),
-        equalTo(ImmutableSet.of(new PartialMatch(Type.IP_ADDRESS, "1.1.1", null))));
+        getPotentialMatches(
+            (InvalidInputError) result.parseErrors.get(0), TestParser.COMPLETION_TYPES, false),
+        equalTo(ImmutableSet.of(new PotentialMatch(Type.IP_ADDRESS, "1.1.1", null))));
   }
 
   @Test
   public void testGetPartialMatchesIncompleteList() {
     ParsingResult<?> resultEmpty = getRunner().run("a,");
     assertThat(
-        getPartialMatches(
-            (InvalidInputError) resultEmpty.parseErrors.get(0), TestParser.COMPLETION_TYPES),
+        getPotentialMatches(
+            (InvalidInputError) resultEmpty.parseErrors.get(0), TestParser.COMPLETION_TYPES, false),
         equalTo(_validStarts));
   }
 
@@ -139,8 +80,8 @@ public class ParserUtilsTest {
   public void testGetPartialMatchesOpenParens() {
     ParsingResult<?> resultEmpty = getRunner().run("(");
     assertThat(
-        getPartialMatches(
-            (InvalidInputError) resultEmpty.parseErrors.get(0), TestParser.COMPLETION_TYPES),
+        getPotentialMatches(
+            (InvalidInputError) resultEmpty.parseErrors.get(0), TestParser.COMPLETION_TYPES, false),
         equalTo(_validStarts));
   }
 
@@ -148,8 +89,8 @@ public class ParserUtilsTest {
   public void testGetPartialMatchesOperator() {
     ParsingResult<?> resultEmpty = getRunner().run("!");
     assertThat(
-        getPartialMatches(
-            (InvalidInputError) resultEmpty.parseErrors.get(0), TestParser.COMPLETION_TYPES),
+        getPotentialMatches(
+            (InvalidInputError) resultEmpty.parseErrors.get(0), TestParser.COMPLETION_TYPES, false),
         equalTo(_validStarts));
   }
 
@@ -157,49 +98,50 @@ public class ParserUtilsTest {
   public void testGetPartialMatchesMissingCloseParens() {
     ParsingResult<?> result = getRunner().run("(1.1.1.1");
     assertThat(
-        getPartialMatches(
-            (InvalidInputError) result.parseErrors.get(0), TestParser.COMPLETION_TYPES),
+        getPotentialMatches(
+            (InvalidInputError) result.parseErrors.get(0), TestParser.COMPLETION_TYPES, false),
         equalTo(
             ImmutableSet.of(
-                new PartialMatch(Type.STRING_LITERAL, "", ")"),
-                new PartialMatch(Type.IP_ADDRESS, "1.1.1.1", null))));
+                new PotentialMatch(Type.STRING_LITERAL, "", ")"),
+                new PotentialMatch(Type.IP_ADDRESS, "1.1.1.1", null),
+                new PotentialMatch(Type.STRING_LITERAL, "", "-"))));
   }
 
   @Test
   public void testGetPartialMatchesSpecifierComplete() {
     ParsingResult<?> result = getRunner().run("@specifier");
     assertThat(
-        getPartialMatches(
-            (InvalidInputError) result.parseErrors.get(0), TestParser.COMPLETION_TYPES),
-        equalTo(ImmutableSet.of(new PartialMatch(Completion.Type.STRING_LITERAL, "", "("))));
+        getPotentialMatches(
+            (InvalidInputError) result.parseErrors.get(0), TestParser.COMPLETION_TYPES, false),
+        equalTo(ImmutableSet.of(new PotentialMatch(Completion.Type.STRING_LITERAL, "", "("))));
   }
 
   @Test
   public void testGetPartialMatchesSpecifierOpenParens() {
     ParsingResult<?> result = getRunner().run("@specifier(");
     assertThat(
-        getPartialMatches(
-            (InvalidInputError) result.parseErrors.get(0), TestParser.COMPLETION_TYPES),
-        equalTo(ImmutableSet.of(new PartialMatch(Type.ADDRESS_GROUP_AND_BOOK, "", null))));
+        getPotentialMatches(
+            (InvalidInputError) result.parseErrors.get(0), TestParser.COMPLETION_TYPES, false),
+        equalTo(ImmutableSet.of(new PotentialMatch(Type.ADDRESS_GROUP_AND_BOOK, "", null))));
   }
 
   @Test
   public void testGetPartialMatchesSpecifierSubstring() {
     ParsingResult<?> result = getRunner().run("@specifi");
     assertThat(
-        getPartialMatches(
-            (InvalidInputError) result.parseErrors.get(0), TestParser.COMPLETION_TYPES),
+        getPotentialMatches(
+            (InvalidInputError) result.parseErrors.get(0), TestParser.COMPLETION_TYPES, false),
         equalTo(
-            ImmutableSet.of(new PartialMatch(Completion.Type.STRING_LITERAL, "@specifi", "er"))));
+            ImmutableSet.of(new PotentialMatch(Completion.Type.STRING_LITERAL, "@specifi", "er"))));
   }
 
   @Test
   public void testGetPartialMatchesSpecifierIncorrect() {
     ParsingResult<?> result = getRunner().run("@wrong");
     assertThat(
-        getPartialMatches(
-            (InvalidInputError) result.parseErrors.get(0), TestParser.COMPLETION_TYPES),
+        getPotentialMatches(
+            (InvalidInputError) result.parseErrors.get(0), TestParser.COMPLETION_TYPES, false),
         equalTo(
-            ImmutableSet.of(new PartialMatch(Completion.Type.STRING_LITERAL, "@", "specifier"))));
+            ImmutableSet.of(new PotentialMatch(Completion.Type.STRING_LITERAL, "@", "specifier"))));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserUtilsTest.java
@@ -45,7 +45,7 @@ public class ParserUtilsTest {
     ParsingResult<?> resultEmpty = getRunner().run("");
     assertThat(
         getPotentialMatches(
-            (InvalidInputError) resultEmpty.parseErrors.get(0), TestParser.COMPLETION_TYPES, false),
+            (InvalidInputError) resultEmpty.parseErrors.get(0), TestParser.ANCHORS, false),
         equalTo(_validStarts));
   }
 
@@ -54,7 +54,7 @@ public class ParserUtilsTest {
     ParsingResult<?> resultEmpty = getRunner().run("[");
     assertThat(
         getPotentialMatches(
-            (InvalidInputError) resultEmpty.parseErrors.get(0), TestParser.COMPLETION_TYPES, false),
+            (InvalidInputError) resultEmpty.parseErrors.get(0), TestParser.ANCHORS, false),
         equalTo(_validStarts));
   }
 
@@ -63,7 +63,7 @@ public class ParserUtilsTest {
     ParsingResult<?> result = getRunner().run("(1.1.1.");
     assertThat(
         getPotentialMatches(
-            (InvalidInputError) result.parseErrors.get(0), TestParser.COMPLETION_TYPES, false),
+            (InvalidInputError) result.parseErrors.get(0), TestParser.ANCHORS, false),
         equalTo(ImmutableSet.of(new PotentialMatch(Type.IP_ADDRESS, "1.1.1.", null))));
   }
 
@@ -72,7 +72,7 @@ public class ParserUtilsTest {
     ParsingResult<?> resultEmpty = getRunner().run("a,");
     assertThat(
         getPotentialMatches(
-            (InvalidInputError) resultEmpty.parseErrors.get(0), TestParser.COMPLETION_TYPES, false),
+            (InvalidInputError) resultEmpty.parseErrors.get(0), TestParser.ANCHORS, false),
         equalTo(_validStarts));
   }
 
@@ -81,7 +81,7 @@ public class ParserUtilsTest {
     ParsingResult<?> resultEmpty = getRunner().run("(");
     assertThat(
         getPotentialMatches(
-            (InvalidInputError) resultEmpty.parseErrors.get(0), TestParser.COMPLETION_TYPES, false),
+            (InvalidInputError) resultEmpty.parseErrors.get(0), TestParser.ANCHORS, false),
         equalTo(_validStarts));
   }
 
@@ -90,7 +90,7 @@ public class ParserUtilsTest {
     ParsingResult<?> resultEmpty = getRunner().run("!");
     assertThat(
         getPotentialMatches(
-            (InvalidInputError) resultEmpty.parseErrors.get(0), TestParser.COMPLETION_TYPES, false),
+            (InvalidInputError) resultEmpty.parseErrors.get(0), TestParser.ANCHORS, false),
         equalTo(_validStarts));
   }
 
@@ -99,7 +99,7 @@ public class ParserUtilsTest {
     ParsingResult<?> result = getRunner().run("(1.1.1.1");
     assertThat(
         getPotentialMatches(
-            (InvalidInputError) result.parseErrors.get(0), TestParser.COMPLETION_TYPES, false),
+            (InvalidInputError) result.parseErrors.get(0), TestParser.ANCHORS, false),
         equalTo(
             ImmutableSet.of(
                 new PotentialMatch(Type.STRING_LITERAL, "", ")"),
@@ -112,7 +112,7 @@ public class ParserUtilsTest {
     ParsingResult<?> result = getRunner().run("@specifier");
     assertThat(
         getPotentialMatches(
-            (InvalidInputError) result.parseErrors.get(0), TestParser.COMPLETION_TYPES, false),
+            (InvalidInputError) result.parseErrors.get(0), TestParser.ANCHORS, false),
         equalTo(ImmutableSet.of(new PotentialMatch(Anchor.Type.STRING_LITERAL, "", "("))));
   }
 
@@ -121,7 +121,7 @@ public class ParserUtilsTest {
     ParsingResult<?> result = getRunner().run("@specifier(");
     assertThat(
         getPotentialMatches(
-            (InvalidInputError) result.parseErrors.get(0), TestParser.COMPLETION_TYPES, false),
+            (InvalidInputError) result.parseErrors.get(0), TestParser.ANCHORS, false),
         equalTo(ImmutableSet.of(new PotentialMatch(Type.ADDRESS_GROUP_AND_BOOK, "", null))));
   }
 
@@ -130,7 +130,7 @@ public class ParserUtilsTest {
     ParsingResult<?> result = getRunner().run("@specifi");
     assertThat(
         getPotentialMatches(
-            (InvalidInputError) result.parseErrors.get(0), TestParser.COMPLETION_TYPES, false),
+            (InvalidInputError) result.parseErrors.get(0), TestParser.ANCHORS, false),
         equalTo(ImmutableSet.of(new PotentialMatch(Anchor.Type.STRING_LITERAL, "@specifi", "er"))));
   }
 
@@ -139,7 +139,7 @@ public class ParserUtilsTest {
     ParsingResult<?> result = getRunner().run("@wrong");
     assertThat(
         getPotentialMatches(
-            (InvalidInputError) result.parseErrors.get(0), TestParser.COMPLETION_TYPES, false),
+            (InvalidInputError) result.parseErrors.get(0), TestParser.ANCHORS, false),
         equalTo(ImmutableSet.of(new PotentialMatch(Anchor.Type.STRING_LITERAL, "@", "specifier"))));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserUtilsTest.java
@@ -7,7 +7,7 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableSet;
 import java.util.Set;
-import org.batfish.specifier.parboiled.Completion.Type;
+import org.batfish.specifier.parboiled.Anchor.Type;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.parboiled.errors.InvalidInputError;
@@ -27,10 +27,10 @@ public class ParserUtilsTest {
   /** These represent all the ways valid input can start */
   private Set<PotentialMatch> _validStarts =
       ImmutableSet.of(
-          new PotentialMatch(Completion.Type.STRING_LITERAL, "", "@specifier"),
-          new PotentialMatch(Completion.Type.STRING_LITERAL, "", "!"),
+          new PotentialMatch(Anchor.Type.STRING_LITERAL, "", "@specifier"),
+          new PotentialMatch(Anchor.Type.STRING_LITERAL, "", "!"),
           new PotentialMatch(Type.IP_ADDRESS, "", null),
-          new PotentialMatch(Completion.Type.STRING_LITERAL, "", "("));
+          new PotentialMatch(Anchor.Type.STRING_LITERAL, "", "("));
 
   @Test
   public void testGetErrorString() {
@@ -60,11 +60,11 @@ public class ParserUtilsTest {
 
   @Test
   public void testGetPartialMatchesIncompleteBase() {
-    ParsingResult<?> result = getRunner().run("(1.1.1");
+    ParsingResult<?> result = getRunner().run("(1.1.1.");
     assertThat(
         getPotentialMatches(
             (InvalidInputError) result.parseErrors.get(0), TestParser.COMPLETION_TYPES, false),
-        equalTo(ImmutableSet.of(new PotentialMatch(Type.IP_ADDRESS, "1.1.1", null))));
+        equalTo(ImmutableSet.of(new PotentialMatch(Type.IP_ADDRESS, "1.1.1.", null))));
   }
 
   @Test
@@ -113,7 +113,7 @@ public class ParserUtilsTest {
     assertThat(
         getPotentialMatches(
             (InvalidInputError) result.parseErrors.get(0), TestParser.COMPLETION_TYPES, false),
-        equalTo(ImmutableSet.of(new PotentialMatch(Completion.Type.STRING_LITERAL, "", "("))));
+        equalTo(ImmutableSet.of(new PotentialMatch(Anchor.Type.STRING_LITERAL, "", "("))));
   }
 
   @Test
@@ -131,8 +131,7 @@ public class ParserUtilsTest {
     assertThat(
         getPotentialMatches(
             (InvalidInputError) result.parseErrors.get(0), TestParser.COMPLETION_TYPES, false),
-        equalTo(
-            ImmutableSet.of(new PotentialMatch(Completion.Type.STRING_LITERAL, "@specifi", "er"))));
+        equalTo(ImmutableSet.of(new PotentialMatch(Anchor.Type.STRING_LITERAL, "@specifi", "er"))));
   }
 
   @Test
@@ -141,7 +140,6 @@ public class ParserUtilsTest {
     assertThat(
         getPotentialMatches(
             (InvalidInputError) result.parseErrors.get(0), TestParser.COMPLETION_TYPES, false),
-        equalTo(
-            ImmutableSet.of(new PotentialMatch(Completion.Type.STRING_LITERAL, "@", "specifier"))));
+        equalTo(ImmutableSet.of(new PotentialMatch(Anchor.Type.STRING_LITERAL, "@", "specifier"))));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/TestParser.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/TestParser.java
@@ -17,7 +17,7 @@ class TestParser extends CommonParser {
 
   public static final TestParser INSTANCE = Parboiled.createParser(TestParser.class);
 
-  public static final Map<String, Type> COMPLETION_TYPES = initCompletionTypes(TestParser.class);
+  public static final Map<String, Type> ANCHORS = initAnchors(TestParser.class);
 
   /**
    * Test grammar

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/TestParser.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/TestParser.java
@@ -1,7 +1,7 @@
 package org.batfish.specifier.parboiled;
 
 import java.util.Map;
-import org.batfish.specifier.parboiled.Completion.Type;
+import org.batfish.specifier.parboiled.Anchor.Type;
 import org.parboiled.Parboiled;
 import org.parboiled.Rule;
 
@@ -58,7 +58,7 @@ class TestParser extends CommonParser {
     return Sequence("! ", TestNot("! "), TestTerm());
   }
 
-  @Completion(Type.ADDRESS_GROUP_AND_BOOK)
+  @Anchor(Type.ADDRESS_GROUP_AND_BOOK)
   public Rule TestSpecifierInput() {
     return Sequence(
         ReferenceObjectNameLiteral(),
@@ -69,13 +69,13 @@ class TestParser extends CommonParser {
   }
 
   /** An instance of base dynamic value */
-  @Completion(Type.IP_ADDRESS)
+  @Anchor(Type.IP_ADDRESS)
   public Rule TestIpAddress() {
     return IpAddressUnchecked();
   }
 
   /** An instance of complex dynamic value */
-  @Completion(Type.IP_RANGE)
+  @Anchor(Type.IP_RANGE)
   public Rule TestIpRange() {
     return Sequence(TestIpAddress(), WhiteSpace(), "- ", TestIpAddress());
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/TestParser.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/TestParser.java
@@ -1,0 +1,82 @@
+package org.batfish.specifier.parboiled;
+
+import java.util.Map;
+import org.batfish.specifier.parboiled.Completion.Type;
+import org.parboiled.Parboiled;
+import org.parboiled.Rule;
+
+/**
+ * A shared test grammar that is used by several tests in this package. It has been designed to
+ * include one instance of all types of features our real grammars use.
+ */
+@SuppressWarnings({
+  "checkstyle:methodname", // this class uses idiomatic names
+  "WeakerAccess", // access of Rule methods is needed for parser auto-generation.
+})
+class TestParser extends CommonParser {
+
+  public static final TestParser INSTANCE = Parboiled.createParser(TestParser.class);
+
+  public static final Map<String, Type> COMPLETION_TYPES = initCompletionTypes(TestParser.class);
+
+  /**
+   * Test grammar
+   *
+   * <pre>
+   * testExpr := testTerm [, testTerm]*
+   *
+   * testTerm := @specifier(specifierInput)
+   *               | (testTerm)
+   *               | ! testTerm
+   *               | testBase
+   *
+   * specifierInput := REFERENCE_OBJECT_NAME_LITERAL
+   *
+   * testBase := IP_ADDRESS
+   * </pre>
+   */
+
+  /* An Test expression is a comma-separated list of TestTerms */
+  public Rule TestExpression() {
+    return Sequence(TestTerm(), WhiteSpace(), ZeroOrMore(", ", TestTerm(), WhiteSpace()));
+  }
+
+  /* An Test term is one of these things */
+  public Rule TestTerm() {
+    return FirstOf(TestParens(), TestSpecifier(), TestNotOp(), TestIpRange(), TestIpAddress());
+  }
+
+  public Rule TestParens() {
+    return Sequence("( ", TestTerm(), ") ");
+  }
+
+  public Rule TestSpecifier() {
+    return Sequence("@specifier ", "( ", TestSpecifierInput(), ") ");
+  }
+
+  public Rule TestNotOp() {
+    return Sequence("! ", TestNot("! "), TestTerm());
+  }
+
+  @Completion(Type.ADDRESS_GROUP_AND_BOOK)
+  public Rule TestSpecifierInput() {
+    return Sequence(
+        ReferenceObjectNameLiteral(),
+        WhiteSpace(),
+        ", ",
+        ReferenceObjectNameLiteral(),
+        WhiteSpace());
+  }
+
+  /** An instance of base dynamic value */
+  @Completion(Type.IP_ADDRESS)
+  public Rule TestIpAddress() {
+    return IpAddressUnchecked();
+  }
+
+  /** An instance of complex dynamic value */
+  @Completion(Type.IP_RANGE)
+  public Rule TestIpRange() {
+    return Sequence(TestIpAddress(), WhiteSpace(), "- ", TestIpAddress());
+  }
+}


### PR DESCRIPTION
A bunch of things, some trivial some not so trivial:
 1/ Rename Completion annotation to Anchor
 1/ Rename UsefulPointInPath to PathAnchor
 2/ Rename PartialMatch to PotentialMatch
 3/ Auto completion now considers only strict prefixes, i.e., "10" is not auto completed to "10"
 4/ Put the TestParser defined in two places in its own class that is shared
 5/ For error reporting, search for anchors from top to bottom. For auto completion, search for anchors bottom to top. So 
- when `1.1.1` is supplied as input, the error is `Error parsing '1.1.1' as IpSpace after index 5. Valid continuations are IP_PREFIX or IP_WILDCARD or IP_RANGE or IP_ADDRESS.`
- when `1.1.1` is auto completed, we get suggestions as `.` (next char for any prefix), `.1/32` (matching prefix in snapshot) and `.1` (matching ip address in snapshot).