### PR TITLE
Remove bgpMP as a valid rib parameter in routesQuestion

### DIFF
--- a/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswerer.java
@@ -91,16 +91,6 @@ public class RoutesAnswerer extends Answerer {
                 vrfRegex);
         break;
 
-      case BGPMP:
-        rows =
-            getBgpRibRoutes(
-                dp.getBgpRoutes(true),
-                RibProtocol.BGPMP,
-                matchingNodes,
-                network,
-                protocolSpec,
-                vrfRegex);
-        break;
       case MAIN:
       default:
         rows =
@@ -149,22 +139,6 @@ public class RoutesAnswerer extends Answerer {
         rows = getBgpRouteRowsDiff(routesDiffRaw, RibProtocol.BGP);
         break;
 
-      case BGPMP:
-        _batfish.pushBaseSnapshot();
-        dp = _batfish.loadDataPlane();
-        routesGroupedByKeyInBase =
-            groupBgpRoutes(dp.getBgpRoutes(true), matchingNodes, vrfRegex, network, vrfRegex);
-        _batfish.popSnapshot();
-
-        _batfish.pushDeltaSnapshot();
-        dp = _batfish.loadDataPlane();
-        routesGroupedByKeyInDelta =
-            groupBgpRoutes(dp.getBgpRoutes(true), matchingNodes, vrfRegex, network, vrfRegex);
-        _batfish.popSnapshot();
-        routesDiffRaw = getRoutesDiff(routesGroupedByKeyInBase, routesGroupedByKeyInDelta);
-        rows = getBgpRouteRowsDiff(routesDiffRaw, RibProtocol.BGPMP);
-        break;
-
       case MAIN:
       default:
         _batfish.pushBaseSnapshot();
@@ -196,7 +170,6 @@ public class RoutesAnswerer extends Answerer {
     addCommonTableColumnsAtStart(columnBuilder);
     switch (rib) {
       case BGP:
-      case BGPMP:
         columnBuilder.add(
             new ColumnMetadata(
                 COL_NEXT_HOP_IP, Schema.IP, "Route's Next Hop IP", Boolean.FALSE, Boolean.TRUE));
@@ -295,7 +268,6 @@ public class RoutesAnswerer extends Answerer {
             Boolean.TRUE));
     switch (rib) {
       case BGP:
-      case BGPMP:
         columnBuilder.add(
             new ColumnMetadata(
                 COL_BASE_PREFIX + COL_NEXT_HOP_IP,

--- a/projects/question/src/main/java/org/batfish/question/routes/RoutesQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RoutesQuestion.java
@@ -25,8 +25,7 @@ public class RoutesQuestion extends Question {
   /** RIBs of these protocols are available for examining routes using {@link RoutesQuestion}. */
   public enum RibProtocol {
     MAIN("main"),
-    BGP("bgp"),
-    BGPMP("bgpmp"); // BGP multi path
+    BGP("bgp");
 
     private final String _protocolName;
 

--- a/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
@@ -34,7 +34,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Multiset;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -266,14 +265,12 @@ public class RoutesAnswererTest {
         COL_TAG);
     List<String> expected = expectedBuilder.build();
 
-    for (RibProtocol rib : Arrays.asList(RibProtocol.BGP, RibProtocol.BGPMP)) {
-      List<ColumnMetadata> columnMetadata = getTableMetadata(rib).getColumnMetadata();
-      assertThat(
-          columnMetadata.stream()
-              .map(ColumnMetadata::getName)
-              .collect(ImmutableList.toImmutableList()),
-          equalTo(expected));
-    }
+    List<ColumnMetadata> columnMetadata = getTableMetadata(RibProtocol.BGP).getColumnMetadata();
+    assertThat(
+        columnMetadata.stream()
+            .map(ColumnMetadata::getName)
+            .collect(ImmutableList.toImmutableList()),
+        equalTo(expected));
   }
 
   @Test
@@ -374,20 +371,18 @@ public class RoutesAnswererTest {
         Schema.INTEGER,
         Schema.INTEGER);
 
-    for (RibProtocol rib : Arrays.asList(RibProtocol.BGP, RibProtocol.BGPMP)) {
-      List<ColumnMetadata> columnMetadata = getDiffTableMetadata(rib).getColumnMetadata();
-      assertThat(
-          columnMetadata.stream()
-              .map(ColumnMetadata::getName)
-              .collect(ImmutableList.toImmutableList()),
-          equalTo(expectedBuilder.build()));
+    List<ColumnMetadata> columnMetadata = getDiffTableMetadata(RibProtocol.BGP).getColumnMetadata();
+    assertThat(
+        columnMetadata.stream()
+            .map(ColumnMetadata::getName)
+            .collect(ImmutableList.toImmutableList()),
+        equalTo(expectedBuilder.build()));
 
-      assertThat(
-          columnMetadata.stream()
-              .map(ColumnMetadata::getSchema)
-              .collect(ImmutableList.toImmutableList()),
-          equalTo(schemaBuilderList.build()));
-    }
+    assertThat(
+        columnMetadata.stream()
+            .map(ColumnMetadata::getSchema)
+            .collect(ImmutableList.toImmutableList()),
+        equalTo(schemaBuilderList.build()));
   }
 
   /** Run through full pipeline (create question and answerer), */

--- a/questions/stable/routes.json
+++ b/questions/stable/routes.json
@@ -44,9 +44,6 @@
                     },
                     {
                         "name": "bgp"
-                    },
-                    {
-                        "name": "bgpmp"
                     }
                 ],
                 "displayName": "RIB"

--- a/tests/questions/stable/routes.ref
+++ b/tests/questions/stable/routes.ref
@@ -40,7 +40,6 @@
       "rib" : {
         "allowedValues" : [
           "bgp",
-          "bgpmp",
           "main"
         ],
         "description" : "Only return routes from a given protocol RIB",
@@ -54,9 +53,6 @@
           },
           {
             "name" : "bgp"
-          },
-          {
-            "name" : "bgpmp"
           }
         ]
       },


### PR DESCRIPTION
Since we no longer split bgp best paths and multi-path ribs.