### PR TITLE
Plug in packet policy into VI configuration

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Configuration.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Configuration.java
@@ -29,6 +29,7 @@ import org.batfish.common.BatfishException;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.NetworkFactory.NetworkFactoryBuilder;
 import org.batfish.datamodel.ospf.OspfProcess;
+import org.batfish.datamodel.packet_policy.PacketPolicy;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
 import org.batfish.datamodel.tracking.TrackMethod;
 import org.batfish.datamodel.vendor_family.VendorFamily;
@@ -150,6 +151,8 @@ public final class Configuration implements Serializable {
 
   private static final String PROP_NTP_SOURCE_INTERFACE = "ntpSourceInterface";
 
+  private static final String PROP_PACKET_POLICIES = "packetPolicies";
+
   private static final String PROP_ROUTE6_FILTER_LISTS = "route6FilterLists";
 
   private static final String PROP_ROUTE_FILTER_LISTS = "routeFilterLists";
@@ -237,6 +240,8 @@ public final class Configuration implements Serializable {
 
   private String _ntpSourceInterface;
 
+  private NavigableMap<String, PacketPolicy> _packetPolicies;
+
   private NavigableMap<String, Route6FilterList> _route6FilterLists;
 
   private NavigableMap<String, RouteFilterList> _routeFilterLists;
@@ -292,6 +297,7 @@ public final class Configuration implements Serializable {
     _mlags = ImmutableSortedMap.of();
     _normalVlanRange = new SubRange(VLAN_NORMAL_MIN_DEFAULT, VLAN_NORMAL_MAX_DEFAULT);
     _ntpServers = new TreeSet<>();
+    _packetPolicies = new TreeMap<>();
     _routeFilterLists = new TreeMap<>();
     _route6FilterLists = new TreeMap<>();
     _routingPolicies = new TreeMap<>();
@@ -536,6 +542,12 @@ public final class Configuration implements Serializable {
     return _ntpSourceInterface;
   }
 
+  /** Return the defined policies that can be used for policy-based routing */
+  @JsonProperty(PROP_PACKET_POLICIES)
+  public Map<String, PacketPolicy> getPacketPolicies() {
+    return _packetPolicies;
+  }
+
   @JsonPropertyDescription("Dictionary of all IPV6 route filter lists for this node.")
   @JsonProperty(PROP_ROUTE6_FILTER_LISTS)
   public NavigableMap<String, Route6FilterList> getRoute6FilterLists() {
@@ -767,6 +779,11 @@ public final class Configuration implements Serializable {
   @JsonProperty(PROP_ROUTING_POLICIES)
   public void setRoutingPolicies(NavigableMap<String, RoutingPolicy> routingPolicies) {
     _routingPolicies = routingPolicies;
+  }
+
+  @JsonProperty(PROP_PACKET_POLICIES)
+  public void setPacketPolicies(NavigableMap<String, PacketPolicy> packetPolicies) {
+    _packetPolicies = packetPolicies;
   }
 
   @JsonProperty(PROP_SNMP_SOURCE_INTERFACE)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -32,7 +32,6 @@ import org.batfish.datamodel.isis.IsisInterfaceMode;
 import org.batfish.datamodel.isis.IsisInterfaceSettings;
 import org.batfish.datamodel.ospf.OspfArea;
 import org.batfish.datamodel.ospf.OspfProcess;
-import org.batfish.datamodel.routing_policy.RoutingPolicy;
 import org.batfish.datamodel.transformation.Transformation;
 
 public final class Interface extends ComparableStructure<String> {
@@ -835,9 +834,7 @@ public final class Interface extends ComparableStructure<String> {
 
   private boolean _ripPassive;
 
-  private RoutingPolicy _routingPolicy;
-
-  private transient String _routingPolicyName;
+  private String _routingPolicyName;
 
   private boolean _spanningTreePortfast;
 
@@ -974,9 +971,6 @@ public final class Interface extends ComparableStructure<String> {
       return false;
     }
     if (!_proxyArp == other._proxyArp) {
-      return false;
-    }
-    if (!Objects.equals(this._routingPolicy, other._routingPolicy)) {
       return false;
     }
     if (!Objects.equals(_speed, other._speed)) {
@@ -1348,21 +1342,13 @@ public final class Interface extends ComparableStructure<String> {
     return _ripPassive;
   }
 
-  @JsonIgnore
-  public RoutingPolicy getRoutingPolicy() {
-    return _routingPolicy;
-  }
-
+  /**
+   * The name of the policy used on this interface for policy routing (as opposed to
+   * destination-based routing).
+   */
   @JsonProperty(PROP_ROUTING_POLICY)
-  @JsonPropertyDescription(
-      "The routing policy used on this interface for policy-routing (as opposed to destination-"
-          + "routing). Stored as @id")
   public String getRoutingPolicyName() {
-    if (_routingPolicy != null) {
-      return _routingPolicy.getName();
-    } else {
-      return _routingPolicyName;
-    }
+    return _routingPolicyName;
   }
 
   @JsonProperty(PROP_SPANNING_TREE_PORTFAST)
@@ -1717,11 +1703,6 @@ public final class Interface extends ComparableStructure<String> {
   @JsonProperty(PROP_RIP_PASSIVE)
   public void setRipPassive(boolean ripPassive) {
     _ripPassive = ripPassive;
-  }
-
-  @JsonIgnore
-  public void setRoutingPolicy(RoutingPolicy routingPolicy) {
-    _routingPolicy = routingPolicy;
   }
 
   @JsonProperty(PROP_ROUTING_POLICY)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -973,6 +973,9 @@ public final class Interface extends ComparableStructure<String> {
     if (!_proxyArp == other._proxyArp) {
       return false;
     }
+    if (!Objects.equals(_routingPolicyName, other._routingPolicyName)) {
+      return false;
+    }
     if (!Objects.equals(_speed, other._speed)) {
       return false;
     }

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -3929,7 +3929,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
     FwThenNextIp then = new FwThenNextIp(nextPrefix);
     _currentFwTerm.getThens().add(then);
     _currentFwTerm.getThens().add(FwThenAccept.INSTANCE);
-    _currentFilter.setRoutingPolicy(true);
+    _currentFilter.setUsedForFBF(true);
   }
 
   @Override
@@ -3951,6 +3951,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   public void exitFftt_routing_instance(Fftt_routing_instanceContext ctx) {
     String name = unquote(ctx.name.getText());
     _currentFwTerm.getThens().add(new FwThenRoutingInstance(name));
+    _currentFilter.setUsedForFBF(true);
     _configuration.referenceStructure(
         ROUTING_INSTANCE, name, FIREWALL_FILTER_THEN_ROUTING_INSTANCE, ctx.getStart().getLine());
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FirewallFilter.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FirewallFilter.java
@@ -5,9 +5,9 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
 
+/** A firewall filter on Juniper */
 public final class FirewallFilter implements Serializable {
 
-  /** */
   private static final long serialVersionUID = 1L;
 
   private final Family _family;
@@ -17,11 +17,8 @@ public final class FirewallFilter implements Serializable {
    * apply to specific from-zones)
    */
   private String _fromZone;
-
   private final String _name;
-
-  private boolean _routingPolicy;
-
+  private boolean _usedForFBF;
   private final Map<String, FwTerm> _terms;
 
   public FirewallFilter(String name, Family family) {
@@ -43,16 +40,17 @@ public final class FirewallFilter implements Serializable {
     return _name;
   }
 
-  public boolean getRoutingPolicy() {
-    return _routingPolicy;
+  /** Whether or not this filter is used for Filter-Based Forwarding (FBF) */
+  public boolean isUsedForFBF() {
+    return _usedForFBF;
   }
 
   public Map<String, FwTerm> getTerms() {
     return _terms;
   }
 
-  public void setRoutingPolicy(boolean routingPolicy) {
-    _routingPolicy = routingPolicy;
+  public void setUsedForFBF(boolean usedForFBF) {
+    _usedForFBF = usedForFBF;
   }
 
   public void setFromZone(String fromZone) {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwThen.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwThen.java
@@ -2,4 +2,6 @@ package org.batfish.representation.juniper;
 
 import java.io.Serializable;
 
-public interface FwThen extends Serializable {}
+public interface FwThen extends Serializable {
+  <T> T accept(FwThenVisitor<T> visitor);
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwThenAccept.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwThenAccept.java
@@ -1,5 +1,11 @@
 package org.batfish.representation.juniper;
 
+/** Firewall filter ACCEPT action */
 public enum FwThenAccept implements FwThen {
-  INSTANCE
+  INSTANCE;
+
+  @Override
+  public <T> T accept(FwThenVisitor<T> visitor) {
+    return visitor.visitFwThenAccept(this);
+  }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwThenDiscard.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwThenDiscard.java
@@ -1,5 +1,11 @@
 package org.batfish.representation.juniper;
 
+/** Firewall filter DROP action */
 public enum FwThenDiscard implements FwThen {
-  INSTANCE
+  INSTANCE;
+
+  @Override
+  public <T> T accept(FwThenVisitor<T> visitor) {
+    return visitor.visitFwThenDiscard(this);
+  }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwThenNextIp.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwThenNextIp.java
@@ -4,7 +4,6 @@ import org.batfish.datamodel.Prefix;
 
 public class FwThenNextIp implements FwThen {
 
-  /** */
   private static final long serialVersionUID = 1L;
 
   private final Prefix _nextPrefix;
@@ -15,5 +14,10 @@ public class FwThenNextIp implements FwThen {
 
   public Prefix getNextPrefix() {
     return _nextPrefix;
+  }
+
+  @Override
+  public <T> T accept(FwThenVisitor<T> visitor) {
+    return visitor.visitFwThenNextIp(this);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwThenNextTerm.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwThenNextTerm.java
@@ -1,5 +1,10 @@
 package org.batfish.representation.juniper;
 
 public enum FwThenNextTerm implements FwThen {
-  INSTANCE
+  INSTANCE;
+
+  @Override
+  public <T> T accept(FwThenVisitor<T> visitor) {
+    return visitor.visitFwThenNextTerm(this);
+  }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwThenNop.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwThenNop.java
@@ -1,5 +1,10 @@
 package org.batfish.representation.juniper;
 
 public enum FwThenNop implements FwThen {
-  INSTANCE
+  INSTANCE;
+
+  @Override
+  public <T> T accept(FwThenVisitor<T> visitor) {
+    return visitor.visitFwThenNop(this);
+  }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwThenRoutingInstance.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwThenRoutingInstance.java
@@ -13,4 +13,9 @@ public final class FwThenRoutingInstance implements FwThen {
   public String getInstanceName() {
     return _instanceName;
   }
+
+  @Override
+  public <T> T accept(FwThenVisitor<T> visitor) {
+    return visitor.visitThenRoutingInstance(this);
+  }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwThenVisitor.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwThenVisitor.java
@@ -1,0 +1,21 @@
+package org.batfish.representation.juniper;
+
+/** A visitor that helps evaluate (or convert) {@link FwThen} statements. */
+public interface FwThenVisitor<T> {
+
+  default T visit(FwThen then) {
+    return then.accept(this);
+  }
+
+  T visitFwThenAccept(FwThenAccept accept);
+
+  T visitFwThenDiscard(FwThenDiscard discard);
+
+  T visitFwThenNextIp(FwThenNextIp nextIp);
+
+  T visitFwThenNextTerm(FwThenNextTerm accept);
+
+  T visitFwThenNop(FwThenNop nop);
+
+  T visitThenRoutingInstance(FwThenRoutingInstance routingInstance);
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -110,6 +110,10 @@ import org.batfish.datamodel.isis.IsisProcess;
 import org.batfish.datamodel.ospf.OspfAreaSummary;
 import org.batfish.datamodel.ospf.OspfMetricType;
 import org.batfish.datamodel.ospf.OspfProcess;
+import org.batfish.datamodel.packet_policy.Drop;
+import org.batfish.datamodel.packet_policy.PacketMatchExpr;
+import org.batfish.datamodel.packet_policy.PacketPolicy;
+import org.batfish.datamodel.packet_policy.Return;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
 import org.batfish.datamodel.routing_policy.expr.BooleanExpr;
 import org.batfish.datamodel.routing_policy.expr.BooleanExprs;
@@ -1351,15 +1355,15 @@ public final class JuniperConfiguration extends VendorConfiguration {
               iface.getOutgoingFilter()));
     }
 
-    String inAclName = iface.getIncomingFilter();
-    if (inAclName != null) {
-      IpAccessList inAcl = _c.getIpAccessLists().get(inAclName);
+    String incomingFilterName = iface.getIncomingFilter();
+    if (incomingFilterName != null) {
+      IpAccessList inAcl = _c.getIpAccessLists().get(incomingFilterName);
       if (inAcl != null) {
-        FirewallFilter inFilter = _masterLogicalSystem.getFirewallFilters().get(inAclName);
-        if (inFilter.getRoutingPolicy()) {
-          RoutingPolicy routingPolicy = _c.getRoutingPolicies().get(inAclName);
+        FirewallFilter inFilter = _masterLogicalSystem.getFirewallFilters().get(incomingFilterName);
+        if (inFilter.isUsedForFBF()) {
+          PacketPolicy routingPolicy = _c.getPacketPolicies().get(incomingFilterName);
           if (routingPolicy != null) {
-            newIface.setRoutingPolicy(inAclName);
+            newIface.setRoutingPolicy(incomingFilterName);
           } else {
             throw new BatfishException("Expected interface routing-policy to exist");
           }
@@ -2039,100 +2043,44 @@ public final class JuniperConfiguration extends VendorConfiguration {
     return new RibId(hostname, vrfName, ribName);
   }
 
-  private RoutingPolicy toRoutingPolicy(FirewallFilter filter) {
-    String name = filter.getName();
-    RoutingPolicy routingPolicy = new RoutingPolicy(name, _c);
-    // for (Entry<String, FwTerm> e : filter.getTerms().entrySet()) {
-    // String termName = e.getKey();
-    // FwTerm term = e.getValue();
-    // PolicyMapClause clause = new PolicyMapClause();
-    // clause.setName(termName);
-    // routingPolicy.getClauses().add(clause);
-    // Set<Prefix> destinationPrefixes = new TreeSet<>();
-    // ;
-    // List<SubRange> destinationPortRanges = new ArrayList<>();
-    // Set<Prefix> sourcePrefixes = new TreeSet<>();
-    // List<SubRange> sourcePortRanges = new ArrayList<>();
-    //
-    // for (FwFrom from : term.getFroms()) {
-    // if (from instanceof FwFromDestinationAddress) {
-    // FwFromDestinationAddress fromDestinationAddress =
-    // (FwFromDestinationAddress) from;
-    // Prefix destinationPrefix = fromDestinationAddress.getIp();
-    // destinationPrefixes.add(destinationPrefix);
-    // }
-    // if (from instanceof FwFromDestinationPort) {
-    // FwFromDestinationPort fromDestinationPort = (FwFromDestinationPort)
-    // from;
-    // SubRange destinationPortRange = fromDestinationPort
-    // .getPortRange();
-    // destinationPortRanges.add(destinationPortRange);
-    // }
-    // else if (from instanceof FwFromSourceAddress) {
-    // FwFromSourceAddress fromSourceAddress = (FwFromSourceAddress) from;
-    // Prefix sourcePrefix = fromSourceAddress.getIp();
-    // sourcePrefixes.add(sourcePrefix);
-    // }
-    // if (from instanceof FwFromSourcePort) {
-    // FwFromSourcePort fromSourcePort = (FwFromSourcePort) from;
-    // SubRange sourcePortRange = fromSourcePort.getPortRange();
-    // sourcePortRanges.add(sourcePortRange);
-    // }
-    // }
-    // if (!destinationPrefixes.isEmpty() || !destinationPortRanges.isEmpty()
-    // || !sourcePrefixes.isEmpty() || !sourcePortRanges.isEmpty()) {
-    // String termIpAccessListName = "~" + name + ":" + termName + "~";
-    // IpAccessListLine line = new IpAccessListLine();
-    // for (Prefix dstPrefix : destinationPrefixes) {
-    // IpWildcard dstWildcard = new IpWildcard(dstPrefix);
-    // line.getDstIps().add(dstWildcard);
-    // }
-    // line.getDstPorts().addAll(destinationPortRanges);
-    // for (Prefix srcPrefix : sourcePrefixes) {
-    // IpWildcard srcWildcard = new IpWildcard(srcPrefix);
-    // line.getSrcIps().add(srcWildcard);
-    // }
-    // line.getDstPorts().addAll(sourcePortRanges);
-    // line.setAction(LineAction.PERMIT);
-    // IpAccessList termIpAccessList = new IpAccessList(
-    // termIpAccessListName, Collections.singletonList(line));
-    // _c.getIpAccessLists().put(termIpAccessListName, termIpAccessList);
-    // PolicyMapMatchIpAccessListLine matchListLine = new
-    // PolicyMapMatchIpAccessListLine(
-    // Collections.singleton(termIpAccessList));
-    // clause.getMatchLines().add(matchListLine);
-    // }
-    // List<Prefix> nextPrefixes = new ArrayList<>();
-    // for (FwThen then : term.getThens()) {
-    // if (then instanceof FwThenNextIp) {
-    // FwThenNextIp thenNextIp = (FwThenNextIp) then;
-    // Prefix nextIp = thenNextIp.getNextPrefix();
-    // nextPrefixes.add(nextIp);
-    // }
-    // else if (then == FwThenDiscard.INSTANCE) {
-    // clause.setAction(PolicyMapAction.DENY);
-    // }
-    // else if (then == FwThenAccept.INSTANCE) {
-    // clause.setAction(PolicyMapAction.PERMIT);
-    // }
-    // }
-    // if (!nextPrefixes.isEmpty()) {
-    // List<Ip> nextHopIps = new ArrayList<>();
-    // for (Prefix nextPrefix : nextPrefixes) {
-    // nextHopIps.add(nextPrefix.getIp());
-    // int prefixLength = nextPrefix.getPrefixLength();
-    // if (prefixLength != 32) {
-    // _w.redFlag(
-    // "Not sure how to interpret nextIp with prefix-length not equal to 32: "
-    // + prefixLength);
-    // }
-    // }
-    // PolicyMapSetNextHopLine setNextHop = new PolicyMapSetNextHopLine(
-    // nextHopIps);
-    // clause.getSetLines().add(setNextHop);
-    // }
-    // }
-    return routingPolicy;
+  /**
+   * Convert a firewall filter into a policy that can be used for policy-based routing (or
+   * filter-based forwarding, in Juniper parlance).
+   */
+  private PacketPolicy toPacketPolicy(FirewallFilter filter) {
+    ImmutableList.Builder<org.batfish.datamodel.packet_policy.Statement> builder =
+        ImmutableList.builder();
+    for (Entry<String, FwTerm> e : filter.getTerms().entrySet()) {
+      FwTerm term = e.getValue();
+
+      /*
+       * Convert "from" statements. Currently, the only supported "from"s are the ones matching on
+       * headerspace, and they are ANDed together, so we collapse them into one big
+       * AclMatch expression.
+       */
+      HeaderSpace.Builder matchCondition = HeaderSpace.builder();
+      for (FwFrom from : term.getFroms()) {
+        from.applyTo(matchCondition, this, _w, _c);
+      }
+
+      // A term will become an If statement. If (matchCondition) -> execute "then" statements
+      TermFwThenToPacketPolicyStatement thenConverter =
+          new TermFwThenToPacketPolicyStatement(Configuration.DEFAULT_VRF_NAME);
+      builder.add(
+          new org.batfish.datamodel.packet_policy.If(
+              new PacketMatchExpr(
+                  new MatchHeaderSpace(
+                      matchCondition.build(),
+                      String.format("Firewall filter term %s", term.getName()))),
+              // Convert "then"s to action statements.
+              term.getThens().stream()
+                  .map(thenConverter::visit)
+                  .filter(Objects::nonNull)
+                  .collect(ImmutableList.toImmutableList())));
+    }
+
+    // Make the policy, with an implicit deny all at the end as the default action
+    return new PacketPolicy(filter.getName(), builder.build(), new Return(Drop.instance()));
   }
 
   private RoutingPolicy toRoutingPolicy(PolicyStatement ps) {
@@ -2522,18 +2470,16 @@ public final class JuniperConfiguration extends VendorConfiguration {
       _c.getIpAccessLists().put(name, list);
     }
 
-    // convert firewall filters implementing routing policy to RoutingPolicy
-    // objects
+    // convert firewall filters implementing packet policy to PacketPolicy objects
     for (Entry<String, FirewallFilter> e : _masterLogicalSystem.getFirewallFilters().entrySet()) {
       String name = e.getKey();
       FirewallFilter filter = e.getValue();
-      if (filter.getRoutingPolicy()) {
+      if (filter.isUsedForFBF()) {
         // TODO: support other filter families
         if (filter.getFamily() != Family.INET) {
           continue;
         }
-        RoutingPolicy routingPolicy = toRoutingPolicy(filter);
-        _c.getRoutingPolicies().put(name, routingPolicy);
+        _c.getPacketPolicies().put(name, toPacketPolicy(filter));
       }
     }
 
@@ -2835,8 +2781,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
     }
 
     // Count and mark structure usages and identify undefined references
-    markConcreteStructure(
-        JuniperStructureType.ADDRESS_BOOK, JuniperStructureUsage.ADDRESS_BOOK_ATTACH_ZONE);
+    markConcreteStructure(ADDRESS_BOOK, JuniperStructureUsage.ADDRESS_BOOK_ATTACH_ZONE);
     markConcreteStructure(
         JuniperStructureType.AUTHENTICATION_KEY_CHAIN,
         JuniperStructureUsage.AUTHENTICATION_KEY_CHAINS_POLICY);

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -2067,19 +2067,13 @@ public final class JuniperConfiguration extends VendorConfiguration {
       }
 
       // A term will become an If statement. If (matchCondition) -> execute "then" statements
-      TermFwThenToPacketPolicyStatement thenConverter =
-          new TermFwThenToPacketPolicyStatement(Configuration.DEFAULT_VRF_NAME);
       builder.add(
           new org.batfish.datamodel.packet_policy.If(
               new PacketMatchExpr(
                   new MatchHeaderSpace(
                       matchCondition.build(),
                       String.format("Firewall filter term %s", term.getName()))),
-              // Convert "then"s to action statements.
-              term.getThens().stream()
-                  .map(thenConverter::visit)
-                  .filter(Objects::nonNull)
-                  .collect(ImmutableList.toImmutableList())));
+              TermFwThenToPacketPolicyStatement.convert(term, Configuration.DEFAULT_VRF_NAME)));
     }
 
     // Make the policy, with an implicit deny all at the end as the default action

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -39,7 +39,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.collections4.list.TreeList;
 import org.apache.commons.lang3.SerializationUtils;
-import org.batfish.common.BatfishException;
 import org.batfish.common.VendorConversionException;
 import org.batfish.common.Warnings;
 import org.batfish.common.util.CommonUtil;
@@ -1365,7 +1364,11 @@ public final class JuniperConfiguration extends VendorConfiguration {
           if (routingPolicy != null) {
             newIface.setRoutingPolicy(incomingFilterName);
           } else {
-            throw new BatfishException("Expected interface routing-policy to exist");
+            newIface.setRoutingPolicy(null);
+            _w.redFlag(
+                String.format(
+                    "Interface %s: cannot resolve applied filter %s, defaulting to no filter",
+                    name, incomingFilterName));
           }
         }
       }
@@ -2781,7 +2784,8 @@ public final class JuniperConfiguration extends VendorConfiguration {
     }
 
     // Count and mark structure usages and identify undefined references
-    markConcreteStructure(ADDRESS_BOOK, JuniperStructureUsage.ADDRESS_BOOK_ATTACH_ZONE);
+    markConcreteStructure(
+        JuniperStructureType.ADDRESS_BOOK, JuniperStructureUsage.ADDRESS_BOOK_ATTACH_ZONE);
     markConcreteStructure(
         JuniperStructureType.AUTHENTICATION_KEY_CHAIN,
         JuniperStructureUsage.AUTHENTICATION_KEY_CHAINS_POLICY);

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/TermFwThenToPacketPolicyStatement.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/TermFwThenToPacketPolicyStatement.java
@@ -3,17 +3,16 @@ package org.batfish.representation.juniper;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.packet_policy.Drop;
 import org.batfish.datamodel.packet_policy.FibLookup;
-import org.batfish.datamodel.packet_policy.PacketPolicy;
 import org.batfish.datamodel.packet_policy.Return;
 import org.batfish.datamodel.packet_policy.Statement;
 
 /**
- * Converts <i>then</i> statements in the {@link FirewallFilter} to statements in the {@link
- * PacketPolicy}
+ * Converts <em>then</em> statements in the {@link FirewallFilter} to statements in the {@link
+ * org.batfish.datamodel.packet_policy.PacketPolicy}
  *
- * <p><em>Note:</em>It can return {@code null} for statements that must be skipped or we currently
- * do not support. In particular, this visitor is stateful and will skip converting statements after
- * {@link FwThenNextTerm} has been encountered.
+ * <p><strong>Note:</strong>It can return {@code null} for statements that must be skipped or we
+ * currently do not support. In particular, this visitor is stateful and will skip converting
+ * statements after {@link FwThenNextTerm} has been encountered.
  */
 public final class TermFwThenToPacketPolicyStatement implements FwThenVisitor<Statement> {
 

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/TermFwThenToPacketPolicyStatement.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/TermFwThenToPacketPolicyStatement.java
@@ -1,0 +1,59 @@
+package org.batfish.representation.juniper;
+
+import javax.annotation.Nullable;
+import org.batfish.datamodel.packet_policy.Drop;
+import org.batfish.datamodel.packet_policy.FibLookup;
+import org.batfish.datamodel.packet_policy.PacketPolicy;
+import org.batfish.datamodel.packet_policy.Return;
+import org.batfish.datamodel.packet_policy.Statement;
+
+/**
+ * Converts <i>then</i> statements in the {@link FirewallFilter} to statements in the {@link
+ * PacketPolicy}
+ *
+ * <p><em>Note:</em>It can return {@code null} for statements that must be skipped or we currently
+ * do not support. In particular, this visitor is stateful and will skip converting statements after
+ * {@link FwThenNextTerm} has been encountered.
+ */
+public final class TermFwThenToPacketPolicyStatement implements FwThenVisitor<Statement> {
+
+  private final String _vrfToUse;
+  private boolean _skipRest;
+
+  /** Create a new converter, with a default VRF to be used for FIB lookups */
+  public TermFwThenToPacketPolicyStatement(String vrfToUse) {
+    _vrfToUse = vrfToUse;
+  }
+
+  @Override
+  public Statement visitFwThenAccept(FwThenAccept accept) {
+    return _skipRest ? null : new Return(new FibLookup(_vrfToUse));
+  }
+
+  @Override
+  public Statement visitFwThenDiscard(FwThenDiscard discard) {
+    return _skipRest ? null : new Return(Drop.instance());
+  }
+
+  @Override
+  @Nullable
+  public Statement visitFwThenNextIp(FwThenNextIp nextIp) {
+    return null;
+  }
+
+  @Override
+  public Statement visitFwThenNextTerm(FwThenNextTerm accept) {
+    _skipRest = true;
+    return null;
+  }
+
+  @Override
+  public Statement visitFwThenNop(FwThenNop nop) {
+    return null;
+  }
+
+  @Override
+  public Statement visitThenRoutingInstance(FwThenRoutingInstance routingInstance) {
+    return _skipRest ? null : new Return(new FibLookup(routingInstance.getInstanceName()));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/TermFwThenToPacketPolicyStatementTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/TermFwThenToPacketPolicyStatementTest.java
@@ -1,0 +1,90 @@
+package org.batfish.representation.juniper;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.collect.ImmutableList;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.packet_policy.Drop;
+import org.batfish.datamodel.packet_policy.FibLookup;
+import org.batfish.datamodel.packet_policy.Return;
+import org.junit.Before;
+import org.junit.Test;
+
+/** Tests of {@link TermFwThenToPacketPolicyStatement} */
+public class TermFwThenToPacketPolicyStatementTest {
+  private FwTerm _fwTerm;
+
+  @Before
+  public void setUp() {
+    _fwTerm = new FwTerm("termName");
+  }
+
+  @Test
+  public void testVisitAccept() {
+    _fwTerm.getThens().add(FwThenAccept.INSTANCE);
+    assertThat(
+        TermFwThenToPacketPolicyStatement.convert(_fwTerm, "someVRF"),
+        equalTo(ImmutableList.of(new Return(new FibLookup("someVRF")))));
+  }
+
+  @Test
+  public void testVisitAcceptAfterNextTerm() {
+    _fwTerm.getThens().addAll(ImmutableList.of(FwThenNextTerm.INSTANCE, FwThenAccept.INSTANCE));
+    assertThat(
+        TermFwThenToPacketPolicyStatement.convert(_fwTerm, "someVRF"), equalTo(ImmutableList.of()));
+  }
+
+  @Test
+  public void testVisitNextTermAfterAccept() {
+    _fwTerm.getThens().addAll(ImmutableList.of(FwThenAccept.INSTANCE, FwThenNextTerm.INSTANCE));
+    assertThat(
+        TermFwThenToPacketPolicyStatement.convert(_fwTerm, "someVRF"),
+        equalTo(ImmutableList.of(new Return(new FibLookup("someVRF")))));
+  }
+
+  @Test
+  public void testVisitNop() {
+    _fwTerm.getThens().add(FwThenNop.INSTANCE);
+    assertThat(
+        TermFwThenToPacketPolicyStatement.convert(_fwTerm, "someVRF"), equalTo(ImmutableList.of()));
+  }
+
+  @Test
+  public void testVisitDiscard() {
+    _fwTerm.getThens().add(FwThenDiscard.INSTANCE);
+    assertThat(
+        TermFwThenToPacketPolicyStatement.convert(_fwTerm, "someVRF"),
+        equalTo(ImmutableList.of(new Return(Drop.instance()))));
+  }
+
+  @Test
+  public void testVisitDiscardAfterSkip() {
+    _fwTerm.getThens().addAll(ImmutableList.of(FwThenNextTerm.INSTANCE, FwThenDiscard.INSTANCE));
+    assertThat(TermFwThenToPacketPolicyStatement.convert(_fwTerm, "someVRF"), empty());
+  }
+
+  @Test
+  public void testVisitNextIp() {
+    _fwTerm.getThens().add(new FwThenNextIp(Prefix.parse("1.1.1.0/24")));
+    // Not implemented yet:
+    assertThat(TermFwThenToPacketPolicyStatement.convert(_fwTerm, "someVRF"), empty());
+  }
+
+  @Test
+  public void testVisitRoutingInstance() {
+    _fwTerm.getThens().add(new FwThenRoutingInstance("otherVRF"));
+    assertThat(
+        TermFwThenToPacketPolicyStatement.convert(_fwTerm, "someVRF"),
+        equalTo(ImmutableList.of(new Return(new FibLookup("otherVRF")))));
+  }
+
+  @Test
+  public void testVisitRoutingInstanceAfterSkip() {
+    _fwTerm
+        .getThens()
+        .addAll(ImmutableList.of(FwThenNextTerm.INSTANCE, new FwThenRoutingInstance("otherVRF")));
+    assertThat(TermFwThenToPacketPolicyStatement.convert(_fwTerm, "someVRF"), empty());
+  }
+}

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -17312,6 +17312,132 @@
             "sourceType" : "firewall filter"
           }
         },
+        "packetPolicies" : {
+          "blah" : {
+            "defaultAction" : {
+              "class" : "org.batfish.datamodel.packet_policy.Return",
+              "action" : {
+                "class" : "org.batfish.datamodel.packet_policy.Drop"
+              }
+            },
+            "name" : "blah",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.packet_policy.If",
+                "trueStatements" : {
+                  "class" : "org.batfish.datamodel.packet_policy.PacketMatchExpr",
+                  "expression" : {
+                    "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                    "description" : "Firewall filter term blorp",
+                    "headerSpace" : {
+                      "dstIps" : {
+                        "class" : "org.batfish.datamodel.AclIpSpace",
+                        "lines" : [
+                          {
+                            "action" : "PERMIT",
+                            "ipSpace" : {
+                              "class" : "org.batfish.datamodel.AclIpSpace",
+                              "lines" : [
+                                {
+                                  "action" : "PERMIT",
+                                  "ipSpace" : {
+                                    "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                                    "ipWildcard" : "1.2.3.4"
+                                  }
+                                },
+                                {
+                                  "action" : "PERMIT",
+                                  "ipSpace" : {
+                                    "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                                    "ipWildcard" : "1.2.3.5"
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "action" : "PERMIT",
+                            "ipSpace" : {
+                              "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                              "ipWildcard" : "1.2.3.8/30"
+                            }
+                          }
+                        ]
+                      },
+                      "icmpCodes" : [
+                        "2-2"
+                      ],
+                      "icmpTypes" : [
+                        "0-0",
+                        "1-1",
+                        "3-3",
+                        "4-4",
+                        "5-5",
+                        "8-8",
+                        "9-9",
+                        "10-10",
+                        "11-11",
+                        "12-12",
+                        "13-13",
+                        "14-14",
+                        "15-15",
+                        "16-16"
+                      ],
+                      "ipProtocols" : [
+                        "PIM"
+                      ],
+                      "negate" : false,
+                      "packetLengths" : [
+                        "70-12000"
+                      ],
+                      "srcIps" : {
+                        "class" : "org.batfish.datamodel.AclIpSpace",
+                        "lines" : [
+                          {
+                            "action" : "PERMIT",
+                            "ipSpace" : {
+                              "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                              "ipWildcard" : "2.4.6.8/30"
+                            }
+                          },
+                          {
+                            "action" : "PERMIT",
+                            "ipSpace" : {
+                              "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                              "ipWildcard" : "2.4.6.9"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "class" : "org.batfish.datamodel.packet_policy.If",
+                "actions" : [
+                  {
+                    "class" : "org.batfish.datamodel.packet_policy.Return",
+                    "action" : {
+                      "class" : "org.batfish.datamodel.packet_policy.FibLookup",
+                      "vrfName" : "OTHER_INSTANCE"
+                    }
+                  }
+                ],
+                "trueStatements" : {
+                  "class" : "org.batfish.datamodel.packet_policy.PacketMatchExpr",
+                  "expression" : {
+                    "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                    "description" : "Firewall filter term t2",
+                    "headerSpace" : {
+                      "negate" : false
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        },
         "vendorFamily" : {
           "juniper" : {
             "lines" : {


### PR DESCRIPTION
Updates Configuration and the Interface model to remove RoutingPolicy in favor of a pointer to PacketPolicy.