### PR TITLE
Fix EIGRP config on ASA

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -7577,6 +7577,9 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
     // In process context
     Ip address = toIp(ctx.address);
     Ip mask = (ctx.mask != null) ? toIp(ctx.mask) : address.getClassMask().inverted();
+    if (_format == CISCO_ASA) {
+      mask = mask.inverted();
+    }
     _currentEigrpProcess.getWildcardNetworks().add(new IpWildcard(address, mask));
   }
 
@@ -7588,7 +7591,10 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
       return;
     }
     boolean passive = (ctx.NO() == null);
-    String interfaceName = getCanonicalInterfaceName(ctx.i.getText());
+    String interfaceName = ctx.i.getText(); // Note: Interface alias is not canonicalized for ASA
+    if (_format != CISCO_ASA) {
+      interfaceName = getCanonicalInterfaceName(interfaceName);
+    }
     _currentEigrpProcess.getInterfacePassiveStatus().put(interfaceName, passive);
     _configuration.referenceStructure(
         INTERFACE, interfaceName, EIGRP_PASSIVE_INTERFACE, ctx.i.getStart().getLine());

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -2144,7 +2144,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
       boolean passive =
           eigrpProcess
               .getInterfacePassiveStatus()
-              .getOrDefault(iface.getName(), eigrpProcess.getPassiveInterfaceDefault());
+              .getOrDefault(getNewInterfaceName(iface), eigrpProcess.getPassiveInterfaceDefault());
 
       // For bandwidth/delay, defaults are separate from actuals to inform metric calculations
       EigrpMetric metric =

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -354,6 +354,7 @@ import org.batfish.main.TestrigText;
 import org.batfish.representation.cisco.CiscoAsaNat;
 import org.batfish.representation.cisco.CiscoAsaNat.Section;
 import org.batfish.representation.cisco.CiscoConfiguration;
+import org.batfish.representation.cisco.EigrpProcess;
 import org.batfish.representation.cisco.NetworkObject;
 import org.batfish.representation.cisco.NetworkObjectAddressSpecifier;
 import org.batfish.representation.cisco.NetworkObjectGroupAddressSpecifier;
@@ -732,6 +733,23 @@ public class CiscoGrammarTest {
         ccae,
         hasUndefinedReference(
             filename, NETWORK_OBJECT, "onfake1", EXTENDED_ACCESS_LIST_NETWORK_OBJECT));
+  }
+
+  @Test
+  public void testAsaEigrpNetwork() {
+    CiscoConfiguration config = parseCiscoConfig("asa-eigrp", ConfigurationFormat.CISCO_ASA);
+
+    // ASN is 1
+    EigrpProcess eigrpProcess = config.getDefaultVrf().getEigrpProcesses().get(1L);
+    assertThat(eigrpProcess.getWildcardNetworks(), contains(new IpWildcard("10.0.0.0/24")));
+  }
+
+  @Test
+  public void testAsaEigrpPassive() throws IOException {
+    Configuration config = parseConfig("asa-eigrp");
+
+    assertThat(
+        config, hasInterface("inside", hasEigrp(EigrpInterfaceSettingsMatchers.hasPassive(true))));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/asa-eigrp
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/asa-eigrp
@@ -1,0 +1,13 @@
+! This is an ASA device.
+ASA Version 9.9
+!
+hostname asa-eigrp
+!
+interface GigabitEthernet0/1
+ nameif inside
+ ip address 10.0.0.1 255.255.255.0
+!
+router eigrp 1
+ network 10.0.0.0 255.255.255.0
+ passive-interface inside
+!


### PR DESCRIPTION
EIGRP network masks on ASA are inverted as compared to EIGRP on IOS. Similar to OSPF.

'passive-interface' is configured with interface aliases instead of canonical interface names on ASA.

@dhalperi 