### PR TITLE
allow IpSpace references in transformation guards

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/HeaderSpaceToBDD.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/HeaderSpaceToBDD.java
@@ -2,7 +2,6 @@ package org.batfish.common.bdd;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -23,7 +22,6 @@ public final class HeaderSpaceToBDD {
   private final BDDFactory _bddFactory;
   private final BDDOps _bddOps;
   private final BDDPacket _bddPacket;
-  private final Map<String, IpSpace> _namedIpSpaces;
   private final IpSpaceToBDD _dstIpSpaceToBdd;
   private final IpSpaceToBDD _srcIpSpaceToBdd;
 
@@ -31,20 +29,15 @@ public final class HeaderSpaceToBDD {
     _bddFactory = bddPacket.getFactory();
     _bddOps = new BDDOps(_bddFactory);
     _bddPacket = bddPacket;
-    _namedIpSpaces = ImmutableMap.copyOf(namedIpSpaces);
-    _dstIpSpaceToBdd = new IpSpaceToBDD(_bddPacket.getDstIp(), _namedIpSpaces);
-    _srcIpSpaceToBdd = new IpSpaceToBDD(_bddPacket.getSrcIp(), _namedIpSpaces);
+    _dstIpSpaceToBdd = new IpSpaceToBDD(_bddPacket.getDstIp(), namedIpSpaces);
+    _srcIpSpaceToBdd = new IpSpaceToBDD(_bddPacket.getSrcIp(), namedIpSpaces);
   }
 
   public HeaderSpaceToBDD(
-      BDDPacket bddPacket,
-      Map<String, IpSpace> namedIpSpaces,
-      IpSpaceToBDD dstIpSpaceToBdd,
-      IpSpaceToBDD srcIpSpaceToBdd) {
+      BDDPacket bddPacket, IpSpaceToBDD dstIpSpaceToBdd, IpSpaceToBDD srcIpSpaceToBdd) {
     _bddFactory = bddPacket.getFactory();
     _bddOps = new BDDOps(_bddFactory);
     _bddPacket = bddPacket;
-    _namedIpSpaces = ImmutableMap.copyOf(namedIpSpaces);
     _dstIpSpaceToBdd = dstIpSpaceToBdd;
     _srcIpSpaceToBdd = srcIpSpaceToBdd;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/MemoizedIpAccessListToBdd.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/MemoizedIpAccessListToBdd.java
@@ -26,7 +26,6 @@ public final class MemoizedIpAccessListToBdd extends IpAccessListToBdd {
         mgr,
         new HeaderSpaceToBDD(
             packet,
-            namedIpSpaces,
             new MemoizedIpSpaceToBDD(packet.getDstIp(), namedIpSpaces),
             new MemoizedIpSpaceToBDD(packet.getSrcIp(), namedIpSpaces)),
         aclEnv);

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
@@ -153,6 +153,7 @@ public final class BDDReachabilityAnalysisFactory {
 
   private final Map<String, Configuration> _configs;
 
+  // only use this for IpSpaces that have no references
   private final IpSpaceToBDD _dstIpSpaceToBDD;
   private final IpSpaceToBDD _srcIpSpaceToBDD;
 
@@ -282,13 +283,16 @@ public final class BDDReachabilityAnalysisFactory {
   }
 
   private TransformationToTransition initTransformationToTransformation(Configuration node) {
+    IpSpaceToBDD dstIpSpaceToBdd =
+        new MemoizedIpSpaceToBDD(_bddPacket.getDstIp(), node.getIpSpaces());
+    IpSpaceToBDD srcIpSpaceToBdd =
+        new MemoizedIpSpaceToBDD(_bddPacket.getSrcIp(), node.getIpSpaces());
     return new TransformationToTransition(
         _bddPacket,
         new IpAccessListToBddImpl(
             _bddPacket,
             _bddSourceManagers.get(node.getHostname()),
-            new HeaderSpaceToBDD(
-                _bddPacket, node.getIpSpaces(), _dstIpSpaceToBDD, _srcIpSpaceToBDD),
+            new HeaderSpaceToBDD(_bddPacket, dstIpSpaceToBdd, srcIpSpaceToBdd),
             node.getIpAccessLists()));
   }
 


### PR DESCRIPTION
Some devices (e.g. juniper) allow transformation guards to use IpSpaceReferences. They're already supported in traceroute, this PR adds support for them to BDD reachability.