### PR TITLE
Construct the reverse flow transformations for sessions with NAT.

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReverseFlowTransformationFactory.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReverseFlowTransformationFactory.java
@@ -1,0 +1,12 @@
+package org.batfish.bddreachability;
+
+import javax.annotation.Nonnull;
+import org.batfish.bddreachability.transition.Transition;
+
+interface BDDReverseFlowTransformationFactory {
+  @Nonnull
+  Transition reverseFlowIncomingTransformation(String hostname, String iface);
+
+  @Nonnull
+  Transition reverseFlowOutgoingTransformation(String hostname, String iface);
+}

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReverseFlowTransformationFactoryImpl.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReverseFlowTransformationFactoryImpl.java
@@ -1,0 +1,91 @@
+package org.batfish.bddreachability;
+
+import static org.batfish.bddreachability.transition.Transitions.IDENTITY;
+import static org.batfish.bddreachability.transition.Transitions.ZERO;
+import static org.batfish.bddreachability.transition.Transitions.compose;
+import static org.batfish.bddreachability.transition.Transitions.constraint;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+import net.sf.javabdd.BDD;
+import org.batfish.bddreachability.transition.TransformationToTransition;
+import org.batfish.bddreachability.transition.Transition;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.collections.NodeInterfacePair;
+import org.batfish.datamodel.transformation.Transformation;
+
+/**
+ * Construct the transformations for return-flow sessions initialized by forward flows. At a high
+ * level, the return-flow transformation is fairly simple: we run the forward transformation
+ * backward except we transformation src fields instead of dest ones, and vice versa. The caveat is
+ * that the transformations are not usually invertible. For instance a transformation might map all
+ * source IPs to a single target source Ip. When we run that backward on the destination IP, we
+ * first select packets for which the single target Ip is the destination Ip, then unset the
+ * destination Ip (effectively allowing the packet to have any destination Ip). This is problematic
+ * because it could (and almost always would) include Ips that could never be transformed in the
+ * forward direction pass. To remedy this, we constrain the output to be within the input of the
+ * forward transformation, taken from a forward reachability analysis (and swapping source and dest
+ * fields, of course).
+ */
+@ParametersAreNonnullByDefault
+class BDDReverseFlowTransformationFactoryImpl implements BDDReverseFlowTransformationFactory {
+  private final Map<String, Configuration> _configs;
+  private final Map<String, TransformationToTransition> _transformationToTransitions;
+  private final BDDReverseTransformationRanges _reverseTransformationRanges;
+
+  // caches
+  private final Map<NodeInterfacePair, Transition> _reverseFlowIncomingTransformations;
+  private final Map<NodeInterfacePair, Transition> _reverseFlowOutgoingTransformations;
+
+  public BDDReverseFlowTransformationFactoryImpl(
+      Map<String, Configuration> configs,
+      Map<String, TransformationToTransition> transformationToTransitions,
+      BDDReverseTransformationRanges reverseTransformationRanges) {
+    _configs = configs;
+    _transformationToTransitions = transformationToTransitions;
+    _reverseTransformationRanges = reverseTransformationRanges;
+    _reverseFlowIncomingTransformations = new HashMap<>();
+    _reverseFlowOutgoingTransformations = new HashMap<>();
+  }
+
+  @Override
+  public @Nonnull Transition reverseFlowIncomingTransformation(String hostname, String iface) {
+    return _reverseFlowIncomingTransformations.computeIfAbsent(
+        new NodeInterfacePair(hostname, iface),
+        k ->
+            computeReverseFlowTransformation(
+                hostname,
+                _configs.get(hostname).getAllInterfaces().get(iface).getIncomingTransformation(),
+                _reverseTransformationRanges.reverseIncomingTransformationRange(hostname, iface)));
+  }
+
+  @Override
+  public @Nonnull Transition reverseFlowOutgoingTransformation(String hostname, String iface) {
+    return _reverseFlowOutgoingTransformations.computeIfAbsent(
+        new NodeInterfacePair(hostname, iface),
+        k ->
+            computeReverseFlowTransformation(
+                hostname,
+                _configs.get(hostname).getAllInterfaces().get(iface).getOutgoingTransformation(),
+                _reverseTransformationRanges.reverseOutgoingTransformationRange(hostname, iface)));
+  }
+
+  private Transition computeReverseFlowTransformation(
+      String hostname, Transformation transformation, BDD validRange) {
+    if (validRange.isZero()) {
+      // nothing reached here in the forward path
+      return ZERO;
+    }
+    TransformationToTransition toTransition = _transformationToTransitions.get(hostname);
+    Transition transformationTransition = toTransition.toReturnFlowTransition(transformation);
+    return transformationTransition == IDENTITY
+        ? IDENTITY
+        : compose(
+            // first apply the transformation
+            transformationTransition,
+            // then make sure it's in the valid range
+            constraint(validRange));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReverseFlowTransformationFactoryImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReverseFlowTransformationFactoryImplTest.java
@@ -347,6 +347,7 @@ public class BDDReverseFlowTransformationFactoryImplTest {
     assertThat(
         "flows natted to pool2 were matched by match1 and match2",
         transition.transitForward(pool2Bdd),
+        // match2Bdd implies matched by match1 and match2
         equalTo(pool2Bdd.and(match1Bdd.not()).or(match2Bdd)));
     assertThat(
         "flows not natted were not matched by match1",
@@ -361,6 +362,7 @@ public class BDDReverseFlowTransformationFactoryImplTest {
     assertThat(
         "flows natted to pool2 were matched by match1 and match2",
         transition.transitForward(pool2Bdd),
+        // match2Bdd implies matched by match1 and match2
         equalTo(pool2Bdd.and(match1Bdd.not()).or(match2Bdd)));
     assertThat(
         "flows not natted were not matched by match1",

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReverseFlowTransformationFactoryImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReverseFlowTransformationFactoryImplTest.java
@@ -1,0 +1,426 @@
+package org.batfish.bddreachability;
+
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDst;
+import static org.batfish.datamodel.transformation.Noop.NOOP_SOURCE_NAT;
+import static org.batfish.datamodel.transformation.Transformation.always;
+import static org.batfish.datamodel.transformation.Transformation.when;
+import static org.batfish.datamodel.transformation.TransformationStep.assignDestinationIp;
+import static org.batfish.datamodel.transformation.TransformationStep.assignSourceIp;
+import static org.batfish.datamodel.transformation.TransformationStep.shiftDestinationIp;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import java.util.Map;
+import net.sf.javabdd.BDD;
+import org.batfish.bddreachability.transition.TransformationToTransition;
+import org.batfish.bddreachability.transition.Transition;
+import org.batfish.bddreachability.transition.Zero;
+import org.batfish.common.bdd.BDDInteger;
+import org.batfish.common.bdd.BDDPacket;
+import org.batfish.common.bdd.BDDSourceManager;
+import org.batfish.common.bdd.HeaderSpaceToBDD;
+import org.batfish.common.bdd.IpAccessListToBddImpl;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpWildcard;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.collections.NodeInterfacePair;
+import org.batfish.datamodel.transformation.Transformation;
+import org.junit.Before;
+import org.junit.Test;
+
+/** Tests for {@link BDDReverseFlowTransformationFactoryImpl}. */
+public class BDDReverseFlowTransformationFactoryImplTest {
+  private static final BDDPacket PKT = new BDDPacket();
+  private static final BDD ONE = PKT.getFactory().one();
+  private static final BDD ZERO = PKT.getFactory().zero();
+
+  private static final String HOSTNAME = "HOSTNAME";
+  private static final String IFACENAME = "INTERFACE";
+  private static final NodeInterfacePair IFACE = new NodeInterfacePair(HOSTNAME, IFACENAME);
+
+  private static final BDDReverseTransformationRanges FULL_REVERSE_TRANSFORMATION_RANGES =
+      new MockBDDReverseTransformationRanges(
+          ZERO, ImmutableMap.of(IFACE, ONE), ImmutableMap.of(IFACE, ONE));
+
+  private Map<String, TransformationToTransition> _transformationToTransitions;
+  private Map<String, Configuration> _configs;
+  private Interface.Builder _ib;
+  private HeaderSpaceToBDD _headerSpaceToBDD;
+
+  @Before
+  public void setup() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration config =
+        nf.configurationBuilder()
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .setHostname(HOSTNAME)
+            .build();
+    Vrf vrf = nf.vrfBuilder().setOwner(config).build();
+    _ib = nf.interfaceBuilder().setOwner(config).setVrf(vrf).setActive(true).setName(IFACENAME);
+    _configs = ImmutableMap.of(HOSTNAME, config);
+    _headerSpaceToBDD = new HeaderSpaceToBDD(PKT, ImmutableMap.of());
+    _transformationToTransitions =
+        ImmutableMap.of(
+            HOSTNAME,
+            new TransformationToTransition(
+                PKT,
+                new IpAccessListToBddImpl(
+                    PKT,
+                    BDDSourceManager.forInterfaces(PKT, ImmutableSet.of()),
+                    _headerSpaceToBDD,
+                    ImmutableMap.of())));
+  }
+
+  private BDD dstBdd(Ip ip) {
+    return _headerSpaceToBDD.getDstIpSpaceToBdd().toBDD(ip);
+  }
+
+  private BDD dstBdd(Ip low, Ip high) {
+    BDDInteger var = _headerSpaceToBDD.getDstIpSpaceToBdd().getBDDInteger();
+    return var.geq(low.asLong()).and(var.leq(high.asLong()));
+  }
+
+  private BDD srcBdd(Ip ip) {
+    return _headerSpaceToBDD.getSrcIpSpaceToBdd().toBDD(ip);
+  }
+
+  private BDD srcBdd(Prefix prefix) {
+    return _headerSpaceToBDD.getSrcIpSpaceToBdd().toBDD(prefix);
+  }
+
+  private BDD srcBdd(IpWildcard ipWildcard) {
+    return _headerSpaceToBDD.getSrcIpSpaceToBdd().toBDD(ipWildcard);
+  }
+
+  @Test
+  public void testNoTransformation() {}
+
+  @Test
+  public void testNoRange() {
+    /* there is an active interface with transformations, but the relevant states were not reached
+     * in the forward pass. The reverse-pass transformations are constant-ZERO transitions.
+     */
+    Transformation transformation = always().build();
+    Interface i =
+        _ib.setIncomingTransformation(transformation)
+            .setOutgoingTransformation(transformation)
+            .build();
+
+    BDDReverseTransformationRanges reverseTransformationRanges =
+        new MockBDDReverseTransformationRanges(ZERO, ImmutableMap.of(), ImmutableMap.of());
+
+    BDDReverseFlowTransformationFactoryImpl factory =
+        new BDDReverseFlowTransformationFactoryImpl(
+            _configs, _transformationToTransitions, reverseTransformationRanges);
+    assertThat(factory.reverseFlowIncomingTransformation(HOSTNAME, i.getName()), is(Zero.INSTANCE));
+    assertThat(factory.reverseFlowOutgoingTransformation(HOSTNAME, i.getName()), is(Zero.INSTANCE));
+  }
+
+  @Test
+  public void testNontrivialRange() {
+    Transformation transformation = always().apply(NOOP_SOURCE_NAT).build();
+    Interface i =
+        _ib.setIncomingTransformation(transformation)
+            .setOutgoingTransformation(transformation)
+            .build();
+    Prefix incomingRangePrefix = Prefix.parse("2.0.0.0/8");
+    Prefix outgoingRangePrefix = Prefix.parse("3.0.0.0/8");
+    BDD incomingRangeBdd = _headerSpaceToBDD.getDstIpSpaceToBdd().toBDD(incomingRangePrefix);
+    BDD outgoingRangeBdd = _headerSpaceToBDD.getDstIpSpaceToBdd().toBDD(outgoingRangePrefix);
+    NodeInterfacePair nodeIface = new NodeInterfacePair(HOSTNAME, i.getName());
+    BDDReverseTransformationRanges reverseTransformationRanges =
+        new MockBDDReverseTransformationRanges(
+            ZERO,
+            ImmutableMap.of(nodeIface, incomingRangeBdd),
+            ImmutableMap.of(nodeIface, outgoingRangeBdd));
+    BDDReverseFlowTransformationFactoryImpl factory =
+        new BDDReverseFlowTransformationFactoryImpl(
+            _configs, _transformationToTransitions, reverseTransformationRanges);
+
+    Transition incomingTransformation =
+        factory.reverseFlowIncomingTransformation(HOSTNAME, i.getName());
+    assertThat(incomingTransformation.transitForward(ONE), equalTo(incomingRangeBdd));
+
+    Transition outgoingTransformation =
+        factory.reverseFlowOutgoingTransformation(HOSTNAME, i.getName());
+    assertThat(outgoingTransformation.transitForward(ONE), equalTo(outgoingRangeBdd));
+  }
+
+  @Test
+  public void testSrcAssignToPool() {
+    Ip poolStart = Ip.parse("1.1.1.1");
+    Ip poolEnd = Ip.parse("1.1.1.5");
+    Transformation transformation = always().apply(assignSourceIp(poolStart, poolEnd)).build();
+    Interface i =
+        _ib.setIncomingTransformation(transformation)
+            .setOutgoingTransformation(transformation)
+            .build();
+    BDDReverseFlowTransformationFactoryImpl factory =
+        new BDDReverseFlowTransformationFactoryImpl(
+            _configs, _transformationToTransitions, FULL_REVERSE_TRANSFORMATION_RANGES);
+    Transition incomingTransformation =
+        factory.reverseFlowIncomingTransformation(HOSTNAME, i.getName());
+
+    BDD poolBdd = dstBdd(poolStart, poolEnd);
+    assertTrue(
+        "Anything might have been natted", incomingTransformation.transitForward(poolBdd).isOne());
+    assertTrue(
+        "If outside the pool, not natted",
+        incomingTransformation.transitForward(poolBdd.not()).isZero());
+
+    Transition outgoingTransformation =
+        factory.reverseFlowOutgoingTransformation(HOSTNAME, i.getName());
+
+    assertThat(
+        "Anything might have been natted",
+        outgoingTransformation.transitForward(poolBdd),
+        equalTo(ONE));
+    assertThat(
+        "If outside the pool, not natted",
+        outgoingTransformation.transitForward(poolBdd.not()),
+        equalTo(ZERO));
+  }
+
+  @Test
+  public void testMatchAndAssignSameField() {
+    Ip matchIp = Ip.parse("255.255.255.255");
+    Ip poolIp = Ip.parse("0.0.0.0");
+    Transformation transformation =
+        when(matchDst(matchIp)).apply(assignDestinationIp(poolIp, poolIp)).build();
+    Interface i =
+        _ib.setIncomingTransformation(transformation)
+            .setOutgoingTransformation(transformation)
+            .build();
+    BDDReverseFlowTransformationFactoryImpl factory =
+        new BDDReverseFlowTransformationFactoryImpl(
+            _configs, _transformationToTransitions, FULL_REVERSE_TRANSFORMATION_RANGES);
+
+    BDD matchBdd = srcBdd(matchIp);
+    BDD poolBdd = srcBdd(poolIp);
+
+    Transition transition = factory.reverseFlowIncomingTransformation(HOSTNAME, i.getName());
+    assertThat(
+        "pool Ip may or may not have been natted.",
+        transition.transitForward(poolBdd),
+        equalTo(matchBdd.or(poolBdd)));
+    assertThat(
+        "If outside the pool, not matched",
+        transition.transitForward(poolBdd.not()),
+        equalTo(poolBdd.not().and(matchBdd.not())));
+  }
+
+  @Test
+  public void testShiftPrefix() {
+    Prefix shiftPrefix = Prefix.parse("1.1.1.0/24");
+    Transformation transformation = always().apply(shiftDestinationIp(shiftPrefix)).build();
+
+    Interface i =
+        _ib.setIncomingTransformation(transformation)
+            .setOutgoingTransformation(transformation)
+            .build();
+
+    BDDReverseFlowTransformationFactoryImpl factory =
+        new BDDReverseFlowTransformationFactoryImpl(
+            _configs, _transformationToTransitions, FULL_REVERSE_TRANSFORMATION_RANGES);
+
+    BDD shiftPrefixBdd = srcBdd(shiftPrefix);
+
+    Transition transition = factory.reverseFlowIncomingTransformation(HOSTNAME, i.getName());
+    assertThat(
+        "everything is mapped to the shift prefix",
+        transition.transitForward(shiftPrefixBdd),
+        equalTo(ONE));
+    assertThat(
+        "nothing is mapped outside the shift prefix",
+        transition.transitForward(shiftPrefixBdd.not()),
+        equalTo(ZERO));
+
+    transition = factory.reverseFlowOutgoingTransformation(HOSTNAME, i.getName());
+    assertThat(
+        "everything is mapped to the shift prefix",
+        transition.transitForward(shiftPrefixBdd),
+        equalTo(ONE));
+    assertThat(
+        "nothing is mapped outside the shift prefix",
+        transition.transitForward(shiftPrefixBdd.not()),
+        equalTo(ZERO));
+  }
+
+  @Test
+  public void testAssignAndMatchSameField() {
+    // match after assigning the same field.
+
+    Ip poolIp = Ip.parse("2.2.2.2");
+    Prefix shiftPrefix = Prefix.parse("1.1.1.0/24");
+    Ip matchIp = Ip.parse("1.1.1.1");
+    Transformation transformation =
+        always()
+            .apply(shiftDestinationIp(shiftPrefix))
+            .setAndThen(when(matchDst(matchIp)).apply(assignDestinationIp(poolIp, poolIp)).build())
+            .build();
+
+    Interface i =
+        _ib.setIncomingTransformation(transformation)
+            .setOutgoingTransformation(transformation)
+            .build();
+
+    BDDReverseFlowTransformationFactoryImpl factory =
+        new BDDReverseFlowTransformationFactoryImpl(
+            _configs, _transformationToTransitions, FULL_REVERSE_TRANSFORMATION_RANGES);
+
+    BDD poolBdd = srcBdd(poolIp);
+    BDD shiftPrefixBdd = srcBdd(shiftPrefix);
+
+    IpWildcard preshiftMatchWildcard =
+        new IpWildcard(Ip.create(0x00000001L), Ip.create(0xFFFFFF00L));
+    BDD preshiftMatchBdd = srcBdd(preshiftMatchWildcard);
+
+    Transition transition = factory.reverseFlowIncomingTransformation(HOSTNAME, i.getName());
+    assertThat(
+        "pool-natted flows were shifted to the matchIp",
+        transition.transitForward(poolBdd),
+        equalTo(preshiftMatchBdd));
+    assertThat(
+        "non-pool-natted flows are everything that doesn't shift to the matchIp",
+        transition.transitForward(shiftPrefixBdd),
+        equalTo(preshiftMatchBdd.not()));
+    assertThat(
+        "range of the forward transformation is the poolIp and the shift prefix",
+        transition.transitForward(poolBdd.or(shiftPrefixBdd).not()),
+        equalTo(ZERO));
+
+    transition = factory.reverseFlowOutgoingTransformation(HOSTNAME, i.getName());
+    assertThat(
+        "pool-natted flows were shifted to the matchIp",
+        transition.transitForward(poolBdd),
+        equalTo(preshiftMatchBdd));
+    assertThat(
+        "non-pool-natted flows are everything that doesn't shift to the matchIp",
+        transition.transitForward(shiftPrefixBdd),
+        equalTo(preshiftMatchBdd.not()));
+    assertThat(
+        "range of the forward transformation is the poolIp and the shift prefix",
+        transition.transitForward(poolBdd.or(shiftPrefixBdd).not()),
+        equalTo(ZERO));
+  }
+
+  @Test
+  public void testAndThen() {
+    Prefix match1Prefix = Prefix.parse("1.0.0.0/8");
+    Prefix match2Prefix = Prefix.parse("1.1.0.0/16");
+    Ip pool1 = Ip.parse("255.255.255.255");
+    Ip pool2 = Ip.parse("0.0.0.0");
+    Transformation transformation =
+        when(matchDst(match1Prefix))
+            .apply(assignSourceIp(pool1, pool1))
+            .setAndThen(when(matchDst(match2Prefix)).apply(assignSourceIp(pool2, pool2)).build())
+            .build();
+
+    Interface i =
+        _ib.setIncomingTransformation(transformation)
+            .setOutgoingTransformation(transformation)
+            .build();
+
+    BDDReverseFlowTransformationFactoryImpl factory =
+        new BDDReverseFlowTransformationFactoryImpl(
+            _configs, _transformationToTransitions, FULL_REVERSE_TRANSFORMATION_RANGES);
+
+    BDD pool1Bdd = dstBdd(pool1);
+    BDD pool2Bdd = dstBdd(pool2);
+    BDD match1Bdd = srcBdd(match1Prefix);
+    BDD match2Bdd = srcBdd(match2Prefix);
+
+    Transition transition = factory.reverseFlowIncomingTransformation(HOSTNAME, i.getName());
+    assertThat(
+        "flows natted to pool1 were matched by match1 but not match2",
+        transition.transitForward(pool1Bdd),
+        equalTo(pool1Bdd.and(match1Bdd.not()).or(match1Bdd.and(match2Bdd.not()))));
+    assertThat(
+        "flows natted to pool2 were matched by match1 and match2",
+        transition.transitForward(pool2Bdd),
+        equalTo(pool2Bdd.and(match1Bdd.not()).or(match2Bdd)));
+    assertThat(
+        "flows not natted were not matched by match1",
+        transition.transitForward(pool1Bdd.or(pool2Bdd).not()),
+        equalTo(pool1Bdd.or(pool2Bdd).not().and(match1Bdd.not())));
+
+    transition = factory.reverseFlowOutgoingTransformation(HOSTNAME, i.getName());
+    assertThat(
+        "flows natted to pool1 were matched by match1 but not match2",
+        transition.transitForward(pool1Bdd),
+        equalTo(pool1Bdd.and(match1Bdd.not()).or(match1Bdd.and(match2Bdd.not()))));
+    assertThat(
+        "flows natted to pool2 were matched by match1 and match2",
+        transition.transitForward(pool2Bdd),
+        equalTo(pool2Bdd.and(match1Bdd.not()).or(match2Bdd)));
+    assertThat(
+        "flows not natted were not matched by match1",
+        transition.transitForward(pool1Bdd.or(pool2Bdd).not()),
+        equalTo(pool1Bdd.or(pool2Bdd).not().and(match1Bdd.not())));
+  }
+
+  @Test
+  public void testOrElse() {
+    Prefix matchPrefix = Prefix.parse("1.0.0.0/8");
+    Ip pool1 = Ip.parse("5.5.5.5");
+    Ip pool2 = Ip.parse("6.6.6.6");
+    Transformation transformation =
+        when(matchDst(matchPrefix))
+            .apply(assignSourceIp(pool1, pool1))
+            .setOrElse(always().apply(assignSourceIp(pool2, pool2)).build())
+            .build();
+
+    Interface i =
+        _ib.setIncomingTransformation(transformation)
+            .setOutgoingTransformation(transformation)
+            .build();
+
+    BDDReverseFlowTransformationFactoryImpl factory =
+        new BDDReverseFlowTransformationFactoryImpl(
+            _configs, _transformationToTransitions, FULL_REVERSE_TRANSFORMATION_RANGES);
+    Transition incomingTransformation =
+        factory.reverseFlowIncomingTransformation(HOSTNAME, i.getName());
+
+    BDD pool1Bdd = dstBdd(pool1);
+    BDD pool2Bdd = dstBdd(pool2);
+    BDD matchBdd = srcBdd(matchPrefix);
+
+    assertThat(
+        "matched flows are natted to pool1",
+        incomingTransformation.transitForward(pool1Bdd),
+        equalTo(matchBdd));
+    assertThat(
+        "unmatched flows are natted to pool2",
+        incomingTransformation.transitForward(pool2Bdd),
+        equalTo(matchBdd.not()));
+    assertThat(
+        "everything is natted to pool1 or pool2",
+        incomingTransformation.transitForward(pool1Bdd.or(pool2Bdd).not()),
+        equalTo(ZERO));
+
+    Transition outgoingTransformation =
+        factory.reverseFlowOutgoingTransformation(HOSTNAME, i.getName());
+
+    assertThat(
+        "matched flows are natted to pool1",
+        outgoingTransformation.transitForward(pool1Bdd),
+        equalTo(matchBdd));
+    assertThat(
+        "unmatched flows are natted to pool2",
+        outgoingTransformation.transitForward(pool2Bdd),
+        equalTo(matchBdd.not()));
+    assertThat(
+        "everything is natted to pool1 or pool2",
+        outgoingTransformation.transitForward(pool1Bdd.or(pool2Bdd).not()),
+        equalTo(ZERO));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/MockBDDReverseFlowTransformationFactory.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/MockBDDReverseFlowTransformationFactory.java
@@ -1,0 +1,38 @@
+package org.batfish.bddreachability;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import org.batfish.bddreachability.transition.Transition;
+import org.batfish.datamodel.collections.NodeInterfacePair;
+
+final class MockBDDReverseFlowTransformationFactory implements BDDReverseFlowTransformationFactory {
+  private final Map<NodeInterfacePair, Transition> _reverseFlowIncomingTransformations;
+  private final Map<NodeInterfacePair, Transition> _reverseFlowOutgoingTransformations;
+
+  MockBDDReverseFlowTransformationFactory(
+      Map<NodeInterfacePair, Transition> reverseFlowIncomingTransformations,
+      Map<NodeInterfacePair, Transition> reverseFlowOutgoingTransformations) {
+    _reverseFlowIncomingTransformations = ImmutableMap.copyOf(reverseFlowIncomingTransformations);
+    _reverseFlowOutgoingTransformations = ImmutableMap.copyOf(reverseFlowOutgoingTransformations);
+  }
+
+  @Nonnull
+  @Override
+  public Transition reverseFlowIncomingTransformation(String hostname, String iface) {
+    return checkNotNull(
+        _reverseFlowIncomingTransformations.get(new NodeInterfacePair(hostname, iface)),
+        "Missing reverseFlowIncomingTransformations entry for %s:%s",
+        hostname,
+        iface);
+  }
+
+  @Nonnull
+  @Override
+  public Transition reverseFlowOutgoingTransformation(String hostname, String iface) {
+    return checkNotNull(
+        _reverseFlowOutgoingTransformations.get(new NodeInterfacePair(hostname, iface)));
+  }
+}


### PR DESCRIPTION
When we setup a session with NAT, the reverse-flow transformation is
determined by the forward-flow transformation (that was applied to the
initiating flow). BDDReverseFlowTransformationFactory creates
BDD reachability Transitions for reverse flow transformations.