### PR TITLE
add findLongestPrefixMatchNonEmptyNode

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
@@ -207,6 +207,9 @@ public final class PrefixTrieMultiMap<T> implements Serializable {
 
     @Nullable
     Node<T> matchingChild(Prefix prefix) {
+      if (_prefix.getPrefixLength() == Prefix.MAX_PREFIX_LENGTH) {
+        return null;
+      }
       Node<T> child =
           Ip.getBitAtPosition(prefix.getStartIp().asLong(), _prefix.getPrefixLength())
               ? _right

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
@@ -177,27 +177,41 @@ public final class PrefixTrieMultiMap<T> implements Serializable {
       assert this._prefix.containsPrefix(prefix);
 
       Node<T> node = this;
-      long prefixAsLong = prefix.getStartIp().asLong();
       while (true) {
-        if (node._prefix.equals(prefix)) {
-          // found an exact match
+        // Choose which child might have a longer match
+        Node<T> child = matchingChild(prefix);
+        if (child == null) {
           return node;
+        }
+        node = child;
+      }
+    }
+
+    @Nullable
+    Node<T> findLongestPrefixMatchNonEmptyNode(Prefix prefix) {
+      assert this._prefix.containsPrefix(prefix);
+
+      Node<T> longestNonEmpty = null;
+      Node<T> node = this;
+      while (node != null) {
+        if (!node._elements.isEmpty()) {
+          longestNonEmpty = node;
         }
 
         // Choose which child might have a longer match
-        Node<T> child =
-            Ip.getBitAtPosition(prefixAsLong, node._prefix.getPrefixLength())
-                ? node._right
-                : node._left;
-
-        // Check if the child exists and matches
-        if (child == null || !child._prefix.containsPrefix(prefix)) {
-          return node;
-        }
-
-        // Child does have a longer match, keep looking
-        node = child;
+        node = node.matchingChild(prefix);
       }
+
+      return longestNonEmpty;
+    }
+
+    @Nullable
+    Node<T> matchingChild(Prefix prefix) {
+      Node<T> child =
+          Ip.getBitAtPosition(prefix.getStartIp().asLong(), _prefix.getPrefixLength())
+              ? _right
+              : _left;
+      return child == null || !child._prefix.containsPrefix(prefix) ? null : child;
     }
 
     private void setLeft(@Nullable Node<T> left) {
@@ -289,6 +303,12 @@ public final class PrefixTrieMultiMap<T> implements Serializable {
         : _root.findLongestPrefixMatchNode(p);
   }
 
+  private @Nullable Node<T> longestMatchNonEmptyNode(Prefix p) {
+    return _root == null || !_root._prefix.containsPrefix(p)
+        ? null
+        : _root.findLongestPrefixMatchNonEmptyNode(p);
+  }
+
   /** Find the elements associated with the longest matching prefix of a given IP address. */
   @Nonnull
   public Set<T> longestPrefixMatch(Ip address) {
@@ -301,7 +321,8 @@ public final class PrefixTrieMultiMap<T> implements Serializable {
    */
   @Nonnull
   public Set<T> longestPrefixMatch(Ip address, int maxPrefixLength) {
-    Node<T> node = longestMatchNode(Prefix.create(address, maxPrefixLength));
+    Node<T> node = longestMatchNonEmptyNode(Prefix.create(address, maxPrefixLength));
+    assert node == null || !node._elements.isEmpty();
     return node == null ? ImmutableSet.of() : ImmutableSet.copyOf(node._elements);
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
@@ -179,7 +179,7 @@ public final class PrefixTrieMultiMap<T> implements Serializable {
       Node<T> node = this;
       while (true) {
         // Choose which child might have a longer match
-        Node<T> child = matchingChild(prefix);
+        Node<T> child = node.matchingChild(prefix);
         if (child == null) {
           return node;
         }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PrefixTrieMultiMapTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PrefixTrieMultiMapTest.java
@@ -268,4 +268,28 @@ public class PrefixTrieMultiMapTest {
             immutableEntry(Prefix.parse("0.0.0.0/8"), ImmutableSet.of()),
             immutableEntry(Prefix.ZERO, ImmutableSet.of())));
   }
+
+  @Test
+  public void test() {
+    PrefixTrieMultiMap<Integer> map = new PrefixTrieMultiMap<>(Prefix.ZERO);
+    assertThat(entriesPostOrder(map), contains(immutableEntry(Prefix.ZERO, ImmutableSet.of())));
+
+    map.put(Prefix.ZERO, 0);
+    assertThat(entriesPostOrder(map), contains(immutableEntry(Prefix.ZERO, ImmutableSet.of(0))));
+
+    Prefix l = Prefix.parse("0.0.0.0/32");
+    Prefix r = Prefix.parse("0.0.0.1/32");
+    map.put(l, 1);
+    map.put(r, 2);
+    assertThat(
+        entriesPostOrder(map),
+        contains(
+            immutableEntry(l, ImmutableSet.of(1)),
+            immutableEntry(r, ImmutableSet.of(2)),
+            immutableEntry(Prefix.parse("0.0.0.0/31"), ImmutableSet.of()),
+            immutableEntry(Prefix.ZERO, ImmutableSet.of(0))));
+
+    // Since the entry for 0.0.0.0/31 has no elements, return the elements for Prefix.ZERO
+    assertThat(map.longestPrefixMatch(Ip.parse("0.0.0.0"), 31), equalTo(ImmutableSet.of(0)));
+  }
 }


### PR DESCRIPTION
The public longestPrefixMatch method now uses this to ensure that it
returns the elements of the longest matching prefix that has elements.