### PR TITLE
ExplicitAsPathSet: implement

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsPath.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsPath.java
@@ -18,7 +18,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import org.apache.commons.lang3.StringUtils;
 
 @ParametersAreNonnullByDefault
-public class AsPath implements Serializable, Comparable<AsPath> {
+public final class AsPath implements Serializable, Comparable<AsPath> {
 
   private static final long serialVersionUID = 1L;
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/ExplicitAsPathSet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/ExplicitAsPathSet.java
@@ -5,12 +5,23 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.AsPath;
+import org.batfish.datamodel.BgpRoute;
 import org.batfish.datamodel.routing_policy.Environment;
 
+/**
+ * An {@link AsPathSetExpr} that matches an {@link AsPath} if <em>any</em> of the nested {@link
+ * AsPathSetElem} matches the path.
+ *
+ * <p>Initially added for for IOS-XR, see
+ * https://www.cisco.com/c/en/us/td/docs/routers/crs/software/crs_r4-2/routing/command/reference/b_routing_cr42crs/b_routing_cr42crs_chapter_01000.html#wp1469900877.
+ */
 @ParametersAreNonnullByDefault
 public final class ExplicitAsPathSet extends AsPathSetExpr {
   private static final String PROP_ELEMS = "elems";
@@ -26,8 +37,12 @@ public final class ExplicitAsPathSet extends AsPathSetExpr {
     return new ExplicitAsPathSet(firstNonNull(elems, ImmutableList.of()));
   }
 
-  public ExplicitAsPathSet(List<AsPathSetElem> elems) {
-    _elems = elems;
+  public ExplicitAsPathSet(AsPathSetElem... elems) {
+    this(Arrays.asList(elems));
+  }
+
+  public ExplicitAsPathSet(Iterable<AsPathSetElem> elems) {
+    _elems = ImmutableList.copyOf(elems);
   }
 
   @Override
@@ -49,15 +64,31 @@ public final class ExplicitAsPathSet extends AsPathSetExpr {
 
   @Override
   public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + _elems.hashCode();
-    return result;
+    return _elems.hashCode();
   }
 
   @Override
   public boolean matches(Environment environment) {
-    throw new UnsupportedOperationException("no implementation for generated method");
+    AsPath asPath = null;
+    if (environment.getUseOutputAttributes()
+        && environment.getOutputRoute() instanceof BgpRoute.Builder) {
+      BgpRoute.Builder bgpRouteBuilder = (BgpRoute.Builder) environment.getOutputRoute();
+      asPath = bgpRouteBuilder.getAsPath();
+    } else if (environment.getReadFromIntermediateBgpAttributes()) {
+      asPath = environment.getIntermediateBgpAttributes().getAsPath();
+    } else if (environment.getOriginalRoute() instanceof BgpRoute) {
+      BgpRoute bgpRoute = (BgpRoute) environment.getOriginalRoute();
+      asPath = bgpRoute.getAsPath();
+    }
+    if (asPath == null) {
+      return false;
+    }
+    // TODO: need to validate regexes against complex AS-Paths that contain sets. For now, regexes
+    // will not match against AsPaths for which set components have non-trivial filters.
+    String asPathStr = asPath.getAsPathString();
+    return _elems.stream()
+        .map(AsPathSetElem::regex)
+        .anyMatch(r -> Pattern.compile(r).matcher(asPathStr).find());
   }
 
   public void setElems(List<AsPathSetElem> elems) {

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/ExplicitAsPathSetTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/ExplicitAsPathSetTest.java
@@ -1,0 +1,68 @@
+package org.batfish.datamodel.routing_policy.expr;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.testing.EqualsTester;
+import org.batfish.datamodel.AsPath;
+import org.batfish.datamodel.BgpRoute;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.Configuration.Builder;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.OriginType;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.RoutingProtocol;
+import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.routing_policy.Environment;
+import org.junit.Test;
+
+/** Tests of {@link ExplicitAsPathSet}. */
+public class ExplicitAsPathSetTest {
+  private static Environment buildEnvironment(AsPath path) {
+    NetworkFactory nf = new NetworkFactory();
+    Builder cb = nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.JUNIPER);
+    Configuration c = cb.build();
+    c.setVrfs(
+        ImmutableMap.of(Configuration.DEFAULT_VRF_NAME, new Vrf(Configuration.DEFAULT_VRF_NAME)));
+    return Environment.builder(c)
+        .setOriginalRoute(
+            BgpRoute.builder()
+                .setOriginatorIp(Ip.ZERO)
+                .setOriginType(OriginType.INCOMPLETE)
+                .setProtocol(RoutingProtocol.BGP)
+                .setNetwork(Prefix.ZERO)
+                .setAsPath(path)
+                .build())
+        .build();
+  }
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(
+            new ExplicitAsPathSet(new RegexAsPathSetElem("123")),
+            new ExplicitAsPathSet(new RegexAsPathSetElem("123")))
+        .addEqualityGroup(
+            new ExplicitAsPathSet(new RegexAsPathSetElem("123"), new RegexAsPathSetElem("456")))
+        .addEqualityGroup(new ExplicitAsPathSet(new RegexAsPathSetElem("456")))
+        .testEquals();
+  }
+
+  @Test
+  public void testOperation() {
+    ExplicitAsPathSet expr = new ExplicitAsPathSet(new RegexAsPathSetElem("13$"));
+    assertTrue(expr.matches(buildEnvironment(AsPath.ofSingletonAsSets(13L))));
+    assertTrue(expr.matches(buildEnvironment(AsPath.ofSingletonAsSets(11L, 12L, 13L))));
+    assertTrue(expr.matches(buildEnvironment(AsPath.ofSingletonAsSets(13L, 113L))));
+    assertFalse(expr.matches(buildEnvironment(AsPath.ofSingletonAsSets(11L, 12L, 13L, 14L))));
+
+    expr = new ExplicitAsPathSet(new RegexAsPathSetElem("(^| )13$"));
+    assertTrue(expr.matches(buildEnvironment(AsPath.ofSingletonAsSets(13L))));
+    assertTrue(expr.matches(buildEnvironment(AsPath.ofSingletonAsSets(11L, 12L, 13L))));
+    assertFalse(expr.matches(buildEnvironment(AsPath.ofSingletonAsSets(13L, 113L))));
+    assertFalse(expr.matches(buildEnvironment(AsPath.ofSingletonAsSets(11L, 12L, 13L, 14L))));
+  }
+}


### PR DESCRIPTION
The main use of this class right now is in IOS-XR, which according to
docs is a union.

This is for an open source user who is trying to use juniper as-path. The extraction for that
will come in the next PR, but I didn't want to introduce a crash before implementing.