### PR TITLE
New BDD reachability states for ARP failure dispositions.

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
@@ -853,7 +853,6 @@ public final class BDDReachabilityAnalysisFactory {
               return nodeEntry.getValue().getVrfs().entrySet().stream()
                   .flatMap(
                       vrfEntry -> {
-                        String vrf = vrfEntry.getKey();
                         StateExpr postState = new NodeDropAclOut(node);
                         return vrfEntry.getValue().getInterfaces().values().stream()
                             .filter(iface -> iface.getOutgoingFilterName() != null)

--- a/projects/batfish/src/main/java/org/batfish/z3/state/PreOutInterfaceDeliveredToSubnet.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/state/PreOutInterfaceDeliveredToSubnet.java
@@ -1,13 +1,12 @@
 package org.batfish.z3.state;
 
-import org.batfish.datamodel.FlowDisposition;
 import org.batfish.z3.expr.StateExpr;
 import org.batfish.z3.state.visitors.GenericStateExprVisitor;
 
 /**
  * A {@link StateExpr} for flows being forwarded out an interface with the {@link
- * FlowDisposition#DELIVERED_TO_SUBNET} disposition, before the outgoing ACL(s) or transformation
- * are applied.
+ * org.batfish.datamodel.FlowDisposition#DELIVERED_TO_SUBNET} disposition, before the outgoing
+ * ACL(s) or transformation are applied.
  */
 public final class PreOutInterfaceDeliveredToSubnet extends StateExpr {
   private final String _hostname;

--- a/projects/batfish/src/main/java/org/batfish/z3/state/PreOutInterfaceDeliveredToSubnet.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/state/PreOutInterfaceDeliveredToSubnet.java
@@ -1,0 +1,39 @@
+package org.batfish.z3.state;
+
+import org.batfish.datamodel.FlowDisposition;
+import org.batfish.z3.expr.StateExpr;
+import org.batfish.z3.state.visitors.GenericStateExprVisitor;
+
+/**
+ * A {@link StateExpr} for flows being forwarded out an interface with the {@link
+ * FlowDisposition#DELIVERED_TO_SUBNET} disposition, before the outgoing ACL(s) or transformation
+ * are applied.
+ */
+public final class PreOutInterfaceDeliveredToSubnet extends StateExpr {
+  private final String _hostname;
+  private final String _interface;
+
+  public PreOutInterfaceDeliveredToSubnet(String hostname, String iface) {
+    _hostname = hostname;
+    _interface = iface;
+  }
+
+  @Override
+  public <R> R accept(GenericStateExprVisitor<R> visitor) {
+    return visitor.visitPreOutInterfaceDeliveredToSubnet(this);
+  }
+
+  @Override
+  public State getState() {
+    throw new UnsupportedOperationException(
+        "PreOutInterfaceDeliveredToSubnet is unused in NOD reachability");
+  }
+
+  public String getHostname() {
+    return _hostname;
+  }
+
+  public String getInterface() {
+    return _interface;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/z3/state/PreOutInterfaceExitsNetwork.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/state/PreOutInterfaceExitsNetwork.java
@@ -1,13 +1,12 @@
 package org.batfish.z3.state;
 
-import org.batfish.datamodel.FlowDisposition;
 import org.batfish.z3.expr.StateExpr;
 import org.batfish.z3.state.visitors.GenericStateExprVisitor;
 
 /**
  * A {@link StateExpr} for flows being forwarded out an interface with the {@link
- * FlowDisposition#EXITS_NETWORK} disposition, before the outgoing ACL(s) or transformation are
- * applied.
+ * org.batfish.datamodel.FlowDisposition#EXITS_NETWORK} disposition, before the outgoing ACL(s) or
+ * transformation are applied.
  */
 public final class PreOutInterfaceExitsNetwork extends StateExpr {
   private final String _hostname;

--- a/projects/batfish/src/main/java/org/batfish/z3/state/PreOutInterfaceExitsNetwork.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/state/PreOutInterfaceExitsNetwork.java
@@ -1,0 +1,39 @@
+package org.batfish.z3.state;
+
+import org.batfish.datamodel.FlowDisposition;
+import org.batfish.z3.expr.StateExpr;
+import org.batfish.z3.state.visitors.GenericStateExprVisitor;
+
+/**
+ * A {@link StateExpr} for flows being forwarded out an interface with the {@link
+ * FlowDisposition#EXITS_NETWORK} disposition, before the outgoing ACL(s) or transformation are
+ * applied.
+ */
+public final class PreOutInterfaceExitsNetwork extends StateExpr {
+  private final String _hostname;
+  private final String _interface;
+
+  public PreOutInterfaceExitsNetwork(String hostname, String iface) {
+    _hostname = hostname;
+    _interface = iface;
+  }
+
+  @Override
+  public <R> R accept(GenericStateExprVisitor<R> visitor) {
+    return visitor.visitPreOutInterfaceExitsNetwork(this);
+  }
+
+  @Override
+  public State getState() {
+    throw new UnsupportedOperationException(
+        "PreOutInterfaceExitsNetwork is unused in NOD reachability");
+  }
+
+  public String getHostname() {
+    return _hostname;
+  }
+
+  public String getInterface() {
+    return _interface;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/z3/state/PreOutInterfaceInsufficientInfo.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/state/PreOutInterfaceInsufficientInfo.java
@@ -1,13 +1,12 @@
 package org.batfish.z3.state;
 
-import org.batfish.datamodel.FlowDisposition;
 import org.batfish.z3.expr.StateExpr;
 import org.batfish.z3.state.visitors.GenericStateExprVisitor;
 
 /**
  * A {@link StateExpr} for flows being forwarded out an interface with the {@link
- * FlowDisposition#INSUFFICIENT_INFO} disposition, before the outgoing ACL(s) or transformation are
- * applied.
+ * org.batfish.datamodel.FlowDisposition#INSUFFICIENT_INFO} disposition, before the outgoing ACL(s)
+ * or transformation are applied.
  */
 public final class PreOutInterfaceInsufficientInfo extends StateExpr {
   private final String _hostname;

--- a/projects/batfish/src/main/java/org/batfish/z3/state/PreOutInterfaceInsufficientInfo.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/state/PreOutInterfaceInsufficientInfo.java
@@ -1,0 +1,39 @@
+package org.batfish.z3.state;
+
+import org.batfish.datamodel.FlowDisposition;
+import org.batfish.z3.expr.StateExpr;
+import org.batfish.z3.state.visitors.GenericStateExprVisitor;
+
+/**
+ * A {@link StateExpr} for flows being forwarded out an interface with the {@link
+ * FlowDisposition#INSUFFICIENT_INFO} disposition, before the outgoing ACL(s) or transformation are
+ * applied.
+ */
+public final class PreOutInterfaceInsufficientInfo extends StateExpr {
+  private final String _hostname;
+  private final String _interface;
+
+  public PreOutInterfaceInsufficientInfo(String hostname, String iface) {
+    _hostname = hostname;
+    _interface = iface;
+  }
+
+  @Override
+  public <R> R accept(GenericStateExprVisitor<R> visitor) {
+    return visitor.visitPreOutInterfaceInsufficientInfo(this);
+  }
+
+  @Override
+  public State getState() {
+    throw new UnsupportedOperationException(
+        "PreOutInterfaceInsufficientInfo is unused in NOD reachability");
+  }
+
+  public String getHostname() {
+    return _hostname;
+  }
+
+  public String getInterface() {
+    return _interface;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/z3/state/PreOutInterfaceNeighborUnreachable.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/state/PreOutInterfaceNeighborUnreachable.java
@@ -1,13 +1,12 @@
 package org.batfish.z3.state;
 
-import org.batfish.datamodel.FlowDisposition;
 import org.batfish.z3.expr.StateExpr;
 import org.batfish.z3.state.visitors.GenericStateExprVisitor;
 
 /**
  * A {@link StateExpr} for flows being forwarded out an interface with the {@link
- * FlowDisposition#NEIGHBOR_UNREACHABLE} disposition, before the outgoing ACL(s) or transformation
- * are applied.
+ * org.batfish.datamodel.FlowDisposition#NEIGHBOR_UNREACHABLE} disposition, before the outgoing
+ * ACL(s) or transformation are applied.
  */
 public final class PreOutInterfaceNeighborUnreachable extends StateExpr {
   private final String _hostname;

--- a/projects/batfish/src/main/java/org/batfish/z3/state/PreOutInterfaceNeighborUnreachable.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/state/PreOutInterfaceNeighborUnreachable.java
@@ -1,0 +1,39 @@
+package org.batfish.z3.state;
+
+import org.batfish.datamodel.FlowDisposition;
+import org.batfish.z3.expr.StateExpr;
+import org.batfish.z3.state.visitors.GenericStateExprVisitor;
+
+/**
+ * A {@link StateExpr} for flows being forwarded out an interface with the {@link
+ * FlowDisposition#NEIGHBOR_UNREACHABLE} disposition, before the outgoing ACL(s) or transformation
+ * are applied.
+ */
+public final class PreOutInterfaceNeighborUnreachable extends StateExpr {
+  private final String _hostname;
+  private final String _interface;
+
+  public PreOutInterfaceNeighborUnreachable(String hostname, String iface) {
+    _hostname = hostname;
+    _interface = iface;
+  }
+
+  @Override
+  public <R> R accept(GenericStateExprVisitor<R> visitor) {
+    return visitor.visitPreOutInterfaceNeighborUnreachable(this);
+  }
+
+  @Override
+  public State getState() {
+    throw new UnsupportedOperationException(
+        "PreOutInterfaceNeighborUnreachable is unused in NOD reachability");
+  }
+
+  public String getHostname() {
+    return _hostname;
+  }
+
+  public String getInterface() {
+    return _interface;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/z3/state/visitors/GenericStateExprVisitor.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/state/visitors/GenericStateExprVisitor.java
@@ -43,6 +43,10 @@ import org.batfish.z3.state.PostOutEdge;
 import org.batfish.z3.state.PreInInterface;
 import org.batfish.z3.state.PreOutEdge;
 import org.batfish.z3.state.PreOutEdgePostNat;
+import org.batfish.z3.state.PreOutInterfaceDeliveredToSubnet;
+import org.batfish.z3.state.PreOutInterfaceExitsNetwork;
+import org.batfish.z3.state.PreOutInterfaceInsufficientInfo;
+import org.batfish.z3.state.PreOutInterfaceNeighborUnreachable;
 import org.batfish.z3.state.PreOutVrf;
 import org.batfish.z3.state.Query;
 
@@ -138,6 +142,17 @@ public interface GenericStateExprVisitor<R> {
   R visitPreOutEdge(PreOutEdge preOutEdge);
 
   R visitPreOutEdgePostNat(PreOutEdgePostNat preOutInterface);
+
+  R visitPreOutInterfaceDeliveredToSubnet(
+      PreOutInterfaceDeliveredToSubnet preOutInterfaceDeliveredToSubnet);
+
+  R visitPreOutInterfaceExitsNetwork(PreOutInterfaceExitsNetwork preOutInterfaceExitsNetwork);
+
+  R visitPreOutInterfaceInsufficientInfo(
+      PreOutInterfaceInsufficientInfo preOutInterfaceInsufficientInfo);
+
+  R visitPreOutInterfaceNeighborUnreachable(
+      PreOutInterfaceNeighborUnreachable preOutInterfaceNeighborUnreachable);
 
   R visitTransformation(TransformationExpr transformationExpr);
 

--- a/projects/batfish/src/main/java/org/batfish/z3/state/visitors/Parameterizer.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/state/visitors/Parameterizer.java
@@ -56,6 +56,10 @@ import org.batfish.z3.state.PostOutEdge;
 import org.batfish.z3.state.PreInInterface;
 import org.batfish.z3.state.PreOutEdge;
 import org.batfish.z3.state.PreOutEdgePostNat;
+import org.batfish.z3.state.PreOutInterfaceDeliveredToSubnet;
+import org.batfish.z3.state.PreOutInterfaceExitsNetwork;
+import org.batfish.z3.state.PreOutInterfaceInsufficientInfo;
+import org.batfish.z3.state.PreOutInterfaceNeighborUnreachable;
 import org.batfish.z3.state.PreOutVrf;
 import org.batfish.z3.state.Query;
 import org.batfish.z3.state.StateParameter;
@@ -334,6 +338,37 @@ public class Parameterizer implements GenericStateExprVisitor<List<StateParamete
         new StateParameter(preOutEdgePostNat.getSrcIface(), INTERFACE),
         new StateParameter(preOutEdgePostNat.getDstNode(), NODE),
         new StateParameter(preOutEdgePostNat.getDstIface(), INTERFACE));
+  }
+
+  @Override
+  public List<StateParameter> visitPreOutInterfaceDeliveredToSubnet(
+      PreOutInterfaceDeliveredToSubnet state) {
+    return ImmutableList.of(
+        new StateParameter(state.getHostname(), NODE),
+        new StateParameter(state.getInterface(), INTERFACE));
+  }
+
+  @Override
+  public List<StateParameter> visitPreOutInterfaceExitsNetwork(PreOutInterfaceExitsNetwork state) {
+    return ImmutableList.of(
+        new StateParameter(state.getHostname(), NODE),
+        new StateParameter(state.getInterface(), INTERFACE));
+  }
+
+  @Override
+  public List<StateParameter> visitPreOutInterfaceInsufficientInfo(
+      PreOutInterfaceInsufficientInfo state) {
+    return ImmutableList.of(
+        new StateParameter(state.getHostname(), NODE),
+        new StateParameter(state.getInterface(), INTERFACE));
+  }
+
+  @Override
+  public List<StateParameter> visitPreOutInterfaceNeighborUnreachable(
+      PreOutInterfaceNeighborUnreachable state) {
+    return ImmutableList.of(
+        new StateParameter(state.getHostname(), NODE),
+        new StateParameter(state.getInterface(), INTERFACE));
   }
 
   @Override

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
@@ -791,7 +791,6 @@ public final class BDDReachabilityAnalysisFactoryTest {
                 .build());
 
     HeaderSpaceToBDD toBDD = new HeaderSpaceToBDD(PKT, ImmutableMap.of());
-    IpSpaceToBDD dstToBdd = toBDD.getDstIpSpaceToBdd();
     IpSpaceToBDD srcToBdd = toBDD.getSrcIpSpaceToBdd();
 
     BDD preNatOutAclBdd = toBDD.toBDD(preNatOutAclHeaderSpace);

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
@@ -28,6 +28,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -102,12 +103,17 @@ import org.batfish.z3.state.PostInInterface;
 import org.batfish.z3.state.PreInInterface;
 import org.batfish.z3.state.PreOutEdge;
 import org.batfish.z3.state.PreOutEdgePostNat;
+import org.batfish.z3.state.PreOutInterfaceDeliveredToSubnet;
+import org.batfish.z3.state.PreOutInterfaceExitsNetwork;
+import org.batfish.z3.state.PreOutInterfaceInsufficientInfo;
+import org.batfish.z3.state.PreOutInterfaceNeighborUnreachable;
 import org.batfish.z3.state.PreOutVrf;
 import org.batfish.z3.state.Query;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+/** Tests of {@link BDDReachabilityAnalysisFactory}. */
 public final class BDDReachabilityAnalysisFactoryTest {
   @Rule public TemporaryFolder temp = new TemporaryFolder();
 
@@ -684,6 +690,7 @@ public final class BDDReachabilityAnalysisFactoryTest {
                             .build())
                     .build())
             .build();
+    String ifaceName = iface.getName();
 
     SortedMap<String, Configuration> configurations =
         ImmutableSortedMap.of(config.getHostname(), config);
@@ -698,14 +705,14 @@ public final class BDDReachabilityAnalysisFactoryTest {
         factory.bddReachabilityAnalysis(
             IpSpaceAssignment.builder()
                 .assign(
-                    new InterfaceLinkLocation(config.getHostname(), iface.getName()),
+                    new InterfaceLinkLocation(config.getHostname(), ifaceName),
                     UniverseIpSpace.INSTANCE)
                 .build());
     Edge edge =
         analysis
             .getForwardEdgeMap()
-            .get(new PreOutVrf(config.getHostname(), vrf.getName()))
-            .get(new NodeInterfaceDeliveredToSubnet(config.getHostname(), iface.getName()));
+            .get(new PreOutInterfaceDeliveredToSubnet(config.getHostname(), ifaceName))
+            .get(new NodeInterfaceDeliveredToSubnet(config.getHostname(), ifaceName));
 
     HeaderSpaceToBDD toBDD = new HeaderSpaceToBDD(PKT, ImmutableMap.of());
     BDD preNatAclBdd = toBDD.toBDD(preNatAclHeaderSpace);
@@ -713,14 +720,11 @@ public final class BDDReachabilityAnalysisFactoryTest {
     BDD nat2MatchBdd = toBDD.toBDD(nat2MatchHeaderSpace);
     BDD origSrcIpBdd = toBDD.getSrcIpSpaceToBdd().toBDD(Ip.parse("6.6.6.6"));
     BDD poolIpBdd = toBDD.getSrcIpSpaceToBdd().toBDD(poolIp);
-    BDD routeBdd = toBDD.getDstIpSpaceToBdd().toBDD(Prefix.parse("1.0.0.0/24"));
 
     assertThat(
         edge.traverseForward(origSrcIpBdd),
         equalTo(
-            routeBdd
-                .and(preNatAclBdd)
-                .and(nat1MatchBdd.not().and(nat2MatchBdd).ite(poolIpBdd, origSrcIpBdd))));
+            preNatAclBdd.and(nat1MatchBdd.not().and(nat2MatchBdd).ite(poolIpBdd, origSrcIpBdd))));
   }
 
   @Test
@@ -795,55 +799,72 @@ public final class BDDReachabilityAnalysisFactoryTest {
     BDD natMatchBdd = toBDD.toBDD(natMatchHeaderSpace);
     BDD poolIpBdd = srcToBdd.toBDD(poolIp);
 
-    Map<StateExpr, Edge> preOutVrfOutEdges =
-        analysis.getForwardEdgeMap().get(new PreOutVrf(hostname, vrf.getName()));
-
-    // DeliveredToSubnet
-    Edge edge = preOutVrfOutEdges.get(new NodeInterfaceDeliveredToSubnet(hostname, ifaceName));
-
     BDD origSrcIpBdd = srcToBdd.toBDD(Ip.parse("6.6.6.6"));
-    BDD subnetIp = dstToBdd.toBDD(Ip.parse("1.0.0.1"));
-
-    assertThat(
-        edge.traverseForward(origSrcIpBdd),
-        equalTo(
-            subnetIp
-                .and(preNatOutAclBdd)
-                .and(natMatchBdd.ite(poolIpBdd, origSrcIpBdd).and(postNatOutAclBdd))));
-
-    // ExitsNetwork
-    edge = preOutVrfOutEdges.get(new NodeInterfaceExitsNetwork(hostname, ifaceName));
-    BDD staticRoutePrefixBDD = dstToBdd.toBDD(staticRoutePrefix);
-    assertThat(
-        edge.traverseForward(origSrcIpBdd),
-        equalTo(
-            staticRoutePrefixBDD
-                .and(preNatOutAclBdd)
-                .and(natMatchBdd.ite(poolIpBdd, origSrcIpBdd).and(postNatOutAclBdd))));
-
-    // NeighborUnreachable
-    edge = preOutVrfOutEdges.get(new NodeInterfaceNeighborUnreachable(hostname, ifaceName));
-
-    origSrcIpBdd = srcToBdd.toBDD(Ip.parse("6.6.6.6"));
-    BDD ifaceIp = dstToBdd.toBDD(Ip.parse("1.0.0.0"));
-
-    assertThat(
-        edge.traverseForward(origSrcIpBdd),
-        equalTo(
-            ifaceIp
-                .and(preNatOutAclBdd)
-                .and(natMatchBdd.ite(poolIpBdd, origSrcIpBdd).and(postNatOutAclBdd))));
-
-    // DropAclOut
-    edge = preOutVrfOutEdges.get(new NodeDropAclOut(hostname));
     BDD deniedAfterNat = natMatchBdd.ite(poolIpBdd, origSrcIpBdd).and(postNatOutAclBdd.not());
     BDD deniedBeforeNat = origSrcIpBdd.and(preNatOutAclBdd.not());
-    BDD deniedViaDelivered = subnetIp.and(deniedBeforeNat.or(deniedAfterNat));
-    BDD deniedViaExits = staticRoutePrefixBDD.and(deniedBeforeNat.or(deniedAfterNat));
-    BDD deniedViaNU = ifaceIp.and(deniedBeforeNat.or(deniedAfterNat));
-    assertThat(
-        edge.traverseForward(origSrcIpBdd),
-        equalTo(deniedViaDelivered.or(deniedViaExits).or(deniedViaNU)));
+    BDD dropAclOut = deniedBeforeNat.or(deniedAfterNat);
+
+    // BDD of packets that exit the interface and reach the disposition state.
+    BDD dispositionBdd =
+        preNatOutAclBdd.and(natMatchBdd.ite(poolIpBdd, origSrcIpBdd).and(postNatOutAclBdd));
+
+    Map<StateExpr, Map<StateExpr, Edge>> forwardEdges = analysis.getForwardEdgeMap();
+
+    // DeliveredToSubnet
+    Edge edge =
+        forwardEdges
+            .get(new PreOutInterfaceDeliveredToSubnet(hostname, ifaceName))
+            .get(new NodeInterfaceDeliveredToSubnet(hostname, ifaceName));
+    assertThat(edge.traverseForward(origSrcIpBdd), equalTo(dispositionBdd));
+
+    // ExitsNetwork
+    edge =
+        forwardEdges
+            .get(new PreOutInterfaceExitsNetwork(hostname, ifaceName))
+            .get(new NodeInterfaceExitsNetwork(hostname, ifaceName));
+    assertThat(edge.traverseForward(origSrcIpBdd), equalTo(dispositionBdd));
+
+    // InsufficientInfo
+    edge =
+        forwardEdges
+            .get(new PreOutInterfaceInsufficientInfo(hostname, ifaceName))
+            .get(new NodeInterfaceInsufficientInfo(hostname, ifaceName));
+    assertThat(edge.traverseForward(origSrcIpBdd), equalTo(dispositionBdd));
+
+    // NeighborUnreachable
+    edge =
+        forwardEdges
+            .get(new PreOutInterfaceNeighborUnreachable(hostname, ifaceName))
+            .get(new NodeInterfaceNeighborUnreachable(hostname, ifaceName));
+    assertThat(edge.traverseForward(origSrcIpBdd), equalTo(dispositionBdd));
+
+    // DropAclOut via DeliveredToSubnet
+    edge =
+        forwardEdges
+            .get(new PreOutInterfaceDeliveredToSubnet(hostname, ifaceName))
+            .get(new NodeDropAclOut(hostname));
+    assertEquals(edge.traverseForward(origSrcIpBdd), dropAclOut);
+
+    // DropAclOut via ExitsNetwork
+    edge =
+        forwardEdges
+            .get(new PreOutInterfaceExitsNetwork(hostname, ifaceName))
+            .get(new NodeDropAclOut(hostname));
+    assertEquals(edge.traverseForward(origSrcIpBdd), dropAclOut);
+
+    // DropAclOut via InsufficientInfo
+    edge =
+        forwardEdges
+            .get(new PreOutInterfaceInsufficientInfo(hostname, ifaceName))
+            .get(new NodeDropAclOut(hostname));
+    assertEquals(edge.traverseForward(origSrcIpBdd), dropAclOut);
+
+    // DropAclOut via NeighborUnreachable
+    edge =
+        forwardEdges
+            .get(new PreOutInterfaceNeighborUnreachable(hostname, ifaceName))
+            .get(new NodeDropAclOut(hostname));
+    assertEquals(edge.traverseForward(origSrcIpBdd), dropAclOut);
   }
 
   @Test
@@ -997,7 +1018,7 @@ public final class BDDReachabilityAnalysisFactoryTest {
         analysis
             .getForwardEdgeMap()
             .get(new PreOutVrf(c1.getHostname(), v1.getName()))
-            .get(new NodeInterfaceExitsNetwork(c1.getHostname(), i1.getName()));
+            .get(new PreOutInterfaceExitsNetwork(c1.getHostname(), i1.getName()));
 
     HeaderSpaceToBDD toBDD = new HeaderSpaceToBDD(PKT, ImmutableMap.of());
     IpSpaceToBDD dstToBdd = toBDD.getDstIpSpaceToBdd();
@@ -1010,7 +1031,7 @@ public final class BDDReachabilityAnalysisFactoryTest {
         analysis
             .getForwardEdgeMap()
             .get(new PreOutVrf(c1.getHostname(), v1.getName()))
-            .get(new NodeInterfaceInsufficientInfo(c1.getHostname(), i1.getName()));
+            .get(new PreOutInterfaceInsufficientInfo(c1.getHostname(), i1.getName()));
 
     assertThat(edgeII, nullValue());
   }
@@ -1080,7 +1101,7 @@ public final class BDDReachabilityAnalysisFactoryTest {
         analysis
             .getForwardEdgeMap()
             .get(new PreOutVrf(c1.getHostname(), v1.getName()))
-            .get(new NodeInterfaceInsufficientInfo(c1.getHostname(), i1.getName()));
+            .get(new PreOutInterfaceInsufficientInfo(c1.getHostname(), i1.getName()));
 
     HeaderSpaceToBDD toBDD = new HeaderSpaceToBDD(PKT, ImmutableMap.of());
     IpSpaceToBDD dstToBdd = toBDD.getDstIpSpaceToBdd();
@@ -1093,7 +1114,7 @@ public final class BDDReachabilityAnalysisFactoryTest {
         analysis
             .getForwardEdgeMap()
             .get(new PreOutVrf(c1.getHostname(), v1.getName()))
-            .get(new NodeInterfaceExitsNetwork(c1.getHostname(), i1.getName()));
+            .get(new PreOutInterfaceExitsNetwork(c1.getHostname(), i1.getName()));
 
     assertThat(edgeEN.traverseForward(resultBDD), equalTo(PKT.getFactory().zero()));
   }

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisTest.java
@@ -9,7 +9,6 @@ import static org.batfish.bddreachability.TestNetwork.DST_PREFIX_2;
 import static org.batfish.bddreachability.TestNetwork.LINK_1_NETWORK;
 import static org.batfish.bddreachability.TestNetwork.LINK_2_NETWORK;
 import static org.batfish.bddreachability.TestNetwork.POST_SOURCE_NAT_ACL_DEST_PORT;
-import static org.batfish.bddreachability.TestNetwork.SOURCE_NAT_ACL_IP;
 import static org.batfish.common.bdd.BDDMatchers.intersects;
 import static org.batfish.common.bdd.BDDMatchers.isOne;
 import static org.batfish.common.bdd.BDDMatchers.isZero;
@@ -65,6 +64,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+/** Tests of {@link BDDReachabilityAnalysis}. */
 public final class BDDReachabilityAnalysisTest {
   @Rule public TemporaryFolder temp = new TemporaryFolder();
 
@@ -104,7 +104,6 @@ public final class BDDReachabilityAnalysisTest {
   private String _link2DstName;
 
   private BDD _link2SrcIpBDD;
-  private BDD _srcNatAclIpBDD;
 
   private String _srcName;
   private NodeAccept _srcNodeAccept;
@@ -181,7 +180,6 @@ public final class BDDReachabilityAnalysisTest {
         new PreOutEdgePostNat(_srcName, _net._link1Src.getName(), _dstName, _link1DstName);
     _srcPreOutEdgePostNat2 = new PreOutEdgePostNat(_srcName, link2SrcName, _dstName, _link2DstName);
     _srcPreOutVrf = new PreOutVrf(_srcName, DEFAULT_VRF_NAME);
-    _srcNatAclIpBDD = srcIpBDD(SOURCE_NAT_ACL_IP);
   }
 
   private List<Ip> bddIps(BDD bdd) {
@@ -206,10 +204,6 @@ public final class BDDReachabilityAnalysisTest {
 
   private static BDD dstIpBDD(Ip ip) {
     return new IpSpaceToBDD(PKT.getDstIp()).toBDD(ip);
-  }
-
-  private static BDD srcIpBDD(Ip ip) {
-    return new IpSpaceToBDD(PKT.getSrcIp()).toBDD(ip);
   }
 
   private static BDD dstPortBDD(int destPort) {

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
@@ -51,13 +52,13 @@ import org.batfish.z3.state.NodeDropNullRoute;
 import org.batfish.z3.state.NodeInterfaceDeliveredToSubnet;
 import org.batfish.z3.state.NodeInterfaceExitsNetwork;
 import org.batfish.z3.state.NodeInterfaceInsufficientInfo;
-import org.batfish.z3.state.NodeInterfaceNeighborUnreachable;
 import org.batfish.z3.state.OriginateVrf;
 import org.batfish.z3.state.PostInInterface;
 import org.batfish.z3.state.PostInVrf;
 import org.batfish.z3.state.PreInInterface;
 import org.batfish.z3.state.PreOutEdge;
 import org.batfish.z3.state.PreOutEdgePostNat;
+import org.batfish.z3.state.PreOutInterfaceNeighborUnreachable;
 import org.batfish.z3.state.PreOutVrf;
 import org.junit.Before;
 import org.junit.Rule;
@@ -292,19 +293,18 @@ public final class BDDReachabilityAnalysisTest {
     String link2SrcName = _net._link2Src.getName();
     BDD nodeDropNullRoute = bddTransition(_srcPreOutVrf, new NodeDropNullRoute(_srcName));
     BDD nodeInterfaceNeighborUnreachable1 =
-        bddTransition(_srcPreOutVrf, new NodeInterfaceNeighborUnreachable(_srcName, link1SrcName));
+        bddTransition(
+            _srcPreOutVrf, new PreOutInterfaceNeighborUnreachable(_srcName, link1SrcName));
     BDD nodeInterfaceNeighborUnreachable2 =
-        bddTransition(_srcPreOutVrf, new NodeInterfaceNeighborUnreachable(_srcName, link2SrcName));
+        bddTransition(
+            _srcPreOutVrf, new PreOutInterfaceNeighborUnreachable(_srcName, link2SrcName));
     BDD preOutEdge1 = bddTransition(_srcPreOutVrf, _srcPreOutEdge1);
     BDD preOutEdge2 = bddTransition(_srcPreOutVrf, _srcPreOutEdge2);
-    BDD postNatAclBDD = dstPortBDD(POST_SOURCE_NAT_ACL_DEST_PORT);
 
     assertThat(nodeDropNullRoute, isZero());
 
-    assertThat(nodeInterfaceNeighborUnreachable1, equalTo(_link1SrcIpBDD));
-    assertThat(
-        nodeInterfaceNeighborUnreachable2,
-        equalTo(_srcNatAclIpBDD.not().and(_link2SrcIpBDD).and(postNatAclBDD)));
+    assertEquals(nodeInterfaceNeighborUnreachable1, _link1SrcIpBDD);
+    assertEquals(nodeInterfaceNeighborUnreachable2, _link2SrcIpBDD);
 
     assertThat(
         bddIps(preOutEdge1),
@@ -373,17 +373,19 @@ public final class BDDReachabilityAnalysisTest {
     // neighbor unreachable
     assertThat(
         bddTransition(
-            _dstPreOutVrf, new NodeInterfaceNeighborUnreachable(_dstName, _dstIface1Name)),
+            _dstPreOutVrf, new PreOutInterfaceNeighborUnreachable(_dstName, _dstIface1Name)),
         equalTo(_dstIface1IpBDD));
     assertThat(
         bddTransition(
-            _dstPreOutVrf, new NodeInterfaceNeighborUnreachable(_dstName, _dstIface2Name)),
+            _dstPreOutVrf, new PreOutInterfaceNeighborUnreachable(_dstName, _dstIface2Name)),
         equalTo(_dstIface2IpBDD));
     assertThat(
-        bddTransition(_dstPreOutVrf, new NodeInterfaceNeighborUnreachable(_dstName, _link1DstName)),
+        bddTransition(
+            _dstPreOutVrf, new PreOutInterfaceNeighborUnreachable(_dstName, _link1DstName)),
         equalTo(_link1DstIpBDD));
     assertThat(
-        bddTransition(_dstPreOutVrf, new NodeInterfaceNeighborUnreachable(_dstName, _link2DstName)),
+        bddTransition(
+            _dstPreOutVrf, new PreOutInterfaceNeighborUnreachable(_dstName, _link2DstName)),
         equalTo(_link2DstIpBDD));
 
     // insufficient info


### PR DESCRIPTION
Create new states for after we determine that a flow will be forwarded
out an interface leading to an ARP failure disposition, but before the
outgoing filters and transformation have been applied.

This is needed for bidirectional reachability, which needs to know the
flows each transformation is applied to.