### PR TITLE
Compute the ranges of reversed transformations

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReverseTransformationRanges.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReverseTransformationRanges.java
@@ -1,0 +1,12 @@
+package org.batfish.bddreachability;
+
+import javax.annotation.Nonnull;
+import net.sf.javabdd.BDD;
+
+interface BDDReverseTransformationRanges {
+  @Nonnull
+  BDD reverseIncomingTransformationRange(String node, String iface);
+
+  @Nonnull
+  BDD reverseOutgoingTransformationRange(String node, String iface);
+}

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReverseTransformationRangesImpl.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReverseTransformationRangesImpl.java
@@ -1,0 +1,138 @@
+package org.batfish.bddreachability;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.batfish.common.bdd.BDDUtils.swapPairing;
+
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multimap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import net.sf.javabdd.BDD;
+import net.sf.javabdd.BDDPairing;
+import org.batfish.common.bdd.BDDPacket;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.IpAccessList;
+import org.batfish.datamodel.collections.NodeInterfacePair;
+import org.batfish.z3.expr.StateExpr;
+import org.batfish.z3.state.PreInInterface;
+
+/** Implemention of valid ranges (outputs) of reversed transformations (for reverse flows). */
+final class BDDReverseTransformationRangesImpl implements BDDReverseTransformationRanges {
+  private final Map<String, Configuration> _configs;
+
+  // null when _ignoreFilters is true.
+  private final @Nullable Map<String, Map<String, BDD>> _forwardFlowFilterBdds;
+  private final Map<StateExpr, BDD> _forwardReachableSets;
+  private final Map<NodeInterfacePair, BDD> _incomingCache;
+  private final Map<NodeInterfacePair, BDD> _outgoingCache;
+
+  /**
+   * The StateExprs that collectively whose reachable sets (unioned together) define the range of a
+   * reversed outgoing transformation.
+   */
+  private final Multimap<NodeInterfacePair, StateExpr> _outgoingTransformationRangeStates;
+
+  /**
+   * A pairing for converting constraints on forward flows to constraints on reverse flows. It swaps
+   * all src/dst variables.
+   */
+  private final BDDPairing _reverseFlowPairing;
+
+  private final BDD _one;
+  private final BDD _zero;
+
+  public BDDReverseTransformationRangesImpl(
+      Map<String, Configuration> configs,
+      Map<StateExpr, BDD> forwardReachableSets,
+      BDDPacket bddPacket,
+      @Nullable Map<String, Map<String, BDD>> forwardFlowFilterBdds) {
+    _configs = configs;
+    _forwardReachableSets = forwardReachableSets;
+    _forwardFlowFilterBdds = forwardFlowFilterBdds;
+    _incomingCache = new HashMap<>();
+    _outgoingCache = new HashMap<>();
+    _outgoingTransformationRangeStates =
+        computeOutgoingTransformationRangeStates(forwardReachableSets.keySet());
+    _reverseFlowPairing =
+        swapPairing(
+            bddPacket.getDstIp(), bddPacket.getSrcIp(), //
+            bddPacket.getDstPort(), bddPacket.getSrcPort());
+    _one = bddPacket.getFactory().one();
+    _zero = bddPacket.getFactory().zero();
+  }
+
+  @Override
+  public BDD reverseIncomingTransformationRange(String node, String iface) {
+    return _incomingCache.computeIfAbsent(
+        new NodeInterfacePair(node, iface),
+        k -> computeReverseIncomingTransformationRange(node, iface));
+  }
+
+  @Override
+  public BDD reverseOutgoingTransformationRange(String node, String iface) {
+    return _outgoingCache.computeIfAbsent(
+        new NodeInterfacePair(node, iface), this::computeReverseOutgoingTransformationRange);
+  }
+
+  private BDD computeReverseIncomingTransformationRange(String node, String iface) {
+    /* TODO add an intermediate state after checking ingressAcl but before applying transformation
+     * This would simplify this code, allow us to remove dependency on configs and filter BDDS.
+     */
+    BDD preIn = _forwardReachableSets.getOrDefault(new PreInInterface(node, iface), _zero);
+    BDD inAcl = forwardIncomingFilterFlowBdd(node, iface);
+    return preIn.and(inAcl).replace(_reverseFlowPairing);
+  }
+
+  private BDD forwardIncomingFilterFlowBdd(String hostname, String iface) {
+    if (_forwardFlowFilterBdds == null) {
+      // ignoreFilters
+      return _one;
+    }
+    IpAccessList incomingFilter =
+        _configs.get(hostname).getAllInterfaces().get(iface).getIncomingFilter();
+    return incomingFilter == null
+        ? _one
+        : checkNotNull(_forwardFlowFilterBdds.get(hostname).get(incomingFilter.getName()));
+  }
+
+  private BDD computeReverseOutgoingTransformationRange(NodeInterfacePair iface) {
+    BDD outAcl =
+        forwardPreTransformationOutgoingFilterFlowBdd(iface.getHostname(), iface.getInterface());
+    BDD reach =
+        _outgoingTransformationRangeStates.asMap().getOrDefault(iface, ImmutableSet.of()).stream()
+            .map(_forwardReachableSets::get)
+            .reduce(BDD::or)
+            .orElse(_zero);
+    return reach.and(outAcl).replace(_reverseFlowPairing);
+  }
+
+  private BDD forwardPreTransformationOutgoingFilterFlowBdd(String hostname, String iface) {
+    if (_forwardFlowFilterBdds == null) {
+      // ignoreFilters
+      return _one;
+    }
+    IpAccessList preTransformationOutgoingFilter =
+        _configs.get(hostname).getAllInterfaces().get(iface).getPreTransformationOutgoingFilter();
+    return preTransformationOutgoingFilter == null
+        ? _one
+        : checkNotNull(
+            _forwardFlowFilterBdds.get(hostname).get(preTransformationOutgoingFilter.getName()));
+  }
+
+  /** TODO: this currently only includes PreOutEdge states */
+  private static Multimap<NodeInterfacePair, StateExpr> computeOutgoingTransformationRangeStates(
+      Set<StateExpr> states) {
+    ImmutableMultimap.Builder<NodeInterfacePair, StateExpr> builder = ImmutableMultimap.builder();
+    states.forEach(
+        state -> {
+          NodeInterfacePair outIface = state.accept(PreOutgoingTransformationNodeVisitor.INSTANCE);
+          if (outIface != null) {
+            builder.put(outIface, state);
+          }
+        });
+    return builder.build();
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/PreOutgoingTransformationNodeVisitor.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/PreOutgoingTransformationNodeVisitor.java
@@ -1,0 +1,328 @@
+package org.batfish.bddreachability;
+
+import org.batfish.datamodel.collections.NodeInterfacePair;
+import org.batfish.z3.expr.TransformationExpr;
+import org.batfish.z3.expr.TransformationStepExpr;
+import org.batfish.z3.state.Accept;
+import org.batfish.z3.state.AclDeny;
+import org.batfish.z3.state.AclLineIndependentMatch;
+import org.batfish.z3.state.AclLineMatch;
+import org.batfish.z3.state.AclLineNoMatch;
+import org.batfish.z3.state.AclPermit;
+import org.batfish.z3.state.Debug;
+import org.batfish.z3.state.DeliveredToSubnet;
+import org.batfish.z3.state.Drop;
+import org.batfish.z3.state.DropAcl;
+import org.batfish.z3.state.DropAclIn;
+import org.batfish.z3.state.DropAclOut;
+import org.batfish.z3.state.DropNoRoute;
+import org.batfish.z3.state.DropNullRoute;
+import org.batfish.z3.state.ExitsNetwork;
+import org.batfish.z3.state.InsufficientInfo;
+import org.batfish.z3.state.NeighborUnreachable;
+import org.batfish.z3.state.NeighborUnreachableOrExitsNetwork;
+import org.batfish.z3.state.NodeAccept;
+import org.batfish.z3.state.NodeDrop;
+import org.batfish.z3.state.NodeDropAcl;
+import org.batfish.z3.state.NodeDropAclIn;
+import org.batfish.z3.state.NodeDropAclOut;
+import org.batfish.z3.state.NodeDropNoRoute;
+import org.batfish.z3.state.NodeDropNullRoute;
+import org.batfish.z3.state.NodeInterfaceDeliveredToSubnet;
+import org.batfish.z3.state.NodeInterfaceExitsNetwork;
+import org.batfish.z3.state.NodeInterfaceInsufficientInfo;
+import org.batfish.z3.state.NodeInterfaceNeighborUnreachable;
+import org.batfish.z3.state.NodeInterfaceNeighborUnreachableOrExitsNetwork;
+import org.batfish.z3.state.NodeNeighborUnreachableOrExitsNetwork;
+import org.batfish.z3.state.NumberedQuery;
+import org.batfish.z3.state.OriginateInterfaceLink;
+import org.batfish.z3.state.OriginateVrf;
+import org.batfish.z3.state.PostInInterface;
+import org.batfish.z3.state.PostInInterfacePostNat;
+import org.batfish.z3.state.PostInVrf;
+import org.batfish.z3.state.PostOutEdge;
+import org.batfish.z3.state.PreInInterface;
+import org.batfish.z3.state.PreOutEdge;
+import org.batfish.z3.state.PreOutEdgePostNat;
+import org.batfish.z3.state.PreOutInterfaceDeliveredToSubnet;
+import org.batfish.z3.state.PreOutInterfaceExitsNetwork;
+import org.batfish.z3.state.PreOutInterfaceInsufficientInfo;
+import org.batfish.z3.state.PreOutInterfaceNeighborUnreachable;
+import org.batfish.z3.state.PreOutVrf;
+import org.batfish.z3.state.Query;
+import org.batfish.z3.state.visitors.GenericStateExprVisitor;
+
+/**
+ * If the input node occurs right before an outgoing transformation is applied (possibly with an
+ * intermediate ACL), return the node/interface of that transformation. Otherwise, return null.
+ */
+public class PreOutgoingTransformationNodeVisitor
+    implements GenericStateExprVisitor<NodeInterfacePair> {
+  public static final PreOutgoingTransformationNodeVisitor INSTANCE =
+      new PreOutgoingTransformationNodeVisitor();
+
+  private PreOutgoingTransformationNodeVisitor() {}
+
+  @Override
+  public NodeInterfacePair castToGenericStateExprVisitorReturnType(Object o) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitAccept(Accept accept) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitAclDeny(AclDeny aclDeny) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitAclLineIndependentMatch(
+      AclLineIndependentMatch aclLineIndependentMatch) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitAclLineMatch(AclLineMatch aclLineMatch) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitAclLineNoMatch(AclLineNoMatch aclLineNoMatch) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitAclPermit(AclPermit aclPermit) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitDebug(Debug debug) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitDrop(Drop drop) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitDropAcl(DropAcl dropAcl) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitDropAclIn(DropAclIn dropAclIn) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitDropAclOut(DropAclOut dropAclOut) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitDropNoRoute(DropNoRoute dropNoRoute) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitDropNullRoute(DropNullRoute dropNullRoute) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitExitsNetwork(ExitsNetwork exitsNetwork) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitDeliveredToSubnet(DeliveredToSubnet deliveredToSubnet) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitInsufficientInfo(InsufficientInfo insufficientInfo) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitNeighborUnreachable(NeighborUnreachable neighborUnreachable) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitNeighborUnreachableOrExitsNetwork(
+      NeighborUnreachableOrExitsNetwork neighborUnreachableOrExitsNetwork) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitNodeAccept(NodeAccept nodeAccept) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitNodeDrop(NodeDrop nodeDrop) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitNodeDropAcl(NodeDropAcl nodeDropAcl) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitNodeDropAclIn(NodeDropAclIn nodeDropAclIn) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitNodeDropAclOut(NodeDropAclOut nodeDropAclOut) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitNodeDropNoRoute(NodeDropNoRoute nodeDropNoRoute) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitNodeDropNullRoute(NodeDropNullRoute nodeDropNullRoute) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitNodeInterfaceDeliveredToSubnet(
+      NodeInterfaceDeliveredToSubnet nodeInterfaceDeliveredToSubnet) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitNodeInterfaceExitsNetwork(
+      NodeInterfaceExitsNetwork nodeInterfaceExitsNetwork) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitNodeInterfaceInsufficientInfo(
+      NodeInterfaceInsufficientInfo nodeInterfaceInsufficientInfo) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitNodeInterfaceNeighborUnreachable(
+      NodeInterfaceNeighborUnreachable nodeInterfaceNeighborUnreachable) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitNodeInterfaceNeighborUnreachableOrExitsNetwork(
+      NodeInterfaceNeighborUnreachableOrExitsNetwork nodeNeighborUnreachable) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitNodeNeighborUnreachableOrExitsNetwork(
+      NodeNeighborUnreachableOrExitsNetwork nodeNeighborUnreachableOrExitsNetwork) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitNumberedQuery(NumberedQuery numberedQuery) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitOriginateInterfaceLink(
+      OriginateInterfaceLink originateInterfaceLink) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitOriginateVrf(OriginateVrf originateVrf) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitPostInInterface(PostInInterface postInInterface) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitPostInInterfacePostNat(
+      PostInInterfacePostNat postInInterfacePostNat) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitPostInVrf(PostInVrf postInVrf) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitPostOutEdge(PostOutEdge preOutInterface) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitPreInInterface(PreInInterface preInInterface) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitPreOutVrf(PreOutVrf preOutVrf) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitPreOutEdge(PreOutEdge preOutEdge) {
+    return new NodeInterfacePair(preOutEdge.getSrcNode(), preOutEdge.getSrcIface());
+  }
+
+  @Override
+  public NodeInterfacePair visitPreOutEdgePostNat(PreOutEdgePostNat preOutInterface) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitPreOutInterfaceDeliveredToSubnet(
+      PreOutInterfaceDeliveredToSubnet state) {
+    return new NodeInterfacePair(state.getHostname(), state.getInterface());
+  }
+
+  @Override
+  public NodeInterfacePair visitPreOutInterfaceExitsNetwork(PreOutInterfaceExitsNetwork state) {
+    return new NodeInterfacePair(state.getHostname(), state.getInterface());
+  }
+
+  @Override
+  public NodeInterfacePair visitPreOutInterfaceInsufficientInfo(
+      PreOutInterfaceInsufficientInfo state) {
+    return new NodeInterfacePair(state.getHostname(), state.getInterface());
+  }
+
+  @Override
+  public NodeInterfacePair visitPreOutInterfaceNeighborUnreachable(
+      PreOutInterfaceNeighborUnreachable state) {
+    return new NodeInterfacePair(state.getHostname(), state.getInterface());
+  }
+
+  @Override
+  public NodeInterfacePair visitTransformation(TransformationExpr transformationExpr) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitTransformationStep(TransformationStepExpr transformationStepExpr) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitQuery(Query query) {
+    return null;
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReverseTransformationRangesImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReverseTransformationRangesImplTest.java
@@ -1,0 +1,160 @@
+package org.batfish.bddreachability;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import net.sf.javabdd.BDD;
+import org.batfish.common.bdd.BDDPacket;
+import org.batfish.common.bdd.HeaderSpaceToBDD;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.HeaderSpace;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpAccessList;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.SubRange;
+import org.batfish.datamodel.Vrf;
+import org.batfish.z3.expr.StateExpr;
+import org.batfish.z3.state.PreInInterface;
+import org.batfish.z3.state.PreOutEdge;
+import org.junit.Before;
+import org.junit.Test;
+
+/** Tests for {@link BDDReverseTransformationRangesImpl}. */
+public class BDDReverseTransformationRangesImplTest {
+  private static final String HOSTNAME = "HOSTNAME";
+
+  private BDDPacket _bddPacket;
+  private Map<String, Configuration> _configs;
+  private Interface.Builder _ib;
+  private HeaderSpaceToBDD _headerSpaceToBDD;
+
+  @Before
+  public void setup() {
+    _bddPacket = new BDDPacket();
+    NetworkFactory nf = new NetworkFactory();
+    Configuration config =
+        nf.configurationBuilder()
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .setHostname(HOSTNAME)
+            .build();
+    Vrf vrf = nf.vrfBuilder().setOwner(config).build();
+    _ib = nf.interfaceBuilder().setOwner(config).setVrf(vrf).setActive(true);
+    _configs = ImmutableMap.of(HOSTNAME, config);
+    _headerSpaceToBDD = new HeaderSpaceToBDD(_bddPacket, ImmutableMap.of());
+  }
+
+  @Test
+  public void testUnreachable() {
+    /* Should get 0 BDD when the transformation was not reached by the forward analysis (i.e. there
+     * is no entry for the corresponding state(s) in the reachability map.
+     */
+
+    Interface iface = _ib.build();
+
+    BDDReverseTransformationRangesImpl ranges =
+        new BDDReverseTransformationRangesImpl(_configs, ImmutableMap.of(), _bddPacket, null);
+
+    assertTrue(ranges.reverseIncomingTransformationRange(HOSTNAME, iface.getName()).isZero());
+    assertTrue(ranges.reverseOutgoingTransformationRange(HOSTNAME, iface.getName()).isZero());
+  }
+
+  @Test
+  public void testIncomingTransformationRange() {
+    Interface iface = _ib.build();
+
+    BDD fwdPreInBdd = _headerSpaceToBDD.getDstIpSpaceToBdd().toBDD(Ip.parse("1.1.1.1"));
+    BDD bwdPreInBdd = _headerSpaceToBDD.getSrcIpSpaceToBdd().toBDD(Ip.parse("1.1.1.1"));
+
+    Map<StateExpr, BDD> forwardReach =
+        ImmutableMap.of(new PreInInterface(HOSTNAME, iface.getName()), fwdPreInBdd);
+
+    // without incoming filter
+    {
+      BDDReverseTransformationRangesImpl ranges =
+          new BDDReverseTransformationRangesImpl(_configs, forwardReach, _bddPacket, null);
+      assertThat(
+          ranges.reverseIncomingTransformationRange(HOSTNAME, iface.getName()),
+          equalTo(bwdPreInBdd));
+    }
+
+    // with incoming filter
+    {
+      String aclName = "ACL";
+      iface.setIncomingFilter(IpAccessList.builder().setName(aclName).build());
+      BDD fwdAclBdd =
+          _headerSpaceToBDD.toBDD(
+              HeaderSpace.builder().setDstPorts(ImmutableList.of(new SubRange(100, 200))).build());
+      BDD bwdAclBdd =
+          _headerSpaceToBDD.toBDD(
+              HeaderSpace.builder().setSrcPorts(ImmutableList.of(new SubRange(100, 200))).build());
+
+      BDDReverseTransformationRangesImpl ranges =
+          new BDDReverseTransformationRangesImpl(
+              _configs,
+              forwardReach,
+              _bddPacket,
+              ImmutableMap.of(HOSTNAME, ImmutableMap.of(aclName, fwdAclBdd)));
+      assertThat(
+          ranges.reverseIncomingTransformationRange(HOSTNAME, iface.getName()),
+          equalTo(bwdPreInBdd.and(bwdAclBdd)));
+    }
+  }
+
+  @Test
+  public void testOutgoingTransformationRange() {
+    Interface iface = _ib.build();
+
+    BDD fwdPreOutEdge1Bdd = _headerSpaceToBDD.getDstIpSpaceToBdd().toBDD(Ip.parse("1.1.1.1"));
+    BDD fwdPreOutEdge2Bdd = _headerSpaceToBDD.getDstIpSpaceToBdd().toBDD(Ip.parse("1.1.1.2"));
+
+    BDD reach =
+        _headerSpaceToBDD
+            .getSrcIpSpaceToBdd()
+            .toBDD(Ip.parse("1.1.1.1"))
+            .or(_headerSpaceToBDD.getSrcIpSpaceToBdd().toBDD(Ip.parse("1.1.1.2")));
+
+    // two out-edges with iface at the head
+    Map<StateExpr, BDD> forwardReach =
+        ImmutableMap.of(
+            new PreOutEdge(HOSTNAME, iface.getName(), "1", "1"),
+            fwdPreOutEdge1Bdd,
+            new PreOutEdge(HOSTNAME, iface.getName(), "2", "2"),
+            fwdPreOutEdge2Bdd);
+
+    // without pre-transformation outgoing filter
+    {
+      BDDReverseTransformationRangesImpl ranges =
+          new BDDReverseTransformationRangesImpl(_configs, forwardReach, _bddPacket, null);
+      assertThat(
+          ranges.reverseOutgoingTransformationRange(HOSTNAME, iface.getName()), equalTo(reach));
+    }
+
+    // with pre-transformation outgoing filter
+    {
+      String aclName = "ACL";
+      iface.setPreTransformationOutgoingFilter(IpAccessList.builder().setName(aclName).build());
+      BDD fwdAclBdd =
+          _headerSpaceToBDD.toBDD(
+              HeaderSpace.builder().setDstPorts(ImmutableList.of(new SubRange(100, 200))).build());
+      BDD bwdAclBdd =
+          _headerSpaceToBDD.toBDD(
+              HeaderSpace.builder().setSrcPorts(ImmutableList.of(new SubRange(100, 200))).build());
+
+      BDDReverseTransformationRangesImpl ranges =
+          new BDDReverseTransformationRangesImpl(
+              _configs,
+              forwardReach,
+              _bddPacket,
+              ImmutableMap.of(HOSTNAME, ImmutableMap.of(aclName, fwdAclBdd)));
+      assertThat(
+          ranges.reverseOutgoingTransformationRange(HOSTNAME, iface.getName()),
+          equalTo(reach.and(bwdAclBdd)));
+    }
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/MockBDDReverseTransformationRanges.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/MockBDDReverseTransformationRanges.java
@@ -1,0 +1,31 @@
+package org.batfish.bddreachability;
+
+import java.util.Map;
+import javax.annotation.Nonnull;
+import net.sf.javabdd.BDD;
+import org.batfish.datamodel.collections.NodeInterfacePair;
+
+final class MockBDDReverseTransformationRanges implements BDDReverseTransformationRanges {
+  private final Map<NodeInterfacePair, BDD> _incomingTransformationRanges;
+  private final Map<NodeInterfacePair, BDD> _outgoingTransformationRanges;
+  private final BDD _zero;
+
+  MockBDDReverseTransformationRanges(
+      BDD zero,
+      Map<NodeInterfacePair, BDD> incomingTransformationRanges,
+      Map<NodeInterfacePair, BDD> outgoingTransformationRanges) {
+    _zero = zero;
+    _incomingTransformationRanges = incomingTransformationRanges;
+    _outgoingTransformationRanges = outgoingTransformationRanges;
+  }
+
+  @Override
+  public @Nonnull BDD reverseIncomingTransformationRange(String node, String iface) {
+    return _incomingTransformationRanges.getOrDefault(new NodeInterfacePair(node, iface), _zero);
+  }
+
+  @Override
+  public @Nonnull BDD reverseOutgoingTransformationRange(String node, String iface) {
+    return _outgoingTransformationRanges.getOrDefault(new NodeInterfacePair(node, iface), _zero);
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/PreOutgoingTransformationNodeVisitorTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/PreOutgoingTransformationNodeVisitorTest.java
@@ -1,0 +1,41 @@
+package org.batfish.bddreachability;
+
+import static org.junit.Assert.assertEquals;
+
+import org.batfish.datamodel.collections.NodeInterfacePair;
+import org.batfish.z3.state.PreOutEdge;
+import org.batfish.z3.state.PreOutInterfaceDeliveredToSubnet;
+import org.batfish.z3.state.PreOutInterfaceExitsNetwork;
+import org.batfish.z3.state.PreOutInterfaceInsufficientInfo;
+import org.batfish.z3.state.PreOutInterfaceNeighborUnreachable;
+import org.junit.Test;
+
+/** Tests for {@link PreOutgoingTransformationNodeVisitor}. */
+public final class PreOutgoingTransformationNodeVisitorTest {
+
+  @Test
+  public void testPreOutgoingTransformationStates() {
+    String node = "node";
+    String iface = "iface";
+
+    assertEquals(
+        new PreOutEdge(node, iface, "", "").accept(PreOutgoingTransformationNodeVisitor.INSTANCE),
+        new NodeInterfacePair(node, iface));
+    assertEquals(
+        new PreOutInterfaceDeliveredToSubnet(node, iface)
+            .accept(PreOutgoingTransformationNodeVisitor.INSTANCE),
+        new NodeInterfacePair(node, iface));
+    assertEquals(
+        new PreOutInterfaceExitsNetwork(node, iface)
+            .accept(PreOutgoingTransformationNodeVisitor.INSTANCE),
+        new NodeInterfacePair(node, iface));
+    assertEquals(
+        new PreOutInterfaceInsufficientInfo(node, iface)
+            .accept(PreOutgoingTransformationNodeVisitor.INSTANCE),
+        new NodeInterfacePair(node, iface));
+    assertEquals(
+        new PreOutInterfaceNeighborUnreachable(node, iface)
+            .accept(PreOutgoingTransformationNodeVisitor.INSTANCE),
+        new NodeInterfacePair(node, iface));
+  }
+}


### PR DESCRIPTION
When we invert a transformation, we need to constrain its range to be
within the input flows we applied to the original (forward)
transformation. Otherwise, applying the reverse transformation will give
us transformed reverse-direction flows that do not correspond to any
forward flow. BDDReverseTransformationRanges computes the range of each
inverted transformation.