### PR TITLE
Implement FIB as a prefix trie

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Fib.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Fib.java
@@ -16,6 +16,12 @@ public interface Fib extends Serializable {
   Set<String> getNextHopInterfaces(Ip ip);
 
   /**
+   * Return a set of {@link FibEntry fib entries} that match a given IP (using longest prefix match)
+   */
+  @Nonnull
+  Set<FibEntry> get(Ip ip);
+
+  /**
    * Mapping: matching route -&gt; nexthopinterface -&gt; resolved nextHopIP -&gt; interfaceRoutes
    */
   @Nonnull

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibEntry.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibEntry.java
@@ -1,0 +1,81 @@
+package org.batfish.datamodel;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.common.collect.Iterables;
+import java.io.Serializable;
+import java.util.List;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+public final class FibEntry implements Serializable {
+  private static final long serialVersionUID = 1L;
+  @Nonnull private final Ip _arpIP;
+  @Nonnull private final String _interfaceName;
+  @Nonnull private final List<AbstractRoute> _resolutionSteps;
+
+  /**
+   * Create a new FIB entry with the given nextHop/ARP IP, interface name, and resolution steps.
+   *
+   * <p>Note that at least one resolution step is required (even if it is the route itself, e.g. a
+   * connected route)
+   */
+  public FibEntry(Ip arpIP, String interfaceName, List<AbstractRoute> resolutionSteps) {
+    checkArgument(
+        !resolutionSteps.isEmpty(), "FIB resolution steps must contain at least one route");
+    _arpIP = arpIP;
+    _interfaceName = interfaceName;
+    _resolutionSteps = resolutionSteps;
+  }
+
+  /** IP that a router would ARP for to send the packet */
+  @Nonnull
+  public Ip getArpIP() {
+    return _arpIP;
+  }
+
+  /** Name of the interface to be used to send the packet out */
+  @Nonnull
+  public String getInterfaceName() {
+    return _interfaceName;
+  }
+
+  /** A chain of routes that explains how the top route was resolved */
+  @Nonnull
+  public List<AbstractRoute> getResolutionSteps() {
+    return _resolutionSteps;
+  }
+
+  /** Return the top level route for this entry (before recursive resolution) */
+  @Nonnull
+  public AbstractRoute getTopLevelRoute() {
+    return _resolutionSteps.get(0);
+  }
+
+  /** Return the final resolved route */
+  public AbstractRoute getResolvedToRoute() {
+    return Iterables.getLast(_resolutionSteps);
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    FibEntry fibEntry = (FibEntry) o;
+    return Objects.equals(getArpIP(), fibEntry.getArpIP())
+        && Objects.equals(getInterfaceName(), fibEntry.getInterfaceName())
+        && Objects.equals(getResolutionSteps(), fibEntry.getResolutionSteps());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getArpIP(), getInterfaceName(), getResolutionSteps());
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibImpl.java
@@ -1,36 +1,125 @@
 package org.batfish.datamodel;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSet.Builder;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.TreeSet;
-import java.util.function.Function;
+import java.util.Stack;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.common.BatfishException;
 
-public class FibImpl<R extends AbstractRouteDecorator> implements Fib {
+@ParametersAreNonnullByDefault
+public final class FibImpl implements Fib {
+
+  /** Helps perform recursive route resolution and maintain the route chain */
+  private static final class ResolutionTreeNode {
+    private final @Nonnull AbstractRoute _route;
+    private final @Nullable Ip _finalNextHopIp;
+
+    private final @Nonnull List<ResolutionTreeNode> _children;
+
+    /** Use static factories for sanity */
+    private ResolutionTreeNode(
+        AbstractRoute route, @Nullable Ip finalNextHopIp, List<ResolutionTreeNode> children) {
+      _route = route;
+      _finalNextHopIp = finalNextHopIp;
+      _children = children;
+    }
+
+    static ResolutionTreeNode withParent(
+        AbstractRoute route, @Nullable ResolutionTreeNode parent, @Nullable Ip finalNextHopIp) {
+      ResolutionTreeNode child = new ResolutionTreeNode(route, finalNextHopIp, new LinkedList<>());
+      if (parent != null) {
+        parent.addChild(child);
+      }
+      return child;
+    }
+
+    static ResolutionTreeNode root(@Nonnull AbstractRoute route) {
+      return new ResolutionTreeNode(route, null, new LinkedList<>());
+    }
+
+    @Nonnull
+    public AbstractRoute getRoute() {
+      return _route;
+    }
+
+    @Nullable
+    public Ip getFinalNextHopIp() {
+      return _finalNextHopIp;
+    }
+
+    @Nonnull
+    public List<ResolutionTreeNode> getChildren() {
+      return _children;
+    }
+
+    private void addChild(ResolutionTreeNode child) {
+      _children.add(child);
+    }
+  }
 
   private static final int MAX_DEPTH = 10;
-
   private static final long serialVersionUID = 1L;
 
-  private final @Nonnull Map<AbstractRoute, Map<String, Map<Ip, Set<AbstractRoute>>>>
+  /** This trie is the source of truth for all resolved FIB routes */
+  @Nonnull private final PrefixTrieMultiMap<FibEntry> _root;
+
+  private transient Supplier<Map<AbstractRoute, Set<FibEntry>>> _entries;
+  private transient Supplier<Map<AbstractRoute, Map<String, Map<Ip, Set<AbstractRoute>>>>>
       _nextHopInterfaces;
 
-  private final @Nonnull GenericRib<R> _rib;
+  public FibImpl(@Nonnull GenericRib<? extends AbstractRouteDecorator> rib) {
+    _root = new PrefixTrieMultiMap<>(Prefix.ZERO);
+    rib.getRoutes()
+        .forEach(
+            r -> {
+              Set<FibEntry> s = resolveRoute(rib, r);
+              _root.putAll(r.getNetwork(), s);
+            });
+    initSuppliers();
+  }
 
-  public FibImpl(@Nonnull GenericRib<R> rib) {
-    _rib = rib;
-    _nextHopInterfaces =
-        rib.getRoutes().stream()
-            .collect(
-                ImmutableMap.toImmutableMap(
-                    Function.identity(), route -> collectNextHopInterfaces(_rib, route)));
+  private void initSuppliers() {
+    _entries = Suppliers.memoize(this::computeEntries);
+    _nextHopInterfaces = Suppliers.memoize(this::computeNextHopInterfaces);
+  }
+
+  private Map<AbstractRoute, Map<String, Map<Ip, Set<AbstractRoute>>>> computeNextHopInterfaces() {
+    return _root.getAllElements().stream()
+        .collect(
+            Collectors.groupingBy(
+                FibEntry::getTopLevelRoute,
+                Collectors.groupingBy(
+                    FibEntry::getInterfaceName,
+                    Collectors.groupingBy(
+                        FibEntry::getArpIP,
+                        Collectors.mapping(FibEntry::getResolvedToRoute, Collectors.toSet())))));
+  }
+
+  private Map<AbstractRoute, Set<FibEntry>> computeEntries() {
+    return _root.getAllElements().stream()
+        .collect(Collectors.groupingBy(FibEntry::getTopLevelRoute, Collectors.toSet()));
+  }
+
+  @Nonnull
+  public Map<AbstractRoute, Set<FibEntry>> getEntries() {
+    return _entries.get();
   }
 
   /**
@@ -42,32 +131,60 @@ public class FibImpl<R extends AbstractRouteDecorator> implements Fib {
    * @throws BatfishException if resolution depth is exceeded (high likelihood of a routing loop) OR
    *     an invalid route in the RIB has been encountered.
    */
-  private static Map<String, Map<Ip, Set<AbstractRoute>>> collectNextHopInterfaces(
+  @VisibleForTesting
+  Set<FibEntry> resolveRoute(
       GenericRib<? extends AbstractRouteDecorator> rib, AbstractRoute route) {
-    Map<String, Map<Ip, Set<AbstractRoute>>> nextHopInterfaces = new HashMap<>();
-    collectNextHopInterfaces(
+    ResolutionTreeNode resolutionRoot = ResolutionTreeNode.root(route);
+    buildResolutionTree(
         rib,
         route,
         Route.UNSET_ROUTE_NEXT_HOP_IP,
-        nextHopInterfaces,
         new HashSet<>(),
         0,
         Prefix.MAX_PREFIX_LENGTH,
-        null);
-    return ImmutableMap.copyOf(nextHopInterfaces);
+        null,
+        resolutionRoot);
+    Builder<FibEntry> collector = ImmutableSet.builder();
+    collectEntries(resolutionRoot, new Stack<>(), collector);
+    return collector.build();
   }
 
-  private static <T extends AbstractRouteDecorator> void collectNextHopInterfaces(
-      GenericRib<T> rib,
+  private void collectEntries(
+      ResolutionTreeNode node,
+      Stack<AbstractRoute> stack,
+      ImmutableCollection.Builder<FibEntry> entriesBuilder) {
+    if (node.getChildren().isEmpty() && node.getFinalNextHopIp() != null) {
+      entriesBuilder.add(
+          new FibEntry(
+              node.getFinalNextHopIp(),
+              node.getRoute().getNextHopInterface(),
+              ImmutableList.copyOf(stack)));
+      return;
+    }
+    stack.push(node.getRoute());
+    for (ResolutionTreeNode child : node.getChildren()) {
+      collectEntries(child, stack, entriesBuilder);
+    }
+    stack.pop();
+  }
+
+  /**
+   * Tail-recursive method to build a route resolution tree. Each top-level route is mapped to a
+   * number of leaf {@link ResolutionTreeNode}. Leaf nodes must contain non-null {@link
+   * ResolutionTreeNode#_finalNextHopIp}
+   */
+  private void buildResolutionTree(
+      GenericRib<? extends AbstractRouteDecorator> rib,
       AbstractRoute route,
       Ip mostRecentNextHopIp,
-      Map<String, Map<Ip, Set<AbstractRoute>>> nextHopInterfaces,
       Set<Prefix> seenNetworks,
       int depth,
       int maxPrefixLength,
-      @Nullable AbstractRoute parentRoute) {
+      @Nullable AbstractRoute parentRoute,
+      ResolutionTreeNode treeNode) {
     Prefix network = route.getNetwork();
     if (seenNetworks.contains(network)) {
+      // Don't enter a resolution loop
       return;
     }
     Set<Prefix> newSeenNetworks = new HashSet<>(seenNetworks);
@@ -84,84 +201,73 @@ public class FibImpl<R extends AbstractRouteDecorator> implements Fib {
         return;
       } else {
         seenNetworks.remove(parentRoute.getNetwork());
-        collectNextHopInterfaces(
+        buildResolutionTree(
             rib,
             parentRoute,
             mostRecentNextHopIp,
-            nextHopInterfaces,
             seenNetworks,
             depth + 1,
             maxPrefixLength - 1,
-            null);
+            null,
+            treeNode);
         return;
       }
     }
 
     /* For BGP next-hop-discard routes, ignore next-hop-ip and exit early */
     if (route instanceof BgpRoute && ((BgpRoute) route).getDiscard()) {
-      Map<Ip, Set<AbstractRoute>> nextHopInterfaceRoutesByFinalNextHopIp =
-          nextHopInterfaces.computeIfAbsent(Interface.NULL_INTERFACE_NAME, k -> new HashMap<>());
-      Set<AbstractRoute> nextHopInterfaceRoutes =
-          nextHopInterfaceRoutesByFinalNextHopIp.computeIfAbsent(
-              Route.UNSET_ROUTE_NEXT_HOP_IP, k -> new TreeSet<>());
-      nextHopInterfaceRoutes.add(route);
+      ResolutionTreeNode.withParent(route, treeNode, Route.UNSET_ROUTE_NEXT_HOP_IP);
       return;
     }
 
-    String nextHopInterface = route.getNextHopInterface();
-    if (!Route.UNSET_NEXT_HOP_INTERFACE.equals(nextHopInterface)) {
+    if (!Route.UNSET_NEXT_HOP_INTERFACE.equals(route.getNextHopInterface())) {
       Ip finalNextHopIp =
           route.getNextHopIp().equals(Route.UNSET_ROUTE_NEXT_HOP_IP)
               ? mostRecentNextHopIp
               : route.getNextHopIp();
-      Map<Ip, Set<AbstractRoute>> nextHopInterfaceRoutesByFinalNextHopIp =
-          nextHopInterfaces.computeIfAbsent(nextHopInterface, k -> new HashMap<>());
-      Set<AbstractRoute> nextHopInterfaceRoutes =
-          nextHopInterfaceRoutesByFinalNextHopIp.computeIfAbsent(
-              finalNextHopIp, k -> new TreeSet<>());
-      nextHopInterfaceRoutes.add(route);
+      ResolutionTreeNode.withParent(route, treeNode, finalNextHopIp);
     } else {
       Ip nextHopIp = route.getNextHopIp();
-      if (!nextHopIp.equals(Route.UNSET_ROUTE_NEXT_HOP_IP)) {
-        Set<T> nextHopLongestPrefixMatchRoutes = rib.longestPrefixMatch(nextHopIp, maxPrefixLength);
-
-        /* Filter out any non-forwarding routes from the matches */
-        Set<AbstractRoute> forwardingRoutes =
-            nextHopLongestPrefixMatchRoutes.stream()
-                .map(AbstractRouteDecorator::getAbstractRoute)
-                .filter(r -> !r.getNonForwarding())
-                .collect(ImmutableSet.toImmutableSet());
-
-        if (forwardingRoutes.isEmpty()) {
-          // Re-resolve *this route* with less specific prefix match
-          seenNetworks.remove(route.getNetwork());
-          collectNextHopInterfaces(
-              rib,
-              route,
-              mostRecentNextHopIp,
-              nextHopInterfaces,
-              seenNetworks,
-              depth + 1,
-              maxPrefixLength - 1,
-              parentRoute);
-        } else {
-          // We have at least one valid longest-prefix match
-          for (AbstractRoute nextHopLongestPrefixMatchRoute : forwardingRoutes) {
-            collectNextHopInterfaces(
-                rib,
-                nextHopLongestPrefixMatchRoute,
-                nextHopIp,
-                nextHopInterfaces,
-                newSeenNetworks,
-                depth + 1,
-                Prefix.MAX_PREFIX_LENGTH,
-                route);
-          }
-        }
-      } else {
+      if (nextHopIp.equals(Route.UNSET_ROUTE_NEXT_HOP_IP)) {
         // TODO: Declare this using some warning mechanism
         // https://github.com/batfish/batfish/issues/1469
         return;
+      }
+      Set<? extends AbstractRouteDecorator> nextHopLongestPrefixMatchRoutes =
+          rib.longestPrefixMatch(nextHopIp, maxPrefixLength);
+
+      /* Filter out any non-forwarding routes from the matches */
+      Set<AbstractRoute> forwardingRoutes =
+          nextHopLongestPrefixMatchRoutes.stream()
+              .map(AbstractRouteDecorator::getAbstractRoute)
+              .filter(r -> !r.getNonForwarding())
+              .collect(ImmutableSet.toImmutableSet());
+
+      if (forwardingRoutes.isEmpty()) {
+        // Re-resolve *this route* with a less specific prefix match
+        seenNetworks.remove(route.getNetwork());
+        buildResolutionTree(
+            rib,
+            route,
+            mostRecentNextHopIp,
+            seenNetworks,
+            depth + 1,
+            maxPrefixLength - 1,
+            parentRoute,
+            treeNode);
+      } else {
+        // We have at least one valid longest-prefix match
+        for (AbstractRoute nextHopLongestPrefixMatchRoute : forwardingRoutes) {
+          buildResolutionTree(
+              rib,
+              nextHopLongestPrefixMatchRoute,
+              nextHopIp,
+              newSeenNetworks,
+              depth + 1,
+              Prefix.MAX_PREFIX_LENGTH,
+              route,
+              ResolutionTreeNode.withParent(nextHopLongestPrefixMatchRoute, treeNode, null));
+        }
       }
     }
   }
@@ -170,41 +276,57 @@ public class FibImpl<R extends AbstractRouteDecorator> implements Fib {
   @Override
   public @Nonnull Map<AbstractRoute, Map<String, Map<Ip, Set<AbstractRoute>>>>
       getNextHopInterfaces() {
-    return _nextHopInterfaces;
+    return _nextHopInterfaces.get();
   }
 
   @Override
   public @Nonnull Set<String> getNextHopInterfaces(Ip ip) {
-    return _rib.longestPrefixMatch(ip).stream()
-        .map(AbstractRouteDecorator::getAbstractRoute)
-        .flatMap(nextHopRoute -> _nextHopInterfaces.get(nextHopRoute).keySet().stream())
-        .collect(ImmutableSet.toImmutableSet());
+    return get(ip).stream().map(FibEntry::getInterfaceName).collect(ImmutableSet.toImmutableSet());
+  }
+
+  @Nonnull
+  @Override
+  public Set<FibEntry> get(Ip ip) {
+    return _root.longestPrefixMatch(ip);
   }
 
   @Override
   public @Nonnull Map<AbstractRoute, Map<String, Map<Ip, Set<AbstractRoute>>>>
       getNextHopInterfacesByRoute(Ip dstIp) {
-    return _rib.longestPrefixMatch(dstIp).stream()
-        .map(AbstractRouteDecorator::getAbstractRoute)
-        .collect(ImmutableMap.toImmutableMap(Function.identity(), _nextHopInterfaces::get));
+    return get(dstIp).stream()
+        .collect(
+            Collectors.groupingBy(
+                FibEntry::getTopLevelRoute,
+                Collectors.groupingBy(
+                    FibEntry::getInterfaceName,
+                    Collectors.groupingBy(
+                        FibEntry::getArpIP,
+                        Collectors.mapping(FibEntry::getResolvedToRoute, Collectors.toSet())))));
   }
 
   @Override
   public @Nonnull Map<String, Set<AbstractRoute>> getRoutesByNextHopInterface() {
     Map<String, ImmutableSet.Builder<AbstractRoute>> routesByNextHopInterface = new HashMap<>();
-    _nextHopInterfaces.forEach(
-        (route, nextHopInterfaceMap) ->
-            nextHopInterfaceMap
-                .keySet()
-                .forEach(
-                    nextHopInterface ->
-                        routesByNextHopInterface
-                            .computeIfAbsent(nextHopInterface, n -> ImmutableSet.builder())
-                            .add(route)));
+    getNextHopInterfaces()
+        .forEach(
+            (route, nextHopInterfaceMap) ->
+                nextHopInterfaceMap
+                    .keySet()
+                    .forEach(
+                        nextHopInterface ->
+                            routesByNextHopInterface
+                                .computeIfAbsent(nextHopInterface, n -> ImmutableSet.builder())
+                                .add(route)));
     return routesByNextHopInterface.entrySet().stream()
         .collect(
             ImmutableMap.toImmutableMap(
                 Entry::getKey /* interfaceName */,
                 routesByNextHopInterfaceEntry -> routesByNextHopInterfaceEntry.getValue().build()));
+  }
+
+  private void readObject(java.io.ObjectInputStream stream)
+      throws IOException, ClassNotFoundException {
+    stream.defaultReadObject();
+    initSuppliers();
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/FibEntryTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/FibEntryTest.java
@@ -1,0 +1,48 @@
+package org.batfish.datamodel;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/** Test of {@link FibEntry} */
+public class FibEntryTest {
+
+  private static final ImmutableList<AbstractRoute> RESOLUTION_STEPS =
+      ImmutableList.of(new ConnectedRoute(Prefix.parse("2.2.2.2/31"), "Eth1"));
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(
+            new FibEntry(Ip.parse("1.1.1.1"), "Eth1", RESOLUTION_STEPS),
+            new FibEntry(Ip.parse("1.1.1.1"), "Eth1", RESOLUTION_STEPS))
+        .addEqualityGroup(new FibEntry(Ip.parse("1.1.1.2"), "Eth1", RESOLUTION_STEPS))
+        .addEqualityGroup(new FibEntry(Ip.parse("1.1.1.1"), "Eth2", RESOLUTION_STEPS))
+        .addEqualityGroup(
+            new FibEntry(
+                Ip.parse("1.1.1.1"),
+                "Eth1",
+                ImmutableList.of(new ConnectedRoute(Prefix.parse("2.2.2.4/31"), "Eth100"))))
+        .addEqualityGroup(new Object())
+        .testEquals();
+  }
+
+  @Test
+  public void testJavaSerialization() {
+    FibEntry fe = new FibEntry(Ip.parse("1.1.1.1"), "Eth1", RESOLUTION_STEPS);
+    assertThat(SerializationUtils.clone(fe), equalTo(fe));
+  }
+
+  @Test
+  public void requiresSteps() {
+    thrown.expect(IllegalArgumentException.class);
+    new FibEntry(Ip.parse("1.1.1.1"), "Eth1", ImmutableList.of());
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockFib.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockFib.java
@@ -90,6 +90,12 @@ public class MockFib implements Fib {
     return _nextHopInterfacesByIp.getOrDefault(ip, ImmutableMap.of()).keySet();
   }
 
+  @Nonnull
+  @Override
+  public Set<FibEntry> get(Ip ip) {
+    throw new UnsupportedOperationException();
+  }
+
   @Override
   public @Nonnull Map<AbstractRoute, Map<String, Map<Ip, Set<AbstractRoute>>>>
       getNextHopInterfacesByRoute(Ip dstIp) {

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -587,7 +587,7 @@ public class VirtualRouter implements Serializable {
 
   /** Compute the FIB from the main RIB */
   public void computeFib() {
-    _fib = new FibImpl<>(_mainRib);
+    _fib = new FibImpl(_mainRib);
   }
 
   boolean computeInterAreaSummaries() {

--- a/projects/batfish/src/test/java/org/batfish/dataplane/FibImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/FibImplTest.java
@@ -187,7 +187,7 @@ public class FibImplTest {
     rib.mergeRoute(annotateRoute(nonForwardingRoute));
     rib.mergeRoute(annotateRoute(forwardingRoute));
 
-    Fib fib = new FibImpl<>(rib);
+    Fib fib = new FibImpl(rib);
     Set<AbstractRoute> fibRoutes = fib.getRoutesByNextHopInterface().get("Eth1");
 
     assertThat(fibRoutes, not(hasItem(hasPrefix(Prefix.parse("1.1.1.0/24")))));
@@ -226,7 +226,7 @@ public class FibImplTest {
     rib.mergeRoute(annotateRoute(forwardingLessSpecificRoute));
     rib.mergeRoute(annotateRoute(testRoute));
 
-    Fib fib = new FibImpl<>(rib);
+    Fib fib = new FibImpl(rib);
     Set<AbstractRoute> fibRoutesEth1 = fib.getRoutesByNextHopInterface().get("Eth1");
 
     /* 2.2.2.0/24 should resolve to the "forwardingLessSpecificRoute" and thus eth1 */
@@ -287,7 +287,7 @@ public class FibImplTest {
     rib.mergeRoute(annotateRoute(ecmpForwardingRoute1));
     rib.mergeRoute(annotateRoute(ecmpForwardingRoute2));
 
-    Fib fib = new FibImpl<>(rib);
+    Fib fib = new FibImpl(rib);
 
     /* 2.2.2.0/24 should resolve to eth3 and eth4*/
     assertThat(fib.getRoutesByNextHopInterface().get("Eth3"), hasItem(hasPrefix(TEST_PREFIX)));


### PR DESCRIPTION
Take 2. Exactly the same as #3201, but with the added benefit of #3213 fixing LPM. thanks, @anothermattbrown 

I've verified that default routes are matchable in traceroute.

Benefits:
* Single source of truth
* New saner get + FibEntry API instead of maps
* Support for longest prefix match
* No need to store pointer to RIB