### PR TITLE
Simplify traceroute route resolution after #3201

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Fib.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Fib.java
@@ -11,8 +11,13 @@ public interface Fib extends Serializable {
   @Nonnull
   Map<AbstractRoute, Map<String, Map<Ip, Set<AbstractRoute>>>> getNextHopInterfaces();
 
-  /** Set of interfaces used to forward traffic destined to this IP. */
+  /**
+   * Set of interfaces used to forward traffic destined to this IP.
+   *
+   * @deprecated in favor of more general {@link Fib#get(Ip)}
+   */
   @Nonnull
+  @Deprecated
   Set<String> getNextHopInterfaces(Ip ip);
 
   /**
@@ -23,8 +28,11 @@ public interface Fib extends Serializable {
 
   /**
    * Mapping: matching route -&gt; nexthopinterface -&gt; resolved nextHopIP -&gt; interfaceRoutes
+   *
+   * @deprecated in favor of more general {@link Fib#get(Ip)}
    */
   @Nonnull
+  @Deprecated
   Map<AbstractRoute, Map<String, Map<Ip, Set<AbstractRoute>>>> getNextHopInterfacesByRoute(
       Ip dstIp);
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibImpl.java
@@ -280,6 +280,7 @@ public final class FibImpl implements Fib {
   }
 
   @Override
+  @Deprecated
   public @Nonnull Set<String> getNextHopInterfaces(Ip ip) {
     return get(ip).stream().map(FibEntry::getInterfaceName).collect(ImmutableSet.toImmutableSet());
   }
@@ -291,6 +292,7 @@ public final class FibImpl implements Fib {
   }
 
   @Override
+  @Deprecated
   public @Nonnull Map<AbstractRoute, Map<String, Map<Ip, Set<AbstractRoute>>>>
       getNextHopInterfacesByRoute(Ip dstIp) {
     return get(dstIp).stream()

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockFib.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockFib.java
@@ -1,6 +1,9 @@
 package org.batfish.datamodel;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nonnull;
@@ -18,11 +21,14 @@ public class MockFib implements Fib {
 
     private Map<String, Set<AbstractRoute>> _routesByNextHopInterface;
 
+    private Map<Ip, Set<FibEntry>> _fibEntries;
+
     private Builder() {
       _nextHopInterfaces = ImmutableMap.of();
       _nextHopInterfacesByIp = ImmutableMap.of();
       _nextHopInterfacesByRoute = ImmutableMap.of();
       _routesByNextHopInterface = ImmutableMap.of();
+      _fibEntries = ImmutableMap.of();
     }
 
     public MockFib build() {
@@ -35,12 +41,14 @@ public class MockFib implements Fib {
       return this;
     }
 
+    @Deprecated
     public Builder setNextHopInterfacesByIp(
         @Nonnull Map<Ip, Map<String, Map<Ip, Set<AbstractRoute>>>> nextHopInterfacesByIp) {
       _nextHopInterfacesByIp = nextHopInterfacesByIp;
       return this;
     }
 
+    @Deprecated
     public Builder setNextHopInterfacesByRoute(
         @Nonnull
             Map<Ip, Map<AbstractRoute, Map<String, Map<Ip, Set<AbstractRoute>>>>>
@@ -52,6 +60,11 @@ public class MockFib implements Fib {
     public Builder setRoutesByNextHopInterface(
         @Nonnull Map<String, Set<AbstractRoute>> routesByNextHopInterface) {
       _routesByNextHopInterface = routesByNextHopInterface;
+      return this;
+    }
+
+    public Builder setFibEntries(@Nonnull Map<Ip, Set<FibEntry>> fibEntries) {
+      _fibEntries = fibEntries;
       return this;
     }
   }
@@ -72,11 +85,14 @@ public class MockFib implements Fib {
 
   private final Map<String, Set<AbstractRoute>> _routesByNextHopInterface;
 
+  private Map<Ip, Set<FibEntry>> _fibEntries;
+
   private MockFib(Builder builder) {
     _nextHopInterfaces = ImmutableMap.copyOf(builder._nextHopInterfaces);
     _nextHopInterfacesByIp = ImmutableMap.copyOf(builder._nextHopInterfacesByIp);
     _nextHopInterfacesByRoute = ImmutableMap.copyOf(builder._nextHopInterfacesByRoute);
     _routesByNextHopInterface = ImmutableMap.copyOf(builder._routesByNextHopInterface);
+    _fibEntries = ImmutableMap.copyOf(builder._fibEntries);
   }
 
   @Override
@@ -86,6 +102,7 @@ public class MockFib implements Fib {
   }
 
   @Override
+  @Deprecated
   public @Nonnull Set<String> getNextHopInterfaces(Ip ip) {
     return _nextHopInterfacesByIp.getOrDefault(ip, ImmutableMap.of()).keySet();
   }
@@ -93,10 +110,11 @@ public class MockFib implements Fib {
   @Nonnull
   @Override
   public Set<FibEntry> get(Ip ip) {
-    throw new UnsupportedOperationException();
+    return firstNonNull(_fibEntries.get(ip), ImmutableSet.of());
   }
 
   @Override
+  @Deprecated
   public @Nonnull Map<AbstractRoute, Map<String, Map<Ip, Set<AbstractRoute>>>>
       getNextHopInterfacesByRoute(Ip dstIp) {
     return _nextHopInterfacesByRoute.get(dstIp);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/FibEntryMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/FibEntryMatchers.java
@@ -1,0 +1,15 @@
+package org.batfish.datamodel.matchers;
+
+import static org.hamcrest.Matchers.equalTo;
+
+import org.batfish.datamodel.FibEntry;
+import org.batfish.datamodel.matchers.FibEntryMatchersImpl.HasInterface;
+
+/** Matchers for {@link FibEntry} */
+public final class FibEntryMatchers {
+  public static HasInterface hasInterface(String interfaceName) {
+    return new HasInterface(equalTo(interfaceName));
+  }
+
+  private FibEntryMatchers() {}
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/FibEntryMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/FibEntryMatchersImpl.java
@@ -1,0 +1,22 @@
+package org.batfish.datamodel.matchers;
+
+import org.batfish.datamodel.FibEntry;
+import org.hamcrest.FeatureMatcher;
+import org.hamcrest.Matcher;
+
+final class FibEntryMatchersImpl {
+
+  static final class HasInterface extends FeatureMatcher<FibEntry, String> {
+
+    public HasInterface(Matcher<? super String> subMatcher) {
+      super(subMatcher, "A FibEntry with: nextHopInterface", "nextHopInterface");
+    }
+
+    @Override
+    protected String featureValueOf(FibEntry fibEntry) {
+      return fibEntry.getInterfaceName();
+    }
+  }
+
+  private FibEntryMatchersImpl() {}
+}

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteUtils.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteUtils.java
@@ -13,16 +13,13 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
-import com.google.common.collect.TreeMultimap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.SortedSet;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
-import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.FilterResult;
 import org.batfish.datamodel.Flow;
@@ -33,7 +30,6 @@ import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.LineAction;
-import org.batfish.datamodel.Route;
 import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.flow.EnterInputIfaceStep;
 import org.batfish.datamodel.flow.EnterInputIfaceStep.EnterInputIfaceStepDetail;
@@ -201,34 +197,6 @@ public final class TracerouteUtils {
                         builder.put(
                             new NodeInterfacePair(session.getHostname(), incomingIface), session)));
     return builder.build();
-  }
-
-  @Nonnull
-  static Multimap<Ip, AbstractRoute> resolveNextHopIpRoutes(
-      String nextHopInterfaceName,
-      Map<AbstractRoute, Map<String, Map<Ip, Set<AbstractRoute>>>> nextHopInterfacesByRoute) {
-    TreeMultimap<Ip, AbstractRoute> resolvedNextHopWithRoutes = TreeMultimap.create();
-
-    // Loop over all matching routes that use nextHopInterfaceName as one of the next hop
-    // interfaces.
-    for (Entry<AbstractRoute, Map<String, Map<Ip, Set<AbstractRoute>>>> e :
-        nextHopInterfacesByRoute.entrySet()) {
-      Map<Ip, Set<AbstractRoute>> finalNextHops = e.getValue().get(nextHopInterfaceName);
-      if (finalNextHops == null || finalNextHops.isEmpty()) {
-        continue;
-      }
-
-      AbstractRoute routeCandidate = e.getKey();
-      Ip nextHopIp = routeCandidate.getNextHopIp();
-      if (nextHopIp.equals(Route.UNSET_ROUTE_NEXT_HOP_IP)) {
-        resolvedNextHopWithRoutes.put(nextHopIp, routeCandidate);
-      } else {
-        for (Ip resolvedNextHopIp : finalNextHops.keySet()) {
-          resolvedNextHopWithRoutes.put(resolvedNextHopIp, routeCandidate);
-        }
-      }
-    }
-    return resolvedNextHopWithRoutes;
   }
 
   @Nullable


### PR DESCRIPTION
* Switch to using FibEntries instead of the really weird logic we had
* Deprecated newly unused Fib methods
* Add a matcher for FibEntry to simplify some tests