### PR TITLE
PacketPolicy: VI skeleton

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/Action.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/Action.java
@@ -1,0 +1,14 @@
+package org.batfish.datamodel.packet_policy;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.io.Serializable;
+
+/**
+ * A type of {@link Statement policy statement} that signifies an action should be taken on a
+ * packet/flow
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "class")
+public interface Action extends Serializable {
+
+  <T> T accept(ActionVisitor<T> visitor);
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/ActionVisitor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/ActionVisitor.java
@@ -1,0 +1,13 @@
+package org.batfish.datamodel.packet_policy;
+
+/** Visitor for packet policy {@link Action actions} */
+public interface ActionVisitor<T> {
+
+  default T visit(Action action) {
+    return action.accept(this);
+  }
+
+  T visitDrop(Drop drop);
+
+  T visitFibLookup(FibLookup fibLookup);
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/BoolExpr.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/BoolExpr.java
@@ -1,0 +1,11 @@
+package org.batfish.datamodel.packet_policy;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.io.Serializable;
+
+/** Represents a {@link PacketPolicy} boolean expression */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "class")
+public interface BoolExpr extends Serializable {
+
+  <T> T accept(BoolExprVisitor<T> tBoolExprVisitor);
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/BoolExprVisitor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/BoolExprVisitor.java
@@ -1,0 +1,11 @@
+package org.batfish.datamodel.packet_policy;
+
+/** Evaluates {@link BoolExpr} */
+public interface BoolExprVisitor<T> {
+
+  default T visit(BoolExpr expr) {
+    return expr.accept(this);
+  }
+
+  T visitPacketMatchExpr(PacketMatchExpr expr);
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/Drop.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/Drop.java
@@ -1,0 +1,41 @@
+package org.batfish.datamodel.packet_policy;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.google.common.base.MoreObjects;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+/** Drop the packet */
+@ParametersAreNonnullByDefault
+public final class Drop implements Action {
+
+  private static final long serialVersionUID = 1L;
+  private static final Drop INSTANCE = new Drop();
+
+  private Drop() {}
+
+  @Override
+  public <T> T accept(ActionVisitor<T> visitor) {
+    return visitor.visitDrop(this);
+  }
+
+  @JsonCreator
+  public static Drop instance() {
+    return INSTANCE;
+  }
+
+  @Override
+  public int hashCode() {
+    return 0;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object obj) {
+    return obj instanceof Drop;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).toString();
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/FibLookup.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/FibLookup.java
@@ -1,0 +1,68 @@
+package org.batfish.datamodel.packet_policy;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+/**
+ * Switch to a regular destination-based forwarding pipeline. That is, perform a FIB lookup in a
+ * given VRF, use the results to forward packet.
+ */
+@ParametersAreNonnullByDefault
+public final class FibLookup implements Action {
+
+  private static final long serialVersionUID = 1L;
+
+  private static final String PROP_VRF_NAME = "vrfName";
+
+  @Nonnull private final String _vrfName;
+
+  public FibLookup(String vrfName) {
+    _vrfName = vrfName;
+  }
+
+  @JsonCreator
+  private static FibLookup jsonCreator(@Nullable @JsonProperty(PROP_VRF_NAME) String vrfName) {
+    checkArgument(vrfName != null, "Missing %s", PROP_VRF_NAME);
+    return new FibLookup(vrfName);
+  }
+
+  @JsonProperty(PROP_VRF_NAME)
+  @Nonnull
+  public String getVrfName() {
+    return _vrfName;
+  }
+
+  @Override
+  public <T> T accept(ActionVisitor<T> visitor) {
+    return visitor.visitFibLookup(this);
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    FibLookup fibLookup = (FibLookup) o;
+    return Objects.equals(getVrfName(), fibLookup.getVrfName());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getVrfName());
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("vrfName", _vrfName).toString();
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/FlowEvaluator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/FlowEvaluator.java
@@ -1,0 +1,129 @@
+package org.batfish.datamodel.packet_policy;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.Flow;
+import org.batfish.datamodel.acl.Evaluator;
+
+/**
+ * Evaluates a {@link PacketPolicy} against a given {@link Flow}.
+ *
+ * <p>To evaluate an entire policy, see {@link #evaluate(Flow, String, PacketPolicy)} which will
+ * return a {@link FlowResult}.
+ */
+@ParametersAreNonnullByDefault
+public final class FlowEvaluator {
+  // Start state
+  @Nonnull private final String _srcInterface;
+
+  // Modified state
+  @Nonnull private Flow.Builder _currentFlow;
+
+  // Expr and stmt visitors
+  @Nonnull private BoolExprEvaluator _boolExprEvaluator = new BoolExprEvaluator();
+  @Nonnull private StatementEvaluator _stmtEvaluator = new StatementEvaluator();
+
+  private final class BoolExprEvaluator implements BoolExprVisitor<Boolean> {
+
+    @Override
+    public Boolean visitPacketMatchExpr(PacketMatchExpr expr) {
+      return Evaluator.matches(
+          expr.getExpr(),
+          _currentFlow.build(),
+          _srcInterface,
+          ImmutableMap.of(),
+          ImmutableMap.of());
+    }
+  }
+
+  private final class StatementEvaluator implements StatementVisitor<Action> {
+    StatementEvaluator() {}
+
+    @Override
+    @Nullable
+    public Action visitIf(If ifStmt) {
+      if (ifStmt.getMatchCondition().accept(_boolExprEvaluator)) {
+        return ifStmt.getTrueStatements().stream()
+            .map(this::visit)
+            .filter(Objects::nonNull)
+            .findFirst()
+            .orElse(null);
+      }
+      return null;
+    }
+
+    @Override
+    public Action visitReturn(Return returnStmt) {
+      return returnStmt.getAction();
+    }
+  }
+
+  @VisibleForTesting
+  FlowEvaluator(Flow originalFlow, String srcInterface) {
+    _currentFlow = originalFlow.toBuilder();
+    _srcInterface = srcInterface;
+  }
+
+  @Nonnull
+  private Flow getTransformedFlow() {
+    return _currentFlow.build();
+  }
+
+  private FlowResult evaluate(PacketPolicy policy) {
+    Action action =
+        policy.getStatements().stream()
+            .map(_stmtEvaluator::visit)
+            .filter(Objects::nonNull)
+            .findFirst()
+            /* Fail-closed is the default behavior for filters in many vendors,
+             * but if we get here, the problem is likely in conversion.
+             */
+            .orElse(Drop.instance());
+    return new FlowResult(getTransformedFlow(), action);
+  }
+
+  public static FlowResult evaluate(Flow f, String srcInterface, PacketPolicy policy) {
+    return new FlowEvaluator(f, srcInterface).evaluate(policy);
+  }
+
+  /** Combination of final (possibly transformed) {@link Flow} and the action taken */
+  public static final class FlowResult {
+    private final Flow _finalFlow;
+    private final Action _action;
+
+    FlowResult(Flow finalFlow, Action action) {
+      _finalFlow = finalFlow;
+      _action = action;
+    }
+
+    public Flow getFinalFlow() {
+      return _finalFlow;
+    }
+
+    public Action getAction() {
+      return _action;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      FlowResult that = (FlowResult) o;
+      return Objects.equals(getFinalFlow(), that.getFinalFlow())
+          && Objects.equals(getAction(), that.getAction());
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(getFinalFlow(), getAction());
+    }
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/If.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/If.java
@@ -1,0 +1,79 @@
+package org.batfish.datamodel.packet_policy;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+public final class If implements Statement {
+
+  private static final String PROP_ACTIONS = "actions";
+  private static final String PROP_TRUE_STATEMENTS = "trueStatements";
+  private static final long serialVersionUID = 1;
+
+  @Nonnull private final BoolExpr _matchCondition;
+  @Nonnull private final List<Statement> _trueStatements;
+
+  public If(BoolExpr matchCondition, List<Statement> trueStatements) {
+    _matchCondition = matchCondition;
+    _trueStatements = ImmutableList.copyOf(trueStatements);
+  }
+
+  @JsonCreator
+  @Nonnull
+  private static If jsonCreator(
+      @Nullable @JsonProperty(PROP_ACTIONS) List<Statement> actions,
+      @Nullable @JsonProperty(PROP_TRUE_STATEMENTS) BoolExpr matchCondition) {
+    checkArgument(matchCondition != null, "Missing %s", PROP_TRUE_STATEMENTS);
+    return new If(matchCondition, firstNonNull(actions, ImmutableList.of()));
+  }
+
+  @Nonnull
+  @JsonProperty(PROP_ACTIONS)
+  public List<Statement> getTrueStatements() {
+    return _trueStatements;
+  }
+
+  @Nonnull
+  @JsonProperty(PROP_TRUE_STATEMENTS)
+  public BoolExpr getMatchCondition() {
+    return _matchCondition;
+  }
+
+  @Override
+  public <T> T accept(StatementVisitor<T> visitor) {
+    return visitor.visitIf(this);
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    If anIf = (If) o;
+    return Objects.equals(getMatchCondition(), anIf.getMatchCondition())
+        && Objects.equals(getTrueStatements(), anIf.getTrueStatements());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getMatchCondition(), getTrueStatements());
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).toString();
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/If.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/If.java
@@ -13,6 +13,10 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+/**
+ * A {@link PacketPolicy} If statement. Executes inner statements only if the {@link
+ * #getMatchCondition()} is true.
+ */
 @ParametersAreNonnullByDefault
 public final class If implements Statement {
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/PacketMatchExpr.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/PacketMatchExpr.java
@@ -1,0 +1,63 @@
+package org.batfish.datamodel.packet_policy;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import java.util.Objects;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
+
+@ParametersAreNonnullByDefault
+public final class PacketMatchExpr implements BoolExpr {
+  private static final long serialVersionUID = 1L;
+
+  private static final String PROP_EXPR = "expression";
+
+  private final AclLineMatchExpr _expr;
+
+  public PacketMatchExpr(AclLineMatchExpr expr) {
+    _expr = expr;
+  }
+
+  @JsonCreator
+  private static PacketMatchExpr jsonCreator(
+      @Nullable @JsonProperty(PROP_EXPR) AclLineMatchExpr expr) {
+    checkArgument(expr != null, "Missing %s", PROP_EXPR);
+    return new PacketMatchExpr(expr);
+  }
+
+  @Override
+  public <T> T accept(BoolExprVisitor<T> visitor) {
+    return visitor.visitPacketMatchExpr(this);
+  }
+
+  @JsonProperty(PROP_EXPR)
+  public AclLineMatchExpr getExpr() {
+    return _expr;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    PacketMatchExpr that = (PacketMatchExpr) o;
+    return Objects.equals(getExpr(), that.getExpr());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getExpr());
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("expr", _expr).toString();
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/PacketMatchExpr.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/PacketMatchExpr.java
@@ -10,6 +10,9 @@ import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
 
+/**
+ * A boolean expression that returns true if a packet/flow matches a given {@link AclLineMatchExpr}
+ */
 @ParametersAreNonnullByDefault
 public final class PacketMatchExpr implements BoolExpr {
   private static final long serialVersionUID = 1L;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/PacketPolicy.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/PacketPolicy.java
@@ -1,0 +1,75 @@
+package org.batfish.datamodel.packet_policy;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+import java.io.Serializable;
+import java.util.List;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+/** A policy used to perform policy-based routing */
+@ParametersAreNonnullByDefault
+public final class PacketPolicy implements Serializable {
+
+  private static final String PROP_NAME = "name";
+  private static final String PROP_STATEMENTS = "statements";
+  private static final long serialVersionUID = 1L;
+
+  @Nonnull private final String _name;
+  @Nonnull private final List<Statement> _statements;
+
+  public PacketPolicy(String name, List<Statement> statements) {
+    _name = name;
+    _statements = ImmutableList.copyOf(statements);
+  }
+
+  @JsonCreator
+  private static PacketPolicy jsonCreator(
+      @Nullable @JsonProperty(PROP_NAME) String name,
+      @Nullable @JsonProperty(PROP_STATEMENTS) List<Statement> statements) {
+    checkArgument(name != null, "Missing %s", PROP_NAME);
+    return new PacketPolicy(name, firstNonNull(statements, ImmutableList.of()));
+  }
+
+  @Nonnull
+  @JsonProperty(PROP_NAME)
+  public String getName() {
+    return _name;
+  }
+
+  @Nonnull
+  @JsonProperty(PROP_STATEMENTS)
+  public List<Statement> getStatements() {
+    return _statements;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    PacketPolicy that = (PacketPolicy) o;
+    return Objects.equals(getStatements(), that.getStatements())
+        && Objects.equals(getName(), that.getName());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getStatements(), getName());
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("name", _name).toString();
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/PacketPolicy.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/PacketPolicy.java
@@ -18,24 +18,30 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @ParametersAreNonnullByDefault
 public final class PacketPolicy implements Serializable {
 
+  private static final String PROP_DEFAULT_ACTION = "defaultAction";
   private static final String PROP_NAME = "name";
   private static final String PROP_STATEMENTS = "statements";
+
   private static final long serialVersionUID = 1L;
 
   @Nonnull private final String _name;
   @Nonnull private final List<Statement> _statements;
+  @Nonnull private final Return _defaultAction;
 
-  public PacketPolicy(String name, List<Statement> statements) {
+  public PacketPolicy(String name, List<Statement> statements, Return defaultAction) {
     _name = name;
     _statements = ImmutableList.copyOf(statements);
+    _defaultAction = defaultAction;
   }
 
   @JsonCreator
   private static PacketPolicy jsonCreator(
+      @Nullable @JsonProperty(PROP_DEFAULT_ACTION) Return defaultAction,
       @Nullable @JsonProperty(PROP_NAME) String name,
       @Nullable @JsonProperty(PROP_STATEMENTS) List<Statement> statements) {
-    checkArgument(name != null, "Missing %s", PROP_NAME);
-    return new PacketPolicy(name, firstNonNull(statements, ImmutableList.of()));
+    checkArgument(name != null, "Missing %s", PROP_DEFAULT_ACTION);
+    checkArgument(defaultAction != null, "Missing %s", PROP_NAME);
+    return new PacketPolicy(name, firstNonNull(statements, ImmutableList.of()), defaultAction);
   }
 
   @Nonnull
@@ -50,6 +56,13 @@ public final class PacketPolicy implements Serializable {
     return _statements;
   }
 
+  /** Return the default action for this policy */
+  @Nonnull
+  @JsonProperty(PROP_DEFAULT_ACTION)
+  public Return getDefaultAction() {
+    return _defaultAction;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -60,12 +73,13 @@ public final class PacketPolicy implements Serializable {
     }
     PacketPolicy that = (PacketPolicy) o;
     return Objects.equals(getStatements(), that.getStatements())
-        && Objects.equals(getName(), that.getName());
+        && Objects.equals(getName(), that.getName())
+        && Objects.equals(getDefaultAction(), that.getDefaultAction());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(getStatements(), getName());
+    return Objects.hash(getStatements(), getName(), getDefaultAction());
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/Return.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/Return.java
@@ -1,0 +1,62 @@
+package org.batfish.datamodel.packet_policy;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import java.util.Objects;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+/** Return a particular {@link Action} and stop policy evaluation */
+@ParametersAreNonnullByDefault
+public class Return implements Statement {
+
+  private static final String PROP_ACTION = "action";
+  private static final long serialVersionUID = 1;
+
+  private final Action _action;
+
+  public Return(Action action) {
+    _action = action;
+  }
+
+  @JsonCreator
+  private static Return jsonCreator(@Nullable @JsonProperty(PROP_ACTION) Action action) {
+    checkArgument(action != null, "Missing %s", PROP_ACTION);
+    return new Return(action);
+  }
+
+  @JsonProperty(PROP_ACTION)
+  public Action getAction() {
+    return _action;
+  }
+
+  @Override
+  public <T> T accept(StatementVisitor<T> visitor) {
+    return visitor.visitReturn(this);
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Return aReturn = (Return) o;
+    return Objects.equals(getAction(), aReturn.getAction());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getAction());
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("action", _action).toString();
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/Statement.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/Statement.java
@@ -1,0 +1,10 @@
+package org.batfish.datamodel.packet_policy;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.io.Serializable;
+
+/** A general {@link PacketPolicy} statement */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "class")
+public interface Statement extends Serializable {
+  <T> T accept(StatementVisitor<T> visitor);
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/StatementVisitor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/StatementVisitor.java
@@ -1,0 +1,15 @@
+package org.batfish.datamodel.packet_policy;
+
+/**
+ * All evaluators of {@link PacketPolicy} must implement this interface to correctly handle
+ * available statement types.
+ */
+public interface StatementVisitor<T> {
+  default T visit(Statement step) {
+    return step.accept(this);
+  }
+
+  T visitIf(If ifStmt);
+
+  T visitReturn(Return returnStmt);
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/DropTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/DropTest.java
@@ -1,0 +1,38 @@
+package org.batfish.datamodel.packet_policy;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.testing.EqualsTester;
+import java.io.IOException;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.junit.Test;
+
+/** Tests of {@link Drop} */
+public class DropTest {
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(Drop.instance(), Drop.instance())
+        .addEqualityGroup(new Object())
+        .testEquals();
+  }
+
+  @Test
+  public void testJavaSerialization() {
+    assertThat(SerializationUtils.clone(Drop.instance()), equalTo(Drop.instance()));
+  }
+
+  @Test
+  public void testJsonSerialization() throws IOException {
+    assertThat(BatfishObjectMapper.clone(Drop.instance(), Drop.class), equalTo(Drop.instance()));
+  }
+
+  @Test
+  public void testToString() {
+    assertTrue(Drop.instance().toString().contains(Drop.class.getSimpleName()));
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/FibLookupTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/FibLookupTest.java
@@ -1,0 +1,44 @@
+package org.batfish.datamodel.packet_policy;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.testing.EqualsTester;
+import java.io.IOException;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.junit.Test;
+
+/** Tests of {@link FibLookup} */
+public class FibLookupTest {
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(new FibLookup("name"), new FibLookup("name"))
+        .addEqualityGroup(new FibLookup("otherName"))
+        .addEqualityGroup(new Object())
+        .testEquals();
+  }
+
+  @Test
+  public void testJavaSerialization() {
+    FibLookup fl = new FibLookup("name");
+    assertThat(SerializationUtils.clone(fl), equalTo(fl));
+  }
+
+  @Test
+  public void testJsonSerialization() throws IOException {
+    FibLookup fl = new FibLookup("name");
+    assertThat(BatfishObjectMapper.clone(fl, FibLookup.class), equalTo(fl));
+  }
+
+  @Test
+  public void testToString() {
+    FibLookup fl = new FibLookup("xxxxxx");
+    assertTrue(fl.toString().contains(fl.getClass().getSimpleName()));
+    assertTrue(fl.toString().contains("vrfName"));
+    assertTrue(fl.toString().contains(fl.getVrfName()));
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/FlowEvaluatorTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/FlowEvaluatorTest.java
@@ -16,7 +16,6 @@ import org.parboiled.common.ImmutableList;
 /** Tests of {@link FlowEvaluator} */
 public class FlowEvaluatorTest {
 
-  private FlowEvaluator _evaluator;
   private Flow _flow;
 
   @Before
@@ -29,7 +28,6 @@ public class FlowEvaluatorTest {
             .setSrcIp(Ip.parse("1.1.1.1"))
             .setDstIp(Ip.parse("2.2.2.2"))
             .build();
-    _evaluator = new FlowEvaluator(_flow, "Eth0");
   }
 
   private PacketPolicy singletonPolicy(Statement t) {

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/FlowEvaluatorTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/FlowEvaluatorTest.java
@@ -1,0 +1,112 @@
+package org.batfish.datamodel.packet_policy;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.testing.EqualsTester;
+import org.batfish.datamodel.Flow;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.acl.FalseExpr;
+import org.batfish.datamodel.acl.TrueExpr;
+import org.batfish.datamodel.packet_policy.FlowEvaluator.FlowResult;
+import org.junit.Before;
+import org.junit.Test;
+import org.parboiled.common.ImmutableList;
+
+/** Tests of {@link FlowEvaluator} */
+public class FlowEvaluatorTest {
+
+  private FlowEvaluator _evaluator;
+  private Flow _flow;
+
+  @Before
+  public void setup() {
+    _flow =
+        Flow.builder()
+            .setIngressNode("someNode")
+            .setIngressInterface("Eth0")
+            .setTag("noTag")
+            .setSrcIp(Ip.parse("1.1.1.1"))
+            .setDstIp(Ip.parse("2.2.2.2"))
+            .build();
+    _evaluator = new FlowEvaluator(_flow, "Eth0");
+  }
+
+  private PacketPolicy singletonPolicy(Statement t) {
+    return new PacketPolicy("policyName", ImmutableList.of(t));
+  }
+
+  @Test
+  public void evaluateReturn() {
+    FibLookup fl = new FibLookup("vrf");
+    FlowResult r = FlowEvaluator.evaluate(_flow, "Eth0", singletonPolicy(new Return(fl)));
+
+    assertThat(r.getAction(), equalTo(fl));
+    assertThat(r.getFinalFlow(), equalTo(_flow));
+  }
+
+  @Test
+  public void evaluateIfWithMatch() {
+    FibLookup fl = new FibLookup("vrf");
+    FlowResult r =
+        FlowEvaluator.evaluate(
+            _flow,
+            "Eth0",
+            singletonPolicy(
+                new If(new PacketMatchExpr(TrueExpr.INSTANCE), ImmutableList.of(new Return(fl)))));
+
+    assertThat(r.getAction(), equalTo(fl));
+    assertThat(r.getFinalFlow(), equalTo(_flow));
+  }
+
+  @Test
+  public void evaluateIfNoMatch() {
+    FibLookup fl = new FibLookup("vrf");
+    FlowResult r =
+        FlowEvaluator.evaluate(
+            _flow,
+            "Eth0",
+            singletonPolicy(
+                new If(new PacketMatchExpr(FalseExpr.INSTANCE), ImmutableList.of(new Return(fl)))));
+
+    // Implicit deny all was hit
+    assertThat(r.getAction(), equalTo(Drop.instance()));
+    assertThat(r.getFinalFlow(), equalTo(_flow));
+  }
+
+  @Test
+  public void testFlowResultEquality() {
+    new EqualsTester()
+        .addEqualityGroup(
+            new FlowResult(_flow, Drop.instance()), new FlowResult(_flow, Drop.instance()))
+        .addEqualityGroup(
+            new FlowResult(
+                _flow.toBuilder().setIngressNode("differentNode").build(), Drop.instance()))
+        .addEqualityGroup(new FlowResult(_flow, new FibLookup("aVRF")))
+        .addEqualityGroup(new Object())
+        .testEquals();
+  }
+
+  @Test
+  public void testEvaluateFindsFirstReachableTerminalAction() {
+    // Setup policy
+    PacketPolicy policy =
+        new PacketPolicy(
+            "policyName",
+            ImmutableList.of(
+                new If(
+                    new PacketMatchExpr(FalseExpr.INSTANCE),
+                    ImmutableList.of(new Return(new FibLookup("Unreachable")))),
+                new If(
+                    new PacketMatchExpr(TrueExpr.INSTANCE),
+                    ImmutableList.of(new Return(Drop.instance()))),
+                new Return(new FibLookup("lastVRF"))));
+
+    // Test:
+    FlowResult result = FlowEvaluator.evaluate(_flow, "Eth0", policy);
+
+    assertThat(result.getAction(), equalTo(Drop.instance()));
+    // No transformations occurred
+    assertThat(result.getFinalFlow(), equalTo(_flow));
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/IfTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/IfTest.java
@@ -1,0 +1,51 @@
+package org.batfish.datamodel.packet_policy;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.testing.EqualsTester;
+import java.io.IOException;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.acl.FalseExpr;
+import org.batfish.datamodel.acl.TrueExpr;
+import org.junit.Test;
+
+/** Tests of {@link If} */
+public class IfTest {
+
+  @Test
+  public void testEquals() {
+    If ifExpr = new If(new PacketMatchExpr(FalseExpr.INSTANCE), ImmutableList.of());
+    new EqualsTester()
+        .addEqualityGroup(
+            ifExpr, ifExpr, new If(new PacketMatchExpr(FalseExpr.INSTANCE), ImmutableList.of()))
+        .addEqualityGroup(new If(new PacketMatchExpr(TrueExpr.INSTANCE), ImmutableList.of()))
+        .addEqualityGroup(
+            new If(
+                new PacketMatchExpr(FalseExpr.INSTANCE),
+                ImmutableList.of(new Return(Drop.instance()))))
+        .addEqualityGroup(new Object())
+        .testEquals();
+  }
+
+  @Test
+  public void testJavaSerialization() {
+    If ifExpr = new If(new PacketMatchExpr(FalseExpr.INSTANCE), ImmutableList.of());
+    assertThat(SerializationUtils.clone(ifExpr), equalTo(ifExpr));
+  }
+
+  @Test
+  public void testJsonSerialization() throws IOException {
+    If ifExpr = new If(new PacketMatchExpr(FalseExpr.INSTANCE), ImmutableList.of());
+    assertThat(BatfishObjectMapper.clone(ifExpr, If.class), equalTo(ifExpr));
+  }
+
+  @Test
+  public void testToString() {
+    If ifExpr = new If(new PacketMatchExpr(FalseExpr.INSTANCE), ImmutableList.of());
+    assertTrue(ifExpr.toString().contains(ifExpr.getClass().getSimpleName()));
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/PacketMatchExprTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/PacketMatchExprTest.java
@@ -1,0 +1,45 @@
+package org.batfish.datamodel.packet_policy;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.testing.EqualsTester;
+import java.io.IOException;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.acl.FalseExpr;
+import org.batfish.datamodel.acl.TrueExpr;
+import org.junit.Test;
+
+/** Tests of {@link PacketMatchExpr} */
+public class PacketMatchExprTest {
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(
+            new PacketMatchExpr(TrueExpr.INSTANCE), new PacketMatchExpr(TrueExpr.INSTANCE))
+        .addEqualityGroup(new PacketMatchExpr(FalseExpr.INSTANCE))
+        .addEqualityGroup(new Object())
+        .testEquals();
+  }
+
+  @Test
+  public void testJavaSerialization() {
+    PacketMatchExpr pm = new PacketMatchExpr(TrueExpr.INSTANCE);
+    assertThat(SerializationUtils.clone(pm), equalTo(pm));
+  }
+
+  @Test
+  public void testJsonSerialization() throws IOException {
+    PacketMatchExpr pm = new PacketMatchExpr(TrueExpr.INSTANCE);
+    assertThat(BatfishObjectMapper.clone(pm, PacketMatchExpr.class), equalTo(pm));
+  }
+
+  @Test
+  public void testToString() {
+    PacketMatchExpr pm = new PacketMatchExpr(TrueExpr.INSTANCE);
+    assertTrue(pm.toString().contains(pm.getClass().getSimpleName()));
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/PacketPolicyTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/PacketPolicyTest.java
@@ -14,34 +14,44 @@ import org.junit.Test;
 /** Tests of {@link PacketPolicy} */
 public class PacketPolicyTest {
 
+  private final Return _defaultAction = new Return(new FibLookup("default"));
+
   @Test
   public void testEquals() {
-    PacketPolicy p = new PacketPolicy("name", ImmutableList.of(new Return(Drop.instance())));
+    PacketPolicy p =
+        new PacketPolicy("name", ImmutableList.of(new Return(Drop.instance())), _defaultAction);
     new EqualsTester()
         .addEqualityGroup(
-            p, p, new PacketPolicy("name", ImmutableList.of(new Return(Drop.instance()))))
+            p,
+            p,
+            new PacketPolicy("name", ImmutableList.of(new Return(Drop.instance())), _defaultAction))
         .addEqualityGroup(
-            new PacketPolicy("otherName", ImmutableList.of(new Return(Drop.instance()))))
-        .addEqualityGroup(new PacketPolicy("name", ImmutableList.of()))
+            new PacketPolicy(
+                "otherName", ImmutableList.of(new Return(Drop.instance())), _defaultAction))
+        .addEqualityGroup(new PacketPolicy("name", ImmutableList.of(), _defaultAction))
+        .addEqualityGroup(new PacketPolicy("name", ImmutableList.of(), new Return(Drop.instance())))
         .addEqualityGroup(new Object())
         .testEquals();
   }
 
   @Test
   public void testJavaSerialization() {
-    PacketPolicy p = new PacketPolicy("name", ImmutableList.of(new Return(Drop.instance())));
+    PacketPolicy p =
+        new PacketPolicy("name", ImmutableList.of(new Return(Drop.instance())), _defaultAction);
     assertThat(SerializationUtils.clone(p), equalTo(p));
   }
 
   @Test
   public void testJsonSerialization() throws IOException {
-    PacketPolicy p = new PacketPolicy("name", ImmutableList.of(new Return(Drop.instance())));
+    PacketPolicy p =
+        new PacketPolicy("name", ImmutableList.of(new Return(Drop.instance())), _defaultAction);
     assertThat(BatfishObjectMapper.clone(p, PacketPolicy.class), equalTo(p));
   }
 
   @Test
   public void testToString() {
-    PacketPolicy p = new PacketPolicy("name", ImmutableList.of(new Return(Drop.instance())));
+    PacketPolicy p =
+        new PacketPolicy("name", ImmutableList.of(new Return(Drop.instance())), _defaultAction);
     assertTrue(p.toString().contains(p.getClass().getSimpleName()));
     assertTrue(p.toString().contains("name"));
     assertTrue(p.toString().contains(p.getName()));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/PacketPolicyTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/PacketPolicyTest.java
@@ -1,0 +1,49 @@
+package org.batfish.datamodel.packet_policy;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.testing.EqualsTester;
+import java.io.IOException;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.junit.Test;
+
+/** Tests of {@link PacketPolicy} */
+public class PacketPolicyTest {
+
+  @Test
+  public void testEquals() {
+    PacketPolicy p = new PacketPolicy("name", ImmutableList.of(new Return(Drop.instance())));
+    new EqualsTester()
+        .addEqualityGroup(
+            p, p, new PacketPolicy("name", ImmutableList.of(new Return(Drop.instance()))))
+        .addEqualityGroup(
+            new PacketPolicy("otherName", ImmutableList.of(new Return(Drop.instance()))))
+        .addEqualityGroup(new PacketPolicy("name", ImmutableList.of()))
+        .addEqualityGroup(new Object())
+        .testEquals();
+  }
+
+  @Test
+  public void testJavaSerialization() {
+    PacketPolicy p = new PacketPolicy("name", ImmutableList.of(new Return(Drop.instance())));
+    assertThat(SerializationUtils.clone(p), equalTo(p));
+  }
+
+  @Test
+  public void testJsonSerialization() throws IOException {
+    PacketPolicy p = new PacketPolicy("name", ImmutableList.of(new Return(Drop.instance())));
+    assertThat(BatfishObjectMapper.clone(p, PacketPolicy.class), equalTo(p));
+  }
+
+  @Test
+  public void testToString() {
+    PacketPolicy p = new PacketPolicy("name", ImmutableList.of(new Return(Drop.instance())));
+    assertTrue(p.toString().contains(p.getClass().getSimpleName()));
+    assertTrue(p.toString().contains("name"));
+    assertTrue(p.toString().contains(p.getName()));
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/ReturnTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/ReturnTest.java
@@ -1,0 +1,44 @@
+package org.batfish.datamodel.packet_policy;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.testing.EqualsTester;
+import java.io.IOException;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.junit.Test;
+
+public class ReturnTest {
+
+  @Test
+  public void testEquals() {
+    Return r = new Return(Drop.instance());
+    new EqualsTester()
+        .addEqualityGroup(r, r, new Return(Drop.instance()))
+        .addEqualityGroup(new Return(new FibLookup("vrf")))
+        .addEqualityGroup(new Object())
+        .testEquals();
+  }
+
+  @Test
+  public void testJavaSerialization() {
+    Return r = new Return(Drop.instance());
+    assertThat(SerializationUtils.clone(r), equalTo(r));
+  }
+
+  @Test
+  public void testJsonSerialization() throws IOException {
+    Return r = new Return(Drop.instance());
+    assertThat(BatfishObjectMapper.clone(r, Return.class), equalTo(r));
+  }
+
+  @Test
+  public void testToString() {
+    Return r = new Return(Drop.instance());
+    assertTrue(r.toString().contains(Return.class.getSimpleName()));
+    assertTrue(r.toString().contains("action"));
+    assertTrue(r.toString().contains(r.getAction().toString()));
+  }
+}


### PR DESCRIPTION
Implement the datamodel (and simple evaluation) of very basic policy statements needed for Policy-based Routing.

This is intentionally not plugged into anything yet.