### PR TITLE
Grammar for EIGRP metric weights

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
@@ -7429,6 +7429,11 @@ MAXIMUM_ACCEPTED_ROUTES
    'maximum-accepted-routes'
 ;
 
+MAXIMUM_HOPS
+:
+   'maximum-hops'
+;
+
 MAXIMUM_PATHS
 :
    'maximum-paths'
@@ -10689,6 +10694,11 @@ RIB_METRIC_AS_EXTERNAL
 RIB_METRIC_AS_INTERNAL
 :
    'rib-metric-as-internal'
+;
+
+RIB_SCALE
+:
+   'rib-scale'
 ;
 
 RING
@@ -14008,6 +14018,11 @@ WEIGHT
 WEIGHTING
 :
    'weighting'
+;
+
+WEIGHTS
+:
+   'weights'
 ;
 
 WELCOME_PAGE

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_eigrp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_eigrp.g4
@@ -17,6 +17,7 @@ re_classic_tail
    re_eigrp_null
    | re_eigrp_router_id
    | rec_address_family
+   | rec_metric_weights
    | rec_null
    | re_default_metric
    | re_network
@@ -242,7 +243,7 @@ reaf_topology_null
       | DISTRIBUTE_LIST
       | FAST_REROUTE
       | MAXIMUM_PATHS
-      | METRIC
+      | (METRIC MAXIMUM_HOPS)
       | OFFSET_LIST
       | SNMP
       | SUMMARY_METRIC
@@ -282,7 +283,7 @@ rec_address_family_null
       | DISTRIBUTE_LIST
       | MAXIMUM_PATHS
       | MAXIMUM_PREFIX
-      | METRIC
+      | (METRIC MAXIMUM_HOPS)
       | NEIGHBOR
       | NSF
       | OFFSET_LIST
@@ -300,6 +301,12 @@ rec_address_family_tail
    | re_passive_interface
    | re_redistribute
    | rec_address_family_null
+   | rec_metric_weights
+;
+
+rec_metric_weights
+:
+   METRIC WEIGHTS tos = DEC k1 = DEC k2 = DEC k3 = DEC k4 = DEC k5 = DEC NEWLINE
 ;
 
 rec_null
@@ -313,7 +320,7 @@ rec_null
       | DISTRIBUTE_LIST
       | HELLO_INTERVAL
       | MAXIMUM_PATHS
-      | METRIC
+      | (METRIC MAXIMUM_HOPS)
       | NEIGHBOR
       | NSF
       | OFFSET_LIST
@@ -348,7 +355,7 @@ ren_address_family_null
    NO?
    (
       MAXIMUM_PREFIX
-      | METRIC
+      | (METRIC RIB_SCALE)
       | NEIGHBOR
       | NSF
       | REMOTE_NEIGHBORS
@@ -368,6 +375,13 @@ ren_address_family_tail
    | reaf_interface
    | reaf_topology
    | ren_address_family_null
+   | ren_metric_weights
+;
+
+ren_metric_weights
+:
+   METRIC WEIGHTS
+   tos = DEC (k1 = DEC)? (k2 = DEC)? (k3 = DEC)? (k4 = DEC)? (k5 = DEC)? (k6 = DEC)? NEWLINE
 ;
 
 ren_null
@@ -398,9 +412,11 @@ ren_service_family_tail
 :
    re_eigrp_null
    | re_eigrp_router_id
+   | ren_metric_weights
    | ren_service_family_null
    | resf_interface_default
    | resf_interface
+   | resf_null
    | resf_topology
 ;
 
@@ -447,7 +463,6 @@ resf_null
    NO?
    (
       EIGRP
-      | METRIC
       | NEIGHBOR
       | REMOTE_NEIGHBORS
       | SHUTDOWN
@@ -465,7 +480,7 @@ resf_topology_null
 :
    NO?
    (
-      METRIC
+      (METRIC MAXIMUM_HOPS)
       | TIMERS
    ) null_rest_of_line
 ;

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -924,6 +924,7 @@ import org.batfish.grammar.cisco.CiscoParser.Reaf_interfaceContext;
 import org.batfish.grammar.cisco.CiscoParser.Reaf_interface_defaultContext;
 import org.batfish.grammar.cisco.CiscoParser.Reafi_passive_interfaceContext;
 import org.batfish.grammar.cisco.CiscoParser.Rec_address_familyContext;
+import org.batfish.grammar.cisco.CiscoParser.Rec_metric_weightsContext;
 import org.batfish.grammar.cisco.CiscoParser.Redistribute_aggregate_bgp_tailContext;
 import org.batfish.grammar.cisco.CiscoParser.Redistribute_connected_bgp_tailContext;
 import org.batfish.grammar.cisco.CiscoParser.Redistribute_connected_is_stanzaContext;
@@ -935,6 +936,7 @@ import org.batfish.grammar.cisco.CiscoParser.Redistribute_static_is_stanzaContex
 import org.batfish.grammar.cisco.CiscoParser.Remote_as_bgp_tailContext;
 import org.batfish.grammar.cisco.CiscoParser.Remove_private_as_bgp_tailContext;
 import org.batfish.grammar.cisco.CiscoParser.Ren_address_familyContext;
+import org.batfish.grammar.cisco.CiscoParser.Ren_metric_weightsContext;
 import org.batfish.grammar.cisco.CiscoParser.Ro_areaContext;
 import org.batfish.grammar.cisco.CiscoParser.Ro_area_filterlistContext;
 import org.batfish.grammar.cisco.CiscoParser.Ro_area_nssaContext;
@@ -7821,8 +7823,20 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   }
 
   @Override
+  public void exitRec_metric_weights(Rec_metric_weightsContext ctx) {
+    // See https://github.com/batfish/batfish/issues/1946
+    todo(ctx);
+  }
+
+  @Override
   public void exitRen_address_family(Ren_address_familyContext ctx) {
     exitEigrpProcess(ctx);
+  }
+
+  @Override
+  public void exitRen_metric_weights(Ren_metric_weightsContext ctx) {
+    // See https://github.com/batfish/batfish/issues/1946
+    todo(ctx);
   }
 
   @Override
@@ -10207,6 +10221,8 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
     return new ExplicitAsPathSet(elems);
   }
 
+  @Nullable
+  @SuppressWarnings("unused")
   private EigrpMetric toEigrpMetric(
       ParserRuleContext ctx,
       Token ctxBw,
@@ -10218,23 +10234,28 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
       return null;
     }
     EigrpMetric.Builder builder = EigrpMetric.builder();
-    double bandwidth = toLong(ctxBw) * 1000.0D;
-    builder.setBandwidth(bandwidth);
-    double delay = toLong(ctxDelay) * 1E7;
-    builder.setDelay(delay);
-    int reliability = toInteger(ctxReliability);
-    if (reliability != 0) {
-      todo(ctx);
-    }
-    int effBw = toInteger(ctxEffBw);
-    if (effBw != 0) {
-      todo(ctx);
-    }
-    int mtu = toInteger(ctxMtu);
-    if (mtu != 0) {
-      todo(ctx);
-    }
 
+    long bandwidthLong = toLong(ctxBw);
+    if (bandwidthLong < 1 || bandwidthLong >= (1L << 32)) {
+      _w.redFlag("EIGRP metric has invalid bandwidth");
+      return null;
+    }
+    double bandwidth = bandwidthLong * 1000.0D;
+    builder.setBandwidth(bandwidth);
+
+    long delayLong = toLong(ctxDelay);
+    if (delayLong < 1 || delayLong >= (1L << 32)) {
+      _w.redFlag("EIGRP metric has invalid delay");
+      return null;
+    }
+    double delay = delayLong * 1E7;
+    builder.setDelay(delay);
+
+    /*
+     * The other three metrics (reliability, load, and MTU) may be non-zero but are only used if
+     * the K constants are configured.
+     * See https://github.com/batfish/batfish/issues/1946
+     */
     builder.setMode(_currentEigrpProcess.getMode());
     return builder.build();
   }

--- a/tests/parsing-tests/networks/unit-tests/configs/cisco_eigrp
+++ b/tests/parsing-tests/networks/unit-tests/configs/cisco_eigrp
@@ -10,6 +10,8 @@ object-group ip address _anonymized2_
 router eigrp 5
  address-family ipv4 unicast vrf default autonomous-system 55
   autonomous-system 65500
+  metric weights 0 1 2 3 4 5
+  metric maximum-hops 11
   network 1.1.2.1
  exit-address-family
  default-metric 1 2 3 4 5
@@ -17,6 +19,8 @@ router eigrp 5
  eigrp log-neighbor-changes
  eigrp log-neighbor-warnings 300
  eigrp router-id 100.1.1.1
+ metric maximum-hops 12
+ metric weights 0 1 2 3 4 5
  network 1.1.1.1 255.255.255.255
  network 5.5.5.5
  no auto-summary
@@ -125,9 +129,12 @@ router eigrp virtual
    passive-interface
   exit-af-interface
   eigrp default-route-tag 2
+  metric rib-scale 100
+  metric weights 0 1 2 3
   network 1.1.1.100
   remote-neighbors source GigabitEthernet0/0/1 unicast-listen lisp-encap 2
   topology base
+   metric maximum-hops 10
    offset-list 21 out 10
    summary-metric 192.168.0.0/16 10000 10 255 1 1500 distance 20
    traffic-share balanced
@@ -140,6 +147,8 @@ router eigrp virtual
   no passive-interface FastEthernet0/1
  exit-address-family
  service-family ipv4 vrf service-family autonomous-system 3
+  eigrp log-neighbor-changes
+  metric weights 0 1 2 3 4 5 6
   sf-interface Ethernet0
    bandwidth-percent 75
    dampening-change 75
@@ -150,6 +159,7 @@ router eigrp virtual
    no split-horizon
   exit-sf-interface
   topology base
+   metric maximum-hops 20
  exit-service-family
 !
 interface Ethernet0

--- a/tests/parsing-tests/unit-tests-undefined.ref
+++ b/tests/parsing-tests/unit-tests-undefined.ref
@@ -990,7 +990,7 @@
         "Lines" : {
           "filename" : "configs/cisco_eigrp",
           "lines" : [
-            140
+            147
           ]
         }
       },
@@ -1002,7 +1002,7 @@
         "Lines" : {
           "filename" : "configs/cisco_eigrp",
           "lines" : [
-            23
+            27
           ]
         }
       },
@@ -1014,7 +1014,7 @@
         "Lines" : {
           "filename" : "configs/cisco_eigrp",
           "lines" : [
-            24
+            28
           ]
         }
       },
@@ -1026,7 +1026,7 @@
         "Lines" : {
           "filename" : "configs/cisco_eigrp",
           "lines" : [
-            25
+            29
           ]
         }
       },
@@ -1038,7 +1038,7 @@
         "Lines" : {
           "filename" : "configs/cisco_eigrp",
           "lines" : [
-            26
+            30
           ]
         }
       },
@@ -1050,7 +1050,7 @@
         "Lines" : {
           "filename" : "configs/cisco_eigrp",
           "lines" : [
-            31
+            35
           ]
         }
       },
@@ -1062,7 +1062,7 @@
         "Lines" : {
           "filename" : "configs/cisco_eigrp",
           "lines" : [
-            32
+            36
           ]
         }
       },
@@ -1074,7 +1074,7 @@
         "Lines" : {
           "filename" : "configs/cisco_eigrp",
           "lines" : [
-            33
+            37
           ]
         }
       },
@@ -1086,7 +1086,7 @@
         "Lines" : {
           "filename" : "configs/cisco_eigrp",
           "lines" : [
-            34
+            38
           ]
         }
       },
@@ -1098,7 +1098,7 @@
         "Lines" : {
           "filename" : "configs/cisco_eigrp",
           "lines" : [
-            35
+            39
           ]
         }
       },
@@ -1110,7 +1110,7 @@
         "Lines" : {
           "filename" : "configs/cisco_eigrp",
           "lines" : [
-            36
+            40
           ]
         }
       },
@@ -1122,7 +1122,7 @@
         "Lines" : {
           "filename" : "configs/cisco_eigrp",
           "lines" : [
-            37
+            41
           ]
         }
       },

--- a/tests/parsing-tests/unit-tests-unused.ref
+++ b/tests/parsing-tests/unit-tests-unused.ref
@@ -634,13 +634,13 @@
         "Source_Lines" : {
           "filename" : "configs/cisco_eigrp",
           "lines" : [
-            45,
-            46,
-            47,
-            48,
             49,
             50,
-            51
+            51,
+            52,
+            53,
+            54,
+            55
           ]
         }
       },
@@ -650,8 +650,8 @@
         "Source_Lines" : {
           "filename" : "configs/cisco_eigrp",
           "lines" : [
-            114,
-            115
+            118,
+            119
           ]
         }
       },

--- a/tests/parsing-tests/unit-tests-warnings.ref
+++ b/tests/parsing-tests/unit-tests-warnings.ref
@@ -247,72 +247,58 @@
       },
       {
         "Filename" : "configs/cisco_eigrp",
-        "Line" : 115,
+        "Line" : 119,
         "Text" : "addrgroup bleep_blorp",
         "Parser_Context" : "[access_list_ip_range extended_access_list_tail extended_access_list_stanza stanza cisco_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {
         "Filename" : "configs/cisco_eigrp",
-        "Line" : 118,
-        "Text" : "address-family ipv4 multicast vrf autonomous-system autonomous-system 4\n  af-interface Ethernet0\n   add-paths 4\n   bandwidth-percent 75\n   dampening-change 75\n   dampening-interval 45\n   hold-time 40\n   passive-interface\n  exit-af-interface\n  eigrp default-route-tag 2\n  network 1.1.1.100\n  remote-neighbors source GigabitEthernet0/0/1 unicast-listen lisp-encap 2\n  topology base\n   offset-list 21 out 10\n   summary-metric 192.168.0.0/16 10000 10 255 1 1500 distance 20\n   traffic-share balanced\n   variance 4\n  exit-af-topology\n  topology VOICE tid 1000\n   no auto-summary\n  exit-af-topology\n  passive-interface default\n  no passive-interface FastEthernet0/1\n exit-address-family",
+        "Line" : 122,
+        "Text" : "address-family ipv4 multicast vrf autonomous-system autonomous-system 4\n  af-interface Ethernet0\n   add-paths 4\n   bandwidth-percent 75\n   dampening-change 75\n   dampening-interval 45\n   hold-time 40\n   passive-interface\n  exit-af-interface\n  eigrp default-route-tag 2\n  metric rib-scale 100\n  metric weights 0 1 2 3\n  network 1.1.1.100\n  remote-neighbors source GigabitEthernet0/0/1 unicast-listen lisp-encap 2\n  topology base\n   metric maximum-hops 10\n   offset-list 21 out 10\n   summary-metric 192.168.0.0/16 10000 10 255 1 1500 distance 20\n   traffic-share balanced\n   variance 4\n  exit-af-topology\n  topology VOICE tid 1000\n   no auto-summary\n  exit-af-topology\n  passive-interface default\n  no passive-interface FastEthernet0/1\n exit-address-family",
         "Parser_Context" : "[ren_address_family re_named_tail re_named s_router_eigrp stanza cisco_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {
         "Filename" : "configs/cisco_eigrp",
-        "Line" : 15,
-        "Text" : "default-metric 1 2 3 4 5",
-        "Parser_Context" : "[re_default_metric re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]",
+        "Line" : 13,
+        "Text" : "metric weights 0 1 2 3 4 5",
+        "Parser_Context" : "[rec_metric_weights rec_address_family_tail rec_address_family re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {
         "Filename" : "configs/cisco_eigrp",
-        "Line" : 15,
-        "Text" : "default-metric 1 2 3 4 5",
-        "Parser_Context" : "[re_default_metric re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]",
+        "Line" : 133,
+        "Text" : "metric weights 0 1 2 3",
+        "Parser_Context" : "[ren_metric_weights ren_address_family_tail ren_address_family re_named_tail re_named s_router_eigrp stanza cisco_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {
         "Filename" : "configs/cisco_eigrp",
-        "Line" : 15,
-        "Text" : "default-metric 1 2 3 4 5",
-        "Parser_Context" : "[re_default_metric re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]",
+        "Line" : 151,
+        "Text" : "metric weights 0 1 2 3 4 5 6",
+        "Parser_Context" : "[ren_metric_weights ren_service_family_tail ren_service_family re_named_tail re_named s_router_eigrp stanza cisco_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {
         "Filename" : "configs/cisco_eigrp",
-        "Line" : 34,
+        "Line" : 23,
+        "Text" : "metric weights 0 1 2 3 4 5",
+        "Parser_Context" : "[rec_metric_weights re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]",
+        "Comment" : "This feature is not currently supported"
+      },
+      {
+        "Filename" : "configs/cisco_eigrp",
+        "Line" : 38,
         "Text" : "redistribute isis route-map ISIS_TO_EIGRP",
         "Parser_Context" : "[re_redistribute_isis re_redistribute re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]",
         "Comment" : "ISIS redistribution in EIGRP is not implemented"
       },
       {
         "Filename" : "configs/cisco_eigrp",
-        "Line" : 35,
+        "Line" : 39,
         "Text" : "redistribute ospf 4 route-map OSPF_TO_EIGRP",
         "Parser_Context" : "[re_redistribute_ospf re_redistribute re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]",
-        "Comment" : "This feature is not currently supported"
-      },
-      {
-        "Filename" : "configs/cisco_eigrp",
-        "Line" : 37,
-        "Text" : "redistribute static metric 10000 10 255 1 1500 route-map STATIC_TO_EIGRP",
-        "Parser_Context" : "[re_redistribute_static re_redistribute re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]",
-        "Comment" : "This feature is not currently supported"
-      },
-      {
-        "Filename" : "configs/cisco_eigrp",
-        "Line" : 37,
-        "Text" : "redistribute static metric 10000 10 255 1 1500 route-map STATIC_TO_EIGRP",
-        "Parser_Context" : "[re_redistribute_static re_redistribute re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]",
-        "Comment" : "This feature is not currently supported"
-      },
-      {
-        "Filename" : "configs/cisco_eigrp",
-        "Line" : 37,
-        "Text" : "redistribute static metric 10000 10 255 1 1500 route-map STATIC_TO_EIGRP",
-        "Parser_Context" : "[re_redistribute_static re_redistribute re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {
@@ -2046,10 +2032,10 @@
       }
     ],
     "summary" : {
-      "notes" : "Found 286 results",
+      "notes" : "Found 284 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 286
+      "numResults" : 284
     }
   }
 ]

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -20208,6 +20208,24 @@
             "                asnum = DEC:'65500'",
             "                NEWLINE:'\\n'))",
             "            (rec_address_family_tail",
+            "              (rec_metric_weights",
+            "                METRIC:'metric'",
+            "                WEIGHTS:'weights'",
+            "                tos = DEC:'0'",
+            "                k1 = DEC:'1'",
+            "                k2 = DEC:'2'",
+            "                k3 = DEC:'3'",
+            "                k4 = DEC:'4'",
+            "                k5 = DEC:'5'",
+            "                NEWLINE:'\\n'))",
+            "            (rec_address_family_tail",
+            "              (rec_address_family_null",
+            "                METRIC:'metric'",
+            "                MAXIMUM_HOPS:'maximum-hops'",
+            "                (null_rest_of_line",
+            "                  DEC:'11'",
+            "                  NEWLINE:'\\n')))",
+            "            (rec_address_family_tail",
             "              (re_network",
             "                NETWORK:'network'",
             "                address = IP_ADDRESS:'1.1.2.1'",
@@ -20249,6 +20267,24 @@
             "            EIGRP:'eigrp'",
             "            ROUTER_ID:'router-id'",
             "            id = IP_ADDRESS:'100.1.1.1'",
+            "            NEWLINE:'\\n'))",
+            "        (re_classic_tail",
+            "          (rec_null",
+            "            METRIC:'metric'",
+            "            MAXIMUM_HOPS:'maximum-hops'",
+            "            (null_rest_of_line",
+            "              DEC:'12'",
+            "              NEWLINE:'\\n')))",
+            "        (re_classic_tail",
+            "          (rec_metric_weights",
+            "            METRIC:'metric'",
+            "            WEIGHTS:'weights'",
+            "            tos = DEC:'0'",
+            "            k1 = DEC:'1'",
+            "            k2 = DEC:'2'",
+            "            k3 = DEC:'3'",
+            "            k4 = DEC:'4'",
+            "            k5 = DEC:'5'",
             "            NEWLINE:'\\n'))",
             "        (re_classic_tail",
             "          (re_network",
@@ -21120,6 +21156,22 @@
             "                  DEC:'2'",
             "                  NEWLINE:'\\n')))",
             "            (ren_address_family_tail",
+            "              (ren_address_family_null",
+            "                METRIC:'metric'",
+            "                RIB_SCALE:'rib-scale'",
+            "                (null_rest_of_line",
+            "                  DEC:'100'",
+            "                  NEWLINE:'\\n')))",
+            "            (ren_address_family_tail",
+            "              (ren_metric_weights",
+            "                METRIC:'metric'",
+            "                WEIGHTS:'weights'",
+            "                tos = DEC:'0'",
+            "                k1 = DEC:'1'",
+            "                k2 = DEC:'2'",
+            "                k3 = DEC:'3'",
+            "                NEWLINE:'\\n'))",
+            "            (ren_address_family_tail",
             "              (re_network",
             "                NETWORK:'network'",
             "                address = IP_ADDRESS:'1.1.1.100'",
@@ -21140,6 +21192,13 @@
             "                  TOPOLOGY:'topology'",
             "                  BASE:'base'",
             "                  NEWLINE:'\\n')",
+            "                (reaf_topology_tail",
+            "                  (reaf_topology_null",
+            "                    METRIC:'metric'",
+            "                    MAXIMUM_HOPS:'maximum-hops'",
+            "                    (null_rest_of_line",
+            "                      DEC:'10'",
+            "                      NEWLINE:'\\n')))",
             "                (reaf_topology_tail",
             "                  (reaf_topology_null",
             "                    OFFSET_LIST:'offset-list'",
@@ -21223,6 +21282,24 @@
             "            asnum = DEC:'3'",
             "            NEWLINE:'\\n'",
             "            (ren_service_family_tail",
+            "              (re_eigrp_null",
+            "                EIGRP:'eigrp'",
+            "                LOG_NEIGHBOR_CHANGES:'log-neighbor-changes'",
+            "                (null_rest_of_line",
+            "                  NEWLINE:'\\n')))",
+            "            (ren_service_family_tail",
+            "              (ren_metric_weights",
+            "                METRIC:'metric'",
+            "                WEIGHTS:'weights'",
+            "                tos = DEC:'0'",
+            "                k1 = DEC:'1'",
+            "                k2 = DEC:'2'",
+            "                k3 = DEC:'3'",
+            "                k4 = DEC:'4'",
+            "                k5 = DEC:'5'",
+            "                k6 = DEC:'6'",
+            "                NEWLINE:'\\n'))",
+            "            (ren_service_family_tail",
             "              (resf_interface",
             "                SF_INTERFACE:'sf-interface'",
             "                iname = (interface_name",
@@ -21275,7 +21352,14 @@
             "                (re_topology_base",
             "                  TOPOLOGY:'topology'",
             "                  BASE:'base'",
-            "                  NEWLINE:'\\n')))",
+            "                  NEWLINE:'\\n')",
+            "                (resf_topology_tail",
+            "                  (resf_topology_null",
+            "                    METRIC:'metric'",
+            "                    MAXIMUM_HOPS:'maximum-hops'",
+            "                    (null_rest_of_line",
+            "                      DEC:'20'",
+            "                      NEWLINE:'\\n')))))",
             "            (resf_footer",
             "              EXIT_SERVICE_FAMILY:'exit-service-family'",
             "              NEWLINE:'\\n'))))))",
@@ -67887,63 +67971,51 @@
           "Parse warnings" : [
             {
               "Comment" : "This feature is not currently supported",
-              "Line" : 15,
-              "Parser_Context" : "[re_default_metric re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]",
-              "Text" : "default-metric 1 2 3 4 5"
+              "Line" : 13,
+              "Parser_Context" : "[rec_metric_weights rec_address_family_tail rec_address_family re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]",
+              "Text" : "metric weights 0 1 2 3 4 5"
             },
             {
               "Comment" : "This feature is not currently supported",
-              "Line" : 15,
-              "Parser_Context" : "[re_default_metric re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]",
-              "Text" : "default-metric 1 2 3 4 5"
-            },
-            {
-              "Comment" : "This feature is not currently supported",
-              "Line" : 15,
-              "Parser_Context" : "[re_default_metric re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]",
-              "Text" : "default-metric 1 2 3 4 5"
+              "Line" : 23,
+              "Parser_Context" : "[rec_metric_weights re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]",
+              "Text" : "metric weights 0 1 2 3 4 5"
             },
             {
               "Comment" : "ISIS redistribution in EIGRP is not implemented",
-              "Line" : 34,
+              "Line" : 38,
               "Parser_Context" : "[re_redistribute_isis re_redistribute re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]",
               "Text" : "redistribute isis route-map ISIS_TO_EIGRP"
             },
             {
               "Comment" : "This feature is not currently supported",
-              "Line" : 35,
+              "Line" : 39,
               "Parser_Context" : "[re_redistribute_ospf re_redistribute re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]",
               "Text" : "redistribute ospf 4 route-map OSPF_TO_EIGRP"
             },
             {
               "Comment" : "This feature is not currently supported",
-              "Line" : 37,
-              "Parser_Context" : "[re_redistribute_static re_redistribute re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]",
-              "Text" : "redistribute static metric 10000 10 255 1 1500 route-map STATIC_TO_EIGRP"
-            },
-            {
-              "Comment" : "This feature is not currently supported",
-              "Line" : 37,
-              "Parser_Context" : "[re_redistribute_static re_redistribute re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]",
-              "Text" : "redistribute static metric 10000 10 255 1 1500 route-map STATIC_TO_EIGRP"
-            },
-            {
-              "Comment" : "This feature is not currently supported",
-              "Line" : 37,
-              "Parser_Context" : "[re_redistribute_static re_redistribute re_classic_tail re_classic s_router_eigrp stanza cisco_configuration]",
-              "Text" : "redistribute static metric 10000 10 255 1 1500 route-map STATIC_TO_EIGRP"
-            },
-            {
-              "Comment" : "This feature is not currently supported",
-              "Line" : 115,
+              "Line" : 119,
               "Parser_Context" : "[access_list_ip_range extended_access_list_tail extended_access_list_stanza stanza cisco_configuration]",
               "Text" : "addrgroup bleep_blorp"
             },
             {
               "Comment" : "This feature is not currently supported",
-              "Line" : 118,
+              "Line" : 122,
               "Parser_Context" : "[ren_address_family re_named_tail re_named s_router_eigrp stanza cisco_configuration]",
-              "Text" : "address-family ipv4 multicast vrf autonomous-system autonomous-system 4\n  af-interface Ethernet0\n   add-paths 4\n   bandwidth-percent 75\n   dampening-change 75\n   dampening-interval 45\n   hold-time 40\n   passive-interface\n  exit-af-interface\n  eigrp default-route-tag 2\n  network 1.1.1.100\n  remote-neighbors source GigabitEthernet0/0/1 unicast-listen lisp-encap 2\n  topology base\n   offset-list 21 out 10\n   summary-metric 192.168.0.0/16 10000 10 255 1 1500 distance 20\n   traffic-share balanced\n   variance 4\n  exit-af-topology\n  topology VOICE tid 1000\n   no auto-summary\n  exit-af-topology\n  passive-interface default\n  no passive-interface FastEthernet0/1\n exit-address-family"
+              "Text" : "address-family ipv4 multicast vrf autonomous-system autonomous-system 4\n  af-interface Ethernet0\n   add-paths 4\n   bandwidth-percent 75\n   dampening-change 75\n   dampening-interval 45\n   hold-time 40\n   passive-interface\n  exit-af-interface\n  eigrp default-route-tag 2\n  metric rib-scale 100\n  metric weights 0 1 2 3\n  network 1.1.1.100\n  remote-neighbors source GigabitEthernet0/0/1 unicast-listen lisp-encap 2\n  topology base\n   metric maximum-hops 10\n   offset-list 21 out 10\n   summary-metric 192.168.0.0/16 10000 10 255 1 1500 distance 20\n   traffic-share balanced\n   variance 4\n  exit-af-topology\n  topology VOICE tid 1000\n   no auto-summary\n  exit-af-topology\n  passive-interface default\n  no passive-interface FastEthernet0/1\n exit-address-family"
+            },
+            {
+              "Comment" : "This feature is not currently supported",
+              "Line" : 133,
+              "Parser_Context" : "[ren_metric_weights ren_address_family_tail ren_address_family re_named_tail re_named s_router_eigrp stanza cisco_configuration]",
+              "Text" : "metric weights 0 1 2 3"
+            },
+            {
+              "Comment" : "This feature is not currently supported",
+              "Line" : 151,
+              "Parser_Context" : "[ren_metric_weights ren_service_family_tail ren_service_family re_named_tail re_named s_router_eigrp stanza cisco_configuration]",
+              "Text" : "metric weights 0 1 2 3 4 5 6"
             }
           ]
         },
@@ -71078,20 +71150,20 @@
           "extended ipv4 access-list" : {
             "bippety" : {
               "definitionLines" : [
-                45,
-                46,
-                47,
-                48,
                 49,
                 50,
-                51
+                51,
+                52,
+                53,
+                54,
+                55
               ],
               "numReferrers" : 0
             },
             "bloop_blop" : {
               "definitionLines" : [
-                114,
-                115
+                118,
+                119
               ],
               "numReferrers" : 0
             }
@@ -71099,7 +71171,7 @@
           "interface" : {
             "Ethernet0" : {
               "definitionLines" : [
-                155
+                165
               ],
               "numReferrers" : 2
             }
@@ -76536,72 +76608,72 @@
           "interface" : {
             "Ethernet0" : {
               "eigrp address-family af-interface" : [
-                119
+                123
               ],
               "interface" : [
-                155
+                165
               ]
             },
             "FastEthernet0/1" : {
               "eigrp passive-interface" : [
-                140
+                147
               ]
             },
             "GigabitEthernet1/5/3" : {
               "eigrp passive-interface" : [
-                23
+                27
               ]
             },
             "GigabitEthernet2/5/3" : {
               "eigrp passive-interface" : [
-                24
+                28
               ]
             },
             "Port-Channel34" : {
               "eigrp passive-interface" : [
-                25
+                29
               ]
             },
             "Port-Channel35" : {
               "eigrp passive-interface" : [
-                26
+                30
               ]
             }
           },
           "route-map" : {
             "BGP_TO_EIGRP" : {
               "eigrp redistribute bgp route-map" : [
-                31
+                35
               ]
             },
             "CONNECTED_TO_EIGRP" : {
               "eigrp redistribute connected route-map" : [
-                32
+                36
               ]
             },
             "EIGRP_TO_EIGRP" : {
               "eigrp redistribute eigrp route-map" : [
-                33
+                37
               ]
             },
             "ISIS_TO_EIGRP" : {
               "eigrp redistribute isis route-map" : [
-                34
+                38
               ]
             },
             "OSPF_TO_EIGRP" : {
               "eigrp redistribute ospf route-map" : [
-                35
+                39
               ]
             },
             "RIP_TO_EIGRP" : {
               "eigrp redistribute rip route-map" : [
-                36
+                40
               ]
             },
             "STATIC_TO_EIGRP" : {
               "eigrp redistribute static route-map" : [
-                37
+                41
               ]
             }
           }
@@ -79923,64 +79995,64 @@
           "interface" : {
             "FastEthernet0/1" : {
               "eigrp passive-interface" : [
-                140
+                147
               ]
             },
             "GigabitEthernet1/5/3" : {
               "eigrp passive-interface" : [
-                23
+                27
               ]
             },
             "GigabitEthernet2/5/3" : {
               "eigrp passive-interface" : [
-                24
+                28
               ]
             },
             "Port-Channel34" : {
               "eigrp passive-interface" : [
-                25
+                29
               ]
             },
             "Port-Channel35" : {
               "eigrp passive-interface" : [
-                26
+                30
               ]
             }
           },
           "route-map" : {
             "BGP_TO_EIGRP" : {
               "eigrp redistribute bgp route-map" : [
-                31
+                35
               ]
             },
             "CONNECTED_TO_EIGRP" : {
               "eigrp redistribute connected route-map" : [
-                32
+                36
               ]
             },
             "EIGRP_TO_EIGRP" : {
               "eigrp redistribute eigrp route-map" : [
-                33
+                37
               ]
             },
             "ISIS_TO_EIGRP" : {
               "eigrp redistribute isis route-map" : [
-                34
+                38
               ]
             },
             "OSPF_TO_EIGRP" : {
               "eigrp redistribute ospf route-map" : [
-                35
+                39
               ]
             },
             "RIP_TO_EIGRP" : {
               "eigrp redistribute rip route-map" : [
-                36
+                40
               ]
             },
             "STATIC_TO_EIGRP" : {
               "eigrp redistribute static route-map" : [
-                37
+                41
               ]
             }
           }


### PR DESCRIPTION
The default setting for metric weights is supported, but setting the
them is not supported. Added parsing and a 'todo()' for weights which
allows consolidation of other related warnings. For configurations that
do not set actually set 'metric weights', no warning is necessary.

@dhalperi 