### PR TITLE
Remove next hop interface from EIGRP routes

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EigrpExternalRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EigrpExternalRoute.java
@@ -28,14 +28,12 @@ public class EigrpExternalRoute extends EigrpRoute {
       @Nullable Prefix network,
       int admin,
       long destinationAsn,
-      @Nullable String nextHopInterface,
       @Nullable Ip nextHopIp,
       @Nonnull EigrpMetric metric,
       @Nonnull Long processAsn,
       boolean nonForwarding,
       boolean nonRouting) {
-    super(
-        admin, network, nextHopInterface, nextHopIp, metric, processAsn, nonForwarding, nonRouting);
+    super(admin, network, nextHopIp, metric, processAsn, nonForwarding, nonRouting);
     _destinationAsn = destinationAsn;
   }
 
@@ -44,7 +42,6 @@ public class EigrpExternalRoute extends EigrpRoute {
       @Nullable @JsonProperty(PROP_ADMINISTRATIVE_COST) Integer admin,
       @Nullable @JsonProperty(PROP_DESTINATION_ASN) Long destinationAsn,
       @Nullable @JsonProperty(PROP_NETWORK) Prefix network,
-      @Nullable @JsonProperty(PROP_NEXT_HOP_INTERFACE) String nextHopInterface,
       @Nullable @JsonProperty(PROP_NEXT_HOP_IP) Ip nextHopIp,
       @Nullable @JsonProperty(PROP_EIGRP_METRIC) EigrpMetric metric,
       @Nullable @JsonProperty(PROP_PROCESS_ASN) Long processAsn) {
@@ -53,15 +50,7 @@ public class EigrpExternalRoute extends EigrpRoute {
     checkArgument(metric != null, "EIGRP route: missing %s", PROP_EIGRP_METRIC);
     checkArgument(processAsn != null, "EIGRP route: missing %s", PROP_PROCESS_ASN);
     return new EigrpExternalRoute(
-        network,
-        admin,
-        destinationAsn,
-        nextHopInterface,
-        nextHopIp,
-        metric,
-        processAsn,
-        false,
-        false);
+        network, admin, destinationAsn, nextHopIp, metric, processAsn, false, false);
   }
 
   @Override
@@ -77,7 +66,6 @@ public class EigrpExternalRoute extends EigrpRoute {
         && Objects.equals(_destinationAsn, rhs._destinationAsn)
         && Objects.equals(_metric, rhs._metric)
         && Objects.equals(_network, rhs._network)
-        && Objects.equals(_nextHopInterface, rhs._nextHopInterface)
         && Objects.equals(_nextHopIp, rhs._nextHopIp)
         && Objects.equals(_processAsn, rhs._processAsn);
   }
@@ -101,8 +89,7 @@ public class EigrpExternalRoute extends EigrpRoute {
 
   @Override
   public final int hashCode() {
-    return hash(
-        _admin, _destinationAsn, _metric.hashCode(), _network, _nextHopIp, _nextHopInterface);
+    return hash(_admin, _destinationAsn, _metric.hashCode(), _network, _nextHopIp);
   }
 
   public static Builder builder() {
@@ -113,7 +100,6 @@ public class EigrpExternalRoute extends EigrpRoute {
 
     @Nullable private Long _destinationAsn;
     @Nullable private EigrpMetric _eigrpMetric;
-    @Nullable String _nextHopInterface;
     @Nullable Long _processAsn;
 
     private Builder() {}
@@ -128,7 +114,6 @@ public class EigrpExternalRoute extends EigrpRoute {
           getNetwork(),
           getAdmin(),
           _destinationAsn,
-          _nextHopInterface,
           getNextHopIp(),
           requireNonNull(_eigrpMetric),
           _processAsn,
@@ -148,11 +133,6 @@ public class EigrpExternalRoute extends EigrpRoute {
 
     public Builder setEigrpMetric(@Nonnull EigrpMetric metric) {
       _eigrpMetric = metric;
-      return this;
-    }
-
-    public Builder setNextHopInterface(@Nullable String nextHopInterface) {
-      _nextHopInterface = nextHopInterface;
       return this;
     }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EigrpInternalRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EigrpInternalRoute.java
@@ -18,13 +18,11 @@ public class EigrpInternalRoute extends EigrpRoute {
       int admin,
       long processAsn,
       @Nullable Prefix network,
-      @Nullable String nextHopInterface,
       @Nullable Ip nextHopIp,
       @Nonnull EigrpMetric metric,
       boolean nonForwarding,
       boolean nonRouting) {
-    super(
-        admin, network, nextHopInterface, nextHopIp, metric, processAsn, nonForwarding, nonRouting);
+    super(admin, network, nextHopIp, metric, processAsn, nonForwarding, nonRouting);
   }
 
   @JsonCreator
@@ -32,14 +30,12 @@ public class EigrpInternalRoute extends EigrpRoute {
       @Nullable @JsonProperty(PROP_ADMINISTRATIVE_COST) Integer admin,
       @Nullable @JsonProperty(PROP_PROCESS_ASN) Long processAsn,
       @Nullable @JsonProperty(PROP_NETWORK) Prefix network,
-      @Nullable @JsonProperty(PROP_NEXT_HOP_INTERFACE) String nextHopInterface,
       @Nullable @JsonProperty(PROP_NEXT_HOP_IP) Ip nextHopIp,
       @Nullable @JsonProperty(PROP_EIGRP_METRIC) EigrpMetric metric) {
     checkArgument(admin != null, "EIGRP rooute: missing %s", PROP_ADMINISTRATIVE_COST);
     checkArgument(metric != null, "EIGRP route: missing %s", PROP_EIGRP_METRIC);
     checkArgument(processAsn != null, "EIGRP route: missing %s", PROP_PROCESS_ASN);
-    return new EigrpInternalRoute(
-        admin, processAsn, network, nextHopInterface, nextHopIp, metric, false, false);
+    return new EigrpInternalRoute(admin, processAsn, network, nextHopIp, metric, false, false);
   }
 
   public static Builder builder() {
@@ -58,7 +54,6 @@ public class EigrpInternalRoute extends EigrpRoute {
     return _admin == rhs._admin
         && Objects.equals(_metric, rhs._metric)
         && Objects.equals(_network, rhs._network)
-        && Objects.equals(_nextHopInterface, rhs._nextHopInterface)
         && Objects.equals(_nextHopIp, rhs._nextHopIp)
         && Objects.equals(_processAsn, rhs._processAsn);
   }
@@ -75,13 +70,12 @@ public class EigrpInternalRoute extends EigrpRoute {
 
   @Override
   public final int hashCode() {
-    return Objects.hash(_admin, _metric.hashCode(), _network, _nextHopIp, _nextHopInterface);
+    return Objects.hash(_admin, _metric.hashCode(), _network, _nextHopIp);
   }
 
   public static class Builder extends AbstractRouteBuilder<Builder, EigrpInternalRoute> {
 
     @Nullable private EigrpMetric _eigrpMetric;
-    @Nullable String _nextHopInterface;
     @Nullable Long _processAsn;
 
     @Override
@@ -94,7 +88,6 @@ public class EigrpInternalRoute extends EigrpRoute {
           getAdmin(),
           _processAsn,
           getNetwork(),
-          _nextHopInterface,
           getNextHopIp(),
           _eigrpMetric,
           getNonForwarding(),
@@ -108,11 +101,6 @@ public class EigrpInternalRoute extends EigrpRoute {
 
     public Builder setEigrpMetric(@Nonnull EigrpMetric metric) {
       _eigrpMetric = metric;
-      return this;
-    }
-
-    public Builder setNextHopInterface(@Nullable String nextHopInterface) {
-      _nextHopInterface = nextHopInterface;
       return this;
     }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EigrpRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EigrpRoute.java
@@ -19,7 +19,6 @@ public abstract class EigrpRoute extends AbstractRoute {
 
   protected final int _admin;
   @Nonnull protected final EigrpMetric _metric;
-  @Nonnull protected final String _nextHopInterface;
   @Nonnull protected final Ip _nextHopIp;
 
   /** AS number of the EIGRP process that installed this route in the RIB */
@@ -28,7 +27,6 @@ public abstract class EigrpRoute extends AbstractRoute {
   EigrpRoute(
       int admin,
       Prefix network,
-      @Nullable String nextHopInterface,
       @Nullable Ip nextHopIp,
       @Nullable EigrpMetric metric,
       long processAsn,
@@ -38,7 +36,6 @@ public abstract class EigrpRoute extends AbstractRoute {
     checkArgument(metric != null, "Cannot create EIGRP route: missing %s", PROP_EIGRP_METRIC);
     _admin = admin;
     _metric = metric;
-    _nextHopInterface = firstNonNull(nextHopInterface, Route.UNSET_NEXT_HOP_INTERFACE);
     _nextHopIp = firstNonNull(nextHopIp, Route.UNSET_ROUTE_NEXT_HOP_IP);
     _processAsn = processAsn;
   }
@@ -60,11 +57,9 @@ public abstract class EigrpRoute extends AbstractRoute {
   }
 
   @Nonnull
-  @JsonIgnore(false)
-  @JsonProperty(PROP_NEXT_HOP_INTERFACE)
   @Override
   public String getNextHopInterface() {
-    return _nextHopInterface;
+    return Route.UNSET_NEXT_HOP_INTERFACE;
   }
 
   @Nonnull

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualEigrpProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualEigrpProcess.java
@@ -116,7 +116,6 @@ class VirtualEigrpProcess {
                           c.getConfigurationFormat()))
                   .setEigrpMetric(iface.getEigrp().getMetric())
                   .setNetwork(prefix)
-                  .setNextHopInterface(iface.getName())
                   .setProcessAsn(_asn)
                   .build();
           _internalRib.mergeRoute(route);
@@ -252,9 +251,7 @@ class VirtualEigrpProcess {
           EigrpMetric nextHopIntfMetric = nextHopIntf.getEigrp().getMetric();
           EigrpMetric connectingIntfMetric = connectingIntf.getEigrp().getMetric();
 
-          routeBuilder
-              .setNextHopInterface(nextHopIntf.getName())
-              .setNextHopIp(nextHopIntf.getAddress().getIp());
+          routeBuilder.setNextHopIp(nextHopIntf.getAddress().getIp());
           while (queue.peek() != null) {
             RouteAdvertisement<EigrpExternalRoute> routeAdvert = queue.remove();
             EigrpExternalRoute neighborRoute = routeAdvert.getRoute();
@@ -341,7 +338,6 @@ class VirtualEigrpProcess {
               .setAdmin(_defaultInternalAdminCost)
               .setEigrpMetric(newMetric)
               .setNetwork(neighborRoute.getNetwork())
-              .setNextHopInterface(neighborInterface.getName())
               .setNextHopIp(nextHopIp)
               .setProcessAsn(_asn)
               .build();


### PR DESCRIPTION
Next hop interface was being set incorrectly during propagation and is also unnecessary, since EIGRP routes cannot have an independently configured next hop interface.

@dhalperi @progwriter 