### PR TITLE
ExplicitAsPathSet: fix implementation and add comments

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/AsPathSetElem.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/AsPathSetElem.java
@@ -15,5 +15,12 @@ public abstract class AsPathSetElem implements Serializable {
   @Override
   public abstract int hashCode();
 
+  /**
+   * Returns the regular expression associated with this element.
+   *
+   * <p>The resultant regular expression will be used to match against an AS Path as a string of
+   * numbers, each preceded by a space. An empty AS Path will be represented as an empty string, and
+   * the AS Path {@code 1 2 3} will be represented as {@code " 1 2 3"}.
+   */
   public abstract String regex();
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/ExplicitAsPathSet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/ExplicitAsPathSet.java
@@ -85,7 +85,7 @@ public final class ExplicitAsPathSet extends AsPathSetExpr {
     }
     // TODO: need to validate regexes against complex AS-Paths that contain sets. For now, regexes
     // will not match against AsPaths for which set components have non-trivial filters.
-    String asPathStr = asPath.getAsPathString();
+    String asPathStr = asPath.size() == 0 ? "" : " " + asPath.getAsPathString();
     return _elems.stream()
         .map(AsPathSetElem::regex)
         .anyMatch(r -> Pattern.compile(r).matcher(asPathStr).find());

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/ExplicitAsPathSetTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/ExplicitAsPathSetTest.java
@@ -59,7 +59,7 @@ public class ExplicitAsPathSetTest {
     assertTrue(expr.matches(buildEnvironment(AsPath.ofSingletonAsSets(13L, 113L))));
     assertFalse(expr.matches(buildEnvironment(AsPath.ofSingletonAsSets(11L, 12L, 13L, 14L))));
 
-    expr = new ExplicitAsPathSet(new RegexAsPathSetElem("(^| )13$"));
+    expr = new ExplicitAsPathSet(new RegexAsPathSetElem(" 13$"));
     assertTrue(expr.matches(buildEnvironment(AsPath.ofSingletonAsSets(13L))));
     assertTrue(expr.matches(buildEnvironment(AsPath.ofSingletonAsSets(11L, 12L, 13L))));
     assertFalse(expr.matches(buildEnvironment(AsPath.ofSingletonAsSets(13L, 113L))));


### PR DESCRIPTION
Based on my experience, it's pretty hard to implement regex-based matching on
AS Paths where they are represented as space-separated strings (e.g., `"1 2
3"`).

The reason is optional fields:

- `".* 3"` should match the above but also `"3"`.
- `"1 .*"` should match the above but also `"1"`.
- `".* 2 .*"` should match the above but also `"2"`.
- `"1 2 3"` should match `"1 2 3"`.

and more.

The issue is around leading/trailing space with optional fields. E.g., you want
to translate `"1 .*"` to something like `"1( \d+)*"`, but you also want to
translate `".* 3"` to `"(\d+ )*3"`. In one case, the odd space out is before
the wildcard, in another it's after. Neither `"1"` nor `"3"` need leading
spaces here, but translating the regex `"1 2 3"` to the pattern `"1 2 3"`, we
do need to add spaces.

Seems too hard to get this right in all cases. Instead, make
`ExplicitAsPathSet` use leading spaces in front of all terms: `"1 2 3"` maps to
`" 1 2 3"`. Then all the above is easy.